### PR TITLE
Get items from parent returns too many items

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -971,13 +971,18 @@ abstract class API extends CommonGLPI {
          if (isset($item->fields[$fk_parent])) {
             $where.= " AND `$table`.`$fk_parent` = ".$this->parameters['parent_id'];
          } else if (isset($item->fields['itemtype'])
-                 && isset($item->fields['items_id'])) {
+                 && isset($item->fields['items_id'])) { 
             $where.= " AND `$table`.`itemtype` = '".$this->parameters['parent_itemtype']."'
                        AND `$table`.`items_id` = ".$this->parameters['parent_id'];
          } else if(isset($parent_item->fields[$fk_child])) {
             $parentTable = getTableForItemType($this->parameters['parent_itemtype']);
             $join.= " LEFT JOIN `$parentTable` ON `$parentTable`.`$fk_child` = `$table`.`id` ";
             $where.= " AND `$parentTable`.`id` = '" . $this->parameters['parent_id'] . "'" ;
+         } else if (isset($parent_item->fields['itemtype'])
+                 && isset($parent_item->fields['items_id'])) {
+            $parentTable = getTableForItemType($this->parameters['parent_itemtype']);
+            $join.= " LEFT JOIN `$parentTable` ON `itemtype`='$itemtype' AND `$parentTable`.`items_id` = `$table`.`id` ";
+            $where.= " AND `$parentTable`.`id` = '" . $this->parameters['parent_id'] . "'";
          }
       }
 

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -977,7 +977,7 @@ abstract class API extends CommonGLPI {
          } else if(isset($parent_item->fields[$fk_child])) {
             $parentTable = getTableForItemType($this->parameters['parent_itemtype']);
             $join.= " LEFT JOIN `$parentTable` ON `$parentTable`.`$fk_child` = `$table`.`id` ";
-            $where.= " AND `$parentTable`.`$fk_child` = `$table`.`id`";
+            $where.= " AND `$parentTable`.`id` = '" . $this->parameters['parent_id'] . "'" ;
          }
       }
 

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -971,7 +971,7 @@ abstract class API extends CommonGLPI {
          if (isset($item->fields[$fk_parent])) {
             $where.= " AND `$table`.`$fk_parent` = ".$this->parameters['parent_id'];
          } else if (isset($item->fields['itemtype'])
-                 && isset($item->fields['items_id'])) { 
+                 && isset($item->fields['items_id'])) {
             $where.= " AND `$table`.`itemtype` = '".$this->parameters['parent_itemtype']."'
                        AND `$table`.`items_id` = ".$this->parameters['parent_id'];
          } else if(isset($parent_item->fields[$fk_child])) {

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -956,6 +956,7 @@ abstract class API extends CommonGLPI {
          }
 
          $fk_parent = getForeignKeyFieldForItemType($this->parameters['parent_itemtype']);
+         $fk_child = getForeignKeyFieldForItemType($itemtype);
 
          // check parent rights
          $parent_item = new $this->parameters['parent_itemtype'];
@@ -973,6 +974,10 @@ abstract class API extends CommonGLPI {
                  && isset($item->fields['items_id'])) {
             $where.= " AND `$table`.`itemtype` = '".$this->parameters['parent_itemtype']."'
                        AND `$table`.`items_id` = ".$this->parameters['parent_id'];
+         } else if(isset($parent_item->fields[$fk_child])) {
+            $parentTable = getTableForItemType($this->parameters['parent_itemtype']);
+            $join.= " LEFT JOIN `$parentTable` ON `$parentTable`.`$fk_child` = `$table`.`id` ";
+            $where.= " AND `$parentTable`.`$fk_child` = `$table`.`id`";
          }
       }
 


### PR DESCRIPTION
Replace #1073 

use the relation between the parent and the child itemtypes to restrict the results when the child itemtype does not have an ID