### PR TITLE
uasort is not useful

### DIFF
--- a/ajax/getDropdownUsers.php
+++ b/ajax/getDropdownUsers.php
@@ -102,6 +102,7 @@ if ($DB->numrows($result)) {
    }
 }
 
+/*
 if (!function_exists('dpuser_cmp')) {
    function dpuser_cmp($a, $b) {
       return strcasecmp($a, $b);
@@ -110,6 +111,7 @@ if (!function_exists('dpuser_cmp')) {
 
 // Sort non case sensitive
 uasort($users, 'dpuser_cmp');
+*/
 
 $datas = array();
 


### PR DESCRIPTION
User list has already been sorted by the SQL request in User::getSqlSearchResult() function in file user.class.php
Extract of code from user.class.php:
line 3109:
     if ($_SESSION["glpinames_format"] == self::FIRSTNAME_BEFORE) {
            $query.=" ORDER BY `glpi_users`.`firstname`,
                               `glpi_users`.`realname`,
                               `glpi_users`.`name` ";
         } else {
            $query.=" ORDER BY `glpi_users`.`realname`,
                               `glpi_users`.`firstname`,
                               `glpi_users`.`name` ";
         }