### PR TITLE
Duplicated main tab on some views; fixes #1197

### DIFF
--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -437,6 +437,12 @@ class CommonGLPI {
          case -1 :
             // get tabs and loop over
             $ong = $item->defineAllTabs(array('withtemplate' => $withtemplate));
+
+            if (self::isLayoutExcludedPage() && self::isLayoutWithMain()) {
+               //on classical and vertical split; the main tab is always displayed
+               array_shift($ong);
+            }
+
             if (count($ong)) {
                foreach ($ong as $key => $val) {
                   if ($key != 'empty') {


### PR DESCRIPTION
On classical and splitted views, the main tab
is always displayed, we do not need to display it
again on "all" tab