### PR TITLE
Enhance colorpicker

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3094,9 +3094,14 @@ class Html {
          }
       }
       $field_id = Html::cleanId("color_".$name.$p['rand']);
-      $output   = "<input type='text' id='$field_id' name='$name' value='".$p['value']."'>";
-      $js       = "\$(function() {\$('#$field_id').spectrum({preferredFormat: 'hex'})});";
-      $output  .= Html::scriptBlock($js);
+      $output   = "<input type='color' id='$field_id' name='$name' value='".$p['value']."'>";
+      $output  .= Html::scriptBlock("$(function() {
+         $('#$field_id').spectrum({
+            preferredFormat: 'hex',
+            showInput: true,
+            showInitial: true
+         });
+      });");
 
       if ($p['display']) {
          echo $output;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Changes:
- input is now a 'color' type (html5) instead 'text', this causes a graceful degradation (if no js for example) and display a browser control
- added 'showInput' key to display the rgb text (useful for copy/paste)
- added 'showInitial' key: add a comparison from old color
- clean code (remove '\\' and add indentation)