### PR TITLE
fix warning if no user is logged in

### DIFF
--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -579,7 +579,7 @@ class Link extends CommonDBTM {
                                                        'joinparams' => array('jointype'
                                                                               => 'itemtypeonly')));
       if (!Session::isCron()
-          && !isCommandLine()) {
+          && !isCommandLine() && isset($_SESSION['glpiID'])) {
          $tab[145]['joinparams']['condition'] = getEntitiesRestrictRequest('AND', 'NEWTABLE');
       }
 


### PR DESCRIPTION
Second proposal for #1534

This happens while a user is logging in. Auth::login() updates him with
history.

replaces #1581