### PR TITLE
1383 fix single operation empty message

### DIFF
--- a/apirest.md
+++ b/apirest.md
@@ -1087,7 +1087,7 @@ $ curl -X DELETE \
 'http://path/to/glpi/apirest.php/Computer/'
 
 < 200 OK
-{"11":true, "message": ""}
+[{"11":true, "message": ""}]
 
 
 $ curl -X DELETE \

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1502,7 +1502,7 @@ abstract class API extends CommonGLPI {
             }
          } else {
             if ($failed > 0) {
-               $this->returnError($this->getGlpiLastMessage(), 400, "ERROR_GLPI_ADD", false);
+               $this->returnError($idCollection[0]['message'], 400, "ERROR_GLPI_ADD", false);
             } else {
                return $idCollection[0];
             }
@@ -1598,7 +1598,7 @@ abstract class API extends CommonGLPI {
             }
          } else {
             if ($failed > 0) {
-               $this->returnError($this->getGlpiLastMessage(), 400, "ERROR_GLPI_UPDATE", false);
+               $this->returnError($idCollection[0]['message'], 400, "ERROR_GLPI_UPDATE", false);
             } else {
                return $idCollection; // Return collection, even if the request affects a single item
             }
@@ -1696,7 +1696,7 @@ abstract class API extends CommonGLPI {
             }
          } else {
             if ($failed > 0) {
-               $this->returnError($this->getGlpiLastMessage(), 400, "ERROR_GLPI_DELETE", false);
+               $this->returnError($idCollection[0]['message'], 400, "ERROR_GLPI_DELETE", false);
             } else {
                return $idCollection; // Return collection, even if the request affects a single item
             }


### PR DESCRIPTION
getGlpiLastMessage() is destructive

also revert an error I introduced in my previous PR for the API documentation

