### PR TITLE
distinguish false and 0 when adding an itemtype

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -849,7 +849,7 @@ class CommonDBTM extends CommonGLPI {
          }
 
          if ($this->checkUnicity(true,$options)) {
-            if ($this->addToDB()) {
+            if ($this->addToDB() !== false) {
                $this->post_addItem();
                $this->addMessageOnAddAction();
 


### PR DESCRIPTION
This may happen if the itemtype allows ID = 0
adding it will succeed but post-add hooks won't trigger