### PR TITLE
avoid error on inexistent event.end in planning

### DIFF
--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -615,9 +615,11 @@ class Planning extends CommonGLPI {
                }
 
                // add classes to current event
-               added_classes = event.end.isBefore(moment())      ? ' event_past'   : '';
-               added_classes+= event.end.isAfter(moment())       ? ' event_future' : '';
-               added_classes+= event.end.isSame(moment(), 'day') ? ' event_today'  : '';
+               if (typeof event.end !== 'undefined') {
+                  added_classes = event.end.isBefore(moment())      ? ' event_past'   : '';
+                  added_classes+= event.end.isAfter(moment())       ? ' event_future' : '';
+                  added_classes+= event.end.isSame(moment(), 'day') ? ' event_today'  : '';
+               }
                if (event.state != '') {
                   added_classes+= event.state == 0 ? ' event_info'
                                 : event.state == 1 ? ' event_todo'


### PR DESCRIPTION
Found on http://demo.glpi-project.org/, the central view triggers a javascript error:
"VM1079:63 Uncaught TypeError: Cannot read property 'isBefore' of null"

I can't found the original problem (events should always have an end date), but the proposed test should avoid this situation.