### PR TITLE
Update auth.class.php

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -617,6 +617,7 @@ class Auth extends CommonGLPI {
                                                        'condition'   => $ldap_method["condition"]));
                      if ($user_dn) {
                         $this->user->fields['auths_id'] = $ldap_method['id'];
+                        $this->user->fields['authtype'] = self::LDAP;
                         $this->user->getFromLDAP($ds, $ldap_method, $user_dn['dn'], $login_name,
                                                  !$this->user_present);
                         break;


### PR DESCRIPTION
add authtype when create user from SSO to LDAP.
Lorsqu'un user se créait en SSO à partir d'un LDAP, il n'apparraissait pas comme "synchroniser avec SRVXX" et donc n'appliquait pas les règles, aucune entité et aucun profil.
Par contre en désactivant le SSO l'utilisateur se créait normalement.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

