### PR TITLE
improve dbiterator, accept 'SELECT' and 'FROM'

### DIFF
--- a/inc/db.function.php
+++ b/inc/db.function.php
@@ -1374,6 +1374,11 @@ function TableExists($tablename) {
 function FieldExists($table, $field, $usecache=true) {
    global $DB;
 
+   if (!TableExists($table)) {
+      trigger_error("Table $table does not exists", E_USER_WARNING);
+      return false;
+   }
+
    if ($fields = $DB->list_fields($table, $usecache)) {
       if (isset($fields[$field])) {
          return true;
@@ -1394,6 +1399,11 @@ function FieldExists($table, $field, $usecache=true) {
 **/
 function isIndex($table, $field) {
    global $DB;
+
+   if (!TableExists($table)) {
+      trigger_error("Table $table does not exists", E_USER_WARNING);
+      return false;
+   }
 
    $result = $DB->query("SHOW INDEX FROM `$table`");
 

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -175,6 +175,9 @@ class DBmysql {
          $error .= toolbox::backtrace(false, 'DBmysql->query()', array('Toolbox::backtrace()'));
 
          Toolbox::logInFile("sql-errors", $error);
+         if (class_exists('GlpitestSQLError')) { // For unit test
+            throw new GlpitestSQLError($error);
+         }
 
          if (($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE)
              && $CFG_GLPI["debug_sql"]) {
@@ -227,6 +230,9 @@ class DBmysql {
          $error .= toolbox::backtrace(false, 'DBmysql->prepare()', array('Toolbox::backtrace()'));
 
          Toolbox::logInFile("sql-errors", $error);
+         if (class_exists('GlpitestSQLError')) { // For unit test
+            throw new GlpitestSQLError($error);
+         }
 
          if (($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE)
              && $CFG_GLPI["debug_sql"]) {

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -773,7 +773,6 @@ class DBmysqlIterator  implements Iterator {
             $crit  = $table;
             $table = $crit['FROM'];
             unset($crit['FROM']);
-            var_dump("DEBUG", $table, $crit);
          }
          // Check field, orderby, limit, start in criterias
          $field    = "";
@@ -865,11 +864,21 @@ class DBmysqlIterator  implements Iterator {
 
          // FROM table list
          if (is_array($table)) {
-            $table = array_map([__CLASS__, 'quoteName'], $table);
-            $this->sql .= ' FROM '.implode(", ",$table);
-         } else {
+            if (count($table)) {
+               $table = array_map([__CLASS__, 'quoteName'], $table);
+               $this->sql .= ' FROM '.implode(", ",$table);
+            } else {
+               trigger_error("Missing table name", E_USER_ERROR);
+            }
+         } else if ($table) {
             $table = self::quoteName($table);
             $this->sql .= " FROM $table";
+         } else {
+            /*
+             * TODO filter with if ($where || !empty($crit)) {
+             * but not usefull for now, as we CANNOT write somthing like "SELECT NOW()"
+             */
+            trigger_error("Missing table name", E_USER_ERROR);
          }
 
          // JOIN

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -555,7 +555,7 @@ class Toolbox {
       $user_errors = array(E_USER_ERROR, E_USER_NOTICE, E_USER_WARNING);
 
       $err = '  *** PHP '.$errortype[$errno] . "($errno): $errmsg\n";
-      if (in_array($errno, $user_errors)) {
+      if (in_array($errno, $user_errors) && function_exists('wddx_serialize_value')) {
          $err .= "Variables:".wddx_serialize_value($vars, "Variables")."\n";
       }
 

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -534,23 +534,21 @@ class Toolbox {
    static function userErrorHandlerNormal($errno, $errmsg, $filename, $linenum, $vars) {
 
       // Date et heure de l'erreur
-      $errortype = array(E_ERROR           => 'Error',
-                         E_WARNING         => 'Warning',
-                         E_PARSE           => 'Parsing Error',
-                         E_NOTICE          => 'Notice',
-                         E_CORE_ERROR      => 'Core Error',
-                         E_CORE_WARNING    => 'Core Warning',
-                         E_COMPILE_ERROR   => 'Compile Error',
-                         E_COMPILE_WARNING => 'Compile Warning',
-                         E_USER_ERROR      => 'User Error',
-                         E_USER_WARNING    => 'User Warning',
-                         E_USER_NOTICE     => 'User Notice',
-                         E_STRICT          => 'Runtime Notice',
-                         // Need php 5.2.0
-                         4096 /*E_RECOVERABLE_ERROR*/  => 'Catchable Fatal Error',
-                         // Need php 5.3.0
-                         8192 /* E_DEPRECATED */       => 'Deprecated function',
-                         16384 /* E_USER_DEPRECATED */ => 'User deprecated function');
+      $errortype = array(E_ERROR             => 'Error',
+                         E_WARNING           => 'Warning',
+                         E_PARSE             => 'Parsing Error',
+                         E_NOTICE            => 'Notice',
+                         E_CORE_ERROR        => 'Core Error',
+                         E_CORE_WARNING      => 'Core Warning',
+                         E_COMPILE_ERROR     => 'Compile Error',
+                         E_COMPILE_WARNING   => 'Compile Warning',
+                         E_USER_ERROR        => 'User Error',
+                         E_USER_WARNING      => 'User Warning',
+                         E_USER_NOTICE       => 'User Notice',
+                         E_STRICT            => 'Runtime Notice',
+                         E_RECOVERABLE_ERROR => 'Catchable Fatal Error',
+                         E_DEPRECATED        => 'Deprecated function',
+                         E_USER_DEPRECATED   => 'User deprecated function');
       // Les niveaux qui seront enregistrés
       $user_errors = array(E_USER_ERROR, E_USER_NOTICE, E_USER_WARNING);
 
@@ -571,6 +569,21 @@ class Toolbox {
 
       // Save error
       self::logInFile("php-errors", $err);
+
+      // For unit test
+      if (class_exists('GlpitestPHPerror')) {
+         if (in_array($errno, [E_ERROR, E_USER_ERROR])) {
+            throw new GlpitestPHPerror($err);
+         }
+         /* for tuture usage
+         if (in_array($errno, [E_STRICT, E_WARNING, E_CORE_WARNING, E_USER_WARNING, E_DEPRECATED, E_USER_DEPRECATED])) {
+             throw new GlpitestPHPwarning($err);
+         }
+         if (in_array($errno, [E_NOTICE, E_USER_NOTICE])) {
+            throw new GlpitestPHPnotice($err);
+         }
+         */
+      }
 
       return $errortype[$errno];
    }

--- a/tests/DBmysqlIteratorTest.php
+++ b/tests/DBmysqlIteratorTest.php
@@ -68,18 +68,16 @@ class DBmysqlIteratorTest extends DbTestCase {
 
 
    /**
+    * This is really an error, no table but a WHERE clase
+    *
     * @expectedException        GlpitestPHPerror
     * @expectedExceptionMessage Missing table name
     */
    public function testNoTableWithWhere() {
 
-      file_put_contents(GLPI_LOG_DIR . '/php-errors.log', '');
+      // Really, this is an error
       $it = new DBmysqlIterator(NULL, '', ['foo' => 1]);
       $this->assertEquals('SELECT * WHERE `foo` = 1', $it->getSql(), 'No table');
-
-      // Really, this is an error
-      $buf = file_get_contents(GLPI_LOG_DIR . '/php-errors.log');
-      $this->assertRegExp('/Missing table name/', $buf, 'Missing table with WHERE');
    }
 
 
@@ -97,6 +95,8 @@ class DBmysqlIteratorTest extends DbTestCase {
 
 
    /**
+    * Temporarily, this is an error, will be allowed later
+    *
     * @expectedException        GlpitestPHPerror
     * @expectedExceptionMessage Missing table name
     */
@@ -109,6 +109,7 @@ class DBmysqlIteratorTest extends DbTestCase {
 
    public function testDebug() {
 
+      file_put_contents(GLPI_LOG_DIR . '/php-errors.log', '');
       $it = new DBmysqlIterator(NULL, 'foo', ['FIELDS' => 'name', 'id = ' . mt_rand()], true);
       $buf = file_get_contents(GLPI_LOG_DIR . '/php-errors.log');
       $this->assertTrue(strpos($buf, 'From DBmysqlIterator') > 0, 'From in php_errors.log');

--- a/tests/DBmysqlIteratorTest.php
+++ b/tests/DBmysqlIteratorTest.php
@@ -43,6 +43,17 @@ class DBmysqlIteratorTest extends DbTestCase {
    }
 
 
+   /**
+    * @expectedException        GlpitestSQLerror
+    * @expectedExceptionMessage fakeTable' doesn't exist
+    */
+   public function testSqlError() {
+      global $DB;
+
+      $DB->request('fakeTable');
+   }
+
+
    public function testOnlyTable() {
 
       $it = new DBmysqlIterator(NULL, 'foo');
@@ -56,6 +67,10 @@ class DBmysqlIteratorTest extends DbTestCase {
    }
 
 
+   /**
+    * @expectedException        GlpitestPHPerror
+    * @expectedExceptionMessage Missing table name
+    */
    public function testNoTableWithWhere() {
 
       file_put_contents(GLPI_LOG_DIR . '/php-errors.log', '');
@@ -68,23 +83,27 @@ class DBmysqlIteratorTest extends DbTestCase {
    }
 
 
+   /**
+    * Temporarily, this is an error, will be allowed later
+    *
+    * @expectedException        GlpitestPHPerror
+    * @expectedExceptionMessage Missing table name
+    */
    public function testNoTableWithoutWhere() {
 
-      file_put_contents(GLPI_LOG_DIR . '/php-errors.log', '');
       $it = new DBmysqlIterator(NULL, '');
       $this->assertEquals('SELECT *', $it->getSql(), 'No table');
+   }
 
-      // Temporarily, this is an error, will be allowed later
-      $buf = file_get_contents(GLPI_LOG_DIR . '/php-errors.log');
-      $this->assertRegExp('/Missing table name/', $buf, 'Missing table');
 
-      file_put_contents(GLPI_LOG_DIR . '/php-errors.log', '');
+   /**
+    * @expectedException        GlpitestPHPerror
+    * @expectedExceptionMessage Missing table name
+    */
+   public function testNoTableWithoutWhereBis() {
+
       $it = new DBmysqlIterator(NULL, ['FROM' => []]);
       $this->assertEquals('SELECT *', $it->getSql(), 'No table');
-
-      // Temporarily, this is an error, will be allowed later
-      $buf = file_get_contents(GLPI_LOG_DIR . '/php-errors.log');
-      $this->assertRegExp('/Missing table name/', $buf, 'Missing table');
    }
 
 

--- a/tests/DBmysqlIteratorTest.php
+++ b/tests/DBmysqlIteratorTest.php
@@ -222,8 +222,26 @@ class DBmysqlIteratorTest extends DbTestCase {
                                    ],
                           ],
               ];
+      $sql = "SELECT * FROM `foo` WHERE `a` = 1 AND (`b` = 2 OR NOT (`c` IN (2, 3) AND (`d` = 4 AND `e` = 5)))";
       $it = new DBmysqlIterator(NULL, ['foo'], $crit);
-      $this->assertEquals("SELECT * FROM `foo` WHERE `a` = 1 AND (`b` = 2 OR NOT (`c` IN (2, 3) AND (`d` = 4 AND `e` = 5)))", $it->getSql(), 'Complex case');
+      $this->assertEquals($sql, $it->getSql(), 'Complex case');
+
+      $crit['FROM'] = 'foo';
+      $it = new DBmysqlIterator(NULL, $crit);
+      $this->assertEquals($sql, $it->getSql(), 'Complex case');
+   }
+
+
+   public function testModern() {
+
+      $req = [
+         'SELECT' => ['a', 'b'],
+         'FROM'   => 'foo',
+         'WHERE'  => ['c' => 1],
+      ];
+      $sql = "SELECT `a`, `b` FROM `foo` WHERE `c` = 1";
+      $it = new DBmysqlIterator(NULL, $req);
+      $this->assertEquals($sql, $it->getSql(), 'Mondern syntax');
    }
 
 

--- a/tests/DBmysqlIteratorTest.php
+++ b/tests/DBmysqlIteratorTest.php
@@ -56,6 +56,38 @@ class DBmysqlIteratorTest extends DbTestCase {
    }
 
 
+   public function testNoTableWithWhere() {
+
+      file_put_contents(GLPI_LOG_DIR . '/php-errors.log', '');
+      $it = new DBmysqlIterator(NULL, '', ['foo' => 1]);
+      $this->assertEquals('SELECT * WHERE `foo` = 1', $it->getSql(), 'No table');
+
+      // Really, this is an error
+      $buf = file_get_contents(GLPI_LOG_DIR . '/php-errors.log');
+      $this->assertRegExp('/Missing table name/', $buf, 'Missing table with WHERE');
+   }
+
+
+   public function testNoTableWithoutWhere() {
+
+      file_put_contents(GLPI_LOG_DIR . '/php-errors.log', '');
+      $it = new DBmysqlIterator(NULL, '');
+      $this->assertEquals('SELECT *', $it->getSql(), 'No table');
+
+      // Temporarily, this is an error, will be allowed later
+      $buf = file_get_contents(GLPI_LOG_DIR . '/php-errors.log');
+      $this->assertRegExp('/Missing table name/', $buf, 'Missing table');
+
+      file_put_contents(GLPI_LOG_DIR . '/php-errors.log', '');
+      $it = new DBmysqlIterator(NULL, ['FROM' => []]);
+      $this->assertEquals('SELECT *', $it->getSql(), 'No table');
+
+      // Temporarily, this is an error, will be allowed later
+      $buf = file_get_contents(GLPI_LOG_DIR . '/php-errors.log');
+      $this->assertRegExp('/Missing table name/', $buf, 'Missing table');
+   }
+
+
    public function testDebug() {
 
       $it = new DBmysqlIterator(NULL, 'foo', ['FIELDS' => 'name', 'id = ' . mt_rand()], true);

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -201,6 +201,8 @@ class SearchTest extends DbTestCase {
    /**
     * This test will add all serachoptions in each itemtype and check if the
     * search give a SQL error
+    *
+    * @medium
     */
    public function testSearchOptions() {
 

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -101,7 +101,7 @@ class SearchTest extends DbTestCase {
            }
          }
       }
-      return $classes;
+      return array_unique($classes);
    }
 
 
@@ -209,6 +209,9 @@ class SearchTest extends DbTestCase {
       $displaypref = new DisplayPreference();
       // save table glpi_displaypreferences
       $dp = getAllDatasFromTable($displaypref->getTable());
+      foreach ($dp as $line) {
+         $displaypref->delete($line, true);
+      }
 
       $itemtypeslist = $this->getClasses('getSearchOptions');
       foreach ($itemtypeslist as $itemtype) {
@@ -233,7 +236,7 @@ class SearchTest extends DbTestCase {
                    'users_id' => 0,
                    'num' => $key,
                );
-               $displaypref->add($input);
+                $displaypref->add($input);
                $number++;
             }
          }
@@ -251,6 +254,7 @@ class SearchTest extends DbTestCase {
          $this->assertNotCount(0, $data['data'], $data['last_errors']);
       }
       // restore displaypreference table
+      /// TODO: review, this can't work.
       foreach (getAllDatasFromTable($displaypref->getTable()) as $line) {
          $displaypref->delete($line, true);
       }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,6 +41,19 @@ include_once __DIR__ . '/DbTestCase.php';
 define('TU_USER', '_test_user');
 define('TU_PASS', 'PhpUnit_4');
 
+class GlpitestPHPerror extends Exception
+{
+}
+class GlpitestPHPwarning extends Exception
+{
+}
+class GlpitestPHPnotice extends Exception
+{
+}
+class GlpitestSQLError extends Exception
+{
+}
+
 function loadDataset() {
    global $CFG_GLPI;
 
@@ -142,7 +155,7 @@ function loadDataset() {
    $CFG_GLPI['url_base']      = GLPI_URI;
    $CFG_GLPI['url_base_api']  = GLPI_URI . '/apirest.php';
 
-   @mkdir(GLPI_LOG_DIR, 0755, true);
+   is_dir(GLPI_LOG_DIR) or mkdir(GLPI_LOG_DIR, 0755, true);
 
    $conf = Config::getConfigurationValues('phpunit');
    if (isset($conf['dataset']) && $conf['dataset']==$data['_version']) {


### PR DESCRIPTION
Just because this seems more legible:
```
      $sql = [
         'SELECT' => ['a', 'b'],
         'FROM'   => 'foo',
         'WHERE'  => ['c' => 1],
      ];
      $req = $DB->request($sql);
```

Also, use switch instead of if ... elseif... elseif...