### PR TITLE
fix showMAssiveActions method

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -2895,14 +2895,15 @@ class Html {
                $js_modal_fields = "";
             }
 
-            Ajax::createModalWindow('massiveaction_window'.$identifier,
-                                    $url,
-                                    array('title'           => $p['title'],
-                                          'container'       => 'massiveactioncontent'.$identifier,
-                                          'extraparams'     => $p['extraparams'],
-                                          'width'           => $p['width'],
-                                          'height'          => $p['height'],
-                                          'js_modal_fields' => $js_modal_fields));
+            $out .= Ajax::createModalWindow('massiveaction_window'.$identifier,
+                                            $url,
+                                            array('title'           => $p['title'],
+                                                  'container'       => 'massiveactioncontent'.$identifier,
+                                                  'extraparams'     => $p['extraparams'],
+                                                  'width'           => $p['width'],
+                                                  'height'          => $p['height'],
+                                                  'js_modal_fields' => $js_modal_fields,
+                                                  'display'         => false));
          }
          $out .= "<table class='tab_glpi' width='$width'><tr>";
          if ($p['display_arrow']) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

I missed an output in https://github.com/glpi-project/glpi/pull/1835 which breaks massive actions modal.

Here is the fix.