### PR TITLE
display recursive list of users, and lock those from upper entities

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1412,6 +1412,11 @@ class Search {
                      && !in_array($row["id"], $_SESSION["glpiactiveentities"])) {
                   $tmpcheck = "&nbsp;";
 
+               } else if ($data['itemtype'] == 'User'
+                          && !Session::isViewAllEntities()
+                          && !Session::haveAccessToOneOfEntities(Profile_User::getUserEntities($row["id"], false))) {
+                  $tmpcheck = "&nbsp;";
+
                } else if (($data['item'] instanceof CommonDBTM)
                            && $data['item']->maybeRecursive()
                            && !in_array($row["entities_id"], $_SESSION["glpiactiveentities"])) {
@@ -2554,7 +2559,7 @@ class Search {
             if (Session::isViewAllEntities()) {
                return "";
             }
-            return getEntitiesRestrictRequest("","glpi_profiles_users");
+            return getEntitiesRestrictRequest("","glpi_profiles_users", '', '', true);
 
          case 'ProjectTask' :
             $condition  = '';

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -141,6 +141,11 @@ class User extends CommonDBTM {
    }
 
 
+   function canPurgeItem() {
+      return $this->canDeleteItem();
+   }
+
+
    function isEntityAssign() {
       // glpi_users.entities_id is only a pref.
       return false;


### PR DESCRIPTION
See #632 

I juste tested on a "_big_" list of 11k users with various entities, navigating in tree, without noticing a lost of performance.
Maybe tests on a bigger instance can be done, @yllen ?