### PR TITLE
Add mysqli prepared statements capability

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -207,6 +207,31 @@ class DBmysql {
       return $res;
    }
 
+   /**
+    * Prepare a MySQL query
+    *
+    * @param $query Query to prepare
+    *
+    * @return a statement object or FALSE if an error occurred.
+   **/
+   function prepare($query) {
+
+      $res = @$this->dbh->prepare($query);
+      if (!$res) {
+         // no translation for error logs
+         $error = "  *** MySQL prepare error:\n  SQL: ".addslashes($query)."\n  Error: ".
+                   $this->dbh->error."\n";
+         $error .= toolbox::backtrace(false, 'DBmysql->prepare()', array('Toolbox::backtrace()'));
+
+         Toolbox::logInFile("sql-errors", $error);
+
+         if (($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE)
+             && $CFG_GLPI["debug_sql"]) {
+            $DEBUG_SQL["errors"][$SQL_TOTAL_REQUEST] = $this->error();
+         }
+      }
+      return $res;
+   }
 
    /**
     * Give result from a mysql result


### PR DESCRIPTION
Simply add prepare() method in Dbmysql class of glpi.

Why use prepared statements ?
- prevent sql injections
- minimize bandwidth to the server
- reduces parsing time

Prepared vs non prepared :
[http://prntscr.com/brfi69]

Sources :
[http://stackoverflow.com/questions/60174/how-can-i-prevent-sql-injection-in-php]
[http://www.w3schools.com/php/php_mysql_prepared_statements.asp]

Example usage in plugin armadito for GLPI (tested) : 
https://github.com/armadito/armadito-glpi/commit/edd7c7f737134d4ced95e0c192885f604b40e9a1