### PR TITLE
permits to add tasks (from tasktemplates) in tickettemplates

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -3222,7 +3222,8 @@ a.copyright {
 }
 
 .timeline_history .h_content.edited {
-   max-width: 60%;
+   max-width: inherit;
+   width: 69%;
    text-align: center;
 }
 

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -824,6 +824,24 @@ abstract class CommonITILTask  extends CommonDBTM {
          ]
       ];
 
+      $tab[] = [
+         'id'                 => '175',
+         'table'              => TaskTemplate::getTable(),
+         'field'              => 'name',
+         'linkfield'          => 'tasktemplates_id',
+         'name'               => __('Task template'),
+         'datatype'           => 'dropdown',
+         'massiveaction'      => false,
+         'joinparams'         => [
+            'beforejoin'         => [
+               'table'              => static::getTable(),
+               'joinparams'         => [
+                  'jointype'           => 'child'
+               ]
+            ]
+         ]
+      ];
+
       return $tab;
    }
 
@@ -1328,9 +1346,8 @@ abstract class CommonITILTask  extends CommonDBTM {
       echo "<td rowspan='$rowspan' style='width:100px'>".__('Description')."</td>";
       echo "<td rowspan='$rowspan' style='width:65%' id='content$rand_text'>";
 
-      $rand_text = mt_rand();
-      $content_id = "content$rand";
-
+      $rand_text  = mt_rand();
+      $content_id = "content$rand_text";
       $cols       = 90;
       $rows       = 6;
       if ($CFG_GLPI["use_rich_text"]) {
@@ -1353,7 +1370,7 @@ abstract class CommonITILTask  extends CommonDBTM {
 
       echo "<tr class='tab_bg_1'>";
       echo "<td style='width:100px'>"._n('Task template', 'Task templates', 1)."</td><td>";
-      TaskTemplate::dropdown(array('value'     => 0,
+      TaskTemplate::dropdown(array('value'     => $this->fields['tasktemplates_id'],
                                    'entity'    => $this->getEntityID(),
                                    'rand'      => $rand_template,
                                    'on_change' => 'tasktemplate_update(this.value)'));
@@ -1361,19 +1378,30 @@ abstract class CommonITILTask  extends CommonDBTM {
       echo "</tr>";
       echo Html::scriptBlock('
          function tasktemplate_update(value) {
-            jQuery.ajax({
+            $.ajax({
                url: "' . $CFG_GLPI["root_doc"] . '/ajax/task.php",
                type: "POST",
                data: {
                   tasktemplates_id: value
                }
-            }).done(function(datas) {
-               datas.taskcategories_id = isNaN(parseInt(datas.taskcategories_id)) ? 0 : parseInt(datas.taskcategories_id);
-               datas.actiontime = isNaN(parseInt(datas.actiontime)) ? 0 : parseInt(datas.actiontime);
+            }).done(function(data) {
+               var taskcategories_id = isNaN(parseInt(data.taskcategories_id))
+                  ? 0
+                  : parseInt(data.taskcategories_id);
+               var actiontime = isNaN(parseInt(data.actiontime))
+                  ? 0
+                  : parseInt(data.actiontime);
 
-               $("#task' . $rand_text . '").html(datas.content);
-               $("#dropdown_taskcategories_id' . $rand_type . '").select2("val", parseInt(datas.taskcategories_id));
-               $("#dropdown_actiontime' . $rand_time . '").select2("val", parseInt(datas.actiontime));
+               // set textarea content
+               $("#content'.$rand_text.'").html(data.content);
+               // set also tinmyce (if enabled)
+               if (tasktinymce = tinymce.get("content'.$rand_text.'")) {
+                  tasktinymce.setContent(data.content);
+               }
+               // set category
+               $("#dropdown_taskcategories_id'.$rand_type.'").select2("val", taskcategories_id);
+               // set action time
+               $("#dropdown_actiontime'.$rand_time.'").select2("val", actiontime);
             });
          }
       ');

--- a/inc/tasktemplate.class.php
+++ b/inc/tasktemplate.class.php
@@ -59,16 +59,29 @@ class TaskTemplate extends CommonDropdown {
 
    function getAdditionalFields() {
 
-      return array(array('name'  => 'taskcategories_id',
+      return array(array('name'  => 'content',
+                         'label' => __('Content'),
+                         'type'  => 'textarea'),
+                   array('name'  => 'taskcategories_id',
                          'label' => __('Task category'),
                          'type'  => 'dropdownValue',
                          'list'  => true),
+                   array('name'  => 'state',
+                         'label' => __('Status'),
+                         'type'  => 'state'),
+                   array('name'  => 'is_private',
+                         'label' => __('Private'),
+                         'type'  => 'bool'),
                    array('name'  => 'actiontime',
                          'label' => __('Duration'),
                          'type'  => 'actiontime'),
-                   array('name'  => 'content',
-                         'label' => __('Content'),
-                         'type'  => 'textarea'));
+                   array('name'  => 'users_id_tech',
+                         'label' => __('By'),
+                         'type'  => 'users_id_tech'),
+                   array('name'  => 'groups_id_tech',
+                         'label' => __('Group'),
+                         'type'  => 'groups_id_tech'),
+                  );
    }
 
 
@@ -102,6 +115,23 @@ class TaskTemplate extends CommonDropdown {
    function displaySpecificTypeField($ID, $field=array()) {
 
       switch ($field['type']) {
+         case 'state' :
+            Planning::dropdownState("state", $this->fields["state"]);
+            break;
+         case 'users_id_tech' :
+            User::dropdown(['name'   => "users_id_tech",
+                            'right'  => "own_ticket",
+                            'value'  => $this->fields["users_id_tech"],
+                            'entity' => $this->fields["entities_id"],
+            ]);
+            break;
+         case 'groups_id_tech' :
+            Group::dropdown(['name'     => "groups_id_tech",
+                            'condition' => "is_task",
+                            'value'     => $this->fields["groups_id_tech"],
+                            'entity'    => $this->fields["entities_id"],
+            ]);
+            break;
          case 'actiontime' :
             $toadd = array();
             for ($i=9; $i<=100; $i++) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1743,6 +1743,28 @@ class Ticket extends CommonITILObject {
          }
       }
 
+      // Add tasks in tasktemplates if defined in tickettemplate
+      if (isset($this->input['_tasktemplates_id'])
+          && is_array($this->input['_tasktemplates_id'])
+          && count($this->input['_tasktemplates_id'])) {
+         $tasktemplate = new TaskTemplate;
+         $tickettask   = new TicketTask;
+         foreach ($this->input['_tasktemplates_id'] as $tasktemplates_id) {
+            $tasktemplate->getFromDB($tasktemplates_id);
+            $tickettask->add(['tasktemplates_id'  => $tasktemplates_id,
+                              'content'           => $tasktemplate->fields['content'],
+                              'taskcategories_id' => $tasktemplate->fields['taskcategories_id'],
+                              'actiontime'        => $tasktemplate->fields['actiontime'],
+                              'state'             => $tasktemplate->fields['state'],
+                              'tickets_id'        => $this->fields['id'],
+                              'is_private'        => $tasktemplate->fields['is_private'],
+                              'users_id_tech'     => $tasktemplate->fields['users_id_tech'],
+                              'groups_id_tech'    => $tasktemplate->fields['groups_id_tech'],
+                              '_disablenotif'     => true
+                              ]);
+         }
+      }
+
       if (!empty($this->input['items_id'])) {
          $item_ticket = new Item_Ticket();
          foreach ($this->input['items_id'] as $itemtype => $items) {
@@ -3558,6 +3580,7 @@ class Ticket extends CommonITILObject {
                     'users_id_validate'         => array(),
                     'type'                      => $type,
                     '_documents_id'             => array(),
+                    '_tasktemplates_id'         => array(),
                     '_filename'                 => array(),
                     '_tag_filename'             => array());
    }
@@ -3906,6 +3929,11 @@ class Ticket extends CommonITILObject {
                 $CFG_GLPI["root_doc"]."/front/ticket.form.php'>";
          if (isset($options['_projecttasks_id'])) {
             echo "<input type='hidden' name='_projecttasks_id' value='".$options['_projecttasks_id']."'>";
+         }
+         if (isset($this->fields['_tasktemplates_id'])) {
+            foreach ($this->fields['_tasktemplates_id'] as $tasktemplates_id) {
+               echo "<input type='hidden' name='_tasktemplates_id[]' value='$tasktemplates_id'>";
+            }
          }
       }
       echo "<div class='spaced' id='tabsbody'>";

--- a/inc/tickettemplate.class.php
+++ b/inc/tickettemplate.class.php
@@ -188,15 +188,15 @@ class TicketTemplate extends CommonDropdown {
                      $ticket->getSearchOptionIDByField('field', 'global_validation',
                                                        'glpi_tickets')   => 'global_validation',
 
-                     4                                                   => '_users_id_requester',
-                     71                                                  => '_groups_id_requester',
-                     5                                                   => '_users_id_assign',
-                     8                                                   => '_groups_id_assign',
+                                                       4                 => '_users_id_requester',
+                                                       71                => '_groups_id_requester',
+                                                       5                 => '_users_id_assign',
+                                                       8                 => '_groups_id_assign',
                      $ticket->getSearchOptionIDByField('field', 'name',
                                                        'glpi_suppliers') => '_suppliers_id_assign',
 
-                     66                                                  => '_users_id_observer',
-                     65                                                  => '_groups_id_observer',
+                                                       66                => '_users_id_observer',
+                                                       65                => '_groups_id_observer',
              );
 
          if ($withtypeandcategory) {
@@ -225,6 +225,11 @@ class TicketTemplate extends CommonDropdown {
          $allowed_fields[$withtypeandcategory][$withitemtype]
                [$ticket->getSearchOptionIDByField('field', 'name',
                                                   'glpi_documents')] = '_documents_id';
+
+         // Add TicketTask (from task templates)
+         $allowed_fields[$withtypeandcategory][$withitemtype]
+               [$ticket->getSearchOptionIDByField('field', 'name',
+                                                  TaskTemplate::getTable())] = '_tasktemplates_id';
       }
 
       return $allowed_fields[$withtypeandcategory][$withitemtype];
@@ -243,6 +248,10 @@ class TicketTemplate extends CommonDropdown {
          switch ($ID) {
             case -2 :
                $tab[-2] = __('Approval request');
+               break;
+
+            case 175 :
+               $tab[175] = CommonITILTask::getTypeName();
                break;
 
             default :

--- a/inc/tickettemplatehiddenfield.class.php
+++ b/inc/tickettemplatehiddenfield.class.php
@@ -163,6 +163,20 @@ class TicketTemplateHiddenField extends CommonDBChild {
 
 
    /**
+    * Return fields who doesn't need to be used for this part of template
+    *
+    * @since 9.2
+    *
+    * @return array the excluded fields (keys and values are equals)
+    */
+   static function getExcludedFields() {
+      return [
+         175 => 175, // ticket's tasks (template)
+      ];
+   }
+
+
+   /**
     * Print the hidden fields
     *
     * @since version 0.83
@@ -186,6 +200,7 @@ class TicketTemplateHiddenField extends CommonDBChild {
 
       $canedit = $tt->canEdit($ID);
       $fields  = $tt->getAllowedFieldsNames(false);
+      $fields  = array_diff_key($fields, self::getExcludedFields());
       $rand    = mt_rand();
 
       $query = "SELECT `glpi_tickettemplatehiddenfields`.*

--- a/inc/tickettemplatemandatoryfield.class.php
+++ b/inc/tickettemplatemandatoryfield.class.php
@@ -163,6 +163,20 @@ class TicketTemplateMandatoryField extends CommonDBChild {
 
 
    /**
+    * Return fields who doesn't need to be used for this part of template
+    *
+    * @since 9.2
+    *
+    * @return array the excluded fields (keys and values are equals)
+    */
+   static function getExcludedFields() {
+      return [
+         175 => 175, // ticket's tasks
+      ];
+   }
+
+
+   /**
     * Print the mandatory fields
     *
     * @since version 0.83
@@ -184,6 +198,7 @@ class TicketTemplateMandatoryField extends CommonDBChild {
       $ttm               = new self();
       $used              = $ttm->getMandatoryFields($ID);
       $fields            = $tt->getAllowedFieldsNames(true);
+      $fields            = array_diff_key($fields, self::getExcludedFields());
       $simplified_fields = $tt->getSimplifiedInterfaceFields();
       $both_interfaces   = sprintf(__('%1$s + %2$s'), __('Simplified interface'), __
                                    ('Standard interface'));

--- a/inc/tickettemplatepredefinedfield.class.php
+++ b/inc/tickettemplatepredefinedfield.class.php
@@ -199,9 +199,24 @@ class TicketTemplatePredefinedField extends CommonDBChild {
 
       $ticket = new Ticket();
       $fields = array($ticket->getSearchOptionIDByField('field', 'name', 'glpi_documents'),
-                      $ticket->getSearchOptionIDByField('field', 'items_id', 'glpi_items_tickets'));
+                      $ticket->getSearchOptionIDByField('field', 'items_id', 'glpi_items_tickets'),
+                      $ticket->getSearchOptionIDByField('field', 'name', 'glpi_tasktemplates'),
+                     );
 
       return $fields;
+   }
+
+   /**
+    * Return fields who doesn't need to be used for this part of template
+    *
+    * @since 9.2
+    *
+    * @return array the excluded fields (keys and values are equals)
+    */
+   static function getExcludedFields() {
+      return [
+         -2 => -2, // validation request
+      ];
    }
 
 
@@ -227,6 +242,7 @@ class TicketTemplatePredefinedField extends CommonDBChild {
       $canedit       = $tt->canEdit($ID);
 
       $fields        = $tt->getAllowedFieldsNames(true, true);
+      $fields        = array_diff_key($fields, self::getExcludedFields());
       $searchOption  = Search::getOptions('Ticket');
       $ticket        = new Ticket();
       $rand          = mt_rand();
@@ -260,8 +276,6 @@ class TicketTemplatePredefinedField extends CommonDBChild {
             $display_fields[-1] = Dropdown::EMPTY_VALUE;
             $display_fields    += $fields;
 
-            // Force validation request as used
-            $used[-2] = -2;
             // Unset multiple items
             $multiple = self::getMultiplePredefinedValues();
             foreach ($multiple as $val) {

--- a/install/mysql/glpi-9.2-empty.sql
+++ b/install/mysql/glpi-9.2-empty.sql
@@ -663,6 +663,7 @@ CREATE TABLE `glpi_changetasks` (
   `content` longtext COLLATE utf8_unicode_ci,
   `actiontime` int(11) NOT NULL DEFAULT '0',
   `date_mod` datetime DEFAULT NULL,
+  `tasktemplates_id` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `changes_id` (`changes_id`),
   KEY `state` (`state`),
@@ -673,7 +674,8 @@ CREATE TABLE `glpi_changetasks` (
   KEY `date_mod` (`date_mod`),
   KEY `begin` (`begin`),
   KEY `end` (`end`),
-  KEY `taskcategories_id` (`taskcategories_id`)
+  KEY `taskcategories_id` (`taskcategories_id`),
+  KEY `tasktemplates_id` (`tasktemplates_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 
@@ -5760,6 +5762,7 @@ CREATE TABLE `glpi_problemtasks` (
   `actiontime` int(11) NOT NULL DEFAULT '0',
   `state` int(11) NOT NULL DEFAULT '0',
   `date_mod` datetime DEFAULT NULL,
+  `tasktemplates_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `problems_id` (`problems_id`),
   KEY `users_id` (`users_id`),
@@ -5770,7 +5773,8 @@ CREATE TABLE `glpi_problemtasks` (
   KEY `begin` (`begin`),
   KEY `end` (`end`),
   KEY `state` (`state`),
-  KEY `taskcategories_id` (`taskcategories_id`)
+  KEY `taskcategories_id` (`taskcategories_id`),
+  KEY `tasktemplates_id` (`tasktemplates_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 
@@ -7498,13 +7502,20 @@ CREATE TABLE `glpi_tasktemplates` (
   `comment` text COLLATE utf8_unicode_ci,
   `date_mod` datetime DEFAULT NULL,
   `date_creation` datetime DEFAULT NULL,
+  `state` int(11) NOT NULL DEFAULT '0',
+  `is_private` tinyint(1) NOT NULL DEFAULT '0',
+  `users_id_tech` int(11) NOT NULL DEFAULT '0',
+  `groups_id_tech` INT(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `is_recursive` (`is_recursive`),
   KEY `taskcategories_id` (`taskcategories_id`),
   KEY `entities_id` (`entities_id`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `is_private` (`is_private`),
+  KEY `users_id_tech` (`users_id_tech`),
+  KEY `groups_id_tech` (`groups_id_tech`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 
@@ -7713,6 +7724,7 @@ CREATE TABLE `glpi_tickettasks` (
   `users_id_tech` int(11) NOT NULL DEFAULT '0',
   `groups_id_tech` INT(11) NOT NULL DEFAULT '0',
   `date_mod` datetime DEFAULT NULL,
+  `tasktemplates_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `date` (`date`),
   KEY `date_mod` (`date_mod`),
@@ -7724,7 +7736,8 @@ CREATE TABLE `glpi_tickettasks` (
   KEY `users_id_tech` (`users_id_tech`),
   KEY `groups_id_tech` (`groups_id_tech`),
   KEY `begin` (`begin`),
-  KEY `end` (`end`)
+  KEY `end` (`end`),
+  KEY `tasktemplates_id` (`tasktemplates_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 

--- a/install/update_91_92.php
+++ b/install/update_91_92.php
@@ -569,6 +569,28 @@ function update91to92() {
       $query = "UPDATE `glpi_softwarelicenses` SET `completename`=`name`";
       $DB->queryOrDie($query, "9.2 copy name to completename for software licenses");
    }
+
+   // add template key to itiltasks
+   $migration->addField("glpi_tickettasks", "tasktemplates_id", "integer");
+   $migration->addKey("glpi_tickettasks", "tasktemplates_id");
+   $migration->migrationOneTable('glpi_tickettasks');
+   $migration->addField("glpi_problemtasks", "tasktemplates_id", "integer");
+   $migration->addKey("glpi_problemtasks", "tasktemplates_id");
+   $migration->migrationOneTable('glpi_problemtasks');
+   $migration->addField("glpi_changetasks", "tasktemplates_id", "integer");
+   $migration->addKey("glpi_changetasks", "tasktemplates_id");
+   $migration->migrationOneTable('glpi_changetasks');
+
+   // add missing fields to tasktemplate
+   $migration->addField("glpi_tasktemplates", "state", "integer");
+   $migration->addField("glpi_tasktemplates", "is_private", "bool");
+   $migration->addField("glpi_tasktemplates", "users_id_tech", "integer");
+   $migration->addField("glpi_tasktemplates", "groups_id_tech", "integer");
+   $migration->addKey("glpi_tickettasks", "is_private");
+   $migration->addKey("glpi_tickettasks", "users_id_tech");
+   $migration->addKey("glpi_tickettasks", "groups_id_tech");
+   $migration->migrationOneTable('glpi_tasktemplates');
+
    // ************ Keep it at the end **************
    $migration->executeMigration();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | they should

Several modifications in this PR (but for the same goal).
The main purpose is to permit the addition of tasks in ticket's template.
So here is the changes:
- added a fk on glpi_tickettasks to track current tasktemplate
- added a searchoption for this fk
- added a ticket template field based on this searchoption (only for predefined part)
- added a new function to exclude fields from parts of template (hidden, mandatory, predefined).
- fix the task template js currently broken on 9.2 (when choosing a template on task creation)
- added missing fields to task template: is private, state, users_id_tech, groups_id_tech (I deliberately missed planification fields who are harder to achieve)
