### PR TITLE
trim search term

### DIFF
--- a/front/search.php
+++ b/front/search.php
@@ -44,7 +44,7 @@ if (!$CFG_GLPI['allow_search_global']) {
    Html::displayRightError();
 }
 if (isset($_GET["globalsearch"])) {
-   $searchtext=$_GET["globalsearch"];
+   $searchtext=trim($_GET["globalsearch"]);
 
    foreach ($CFG_GLPI["globalsearch_types"] as $itemtype) {
       if (($item = getItemForItemtype($itemtype))


### PR DESCRIPTION
Copy/pasting a value in the search box often doesn't work, because microsoft includes spaces when doubleclicking and copying.
Adding trim() on line 47 solves this really small annoyance.