### PR TITLE
Should not insert a string into a date field

### DIFF
--- a/install/update_0905_91.php
+++ b/install/update_0905_91.php
@@ -402,7 +402,7 @@ function update0905to91() {
                   ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
       $DB->queryOrDie($query, "9.1 add table glpi_apiclients");
       $query = "INSERT INTO `glpi_apiclients`
-                  VALUES (1, 1, 1, 'full access', NOW(), 1, NULL, NULL, NULL, '', '', 0, NULL);";
+                  VALUES (1, 1, 1, 'full access', NOW(), 1, NULL, NULL, NULL, '', NULL, 0, NULL);";
       $DB->queryOrDie($query, "9.1 insert first line into table glpi_apiclients");
    }
 


### PR DESCRIPTION
Migration procedure from 0.90.5 to 9.1 is inserting a string '' into a date field in DB -> sql error.

fixes #877 
