### PR TITLE
Problem with array_unshift which doesn't preserve keys

### DIFF
--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -1688,7 +1688,8 @@ class Dropdown {
       }
 
       if ($param["display_emptychoice"]) {
-         array_unshift($elements, $param['emptylabel']);
+         //array_unshift($elements, $param['emptylabel']); // cannot be used as it doesn't preserve keys when they are numbers
+         $elements = array( 0 => $param['emptylabel'] ) + $elements ;
       }
 
       if ($param["multiple"]) {


### PR DESCRIPTION
Problem with array_unshift which doesn't preserve keys when they are numbers
See: http://php.net/manual/en/function.array-unshift.php