### PR TITLE
external import supports hierarchical dropdown values

### DIFF
--- a/inc/commondropdown.class.php
+++ b/inc/commondropdown.class.php
@@ -687,6 +687,22 @@ abstract class CommonDropdown extends CommonDBTM {
             $input["name"] = $res_rule["name"];
          }
       }
+      return $this->importExternalExec($input, $add);
+   }
+
+
+   /**
+    * Import processed value into dropdown table.
+    *
+    * Rules must have been applied.
+    *
+    * @param $input                    array of value to import
+    * @param $add                      if true, add it if not found. if false,
+    *                                  just check if exists
+    *
+    * @return integer : dropdown id.
+   **/
+   function importExternalExec(array $input, $add) {
       return ($add ? $this->import($input) : $this->findID($input));
    }
 

--- a/inc/commontreedropdown.class.php
+++ b/inc/commontreedropdown.class.php
@@ -793,5 +793,17 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       return $parent;
    }
 
+   /**
+    * @see CommonDropdown::importExternalExec()
+   **/
+   function importExternalExec(array $input, $add) {
+      // generic import doesn't fill "completename" -> copy it manually to there
+      if (!isset($input['completename']) && isset($input['name'])) {
+         $input['completename'] = $input['name'];
+         unset($input['name']);
+      }
+
+      return parent::importExternalExec($input, $add);
+   }
 }
 ?>


### PR DESCRIPTION
This patch enables import of hierarchical values. 

E.g. during import from OCS, a location called "office>room5" is now translated to "location 'room5' with parent location 'office'". Without this patch, using nested locations like this was not possible.

The actual code was actually there, but its use was explicitely disabled for imports from extern.