### PR TITLE
To respect 'editable' field of fullcalendar events

### DIFF
--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -670,7 +670,7 @@ class Planning extends CommonGLPI {
                editEventTimes(event, revertFunc);
             },
             eventClick: function(event) {
-               if (event.ajaxurl && !disable_edit) {
+               if (event.ajaxurl && event.editable && !disable_edit) {
                   $('<div>')
                      .dialog({
                         modal:  true,


### PR DESCRIPTION
To respect 'editable' field of fullcalendar events
This gives the possibility to have a fine granularity on task view on Central or Planning to prevent edit.
Thank you
Regards,
Tomolimo