### PR TITLE
Table names are case sensitive of Linux systems

### DIFF
--- a/inc/networkportfiberchannel.class.php
+++ b/inc/networkportfiberchannel.class.php
@@ -333,7 +333,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation {
      $tab[22]['forcegroupby']  = true;
      $tab[22]['massiveaction'] = false;
      $tab[22]['joinparams']    = array('jointype'   => 'standard',
-                                       'beforejoin' => array('table' => 'glpi_networkportFiberchannels',
+                                       'beforejoin' => array('table' => 'glpi_networkportfiberchannels',
                                                              'joinparams'
                                                                      => $joinparams));
   }


### PR DESCRIPTION
Table names are case sensitive of Linux systems, so keep them lower cases
to fix #877