### PR TITLE
In metaSearch dropdown itemtype : add check about view right on every itemtype

### DIFF
--- a/ajax/searchmetarow.php
+++ b/ajax/searchmetarow.php
@@ -89,6 +89,15 @@ if (isset($_POST["itemtype"])
                            array('value' => $value,
                                  'width' => '40%'));
 
+   // Remove itemtype(s) who user don't have right to view
+   foreach ($linked as $key => $link) {
+      if ($linkitem = getItemForItemtype($link)) {
+         if (! $linkitem->canGlobal(READ)) {
+            unset($linked[$key]);
+         }
+      }
+   }
+
    // Display select of the linked item type available
    foreach ($linked as $key) {
       if (!isset($metanames[$key])) {


### PR DESCRIPTION
Mask itemtype(s) who user don't have right to view in this dropdown.

Ie : for don't propose 'Printer' in itemtype dropdown in metaSearch (in ticket search page)