### PR TITLE
fix lost filename for uploads from the API

### DIFF
--- a/inc/includes.php
+++ b/inc/includes.php
@@ -90,7 +90,8 @@ if (isset($_REQUEST)) {
 }
 if (isset($_FILES)) {
    foreach ($_FILES as &$file) {
-      $file['name'] = Toolbox::sanitize($file['name']);
+      $file['name'] = Toolbox::addslashes_deep($file['name']);
+      $file['name'] = Toolbox::clean_cross_side_scripting_deep($file['name']);
    }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

When processing a HTTP request containing an uploaded file, $_FILES['somefile']['name'] is lost due to a bug when sanitizing $_FILES

```
  *** PHP Warning(2): array_map(): Argument #2 should be an array
  Backtrace :
  :                                                  
  inc/toolbox.class.php:2517                         array_map()
  inc/includes.php:93                                Toolbox::sanitize()
  apirest.php:42                                     include()
```




