### PR TITLE
Fixed default user requester on multiple entities

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -3404,7 +3404,7 @@ class Ticket extends CommonITILObject {
       if (is_numeric(Session::getLoginUserID(false))) {
          $users_id_requester = Session::getLoginUserID();
          // No default requester if own ticket right = tech and update_ticket right to update requester
-         if (Session::haveRightsOr(self::$rightname, array(UPDATE, self::OWN))) {
+         if (Session::haveRightsOr(self::$rightname, array(UPDATE, self::OWN)) && !$_SESSION['glpiset_default_requester']) {
             $users_id_requester = 0;
          }
          $entity      = $_SESSION['glpiactive_entity'];


### PR DESCRIPTION
If default user requester is on multiple entities and `set_default_requester` option is true, not showing entity dropdown.