### PR TITLE
clean external auth; see #1548; should fix #1611

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -584,12 +584,7 @@ class Auth extends CommonGLPI {
             $login_name                        = $this->user->fields['name'];
             $this->auth_succeded               = true;
             $this->user_present                = $this->user->getFromDBbyName(addslashes($login_name));
-            if (self::isAlternateAuth($authtype)) {
-               $this->extauth                  = 0;
-            } else {
-               $this->extauth                  = 1;
-               $this->user->fields['authtype'] = $authtype;
-            }
+            $this->extauth                     = 1;
             $user_dn                           = false;
 
             $ldapservers = '';
@@ -768,10 +763,6 @@ class Auth extends CommonGLPI {
                // Then ensure addslashes
                $input = Toolbox::addslashes_deep($input);
 
-               // blank PWD to clean old database for the external auth
-               if ($this->extauth) {
-                  $input['_extauth'] = 1;
-               }
                $this->user->update($input);
             } else if ($CFG_GLPI["is_users_auto_add"]) {
                // Auto add user
@@ -1033,7 +1024,7 @@ class Auth extends CommonGLPI {
     * @return boolean
    **/
    static function isAlternateAuth($authtype) {
-      return in_array($authtype, array(self::X509, self::CAS, self::EXTERNAL, self::API));
+      return in_array($authtype, array(self::X509, self::CAS, self::EXTERNAL));
    }
 
 

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -1024,7 +1024,7 @@ class Auth extends CommonGLPI {
     * @return boolean
    **/
    static function isAlternateAuth($authtype) {
-      return in_array($authtype, array(self::X509, self::CAS, self::EXTERNAL));
+      return in_array($authtype, array(self::X509, self::CAS, self::EXTERNAL, self::API));
    }
 
 

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1506,13 +1506,8 @@ class Html {
       echo "<ul>";
 
       echo "<li id='deconnexion'>";
-      echo "<a href='".$CFG_GLPI["root_doc"]."/front/logout.php";
-            /// logout witout noAuto login for extauth
-      if (isset($_SESSION['glpiextauth']) && $_SESSION['glpiextauth']) {
-         echo "?noAUTO=1";
-      }
-
-      echo "' title=\"".__s('Logout')."\">";
+      echo "<a href='".$CFG_GLPI["root_doc"].
+                       "/front/logout.php?noAUTO=1' title=\"".__s('Logout')."\">";
       echo "<span id='logout_icon' title=\"".__s('Logout').
              "\"  alt=\"".__s('Logout')."\" class='button-icon'></span>";
       echo "</a>";

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -759,6 +759,7 @@ class User extends CommonDBTM {
 
       // blank password when authtype changes
       if (isset($input["authtype"])
+          && $input["authtype"] != 1
           && $input["authtype"] != $this->getField('authtype')) {
          $input["password"] = "";
       }

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -757,7 +757,9 @@ class User extends CommonDBTM {
          unset($input["password"]);
       }
 
-      if (isset($input["_extauth"])) {
+      // blank password when authtype changes
+      if (isset($input["authtype"])
+          && $input["authtype"] != $this->getField('authtype')) {
          $input["password"] = "";
       }
 


### PR DESCRIPTION
Ok, another change into auth system needed with the @tomolimo report in #1611.

A resume, in https://github.com/glpi-project/glpi/blob/master/inc/auth.class.php#L581
We are in a condition matching only alternate auth (l581).
So in the lower block if/else, we can never execute "else" part.

The noAuto=1 on logout requires $_SESSION['glpiextauth'] == true
see : https://github.com/glpi-project/glpi/blob/master/inc/html.class.php#L1430
and https://github.com/glpi-project/glpi/blob/b4f97248b3f7da1c787e94cceda6a25edde415bf/inc/session.class.php#L116

In case of autologin, we need to set $this->extauth = 1 to avoid relogin on logout.

IMO, the case of blanking password is needed when when change authtype of a user, so i completely unlink it from authtype or login.

Last changes:
- Api is not an external auth, i think
- Could we always set noAuto=1 in case of logout ?