### PR TITLE
restore slalevels_id in glpi_tickets

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -1106,7 +1106,7 @@ abstract class CommonITILObject extends CommonDBTM {
          $this->fields["begin_waiting_date"] = $_SESSION["glpi_currenttime"];
 
          // Specific for tickets
-         if (isset($this->fields['slas_id']) && ($this->fields['slas_id'] > 0)) {
+         if (isset($this->fields['slts_ttr_id']) && ($this->fields['slts_ttr_id'] > 0)) {
             SLT::deleteLevelsToDo($this);
          }
       }

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -2215,13 +2215,13 @@ class Entity extends CommonTreeDropdown {
       }
 
       if (strstr($url,"[SLALEVEL_ID]")) {
-         $url = str_replace("[SLALEVEL_ID]", $ticket->fields['slalevels_id'], $url);
+         $url = str_replace("[SLALEVEL_ID]", $ticket->fields['ttr_slalevels_id'], $url);
       }
 
       if (strstr($url,"[SLALEVEL_NAME]")) {
          $url = str_replace("[SLALEVEL_NAME]",
                             urlencode(Dropdown::getDropdownName('glpi_slalevels',
-                                                                $ticket->fields['slalevels_id'])),
+                                                                $ticket->fields['ttr_slalevels_id'])),
                             $url);
       }
 

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -469,7 +469,8 @@ $RELATION = array("glpi_authldaps"
 
                   "glpi_slalevels"
                         => array('glpi_slalevelactions'   => 'slalevels_id',
-                                 'glpi_tickets'           => 'slalevels_id',
+                                 'glpi_slalevelcriterias' => 'slalevels_id',
+                                 'glpi_tickets'           => 'ttr_slalevels_id',
                                  'glpi_slalevels_tickets' => 'slalevels_id'),
 
                   "glpi_slts"

--- a/inc/slt.class.php
+++ b/inc/slt.class.php
@@ -910,8 +910,10 @@ class SLT extends CommonDBChild {
     *
     * @return execution date time (NULL if sla not exists)
    **/
-   function addLevelToDo(Ticket $ticket, $slalevels_id) {
+   function addLevelToDo(Ticket $ticket, $slalevels_id = 0) {
 
+      $slalevels_id = ($slalevels_id ? $slalevels_id
+                                     : $ticket->fields["ttr_slalevels_id"]);
       if ($slalevels_id > 0) {
          $toadd = array();
          $date = $this->computeExecutionDate($ticket->fields['date'], $slalevels_id,
@@ -937,7 +939,7 @@ class SLT extends CommonDBChild {
    static function deleteLevelsToDo(Ticket $ticket) {
       global $DB;
 
-      if ($ticket->fields["slalevels_id"] > 0) {
+      if ($ticket->fields["ttr_slalevels_id"] > 0) {
          $query = "SELECT *
                    FROM `glpi_slalevels_tickets`
                    WHERE `tickets_id` = '".$ticket->fields["id"]."'";

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -351,12 +351,15 @@ class Ticket extends CommonITILObject {
       $slt = new SLT();
       if ($slt->getFromDB($slts_id)) {
          $slt->setTicketCalendar($calendars_id);
+         if ($slt->fields['type'] == SLT::TTR) {
+            $data["ttr_slalevels_id"] = SlaLevel::getFirstSltLevel($slts_id);
+         }
          // Compute due_date
          $data[$dateField]             = $slt->computeDate($date);
          $data['sla_waiting_duration'] = 0;
 
       } else {
-         $data["slalevels_id"]         = 0;
+         $data["ttr_slalevels_id"]     = 0;
          $data[$sltField]              = 0;
          $data['sla_waiting_duration'] = 0;
       }

--- a/install/mysql/glpi-9.1-empty.sql
+++ b/install/mysql/glpi-9.1-empty.sql
@@ -7182,6 +7182,7 @@ CREATE TABLE `glpi_tickets` (
   `global_validation` int(11) NOT NULL DEFAULT '1',
   `slts_tto_id` int(11) NOT NULL DEFAULT '0',
   `slts_ttr_id` int(11) NOT NULL DEFAULT '0',
+  `ttr_slalevels_id` int(11) NOT NULL DEFAULT '0',
   `due_date` datetime DEFAULT NULL,
   `time_to_own` datetime DEFAULT NULL,
   `begin_waiting_date` datetime DEFAULT NULL,

--- a/install/update_0905_91.php
+++ b/install/update_0905_91.php
@@ -769,6 +769,7 @@ function update0905to91() {
       $migration->addField("glpi_tickets", "time_to_own", "datetime", array('after' => 'due_date'));
       $migration->addKey('glpi_tickets', 'slts_tto_id');
       $migration->addKey('glpi_tickets', 'time_to_own');
+      $migration->changeField('glpi_tickets', 'slalevels_id', 'ttr_slalevels_id', 'integer');
 
       // Unique key for slalevel_ticket
       $migration->addKey('glpi_slalevels_tickets', array('tickets_id', 'slalevels_id'),


### PR DESCRIPTION
now named ttr_slalevels_id according to its usage
Its purpose is to store last sla level when ticket is set to waiting status.
When the ticket return from waiting, we reinsert in glpi_slalevels_tickets this value.

see #461