### PR TITLE
Add a hook to display additional informations on financial infomation…

### DIFF
--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -1178,6 +1178,8 @@ class Infocom extends CommonDBChild {
             }
             echo "</td></tr>";
 
+            Plugin::doHook("infocom", $item);
+
             if ($canedit) {
                echo "<tr>";
                echo "<td class='tab_bg_2 center' colspan='2'>";

--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -1178,7 +1178,10 @@ class Infocom extends CommonDBChild {
             }
             echo "</td></tr>";
 
-            Plugin::doHook("infocom", $item);
+            //We use a static method to call the hook
+            //It's then easier for plugins to detect if the hook is available or not
+            //The just have to look for the addPluginInfos method
+            self::addPluginInfos($item);
 
             if ($canedit) {
                echo "<tr>";
@@ -1202,6 +1205,10 @@ class Infocom extends CommonDBChild {
       }
    }
 
+
+   static function addPluginInfos(CommonDBTM $item) {
+      Plugin::doHook("infocom", $item);
+   }
 
    /**
     * @param $itemtype


### PR DESCRIPTION
This hook allows plugins to add informations related to financial and adminstrative informations.
The following screen capture shows how the order plugin could avoid creating a new tab and add order information related to the asset in this tab.
![infocom](https://cloud.githubusercontent.com/assets/341007/13380060/f0250f3c-de38-11e5-819a-65ac969ae4de.png)
 