### PR TITLE
Add support for tooltips in Dropdown::showFromArray

### DIFF
--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -1646,6 +1646,8 @@ class Dropdown {
     *    - width               : specific width needed (default not set)
     *    - emptylabel          : empty label if empty displayed (default self::EMPTY_VALUE)
     *    - display_emptychoice : display empty choice (default false)
+    *    - tooltip             : string / message to add as tooltip on the dropdown (default '')
+    *    - option_tooltips     : array / message to add as tooltip on the dropdown options. Use the same keys as for the $elements parameter, but none is mandotary. Missing keys will just be ignored and no tooltip will be added. To add a tooltip on an option group, is the '__optgroup_label' key inside the array describing option tooltips : 'optgroupname1' => array('__optgroup_label' => 'tooltip for option group') (default empty)
     *
     * Permit to use optgroup defining items in arrays
     * array('optgroupname'  => array('key1' => 'val1',
@@ -1657,6 +1659,8 @@ class Dropdown {
 
       $param['value']               = '';
       $param['values']              = array('');
+      $param['tooltip']             = '';
+      $param['option_tooltips']     = array();
       $param['used']                = array();
       $param['readonly']            = false;
       $param['on_change']           = '';
@@ -1693,6 +1697,8 @@ class Dropdown {
          }
       }
 
+      $param['option_tooltips'] = Html::entities_deep($param['option_tooltips']);
+
       if ($param["display_emptychoice"]) {
          $elements = array( 0 => $param['emptylabel'] ) + $elements ;
       }
@@ -1719,6 +1725,10 @@ class Dropdown {
 
          $output  .= "<select name='$field_name' id='$field_id'";
 
+         if($param['tooltip']) {
+            $output .= ' title="'.Html::entities_deep($param['tooltip']).'"';
+         }
+
          if (!empty($param["on_change"])) {
             $output .= " onChange='".$param["on_change"]."'";
          }
@@ -1740,7 +1750,21 @@ class Dropdown {
                if ($max_option_size < strlen($opt_goup)) {
                   $max_option_size = strlen($opt_goup);
                }
-               $output .= "<optgroup label=\"$opt_goup\">";
+
+               $output .= "<optgroup label=\"$opt_goup\"";
+               $optgroup_tooltips = false;
+               if(isset($param['option_tooltips'][$key])) {
+                  if(is_array($param['option_tooltips'][$key])) {
+                     if(isset($param['option_tooltips'][$key]['__optgroup_label'])){
+                        $output .= ' title="'.$param['option_tooltips'][$key]['__optgroup_label'].'"';
+                     }
+                     $optgroup_tooltips = $param['option_tooltips'][$key];
+                  } else {
+                     $output .= ' title="'.$param['option_tooltips'][$key].'"';
+                  }
+               }
+               $output .= ">";
+
                foreach ($val as $key2 => $val2) {
                   if (!isset($param['used'][$key2])) {
                      $output .= "<option value='".$key2."'";
@@ -1750,6 +1774,9 @@ class Dropdown {
                            $output .= " selected";
                            break;
                        }
+                     }
+                     if($optgroup_tooltips && isset($optgroup_tooltips[$key2])) {
+                        $output .= ' title="'.$optgroup_tooltips[$key2].'"';
                      }
                      $output .= ">" .  $val2 . "</option>";
                      if ($max_option_size < strlen($val2)) {
@@ -1767,6 +1794,9 @@ class Dropdown {
                         $output .= " selected";
                         break;
                      }
+                  }
+                  if(isset($param['option_tooltips'][$key])) {
+                     $output .= ' title="'.$param['option_tooltips'][$key].'"';
                   }
                   $output .= ">" .$val . "</option>";
                   if ($max_option_size < strlen($val)) {

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -4587,7 +4587,8 @@ class Html {
                      return text;
                   },
                   formatResult: function (result, container) {
-                     return $('<div>', {title: result.title}).text(result.text);
+                     container.attr('title', result.title || result.element[0].title);
+                     return result.text;
                   }
 
              });";


### PR DESCRIPTION
It's a bit of a selfish PR, because it is a functionality that I'd like in for a plugin I'm doing for me. Anyway, it is totally optional and retro-compatible, so at worst, it's not used by anyone.
The container part in `html.class.php` is I think a better way to do it than a nested div, because that way, the area where the tooltip triggers is as big as the select blue square. Also, it's the method you use in `Html::jsAjaxDropdown`
I'm not sure the `result.title ||` is useful, as I don't see any situation where `result.title` would not be undefined, but I kept it just in case.

Dropdown example with tooltips : 
```
Dropdown::showFromArray('test', array(
            'coucou1' => 'coucou1',
            'coucou-group1' => array(
                  'coucou-group1.1' => 'coucou-group1.1',
                  'coucou-group1.2' => 'coucou-group1.2',
                  'coucou-group1.3' => 'coucou-group1.3'
            ),
            'coucou2' => 'coucou2',
            'coucou3' => 'coucou3',
            'coucou-group2' => array(
                  'coucou-group2.1' => 'coucou-group2.1',
                  'coucou-group2.2' => 'coucou-group2.2',
                  'coucou-group2.3' => 'coucou-group2.3'
            ),
            'coucou4' => 'coucou4',
            'coucou-group3' => array(
                  'coucou-group3.1' => 'coucou-group3.1',
                  'coucou-group3.2' => 'coucou-group3.2'
            ),
      ), array(
            'tooltip' => 'main tooltip',
            'option_tooltips' => array(
               'coucou1' => '<script> alert("coucou");</script>',
               'coucou-group1' => array(
                     '__optgroup_label' => 'tool"ti\'p<-c>oucou-group1',
                     'coucou-group1.1' => 'tooltip-coucou-group1.1',
                     'coucou-group1.2' => 'tooltip-coucou-group1.2',
               ),
               'coucou3' => 'tooltip-coucou3',
               'coucou-group2' => array(
                     'coucou-group2.1' => 'tooltip-coucou-group2.1',
                     'coucou-group2.3' => 'tooltip-coucou-group2.3',
               ),
               'coucou4' => 'tooltip-coucou4'
         )
      ));
```