### PR TITLE
api: add ip adresses to with_networkports option

### DIFF
--- a/front/networkport.form.php
+++ b/front/networkport.form.php
@@ -59,9 +59,7 @@ if (isset($_POST["add"])) {
 
    if (!isset($_POST["several"])) {
       $np->check(-1, UPDATE, $_POST);
-      $np->splitInputForElements($_POST);
       $newID = $np->add($_POST);
-      $np->updateDependencies(1);
       Event::log($newID, "networkport", 5, "inventory",
                  //TRANS: %s is the user login
                  sprintf(__('%s adds an item'), $_SESSION["glpiname"]));
@@ -85,9 +83,7 @@ if (isset($_POST["add"])) {
          unset($np->fields["id"]);
 
          if ($np->can(-1, CREATE, $input)) {
-            $np->splitInputForElements($input);
             $np->add($input);
-            $np->updateDependencies(1);
          }
       }
       Event::log(0, "networkport", 5, "inventory",
@@ -111,9 +107,7 @@ if (isset($_POST["add"])) {
 } else if (isset($_POST["update"])) {
    $np->check($_POST['id'], UPDATE);
 
-   $np->splitInputForElements($_POST);
    $np->update($_POST);
-   $np->updateDependencies(1);
    Event::log($_POST["id"], "networkport", 4, "inventory",
               //TRANS: %s is the user login
               sprintf(__('%s updates an item'), $_SESSION["glpiname"]));

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -570,10 +570,15 @@ abstract class API extends CommonGLPI {
                            netp.`mac`,
                            netp.`comment`,
                            netp.`is_dynamic`,
-                           netp_subtable.*
+                           netp_subtable.*,
+                           GROUP_CONCAT(ipadr.name) as ip
                          FROM glpi_networkports AS netp
                          LEFT JOIN ".$networkport_type::getTable()." AS netp_subtable
                            ON netp_subtable.`networkports_id` = netp.`id`
+                         LEFT JOIN glpi_networknames AS netn
+                           ON netn.itemtype = 'NetworkPort' AND netn.items_id = netp.id
+                         LEFT JOIN glpi_ipaddresses AS ipadr
+                           ON ipadr.itemtype = 'NetworkName' AND ipadr.items_id = netn.id
                          WHERE netp.`instantiation_type` = '$networkport_type'
                                AND netp.`items_id` = '$id'
                                AND netp.`itemtype` = '$itemtype'

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -582,7 +582,8 @@ abstract class API extends CommonGLPI {
                          WHERE netp.`instantiation_type` = '$networkport_type'
                                AND netp.`items_id` = '$id'
                                AND netp.`itemtype` = '$itemtype'
-                               AND netp.`is_deleted` = '0'";
+                               AND netp.`is_deleted` = '0'
+                         GROUP BY netp.id";
                if ($result = $DB->query($query)) {
                   while ($data = $DB->fetch_assoc($result)) {
                      $fields['_networkports'][$networkport_type][] = $data;

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1330,7 +1330,7 @@ abstract class API extends CommonGLPI {
          $idCollection = array();
          $failed       = 0;
          foreach($input as $object) {
-            $object = get_object_vars($object);
+            $object = self::inputObjectToArray($object);
             //check rights
             if (!$item->can(-1, CREATE, $object)) {
                $idCollection[] = array('error' => $this->messageRightError(false));
@@ -1358,7 +1358,7 @@ abstract class API extends CommonGLPI {
          return $idCollection;
 
       } else if (is_object($input)) {
-         $input = get_object_vars($input);
+         $input = self::inputObjectToArray($input);
 
          //check rights
          if (!$item->can(-1, CREATE, $input)) {
@@ -1380,6 +1380,28 @@ abstract class API extends CommonGLPI {
       } else {
          $this->messageBadArrayError();
       }
+   }
+
+   /**
+    * Transform all stdobject retrieved from a json_decode into arrays
+    *
+    * @since 9.1
+    *
+    * @param  mixed $input can be an object or array
+    * @return array the cleaned input
+    */
+   private function inputObjectToArray($input) {
+      if (is_object($input)) {
+         $input = get_object_vars($input);
+      }
+
+      if (is_array($input)) {
+         foreach ($input as $key => &$sub_input) {
+            $sub_input = self::inputObjectToArray($sub_input);
+         }
+      }
+
+      return $input;
    }
 
 

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -186,6 +186,10 @@ class NetworkPort extends CommonDBChild {
       return true;
    }
 
+   function prepareInputForUpdate($input) {
+      return $this->splitInputForElements($input);
+   }
+
    function post_updateItem($history=1) {
       global $DB;
 
@@ -210,6 +214,8 @@ class NetworkPort extends CommonDBChild {
          }
       }
       parent::post_updateItem($history);
+
+      $this->updateDependencies(1);
    }
 
 
@@ -353,7 +359,13 @@ class NetworkPort extends CommonDBChild {
          unset($input["logical_number"]);
       }
 
+      $input = $this->splitInputForElements($input);
+
       return parent::prepareInputForAdd($input);
+   }
+
+   function post_addItem() {
+      $this->updateDependencies(1);
    }
 
 

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -186,10 +186,16 @@ class NetworkPort extends CommonDBChild {
       return true;
    }
 
+   /**
+    * @see CommonDBTM::prepareInputForUpdate
+    */
    function prepareInputForUpdate($input) {
       return $this->splitInputForElements($input);
    }
 
+   /**
+    * @see CommonDBTM::post_updateItem
+    */
    function post_updateItem($history=1) {
       global $DB;
 
@@ -353,6 +359,9 @@ class NetworkPort extends CommonDBChild {
    }
 
 
+   /**
+    * @see CommonDBTM::prepareInputForAdd
+    */
    function prepareInputForAdd($input) {
 
       if (isset($input["logical_number"]) && (strlen($input["logical_number"]) == 0)) {
@@ -364,6 +373,9 @@ class NetworkPort extends CommonDBChild {
       return parent::prepareInputForAdd($input);
    }
 
+   /**
+    * @see CommonDBTM::post_addItem
+    */
    function post_addItem() {
       $this->updateDependencies(1);
    }

--- a/tests/API/APIRestTest.php
+++ b/tests/API/APIRestTest.php
@@ -512,7 +512,14 @@ class APIRestTest extends PHPUnit_Framework_TestCase {
       $this->assertArrayHasKey('id', $data);
       $this->assertArrayHasKey('name', $data);
       $this->assertArrayHasKey('_networkports', $data);
-      $this->assertEquals('1.2.3.4', $data['_networkports']['NetworkPortEthernet'][0]['ip']);
+      $this->assertArrayHasKey('NetworkName', $data['_networkports']['NetworkPortEthernet'][0]);
+      $networkname = $data['_networkports']['NetworkPortEthernet'][0]['NetworkName'];
+      $this->assertArrayHasKey('IPAddress', $networkname);
+      $this->assertArrayHasKey('FQDN', $networkname);
+      $this->assertArrayHasKey('id', $networkname['IPAddress'][0]);
+      $this->assertArrayHasKey('name', $networkname['IPAddress'][0]);
+      $this->assertArrayHasKey('IPNetwork', $networkname['IPAddress'][0]);
+      $this->assertEquals('1.2.3.4', $networkname['IPAddress'][0]['name']);
    }
 
 

--- a/tests/API/APIRestTest.php
+++ b/tests/API/APIRestTest.php
@@ -399,7 +399,6 @@ class APIRestTest extends PHPUnit_Framework_TestCase {
                                                 'instantiation_type'       => "NetworkPortEthernet",
                                                 'name'                     => "test port",
                                                 'logical_number'           => 1,
-                                                'logical_number'           => 1,
                                                 'items_id'                 => $computers_id,
                                                 'itemtype'                 => "Computer",
                                                 'NetworkName_name'         => "testname",


### PR DESCRIPTION
Here is an example: 

```
http://.../apirest.php/Computer/71?with_networkports=true
{
	"id": 71,
	"entities_id": 0,
	"name": "adelaunay-ThinkPad-Edge-E320",
	"serial": "LR9NKZ7",
	"otherserial": "test2qsdq",
	"contact": "adelaunay",
	"contact_num": "qds",
	"users_id_tech": 0,
	"groups_id_tech": 0,
	"comment": "test222222qsdqsd",
	"date_mod": "2016-06-30 15:03:59",
	"operatingsystems_id": 32,
	"operatingsystemversions_id": 48,
	"operatingsystemservicepacks_id": 0,
	"os_license_number": null,
	"os_licenseid": null,
	"os_kernel_version": null,
	"autoupdatesystems_id": 0,
	"locations_id": 3,
	"domains_id": 18,
	"networks_id": 0,
	"computermodels_id": 11,
	"computertypes_id": 3,
	"is_template": 0,
	"template_name": null,
	"manufacturers_id": 260,
	"is_deleted": 0,
	"is_dynamic": 1,
	"users_id": 0,
	"groups_id": 0,
	"states_id": 1,
	"ticket_tco": 0,
	"uuid": "725BA801-507B-11CB-95E6-C66052AAC597",
	"date_creation": null,
	"is_recursive": 0,
	"operatingsystemarchitectures_id": null,
	"_networkports": {
		"NetworkPortEthernet": [
			{
				"entities_id": 0,
				"is_recursive": 0,
				"logical_number": 1,
				"name": "Intel(R) Ethernet Connection I217-LM",
				"mac": "40:a8:f0:60:e3:33",
				"comment": null,
				"is_dynamic": 1,
				"id": 156,
				"networkports_id": 404,
				"items_devicenetworkcards_id": 0,
				"netpoints_id": 0,
				"type": "",
				"speed": 0,
				"date_mod": "2016-09-19 15:28:31",
				"date_creation": "2016-09-19 15:28:31",
				"ip": "10.2.41.127",
				"links": [
					{
						"rel": "Entity",
						"href": "http://localhost/glpi/0.91-git/apirest.php/Entity/0"
					},
					{
						"rel": "NetworkPort",
						"href": "http://localhost/glpi/0.91-git/apirest.php/NetworkPort/404"
					}
				]
			}
		],
...
```