### PR TITLE
When apc is used with more than 1 seg, then $used is negative 9.1RC2

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1533,7 +1533,7 @@ class Config extends CommonDBTM {
          // echo "<tr><td><pre>Info:".print_r($info, true)."Stat:".print_r($stat, true)."</pre></td></tr>";
 
          // Memory
-         $max  = $info['num_seg'] + $info['seg_size'];
+         $max  = $info['num_seg'] * $info['seg_size'];
          $free = $info['avail_mem'];
          $used = $max - $free;
          $rate = round(100.0 * $used / $max);


### PR DESCRIPTION
I believe that to know the $max amount of memory with we must multiply the segment qt with the size of the segments.