### PR TITLE
[API] /getMyEntities output proposal

### DIFF
--- a/apirest.md
+++ b/apirest.md
@@ -287,12 +287,15 @@ $ curl -X POST \
 'http://path/to/glpi/apirest.php/getMyEntities'
 
 < 200 OK
-< [{
-      'id':   71
-      'name': "my_entity"
-   },
+< {
+   'myentities': [
+     {
+       'id':   71
+       'name': "my_entity"
+     },
    ....
-]
+   ]
+  }
 ```
 
 

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -367,7 +367,7 @@ abstract class API extends CommonGLPI {
    protected function getActiveProfile() {
 
       $this->initEndpoint();
-      return $_SESSION['glpiactiveprofile'];
+      return ["active_profile" => $_SESSION['glpiactiveprofile']];
    }
 
 
@@ -381,7 +381,7 @@ abstract class API extends CommonGLPI {
    protected function getFullSession() {
 
       $this->initEndpoint();
-      return $_SESSION;
+      return ['session' => $_SESSION];
    }
 
 

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -275,11 +275,11 @@ abstract class API extends CommonGLPI {
 
       $myentities = array();
       foreach ($_SESSION['glpiactiveprofile']['entities'] as $entity) {
-         $myentities[$entity['id']] = array('id'   => $entity['id'],
+         $myentities[] = array('id'   => $entity['id'],
                                             'name' => Dropdown::getDropdownName("glpi_entities",
                                                                                 $entity['id']));
       }
-      return $myentities;
+      return array('myentities' => $myentities);
    }
 
 

--- a/tests/API/APIRestTest.php
+++ b/tests/API/APIRestTest.php
@@ -147,8 +147,9 @@ class APIRestTest extends PHPUnit_Framework_TestCase {
       $body = $res->getBody();
       $data = json_decode($body, true);
       $this->assertNotEquals(false, $data);
-      $this->assertArrayHasKey('id', $data[0]); // check presence of first entity
-      $this->assertEquals(0, $data[0]['id']); // check presence of root entity
+      $this->assertArrayHasKey('myentities', $data); // check presence of first entity
+      $this->assertArrayHasKey('id', $data['myentities'][0]); // check presence of first entity
+      $this->assertEquals(0, $data['myentities'][0]['id']); // check presence of root entity
    }
 
 

--- a/tests/API/APIRestTest.php
+++ b/tests/API/APIRestTest.php
@@ -219,9 +219,10 @@ class APIRestTest extends PHPUnit_Framework_TestCase {
       $body = $res->getBody();
       $data = json_decode($body, true);
       $this->assertNotEquals(false, $data);
-      $this->assertArrayHasKey('id', $data);
-      $this->assertArrayHasKey('name', $data);
-      $this->assertArrayHasKey('interface', $data);
+      $this->assertArrayHasKey('active_profile', $data);
+      $this->assertArrayHasKey('id', $data['active_profile']);
+      $this->assertArrayHasKey('name', $data['active_profile']);
+      $this->assertArrayHasKey('interface', $data['active_profile']);
    }
 
 
@@ -238,11 +239,12 @@ class APIRestTest extends PHPUnit_Framework_TestCase {
       $body = $res->getBody();
       $data = json_decode($body, true);
       $this->assertNotEquals(false, $data);
-      $this->assertArrayHasKey('glpiID', $data);
-      $this->assertArrayHasKey('glpiname', $data);
-      $this->assertArrayHasKey('glpiroot', $data);
-      $this->assertArrayHasKey('glpilanguage', $data);
-      $this->assertArrayHasKey('glpilist_limit', $data);
+      $this->assertArrayHasKey('session', $data);
+      $this->assertArrayHasKey('glpiID', $data['session']);
+      $this->assertArrayHasKey('glpiname', $data['session']);
+      $this->assertArrayHasKey('glpiroot', $data['session']);
+      $this->assertArrayHasKey('glpilanguage', $data['session']);
+      $this->assertArrayHasKey('glpilist_limit', $data['session']);
    }
 
 

--- a/tests/API/APIXmlrpcTest.php
+++ b/tests/API/APIXmlrpcTest.php
@@ -101,7 +101,10 @@ class APIXmlrpcTest extends PHPUnit_Framework_TestCase {
 
       $data = xmlrpc_decode($res->getBody());
       $this->assertNotEquals(false, $data);
-      $this->assertArrayHasKey(0, $data); // check presence of root entity
+      $this->assertNotEquals(false, $data);
+      $this->assertArrayHasKey('myentities', $data); // check presence of first entity
+      $this->assertArrayHasKey('id', $data['myentities'][0]); // check presence of first entity
+      $this->assertEquals(0, $data['myentities'][0]['id']); // check presence of root entity
    }
 
 

--- a/tests/API/APIXmlrpcTest.php
+++ b/tests/API/APIXmlrpcTest.php
@@ -159,9 +159,10 @@ class APIXmlrpcTest extends PHPUnit_Framework_TestCase {
 
       $data = xmlrpc_decode($res->getBody());
       $this->assertNotEquals(false, $data);
-      $this->assertArrayHasKey('id', $data);
-      $this->assertArrayHasKey('name', $data);
-      $this->assertArrayHasKey('interface', $data);
+      $this->assertArrayHasKey('active_profile', $data);
+      $this->assertArrayHasKey('id', $data['active_profile']);
+      $this->assertArrayHasKey('name', $data['active_profile']);
+      $this->assertArrayHasKey('interface', $data['active_profile']);
    }
 
 
@@ -174,11 +175,12 @@ class APIXmlrpcTest extends PHPUnit_Framework_TestCase {
 
       $data = xmlrpc_decode($res->getBody());
       $this->assertNotEquals(false, $data);
-      $this->assertArrayHasKey('glpiID', $data);
-      $this->assertArrayHasKey('glpiname', $data);
-      $this->assertArrayHasKey('glpiroot', $data);
-      $this->assertArrayHasKey('glpilanguage', $data);
-      $this->assertArrayHasKey('glpilist_limit', $data);
+      $this->assertArrayHasKey('session', $data);
+      $this->assertArrayHasKey('glpiID', $data['session']);
+      $this->assertArrayHasKey('glpiname', $data['session']);
+      $this->assertArrayHasKey('glpiroot', $data['session']);
+      $this->assertArrayHasKey('glpilanguage', $data['session']);
+      $this->assertArrayHasKey('glpilist_limit', $data['session']);
    }
 
 


### PR DESCRIPTION
Following recent API responses changes, to be consistent, i would like to propose to change output of /getMyEntities to:

```json
{
	"myentities": [{
		"id": 1,
		"name": "Root entity > Sub1"
	}]
}
```

- "myentities" as top entry
- don't keep keys for entities