### PR TITLE
Some improvements

### DIFF
--- a/tests/DbFunctionTest.php
+++ b/tests/DbFunctionTest.php
@@ -382,8 +382,8 @@ class DbFunctionTest extends DbTestCase {
       $it = new DBmysqlIterator(NULL, 'glpi_computers', getEntitiesRestrictCriteria('glpi_computers', '', '', true));
       $this->assertEquals('SELECT * FROM `glpi_computers` WHERE (`glpi_computers`.`entities_id` IN (3) OR (`glpi_computers`.`is_recursive` = 1 AND `glpi_computers`.`entities_id` IN (0, 1)))', $it->getSql());
 
-      // Child + parent without table
-      $this->assertEquals("WHERE ( `entities_id` IN ('3')  OR (`is_recursive`='1' AND `entities_id` IN ('0','1')) ) ",
+      // Child + parent without table - TODO: check the missing table warning has been added in logs
+      $this->assertEquals("WHERE ( `entities_id` IN ('3')  OR `entities_id` IN ('0','1') ) ",
                           getEntitiesRestrictRequest('WHERE', '', '', '', true));
       $it = new DBmysqlIterator(NULL, 'glpi_computers', getEntitiesRestrictCriteria('', '', '', true));
       $this->assertEquals('SELECT * FROM `glpi_computers` WHERE (`entities_id` IN (3) OR (`is_recursive` = 1 AND `entities_id` IN (0, 1)))', $it->getSql());

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -57,6 +57,9 @@ class DbTestCase extends PHPUnit_Framework_TestCase {
          }
       }
       unset($DB->objcreated);
+
+      //reset entity in session
+      Session::changeActiveEntities(getItemByTypeName('Entity', '_test_root_entity',  true), true);
    }
 
 


### PR DESCRIPTION
* Reset entity after each tests to prevent issues,
* Improve recursivity detection in `getEntitiesRestrictRequest` function

Note that I've added a warning if `getEntitiesRestrictRequest` was called with an empty table, because of recursivity checking.
I've checked in the code, a table name is always provided. The only exception was in the unit tests.