### PR TITLE
should be an array, not a string

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -68,7 +68,7 @@ abstract class API extends CommonGLPI {
       ini_set('display_errors', 'Off');
 
       // Avoid keeping messages between api calls
-      $_SESSION["MESSAGE_AFTER_REDIRECT"] = '';
+      $_SESSION["MESSAGE_AFTER_REDIRECT"] = [];
 
       // check if api is enabled
       if (!$CFG_GLPI['enable_api']) {


### PR DESCRIPTION
api::getGlpiLastMessage() expects $_SESSION["MESSAGE_AFTER_REDIRECT"] to be an array. 

If there are no error message while processing a request, this method generates errors.

