### PR TITLE
Added default icon when icon is not defined in document type

### DIFF
--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -513,6 +513,9 @@ class Document extends CommonDBTM {
          if ($result = $DB->query($query)) {
             if ($DB->numrows($result) > 0) {
                $icon = $DB->result($result,0,'icon');
+               if (!file_exists(GLPI_ROOT."/".$CFG_GLPI["typedoc_icon_dir"]."/$icon")) {
+                  $icon = "defaut-dist.png" ;
+               }
                $out .= "&nbsp;<img class='middle' style='margin-left:3px; margin-right:6px;' alt=\"".
                                $initfileout."\" title=\"".$initfileout."\" src='".
                                $CFG_GLPI["typedoc_icon_dir"]."/$icon'>";


### PR DESCRIPTION
Added default icon when icon is not defined in document type.
To fix #451 