### PR TITLE
shorten function name

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -2314,7 +2314,7 @@ abstract class API extends CommonGLPI {
     *
     * @return string
     */
-   protected function getHttpBodyStream() {
+   protected function getHttpBody() {
       return file_get_contents('php://input');
    }
 }

--- a/inc/apirest.class.php
+++ b/inc/apirest.class.php
@@ -361,7 +361,7 @@ class APIRest extends API {
       }
 
       // now how about PUT/POST bodies? These override what we got from GET
-      $body = trim($this->getHttpBodyStream());
+      $body = trim($this->getHttpBody());
       if (strlen($body) > 0 && $this->verb == "GET") {
          // GET method requires an empty body
          $this->returnError("GET Request should not have json payload (http body)", 400,

--- a/inc/apixmlrpc.class.php
+++ b/inc/apixmlrpc.class.php
@@ -238,7 +238,7 @@ class APIXmlrpc extends API {
       $parameters = array();
       $resource = "";
 
-      $parameters = xmlrpc_decode_request(trim($this->getHttpBodyStream()),
+      $parameters = xmlrpc_decode_request(trim($this->getHttpBody()),
                                           $resource,
                                           'UTF-8');
 


### PR DESCRIPTION
In order to get the glpi code in hands this is a one-commit PR.
I thought that the method `protected function getHttpBodyStream()` name's meaning was unclear as the function returns a `string` and not a PHP stream.
I changed the method's signature to `protected function getHttpBody()`