### PR TITLE
To fix #537 Default Language for Notification Template Translation is not correctly set

### DIFF
--- a/inc/notificationtemplatetranslation.class.php
+++ b/inc/notificationtemplatetranslation.class.php
@@ -266,11 +266,17 @@ class NotificationTemplateTranslation extends CommonDBChild {
 
 
    function prepareInputForAdd($input) {
+      if( $input['language'] == 0 ) {
+         $input['language'] = ''; // for default tanslation
+      }
       return parent::prepareInputForAdd(self::cleanContentHtml($input));
    }
 
 
    function prepareInputForUpdate($input) {
+      if( $input['language'] == 0 ) {
+         $input['language'] = ''; // for default tanslation
+      }
       return parent::prepareInputForUpdate(self::cleanContentHtml($input));
    }
 


### PR DESCRIPTION
To fix #537 
Default Language for Notification Template Translation is not correctly set