### PR TITLE
fix warning

### DIFF
--- a/inc/apirest.class.php
+++ b/inc/apirest.class.php
@@ -222,7 +222,7 @@ class APIRest extends API {
             case "POST" : // create item(s)
                $response = $this->createItems($itemtype, $this->parameters);
                $code     = 201;
-               if (count($response) == 1) {
+               if (isset($response['id'])) {
                   // add a location targetting created element
                   $additionalheaders['location'] = self::$api_url.$itemtype."/".$response['id'];
                } else {


### PR DESCRIPTION
the api needs an other way to distinguish single item and multiple item
for POST because a single intem contains a message and count is always > 1