### PR TITLE
Fix database inconsistency between raw 9.2 and 9.1 updated to 9.2

### DIFF
--- a/install/mysql/glpi-9.2-empty.sql
+++ b/install/mysql/glpi-9.2-empty.sql
@@ -2693,6 +2693,7 @@ CREATE TABLE `glpi_infocoms` (
   `date_mod` datetime DEFAULT NULL,
   `date_creation` datetime DEFAULT NULL,
   `decommission_date` datetime DEFAULT NULL,
+  `businesscriticities_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`itemtype`,`items_id`),
   KEY `buy_date` (`buy_date`),
@@ -2702,7 +2703,8 @@ CREATE TABLE `glpi_infocoms` (
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `businesscriticities_id` (`businesscriticities_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 
@@ -6835,17 +6837,17 @@ CREATE TABLE `glpi_softwarelicenses` (
 DROP TABLE IF EXISTS `glpi_softwarelicensetypes`;
 CREATE TABLE `glpi_softwarelicensetypes` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `entities_id` int(11) NOT NULL DEFAULT '0',
-  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `comment` text COLLATE utf8_unicode_ci,
   `date_mod` datetime DEFAULT NULL,
   `date_creation` datetime DEFAULT NULL,
   `softwarelicensetypes_id` int(11) NOT NULL DEFAULT '0',
-  `completename` text COLLATE utf8_unicode_ci,
   `level` int(11) NOT NULL DEFAULT '0',
   `ancestors_cache` longtext COLLATE utf8_unicode_ci,
   `sons_cache` longtext COLLATE utf8_unicode_ci,
+  `entities_id` int(11) NOT NULL DEFAULT '0',
+  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+  `completename` text COLLATE utf8_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
@@ -6853,7 +6855,7 @@ CREATE TABLE `glpi_softwarelicensetypes` (
   KEY `softwarelicensetypes_id` (`softwarelicensetypes_id`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
-INSERT INTO `glpi_softwarelicensetypes` VALUES ('1', '0', '1', 'OEM','',NULL,NULL, '0', 'OEM', '0',NULL,NULL);
+INSERT INTO `glpi_softwarelicensetypes` VALUES ('1', 'OEM', '', NULL, NULL, '0', '0', NULL, NULL, '0', '1', 'OEM');
 
 ### Dump table glpi_softwares
 
@@ -7103,7 +7105,6 @@ CREATE TABLE `glpi_taskcategories` (
   `entities_id` int(11) NOT NULL DEFAULT '0',
   `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
   `taskcategories_id` int(11) NOT NULL DEFAULT '0',
-  `knowbaseitemcategories_id` int(11) NOT NULL DEFAULT '0',
   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `completename` text COLLATE utf8_unicode_ci,
   `comment` text COLLATE utf8_unicode_ci,
@@ -7114,16 +7115,17 @@ CREATE TABLE `glpi_taskcategories` (
   `is_helpdeskvisible` tinyint(1) NOT NULL DEFAULT '1',
   `date_mod` datetime DEFAULT NULL,
   `date_creation` datetime DEFAULT NULL,
+  `knowbaseitemcategories_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `taskcategories_id` (`taskcategories_id`),
-  KEY `knowbaseitemcategories_id` (`knowbaseitemcategories_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `is_active` (`is_active`),
   KEY `is_helpdeskvisible` (`is_helpdeskvisible`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `knowbaseitemcategories_id` (`knowbaseitemcategories_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 

--- a/install/update_91_92.php
+++ b/install/update_91_92.php
@@ -158,7 +158,7 @@ function update91to92() {
                  `name` text COLLATE utf8_unicode_ci,
                  `answer` longtext COLLATE utf8_unicode_ci,
                  `language` varchar(5) COLLATE utf8_unicode_ci DEFAULT NULL,
-                 `users_id` int(11) NOT NULL,
+                 `users_id` int(11) NOT NULL DEFAULT '0',
                  `date_creation` datetime DEFAULT NULL,
                  PRIMARY KEY (`id`),
                  UNIQUE KEY `unicity` (`knowbaseitems_id`, `revision`, `language`),
@@ -187,8 +187,8 @@ function update91to92() {
       }
    }
 
-   $migration->addField("glpi_knowbaseitemtranslations", "date_creation", "DATE");
-   $migration->addField("glpi_knowbaseitemtranslations", "date_mod", "DATE");
+   $migration->addField("glpi_knowbaseitemtranslations", "date_mod", "DATETIME");
+   $migration->addField("glpi_knowbaseitemtranslations", "date_creation", "DATETIME");
 
    $migration->displayMessage(sprintf(__('Add of - %s to database'), 'Knowbase item comments'));
    if (!TableExists('glpi_knowbaseitems_comments')) {
@@ -213,6 +213,7 @@ function update91to92() {
 
    // add kb category to task categories
    $migration->addField("glpi_taskcategories", "knowbaseitemcategories_id", "integer");
+   $migration->addKey("glpi_taskcategories", "knowbaseitemcategories_id");
 
    // #1476 - Add users_id on glpi_documents_items
    $migration->addField("glpi_documents_items", "users_id", "integer", ['null' => TRUE]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

A diff on a dump from a database created directly on current master and another one from a fresh 9.1 database updated to master shows differences.