### PR TITLE
Add a local define file for a clean override of some options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /config/config_db*
 /config/config_path.php
+/config/local_define.php
 /tests/config_db*
 /plugins/
 /files/

--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -38,8 +38,8 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
-include_once (GLPI_ROOT."/inc/define.php");
 include_once (GLPI_ROOT."/inc/based_config.php");
+include_once (GLPI_ROOT."/inc/define.php");
 
 define ('NS_GLPI', 'Glpi\\');
 define ('NS_PLUG', 'GlpiPlugin\\');

--- a/inc/define.php
+++ b/inc/define.php
@@ -35,14 +35,21 @@
 * @brief
 */
 
+if (file_exists(GLPI_CONFIG_DIR . '/local_define.php')) {
+   require_once GLPI_CONFIG_DIR . '/local_define.php';
+}
+
 // Current version of GLPI
 define("GLPI_VERSION", "9.2");
 define("GLPI_SCHEMA_VERSION", "9.2");
 define('GLPI_MIN_PHP', '5.6.0');
 define('GLPI_YEAR', '2016');
-define("GLPI_DEMO_MODE", "0");
-
-define("GLPI_USE_CSRF_CHECK", "1");
+if (!defined('GLPI_DEMO_MODE')) {
+   define('GLPI_DEMO_MODE', '0');
+}
+if (!defined('GLPI_USE_CSRF_CHECK')) {
+   define('GLPI_USE_CSRF_CHECK', '1');
+}
 define("GLPI_CSRF_EXPIRES", "7200");
 define("GLPI_CSRF_MAX_TOKENS", "100");
 

--- a/index.php
+++ b/index.php
@@ -40,6 +40,7 @@ use Glpi\Event;
 
 //Load GLPI constants
 define('GLPI_ROOT', __DIR__);
+include (GLPI_ROOT . "/inc/based_config.php");
 include_once (GLPI_ROOT . "/inc/define.php");
 
 // Check PHP version not to have trouble
@@ -48,9 +49,8 @@ if (version_compare(PHP_VERSION, GLPI_MIN_PHP) < 0) {
 }
 
 define('DO_NOT_CHECK_HTTP_REFERER', 1);
-// If config_db doesn't exist -> start installation
-include (GLPI_ROOT . "/inc/based_config.php");
 
+// If config_db doesn't exist -> start installation
 if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
    include_once (GLPI_ROOT . "/inc/autoload.function.php");
    Html::redirect("install/install.php");


### PR DESCRIPTION
Just create a `config/local_define.php`; add overdidable
defines declarations in it (GLPI_DEMO_MODE and GLPI_USE_CSRF_CHECK
for now)

Ensure based_config is always loaded before define file

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes