### PR TITLE
Fixing #1734

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -3855,11 +3855,11 @@ abstract class CommonITILObject extends CommonDBTM {
             $this->showActorAddFormOnCreate(CommonITILActor::OBSERVER, $options);
             echo '<hr>';
          } else { // predefined value
-            if (isset($options["_users_id_observer"]) && $options["_users_id_observer"]) {
+            if (isset($options["_users_id_observer"][0]) && $options["_users_id_observer"][0]) {
                echo self::getActorIcon('user', CommonITILActor::OBSERVER)."&nbsp;";
-               echo Dropdown::getDropdownName("glpi_users", $options["_users_id_observer"]);
+               echo Dropdown::getDropdownName("glpi_users", $options["_users_id_observer"][0]);
                echo "<input type='hidden' name='_users_id_observer' value=\"".
-                      $options["_users_id_observer"]."\">";
+                      $options["_users_id_observer"][0]."\">";
                echo '<hr>';
             }
          }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1734 

The commit ec5144cdbaaf8b78609c2cefbbec184759918c6b was letting users select many watchers on a single ticket on the self-service interface. This change made `$options["_users_id_observer"]` become an array. However, when the field is hidden, the dropdown is still waiting for a single id.
Since the default interface is not supporting many watchers on a single ticket, this fix is displaying the first user.

I'm not sure it's the cleanest way to do it, let me know if it should be done a different way.