### PR TITLE
fix add empty requesters when some business rules match a ticket

### DIFF
--- a/inc/ruleticketcollection.class.php
+++ b/inc/ruleticketcollection.class.php
@@ -113,9 +113,11 @@ class RuleTicketCollection extends RuleCollection {
       // Get groups of users
       if (isset($input['_users_id_requester'])) {
          if (!is_array($input['_users_id_requester'])) {
-            $input['_users_id_requester'] = array($input['_users_id_requester']);
+            $requesters = array($input['_users_id_requester']);
+         } else {
+            $requesters = $input['_users_id_requester'];
          }
-         foreach ($input['_users_id_requester'] as $uid) {
+         foreach ($requesters as $uid) {
             foreach (Group_User::getUserGroups($uid) as $g) {
                $input['_groups_id_of_requester'][$g['id']] = $g['id'];
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

To reproduce the bug : 
- create a ticket rule for ticket updates (important).
- create a ticket matching the rule
- update the ticket by adding a requester
- after the update observe you got all expcted users, but an empty requester is also added

