### PR TITLE
Encode in UTF8 ticket title if needed when ticket is opened through a…

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -879,6 +879,11 @@ class MailCollector  extends CommonDBTM {
       if ($this->addtobody) {
          $tkt['content'] .= $this->addtobody;
       }
+
+      if (!Toolbox::seems_utf8($tkt['name'])) {
+         $tkt['name'] = Toolbox::encodeInUtf8($tkt['name']);
+      }
+
       $tkt['name'] = $this->textCleaner($head['subject']);
       if (!isset($tkt['tickets_id'])) {
          // Which entity ?


### PR DESCRIPTION
When a ticket is opened through an email, we do not check if email subject is really encoded in utf8.
We do it for email body.

With this PR, we try to encode in utf8 is necessary the ticket title.