### PR TITLE
Master+multiple values per column

### DIFF
--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -1036,6 +1036,7 @@ class Computer extends CommonDBTM {
       $tab[152]['datatype']      = 'decimal';
       $tab[152]['width']         = 2;
       $tab[152]['computation']   = "ROUND(100*TABLE.freesize/TABLE.totalsize)";
+      $tab[152]['computationgroupby'] = true;
       $tab[152]['unit']          = '%';
       $tab[152]['massiveaction'] = false;
       $tab[152]['joinparams']    = array('jointype' => 'child');

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2499,7 +2499,9 @@ class Search {
       // Default case
       if ($meta
           || (isset($searchopt[$ID]["forcegroupby"]) && $searchopt[$ID]["forcegroupby"]
-              /* && !isset($searchopt[$ID]["computation"])*/ )) { // Not specific computation
+              && (!isset($searchopt[$ID]["computation"])
+                  || isset($searchopt[$ID]["computationgroupby"])
+                     && $searchopt[$ID]["computationgroupby"]))) { // Not specific computation
          $TRANS = '';
          if (Session::haveTranslations(getItemTypeForTable($table), $field)) {
             $TRANS = "IFNULL(GROUP_CONCAT(DISTINCT CONCAT(IFNULL($tocomputetrans, '".self::NULLVALUE."'),

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2499,7 +2499,7 @@ class Search {
       // Default case
       if ($meta
           || (isset($searchopt[$ID]["forcegroupby"]) && $searchopt[$ID]["forcegroupby"]
-              && !isset($searchopt[$ID]["computation"]))) { // Not specific computation
+              /* && !isset($searchopt[$ID]["computation"])*/ )) { // Not specific computation
          $TRANS = '';
          if (Session::haveTranslations(getItemTypeForTable($table), $field)) {
             $TRANS = "IFNULL(GROUP_CONCAT(DISTINCT CONCAT(IFNULL($tocomputetrans, '".self::NULLVALUE."'),


### PR DESCRIPTION
Displaying free percentage of volumes for computers shows only the first value (when there are several volumes).

With this patch, all percentages are visible