### PR TITLE
Add korial29 "	Fix text is lost from the ticket timeline when contains '<' or '>'" to the ticket timeline

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -50,38 +50,50 @@ class Html {
     * Clean display value deleting html tags
     *
     * @param $value string: string value
-    *
+    * @param $striptags bool: strip all html tags
+    * @param $keep_bad int:
+    *          1 : neutralize tag anb content,
+    *          2 : remove tag and neutralize content
     * @return clean value
    **/
-   static function clean($value) {
-
-      $specialfilter = array('@<div[^>]*?tooltip_picture[^>]*?>.*?</div[^>]*?>@si'); // Strip ToolTips
-      $value         = preg_replace($specialfilter, '', $value);
-      $specialfilter = array('@<div[^>]*?tooltip_text[^>]*?>.*?</div[^>]*?>@si'); // Strip ToolTips
-      $value         = preg_replace($specialfilter, '', $value);
-      $specialfilter = array('@<div[^>]*?tooltip_picture_border[^>]*?>.*?</div[^>]*?>@si'); // Strip ToolTips
-      $value         = preg_replace($specialfilter, '', $value);
-      $specialfilter = array('@<div[^>]*?invisible[^>]*?>.*?</div[^>]*?>@si'); // Strip ToolTips
-      $value         = preg_replace($specialfilter, '', $value);
-
-      $value = preg_replace("/<(p|br|div)( [^>]*)?".">/i", "\n", $value);
-      $value = preg_replace("/(&nbsp;| )+/", " ", $value);
-
-
-      $search        = array('@<script[^>]*?>.*?</script[^>]*?>@si', // Strip out javascript
-                             '@<style[^>]*?>.*?</style[^>]*?>@si', // Strip out style
-                             '@<!DOCTYPE[^>]*?>@si', // Strip out !DOCTYPE
-                              );
-
-      $value = preg_replace($search, '', $value);
+   static function clean($value, $striptags=true, $keep_bad=2) {
 
       include_once(GLPI_HTMLAWED);
 
-      $value = htmLawed($value, array('elements' => 'none',
-                                      'keep_bad' => 2, // remove tag / neutralize content
+      $value = Html::entity_decode_deep($value);
+
+      // Clean MS office tags
+      $value = str_replace(array("<![if !supportLists]>", "<![endif]>"), '', $value);
+
+      if ($striptags) {
+         $specialfilter = array('@<div[^>]*?tooltip_picture[^>]*?>.*?</div[^>]*?>@si'); // Strip ToolTips
+         $value         = preg_replace($specialfilter, '', $value);
+         $specialfilter = array('@<div[^>]*?tooltip_text[^>]*?>.*?</div[^>]*?>@si'); // Strip ToolTips
+         $value         = preg_replace($specialfilter, '', $value);
+         $specialfilter = array('@<div[^>]*?tooltip_picture_border[^>]*?>.*?</div[^>]*?>@si'); // Strip ToolTips
+         $value         = preg_replace($specialfilter, '', $value);
+         $specialfilter = array('@<div[^>]*?invisible[^>]*?>.*?</div[^>]*?>@si'); // Strip ToolTips
+         $value         = preg_replace($specialfilter, '', $value);
+
+         $value = preg_replace("/<(p|br|div)( [^>]*)?".">/i", "\n", $value);
+         $value = preg_replace("/(&nbsp;| )+/", " ", $value);
+
+
+         $search        = array('@<script[^>]*?>.*?</script[^>]*?>@si', // Strip out javascript
+                                '@<style[^>]*?>.*?</style[^>]*?>@si', // Strip out style
+                                '@<!DOCTYPE[^>]*?>@si', // Strip out !DOCTYPE
+                                 );
+
+         $value = preg_replace($search, '', $value);
+      }
+
+      $value = htmLawed($value, array('elements' => ($striptags) ? 'none' : '',
+                                      'keep_bad' => $keep_bad, // 1 : neutralize tag and content, 2 : remove tag and neutralize content
                                       'comment' => 1, // DROP
                                       'cdata'   => 1, // DROP
                                       ));
+
+      $value = str_replace(array('&lt;', '&gt;'), array('&amp;lt;', '&amp;gt;'), $value);
 
 /*
       $specialfilter = array('@<span[^>]*?x-hidden[^>]*?>.*?</span[^>]*?>@si'); // Strip ToolTips

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -750,11 +750,8 @@ class MailCollector  extends CommonDBTM {
          $tkt['tickets_id'] = intval($match[1]);
       }
 
-      $striptags = true;
-      if ($CFG_GLPI["use_rich_text"] && !isset($tkt['tickets_id'])) {
-         $tkt['content'] = str_replace(array('&lt;', '&gt;'), array('&amp;lt;', '&amp;gt;'), $tkt['content']);
-         $striptags = false;
-      }
+      // Double encoding for > and < char to avoid misinterpretations
+      $tkt['content'] = str_replace(array('&lt;', '&gt;'), array('&amp;lt;', '&amp;gt;'), $tkt['content']);
 
       $is_html = false;
       //If files are present and content is html
@@ -768,6 +765,11 @@ class MailCollector  extends CommonDBTM {
                                                            $this->tags);
       }
 
+      // Clean mail content
+      $striptags = true;
+      if ($CFG_GLPI["use_rich_text"] && !isset($tkt['tickets_id'])) {
+         $striptags = false;
+      }
       $tkt['content'] = $this->cleanMailContent(Html::entities_deep($tkt['content']), $striptags);
 
       if ($is_html && !isset($tkt['tickets_id'])) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1400,7 +1400,10 @@ class Ticket extends CommonITILObject {
       if (isset($input["content"])) {
          $input["content"] = preg_replace('/\\\\r\\\\n/',"\n",$input['content']);
          $input["content"] = preg_replace('/\\\\n/',"\n",$input['content']);
-         $input["content"] = Html::clean($input["content"]);
+         if (!$CFG_GLPI['use_rich_text']) {
+            $input["content"] = Html::entity_decode_deep($input["content"]);
+            $input["content"] = Html::clean($input["content"]);
+         }
       }
 
       $input = $rules->processAllRules(Toolbox::stripslashes_deep($input),
@@ -3467,7 +3470,7 @@ class Ticket extends CommonITILObject {
       if (isset($values['name'])) {
          $values['name'] = str_replace("\\", "", $values['name']);
       }
-
+      
       if (!$ID) {
          // Override defaut values from projecttask if needed
          if (isset($options['_projecttasks_id'])) {
@@ -6025,16 +6028,16 @@ class Ticket extends CommonITILObject {
    **/
    function setSimpleTextContent($content) {
 
-     $text = Html::entity_decode_deep($content);
+      $content = Html::entity_decode_deep($content);
 
       // If is html content
-      if ($text != strip_tags($text)) {
-         $content = Html::clean($this->convertImageToTag($text));
+      if ($content != strip_tags($content)) {
+         $content = Html::clean($this->convertImageToTag($content), false, 1);
+         $content = Html::entity_decode_deep(Html::clean($this->convertImageToTag($content)));
       }
 
       return $content;
    }
-
 
    /**
     * Convert simple text content to rich text content, init html editor
@@ -6057,13 +6060,14 @@ class Ticket extends CommonITILObject {
          $content = $this->convertTagToImage($content);
       }
 
-      // If content does not contain <br> or <p> html tag, use nl2br
-      $content = Html::entity_decode_deep($content);
+      // Neutralize non valid HTML tags
+      $content = html::clean($content, false, 1);
 
+      // If content does not contain <br> or <p> html tag, use nl2br
       if (!preg_match("/<br\s?\/?>/", $content) && !preg_match("/<p>/", $content)) {
          $content = nl2br($content);
       }
-      return Toolbox::clean_cross_side_scripting_deep($content);
+      return $content;
    }
 
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1401,6 +1401,7 @@ class Ticket extends CommonITILObject {
          $input["content"] = preg_replace('/\\\\r\\\\n/',"\n",$input['content']);
          $input["content"] = preg_replace('/\\\\n/',"\n",$input['content']);
          if (!$CFG_GLPI['use_rich_text']) {
+         $input["content"] = Html::entity_decode_deep($input["content"]);
             $input["content"] = Html::entity_decode_deep($input["content"]);
             $input["content"] = Html::clean($input["content"]);
          }
@@ -6487,7 +6488,9 @@ class Ticket extends CommonITILObject {
          echo "</div>";
 
          echo "<div class='ticket_description'>";
-         echo Toolbox::unclean_cross_side_scripting_deep(Html::entity_decode_deep($this->fields['content']));
+
+         echo $this->setSimpleTextContent($this->fields['content']);
+
          echo "</div>";
 
          echo "</div>"; // h_content TicketContent
@@ -6495,15 +6498,15 @@ class Ticket extends CommonITILObject {
          echo "</div>"; // h_item middle
 
          echo "<div class='break'></div>";
-      }
+         }
 
       // end timeline
       echo "</div>"; // h_item $user_position
       echo "<script type='text/javascript'>read_more();</script>";
-   }
+      }
 
 
-   /**
+    /**
     * @since version 0.90
    **/
    function getTicketActors() {

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -321,8 +321,8 @@ class Toolbox {
    **/
    static function clean_cross_side_scripting_deep($value) {
 
-      $in  = array('&lt;', '&gt;', '<', '>');
-      $out = array('&amp;lt;', '&amp;gt;', '&lt;', '&gt;');
+      $in  = array('<', '>');
+      $out = array('&lt;', '&gt;');
 
       $value = ((array) $value === $value)
                   ? array_map(array(__CLASS__, 'clean_cross_side_scripting_deep'), $value)
@@ -345,8 +345,8 @@ class Toolbox {
    **/
    static function unclean_cross_side_scripting_deep($value) {
 
-      $in  = array('&lt;', '&gt;', '<', '>');
-      $out = array('&amp;lt;', '&amp;gt;', '&lt;', '&gt;');
+      $in  = array('<', '>');
+      $out = array('&lt;', '&gt;');
 
       $value = ((array) $value === $value)
                   ? array_map(array(__CLASS__, 'unclean_cross_side_scripting_deep'), $value)

--- a/lib/htmlawed/htmLawed.php
+++ b/lib/htmlawed/htmLawed.php
@@ -101,6 +101,7 @@ if($C['show_setting'] && preg_match('`^[a-z][a-z0-9_]*$`i', $C['show_setting']))
  $GLOBALS[$C['show_setting']] = array('config'=>$C, 'spec'=>$S, 'time'=>microtime());
 }
 
+// Neutralize not well formatted html tags
 if ($C['keep_bad'] == 1) {
    if (preg_match_all('/<[^\s><\/]+/', $t, $matches)) {
       foreach ($matches[0] as $match) {

--- a/lib/htmlawed/htmLawed.php
+++ b/lib/htmlawed/htmLawed.php
@@ -100,6 +100,18 @@ if($C['hook']){$t = $C['hook']($t, $C, $S);}
 if($C['show_setting'] && preg_match('`^[a-z][a-z0-9_]*$`i', $C['show_setting'])){
  $GLOBALS[$C['show_setting']] = array('config'=>$C, 'spec'=>$S, 'time'=>microtime());
 }
+
+if ($C['keep_bad'] == 1) {
+   if (preg_match_all('/<[^\s><\/]+/', $t, $matches)) {
+      foreach ($matches[0] as $match) {
+         $search = str_replace('<', '', $match);
+         if (!in_array($search, array_keys($C['elements']))) {
+            $t = str_replace($match, '&lt;'.$search, $t);
+         }
+      }
+   }
+}
+
 // main
 $t = preg_replace_callback('`<(?:(?:\s|$)|(?:[^>]*(?:>|$)))|>`m', 'hl_tag', $t);
 $t = $C['balance'] ? hl_bal($t, $C['keep_bad'], $C['parent']) : $t;


### PR DESCRIPTION
This tries to avoid cleaning too much content in the ticket timeline. It applies the fix proposed by @korial29 in #140