### PR TITLE
update0905to091 function is not existing

### DIFF
--- a/tools/cliupdate.php
+++ b/tools/cliupdate.php
@@ -331,7 +331,7 @@ switch ($current_version) {
 
    case "0.90.5" :
       include_once("../install/update_0905_91.php");
-      update0905to091();
+      update0905to91();
 
    /* remember to also change --force below for last version */
 


### PR DESCRIPTION
Error message is

> Fatal error: Uncaught Error: Call to undefined function update0905to091() in L:\inetpub\wwwroot\glpi091\tools\cliupdate.php:334
> Stack trace:
> #0 {main}
>   thrown in L:\inetpub\wwwroot\glpi091\tools\cliupdate.php on line 334

Renamed it to update0905to91