### PR TITLE
Fix entities restriction on KB items; closes #1391

### DIFF
--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -396,11 +396,7 @@ class KnowbaseItem extends CommonDBTM {
                      return true;
                   }
                   // Restrict to entities
-                  $entities = array($group['entities_id']);
-                  if ($group['is_recursive']) {
-                     $entities = getSonsOf('glpi_entities', $group['entities_id']);
-                  }
-                  if (Session::haveAccessToOneOfEntities($entities, true)) {
+                  if (Session::haveAccessToEntity($group['entities_id'], $group['is_recursive'])) {
                      return true;
                   }
                }
@@ -414,11 +410,7 @@ class KnowbaseItem extends CommonDBTM {
 
          foreach ($this->entities as $key => $data) {
             foreach ($data as $entity) {
-               $entities = array($entity['entities_id']);
-               if ($entity['is_recursive']) {
-                  $entities = getSonsOf('glpi_entities', $entity['entities_id']);
-               }
-               if (Session::haveAccessToOneOfEntities($entities, true)) {
+               if (Session::haveAccessToEntity($entity['entities_id'], $entity['is_recursive'])) {
                   return true;
                }
             }
@@ -436,11 +428,7 @@ class KnowbaseItem extends CommonDBTM {
                   return true;
                }
                // Restrict to entities
-               $entities = array($profile['entities_id']);
-               if ($profile['is_recursive']) {
-                  $entities = getSonsOf('glpi_entities', $profile['entities_id']);
-               }
-               if (Session::haveAccessToOneOfEntities($entities, true)) {
+               if (Session::haveAccessToEntity($profile['entities_id'], $profile['is_recursive'])) {
                   return true;
                }
             }

--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -217,11 +217,7 @@ class Reminder extends CommonDBTM {
                      return true;
                   }
                   // Restrict to entities
-                  $entities = array($group['entities_id']);
-                  if ($group['is_recursive']) {
-                     $entities = getSonsOf('glpi_entities', $group['entities_id']);
-                  }
-                  if (Session::haveAccessToOneOfEntities($entities, true)) {
+                  if (Session::haveAccessToEntity($group['entities_id'], $groups['is_recursive'])) {
                      return true;
                   }
                }
@@ -234,11 +230,7 @@ class Reminder extends CommonDBTM {
           && isset($_SESSION["glpiactiveentities"]) && count($_SESSION["glpiactiveentities"])) {
          foreach ($this->entities as $key => $data) {
             foreach ($data as $entity) {
-               $entities = array($entity['entities_id']);
-               if ($entity['is_recursive']) {
-                  $entities = getSonsOf('glpi_entities', $entity['entities_id']);
-               }
-               if (Session::haveAccessToOneOfEntities($entities, true)) {
+               if (Session::haveAccessToEntity($entity['entities_id'], $entity['is_recursive'])) {
                   return true;
                }
             }

--- a/inc/rssfeed.class.php
+++ b/inc/rssfeed.class.php
@@ -231,11 +231,7 @@ class RSSFeed extends CommonDBTM {
                      return true;
                   }
                   // Restrict to entities
-                  $entities    = array($group['entities_id']);
-                  if ($group['is_recursive']) {
-                     $entities = getSonsOf('glpi_entities', $group['entities_id']);
-                  }
-                  if (Session::haveAccessToOneOfEntities($entities, true)) {
+                  if (Session::haveAccessToEntity($group['entities_id'], $group['is_recursive'])) {
                      return true;
                   }
                }
@@ -248,11 +244,7 @@ class RSSFeed extends CommonDBTM {
           && isset($_SESSION["glpiactiveentities"]) && count($_SESSION["glpiactiveentities"])) {
          foreach ($this->entities as $key => $data) {
             foreach ($data as $entity) {
-               $entities    = array($entity['entities_id']);
-               if ($entity['is_recursive']) {
-                  $entities = getSonsOf('glpi_entities', $entity['entities_id']);
-               }
-               if (Session::haveAccessToOneOfEntities($entities, true)) {
+               if (Session::haveAccessToEntity($entity['entities_id'], $entity['is_recursive'])) {
                   return true;
                }
             }
@@ -270,11 +262,7 @@ class RSSFeed extends CommonDBTM {
                   return true;
                }
                // Restrict to entities
-               $entities    = array($profile['entities_id']);
-               if ($profile['is_recursive']) {
-                  $entities = getSonsOf('glpi_entities',$profile['entities_id']);
-               }
-               if (Session::haveAccessToOneOfEntities($entities, true)) {
+               if (Session::haveAccessToEntity($profile['entities_id'], $profile['is_recursive'])) {
                   return true;
                }
             }


### PR DESCRIPTION
Two problems spotted:

* what is the need for `getSonsOf`?
* recursivity check should not be harcoded.

There are many, many possible use cases on KB along with entities, this would require a big set of unit tests; but probably in the master. 