### PR TITLE
Fix multiple XML response in apixmlrpc on error

### DIFF
--- a/inc/apixmlrpc.class.php
+++ b/inc/apixmlrpc.class.php
@@ -254,6 +254,7 @@ class APIXmlrpc extends API {
       $out = xmlrpc_encode_request(NULL, $response, array('encoding' => 'UTF-8',
                                                           'escaping' => 'markup'));
       echo $out;
+      exit;
    }
 
    /**


### PR DESCRIPTION
If method `returnError` is called, the `returnResponse` is called two times.