### PR TITLE
UI Improvements : creation of ticket validation

### DIFF
--- a/inc/commonitilvalidation.class.php
+++ b/inc/commonitilvalidation.class.php
@@ -819,9 +819,9 @@ abstract class CommonITILValidation  extends CommonDBChild {
          if ($canadd) {
             if (!in_array($item->fields['status'], array_merge($item->getSolvedStatusArray(),
                $item->getClosedStatusArray()))) {
-                  echo "<tr><th colspan='" . $nb_colonnes . "'>";
+                  echo "<tr class='tab_bg_1'><th colspan='" . $nb_colonnes . "'>";
                   echo "<a class='vsubmit' href='javascript:viewAddValidation".$tID."$rand();'>";
-                  echo __('Send an approval request')."</a></th></tr>\n";
+                  echo __('Create an approval request')."</a></th></tr>\n";
             }
          }
          $header = "<tr>";

--- a/inc/commonitilvalidation.class.php
+++ b/inc/commonitilvalidation.class.php
@@ -830,7 +830,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
          }
          $header .= "</tr>";
          echo $header;
-          
+
          Session::initNavigateListItems($this->getType(),
                //TRANS : %1$s is the itemtype name, %2$s is the name of the item (used for headings of a list)
                                         sprintf(__('%1$s = %2$s'), $item->getTypeName(1),

--- a/inc/commonitilvalidation.class.php
+++ b/inc/commonitilvalidation.class.php
@@ -806,31 +806,31 @@ abstract class CommonITILValidation  extends CommonDBChild {
       $result = $DB->query($query);
       $number = $DB->numrows($result);
 
-      if ($number) {
-         $colonnes = array(_x('item', 'State'), __('Request date'), __('Approval requester'),
-                           __('Request comments'), __('Approval status'),
-                           __('Approver'), __('Approval comments'));
-         $nb_colonnes = count($colonnes);
+      $colonnes = array(_x('item', 'State'), __('Request date'), __('Approval requester'),
+                     __('Request comments'), __('Approval status'),
+                     __('Approver'), __('Approval comments'));
+      $nb_colonnes = count($colonnes);
 
-         echo "<table class='tab_cadre_fixehov'>";
-         echo "<tr class='noHover'><th colspan='".$nb_colonnes."'>".__('Approvals for the ticket').
-              "</th></tr>";
+      echo "<table class='tab_cadre_fixehov'>";
+      echo "<tr class='noHover'><th colspan='".$nb_colonnes."'>".__('Approvals for the ticket').
+           "</th></tr>";
 
-         if ($canadd) {
-            if (!in_array($item->fields['status'], array_merge($item->getSolvedStatusArray(),
-               $item->getClosedStatusArray()))) {
-                  echo "<tr class='tab_bg_1'><th colspan='" . $nb_colonnes . "'>";
-                  echo "<a class='vsubmit' href='javascript:viewAddValidation".$tID."$rand();'>";
-                  echo __('Create an approval request')."</a></th></tr>\n";
-            }
+      if ($canadd) {
+         if (!in_array($item->fields['status'], array_merge($item->getSolvedStatusArray(),
+            $item->getClosedStatusArray()))) {
+               echo "<tr class='tab_bg_1 noHover'><td class='center' colspan='" . $nb_colonnes . "'>";
+               echo "<a class='vsubmit' href='javascript:viewAddValidation".$tID."$rand();'>";
+               echo __('Create an approval request')."</a></td></tr>\n";
          }
+      }
+      if ($number) {
          $header = "<tr>";
          foreach ($colonnes as $colonne) {
             $header .= "<th>".$colonne."</th>";
          }
          $header .= "</tr>";
          echo $header;
-
+          
          Session::initNavigateListItems($this->getType(),
                //TRANS : %1$s is the itemtype name, %2$s is the name of the item (used for headings of a list)
                                         sprintf(__('%1$s = %2$s'), $item->getTypeName(1),
@@ -875,10 +875,12 @@ abstract class CommonITILValidation  extends CommonDBChild {
             echo "</tr>";
          }
          echo $header;
-         echo "</table>";
       } else {
-         echo "<div class='center b'>".__('No item found')."</div>";
+         //echo "<div class='center b'>".__('No item found')."</div>";
+         echo "<tr class='tab_bg_1 noHover'><th colspan='" . $nb_colonnes . "'>";
+         echo __('No item found')."</th></tr>\n";
       }
+      echo "</table>";
    }
 
 

--- a/inc/commonitilvalidation.class.php
+++ b/inc/commonitilvalidation.class.php
@@ -792,12 +792,6 @@ abstract class CommonITILValidation  extends CommonDBChild {
                                 $params);
          echo "};";
          echo "</script>\n";
-         if (!in_array($item->fields['status'], array_merge($item->getSolvedStatusArray(),
-                                                           $item->getClosedStatusArray()))) {
-            echo "<div class='center'>";
-            echo "<a class='vsubmit' href='javascript:viewAddValidation".$tID."$rand();'>";
-            echo __('Send an approval request')."</a></div><br>\n";
-         }
       }
 
       $query = "SELECT *
@@ -822,6 +816,14 @@ abstract class CommonITILValidation  extends CommonDBChild {
          echo "<tr class='noHover'><th colspan='".$nb_colonnes."'>".__('Approvals for the ticket').
               "</th></tr>";
 
+         if ($canadd) {
+            if (!in_array($item->fields['status'], array_merge($item->getSolvedStatusArray(),
+               $item->getClosedStatusArray()))) {
+                  echo "<tr><th colspan='" . $nb_colonnes . "'>";
+                  echo "<a class='vsubmit' href='javascript:viewAddValidation".$tID."$rand();'>";
+                  echo __('Send an approval request')."</a></th></tr>\n";
+            }
+         }
          $header = "<tr>";
          foreach ($colonnes as $colonne) {
             $header .= "<th>".$colonne."</th>";


### PR DESCRIPTION
Here is an idea to clarify the interface

# Before the patch : 

When there is no validation for the ticket
![image](https://cloud.githubusercontent.com/assets/14139801/15498585/7dd814a0-21a0-11e6-9d20-e32cd549f5fe.png)

When the user creates the first validation
![image](https://cloud.githubusercontent.com/assets/14139801/15498618/a1117b50-21a0-11e6-943f-a2a80f69aa97.png)

When there is at least one validation for the ticket
![image](https://cloud.githubusercontent.com/assets/14139801/15498575/767d950e-21a0-11e6-818e-5eba504128ba.png)
***
# With the patch : 
When there is no validation for the ticket
![image](https://cloud.githubusercontent.com/assets/14139801/15498685/e7451c4e-21a0-11e6-9054-6d7421ea76a7.png)

When the user creates the first validation
![image](https://cloud.githubusercontent.com/assets/14139801/15498700/f7787a7a-21a0-11e6-982d-9d5e5e33978d.png)

When there is at least one validation for the ticket
![image](https://cloud.githubusercontent.com/assets/14139801/15498709/053157b8-21a1-11e6-9e52-0b09f9522d75.png)
