### PR TITLE
Secure contexts

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -91,7 +91,7 @@ class Config extends CommonDBTM {
 
 
    function canViewItem() {
-      if (in_array($this->fields['context'], $_SESSION['glpi_plugins'])) {
+      if ($this->fields['context'] == 'core' || in_array($this->fields['context'], $_SESSION['glpi_plugins'])) {
          return true;
       }
       return false;

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -90,6 +90,14 @@ class Config extends CommonDBTM {
    }
 
 
+   function canViewItem() {
+      if (in_array($this->fields['context'], $_SESSION['glpi_plugins'])) {
+         return true;
+      }
+      return false;
+   }
+
+
    function defineTabs($options=array()) {
 
       $ong = array();

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2756,6 +2756,12 @@ class Search {
             }
             return $condition;
 
+         case 'Config':
+            $availableContexts = array('core') + $_SESSION['glpi_plugins'];
+            $availableContexts = implode("', '", $availableContexts);
+            $condition = "`context` IN ('$availableContexts')";
+            return $condition;
+
          default :
             // Plugin can override core definition for its type
             if ($plug = isPluginItemType($itemtype)) {


### PR DESCRIPTION
a inactive plugin cannot protect its configuration data from access via the API. 