### PR TITLE
In metaSearch, don't try to charge '0' class

### DIFF
--- a/ajax/updateMetaSearch.php
+++ b/ajax/updateMetaSearch.php
@@ -39,7 +39,7 @@ include ('../inc/includes.php');
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-if (!($item = getItemForItemtype($_POST['itemtype']))) {
+if (empty($_POST['itemtype']) || !($item = getItemForItemtype($_POST['itemtype']))) {
    exit();
 }
 


### PR DESCRIPTION
In metaSearch, don't try to charge '0' class when user select '----' value in itemtype dropdown