### PR TITLE
To give possibility to use specific process to get data for dropdowns

### DIFF
--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -189,7 +189,7 @@ class CronTask extends CommonDBTM{
 
       $query = "UPDATE `".$this->getTable()."`
                 SET `state` = '".self::STATE_RUNNING."',
-                    `lastrun` = NOW()
+                    `lastrun` = DATE_FORMAT(NOW(),'%Y-%m-%d %H:%i:00')
                 WHERE `id` = '".$this->fields['id']."'
                       AND `state` != '".self::STATE_RUNNING."'";
       $result = $DB->query($query);
@@ -250,8 +250,7 @@ class CronTask extends CommonDBTM{
          return false;
       }
       $query = "UPDATE `".$this->getTable()."`
-                SET `state` = '".$this->fields['state']."',
-                    `lastrun` = DATE_FORMAT(NOW(),'%Y-%m-%d %H:%i:00')
+                SET `state` = '".$this->fields['state']."'
                 WHERE `id` = '".$this->fields['id']."'
                       AND `state` = '".self::STATE_RUNNING."'";
       $result = $DB->query($query);

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -75,6 +75,8 @@ class Dropdown {
     *    - permit_select_parent : boolean / for tree dropdown permit to see parent items
     *                                       not available by default (default false)
     *    - specific_tags        : array of HTML5 tags to add the the field
+    *    - url                  : url of the ajax php code which should return the json data to show in
+    *                                       the dropdown
     *
     * @return boolean : false if error and random id if OK
    **/
@@ -109,6 +111,7 @@ class Dropdown {
       $params['permit_select_parent'] = false;
       $params['addicon']              = true;
       $params['specific_tags']        = array();
+      $params['url']                  = $CFG_GLPI['root_doc']."/ajax/getDropdownValue.php" ;
 
 
       if (is_array($options) && count($options)) {
@@ -177,7 +180,7 @@ class Dropdown {
                 );
 
       $output = Html::jsAjaxDropdown($params['name'], $field_id,
-                                     $CFG_GLPI['root_doc']."/ajax/getDropdownValue.php",
+                                     $params['url'],
                                      $p);
       // Display comment
       if ($params['comments']) {


### PR DESCRIPTION
This modification gives the possibility to set a parameter as URL for getting the data of the dropdowns.
This can be useful for plugins which may have special filters (like JOINs). 
This will permit to re-use the GLPI standart dropdown mechanism instead of re-written the wheel.
Thank you,
regards,
Tomolimo