### PR TITLE
Remove more SQL

### DIFF
--- a/front/central.php
+++ b/front/central.php
@@ -9,7 +9,7 @@
 
  based on GLPI - Gestionnaire Libre de Parc Informatique
  Copyright (C) 2003-2014 by the INDEPNET Development Team.
- 
+
  -------------------------------------------------------------------------
 
  LICENSE

--- a/inc/apiclient.class.php
+++ b/inc/apiclient.class.php
@@ -275,15 +275,9 @@ class APIClient extends CommonDBTM {
       $ok = false;
       do {
          $key    = Toolbox::getRandomString(40);
-         $query  = "SELECT COUNT(*)
-                    FROM `".self::getTable()."`
-                    WHERE `app_token` = '$key'";
-         $result = $DB->query($query);
-
-         if ($DB->result($result,0,0) == 0) {
+         if (countElementsInTable(self::getTable(), ['app_token' => $key]) == 0) {
             return $key;
          }
       } while (!$ok);
-
    }
 }

--- a/inc/db.function.php
+++ b/inc/db.function.php
@@ -298,27 +298,24 @@ function getSingular($string) {
  * Count the number of elements in a table.
  *
  * @param $table        string/array   table names
- * @param $condition    string         condition to use (default '')
+ * @param $condition    string/array   condition to use (default '') or array of criteria
  *
  * @return int nb of elements in table
 **/
 function countElementsInTable($table, $condition="") {
    global $DB;
 
-   if (is_array($table)) {
-      $table = implode('`,`',$table);
+   if (!is_array($condition)) {
+      if (empty($condition)) {
+         $condition = [];
+      } else {
+         $condition = ['WHERE' => $condition]; // Deprecated use case
+      }
    }
+   $condition['COUNT'] = 'cpt';
 
-   $query = "SELECT COUNT(*) AS cpt
-             FROM `$table`";
-
-   if (!empty($condition)) {
-      $query .= " WHERE $condition ";
-   }
-
-   $result = $DB->query($query);
-   $ligne  = $DB->fetch_assoc($result);
-   return $ligne['cpt'];
+   $row = $DB->request($table, $condition)->next();
+   return ($row ? $row['cpt'] : 0);
 }
 
 /**

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -761,6 +761,9 @@ class DBmysqlIterator  implements Iterator {
 
       $this->conn = $dbconnexion;
       if (is_string($table) && strpos($table, " ")) {
+//          if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
+//             trigger_error("Deprecated usage of SQL in DB/request (full query)", E_USER_DEPRECATED);
+//          }
          $this->sql = $table;
       } else {
          // Check field, orderby, limit, start in criterias
@@ -770,6 +773,7 @@ class DBmysqlIterator  implements Iterator {
          $start    = 0;
          $distinct = '';
          $where    = '';
+         $count    = '';
          if (is_array($crit) && count($crit)) {
             foreach ($crit as $key => $val) {
                if ($key === "FIELDS") {
@@ -778,6 +782,9 @@ class DBmysqlIterator  implements Iterator {
                } else if ($key === "DISTINCT FIELDS") {
                   $field = $val;
                   $distinct = "DISTINCT";
+                  unset($crit[$key]);
+               } else if ($key === "COUNT") {
+                  $count = $val;
                   unset($crit[$key]);
                } else if ($key === "ORDER") {
                   $orderby = $val;
@@ -796,7 +803,9 @@ class DBmysqlIterator  implements Iterator {
          }
 
          // SELECT field list
-         if (is_array($field)) {
+         if ($count) {
+            $this->sql = "SELECT COUNT(*) AS $count";
+         } else if (is_array($field)) {
             $this->sql = "";
             foreach ($field as $t => $f) {
                if (is_numeric($t)) {
@@ -814,7 +823,7 @@ class DBmysqlIterator  implements Iterator {
          } else if (empty($field)) {
             $this->sql = "SELECT *";
          } else {
-            $this->sql = "SELECT $distinct `$field`";
+            $this->sql = "SELECT $distinct " . self::quoteName($field);
          }
 
          // FROM table list
@@ -897,6 +906,9 @@ class DBmysqlIterator  implements Iterator {
    private function analyseCrit ($crit, $bool="AND") {
 
       if (!is_array($crit)) {
+//          if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
+//             trigger_error("Deprecated usage of SQL in DB/request (criteria)", E_USER_DEPRECATED);
+//          }
          return $crit;
       }
       $ret = "";

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -894,6 +894,14 @@ class DBmysqlIterator  implements Iterator {
    }
 
 
+   /**
+    * Quote field name
+    *
+    * @since 9.1
+    *
+    * @param string $name of field to quote (or table.field)
+    * @return string
+   **/
    private static function quoteName($name) {
 
       if (strpos($name, '.')) {
@@ -904,6 +912,11 @@ class DBmysqlIterator  implements Iterator {
    }
 
 
+   /**
+    * Retrieve the SQL statement
+    *
+    * @since 9.1
+   **/
    public function getSql() {
       return preg_replace('/ +/', ' ', $this->sql);
    }
@@ -918,8 +931,12 @@ class DBmysqlIterator  implements Iterator {
 
 
    /**
-    * @param $crit
-    * @param $bool (default AND)
+    * Generate the SQL statement for a array of criteria
+    *
+    * @param array  $crit
+    * @param string $bool (default AND)
+    *
+    * @return string
    **/
    private function analyseCrit ($crit, $bool="AND") {
 

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -761,9 +761,9 @@ class DBmysqlIterator  implements Iterator {
 
       $this->conn = $dbconnexion;
       if (is_string($table) && strpos($table, " ")) {
-//          if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
-//             trigger_error("Deprecated usage of SQL in DB/request (full query)", E_USER_DEPRECATED);
-//          }
+         //if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
+         //   trigger_error("Deprecated usage of SQL in DB/request (full query)", E_USER_DEPRECATED);
+         //}
          $this->sql = $table;
       } else {
          // Check field, orderby, limit, start in criterias
@@ -943,9 +943,9 @@ class DBmysqlIterator  implements Iterator {
       static $operators = ['=', '<', '<=', '>', '>=', 'LIKE', 'REGEXP', 'NOT LIKE', 'NOT REGEX'];
 
       if (!is_array($crit)) {
-//          if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
-//             trigger_error("Deprecated usage of SQL in DB/request (criteria)", E_USER_DEPRECATED);
-//          }
+         //if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
+         //  trigger_error("Deprecated usage of SQL in DB/request (criteria)", E_USER_DEPRECATED);
+         //}
          return $crit;
       }
       $ret = "";

--- a/tests/DBmysqlIteratorTest.php
+++ b/tests/DBmysqlIteratorTest.php
@@ -106,6 +106,12 @@ class DBmysqlIteratorTest extends DbTestCase {
    }
 
 
+   public function testCount() {
+      $it = new DBmysqlIterator(NULL, 'foo', ['COUNT' => 'cpt']);
+      $this->assertEquals('SELECT COUNT(*) AS cpt FROM `foo`', $it->getSql(), 'Simple count');
+   }
+
+
    public function testWhere() {
 
       $it = new DBmysqlIterator(NULL, 'foo', 'id=1');

--- a/tests/DBmysqlIteratorTest.php
+++ b/tests/DBmysqlIteratorTest.php
@@ -125,6 +125,28 @@ class DBmysqlIteratorTest extends DbTestCase {
    }
 
 
+   public function testOperators() {
+
+      $it = new DBmysqlIterator(NULL, 'foo', ['a' => 1]);
+      $this->assertEquals('SELECT * FROM `foo` WHERE `a` = 1', $it->getSql(), 'Operator, implicit =');
+
+      $it = new DBmysqlIterator(NULL, 'foo', ['a' => ['=', 1]]);
+      $this->assertEquals('SELECT * FROM `foo` WHERE `a` = 1', $it->getSql(), 'Operator, explicit =');
+
+      $it = new DBmysqlIterator(NULL, 'foo', ['a' => ['>', 1]]);
+      $this->assertEquals('SELECT * FROM `foo` WHERE `a` > 1', $it->getSql(), 'Operator, >');
+
+      $it = new DBmysqlIterator(NULL, 'foo', ['a' => ['LIKE', '%bar%']]);
+      $this->assertEquals('SELECT * FROM `foo` WHERE `a` LIKE \'%bar%\'', $it->getSql(), 'Operator, LIKE');
+
+      $it = new DBmysqlIterator(NULL, 'foo', ['NOT' => ['a' => ['LIKE', '%bar%']]]);
+      $this->assertEquals('SELECT * FROM `foo` WHERE NOT (`a` LIKE \'%bar%\')', $it->getSql(), 'Operator, NOT / LIKE');
+
+      $it = new DBmysqlIterator(NULL, 'foo', ['a' => ['NOT LIKE', '%bar%']]);
+      $this->assertEquals('SELECT * FROM `foo` WHERE `a` NOT LIKE \'%bar%\'', $it->getSql(), 'Operator, NOT LIKE');
+   }
+
+
    public function testWhere() {
 
       $it = new DBmysqlIterator(NULL, 'foo', 'id=1');
@@ -143,7 +165,10 @@ class DBmysqlIteratorTest extends DbTestCase {
       $this->assertEquals('SELECT * FROM `foo` WHERE `bar` = 1', $it->getSql(), 'Integer value');
 
       $it = new DBmysqlIterator(NULL, 'foo', ['bar' => [1, 2, 4]]);
-      $this->assertEquals("SELECT * FROM `foo` WHERE `bar` IN ('1','2','4')", $it->getSql(), 'Multiple values');
+      $this->assertEquals("SELECT * FROM `foo` WHERE `bar` IN (1, 2, 4)", $it->getSql(), 'Multiple integer values');
+
+      $it = new DBmysqlIterator(NULL, 'foo', ['bar' => ['a', 'b', 'c']]);
+      $this->assertEquals("SELECT * FROM `foo` WHERE `bar` IN ('a', 'b', 'c')", $it->getSql(), 'Multiple string values');
 
       $it = new DBmysqlIterator(NULL, 'foo', ['bar' => 'val']);
       $this->assertEquals("SELECT * FROM `foo` WHERE `bar` = 'val'", $it->getSql(), 'String value');
@@ -198,7 +223,7 @@ class DBmysqlIteratorTest extends DbTestCase {
                           ],
               ];
       $it = new DBmysqlIterator(NULL, ['foo'], $crit);
-      $this->assertEquals("SELECT * FROM `foo` WHERE `a` = 1 AND (`b` = 2 OR NOT (`c` IN ('2','3') AND (`d` = 4 AND `e` = 5)))", $it->getSql(), 'Complex case');
+      $this->assertEquals("SELECT * FROM `foo` WHERE `a` = 1 AND (`b` = 2 OR NOT (`c` IN (2, 3) AND (`d` = 4 AND `e` = 5)))", $it->getSql(), 'Complex case');
    }
 
 

--- a/tests/DBmysqlIteratorTest.php
+++ b/tests/DBmysqlIteratorTest.php
@@ -112,6 +112,19 @@ class DBmysqlIteratorTest extends DbTestCase {
    }
 
 
+   public function testJoin() {
+
+      $it = new DBmysqlIterator(NULL, 'foo', ['JOIN' => ['bar' => ['FKEY' => ['bar' => 'id', 'foo' => 'fk']]]]);
+      $this->assertEquals('SELECT * FROM `foo` LEFT JOIN `bar` ON (`bar`.`id` = `foo`.`fk`)', $it->getSql(), 'Left join using FK table => field');
+
+      $it = new DBmysqlIterator(NULL, 'foo', ['JOIN' => ['bar' => ['FKEY' => ['bar.id', 'foo.fk']]]]);
+      $this->assertEquals('SELECT * FROM `foo` LEFT JOIN `bar` ON (`bar`.`id` = `foo`.`fk`)', $it->getSql(), 'Left join using FK table.field');
+
+      $it = new DBmysqlIterator(NULL, 'foo', ['JOIN' => ['bar' => ['FKEY' => ['id', 'fk'], 'val' => 1]]]);
+      $this->assertEquals('SELECT * FROM `foo` LEFT JOIN `bar` ON (`id` = `fk` AND `val` = 1)', $it->getSql(), 'Left join using FK fields + other crit');
+   }
+
+
    public function testWhere() {
 
       $it = new DBmysqlIterator(NULL, 'foo', 'id=1');

--- a/tests/DbFunctionTest.php
+++ b/tests/DbFunctionTest.php
@@ -198,6 +198,10 @@ class DbFunctionTest extends DbTestCase {
       $this->assertEquals(1, countElementsInTable('glpi_configs', "context = 'core'
                                                    AND `name` = 'version'"));
       $this->assertEquals(0, countElementsInTable('glpi_configs', "context = 'fakecontext'"));
+      // Using iterator
+      $this->assertEquals(1, countElementsInTable('glpi_configs', ['context' => 'core', 'name' => 'version']));
+      $this->assertGreaterThan(100, countElementsInTable('glpi_configs', ['context' => 'core']));
+      $this->assertEquals(0, countElementsInTable('glpi_configs', ['context' => 'fakecontext']));
    }
 
 


### PR DESCRIPTION
- support for COUNT(*) in DBmysqlIterator
- rewrite countElementsInTable to use $DB->request()
- drop last query in APIClient
- handle LEFT JOIN
- handle operators in criteria


Notice: add deprecated messages about direct SQL usage,
in comment for now (else, too much messages raised)