### PR TITLE
Wrong entities_id for task creation

### DIFF
--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1388,7 +1388,7 @@ abstract class CommonITILTask  extends CommonDBTM {
             echo Html::jsHide("plan$rand_text");
             $params = array('action'    => 'add_event_classic_form',
                             'form'      => 'followups',
-                            'entity'    => $_SESSION["glpiactive_entity"],
+                            'entity'    => $item->fields['entities_id'],
                             'rand_user' => $rand_user,
                             'rand_group' => $rand_group,
                             'itemtype'  => $this->getType(),


### PR DESCRIPTION
When creating a new task for an object (Ticket, Problem or  Change): should use entities_id of the parent object, and not the session entity.