### PR TITLE
Add hook for plugin config confidentiality

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -244,6 +244,8 @@ class Config extends CommonDBTM {
          if ($fields['context'] == 'core'
             && in_array($fields['name'], self::$undisclosedFields)) {
             unset($fields['value']);
+         } else {
+            $fields = Plugin::doHookFunction('undiscloseConfigValue', $fields);
          }
       }
    }


### PR DESCRIPTION
If a plugin uses the itemtype Config to store its configuration, this hook provides a way to undisclose sensitive settings.

