### PR TITLE
Fix #1032 implement a signal handler for cron task in CLI mode

### DIFF
--- a/front/cron.php
+++ b/front/cron.php
@@ -9,7 +9,7 @@
 
  based on GLPI - Gestionnaire Libre de Parc Informatique
  Copyright (C) 2003-2014 by the INDEPNET Development Team.
- 
+
  -------------------------------------------------------------------------
 
  LICENSE
@@ -36,7 +36,7 @@
 */
 
 // Ensure current directory when run from crontab
-chdir(dirname($_SERVER["SCRIPT_FILENAME"]));
+chdir(__DIR__);
 
 
 define('DO_NOT_CHECK_HTTP_REFERER', 1);

--- a/front/cron.php
+++ b/front/cron.php
@@ -78,8 +78,8 @@ if (!isCommandLine()) {
          // Only check first parameter when numeric is passed
          break;
       } else {
-         // Task name
-         CronTask::launch($mode, $CFG_GLPI['cron_limit'], $_SERVER['argv'][$i]);
+         // Single Task name
+         CronTask::launch($mode, 1, $_SERVER['argv'][$i]);
       }
    }
 

--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -47,7 +47,7 @@ include_once (GLPI_ROOT."/config/define.php");
  * @return boolean
 **/
 function isCommandLine() {
-   return (!isset($_SERVER["SERVER_NAME"]));
+   return (PHP_SAPI == 'cli');
 }
 
 /**

--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -36,6 +36,9 @@
 * @brief
 */
 
+// Needed for signal handler
+declare(ticks = 1);
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -180,6 +183,26 @@ class CronTask extends CommonDBTM{
     }
 
    /**
+    * Signal handler callback
+    *
+    * @since 9.1
+    */
+   function signal($signo) {
+      if ($signo == SIGTERM) {
+         pcntl_signal(SIGTERM, SIG_DFL);
+
+         // End of this task
+         $this->end(NULL);
+
+         // End of this cron
+         $_SESSION["glpicronuserrunning"]='';
+         self::release_lock();
+         Toolbox::logInFile('cron', __('Action aborted')."\n");
+         exit;
+      }
+   }
+
+   /**
     * Start a task, timer, stat, log, ...
     *
     * @return bool : true if ok (not start by another)
@@ -189,6 +212,10 @@ class CronTask extends CommonDBTM{
 
       if (!isset($this->fields['id']) || ($DB->isSlave())) {
          return false;
+      }
+
+      if (PHP_SAPI == "cli" && function_exists('pcntl_signal')) {
+         pcntl_signal(SIGTERM, [$this, 'signal']);
       }
 
       $query = "UPDATE `".$this->getTable()."`
@@ -262,7 +289,11 @@ class CronTask extends CommonDBTM{
       if ($DB->affected_rows($result) > 0) {
          // No gettext for log but add gettext line to be parsed for pot generation
          // order is important for insertion in english in the database
-         if ($retcode < 0) {
+         if (is_null($retcode)) {
+            $content = __('Action aborted');
+            $content = 'Action aborted';
+         }
+         else if ($retcode < 0) {
             $content = __('Action completed, partially processed');
             $content = 'Action completed, partially processed';
 

--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -214,7 +214,7 @@ class CronTask extends CommonDBTM{
          return false;
       }
 
-      if (PHP_SAPI == "cli" && function_exists('pcntl_signal')) {
+      if (isCommandLine() && function_exists('pcntl_signal')) {
          pcntl_signal(SIGTERM, [$this, 'signal']);
       }
 


### PR DESCRIPTION
To test, add in  CronTask::cronLogs()

```
      Toolbox::logInFile('cron', "process ".posix_getpid()."\n");
      sleep(10);
```
And from command line

```
$ php front/cron.php --force logs&
[1] 2319
$ kill 2319
```

Should  trace:

```
2016-09-22 13:42:32 [@xx]
Externe #1 : Démarrage logs
2016-09-22 13:42:32 [@xx]
process 2319
2016-09-22 13:42:39 [@xx]
Action aborted
```