### PR TITLE
WIP - proposal - Api blacklist fields

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -447,12 +447,10 @@ abstract class API extends CommonGLPI {
          return $this->messageRightError();
       }
 
-      $fields =  $item->fields;
-
       // avoid disclosure of critical fields
-      foreach($this->excluded_fields as $key) {
-         unset($fields[$key]);
-      }
+      $item->post_getFromDBByApi();
+
+      $fields =  $item->fields;
 
       // retrieve devices
       if (isset($params['with_devices'])

--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -108,7 +108,12 @@ class AuthLDAP extends CommonDBTM {
    }
 
 
-   /**
+   function post_getFromDbByApi() {
+      unset($this->fields['rootdn_passwd']);
+   }
+
+
+    /**
     * Preconfig datas for standard system
     *
     * @param $type type of standard system : AD

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -223,6 +223,16 @@ class CommonDBTM extends CommonGLPI {
 
 
    /**
+    * List of fields to not return from the API
+    * 
+    * @return array of fields to not provide
+    */
+   static function getApiExcludedFields() {
+      return $this->apiFieldBlacklist;
+   }
+
+
+   /**
     * Retrieve all items from the database
     *
     * @param $condition    condition used to search if needed (empty get all) (default '')

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -223,12 +223,11 @@ class CommonDBTM extends CommonGLPI {
 
 
    /**
-    * List of fields to not return from the API
+    * Obsfucate sensitive data when the item is retrieved by an API
     * 
     * @return array of fields to not provide
     */
-   static function getApiExcludedFields() {
-      return $this->apiFieldBlacklist;
+   function post_getFromDbByApi() {
    }
 
 

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -239,6 +239,13 @@ class Config extends CommonDBTM {
    }
 
 
+   function post_getFromDbByApi() {
+      if ($this->fields['context'] == 'core' && in_array($this->fields['name'], array('smtp_passwd', 'proxy_passwd'))) {
+         $this->fields['value'] = '';
+      }
+   }
+
+
    /**
     * Print the config form for display
     *

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -245,6 +245,54 @@ class Config extends CommonDBTM {
       }
    }
 
+   function getSearchOptions() {
+      $tab                     = array();
+      $tab['common']           =__('Characteristics');
+
+      $tab[1]['table']         = $this->getTable();
+      $tab[1]['field']         = 'name';
+      $tab[1]['name']          = __('Name');
+      $tab[1]['datatype']      = 'itemlink';
+      $tab[1]['massiveaction'] = false;
+
+      $tab[2]['table']         = $this->getTable();
+      $tab[2]['field']         = 'id';
+      $tab[2]['name']          = __('ID');
+      $tab[2]['datatype']      = 'number';
+      $tab[2]['massiveaction'] = false;
+
+      $tab[3]['table']         = $this->getTable();
+      $tab[3]['field']         = 'context';
+      $tab[3]['name']          = __('Context');
+      $tab[3]['datatype']      = 'string';
+      $tab[3]['massiveaction'] = false;
+
+      $tab[4]['table']         = $this->getTable();
+      $tab[4]['field']         = 'value';
+      $tab[4]['name']          = __('Value');
+      $tab[4]['datatype']      = 'string';
+      $tab[4]['massiveaction'] = false;
+
+      return $tab;
+   }
+
+   static function addVisibilityRestrict() {
+      $condition = '';
+      $link = '';
+
+      $protectedValues = Plugin::doHookFunction('undiscloseConfig', array());
+      $protectedValues['core'] = array(
+            'proxy_passwd',
+            'smtp_passwd',
+      );
+      foreach ($protectedValues as $context => $values) {
+         $values = "'" . implode("', '", $values) . "'";
+         $condition .= " $link (`glpi_configs`.`context` = '$context' 
+                        AND `glpi_configs`.`name` IN ($values))"; 
+         $link = 'OR';
+      }
+      return "NOT (" . $condition . ")";
+   }
 
    /**
     * Print the config form for display

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2767,6 +2767,9 @@ class Search {
                   $condition .= ") ";
                }
                return $condition;
+         
+            case 'Config':
+               return Config::addVisibilityRestrict();
 
          default :
             // Plugin can override core definition for its type

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -278,6 +278,11 @@ class User extends CommonDBTM {
    }
 
 
+   function post_getFromDbByApi() {
+      unset($this->fields['password']);
+   }
+
+
    function pre_deleteItem() {
       global $DB;
 


### PR DESCRIPTION
This is an attempt to avoid disclosure of sensitive data : 

- Config now have search options making them useable with an API
- To prevent some sensitive settings to be disclosed, I added a default Where clause for Config
- To allow plugins to protect their own settings in Config, I added a new hook (I don't see a better way)

itemtypes from a plugin may need to protect some fields too. I added a empty method in CommonDBTM to override in itemtypes to empty sensitive fields, w hen needed (and ported the already protected fields in GLPi).

Hook tested with a plugin

Still Needs Unit Tests, and comments
