### PR TITLE
#1476 - Display correct user & date of attachment of a file to a ticket

### DIFF
--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -108,6 +108,13 @@ class Document_Item extends CommonDBRelation{
                                'items_id'     => $input['items_id']]) > 0) {
          return false;
       }
+
+      // #1476 - Inject ID of the actual user to known who attach an already existing document
+      // to another item
+      if (!isset($input['users_id'])) {
+         $input['users_id'] = Session::getLoginUserID();
+      }
+
       return parent::prepareInputForAdd($input);
    }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -6047,7 +6047,12 @@ class Ticket extends CommonITILObject {
       $document_items = $document_item_obj->find("itemtype = 'Ticket' AND items_id = ".$this->getID());
       foreach ($document_items as $document_item) {
          $document_obj->getFromDB($document_item['documents_id']);
-         $timeline[$document_obj->fields['date_mod']."_document_".$document_item['documents_id']]
+
+         // #1476 - override document date_mod to ticket attachment date_mod
+         $document_obj->fields['date_mod'] = $document_item['date_mod'];
+         // #1476 - override document "owner" to ticket attachment user
+         $document_obj->fields['users_id'] = $document_item['users_id'];
+         $timeline[$document_item['date_mod']."_document_".$document_item['documents_id']]
             = array('type' => 'Document_Item', 'item' => $document_obj->fields);
       }
 

--- a/install/mysql/glpi-9.2-empty.sql
+++ b/install/mysql/glpi-9.2-empty.sql
@@ -2086,9 +2086,11 @@ CREATE TABLE `glpi_documents_items` (
   `entities_id` int(11) NOT NULL DEFAULT '0',
   `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
   `date_mod` datetime DEFAULT NULL,
+  `users_id` int(11) DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`documents_id`,`itemtype`,`items_id`),
-  KEY `item` (`itemtype`,`items_id`,`entities_id`,`is_recursive`)
+  KEY `item` (`itemtype`,`items_id`,`entities_id`,`is_recursive`),
+  KEY `users_id` (`users_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 

--- a/install/update_91_92.php
+++ b/install/update_91_92.php
@@ -212,6 +212,12 @@ function update91to92() {
    // add kb category to task categories
    $migration->addField("glpi_taskcategories", "knowbaseitemcategories_id", "integer");
 
+   // #1476 - Add users_id on glpi_documents_items
+   $migration->addField("glpi_documents_items", "users_id", "integer", ['null' => TRUE]);
+   $migration->addKey("glpi_documents_items", "users_id");
+   $query = "UPDATE glpi_documents_items GDI, glpi_documents GD SET GDI.users_id = GD.users_id WHERE GDI.documents_id = GD.id";
+   $DB->queryOrDie($query, "9.2 update set users_id on glpi_documents_items");
+
    // ************ Keep it at the end **************
    $migration->executeMigration();
 


### PR DESCRIPTION
Fix #1476 : if we attach an already existing document to a ticket, the attachment date is the file upload date & the user logged is the uploader

** Requiered #1560 to be merged first **