### PR TITLE
Adds smtp max retries mechanism

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -150,6 +150,9 @@ define("MAIL_SMTP", 1);
 define("MAIL_SMTPSSL", 2);
 define("MAIL_SMTPTLS", 3);
 
+if (!isset($CFG_GLPI['smtp_max_retries'])) {
+   $CFG_GLPI['smtp_max_retries'] = 5;
+}
 
 // MESSAGE TYPE
 define("INFO", 0);

--- a/inc/notificationmailsetting.class.php
+++ b/inc/notificationmailsetting.class.php
@@ -217,7 +217,7 @@ class NotificationMailSetting extends CommonDBTM {
          echo "</td></tr>";
 
          echo "<tr class='tab_bg_2'>";
-         echo "<td >" . __('SMTP Max Delivery Retries') . "</td>";
+         echo "<td >" . __('SMTP max. delivery retries') . "</td>";
          echo "<td><input type='text' name='smtp_max_retries' size='5' value='" . $CFG_GLPI["smtp_max_retries"] . "'></td>";
 
          echo "</tr>";

--- a/inc/notificationmailsetting.class.php
+++ b/inc/notificationmailsetting.class.php
@@ -216,6 +216,13 @@ class NotificationMailSetting extends CommonDBTM {
 
          echo "</td></tr>";
 
+         echo "<tr class='tab_bg_2'>";
+         echo "<td >" . __('SMTP Max Delivery Retries') . "</td>";
+         echo "<td><input type='text' name='smtp_max_retries' size='5' value='" .
+                    ($CFG_GLPI["smtp_max_retries"]?: 30) . "'></td>";
+
+         echo "</tr>";
+
       } else {
          echo "<td colspan='2'></td></tr>";
       }

--- a/inc/notificationmailsetting.class.php
+++ b/inc/notificationmailsetting.class.php
@@ -218,8 +218,7 @@ class NotificationMailSetting extends CommonDBTM {
 
          echo "<tr class='tab_bg_2'>";
          echo "<td >" . __('SMTP Max Delivery Retries') . "</td>";
-         echo "<td><input type='text' name='smtp_max_retries' size='5' value='" .
-                    ($CFG_GLPI["smtp_max_retries"]?: 30) . "'></td>";
+         echo "<td><input type='text' name='smtp_max_retries' size='5' value='" . $CFG_GLPI["smtp_max_retries"] . "'></td>";
 
          echo "</tr>";
 

--- a/inc/queuedmail.class.php
+++ b/inc/queuedmail.class.php
@@ -460,24 +460,23 @@ class QueuedMail extends CommonDBTM {
          if (!$mmail->Send()) {
             Session::addMessageAfterRedirect($messageerror."<br>".$mmail->ErrorInfo, true);
 
-            if (isset($CFG_GLPI['smtp_max_retries'])) {
-               $retries = $CFG_GLPI['smtp_max_retries'] - $this->fields['sent_try'];
-               Toolbox::logInFile("mail",
-                                sprintf(__('%1$s. Message: %2$s, Error: %3$s'),
-                                         sprintf(__('Warning: an email was undeliverable to %s with %d retries remaining'),
-                                                 $this->fields['recipient'], $retries),
-                                         $this->fields['name'],
-                                         $mmail->ErrorInfo."\n"));
+            $retries = $CFG_GLPI['smtp_max_retries'] - $this->fields['sent_try'];
+            Toolbox::logInFile("mail-error",
+                              sprintf(__('%1$s. Message: %2$s, Error: %3$s'),
+                                       sprintf(__('Warning: an email was undeliverable to %s with %d retries remaining'),
+                                                $this->fields['recipient'], $retries),
+                                       $this->fields['name'],
+                                       $mmail->ErrorInfo."\n"));
 
-               if ($retries <= 0) {
-                  Toolbox::logInFile("mail",
-                                  sprintf(__('%1$s: %2$s'),
-                                           sprintf(__('Fatal error: giving up delivery of email to %s'),
-                                                   $this->fields['recipient']),
-                                           $this->fields['name']."\n"));
-                  $this->delete(array('id' => $this->fields['id']));
-               }
+            if ($retries <= 0) {
+               Toolbox::logInFile("mail-error",
+                                 sprintf(__('%1$s: %2$s'),
+                                          sprintf(__('Fatal error: giving up delivery of email to %s'),
+                                                $this->fields['recipient']),
+                                          $this->fields['name']."\n"));
+               $this->delete(array('id' => $this->fields['id']));
             }
+
             $mmail->ClearAddresses();
             $this->update(array('id'        => $this->fields['id'],
                                 'sent_try' => $this->fields['sent_try']+1));


### PR DESCRIPTION
If the sent_try count for a message exceeds the smtp_max_retries
threshold, the event is logged to file and marked for deletion so that
no more delivery attempts are made.

Further, if the smtp_max_retries config is set, GLPI will begin logging
a warning when an SMTP delivery fails.

Attempts to address #1873
```
| Q             | A
| ------------- | ---
| Bug fix?      | kinda
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes (no new failures)
| Fixed tickets | #1873
```
*Please update this template with something that matches your PR*