### PR TITLE
Permit to add multiple plugin objects into menu

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1276,8 +1276,14 @@ class Html {
             foreach  ($PLUGIN_HOOKS["menu_toadd"] as $plugin => $items) {
                if (count($items)) {
                   foreach ($items as $key => $val) {
-                     if (isset($menu[$key])) {
-                        $menu[$key]['types'][] = $val;
+                     if (is_array($val)) {
+                        foreach ($val as $k => $object) {
+                           $menu[$key]['types'][] = $object;
+                        }
+                     } else {
+                        if (isset($menu[$key])) {
+                           $menu[$key]['types'][] = $val;
+                        }
                      }
                   }
                }


### PR DESCRIPTION
Permit to add multiple plugin objects into menu **from a single plugin** : 

Example 
```
$PLUGIN_HOOKS['menu_toadd']['example'] = array('assets' => array('PluginExampleExample1', 'PluginExampleExample2'));
```