### PR TITLE
WIP : 1227 multiple acountless actors

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -1283,14 +1283,18 @@ abstract class CommonITILObject extends CommonDBTM {
       if (!is_null($useractors)) {
          if (isset($this->input["_users_id_requester"])) {
 
-            if (is_array($this->input["_users_id_requester"])) {
-               $tab_requester = array_unique($this->input["_users_id_requester"]);
-            } else {
+            if (!is_array($this->input["_users_id_requester"])) {
                $tab_requester   = array();
                $tab_requester[] = $this->input["_users_id_requester"];
             }
 
+            $requesterToAdd = array();
             foreach ($tab_requester as $key_requester => $requester) {
+               if (in_array($requester, $requesterToAdd)) {
+                  // This requester ID is already added;
+                  continue;
+               }
+
                $input2 = array($useractors->getItilObjectForeignKey() => $this->fields['id'],
                               'users_id'                              => $requester,
                               'type'                                  => CommonITILActor::REQUESTER);
@@ -1306,6 +1310,8 @@ abstract class CommonITILObject extends CommonDBTM {
                    && (!isset($input2['alternative_email'])
                        || empty($input2['alternative_email']))) {
                   continue;
+               } else {
+                  $requesterToAdd[] = $requester;
                }
 
                $input2['_from_object'] = true;
@@ -1316,13 +1322,19 @@ abstract class CommonITILObject extends CommonDBTM {
          if (isset($this->input["_users_id_observer"])) {
 
             if (is_array($this->input["_users_id_observer"])) {
-               $tab_observer = array_unique($this->input["_users_id_observer"]);
-            } else {
+               $tab_observer = $this->input["_users_id_observer"];
+               } else {
                $tab_observer   = array();
                $tab_observer[] = $this->input["_users_id_observer"];
             }
 
+            $observerToAdd = array();
             foreach ($tab_observer as $key_observer => $observer) {
+               if (in_array($observer, $observerToAdd)) {
+                  // This observer ID is already added;
+                  continue;
+               }
+
                $input2 = array($useractors->getItilObjectForeignKey() => $this->fields['id'],
                               'users_id'                              => $observer,
                               'type'                                  => CommonITILActor::OBSERVER);
@@ -1338,6 +1350,8 @@ abstract class CommonITILObject extends CommonDBTM {
                    && (!isset($input2['alternative_email'])
                        || empty($input2['alternative_email']))) {
                   continue;
+               } else {
+                  $observerToAdd[] = $observer;
                }
 
                $input2['_from_object'] = true;
@@ -1347,14 +1361,20 @@ abstract class CommonITILObject extends CommonDBTM {
 
          if (isset($this->input["_users_id_assign"])) {
 
-            if (is_array($this->input["_users_id_assign"])) {
-               $tab_assign = array_unique($this->input["_users_id_assign"]);
+            if (!is_array($this->input["_users_id_assign"])) {
+               $tab_assign = $this->input["_users_id_assign"];
             } else {
                $tab_assign   = array();
                $tab_assign[] = $this->input["_users_id_assign"];
             }
 
+            $assignToAdd = array();
             foreach ($tab_assign as $key_assign => $assign) {
+               if (in_array($assign, $assignToAdd)) {
+                  // This assigned user ID is already added;
+                  continue;
+               }
+
                $input2 = array($useractors->getItilObjectForeignKey() => $this->fields['id'],
                               'users_id'                              => $assign,
                               'type'                                  => CommonITILActor::ASSIGN);
@@ -1370,6 +1390,8 @@ abstract class CommonITILObject extends CommonDBTM {
                    && (!isset($input2['alternative_email'])
                        || empty($input2['alternative_email']))) {
                   continue;
+               } else {
+                  $assignToAdd[] = $assign;
                }
 
                $input2['_from_object'] = true;
@@ -1411,12 +1433,18 @@ abstract class CommonITILObject extends CommonDBTM {
              && ($this->input["_suppliers_id_assign"] > 0)) {
 
             if (is_array($this->input["_suppliers_id_assign"])) {
-               $tab_assign = array_unique($this->input["_suppliers_id_assign"]);
+               $tab_assign = $this->input["_suppliers_id_assign"];
             } else {
                $tab_assign   = array();
                $tab_assign[] = $this->input["_suppliers_id_assign"];
             }
+
+            $supplierToAdd = array();
             foreach ($tab_assign as $key_assign => $assign) {
+               if (in_array($assign, $supplierToAdd)) {
+                  // This assigned supplier ID is already added;
+                  continue;
+               }
                $input3 = array($supplieractors->getItilObjectForeignKey()
                                               => $this->fields['id'],
                                'suppliers_id' => $assign,
@@ -1433,6 +1461,8 @@ abstract class CommonITILObject extends CommonDBTM {
                    && (!isset($input3['alternative_email'])
                        || empty($input3['alternative_email']))) {
                   continue;
+               } else {
+                  $supplierToAdd[] = $assign;
                }
 
                 $input3['_from_object'] = true;

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -1283,7 +1283,9 @@ abstract class CommonITILObject extends CommonDBTM {
       if (!is_null($useractors)) {
          if (isset($this->input["_users_id_requester"])) {
 
-            if (!is_array($this->input["_users_id_requester"])) {
+            if (is_array($this->input["_users_id_requester"])) {
+               $tab_requester = $this->input["_users_id_requester"];
+            } else {
                $tab_requester   = array();
                $tab_requester[] = $this->input["_users_id_requester"];
             }
@@ -1310,7 +1312,7 @@ abstract class CommonITILObject extends CommonDBTM {
                    && (!isset($input2['alternative_email'])
                        || empty($input2['alternative_email']))) {
                   continue;
-               } else {
+               } else if ($requester != 0) {
                   $requesterToAdd[] = $requester;
                }
 
@@ -1323,7 +1325,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
             if (is_array($this->input["_users_id_observer"])) {
                $tab_observer = $this->input["_users_id_observer"];
-               } else {
+            } else {
                $tab_observer   = array();
                $tab_observer[] = $this->input["_users_id_observer"];
             }
@@ -1350,7 +1352,7 @@ abstract class CommonITILObject extends CommonDBTM {
                    && (!isset($input2['alternative_email'])
                        || empty($input2['alternative_email']))) {
                   continue;
-               } else {
+               } else if ($observer != 0) {
                   $observerToAdd[] = $observer;
                }
 
@@ -1361,7 +1363,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
          if (isset($this->input["_users_id_assign"])) {
 
-            if (!is_array($this->input["_users_id_assign"])) {
+            if (is_array($this->input["_users_id_assign"])) {
                $tab_assign = $this->input["_users_id_assign"];
             } else {
                $tab_assign   = array();
@@ -1390,7 +1392,7 @@ abstract class CommonITILObject extends CommonDBTM {
                    && (!isset($input2['alternative_email'])
                        || empty($input2['alternative_email']))) {
                   continue;
-               } else {
+               } else if ($assign != 0) {
                   $assignToAdd[] = $assign;
                }
 
@@ -1461,11 +1463,11 @@ abstract class CommonITILObject extends CommonDBTM {
                    && (!isset($input3['alternative_email'])
                        || empty($input3['alternative_email']))) {
                   continue;
-               } else {
+               } else if ($assign != 0) {
                   $supplierToAdd[] = $assign;
                }
 
-                $input3['_from_object'] = true;
+               $input3['_from_object'] = true;
                $supplieractors->add($input3);
             }
          }

--- a/inc/ruleticketcollection.class.php
+++ b/inc/ruleticketcollection.class.php
@@ -9,7 +9,7 @@
 
  based on GLPI - Gestionnaire Libre de Parc Informatique
  Copyright (C) 2003-2014 by the INDEPNET Development Team.
- 
+
  -------------------------------------------------------------------------
 
  LICENSE
@@ -112,8 +112,13 @@ class RuleTicketCollection extends RuleCollection {
       $input['_groups_id_of_requester'] = array();
       // Get groups of users
       if (isset($input['_users_id_requester'])) {
-         foreach (Group_User::getUserGroups($input['_users_id_requester']) as $g) {
-            $input['_groups_id_of_requester'][$g['id']] = $g['id'];
+         if (!is_array($input['_users_id_requester'])) {
+            $input['_users_id_requester'] = array($input['_users_id_requester']);
+         }
+         foreach ($input['_users_id_requester'] as $uid) {
+            foreach (Group_User::getUserGroups($uid) as $g) {
+               $input['_groups_id_of_requester'][$g['id']] = $g['id'];
+            }
          }
       }
       return $input;

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1504,6 +1504,7 @@ class Ticket extends CommonITILObject {
       // Set unset variables with are needed
       $user = new User();
       if (isset($input["_users_id_requester"])
+          && !is_array($input["_users_id_requester"])
           && $user->getFromDB($input["_users_id_requester"])) {
          $input['users_locations'] = $user->fields['locations_id'];
          $tmprequester = $input["_users_id_requester"];
@@ -1531,6 +1532,7 @@ class Ticket extends CommonITILObject {
       $input = $this->computeDefaultValuesForAdd($input);
 
       if (isset($input['_users_id_requester'])
+          && !is_array($input['_users_id_requester'])
           && ($input['_users_id_requester'] != $tmprequester)) {
          // if requester set by rule, clear address from mailcollector
          unset($input['_users_id_requester_notif']);
@@ -1607,9 +1609,12 @@ class Ticket extends CommonITILObject {
       }
 
       // Replay setting auto assign if set in rules engine or by auto_assign_mode
-      if (((isset($input["_users_id_assign"]) && ($input["_users_id_assign"] > 0))
-           || (isset($input["_groups_id_assign"]) && ($input["_groups_id_assign"] > 0))
-           || (isset($input["_suppliers_id_assign"]) && ($input["_suppliers_id_assign"] > 0)))
+      if (((isset($input["_users_id_assign"]) && ($input["_users_id_assign"] > 0)
+           || is_array($input['_users_id_assign']) && count($input['_users_id_assign']) > 0)
+           || (isset($input["_groups_id_assign"]) && ($input["_groups_id_assign"] > 0)
+           || is_array($input['_groups_id_assign']) && count($input['_groups_id_assign']) > 0)
+           || (isset($input["_suppliers_id_assign"]) && ($input["_suppliers_id_assign"] > 0)
+           || is_array($input['_suppliers_id_assign']) && count($input['_suppliers_id_assign']) > 0))
           && (in_array($input['status'], $this->getNewStatusArray()))) {
 
          $input["status"] = self::ASSIGNED;

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1610,13 +1610,13 @@ class Ticket extends CommonITILObject {
 
       // Replay setting auto assign if set in rules engine or by auto_assign_mode
       if (((isset($input["_users_id_assign"])
-           && (($input["_users_id_assign"] > 0)
+           && ((!is_array($input['_users_id_assign']) &&  $input["_users_id_assign"] > 0)
                || is_array($input['_users_id_assign']) && count($input['_users_id_assign']) > 0))
            || (isset($input["_groups_id_assign"])
-           && (($input["_groups_id_assign"] > 0)
+           && ((!is_array($input['_groups_id_assign']) && $input["_groups_id_assign"] > 0)
                || is_array($input['_groups_id_assign']) && count($input['_groups_id_assign']) > 0))
            || (isset($input["_suppliers_id_assign"])
-           && (($input["_suppliers_id_assign"] > 0)
+           && ((!is_array($input['_suppliers_id_assign']) && $input["_suppliers_id_assign"] > 0)
                || is_array($input['_suppliers_id_assign']) && count($input['_suppliers_id_assign']) > 0)))
           && (in_array($input['status'], $this->getNewStatusArray()))) {
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1609,12 +1609,15 @@ class Ticket extends CommonITILObject {
       }
 
       // Replay setting auto assign if set in rules engine or by auto_assign_mode
-      if (((isset($input["_users_id_assign"]) && ($input["_users_id_assign"] > 0)
-           || is_array($input['_users_id_assign']) && count($input['_users_id_assign']) > 0)
-           || (isset($input["_groups_id_assign"]) && ($input["_groups_id_assign"] > 0)
-           || is_array($input['_groups_id_assign']) && count($input['_groups_id_assign']) > 0)
-           || (isset($input["_suppliers_id_assign"]) && ($input["_suppliers_id_assign"] > 0)
-           || is_array($input['_suppliers_id_assign']) && count($input['_suppliers_id_assign']) > 0))
+      if (((isset($input["_users_id_assign"])
+           && (($input["_users_id_assign"] > 0)
+               || is_array($input['_users_id_assign']) && count($input['_users_id_assign']) > 0))
+           || (isset($input["_groups_id_assign"])
+           && (($input["_groups_id_assign"] > 0)
+               || is_array($input['_groups_id_assign']) && count($input['_groups_id_assign']) > 0))
+           || (isset($input["_suppliers_id_assign"])
+           && (($input["_suppliers_id_assign"] > 0)
+               || is_array($input['_suppliers_id_assign']) && count($input['_suppliers_id_assign']) > 0)))
           && (in_array($input['status'], $this->getNewStatusArray()))) {
 
          $input["status"] = self::ASSIGNED;

--- a/tests/TicketTest.php
+++ b/tests/TicketTest.php
@@ -1,0 +1,119 @@
+<?php
+/*
+ -------------------------------------------------------------------------
+ GLPI - Gestionnaire Libre de Parc Informatique
+ Copyright (C) 2015-2016 Teclib'.
+
+ http://glpi-project.org
+
+ based on GLPI - Gestionnaire Libre de Parc Informatique
+ Copyright (C) 2003-2014 by the INDEPNET Development Team.
+
+ -------------------------------------------------------------------------
+
+ LICENSE
+
+ This file is part of GLPI.
+
+ GLPI is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+
+ GLPI is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ --------------------------------------------------------------------------
+ */
+
+/* Test for inc/ticket.class.php */
+
+class TicketTest extends PHPUnit_Framework_TestCase {
+
+   public function ticketProvider() {
+      return array(
+            'single requester'   => array(
+                  array(
+                     '_users_id_requester'   => '3'
+                  ),
+            ),
+            'multiple requesters'   => array(
+                  array(
+                        '_users_id_requester'   => array('3', '5'),
+                  ),
+            ),
+            'single observer'   => array(
+                  array(
+                        '_users_id_observer'   => '3'
+                  ),
+            ),
+            'multiple observers'   => array(
+                  array(
+                        '_users_id_observer'   => array('3', '5'),
+                  ),
+            ),
+            'single assign'   => array(
+                  array(
+                        '_users_id_observer'   => '3'
+                  ),
+            ),
+            'multiple assigns'   => array(
+                  array(
+                        '_users_id_observer'   => array('3', '5'),
+                  ),
+            ),
+      );
+   }
+
+   /**
+    * @dataProvider ticketProvider
+    */
+   public function testCreateTicketWithActors($ticketActors) {
+      $ticket = new Ticket();
+      $ticket->add(array(
+            'name'         => 'ticket title',
+            'description'  => 'a description'
+      ) + $ticketActors);
+
+      $this->assertFalse($ticket->isNewItem());
+      $ticketId = $ticket->getID();
+
+      foreach ($ticketActors as $actorType => $actorsList) {
+         // Convert single actor (scalar value) to array
+         if (!is_array($actorsList)) {
+            $actorsList = array($actorsList);
+         }
+
+         // Check all actors are assigned to the ticket
+         foreach ($actorsList as $actor) {
+            switch ($actorType) {
+               case '_users_id_assign':
+                  $this->_testTicketUser($ticket, $actor, CommonITILActor::REQUESTER);
+                  break;
+               case '_users_id_observer':
+                  $this->_testTicketUser($ticket, $actor, CommonITILActor::OBSERVER);
+                  break;
+               case '_users_id_assign':
+                  $this->_testTicketUser($ticket, $actor, CommonITILActor::ASSIGN);
+                  break;
+            }
+         }
+      }
+   }
+
+   protected function _testTicketUser(Ticket $ticket, $actor, $role) {
+      $user = new User();
+      $user->getFromDB($actor);
+      $this->assertFalse($user->isNewItem());
+
+      $ticketUser = new Ticket_User();
+      $ticketUser->getFromDBForItems($ticket, $user);
+      $this->assertFalse($ticketUser->isNewItem());
+      $this->assertEquals($role, $ticketUser->getField('type'));
+   }
+
+}


### PR DESCRIPTION
There are 2 problems : 
- deduplication of users does not works for emails which don't match a user account
- some code has been added to allow Ticket::add() to add several users at once for a single actor type (requester, observer, ...) but not usable by a plugin yet (see #21 and #56)

