### PR TITLE
To fix #755

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -2520,6 +2520,7 @@ class CommonDBTM extends CommonGLPI {
 
       // Check item exists
       if (!$this->isNewID($ID)
+          && (!isset($this->fields['id']) || $this->fields['id'] != $ID)
           && !$this->getFromDB($ID)) {
          // Gestion timeout session
          Session::redirectIfNotLoggedIn();


### PR DESCRIPTION
Added a condition to existing test to prevent reload of current object when already loaded
Will reload only when passed $ID is different from $this->field['id'] or if $this->field['id'] is not exiting