### PR TITLE
Check software name in case insensitive

### DIFF
--- a/inc/ruledictionnarysoftwarecollection.class.php
+++ b/inc/ruledictionnarysoftwarecollection.class.php
@@ -9,7 +9,7 @@
 
  based on GLPI - Gestionnaire Libre de Parc Informatique
  Copyright (C) 2003-2014 by the INDEPNET Development Team.
- 
+
  -------------------------------------------------------------------------
 
  LICENSE
@@ -164,7 +164,7 @@ class RuleDictionnarySoftwareCollection extends RuleCollection {
             //Replay software dictionnary rules
             $res_rule = $this->processAllRules($input, array(), array());
 
-            if ((isset($res_rule["name"]) && ($res_rule["name"] != $input["name"]))
+            if ((isset($res_rule["name"]) && (strtolower($res_rule["name"]) != strtolower($input["name"])))
                 || (isset($res_rule["version"]) && ($res_rule["version"] != ''))
                 || (isset($res_rule['new_entities_id'])
                     && ($res_rule['new_entities_id'] != $input['entities_id']))
@@ -290,7 +290,7 @@ class RuleDictionnarySoftwareCollection extends RuleCollection {
       }
 
       //Software's name has changed or entity
-      if ((isset($res_rule["name"]) && ($res_rule["name"] != $name))
+      if ((isset($res_rule["name"]) && (strtolower($res_rule["name"]) != strtolower($name)))
             //Entity has changed, and new entity is a parent of the current one
           || (!isset($res_rule["name"])
               && isset($res_rule['new_entities_id'])


### PR DESCRIPTION
When replaying a software dictionnary on an existing DB, check if the software exists in case insensitive, to avoid doubles