### PR TITLE
fix 9.1 update

### DIFF
--- a/install/update_0905_91.php
+++ b/install/update_0905_91.php
@@ -437,7 +437,8 @@ function update0905to91() {
          $migration->migrationOneTable($table);
       }
 
-      if (!FieldExists($table, 'date_creation')) {
+      if (TableExists($table)
+          && !FieldExists($table, 'date_creation')) {
          $migration->displayMessage(sprintf(__('Add date_creation to %s'), $table));
 
          //Add date_creation field

--- a/install/update_0905_91.php
+++ b/install/update_0905_91.php
@@ -460,7 +460,8 @@ function update0905to91() {
    $item_num     = 0;
    $itemtype_num = 0;
    foreach ($searchOption as $num => $option) {
-      if (is_array($option)) {
+      if (is_array($option)
+          && isset($option['field'])) {
          if ($option['field'] == 'items_id') {
             $item_num = $num;
          } else if ($option['field'] == 'itemtype') {

--- a/install/update_0905_91.php
+++ b/install/update_0905_91.php
@@ -427,7 +427,8 @@ function update0905to91() {
    foreach ($types as $type) {
       $table = getTableForItemType($type);
 
-      if (!FieldExists($table, 'date_mod')) {
+      if (TableExists($table)
+          && !FieldExists($table, 'date_mod')) {
          $migration->displayMessage(sprintf(__('Add date_mod to %s'), $table));
 
          //Add date_mod field if it doesn't exists


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | non
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

It's a annoying bug added with recent devices changes.

In 9.1 update, we added to some CFG_GLPI types the date_mod field.
As master contains news types, they crash (the tables are added in 9.2 update)

Ex:
```
*** PHP User Warning(512): Table glpi_devicefirmwares does not exists
  Backtrace :
  inc/toolbox.class.php:605                          
  :                                                  Toolbox::userErrorHandlerDebug()
  inc/db.function.php:1419                           trigger_error()
  inc/migration.class.php:499                        isIndex()
  install/update_0905_91.php:435                     Migration->addKey()
  install/update.php:795                             update0905to91()
  install/update.php:960                             updateDbUpTo031()

```