### PR TITLE
api: add available searchtypes in searchoptions

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1015,25 +1015,30 @@ abstract class API extends CommonGLPI {
          return $soptions;
       }
 
-      $cleaned_searchoptions = array();
+      $cleaned_soptions = array();
       foreach($soptions as $sID => $option) {
          if (is_int($sID)) {
-            $cleaned_searchoptions[$sID] = array('name'       => $option['name'],
-                                                 'table'      => $option['table'],
-                                                 'field'      => $option['field'],
-                                                 //'linkfield'  => $option['linkfield'],
-                                                 //'joinparams' => $option['joinparams'],
-                                                 'datatype'   => isset($option['datatype'])
+            $available_searchtypes = Search::getActionsFor($itemtype, $sID);
+            unset($available_searchtypes['searchopt']);
+            $available_searchtypes = array_keys($available_searchtypes);
+
+            $cleaned_soptions[$sID] = array('name'                  => $option['name'],
+                                            'table'                 => $option['table'],
+                                            'field'                 => $option['field'],
+                                            //'linkfield'           => $option['linkfield'],
+                                            //'joinparams'          => $option['joinparams'],
+                                            'datatype'              => isset($option['datatype'])
                                                                        ?$option['datatype']
-                                                                       :"");
-            $cleaned_searchoptions[$sID]['uid'] = $this->getSearchOptionUniqID($itemtype,
+                                                                       :"",
+                                            'available_searchtypes' => $available_searchtypes);
+            $cleaned_soptions[$sID]['uid'] = $this->getSearchOptionUniqID($itemtype,
                                                                                $option);
          } else {
-            $cleaned_searchoptions[$sID] = $option;
+            $cleaned_soptions[$sID] = $option;
          }
       }
 
-      return $cleaned_searchoptions;
+      return $cleaned_soptions;
    }
 
 

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1025,8 +1025,6 @@ abstract class API extends CommonGLPI {
             $cleaned_soptions[$sID] = array('name'                  => $option['name'],
                                             'table'                 => $option['table'],
                                             'field'                 => $option['field'],
-                                            //'linkfield'           => $option['linkfield'],
-                                            //'joinparams'          => $option['joinparams'],
                                             'datatype'              => isset($option['datatype'])
                                                                        ?$option['datatype']
                                                                        :"",

--- a/tests/API/APIRestTest.php
+++ b/tests/API/APIRestTest.php
@@ -380,7 +380,8 @@ class APIRestTest extends PHPUnit_Framework_TestCase {
       $this->assertEquals('glpi_computers', $data[1]['table']);
       $this->assertEquals('name', $data[1]['field']);
       $this->assertEquals('itemlink', $data[1]['datatype']);
-      $this->assertArrayHasKey('available_searchtypes', $data[1]);
+      $this->assertEquals(array('contains', 'equals', 'notequals'),
+                                 $data[1]['available_searchtypes']);
    }
 
 

--- a/tests/API/APIRestTest.php
+++ b/tests/API/APIRestTest.php
@@ -380,6 +380,7 @@ class APIRestTest extends PHPUnit_Framework_TestCase {
       $this->assertEquals('glpi_computers', $data[1]['table']);
       $this->assertEquals('name', $data[1]['field']);
       $this->assertEquals('itemlink', $data[1]['datatype']);
+      $this->assertArrayHasKey('available_searchtypes', $data[1]);
    }
 
 


### PR DESCRIPTION
To use the search endpoint we need to provide a 'searchtype' parameter who can be [contains, equals, notequals, lessthan, morethan, under, notunder].
Not all searchoptions support all of this searchtype (see https://github.com/glpi-project/glpi/blob/master/inc/search.class.php#L5569) 

This pr add a new key to listSearchOptions endpoint to get the available searchtypes for each options.
Ex:

```json
{  
   "common":"Characteristics",
   "1":{  
      "name":"Name",
      "table":"glpi_computers",
      "field":"name",
      "datatype":"itemlink",
      "available_searchtypes":[  
         "contains",
         "equals",
         "notequals"
      ],
      "uid":"Computer.name"
   },
   "2":{  
      "name":"ID",
      "table":"glpi_computers",
      "field":"id",
      "datatype":"number",
      "available_searchtypes":[  
         "contains"
      ],
      "uid":"Computer.id"
   },
...
```