### PR TITLE
Fix In-Reply-To token for thread of notifications

### DIFF
--- a/inc/queuedmail.class.php
+++ b/inc/queuedmail.class.php
@@ -351,8 +351,8 @@ class QueuedMail extends CommonDBTM {
          }
 
          // Add custom header for mail grouping in reader
-         $mmail->AddCustomHeader("In-Reply-To: GLPI-".$this->fields["itemtype"]."-".
-                                 $this->fields["items_id"]);
+         $mmail->AddCustomHeader("In-Reply-To: <GLPI-".$this->fields["itemtype"]."-".
+                                 $this->fields["items_id"].">");
 
       $mmail->SetFrom($this->fields['sender'], $this->fields['sendername']);
 


### PR DESCRIPTION
Attended thread view of notifications doesn't work :
  - http://cr.yp.to/immhf/thread.html : In-Reply-To is a tokenisable field
  - http://cr.yp.to/immhf/token.html : An atom shall be around < and >
With this modification, thread view is finally OK…