### PR TITLE
fix networkport adding

### DIFF
--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -190,7 +190,15 @@ class NetworkPort extends CommonDBChild {
     * @see CommonDBTM::prepareInputForUpdate
     */
    function prepareInputForUpdate($input) {
-      return $this->splitInputForElements($input);
+      if (!isset($input["_no_history"])) {
+         $input['_no_history'] = false;
+      }
+      if (isset($input['_create_children'])
+          && $input['_create_children']) {
+         return $this->splitInputForElements($input);
+      }
+
+      return $input;
    }
 
    /**
@@ -261,10 +269,11 @@ class NetworkPort extends CommonDBChild {
       $this->input_for_NetworkName        = array();
       $this->input_for_NetworkPortConnect = array();
 
-      $this->getEmpty();
+      $clone = clone $this;
+      $clone->getEmpty();
 
       foreach ($input as $field => $value) {
-         if (array_key_exists($field, $this->fields)) {
+         if (array_key_exists($field, $clone->fields) || $field[0] == '_') {
             continue;
          }
          if (preg_match('/^NetworkName_/',$field)) {
@@ -300,8 +309,9 @@ class NetworkPort extends CommonDBChild {
    function updateDependencies($history=true) {
 
       $instantiation = $this->getInstantiation();
-      if (($instantiation !== false)
-          && (count($this->input_for_instantiation) > 0)) {
+      if ($instantiation !== false
+          && isset($this->input_for_instantiation)
+          && count($this->input_for_instantiation) > 0) {
          $this->input_for_instantiation['networkports_id'] = $this->getID();
          if ($instantiation->isNewID($instantiation->getID())) {
             $instantiation->add($this->input_for_instantiation, [], $history);
@@ -311,8 +321,9 @@ class NetworkPort extends CommonDBChild {
       }
       unset($this->input_for_instantiation);
 
-      if ((count($this->input_for_NetworkName) > 0)
-          && (!isset($_POST['several']))) {
+      if (isset($this->input_for_NetworkName)
+          && count($this->input_for_NetworkName) > 0
+          && !isset($_POST['several'])) {
 
          // Check to see if the NetworkName is empty
          $empty_networkName = empty($this->input_for_NetworkName['name'])
@@ -342,13 +353,14 @@ class NetworkPort extends CommonDBChild {
             if (!$empty_networkName) { // Only create a NetworkName if it is not empty
                $this->input_for_NetworkName['itemtype'] = 'NetworkPort';
                $this->input_for_NetworkName['items_id'] = $this->getID();
-               $network_name->add($this->input_for_NetworkName, [], $history);
+               $newid = $network_name->add($this->input_for_NetworkName, [], $history);
             }
          }
       }
       unset($this->input_for_NetworkName);
 
-      if (count($this->input_for_NetworkPortConnect) > 0) {
+      if (isset($this->input_for_NetworkPortConnect)
+          && count($this->input_for_NetworkPortConnect) > 0) {
          if (isset($this->input_for_NetworkPortConnect['networkports_id_1'])
              && isset($this->input_for_NetworkPortConnect['networkports_id_2'])
              && !empty($this->input_for_NetworkPortConnect['networkports_id_2'])) {
@@ -370,7 +382,14 @@ class NetworkPort extends CommonDBChild {
          unset($input["logical_number"]);
       }
 
-      $input = $this->splitInputForElements($input);
+      if (!isset($input["_no_history"])) {
+         $input['_no_history'] = false;
+      }
+
+      if (isset($input['_create_children'])
+          && $input['_create_children']) {
+         $input = $this->splitInputForElements($input);
+      }
 
       return parent::prepareInputForAdd($input);
    }

--- a/tests/API/APIRestTest.php
+++ b/tests/API/APIRestTest.php
@@ -476,7 +476,8 @@ class APIRestTest extends PHPUnit_Framework_TestCase {
                                                 'NetworkName_name'         => "testname",
                                                 'NetworkName_fqdns_id'     => 0,
                                                 'NetworkName__ipaddresses' =>
-                                                   array(-1 => "1.2.3.4")]]]);
+                                                   array(-1 => "1.2.3.4"),
+                                                '_create_children'         => true]]]);
       $this->assertNotEquals(null, $res, $this->last_error);
       $this->assertEquals(201, $res->getStatusCode());
       $body = $res->getBody();

--- a/tests/NetworkportTest.php
+++ b/tests/NetworkportTest.php
@@ -42,11 +42,11 @@ class NetworkportTest extends DbTestCase {
       $this->Login();
 
       $computer1 = getItemByTypeName('Computer', '_test_pc01');
+      $networkport = new NetworkPort();
 
-      $ins = new NetworkPort();
       // Be sure added
       $nb_log = countElementsInTable('glpi_logs');
-      $this->assertGreaterThan(0, $ins->add([
+      $new_id = $networkport->add([
          'items_id'           => $computer1->getID(),
          'itemtype'           => 'Computer',
          'entities_id'        => $computer1->fields['entities_id'],
@@ -55,14 +55,16 @@ class NetworkportTest extends DbTestCase {
          'mac'                => '00:24:81:eb:c6:d0',
          'instantiation_type' => 'NetworkPortEthernet',
          'name'               => 'eth1',
-      ]));
+      ]);
+      $this->assertGreaterThan(0, $new_id);
       $this->assertGreaterThan($nb_log, countElementsInTable('glpi_logs'));
 
       // check data in db
-      $networkports = end(getAllDatasFromTable('glpi_networkports', '', false, 'id'));
-      unset($networkports['id']);
-      unset($networkports['date_mod']);
-      unset($networkports['date_creation']);
+      $all_netports = getAllDatasFromTable('glpi_networkports', '', false, 'id');
+      $current_networkport = end($all_netports);
+      unset($current_networkport['id']);
+      unset($current_networkport['date_mod']);
+      unset($current_networkport['date_creation']);
       $expected = [
           'items_id'           => $computer1->getID(),
           'itemtype'           => 'Computer',
@@ -76,18 +78,23 @@ class NetworkportTest extends DbTestCase {
           'is_deleted'         => '0',
           'is_dynamic'         => '0',
       ];
-      $this->assertEquals($expected, $networkports);
+      $this->assertEquals($expected, $current_networkport);
+
+      $all_netportethernets = getAllDatasFromTable('glpi_networkportethernets', '', false, 'id');
+      $networkportethernet = end($all_netportethernets);
+      $this->assertEquals(false, $networkportethernet);
 
       // be sure added and have no logs
       $nb_log = countElementsInTable('glpi_logs');
-      $this->assertGreaterThan(0, $ins->add([
+      $new_id = $networkport->add([
          'items_id'           => $computer1->getID(),
          'itemtype'           => 'Computer',
          'entities_id'        => $computer1->fields['entities_id'],
          'logical_number'     => 2,
          'mac'                => '00:24:81:eb:c6:d1',
          'instantiation_type' => 'NetworkPortEthernet',
-      ], [], false));
+      ], [], false);
+      $this->assertGreaterThan(0, $new_id);
       $this->assertEquals($nb_log, countElementsInTable('glpi_logs'));
    }
 
@@ -101,51 +108,113 @@ class NetworkportTest extends DbTestCase {
       $computer1 = getItemByTypeName('Computer', '_test_pc01');
 
       // Do some installations
-      $ins = new NetworkPort();
+      $networkport = new NetworkPort();
+
       // Be sure added
       $nb_log = countElementsInTable('glpi_logs');
-      $this->assertGreaterThan(0, $ins->add([
-         'items_id'           => $computer1->getID(),
-         'itemtype'           => 'Computer',
-         'entities_id'        => $computer1->fields['entities_id'],
-         'is_recursive'       => 0,
-         'logical_number'     => 3,
-         'mac'                => '00:24:81:eb:c6:d2',
-         'instantiation_type' => 'NetworkPortEthernet',
-         'name'               => 'em3',
-         'comment'            => 'Comment me!',
-         'netpoints_id'       => 0,
+      $new_id = $networkport->add([
+         'items_id'                    => $computer1->getID(),
+         'itemtype'                    => 'Computer',
+         'entities_id'                 => $computer1->fields['entities_id'],
+         'is_recursive'                => 0,
+         'logical_number'              => 3,
+         'mac'                         => '00:24:81:eb:c6:d2',
+         'instantiation_type'          => 'NetworkPortEthernet',
+         'name'                        => 'em3',
+         'comment'                     => 'Comment me!',
+         'netpoints_id'                => 0,
          'items_devicenetworkcards_id' => 0,
-         'type'               => 'T',
-         'speed'              => 1000,
-         'speed_other_value'  => '',
-         'NetworkName_name'   => 'test1.me',
-         'NetworkName_fqdns_id' => 0,
-         'NetworkName__ipaddresses' => ['-1' => '192.168.20.1']
-      ]));
+         'type'                        => 'T',
+         'speed'                       => 1000,
+         'speed_other_value'           => '',
+         'NetworkName_name'            => 'test1',
+         'NetworkName_comment'         => 'test1 comment',
+         'NetworkName_fqdns_id'        => 0,
+         'NetworkName__ipaddresses'    => ['-1' => '192.168.20.1'],
+         '_create_children'            => true // automatically add instancation, networkname and ipadresses
+      ]);
+      $this->assertGreaterThan(0, $new_id);
       $this->assertGreaterThan($nb_log, countElementsInTable('glpi_logs'));
+
+      // check data in db
+      // 1 -> NetworkPortEthernet
+      $all_netportethernets = getAllDatasFromTable('glpi_networkportethernets', '', false, 'id');
+      $networkportethernet = end($all_netportethernets);
+      unset($networkportethernet['id']);
+      unset($networkportethernet['date_mod']);
+      unset($networkportethernet['date_creation']);
+      $expected = [
+          'networkports_id'             => $new_id,
+          'items_devicenetworkcards_id' => '0',
+          'netpoints_id'                => '0',
+          'type'                        => 'T',
+          'speed'                       => '1000',
+      ];
+      $this->assertEquals($expected, $networkportethernet);
+      // 2 -> NetworkName
+      $all_networknames = getAllDatasFromTable('glpi_networknames', '', false, 'id');
+      $networkname = end($all_networknames);
+      $networknames_id = $networkname['id'];
+      unset($networkname['id']);
+      unset($networkname['date_mod']);
+      unset($networkname['date_creation']);
+      $expected = [
+          'entities_id' => $computer1->fields['entities_id'],
+          'items_id'    => $new_id,
+          'itemtype'    => 'NetworkPort',
+          'name'        => 'test1',
+          'comment'     => 'test1 comment',
+          'fqdns_id'    => 0,
+          'is_deleted'  => 0,
+          'is_dynamic'  => 0,
+      ];
+      $this->assertEquals($expected, $networkname);
+      // 3 -> IPAddress
+      $all_ipadresses = getAllDatasFromTable('glpi_ipaddresses', '', false, 'id');
+      $ipadress = end($all_ipadresses);
+      unset($ipadress['id']);
+      unset($ipadress['date_mod']);
+      unset($ipadress['date_creation']);
+      $expected = [
+          'entities_id'  => $computer1->fields['entities_id'],
+          'items_id'     => $networknames_id,
+          'itemtype'     => 'NetworkName',
+          'version'      => '4',
+          'name'         => '192.168.20.1',
+          'binary_0'     => '0',
+          'binary_1'     => '0',
+          'binary_2'     => '65535',
+          'binary_3'     => '3232240641',
+          'is_deleted'   => '0',
+          'is_dynamic'   => '0',
+          'mainitems_id' => $computer1->getID(),
+          'mainitemtype' => 'Computer',
+      ];
+      $this->assertEquals($expected, $ipadress);
+
 
       // be sure added and have no logs
       $nb_log = countElementsInTable('glpi_logs');
-      $this->assertGreaterThan(0, $ins->add([
-         'items_id'           => $computer1->getID(),
-         'itemtype'           => 'Computer',
-         'entities_id'        => $computer1->fields['entities_id'],
-         'is_recursive'       => 0,
-         'logical_number'     => 4,
-         'mac'                => '00:24:81:eb:c6:d4',
-         'instantiation_type' => 'NetworkPortEthernet',
-         'name'               => 'em4',
-         'comment'            => 'Comment me!',
-         'netpoints_id'       => 0,
+      $new_id = $networkport->add([
+         'items_id'                    => $computer1->getID(),
+         'itemtype'                    => 'Computer',
+         'entities_id'                 => $computer1->fields['entities_id'],
+         'is_recursive'                => 0,
+         'logical_number'              => 4,
+         'mac'                         => '00:24:81:eb:c6:d4',
+         'instantiation_type'          => 'NetworkPortEthernet',
+         'name'                        => 'em4',
+         'comment'                     => 'Comment me!',
+         'netpoints_id'                => 0,
          'items_devicenetworkcards_id' => 0,
-         'type'               => 'T',
-         'speed'              => 1000,
-         'speed_other_value'  => '',
-         'NetworkName_name'   => 'test2.me',
-         'NetworkName_fqdns_id' => 0,
-         'NetworkName__ipaddresses' => ['-1' => '192.168.20.2']
-      ], [], false));
+         'type'                        => 'T',
+         'speed'                       => 1000,
+         'speed_other_value'           => '',
+         'NetworkName_name'            => 'test2',
+         'NetworkName_fqdns_id'        => 0,
+         'NetworkName__ipaddresses'    => ['-1' => '192.168.20.2']
+      ], [], false);
+      $this->assertGreaterThan(0, $new_id);
       $this->assertEquals($nb_log, countElementsInTable('glpi_logs'));
    }
 }


### PR DESCRIPTION
Here is some changes for networkports (to unlock the current situation) and fix #1178:

- picked "clone && getempty" from https://github.com/glpi-project/glpi/pull/1156/files#diff-c7d747dcf81a3a688ca5443ebe40f31bL264 (last needed fix i think)
-  add a new input parameter _create_children to let the 9.1.1 keeps the previous behavior (0.90.x). My point is to have releases for ocs and fusion inventory plugins soon (if possible) and let theirs authors the time to support the new behavior.
- avoid notices with default initialization for _no_history 
- complete the unit tests suite by checking children tables. i fixed also network name who shouldn't have '.' char (fqdn yes).