### PR TITLE
minimize impact of $('html') selector

### DIFF
--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -565,7 +565,7 @@ class Planning extends CommonGLPI {
       $(document).ready(function() {
          var disable_qtip = false,
              disable_edit = false;
-         $('html')
+         $('.planning_on_central a')
             .mousedown(function() {
                disable_qtip = true;
                $('.qtip').hide();


### PR DESCRIPTION
Changed it to $('.planning_on_central a') to reduce overall impact of the complete DOM when using $('html')
Fixes #1657