### PR TITLE
Added additional headers for API XMLRPC

### DIFF
--- a/inc/apirest.class.php
+++ b/inc/apirest.class.php
@@ -195,7 +195,7 @@ class APIRest extends API {
                   $response = $this->getItem($itemtype, $id, $this->parameters);
                   if (isset($response['date_mod'])) {
                      $datemod = strtotime($response['date_mod']);
-                     $additionalheaders['Last-Modified'] = date('r', $datemod);
+                     $additionalheaders['Last-Modified'] = gmdate("D, d M Y H:i:s", $datemod)." GMT";
                   }
                } else {
                   // return collection of items

--- a/inc/apixmlrpc.class.php
+++ b/inc/apixmlrpc.class.php
@@ -127,12 +127,17 @@ class APIXmlrpc extends API {
          //search
          $response =  $this->searchItems($this->parameters['itemtype'], $this->parameters);
 
+         //add pagination headers
+         $additionalheaders                  = array();
+         $additionalheaders["Content-Range"] = $response['content-range'];
+         $additionalheaders["Accept-Range"]  = $this->parameters['itemtype']." ".Toolbox::get_max_input_vars();
+
          // diffent http return codes for complete or partial response
          if ($response['count'] < $response['totalcount']) {
             $code = 206; // partial content
          }
 
-         return $this->returnResponse($response, $code);
+         return $this->returnResponse($response, $code, $additionalheaders);
 
       // commonDBTM manipulation
       } else if (in_array($resource,
@@ -156,20 +161,59 @@ class APIXmlrpc extends API {
                $this->returnError(__("missing id"), 400, "ID_RESOURCE_MISSING");
             }
 
-            return $this->returnResponse($this->getItem($this->parameters['itemtype'],
-                                                        $this->parameters['id'],
-                                                        $this->parameters));
+            $response = $this->getItem($this->parameters['itemtype'], $this->parameters['id'], $this->parameters);
+
+            $additionalheaders = array();
+            if (isset($response['date_mod'])) {
+               $datemod = strtotime($response['date_mod']);
+               $additionalheaders['Last-Modified'] = gmdate("D, d M Y H:i:s", $datemod)." GMT";
+            }
+            return $this->returnResponse($response, 200, $additionalheaders);
 
          // get a collection of a CommonDBTM item
          } else if ($resource === "getItems") {
-            return $this->returnResponse($this->getItems($this->parameters['itemtype'],
-                                                         $this->parameters));
+            // return collection of items
+            $totalcount = 0;
+            $response = $this->getItems($this->parameters['itemtype'], $this->parameters, $totalcount);
+
+            //add pagination headers
+            $range = [0, $_SESSION['glpilist_limit']];
+            if (isset($this->parameters['range'])) {
+               $range = explode("-", $this->parameters['range']);
+               // fix end range
+               if($range[1] > $totalcount - 1){
+                  $range[1] = $totalcount - 1;
+               }
+               if($range[1] - $range[0] + 1 < $totalcount){
+                  $code = 206; // partial content
+               }
+            }
+            $additionalheaders                  = array();
+            $additionalheaders["Content-Range"] = implode('-', $range)."/".$totalcount;
+            $additionalheaders["Accept-Range"]  = $this->parameters['itemtype']." ".Toolbox::get_max_input_vars();
+            return $this->returnResponse($response, $code, $additionalheaders);
 
          // create one or many CommonDBTM items
          } else if ($resource === "createItems") {
-            return $this->returnResponse($this->createItems($this->parameters['itemtype'],
-                                                            $this->parameters),
-                                                            201);
+            $response = $this->createItems($this->parameters['itemtype'], $this->parameters);
+
+            $additionalheaders = array();
+            if (count($response) == 1) {
+               // add a location targetting created element
+               $additionalheaders['location'] = self::$api_url.$this->parameters['itemtype']."/".$response['id'];
+            } else {
+               // add a link header targetting created elements
+               $additionalheaders['link'] = "";
+               foreach($response as $created_item) {
+                  if ($created_item['id']) {
+                     $additionalheaders['link'] .= self::$api_url.$this->parameters['itemtype'].
+                                                  "/".$created_item['id'].",";
+                  }
+               }
+               // remove last comma
+               $additionalheaders['link'] = trim($additionalheaders['link'], ",");
+            }
+            return $this->returnResponse($response, 201);
 
          // update one or many CommonDBTM items
          } else if ($resource === "updateItems") {

--- a/tests/API/APIXmlrpcTest.php
+++ b/tests/API/APIXmlrpcTest.php
@@ -239,6 +239,22 @@ class APIXmlrpcTest extends PHPUnit_Framework_TestCase {
       $this->assertFalse(is_numeric($data[0]['entities_id'])); // for expand_dropdowns
 
 
+      // test retrieve partial users
+      $res = $this->doHttpRequest('getItems', ['session_token'    => $session_token,
+                                               'itemtype'         => 'User',
+                                               'range'            => '0-1',
+                                               'expand_dropdowns' => true]);
+      $this->assertEquals(206, $res->getStatusCode());
+      $data = xmlrpc_decode($res->getBody());
+
+      $this->assertGreaterThanOrEqual(2, count($data));
+      $this->assertArrayHasKey('id', $data[0]);
+      $this->assertArrayHasKey('name', $data[0]);
+      $this->assertArrayNotHasKey('password', $data[0]);
+      $this->assertArrayHasKey('is_active', $data[0]);
+      $this->assertFalse(is_numeric($data[0]['entities_id'])); // for expand_dropdowns
+
+
       // Test only_id param
       $res = $this->doHttpRequest('getItems', ['session_token' => $session_token,
                                                'itemtype'      => 'User',


### PR DESCRIPTION
This is necessary to do paging with XMLRPC.

Currently you can not check there more records using only the response for `getItems` and `search`.