### PR TITLE
getTable() is static

### DIFF
--- a/ajax/autocompletion.php
+++ b/ajax/autocompletion.php
@@ -50,7 +50,7 @@ if (!isset($_GET['itemtype']) || !($item = getItemForItemtype($_GET['itemtype'])
 }
 
 $item->getEmpty();
-$table = $item->getTable();
+$table = $item::getTable();
 // Security
 if (!isset($item->fields[$_GET['field']]) || !$item->canView()) {
    exit();

--- a/ajax/getDropdownValue.php
+++ b/ajax/getDropdownValue.php
@@ -57,7 +57,7 @@ if (isset($_POST["entity_restrict"])
 if (!($item = getItemForItemtype($_POST['itemtype']))) {
    exit();
 }
-$table = $item->getTable();
+$table = $item::getTable();
 $datas = array();
 
 $displaywith = false;

--- a/front/dropdown.common.form.php
+++ b/front/dropdown.common.form.php
@@ -79,7 +79,7 @@ if (isset($_POST["add"])) {
    if ($dropdown->isUsed()
        && empty($_POST["forcepurge"])) {
       Html::header($dropdown->getTypeName(1), $_SERVER['PHP_SELF'], "config",
-                   $dropdown->second_level_menu, str_replace('glpi_', '', $dropdown->getTable()));
+                   $dropdown->second_level_menu, str_replace('glpi_', '', $dropdown::getTable()));
       $dropdown->showDeleteConfirmForm($_SERVER['PHP_SELF']);
       Html::footer();
    } else {

--- a/front/group.form.php
+++ b/front/group.form.php
@@ -62,7 +62,7 @@ if (isset($_POST["add"])) {
    if ($group->isUsed()
          && empty($_POST["forcepurge"])) {
       Html::header($group->getTypeName(1), $_SERVER['PHP_SELF'], "admin", "group",
-      str_replace('glpi_', '', $group->getTable()));
+      str_replace('glpi_', '', $group::getTable()));
 
       $group->showDeleteConfirmForm($_SERVER['PHP_SELF']);
       Html::footer();

--- a/front/stat.graph.php
+++ b/front/stat.graph.php
@@ -232,7 +232,7 @@ switch ($_GET["type"]) {
       $val1 = $_GET["id"];
       $val2 = $_GET["champ"];
       if ($item = getItemForItemtype($_GET["champ"])) {
-         $device_table = $item->getTable();
+         $device_table = $item::getTable();
          $values       = Stat::getItems($_GET["itemtype"], $_GET["date1"], $_GET["date2"],
                                         $_GET["champ"]);
 
@@ -250,7 +250,7 @@ switch ($_GET["type"]) {
       $val1  = $_GET["id"];
       $val2  = $_GET["champ"];
       if ($item = getItemForItemtype($_GET["champ"])) {
-         $table  = $item->getTable();
+         $table  = $item::getTable();
          $values = Stat::getItems($_GET["itemtype"], $_GET["date1"], $_GET["date2"],
                                   $_GET["champ"]);
          $title  = sprintf(__('%1$s: %2$s'),

--- a/inc/apiclient.class.php
+++ b/inc/apiclient.class.php
@@ -76,7 +76,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink'
@@ -84,7 +84,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -93,7 +93,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -101,7 +101,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'dolog_method',
          'name'               => __('Log connections'),
          'datatype'           => 'specific'
@@ -114,7 +114,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'ipv4_range_start',
          'name'               => __('IPv4 address range')." - ".__("Start"),
          'datatype'           => 'specific'
@@ -122,7 +122,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'ipv4_range_end',
          'name'               => __('IPv4 address range')." - ".__("End"),
          'datatype'           => 'specific'
@@ -130,7 +130,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'ipv6',
          'name'               => __('IPv6 address'),
          'datatype'           => 'text'
@@ -138,7 +138,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'app_token',
          'name'               => __('Application token'),
          'massiveaction'      => false,

--- a/inc/apiclient.class.php
+++ b/inc/apiclient.class.php
@@ -76,7 +76,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink'
@@ -84,7 +84,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -93,7 +93,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -101,7 +101,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'dolog_method',
          'name'               => __('Log connections'),
          'datatype'           => 'specific'
@@ -114,7 +114,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'ipv4_range_start',
          'name'               => __('IPv4 address range')." - ".__("Start"),
          'datatype'           => 'specific'
@@ -122,7 +122,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'ipv4_range_end',
          'name'               => __('IPv4 address range')." - ".__("End"),
          'datatype'           => 'specific'
@@ -130,7 +130,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'ipv6',
          'name'               => __('IPv6 address'),
          'datatype'           => 'text'
@@ -138,7 +138,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'app_token',
          'name'               => __('Application token'),
          'massiveaction'      => false,

--- a/inc/apiclient.class.php
+++ b/inc/apiclient.class.php
@@ -76,7 +76,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink'
@@ -84,7 +84,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -93,7 +93,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -101,7 +101,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'dolog_method',
          'name'               => __('Log connections'),
          'datatype'           => 'specific'
@@ -114,7 +114,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'ipv4_range_start',
          'name'               => __('IPv4 address range')." - ".__("Start"),
          'datatype'           => 'specific'
@@ -122,7 +122,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'ipv4_range_end',
          'name'               => __('IPv4 address range')." - ".__("End"),
          'datatype'           => 'specific'
@@ -130,7 +130,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'ipv6',
          'name'               => __('IPv6 address'),
          'datatype'           => 'text'
@@ -138,7 +138,7 @@ class APIClient extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'app_token',
          'name'               => __('Application token'),
          'massiveaction'      => false,

--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -810,7 +810,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -819,7 +819,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'datatype'           => 'number',
@@ -828,7 +828,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'host',
          'name'               => __('Server'),
          'datatype'           => 'string'
@@ -836,7 +836,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'port',
          'name'               => __('Port'),
          'datatype'           => 'integer'
@@ -844,7 +844,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'basedn',
          'name'               => __('BaseDN'),
          'datatype'           => 'string'
@@ -852,7 +852,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'condition',
          'name'               => __('Connection filter'),
          'datatype'           => 'text'
@@ -860,7 +860,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_default',
          'name'               => __('Default server'),
          'datatype'           => 'bool',
@@ -869,7 +869,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'login_field',
          'name'               => __('Login field'),
          'massiveaction'      => false,
@@ -878,7 +878,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'realname_field',
          'name'               => __('Surname'),
          'massiveaction'      => false,
@@ -887,7 +887,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'firstname_field',
          'name'               => __('First Name'),
          'massiveaction'      => false,
@@ -896,7 +896,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'phone_field',
          'name'               => __('Phone'),
          'massiveaction'      => false,
@@ -905,7 +905,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'phone2_field',
          'name'               => __('Phone 2'),
          'massiveaction'      => false,
@@ -914,7 +914,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mobile_field',
          'name'               => __('Mobile phone'),
          'massiveaction'      => false,
@@ -923,7 +923,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'title_field',
          'name'               => _x('person', 'Title'),
          'massiveaction'      => false,
@@ -932,7 +932,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'category_field',
          'name'               => __('Category'),
          'massiveaction'      => false,
@@ -941,7 +941,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -949,7 +949,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'email1_field',
          'name'               => __('Email'),
          'massiveaction'      => false,
@@ -958,7 +958,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '25',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'email2_field',
          'name'               => sprintf(__('%1$s %2$s'), _n('Email', 'Emails', 1), '2'),
          'massiveaction'      => false,
@@ -967,7 +967,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '26',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'email3_field',
          'name'               => sprintf(__('%1$s %2$s'), _n('Email', 'Emails', 1), '3'),
          'massiveaction'      => false,
@@ -976,7 +976,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '27',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'email4_field',
          'name'               => sprintf(__('%1$s %2$s'), _n('Email', 'Emails', 1), '4'),
          'massiveaction'      => false,
@@ -985,7 +985,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'use_dn',
          'name'               => __('Use DN in the search'),
          'datatype'           => 'bool',
@@ -994,7 +994,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -1003,7 +1003,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -1012,7 +1012,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'language_field',
          'name'               => __('Language'),
          'massiveaction'      => false,
@@ -1021,7 +1021,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'group_field',
          'name'               => __('User attribute containing its groups'),
          'massiveaction'      => false,
@@ -1030,7 +1030,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'group_condition',
          'name'               => __('Filter to search in groups'),
          'massiveaction'      => false,
@@ -1039,7 +1039,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'group_member_field',
          'name'               => __('Group attribute containing its users'),
          'massiveaction'      => false,
@@ -1048,7 +1048,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'group_search_type',
          'datatype'           => 'specific',
          'name'               => __('Search type'),
@@ -1057,7 +1057,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '30',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -3105,7 +3105,7 @@ class AuthLDAP extends CommonDBTM {
       global $DB;
 
       if (in_array('is_default', $this->updates) && $this->input["is_default"]==1) {
-         $query = "UPDATE `". $this::getTable()."`
+         $query = "UPDATE `". $static::getTable()."`
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->input['id']."'";
          $DB->query($query);
@@ -3116,7 +3116,7 @@ class AuthLDAP extends CommonDBTM {
       global $DB;
 
       if (isset($this->fields['is_default']) && $this->fields["is_default"]==1) {
-         $query = "UPDATE ". $this::getTable()."
+         $query = "UPDATE ". $static::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);

--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -810,7 +810,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -819,7 +819,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'datatype'           => 'number',
@@ -828,7 +828,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'host',
          'name'               => __('Server'),
          'datatype'           => 'string'
@@ -836,7 +836,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'port',
          'name'               => __('Port'),
          'datatype'           => 'integer'
@@ -844,7 +844,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'basedn',
          'name'               => __('BaseDN'),
          'datatype'           => 'string'
@@ -852,7 +852,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'condition',
          'name'               => __('Connection filter'),
          'datatype'           => 'text'
@@ -860,7 +860,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_default',
          'name'               => __('Default server'),
          'datatype'           => 'bool',
@@ -869,7 +869,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'login_field',
          'name'               => __('Login field'),
          'massiveaction'      => false,
@@ -878,7 +878,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'realname_field',
          'name'               => __('Surname'),
          'massiveaction'      => false,
@@ -887,7 +887,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'firstname_field',
          'name'               => __('First Name'),
          'massiveaction'      => false,
@@ -896,7 +896,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'phone_field',
          'name'               => __('Phone'),
          'massiveaction'      => false,
@@ -905,7 +905,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'phone2_field',
          'name'               => __('Phone 2'),
          'massiveaction'      => false,
@@ -914,7 +914,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mobile_field',
          'name'               => __('Mobile phone'),
          'massiveaction'      => false,
@@ -923,7 +923,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'title_field',
          'name'               => _x('person', 'Title'),
          'massiveaction'      => false,
@@ -932,7 +932,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'category_field',
          'name'               => __('Category'),
          'massiveaction'      => false,
@@ -941,7 +941,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -949,7 +949,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'email1_field',
          'name'               => __('Email'),
          'massiveaction'      => false,
@@ -958,7 +958,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '25',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'email2_field',
          'name'               => sprintf(__('%1$s %2$s'), _n('Email', 'Emails', 1), '2'),
          'massiveaction'      => false,
@@ -967,7 +967,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '26',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'email3_field',
          'name'               => sprintf(__('%1$s %2$s'), _n('Email', 'Emails', 1), '3'),
          'massiveaction'      => false,
@@ -976,7 +976,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '27',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'email4_field',
          'name'               => sprintf(__('%1$s %2$s'), _n('Email', 'Emails', 1), '4'),
          'massiveaction'      => false,
@@ -985,7 +985,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'use_dn',
          'name'               => __('Use DN in the search'),
          'datatype'           => 'bool',
@@ -994,7 +994,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -1003,7 +1003,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -1012,7 +1012,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'language_field',
          'name'               => __('Language'),
          'massiveaction'      => false,
@@ -1021,7 +1021,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'group_field',
          'name'               => __('User attribute containing its groups'),
          'massiveaction'      => false,
@@ -1030,7 +1030,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'group_condition',
          'name'               => __('Filter to search in groups'),
          'massiveaction'      => false,
@@ -1039,7 +1039,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'group_member_field',
          'name'               => __('Group attribute containing its users'),
          'massiveaction'      => false,
@@ -1048,7 +1048,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'group_search_type',
          'datatype'           => 'specific',
          'name'               => __('Search type'),
@@ -1057,7 +1057,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '30',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -3105,7 +3105,7 @@ class AuthLDAP extends CommonDBTM {
       global $DB;
 
       if (in_array('is_default', $this->updates) && $this->input["is_default"]==1) {
-         $query = "UPDATE `". $this->getTable()."`
+         $query = "UPDATE `". $this::getTable()."`
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->input['id']."'";
          $DB->query($query);
@@ -3116,7 +3116,7 @@ class AuthLDAP extends CommonDBTM {
       global $DB;
 
       if (isset($this->fields['is_default']) && $this->fields["is_default"]==1) {
-         $query = "UPDATE ". $this->getTable()."
+         $query = "UPDATE ". $this::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);

--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -810,7 +810,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -819,7 +819,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'datatype'           => 'number',
@@ -828,7 +828,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'host',
          'name'               => __('Server'),
          'datatype'           => 'string'
@@ -836,7 +836,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'port',
          'name'               => __('Port'),
          'datatype'           => 'integer'
@@ -844,7 +844,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'basedn',
          'name'               => __('BaseDN'),
          'datatype'           => 'string'
@@ -852,7 +852,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'condition',
          'name'               => __('Connection filter'),
          'datatype'           => 'text'
@@ -860,7 +860,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_default',
          'name'               => __('Default server'),
          'datatype'           => 'bool',
@@ -869,7 +869,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'login_field',
          'name'               => __('Login field'),
          'massiveaction'      => false,
@@ -878,7 +878,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'realname_field',
          'name'               => __('Surname'),
          'massiveaction'      => false,
@@ -887,7 +887,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'firstname_field',
          'name'               => __('First Name'),
          'massiveaction'      => false,
@@ -896,7 +896,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'phone_field',
          'name'               => __('Phone'),
          'massiveaction'      => false,
@@ -905,7 +905,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'phone2_field',
          'name'               => __('Phone 2'),
          'massiveaction'      => false,
@@ -914,7 +914,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mobile_field',
          'name'               => __('Mobile phone'),
          'massiveaction'      => false,
@@ -923,7 +923,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'title_field',
          'name'               => _x('person', 'Title'),
          'massiveaction'      => false,
@@ -932,7 +932,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'category_field',
          'name'               => __('Category'),
          'massiveaction'      => false,
@@ -941,7 +941,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -949,7 +949,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'email1_field',
          'name'               => __('Email'),
          'massiveaction'      => false,
@@ -958,7 +958,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '25',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'email2_field',
          'name'               => sprintf(__('%1$s %2$s'), _n('Email', 'Emails', 1), '2'),
          'massiveaction'      => false,
@@ -967,7 +967,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '26',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'email3_field',
          'name'               => sprintf(__('%1$s %2$s'), _n('Email', 'Emails', 1), '3'),
          'massiveaction'      => false,
@@ -976,7 +976,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '27',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'email4_field',
          'name'               => sprintf(__('%1$s %2$s'), _n('Email', 'Emails', 1), '4'),
          'massiveaction'      => false,
@@ -985,7 +985,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'use_dn',
          'name'               => __('Use DN in the search'),
          'datatype'           => 'bool',
@@ -994,7 +994,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -1003,7 +1003,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -1012,7 +1012,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'language_field',
          'name'               => __('Language'),
          'massiveaction'      => false,
@@ -1021,7 +1021,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'group_field',
          'name'               => __('User attribute containing its groups'),
          'massiveaction'      => false,
@@ -1030,7 +1030,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'group_condition',
          'name'               => __('Filter to search in groups'),
          'massiveaction'      => false,
@@ -1039,7 +1039,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'group_member_field',
          'name'               => __('Group attribute containing its users'),
          'massiveaction'      => false,
@@ -1048,7 +1048,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'group_search_type',
          'datatype'           => 'specific',
          'name'               => __('Search type'),
@@ -1057,7 +1057,7 @@ class AuthLDAP extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '30',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -3105,7 +3105,7 @@ class AuthLDAP extends CommonDBTM {
       global $DB;
 
       if (in_array('is_default', $this->updates) && $this->input["is_default"]==1) {
-         $query = "UPDATE `". $static::getTable()."`
+         $query = "UPDATE `". static::getTable()."`
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->input['id']."'";
          $DB->query($query);
@@ -3116,7 +3116,7 @@ class AuthLDAP extends CommonDBTM {
       global $DB;
 
       if (isset($this->fields['is_default']) && $this->fields["is_default"]==1) {
-         $query = "UPDATE ". $static::getTable()."
+         $query = "UPDATE ". static::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);

--- a/inc/authmail.class.php
+++ b/inc/authmail.class.php
@@ -93,7 +93,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -102,7 +102,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'datatype'           => 'number',
@@ -111,7 +111,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'host',
          'name'               => __('Server'),
          'datatype'           => 'string'
@@ -119,7 +119,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'connect_string',
          'name'               => __('Connection string'),
          'massiveaction'      => false,
@@ -128,7 +128,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -136,7 +136,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -145,7 +145,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/authmail.class.php
+++ b/inc/authmail.class.php
@@ -93,7 +93,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -102,7 +102,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'datatype'           => 'number',
@@ -111,7 +111,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'host',
          'name'               => __('Server'),
          'datatype'           => 'string'
@@ -119,7 +119,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'connect_string',
          'name'               => __('Connection string'),
          'massiveaction'      => false,
@@ -128,7 +128,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -136,7 +136,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -145,7 +145,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/authmail.class.php
+++ b/inc/authmail.class.php
@@ -93,7 +93,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -102,7 +102,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'datatype'           => 'number',
@@ -111,7 +111,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'host',
          'name'               => __('Server'),
          'datatype'           => 'string'
@@ -119,7 +119,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'connect_string',
          'name'               => __('Connection string'),
          'massiveaction'      => false,
@@ -128,7 +128,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -136,7 +136,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -145,7 +145,7 @@ class AuthMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/blacklist.class.php
+++ b/inc/blacklist.class.php
@@ -100,7 +100,7 @@ class Blacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'value',
          'name'               => __('Value'),
          'datatype'           => 'text'
@@ -108,7 +108,7 @@ class Blacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'type',
          'name'               => _n('Type', 'Types', 1),
          'searchtype'         => ['equals', 'notequals'],

--- a/inc/blacklist.class.php
+++ b/inc/blacklist.class.php
@@ -100,7 +100,7 @@ class Blacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'value',
          'name'               => __('Value'),
          'datatype'           => 'text'
@@ -108,7 +108,7 @@ class Blacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'type',
          'name'               => _n('Type', 'Types', 1),
          'searchtype'         => ['equals', 'notequals'],

--- a/inc/blacklist.class.php
+++ b/inc/blacklist.class.php
@@ -100,7 +100,7 @@ class Blacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'value',
          'name'               => __('Value'),
          'datatype'           => 'text'
@@ -108,7 +108,7 @@ class Blacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'type',
          'name'               => _n('Type', 'Types', 1),
          'searchtype'         => ['equals', 'notequals'],

--- a/inc/blacklistedmailcontent.class.php
+++ b/inc/blacklistedmailcontent.class.php
@@ -83,7 +83,7 @@ class BlacklistedMailContent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'content',
          'name'               => __('Content'),
          'datatype'           => 'text',

--- a/inc/blacklistedmailcontent.class.php
+++ b/inc/blacklistedmailcontent.class.php
@@ -83,7 +83,7 @@ class BlacklistedMailContent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'content',
          'name'               => __('Content'),
          'datatype'           => 'text',

--- a/inc/blacklistedmailcontent.class.php
+++ b/inc/blacklistedmailcontent.class.php
@@ -83,7 +83,7 @@ class BlacklistedMailContent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'content',
          'name'               => __('Content'),
          'datatype'           => 'text',

--- a/inc/bookmark.class.php
+++ b/inc/bookmark.class.php
@@ -581,21 +581,21 @@ class Bookmark extends CommonDBTM {
          return false;
       }
 
-      $query = "SELECT `".$this::getTable()."`.*,
+      $query = "SELECT `".$static::getTable()."`.*,
                        `glpi_bookmarks_users`.`id` AS IS_DEFAULT
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 LEFT JOIN `glpi_bookmarks_users`
-                  ON (`".$this::getTable()."`.`itemtype` = `glpi_bookmarks_users`.`itemtype`
-                      AND `".$this::getTable()."`.`id` = `glpi_bookmarks_users`.`bookmarks_id`
+                  ON (`".$static::getTable()."`.`itemtype` = `glpi_bookmarks_users`.`itemtype`
+                      AND `".$static::getTable()."`.`id` = `glpi_bookmarks_users`.`bookmarks_id`
                       AND `glpi_bookmarks_users`.`users_id` = '".Session::getLoginUserID()."')
                 WHERE ";
 
       if ($is_private) {
-         $query .= "(`".$this::getTable()."`.`is_private`='1'
-                     AND `".$this::getTable()."`.`users_id`='".Session::getLoginUserID()."') ";
+         $query .= "(`".$static::getTable()."`.`is_private`='1'
+                     AND `".$static::getTable()."`.`users_id`='".Session::getLoginUserID()."') ";
       } else {
-         $query .= "(`".$this::getTable()."`.`is_private`='0' ".
-                     getEntitiesRestrictRequest("AND", $this::getTable(), "", "", true) . ")";
+         $query .= "(`".$static::getTable()."`.`is_private`='0' ".
+                     getEntitiesRestrictRequest("AND", $static::getTable(), "", "", true) . ")";
       }
 
       $query .= " ORDER BY `itemtype`, `name`";

--- a/inc/bookmark.class.php
+++ b/inc/bookmark.class.php
@@ -581,21 +581,21 @@ class Bookmark extends CommonDBTM {
          return false;
       }
 
-      $query = "SELECT `".$this->getTable()."`.*,
+      $query = "SELECT `".$this::getTable()."`.*,
                        `glpi_bookmarks_users`.`id` AS IS_DEFAULT
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 LEFT JOIN `glpi_bookmarks_users`
-                  ON (`".$this->getTable()."`.`itemtype` = `glpi_bookmarks_users`.`itemtype`
-                      AND `".$this->getTable()."`.`id` = `glpi_bookmarks_users`.`bookmarks_id`
+                  ON (`".$this::getTable()."`.`itemtype` = `glpi_bookmarks_users`.`itemtype`
+                      AND `".$this::getTable()."`.`id` = `glpi_bookmarks_users`.`bookmarks_id`
                       AND `glpi_bookmarks_users`.`users_id` = '".Session::getLoginUserID()."')
                 WHERE ";
 
       if ($is_private) {
-         $query .= "(`".$this->getTable()."`.`is_private`='1'
-                     AND `".$this->getTable()."`.`users_id`='".Session::getLoginUserID()."') ";
+         $query .= "(`".$this::getTable()."`.`is_private`='1'
+                     AND `".$this::getTable()."`.`users_id`='".Session::getLoginUserID()."') ";
       } else {
-         $query .= "(`".$this->getTable()."`.`is_private`='0' ".
-                     getEntitiesRestrictRequest("AND", $this->getTable(), "", "", true) . ")";
+         $query .= "(`".$this::getTable()."`.`is_private`='0' ".
+                     getEntitiesRestrictRequest("AND", $this::getTable(), "", "", true) . ")";
       }
 
       $query .= " ORDER BY `itemtype`, `name`";

--- a/inc/bookmark.class.php
+++ b/inc/bookmark.class.php
@@ -581,21 +581,21 @@ class Bookmark extends CommonDBTM {
          return false;
       }
 
-      $query = "SELECT `".$static::getTable()."`.*,
+      $query = "SELECT `".static::getTable()."`.*,
                        `glpi_bookmarks_users`.`id` AS IS_DEFAULT
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 LEFT JOIN `glpi_bookmarks_users`
-                  ON (`".$static::getTable()."`.`itemtype` = `glpi_bookmarks_users`.`itemtype`
-                      AND `".$static::getTable()."`.`id` = `glpi_bookmarks_users`.`bookmarks_id`
+                  ON (`".static::getTable()."`.`itemtype` = `glpi_bookmarks_users`.`itemtype`
+                      AND `".static::getTable()."`.`id` = `glpi_bookmarks_users`.`bookmarks_id`
                       AND `glpi_bookmarks_users`.`users_id` = '".Session::getLoginUserID()."')
                 WHERE ";
 
       if ($is_private) {
-         $query .= "(`".$static::getTable()."`.`is_private`='1'
-                     AND `".$static::getTable()."`.`users_id`='".Session::getLoginUserID()."') ";
+         $query .= "(`".static::getTable()."`.`is_private`='1'
+                     AND `".static::getTable()."`.`users_id`='".Session::getLoginUserID()."') ";
       } else {
-         $query .= "(`".$static::getTable()."`.`is_private`='0' ".
-                     getEntitiesRestrictRequest("AND", $static::getTable(), "", "", true) . ")";
+         $query .= "(`".static::getTable()."`.`is_private`='0' ".
+                     getEntitiesRestrictRequest("AND", static::getTable(), "", "", true) . ")";
       }
 
       $query .= " ORDER BY `itemtype`, `name`";

--- a/inc/budget.class.php
+++ b/inc/budget.class.php
@@ -195,7 +195,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -204,7 +204,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -213,7 +213,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -222,7 +222,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -239,7 +239,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Start date'),
          'datatype'           => 'date'
@@ -247,7 +247,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'date'
@@ -255,7 +255,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'value',
          'name'               => _x('price', 'Value'),
          'datatype'           => 'decimal'
@@ -263,7 +263,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -280,7 +280,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/budget.class.php
+++ b/inc/budget.class.php
@@ -195,7 +195,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -204,7 +204,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -213,7 +213,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -222,7 +222,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -239,7 +239,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Start date'),
          'datatype'           => 'date'
@@ -247,7 +247,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'date'
@@ -255,7 +255,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'value',
          'name'               => _x('price', 'Value'),
          'datatype'           => 'decimal'
@@ -263,7 +263,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -280,7 +280,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/budget.class.php
+++ b/inc/budget.class.php
@@ -195,7 +195,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -204,7 +204,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -213,7 +213,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -222,7 +222,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -239,7 +239,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Start date'),
          'datatype'           => 'date'
@@ -247,7 +247,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'date'
@@ -255,7 +255,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'value',
          'name'               => _x('price', 'Value'),
          'datatype'           => 'decimal'
@@ -263,7 +263,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -280,7 +280,7 @@ class Budget extends CommonDropdown{
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -358,102 +358,102 @@ class Budget extends CommonDropdown{
             switch ($itemtype) {
 
                case 'Contract' :
-                  $query = "SELECT `".$item->getTable()."`.`id`,
-                                   `".$item->getTable()."`.`entities_id`,
+                  $query = "SELECT `".$item::getTable()."`.`id`,
+                                   `".$item::getTable()."`.`entities_id`,
                                     SUM(`glpi_contractcosts`.`cost`) as value
                             FROM `glpi_contractcosts`
-                            INNER JOIN `".$item->getTable()."`
-                                 ON (`".$item->getTable()."`.`id` = `glpi_contractcosts`.`contracts_id`)
+                            INNER JOIN `".$item::getTable()."`
+                                 ON (`".$item::getTable()."`.`id` = `glpi_contractcosts`.`contracts_id`)
                             WHERE `glpi_contractcosts`.`budgets_id` = '$budgets_id' ".
-                                  getEntitiesRestrictRequest(" AND", $item->getTable())."
-                                  AND NOT `".$item->getTable()."`.`is_template`
-                            GROUP BY `".$item->getTable()."`.`id`, `".$item->getTable()."`.`entities_id`
-                            ORDER BY `".$item->getTable()."`.`entities_id`,
-                                     `".$item->getTable()."`.`name`";
+                                  getEntitiesRestrictRequest(" AND", $item::getTable())."
+                                  AND NOT `".$item::getTable()."`.`is_template`
+                            GROUP BY `".$item::getTable()."`.`id`, `".$item::getTable()."`.`entities_id`
+                            ORDER BY `".$item::getTable()."`.`entities_id`,
+                                     `".$item::getTable()."`.`name`";
                break;
 
                case 'Ticket' :
                case 'Problem' :
                case 'Change' :
                   $costtable = getTableForItemType($item->getType().'Cost');
-                  $query = "SELECT `".$item->getTable()."`.`id`,
-                                   `".$item->getTable()."`.`entities_id`,
+                  $query = "SELECT `".$item::getTable()."`.`id`,
+                                   `".$item::getTable()."`.`entities_id`,
                                     SUM(`$costtable`.`actiontime`*`$costtable`.`cost_time`/".HOUR_TIMESTAMP."
                                           + `$costtable`.`cost_fixed`
                                           + `$costtable`.`cost_material`) as value
                             FROM `$costtable`
-                            INNER JOIN `".$item->getTable()."`
-                                 ON (`".$item->getTable()."`.`id` = `$costtable`.`".$item->getForeignKeyField()."`)
+                            INNER JOIN `".$item::getTable()."`
+                                 ON (`".$item::getTable()."`.`id` = `$costtable`.`".$item->getForeignKeyField()."`)
                             WHERE `$costtable`.`budgets_id` = '$budgets_id' ".
-                                  getEntitiesRestrictRequest(" AND", $item->getTable())."
-                            GROUP BY `".$item->getTable()."`.`id`, `".$item->getTable()."`.`entities_id`
-                            ORDER BY `".$item->getTable()."`.`entities_id`,
-                                     `".$item->getTable()."`.`name`";
+                                  getEntitiesRestrictRequest(" AND", $item::getTable())."
+                            GROUP BY `".$item::getTable()."`.`id`, `".$item::getTable()."`.`entities_id`
+                            ORDER BY `".$item::getTable()."`.`entities_id`,
+                                     `".$item::getTable()."`.`name`";
                break;
 
                case 'Project' :
-                  $query = "SELECT `".$item->getTable()."`.`id`,
-                                   `".$item->getTable()."`.`entities_id`,
+                  $query = "SELECT `".$item::getTable()."`.`id`,
+                                   `".$item::getTable()."`.`entities_id`,
                                     SUM(`glpi_projectcosts`.`cost`) as value
                             FROM `glpi_projectcosts`
-                            INNER JOIN `".$item->getTable()."`
-                                 ON (`".$item->getTable()."`.`id` = `glpi_projectcosts`.`projects_id`)
+                            INNER JOIN `".$item::getTable()."`
+                                 ON (`".$item::getTable()."`.`id` = `glpi_projectcosts`.`projects_id`)
                             WHERE `glpi_projectcosts`.`budgets_id` = '$budgets_id' ".
-                                  getEntitiesRestrictRequest(" AND", $item->getTable())."
-                            GROUP BY `".$item->getTable()."`.`id`, `".$item->getTable()."`.`entities_id`
-                            ORDER BY `".$item->getTable()."`.`entities_id`,
-                                     `".$item->getTable()."`.`name`";
+                                  getEntitiesRestrictRequest(" AND", $item::getTable())."
+                            GROUP BY `".$item::getTable()."`.`id`, `".$item::getTable()."`.`entities_id`
+                            ORDER BY `".$item::getTable()."`.`entities_id`,
+                                     `".$item::getTable()."`.`name`";
                                                 break;
 
                case 'Cartridge' :
-                  $query = "SELECT `".$item->getTable()."`.*,
+                  $query = "SELECT `".$item::getTable()."`.*,
                                    `glpi_cartridgeitems`.`name`,
                                    `glpi_infocoms`.`value`
                             FROM `glpi_infocoms`
-                            INNER JOIN `".$item->getTable()."`
-                                 ON (`".$item->getTable()."`.`id` = `glpi_infocoms`.`items_id`)
+                            INNER JOIN `".$item::getTable()."`
+                                 ON (`".$item::getTable()."`.`id` = `glpi_infocoms`.`items_id`)
                             INNER JOIN `glpi_cartridgeitems`
-                                 ON (`".$item->getTable()."`.`cartridgeitems_id`
+                                 ON (`".$item::getTable()."`.`cartridgeitems_id`
                                        = `glpi_cartridgeitems`.`id`)
                             WHERE `glpi_infocoms`.`itemtype`='$itemtype'
                                   AND `glpi_infocoms`.`budgets_id` = '$budgets_id' ".
-                                  getEntitiesRestrictRequest(" AND", $item->getTable())."
+                                  getEntitiesRestrictRequest(" AND", $item::getTable())."
                             ORDER BY `entities_id`,
                                      `glpi_cartridgeitems`.`name`";
                break;
 
                case 'Consumable' :
-                  $query = "SELECT `".$item->getTable()."`.*,
+                  $query = "SELECT `".$item::getTable()."`.*,
                                    `glpi_consumableitems`.`name`,
                                    `glpi_infocoms`.`value`
                             FROM `glpi_infocoms`
-                            INNER JOIN `".$item->getTable()."`
-                                 ON (`".$item->getTable()."`.`id` = `glpi_infocoms`.`items_id`)
+                            INNER JOIN `".$item::getTable()."`
+                                 ON (`".$item::getTable()."`.`id` = `glpi_infocoms`.`items_id`)
                             INNER JOIN `glpi_consumableitems`
-                                 ON (`".$item->getTable()."`.`consumableitems_id`
+                                 ON (`".$item::getTable()."`.`consumableitems_id`
                                        = `glpi_consumableitems`.`id`)
                             WHERE `glpi_infocoms`.`itemtype` = '$itemtype'
                                   AND `glpi_infocoms`.`budgets_id` = '$budgets_id' ".
-                                  getEntitiesRestrictRequest(" AND", $item->getTable())."
+                                  getEntitiesRestrictRequest(" AND", $item::getTable())."
                             ORDER BY `entities_id`,
                                      `glpi_consumableitems`.`name`";
                break;
 
                default :
-                  $query = "SELECT `".$item->getTable()."`.*,
+                  $query = "SELECT `".$item::getTable()."`.*,
                                    `glpi_infocoms`.`value`
                             FROM `glpi_infocoms`
-                            INNER JOIN `".$item->getTable()."`
-                                 ON (`".$item->getTable()."`.`id` = `glpi_infocoms`.`items_id`)
+                            INNER JOIN `".$item::getTable()."`
+                                 ON (`".$item::getTable()."`.`id` = `glpi_infocoms`.`items_id`)
                             WHERE `glpi_infocoms`.`itemtype` = '$itemtype'
                                   AND `glpi_infocoms`.`budgets_id` = '$budgets_id' ".
-                                  getEntitiesRestrictRequest(" AND", $item->getTable())."
-                                  ".($item->maybeTemplate()?" AND NOT `".$item->getTable()."`.`is_template`":'')."
-                            ORDER BY `".$item->getTable()."`.`entities_id`,";
+                                  getEntitiesRestrictRequest(" AND", $item::getTable())."
+                                  ".($item->maybeTemplate()?" AND NOT `".$item::getTable()."`.`is_template`":'')."
+                            ORDER BY `".$item::getTable()."`.`entities_id`,";
                   if ($item instanceof Item_Devices) {
-                     $query .= " `".$item->getTable()."`.`itemtype`";
+                     $query .= " `".$item::getTable()."`.`itemtype`";
                   } else {
-                     $query .= " `".$item->getTable()."`.`name`";
+                     $query .= " `".$item::getTable()."`.`name`";
                   }
                   break;
             }

--- a/inc/calendar_holiday.class.php
+++ b/inc/calendar_holiday.class.php
@@ -204,7 +204,7 @@ class Calendar_Holiday extends CommonDBRelation {
          switch ($item->getType()) {
             case 'Calendar' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($static::getTable(), ['calendars_id' => $item->getID()]);
+                  $nb = countElementsInTable(static::getTable(), ['calendars_id' => $item->getID()]);
                }
                return self::createTabEntry(_n('Close time', 'Close times', Session::getPluralNumber()),
                                             $nb);

--- a/inc/calendar_holiday.class.php
+++ b/inc/calendar_holiday.class.php
@@ -204,7 +204,7 @@ class Calendar_Holiday extends CommonDBRelation {
          switch ($item->getType()) {
             case 'Calendar' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this->getTable(), ['calendars_id' => $item->getID()]);
+                  $nb = countElementsInTable($this::getTable(), ['calendars_id' => $item->getID()]);
                }
                return self::createTabEntry(_n('Close time', 'Close times', Session::getPluralNumber()),
                                             $nb);

--- a/inc/calendar_holiday.class.php
+++ b/inc/calendar_holiday.class.php
@@ -204,7 +204,7 @@ class Calendar_Holiday extends CommonDBRelation {
          switch ($item->getType()) {
             case 'Calendar' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this::getTable(), ['calendars_id' => $item->getID()]);
+                  $nb = countElementsInTable($static::getTable(), ['calendars_id' => $item->getID()]);
                }
                return self::createTabEntry(_n('Close time', 'Close times', Session::getPluralNumber()),
                                             $nb);

--- a/inc/calendarsegment.class.php
+++ b/inc/calendarsegment.class.php
@@ -413,7 +413,7 @@ class CalendarSegment extends CommonDBChild {
          switch ($item->getType()) {
             case 'Calendar' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($static::getTable(),
+                  $nb = countElementsInTable(static::getTable(),
                                              ['calendars_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/calendarsegment.class.php
+++ b/inc/calendarsegment.class.php
@@ -413,7 +413,7 @@ class CalendarSegment extends CommonDBChild {
          switch ($item->getType()) {
             case 'Calendar' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this::getTable(),
+                  $nb = countElementsInTable($static::getTable(),
                                              ['calendars_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/calendarsegment.class.php
+++ b/inc/calendarsegment.class.php
@@ -413,7 +413,7 @@ class CalendarSegment extends CommonDBChild {
          switch ($item->getType()) {
             case 'Calendar' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this->getTable(),
+                  $nb = countElementsInTable($this::getTable(),
                                              ['calendars_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/cartridge.class.php
+++ b/inc/cartridge.class.php
@@ -231,7 +231,7 @@ class Cartridge extends CommonDBChild {
    function backToStock(array $input, $history=1) {
       global $DB;
 
-      $query = "UPDATE `".$static::getTable()."`
+      $query = "UPDATE `".static::getTable()."`
                 SET `date_out` = NULL,
                     `date_use` = NULL,
                     `printers_id` = '0'
@@ -261,7 +261,7 @@ class Cartridge extends CommonDBChild {
 
       // Get first unused cartridge
       $query = "SELECT `id`
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE (`cartridgeitems_id` = '$tID'
                        AND `date_use` IS NULL)";
       $result = $DB->query($query);
@@ -269,7 +269,7 @@ class Cartridge extends CommonDBChild {
       if ($DB->numrows($result)>0) {
          $cID = $DB->result($result, 0, 0);
          // Mise a jour cartouche en prenant garde aux insertion multiples
-         $query = "UPDATE `".$static::getTable()."`
+         $query = "UPDATE `".static::getTable()."`
                    SET `date_use` = '".date("Y-m-d")."',
                        `printers_id` = '$pID'
                    WHERE (`id`='$cID'
@@ -310,7 +310,7 @@ class Cartridge extends CommonDBChild {
             $toadd .= ", `pages` = '".$printer->fields['last_pages_counter']."' ";
          }
 
-         $query = "UPDATE`".$static::getTable()."`
+         $query = "UPDATE`".static::getTable()."`
                    SET `date_out` = '".date("Y-m-d")."'
                        $toadd
                    WHERE `id`='$ID'";

--- a/inc/cartridge.class.php
+++ b/inc/cartridge.class.php
@@ -231,7 +231,7 @@ class Cartridge extends CommonDBChild {
    function backToStock(array $input, $history=1) {
       global $DB;
 
-      $query = "UPDATE `".$this->getTable()."`
+      $query = "UPDATE `".$this::getTable()."`
                 SET `date_out` = NULL,
                     `date_use` = NULL,
                     `printers_id` = '0'
@@ -261,7 +261,7 @@ class Cartridge extends CommonDBChild {
 
       // Get first unused cartridge
       $query = "SELECT `id`
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE (`cartridgeitems_id` = '$tID'
                        AND `date_use` IS NULL)";
       $result = $DB->query($query);
@@ -269,7 +269,7 @@ class Cartridge extends CommonDBChild {
       if ($DB->numrows($result)>0) {
          $cID = $DB->result($result, 0, 0);
          // Mise a jour cartouche en prenant garde aux insertion multiples
-         $query = "UPDATE `".$this->getTable()."`
+         $query = "UPDATE `".$this::getTable()."`
                    SET `date_use` = '".date("Y-m-d")."',
                        `printers_id` = '$pID'
                    WHERE (`id`='$cID'
@@ -310,7 +310,7 @@ class Cartridge extends CommonDBChild {
             $toadd .= ", `pages` = '".$printer->fields['last_pages_counter']."' ";
          }
 
-         $query = "UPDATE`".$this->getTable()."`
+         $query = "UPDATE`".$this::getTable()."`
                    SET `date_out` = '".date("Y-m-d")."'
                        $toadd
                    WHERE `id`='$ID'";

--- a/inc/cartridge.class.php
+++ b/inc/cartridge.class.php
@@ -231,7 +231,7 @@ class Cartridge extends CommonDBChild {
    function backToStock(array $input, $history=1) {
       global $DB;
 
-      $query = "UPDATE `".$this::getTable()."`
+      $query = "UPDATE `".$static::getTable()."`
                 SET `date_out` = NULL,
                     `date_use` = NULL,
                     `printers_id` = '0'
@@ -261,7 +261,7 @@ class Cartridge extends CommonDBChild {
 
       // Get first unused cartridge
       $query = "SELECT `id`
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE (`cartridgeitems_id` = '$tID'
                        AND `date_use` IS NULL)";
       $result = $DB->query($query);
@@ -269,7 +269,7 @@ class Cartridge extends CommonDBChild {
       if ($DB->numrows($result)>0) {
          $cID = $DB->result($result, 0, 0);
          // Mise a jour cartouche en prenant garde aux insertion multiples
-         $query = "UPDATE `".$this::getTable()."`
+         $query = "UPDATE `".$static::getTable()."`
                    SET `date_use` = '".date("Y-m-d")."',
                        `printers_id` = '$pID'
                    WHERE (`id`='$cID'
@@ -310,7 +310,7 @@ class Cartridge extends CommonDBChild {
             $toadd .= ", `pages` = '".$printer->fields['last_pages_counter']."' ";
          }
 
-         $query = "UPDATE`".$this::getTable()."`
+         $query = "UPDATE`".$static::getTable()."`
                    SET `date_out` = '".date("Y-m-d")."'
                        $toadd
                    WHERE `id`='$ID'";

--- a/inc/cartridgeitem.class.php
+++ b/inc/cartridgeitem.class.php
@@ -279,7 +279,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -288,7 +288,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -297,7 +297,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '34',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'ref',
          'name'               => __('Reference'),
          'datatype'           => 'string'
@@ -321,7 +321,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => '_virtual',
          'name'               => _n('Cartridge', 'Cartridges', Session::getPluralNumber()),
          'datatype'           => 'specific',
@@ -402,7 +402,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'alarm_threshold',
          'name'               => __('Alert threshold'),
          'datatype'           => 'number',
@@ -413,7 +413,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/cartridgeitem.class.php
+++ b/inc/cartridgeitem.class.php
@@ -279,7 +279,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -288,7 +288,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -297,7 +297,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '34',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'ref',
          'name'               => __('Reference'),
          'datatype'           => 'string'
@@ -321,7 +321,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => '_virtual',
          'name'               => _n('Cartridge', 'Cartridges', Session::getPluralNumber()),
          'datatype'           => 'specific',
@@ -402,7 +402,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'alarm_threshold',
          'name'               => __('Alert threshold'),
          'datatype'           => 'number',
@@ -413,7 +413,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/cartridgeitem.class.php
+++ b/inc/cartridgeitem.class.php
@@ -279,7 +279,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -288,7 +288,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -297,7 +297,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '34',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'ref',
          'name'               => __('Reference'),
          'datatype'           => 'string'
@@ -321,7 +321,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => '_virtual',
          'name'               => _n('Cartridge', 'Cartridges', Session::getPluralNumber()),
          'datatype'           => 'specific',
@@ -402,7 +402,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'alarm_threshold',
          'name'               => __('Alert threshold'),
          'datatype'           => 'number',
@@ -413,7 +413,7 @@ class CartridgeItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -421,7 +421,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '60',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'impactcontent',
          'name'               => __('Impact'),
          'massiveaction'      => false,
@@ -430,7 +430,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '61',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'controlistcontent',
          'name'               => __('Control list'),
          'massiveaction'      => false,
@@ -439,7 +439,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '62',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'rolloutplancontent',
          'name'               => __('Deployment plan'),
          'massiveaction'      => false,
@@ -448,7 +448,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '63',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'backoutplancontent',
          'name'               => __('Backup plan'),
          'massiveaction'      => false,
@@ -457,7 +457,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '67',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'checklistcontent',
          'name'               => __('Checklist'),
          'massiveaction'      => false,

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -421,7 +421,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '60',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'impactcontent',
          'name'               => __('Impact'),
          'massiveaction'      => false,
@@ -430,7 +430,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '61',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'controlistcontent',
          'name'               => __('Control list'),
          'massiveaction'      => false,
@@ -439,7 +439,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '62',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'rolloutplancontent',
          'name'               => __('Deployment plan'),
          'massiveaction'      => false,
@@ -448,7 +448,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '63',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'backoutplancontent',
          'name'               => __('Backup plan'),
          'massiveaction'      => false,
@@ -457,7 +457,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '67',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'checklistcontent',
          'name'               => __('Checklist'),
          'massiveaction'      => false,

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -421,7 +421,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '60',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'impactcontent',
          'name'               => __('Impact'),
          'massiveaction'      => false,
@@ -430,7 +430,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '61',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'controlistcontent',
          'name'               => __('Control list'),
          'massiveaction'      => false,
@@ -439,7 +439,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '62',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'rolloutplancontent',
          'name'               => __('Deployment plan'),
          'massiveaction'      => false,
@@ -448,7 +448,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '63',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'backoutplancontent',
          'name'               => __('Backup plan'),
          'massiveaction'      => false,
@@ -457,7 +457,7 @@ class Change extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '67',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'checklistcontent',
          'name'               => __('Checklist'),
          'massiveaction'      => false,

--- a/inc/change_item.class.php
+++ b/inc/change_item.class.php
@@ -72,7 +72,7 @@ class Change_Item extends CommonDBRelation{
       }
 
       // Avoid duplicate entry
-      if (countElementsInTable($static::getTable(), ['changes_id' => $input['changes_id'],
+      if (countElementsInTable(static::getTable(), ['changes_id' => $input['changes_id'],
                                                   'itemtype' => $input['itemtype'],
                                                   'items_id' => $input['items_id']])>0) {
          return false;

--- a/inc/change_item.class.php
+++ b/inc/change_item.class.php
@@ -72,7 +72,7 @@ class Change_Item extends CommonDBRelation{
       }
 
       // Avoid duplicate entry
-      if (countElementsInTable($this::getTable(), ['changes_id' => $input['changes_id'],
+      if (countElementsInTable($static::getTable(), ['changes_id' => $input['changes_id'],
                                                   'itemtype' => $input['itemtype'],
                                                   'items_id' => $input['items_id']])>0) {
          return false;

--- a/inc/change_item.class.php
+++ b/inc/change_item.class.php
@@ -72,7 +72,7 @@ class Change_Item extends CommonDBRelation{
       }
 
       // Avoid duplicate entry
-      if (countElementsInTable($this->getTable(), ['changes_id' => $input['changes_id'],
+      if (countElementsInTable($this::getTable(), ['changes_id' => $input['changes_id'],
                                                   'itemtype' => $input['itemtype'],
                                                   'items_id' => $input['items_id']])>0) {
          return false;

--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -282,7 +282,7 @@ abstract class CommonDBRelation extends CommonDBConnexity {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,

--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -282,7 +282,7 @@ abstract class CommonDBRelation extends CommonDBConnexity {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,

--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -282,7 +282,7 @@ abstract class CommonDBRelation extends CommonDBConnexity {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -161,7 +161,7 @@ class CommonDBTM extends CommonGLPI {
          return false;
       }
 
-      return $this->getFromDBByQuery("WHERE `" . $static::getTable() . "`.`" . $this->getIndexName() .
+      return $this->getFromDBByQuery("WHERE `" . static::getTable() . "`.`" . $this->getIndexName() .
                                      "` = '" . Toolbox::cleanInteger($ID) . "' LIMIT 1");
    }
 
@@ -185,8 +185,8 @@ class CommonDBTM extends CommonGLPI {
          return false;
       }
 
-      $query = "SELECT `".$static::getTable()."`.*
-                FROM `".$static::getTable()."`
+      $query = "SELECT `".static::getTable()."`.*
+                FROM `".static::getTable()."`
                 $query";
 
       if ($result = $DB->query($query)) {
@@ -249,7 +249,7 @@ class CommonDBTM extends CommonGLPI {
       // Make new database object and fill variables
 
       $query = "SELECT *
-                FROM `".$static::getTable()."`";
+                FROM `".static::getTable()."`";
 
       if (!empty($condition)) {
          $query .= " WHERE $condition";
@@ -295,7 +295,7 @@ class CommonDBTM extends CommonGLPI {
       global $DB;
 
       //make an empty database object
-      $table = $static::getTable();
+      $table = static::getTable();
 
       if (!empty($table) &&
           ($fields = $DB->list_fields($table))) {
@@ -354,7 +354,7 @@ class CommonDBTM extends CommonGLPI {
 
       foreach ($updates as $field) {
          if (isset($this->fields[$field])) {
-            $query  = "UPDATE `".$static::getTable()."`
+            $query  = "UPDATE `".static::getTable()."`
                        SET `".$field."`";
 
             if ($this->fields[$field]=="NULL") {
@@ -402,7 +402,7 @@ class CommonDBTM extends CommonGLPI {
       if ($nb_fields > 0) {
          // Build query
          $query = "INSERT
-                   INTO `".$static::getTable()."` (";
+                   INTO `".static::getTable()."` (";
 
          $i = 0;
          foreach ($this->fields as $key => $val) {
@@ -467,7 +467,7 @@ class CommonDBTM extends CommonGLPI {
             $toadd = ", `date_mod` ='".$_SESSION["glpi_currenttime"]."' ";
          }
 
-         $query = "UPDATE `".$static::getTable()."`
+         $query = "UPDATE `".static::getTable()."`
                    SET `is_deleted`='0' $toadd
                    WHERE `id` = '".$this->fields['id']."'";
 
@@ -504,7 +504,7 @@ class CommonDBTM extends CommonGLPI {
          $this->cleanRelationTable();
 
          $query = "DELETE
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `id` = '".$this->fields['id']."'";
          if ($result = $DB->query($query)) {
             $this->post_deleteFromDB();
@@ -518,7 +518,7 @@ class CommonDBTM extends CommonGLPI {
             $toadd = ", `date_mod` ='".$_SESSION["glpi_currenttime"]."' ";
          }
 
-         $query = "UPDATE `".$static::getTable()."`
+         $query = "UPDATE `".static::getTable()."`
                    SET `is_deleted`='1' $toadd
                    WHERE `id` = '".$this->fields['id']."'";
          $this->cleanDBonMarkDeleted();
@@ -561,10 +561,10 @@ class CommonDBTM extends CommonGLPI {
       global $DB, $CFG_GLPI;
 
       $RELATION = getDbRelations();
-      if (isset($RELATION[$static::getTable()])) {
+      if (isset($RELATION[static::getTable()])) {
          $newval = (isset($this->input['_replace_by']) ? $this->input['_replace_by'] : 0);
 
-         foreach ($RELATION[$static::getTable()] as $tablename => $field) {
+         foreach ($RELATION[static::getTable()] as $tablename => $field) {
             if ($tablename[0] != '_') {
 
                $itemtype = getItemTypeForTable($tablename);
@@ -840,7 +840,7 @@ class CommonDBTM extends CommonGLPI {
 
       if ($this->input && is_array($this->input)) {
          $this->fields = array();
-         $table_fields = $DB->list_fields($static::getTable());
+         $table_fields = $DB->list_fields(static::getTable());
 
          // fill array for add
          foreach ($this->input as $key => $val) {
@@ -905,7 +905,7 @@ class CommonDBTM extends CommonGLPI {
                }
                // For unit test (workaround for MyIsam without transaction)
                if (isset($DB->objcreated) && is_array($DB->objcreated)) {
-                  $DB->objcreated[$static::getTable()][] = $this->fields['id'];
+                  $DB->objcreated[static::getTable()][] = $this->fields['id'];
                }
                return $this->fields['id'];
             }
@@ -1112,7 +1112,7 @@ class CommonDBTM extends CommonGLPI {
                   }
                   // Compare item
                   $ischanged = true;
-                  $searchopt = $this->getSearchOptionByField('field', $key, $static::getTable());
+                  $searchopt = $this->getSearchOptionByField('field', $key, static::getTable());
                   if (isset($searchopt['datatype'])) {
                      switch ($searchopt['datatype']) {
                         case 'string' :
@@ -1875,16 +1875,16 @@ class CommonDBTM extends CommonGLPI {
       $RELATION  = getDbRelations();
 
       if ($this instanceof CommonTreeDropdown) {
-         $f = getForeignKeyFieldForTable($static::getTable());
+         $f = getForeignKeyFieldForTable(static::getTable());
 
-         if (countElementsInTable($static::getTable(),
+         if (countElementsInTable(static::getTable(),
                                   [ $f => $ID, 'NOT' => [ 'entities_id' => $entities ]]) > 0) {
             return false;
          }
       }
 
-      if (isset($RELATION[$static::getTable()])) {
-         foreach ($RELATION[$static::getTable()] as $tablename => $field) {
+      if (isset($RELATION[static::getTable()])) {
+         foreach ($RELATION[static::getTable()] as $tablename => $field) {
             if ($tablename[0] != '_') {
 
                $itemtype = getItemTypeForTable($tablename);
@@ -1941,7 +1941,7 @@ class CommonDBTM extends CommonGLPI {
                            }
                         }
 
-                     } else if (($othertable != $static::getTable())
+                     } else if (($othertable != static::getTable())
                               && isset($rel[$tablename])) {
 
                         // Search for another N->N Relation
@@ -3287,7 +3287,7 @@ class CommonDBTM extends CommonGLPI {
 
       $tab[] = [
          'id'            => 1,
-         'table'         => $static::getTable(),
+         'table'         => static::getTable(),
          'field'         => 'name',
          'name'          => __('Name'),
          'datatype'      => 'itemlink',
@@ -3798,7 +3798,7 @@ class CommonDBTM extends CommonGLPI {
                               && ($this->input[$field] > 0)))
                       && !Fieldblacklist::isFieldBlacklisted(get_class($this), $entities_id, $field,
                                                              $this->input[$field])) {
-                     $where .= " AND `".$static::getTable()."`.`$field` = '".$this->input[$field]."'";
+                     $where .= " AND `".static::getTable()."`.`$field` = '".$this->input[$field]."'";
                   } else {
                      $continue = false;
                   }
@@ -3810,7 +3810,7 @@ class CommonDBTM extends CommonGLPI {
                   if ($fields['is_recursive']) {
                      $entities = getSonsOf('glpi_entities', $fields['entities_id']);
                   }
-                  $where_global = getEntitiesRestrictRequest(" AND", $static::getTable(), '',
+                  $where_global = getEntitiesRestrictRequest(" AND", static::getTable(), '',
                                                              $entities);
 
                   $tmp = clone $this;
@@ -3820,10 +3820,10 @@ class CommonDBTM extends CommonGLPI {
 
                   //If update, exclude ID of the current object
                   if (!$add) {
-                     $where .= " AND `".$static::getTable()."`.`id` NOT IN (".$this->input['id'].") ";
+                     $where .= " AND `".static::getTable()."`.`id` NOT IN (".$this->input['id'].") ";
                   }
 
-                  if (countElementsInTable($static::getTable(), "1 $where $where_global") > 0) {
+                  if (countElementsInTable(static::getTable(), "1 $where $where_global") > 0) {
                      if ($p['unicity_error_message']
                          || $p['add_event_on_duplicate']) {
                         $message = array();
@@ -3894,7 +3894,7 @@ class CommonDBTM extends CommonGLPI {
       if (is_array($crit) && (count($crit) > 0)) {
          $crit['FIELDS'] = 'id';
          $ok = true;
-         foreach ($DB->request($static::getTable(), $crit) as $row) {
+         foreach ($DB->request(static::getTable(), $crit) as $row) {
             if (!$this->delete($row, $force, $history)) {
                $ok = false;
             }
@@ -3983,7 +3983,7 @@ class CommonDBTM extends CommonGLPI {
             }
          } else { // Get if field name is passed
             $searchoptions = $this->getSearchOptionByField('field', $field_id_or_search_options,
-                                                           $static::getTable());
+                                                           static::getTable());
          }
       }
 
@@ -4090,7 +4090,7 @@ class CommonDBTM extends CommonGLPI {
                   return "&nbsp;";
 
                case "itemlink" :
-                  if ($searchoptions['table'] == $static::getTable()) {
+                  if ($searchoptions['table'] == static::getTable()) {
                      break;
                   }
 
@@ -4210,7 +4210,7 @@ class CommonDBTM extends CommonGLPI {
             }
          } else { // Get if field name is passed
             $searchoptions = $this->getSearchOptionByField('field', $field_id_or_search_options,
-                                                           $static::getTable());
+                                                           static::getTable());
          }
       }
       if (count($searchoptions)) {

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -161,7 +161,7 @@ class CommonDBTM extends CommonGLPI {
          return false;
       }
 
-      return $this->getFromDBByQuery("WHERE `" . $this->getTable() . "`.`" . $this->getIndexName() .
+      return $this->getFromDBByQuery("WHERE `" . $this::getTable() . "`.`" . $this->getIndexName() .
                                      "` = '" . Toolbox::cleanInteger($ID) . "' LIMIT 1");
    }
 
@@ -185,8 +185,8 @@ class CommonDBTM extends CommonGLPI {
          return false;
       }
 
-      $query = "SELECT `".$this->getTable()."`.*
-                FROM `".$this->getTable()."`
+      $query = "SELECT `".$this::getTable()."`.*
+                FROM `".$this::getTable()."`
                 $query";
 
       if ($result = $DB->query($query)) {
@@ -249,7 +249,7 @@ class CommonDBTM extends CommonGLPI {
       // Make new database object and fill variables
 
       $query = "SELECT *
-                FROM `".$this->getTable()."`";
+                FROM `".$this::getTable()."`";
 
       if (!empty($condition)) {
          $query .= " WHERE $condition";
@@ -295,7 +295,7 @@ class CommonDBTM extends CommonGLPI {
       global $DB;
 
       //make an empty database object
-      $table = $this->getTable();
+      $table = $this::getTable();
 
       if (!empty($table) &&
           ($fields = $DB->list_fields($table))) {
@@ -354,7 +354,7 @@ class CommonDBTM extends CommonGLPI {
 
       foreach ($updates as $field) {
          if (isset($this->fields[$field])) {
-            $query  = "UPDATE `".$this->getTable()."`
+            $query  = "UPDATE `".$this::getTable()."`
                        SET `".$field."`";
 
             if ($this->fields[$field]=="NULL") {
@@ -402,7 +402,7 @@ class CommonDBTM extends CommonGLPI {
       if ($nb_fields > 0) {
          // Build query
          $query = "INSERT
-                   INTO `".$this->getTable()."` (";
+                   INTO `".$this::getTable()."` (";
 
          $i = 0;
          foreach ($this->fields as $key => $val) {
@@ -467,7 +467,7 @@ class CommonDBTM extends CommonGLPI {
             $toadd = ", `date_mod` ='".$_SESSION["glpi_currenttime"]."' ";
          }
 
-         $query = "UPDATE `".$this->getTable()."`
+         $query = "UPDATE `".$this::getTable()."`
                    SET `is_deleted`='0' $toadd
                    WHERE `id` = '".$this->fields['id']."'";
 
@@ -504,7 +504,7 @@ class CommonDBTM extends CommonGLPI {
          $this->cleanRelationTable();
 
          $query = "DELETE
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `id` = '".$this->fields['id']."'";
          if ($result = $DB->query($query)) {
             $this->post_deleteFromDB();
@@ -518,7 +518,7 @@ class CommonDBTM extends CommonGLPI {
             $toadd = ", `date_mod` ='".$_SESSION["glpi_currenttime"]."' ";
          }
 
-         $query = "UPDATE `".$this->getTable()."`
+         $query = "UPDATE `".$this::getTable()."`
                    SET `is_deleted`='1' $toadd
                    WHERE `id` = '".$this->fields['id']."'";
          $this->cleanDBonMarkDeleted();
@@ -561,10 +561,10 @@ class CommonDBTM extends CommonGLPI {
       global $DB, $CFG_GLPI;
 
       $RELATION = getDbRelations();
-      if (isset($RELATION[$this->getTable()])) {
+      if (isset($RELATION[$this::getTable()])) {
          $newval = (isset($this->input['_replace_by']) ? $this->input['_replace_by'] : 0);
 
-         foreach ($RELATION[$this->getTable()] as $tablename => $field) {
+         foreach ($RELATION[$this::getTable()] as $tablename => $field) {
             if ($tablename[0] != '_') {
 
                $itemtype = getItemTypeForTable($tablename);
@@ -840,7 +840,7 @@ class CommonDBTM extends CommonGLPI {
 
       if ($this->input && is_array($this->input)) {
          $this->fields = array();
-         $table_fields = $DB->list_fields($this->getTable());
+         $table_fields = $DB->list_fields($this::getTable());
 
          // fill array for add
          foreach ($this->input as $key => $val) {
@@ -905,7 +905,7 @@ class CommonDBTM extends CommonGLPI {
                }
                // For unit test (workaround for MyIsam without transaction)
                if (isset($DB->objcreated) && is_array($DB->objcreated)) {
-                  $DB->objcreated[$this->getTable()][] = $this->fields['id'];
+                  $DB->objcreated[$this::getTable()][] = $this->fields['id'];
                }
                return $this->fields['id'];
             }
@@ -1112,7 +1112,7 @@ class CommonDBTM extends CommonGLPI {
                   }
                   // Compare item
                   $ischanged = true;
-                  $searchopt = $this->getSearchOptionByField('field', $key, $this->getTable());
+                  $searchopt = $this->getSearchOptionByField('field', $key, $this::getTable());
                   if (isset($searchopt['datatype'])) {
                      switch ($searchopt['datatype']) {
                         case 'string' :
@@ -1224,7 +1224,7 @@ class CommonDBTM extends CommonGLPI {
          foreach (static::$forward_entity_to as $type) {
             $item  = new $type();
             $query = "SELECT `id`
-                      FROM `".$item->getTable()."`
+                      FROM `".$item::getTable()."`
                       WHERE ";
 
             if ($item->isField('itemtype')) {
@@ -1875,16 +1875,16 @@ class CommonDBTM extends CommonGLPI {
       $RELATION  = getDbRelations();
 
       if ($this instanceof CommonTreeDropdown) {
-         $f = getForeignKeyFieldForTable($this->getTable());
+         $f = getForeignKeyFieldForTable($this::getTable());
 
-         if (countElementsInTable($this->getTable(),
+         if (countElementsInTable($this::getTable(),
                                   [ $f => $ID, 'NOT' => [ 'entities_id' => $entities ]]) > 0) {
             return false;
          }
       }
 
-      if (isset($RELATION[$this->getTable()])) {
-         foreach ($RELATION[$this->getTable()] as $tablename => $field) {
+      if (isset($RELATION[$this::getTable()])) {
+         foreach ($RELATION[$this::getTable()] as $tablename => $field) {
             if ($tablename[0] != '_') {
 
                $itemtype = getItemTypeForTable($tablename);
@@ -1941,7 +1941,7 @@ class CommonDBTM extends CommonGLPI {
                            }
                         }
 
-                     } else if (($othertable != $this->getTable())
+                     } else if (($othertable != $this::getTable())
                               && isset($rel[$tablename])) {
 
                         // Search for another N->N Relation
@@ -3287,7 +3287,7 @@ class CommonDBTM extends CommonGLPI {
 
       $tab[] = [
          'id'            => 1,
-         'table'         => $this->getTable(),
+         'table'         => $this::getTable(),
          'field'         => 'name',
          'name'          => __('Name'),
          'datatype'      => 'itemlink',
@@ -3798,7 +3798,7 @@ class CommonDBTM extends CommonGLPI {
                               && ($this->input[$field] > 0)))
                       && !Fieldblacklist::isFieldBlacklisted(get_class($this), $entities_id, $field,
                                                              $this->input[$field])) {
-                     $where .= " AND `".$this->getTable()."`.`$field` = '".$this->input[$field]."'";
+                     $where .= " AND `".$this::getTable()."`.`$field` = '".$this->input[$field]."'";
                   } else {
                      $continue = false;
                   }
@@ -3810,7 +3810,7 @@ class CommonDBTM extends CommonGLPI {
                   if ($fields['is_recursive']) {
                      $entities = getSonsOf('glpi_entities', $fields['entities_id']);
                   }
-                  $where_global = getEntitiesRestrictRequest(" AND", $this->getTable(), '',
+                  $where_global = getEntitiesRestrictRequest(" AND", $this::getTable(), '',
                                                              $entities);
 
                   $tmp = clone $this;
@@ -3820,10 +3820,10 @@ class CommonDBTM extends CommonGLPI {
 
                   //If update, exclude ID of the current object
                   if (!$add) {
-                     $where .= " AND `".$this->getTable()."`.`id` NOT IN (".$this->input['id'].") ";
+                     $where .= " AND `".$this::getTable()."`.`id` NOT IN (".$this->input['id'].") ";
                   }
 
-                  if (countElementsInTable($this->getTable(), "1 $where $where_global") > 0) {
+                  if (countElementsInTable($this::getTable(), "1 $where $where_global") > 0) {
                      if ($p['unicity_error_message']
                          || $p['add_event_on_duplicate']) {
                         $message = array();
@@ -3894,7 +3894,7 @@ class CommonDBTM extends CommonGLPI {
       if (is_array($crit) && (count($crit) > 0)) {
          $crit['FIELDS'] = 'id';
          $ok = true;
-         foreach ($DB->request($this->getTable(), $crit) as $row) {
+         foreach ($DB->request($this::getTable(), $crit) as $row) {
             if (!$this->delete($row, $force, $history)) {
                $ok = false;
             }
@@ -3983,7 +3983,7 @@ class CommonDBTM extends CommonGLPI {
             }
          } else { // Get if field name is passed
             $searchoptions = $this->getSearchOptionByField('field', $field_id_or_search_options,
-                                                           $this->getTable());
+                                                           $this::getTable());
          }
       }
 
@@ -4090,7 +4090,7 @@ class CommonDBTM extends CommonGLPI {
                   return "&nbsp;";
 
                case "itemlink" :
-                  if ($searchoptions['table'] == $this->getTable()) {
+                  if ($searchoptions['table'] == $this::getTable()) {
                      break;
                   }
 
@@ -4210,7 +4210,7 @@ class CommonDBTM extends CommonGLPI {
             }
          } else { // Get if field name is passed
             $searchoptions = $this->getSearchOptionByField('field', $field_id_or_search_options,
-                                                           $this->getTable());
+                                                           $this::getTable());
          }
       }
       if (count($searchoptions)) {
@@ -4423,11 +4423,11 @@ class CommonDBTM extends CommonGLPI {
       }
 
       $query = "SELECT *
-                FROM `".$item->getTable()."`
+                FROM `".$item::getTable()."`
                 WHERE `is_template` = '1' ";
 
       if ($item->isEntityAssign()) {
-         $query .= getEntitiesRestrictRequest('AND', $item->getTable(), 'entities_id',
+         $query .= getEntitiesRestrictRequest('AND', $item::getTable(), 'entities_id',
                                               $_SESSION['glpiactiveentities'],
                                               $item->maybeRecursive());
       }

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -161,7 +161,7 @@ class CommonDBTM extends CommonGLPI {
          return false;
       }
 
-      return $this->getFromDBByQuery("WHERE `" . $this::getTable() . "`.`" . $this->getIndexName() .
+      return $this->getFromDBByQuery("WHERE `" . $static::getTable() . "`.`" . $this->getIndexName() .
                                      "` = '" . Toolbox::cleanInteger($ID) . "' LIMIT 1");
    }
 
@@ -185,8 +185,8 @@ class CommonDBTM extends CommonGLPI {
          return false;
       }
 
-      $query = "SELECT `".$this::getTable()."`.*
-                FROM `".$this::getTable()."`
+      $query = "SELECT `".$static::getTable()."`.*
+                FROM `".$static::getTable()."`
                 $query";
 
       if ($result = $DB->query($query)) {
@@ -249,7 +249,7 @@ class CommonDBTM extends CommonGLPI {
       // Make new database object and fill variables
 
       $query = "SELECT *
-                FROM `".$this::getTable()."`";
+                FROM `".$static::getTable()."`";
 
       if (!empty($condition)) {
          $query .= " WHERE $condition";
@@ -295,7 +295,7 @@ class CommonDBTM extends CommonGLPI {
       global $DB;
 
       //make an empty database object
-      $table = $this::getTable();
+      $table = $static::getTable();
 
       if (!empty($table) &&
           ($fields = $DB->list_fields($table))) {
@@ -354,7 +354,7 @@ class CommonDBTM extends CommonGLPI {
 
       foreach ($updates as $field) {
          if (isset($this->fields[$field])) {
-            $query  = "UPDATE `".$this::getTable()."`
+            $query  = "UPDATE `".$static::getTable()."`
                        SET `".$field."`";
 
             if ($this->fields[$field]=="NULL") {
@@ -402,7 +402,7 @@ class CommonDBTM extends CommonGLPI {
       if ($nb_fields > 0) {
          // Build query
          $query = "INSERT
-                   INTO `".$this::getTable()."` (";
+                   INTO `".$static::getTable()."` (";
 
          $i = 0;
          foreach ($this->fields as $key => $val) {
@@ -467,7 +467,7 @@ class CommonDBTM extends CommonGLPI {
             $toadd = ", `date_mod` ='".$_SESSION["glpi_currenttime"]."' ";
          }
 
-         $query = "UPDATE `".$this::getTable()."`
+         $query = "UPDATE `".$static::getTable()."`
                    SET `is_deleted`='0' $toadd
                    WHERE `id` = '".$this->fields['id']."'";
 
@@ -504,7 +504,7 @@ class CommonDBTM extends CommonGLPI {
          $this->cleanRelationTable();
 
          $query = "DELETE
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `id` = '".$this->fields['id']."'";
          if ($result = $DB->query($query)) {
             $this->post_deleteFromDB();
@@ -518,7 +518,7 @@ class CommonDBTM extends CommonGLPI {
             $toadd = ", `date_mod` ='".$_SESSION["glpi_currenttime"]."' ";
          }
 
-         $query = "UPDATE `".$this::getTable()."`
+         $query = "UPDATE `".$static::getTable()."`
                    SET `is_deleted`='1' $toadd
                    WHERE `id` = '".$this->fields['id']."'";
          $this->cleanDBonMarkDeleted();
@@ -561,10 +561,10 @@ class CommonDBTM extends CommonGLPI {
       global $DB, $CFG_GLPI;
 
       $RELATION = getDbRelations();
-      if (isset($RELATION[$this::getTable()])) {
+      if (isset($RELATION[$static::getTable()])) {
          $newval = (isset($this->input['_replace_by']) ? $this->input['_replace_by'] : 0);
 
-         foreach ($RELATION[$this::getTable()] as $tablename => $field) {
+         foreach ($RELATION[$static::getTable()] as $tablename => $field) {
             if ($tablename[0] != '_') {
 
                $itemtype = getItemTypeForTable($tablename);
@@ -840,7 +840,7 @@ class CommonDBTM extends CommonGLPI {
 
       if ($this->input && is_array($this->input)) {
          $this->fields = array();
-         $table_fields = $DB->list_fields($this::getTable());
+         $table_fields = $DB->list_fields($static::getTable());
 
          // fill array for add
          foreach ($this->input as $key => $val) {
@@ -905,7 +905,7 @@ class CommonDBTM extends CommonGLPI {
                }
                // For unit test (workaround for MyIsam without transaction)
                if (isset($DB->objcreated) && is_array($DB->objcreated)) {
-                  $DB->objcreated[$this::getTable()][] = $this->fields['id'];
+                  $DB->objcreated[$static::getTable()][] = $this->fields['id'];
                }
                return $this->fields['id'];
             }
@@ -1112,7 +1112,7 @@ class CommonDBTM extends CommonGLPI {
                   }
                   // Compare item
                   $ischanged = true;
-                  $searchopt = $this->getSearchOptionByField('field', $key, $this::getTable());
+                  $searchopt = $this->getSearchOptionByField('field', $key, $static::getTable());
                   if (isset($searchopt['datatype'])) {
                      switch ($searchopt['datatype']) {
                         case 'string' :
@@ -1875,16 +1875,16 @@ class CommonDBTM extends CommonGLPI {
       $RELATION  = getDbRelations();
 
       if ($this instanceof CommonTreeDropdown) {
-         $f = getForeignKeyFieldForTable($this::getTable());
+         $f = getForeignKeyFieldForTable($static::getTable());
 
-         if (countElementsInTable($this::getTable(),
+         if (countElementsInTable($static::getTable(),
                                   [ $f => $ID, 'NOT' => [ 'entities_id' => $entities ]]) > 0) {
             return false;
          }
       }
 
-      if (isset($RELATION[$this::getTable()])) {
-         foreach ($RELATION[$this::getTable()] as $tablename => $field) {
+      if (isset($RELATION[$static::getTable()])) {
+         foreach ($RELATION[$static::getTable()] as $tablename => $field) {
             if ($tablename[0] != '_') {
 
                $itemtype = getItemTypeForTable($tablename);
@@ -1941,7 +1941,7 @@ class CommonDBTM extends CommonGLPI {
                            }
                         }
 
-                     } else if (($othertable != $this::getTable())
+                     } else if (($othertable != $static::getTable())
                               && isset($rel[$tablename])) {
 
                         // Search for another N->N Relation
@@ -3287,7 +3287,7 @@ class CommonDBTM extends CommonGLPI {
 
       $tab[] = [
          'id'            => 1,
-         'table'         => $this::getTable(),
+         'table'         => $static::getTable(),
          'field'         => 'name',
          'name'          => __('Name'),
          'datatype'      => 'itemlink',
@@ -3798,7 +3798,7 @@ class CommonDBTM extends CommonGLPI {
                               && ($this->input[$field] > 0)))
                       && !Fieldblacklist::isFieldBlacklisted(get_class($this), $entities_id, $field,
                                                              $this->input[$field])) {
-                     $where .= " AND `".$this::getTable()."`.`$field` = '".$this->input[$field]."'";
+                     $where .= " AND `".$static::getTable()."`.`$field` = '".$this->input[$field]."'";
                   } else {
                      $continue = false;
                   }
@@ -3810,7 +3810,7 @@ class CommonDBTM extends CommonGLPI {
                   if ($fields['is_recursive']) {
                      $entities = getSonsOf('glpi_entities', $fields['entities_id']);
                   }
-                  $where_global = getEntitiesRestrictRequest(" AND", $this::getTable(), '',
+                  $where_global = getEntitiesRestrictRequest(" AND", $static::getTable(), '',
                                                              $entities);
 
                   $tmp = clone $this;
@@ -3820,10 +3820,10 @@ class CommonDBTM extends CommonGLPI {
 
                   //If update, exclude ID of the current object
                   if (!$add) {
-                     $where .= " AND `".$this::getTable()."`.`id` NOT IN (".$this->input['id'].") ";
+                     $where .= " AND `".$static::getTable()."`.`id` NOT IN (".$this->input['id'].") ";
                   }
 
-                  if (countElementsInTable($this::getTable(), "1 $where $where_global") > 0) {
+                  if (countElementsInTable($static::getTable(), "1 $where $where_global") > 0) {
                      if ($p['unicity_error_message']
                          || $p['add_event_on_duplicate']) {
                         $message = array();
@@ -3894,7 +3894,7 @@ class CommonDBTM extends CommonGLPI {
       if (is_array($crit) && (count($crit) > 0)) {
          $crit['FIELDS'] = 'id';
          $ok = true;
-         foreach ($DB->request($this::getTable(), $crit) as $row) {
+         foreach ($DB->request($static::getTable(), $crit) as $row) {
             if (!$this->delete($row, $force, $history)) {
                $ok = false;
             }
@@ -3983,7 +3983,7 @@ class CommonDBTM extends CommonGLPI {
             }
          } else { // Get if field name is passed
             $searchoptions = $this->getSearchOptionByField('field', $field_id_or_search_options,
-                                                           $this::getTable());
+                                                           $static::getTable());
          }
       }
 
@@ -4090,7 +4090,7 @@ class CommonDBTM extends CommonGLPI {
                   return "&nbsp;";
 
                case "itemlink" :
-                  if ($searchoptions['table'] == $this::getTable()) {
+                  if ($searchoptions['table'] == $static::getTable()) {
                      break;
                   }
 
@@ -4210,7 +4210,7 @@ class CommonDBTM extends CommonGLPI {
             }
          } else { // Get if field name is passed
             $searchoptions = $this->getSearchOptionByField('field', $field_id_or_search_options,
-                                                           $this::getTable());
+                                                           $static::getTable());
          }
       }
       if (count($searchoptions)) {

--- a/inc/commondevice.class.php
+++ b/inc/commondevice.class.php
@@ -208,7 +208,7 @@ abstract class CommonDevice extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'designation',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -225,7 +225,7 @@ abstract class CommonDevice extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -233,7 +233,7 @@ abstract class CommonDevice extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -242,7 +242,7 @@ abstract class CommonDevice extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -417,7 +417,7 @@ abstract class CommonDevice extends CommonDropdown {
       }
 
       $query = "SELECT `id`
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE ".  implode(" AND ", $where);
 
       $result = $DB->query($query);

--- a/inc/commondevice.class.php
+++ b/inc/commondevice.class.php
@@ -208,7 +208,7 @@ abstract class CommonDevice extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'designation',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -225,7 +225,7 @@ abstract class CommonDevice extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -233,7 +233,7 @@ abstract class CommonDevice extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -242,7 +242,7 @@ abstract class CommonDevice extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -417,7 +417,7 @@ abstract class CommonDevice extends CommonDropdown {
       }
 
       $query = "SELECT `id`
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE ".  implode(" AND ", $where);
 
       $result = $DB->query($query);

--- a/inc/commondevice.class.php
+++ b/inc/commondevice.class.php
@@ -208,7 +208,7 @@ abstract class CommonDevice extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'designation',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -225,7 +225,7 @@ abstract class CommonDevice extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -233,7 +233,7 @@ abstract class CommonDevice extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -242,7 +242,7 @@ abstract class CommonDevice extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -417,7 +417,7 @@ abstract class CommonDevice extends CommonDropdown {
       }
 
       $query = "SELECT `id`
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE ".  implode(" AND ", $where);
 
       $result = $DB->query($query);

--- a/inc/commondropdown.class.php
+++ b/inc/commondropdown.class.php
@@ -139,7 +139,7 @@ abstract class CommonDropdown extends CommonDBTM {
     * @return array
    **/
    function getAdditionalFields() {
-      if (FieldExists($this->getTable(), 'product_number')) {
+      if (FieldExists($this::getTable(), 'product_number')) {
          return array(array('name' => 'product_number',
                             'type' => 'text',
                             'label' => __('Product Number')));
@@ -345,11 +345,11 @@ abstract class CommonDropdown extends CommonDBTM {
                } else {
                   $restrict = $this->getEntityID();
                }
-               Dropdown::show(getItemTypeForTable($this->getTable()),
+               Dropdown::show(getItemTypeForTable($this::getTable()),
                               array('value'  => $this->fields[$field['name']],
                                     'name'   => $field['name'],
                                     'entity' => $restrict,
-                                    'used'   => ($ID>0 ? getSonsOf($this->getTable(), $ID)
+                                    'used'   => ($ID>0 ? getSonsOf($this::getTable(), $ID)
                                                        : array())));
                break;
 
@@ -430,7 +430,7 @@ abstract class CommonDropdown extends CommonDBTM {
 
       $tab[] = [
          'id'                => '1',
-         'table'             => $this->getTable(),
+         'table'             => $this::getTable(),
          'field'             => 'name',
          'name'              => __('Name'),
          'datatype'          => 'itemlink',
@@ -439,17 +439,17 @@ abstract class CommonDropdown extends CommonDBTM {
 
       $tab[] = [
          'id'                => '2',
-         'table'             => $this->getTable(),
+         'table'             => $this::getTable(),
          'field'             => 'id',
          'name'              => __('ID'),
          'massiveaction'     => false,
          'datatype'          => 'number'
       ];
 
-      if (FieldExists($this->getTable(), 'product_number')) {
+      if (FieldExists($this::getTable(), 'product_number')) {
          $tab[] = [
             'id'  => '3',
-            'table'  => $this->getTable(),
+            'table'  => $this::getTable(),
             'field'  => 'product_number',
             'name'   => __('Product number')
          ];
@@ -457,7 +457,7 @@ abstract class CommonDropdown extends CommonDBTM {
 
       $tab[] = [
          'id'                => '16',
-         'table'             => $this->getTable(),
+         'table'             => $this::getTable(),
          'field'             => 'comment',
          'name'              => __('Comments'),
          'datatype'          => 'text'
@@ -477,7 +477,7 @@ abstract class CommonDropdown extends CommonDBTM {
       if ($this->maybeRecursive()) {
          $tab[] = [
             'id'             => '86',
-            'table'          => $this->getTable(),
+            'table'          => $this::getTable(),
             'field'          => 'is_recursive',
             'name'           => __('Child entities'),
             'datatype'       => 'bool'
@@ -487,7 +487,7 @@ abstract class CommonDropdown extends CommonDBTM {
       if ($this->isField('date_mod')) {
          $tab[] = [
             'id'             => '19',
-            'table'          => $this->getTable(),
+            'table'          => $this::getTable(),
             'field'          => 'date_mod',
             'name'           => __('Last update'),
             'datatype'       => 'datetime',
@@ -498,7 +498,7 @@ abstract class CommonDropdown extends CommonDBTM {
       if ($this->isField('date_creation')) {
          $tab[] = [
             'id'             => '121',
-            'table'          => $this->getTable(),
+            'table'          => $this::getTable(),
             'field'          => 'date_creation',
             'name'           => __('Creation date'),
             'datatype'       => 'datetime',
@@ -523,8 +523,8 @@ abstract class CommonDropdown extends CommonDBTM {
       $ID = $this->fields['id'];
 
       $RELATION = getDbRelations();
-      if (isset($RELATION[$this->getTable()])) {
-         foreach ($RELATION[$this->getTable()] as $tablename => $field) {
+      if (isset($RELATION[$this::getTable()])) {
+         foreach ($RELATION[$this::getTable()] as $tablename => $field) {
             if ($tablename[0] != '_') {
                if (!is_array($field)) {
                   $query = "SELECT COUNT(*) AS cpt
@@ -607,15 +607,15 @@ abstract class CommonDropdown extends CommonDBTM {
       if ($this instanceof CommonTreeDropdown) {
          // TreeDropdown => default replacement is parent
          $fk = $this->getForeignKeyField();
-         Dropdown::show(getItemTypeForTable($this->getTable()),
+         Dropdown::show(getItemTypeForTable($this::getTable()),
                         array('name'   => '_replace_by',
                               'value'  => $this->fields[$fk],
                               'entity' => $this->getEntityID(),
-                              'used'   => getSonsOf($this->getTable(), $ID),
+                              'used'   => getSonsOf($this::getTable(), $ID),
                               'width'   => '100%'));
 
       } else {
-         Dropdown::show(getItemTypeForTable($this->getTable()),
+         Dropdown::show(getItemTypeForTable($this::getTable()),
                         array('name'   => '_replace_by',
                               'entity' => $this->getEntityID(),
                               'used'   => array($ID)));
@@ -643,11 +643,11 @@ abstract class CommonDropdown extends CommonDBTM {
 
       if (!empty($input["name"])) {
          $query = "SELECT `id`
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `name` = '".$input["name"]."'";
 
          if ($this->isEntityAssign()) {
-            $query .= getEntitiesRestrictRequest(' AND ', $this->getTable(), '',
+            $query .= getEntitiesRestrictRequest(' AND ', $this::getTable(), '',
                                                  $input['entities_id'], $this->maybeRecursive());
          }
          $query .= " LIMIT 1";
@@ -726,7 +726,7 @@ abstract class CommonDropdown extends CommonDBTM {
          }
       }
       /*
-      switch ($this->getTable()) {
+      switch ($this::getTable()) {
          case "glpi_computermodels" :
          case "glpi_monitormodels" :
          case "glpi_printermodels" :

--- a/inc/commondropdown.class.php
+++ b/inc/commondropdown.class.php
@@ -139,7 +139,7 @@ abstract class CommonDropdown extends CommonDBTM {
     * @return array
    **/
    function getAdditionalFields() {
-      if (FieldExists($static::getTable(), 'product_number')) {
+      if (FieldExists(static::getTable(), 'product_number')) {
          return array(array('name' => 'product_number',
                             'type' => 'text',
                             'label' => __('Product Number')));
@@ -345,11 +345,11 @@ abstract class CommonDropdown extends CommonDBTM {
                } else {
                   $restrict = $this->getEntityID();
                }
-               Dropdown::show(getItemTypeForTable($static::getTable()),
+               Dropdown::show(getItemTypeForTable(static::getTable()),
                               array('value'  => $this->fields[$field['name']],
                                     'name'   => $field['name'],
                                     'entity' => $restrict,
-                                    'used'   => ($ID>0 ? getSonsOf($static::getTable(), $ID)
+                                    'used'   => ($ID>0 ? getSonsOf(static::getTable(), $ID)
                                                        : array())));
                break;
 
@@ -430,7 +430,7 @@ abstract class CommonDropdown extends CommonDBTM {
 
       $tab[] = [
          'id'                => '1',
-         'table'             => $static::getTable(),
+         'table'             => static::getTable(),
          'field'             => 'name',
          'name'              => __('Name'),
          'datatype'          => 'itemlink',
@@ -439,17 +439,17 @@ abstract class CommonDropdown extends CommonDBTM {
 
       $tab[] = [
          'id'                => '2',
-         'table'             => $static::getTable(),
+         'table'             => static::getTable(),
          'field'             => 'id',
          'name'              => __('ID'),
          'massiveaction'     => false,
          'datatype'          => 'number'
       ];
 
-      if (FieldExists($static::getTable(), 'product_number')) {
+      if (FieldExists(static::getTable(), 'product_number')) {
          $tab[] = [
             'id'  => '3',
-            'table'  => $static::getTable(),
+            'table'  => static::getTable(),
             'field'  => 'product_number',
             'name'   => __('Product number')
          ];
@@ -457,7 +457,7 @@ abstract class CommonDropdown extends CommonDBTM {
 
       $tab[] = [
          'id'                => '16',
-         'table'             => $static::getTable(),
+         'table'             => static::getTable(),
          'field'             => 'comment',
          'name'              => __('Comments'),
          'datatype'          => 'text'
@@ -477,7 +477,7 @@ abstract class CommonDropdown extends CommonDBTM {
       if ($this->maybeRecursive()) {
          $tab[] = [
             'id'             => '86',
-            'table'          => $static::getTable(),
+            'table'          => static::getTable(),
             'field'          => 'is_recursive',
             'name'           => __('Child entities'),
             'datatype'       => 'bool'
@@ -487,7 +487,7 @@ abstract class CommonDropdown extends CommonDBTM {
       if ($this->isField('date_mod')) {
          $tab[] = [
             'id'             => '19',
-            'table'          => $static::getTable(),
+            'table'          => static::getTable(),
             'field'          => 'date_mod',
             'name'           => __('Last update'),
             'datatype'       => 'datetime',
@@ -498,7 +498,7 @@ abstract class CommonDropdown extends CommonDBTM {
       if ($this->isField('date_creation')) {
          $tab[] = [
             'id'             => '121',
-            'table'          => $static::getTable(),
+            'table'          => static::getTable(),
             'field'          => 'date_creation',
             'name'           => __('Creation date'),
             'datatype'       => 'datetime',
@@ -523,8 +523,8 @@ abstract class CommonDropdown extends CommonDBTM {
       $ID = $this->fields['id'];
 
       $RELATION = getDbRelations();
-      if (isset($RELATION[$static::getTable()])) {
-         foreach ($RELATION[$static::getTable()] as $tablename => $field) {
+      if (isset($RELATION[static::getTable()])) {
+         foreach ($RELATION[static::getTable()] as $tablename => $field) {
             if ($tablename[0] != '_') {
                if (!is_array($field)) {
                   $query = "SELECT COUNT(*) AS cpt
@@ -607,15 +607,15 @@ abstract class CommonDropdown extends CommonDBTM {
       if ($this instanceof CommonTreeDropdown) {
          // TreeDropdown => default replacement is parent
          $fk = $this->getForeignKeyField();
-         Dropdown::show(getItemTypeForTable($static::getTable()),
+         Dropdown::show(getItemTypeForTable(static::getTable()),
                         array('name'   => '_replace_by',
                               'value'  => $this->fields[$fk],
                               'entity' => $this->getEntityID(),
-                              'used'   => getSonsOf($static::getTable(), $ID),
+                              'used'   => getSonsOf(static::getTable(), $ID),
                               'width'   => '100%'));
 
       } else {
-         Dropdown::show(getItemTypeForTable($static::getTable()),
+         Dropdown::show(getItemTypeForTable(static::getTable()),
                         array('name'   => '_replace_by',
                               'entity' => $this->getEntityID(),
                               'used'   => array($ID)));
@@ -643,11 +643,11 @@ abstract class CommonDropdown extends CommonDBTM {
 
       if (!empty($input["name"])) {
          $query = "SELECT `id`
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `name` = '".$input["name"]."'";
 
          if ($this->isEntityAssign()) {
-            $query .= getEntitiesRestrictRequest(' AND ', $static::getTable(), '',
+            $query .= getEntitiesRestrictRequest(' AND ', static::getTable(), '',
                                                  $input['entities_id'], $this->maybeRecursive());
          }
          $query .= " LIMIT 1";
@@ -726,7 +726,7 @@ abstract class CommonDropdown extends CommonDBTM {
          }
       }
       /*
-      switch ($static::getTable()) {
+      switch (static::getTable()) {
          case "glpi_computermodels" :
          case "glpi_monitormodels" :
          case "glpi_printermodels" :

--- a/inc/commondropdown.class.php
+++ b/inc/commondropdown.class.php
@@ -139,7 +139,7 @@ abstract class CommonDropdown extends CommonDBTM {
     * @return array
    **/
    function getAdditionalFields() {
-      if (FieldExists($this::getTable(), 'product_number')) {
+      if (FieldExists($static::getTable(), 'product_number')) {
          return array(array('name' => 'product_number',
                             'type' => 'text',
                             'label' => __('Product Number')));
@@ -345,11 +345,11 @@ abstract class CommonDropdown extends CommonDBTM {
                } else {
                   $restrict = $this->getEntityID();
                }
-               Dropdown::show(getItemTypeForTable($this::getTable()),
+               Dropdown::show(getItemTypeForTable($static::getTable()),
                               array('value'  => $this->fields[$field['name']],
                                     'name'   => $field['name'],
                                     'entity' => $restrict,
-                                    'used'   => ($ID>0 ? getSonsOf($this::getTable(), $ID)
+                                    'used'   => ($ID>0 ? getSonsOf($static::getTable(), $ID)
                                                        : array())));
                break;
 
@@ -430,7 +430,7 @@ abstract class CommonDropdown extends CommonDBTM {
 
       $tab[] = [
          'id'                => '1',
-         'table'             => $this::getTable(),
+         'table'             => $static::getTable(),
          'field'             => 'name',
          'name'              => __('Name'),
          'datatype'          => 'itemlink',
@@ -439,17 +439,17 @@ abstract class CommonDropdown extends CommonDBTM {
 
       $tab[] = [
          'id'                => '2',
-         'table'             => $this::getTable(),
+         'table'             => $static::getTable(),
          'field'             => 'id',
          'name'              => __('ID'),
          'massiveaction'     => false,
          'datatype'          => 'number'
       ];
 
-      if (FieldExists($this::getTable(), 'product_number')) {
+      if (FieldExists($static::getTable(), 'product_number')) {
          $tab[] = [
             'id'  => '3',
-            'table'  => $this::getTable(),
+            'table'  => $static::getTable(),
             'field'  => 'product_number',
             'name'   => __('Product number')
          ];
@@ -457,7 +457,7 @@ abstract class CommonDropdown extends CommonDBTM {
 
       $tab[] = [
          'id'                => '16',
-         'table'             => $this::getTable(),
+         'table'             => $static::getTable(),
          'field'             => 'comment',
          'name'              => __('Comments'),
          'datatype'          => 'text'
@@ -477,7 +477,7 @@ abstract class CommonDropdown extends CommonDBTM {
       if ($this->maybeRecursive()) {
          $tab[] = [
             'id'             => '86',
-            'table'          => $this::getTable(),
+            'table'          => $static::getTable(),
             'field'          => 'is_recursive',
             'name'           => __('Child entities'),
             'datatype'       => 'bool'
@@ -487,7 +487,7 @@ abstract class CommonDropdown extends CommonDBTM {
       if ($this->isField('date_mod')) {
          $tab[] = [
             'id'             => '19',
-            'table'          => $this::getTable(),
+            'table'          => $static::getTable(),
             'field'          => 'date_mod',
             'name'           => __('Last update'),
             'datatype'       => 'datetime',
@@ -498,7 +498,7 @@ abstract class CommonDropdown extends CommonDBTM {
       if ($this->isField('date_creation')) {
          $tab[] = [
             'id'             => '121',
-            'table'          => $this::getTable(),
+            'table'          => $static::getTable(),
             'field'          => 'date_creation',
             'name'           => __('Creation date'),
             'datatype'       => 'datetime',
@@ -523,8 +523,8 @@ abstract class CommonDropdown extends CommonDBTM {
       $ID = $this->fields['id'];
 
       $RELATION = getDbRelations();
-      if (isset($RELATION[$this::getTable()])) {
-         foreach ($RELATION[$this::getTable()] as $tablename => $field) {
+      if (isset($RELATION[$static::getTable()])) {
+         foreach ($RELATION[$static::getTable()] as $tablename => $field) {
             if ($tablename[0] != '_') {
                if (!is_array($field)) {
                   $query = "SELECT COUNT(*) AS cpt
@@ -607,15 +607,15 @@ abstract class CommonDropdown extends CommonDBTM {
       if ($this instanceof CommonTreeDropdown) {
          // TreeDropdown => default replacement is parent
          $fk = $this->getForeignKeyField();
-         Dropdown::show(getItemTypeForTable($this::getTable()),
+         Dropdown::show(getItemTypeForTable($static::getTable()),
                         array('name'   => '_replace_by',
                               'value'  => $this->fields[$fk],
                               'entity' => $this->getEntityID(),
-                              'used'   => getSonsOf($this::getTable(), $ID),
+                              'used'   => getSonsOf($static::getTable(), $ID),
                               'width'   => '100%'));
 
       } else {
-         Dropdown::show(getItemTypeForTable($this::getTable()),
+         Dropdown::show(getItemTypeForTable($static::getTable()),
                         array('name'   => '_replace_by',
                               'entity' => $this->getEntityID(),
                               'used'   => array($ID)));
@@ -643,11 +643,11 @@ abstract class CommonDropdown extends CommonDBTM {
 
       if (!empty($input["name"])) {
          $query = "SELECT `id`
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `name` = '".$input["name"]."'";
 
          if ($this->isEntityAssign()) {
-            $query .= getEntitiesRestrictRequest(' AND ', $this::getTable(), '',
+            $query .= getEntitiesRestrictRequest(' AND ', $static::getTable(), '',
                                                  $input['entities_id'], $this->maybeRecursive());
          }
          $query .= " LIMIT 1";
@@ -726,7 +726,7 @@ abstract class CommonDropdown extends CommonDBTM {
          }
       }
       /*
-      switch ($this::getTable()) {
+      switch ($static::getTable()) {
          case "glpi_computermodels" :
          case "glpi_monitormodels" :
          case "glpi_printermodels" :

--- a/inc/commonimplicittreedropdown.class.php
+++ b/inc/commonimplicittreedropdown.class.php
@@ -187,7 +187,7 @@ class CommonImplicitTreeDropdown extends CommonTreeDropdown {
       if ($step != "add") { // Because there is no old sons of new node
          // First, get all my current direct sons (old ones) that are not new potential sons
          $query = "SELECT `id`
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `".$this->getForeignKeyField()."` = '".$this->getID()."'
                          AND `id` NOT IN ('".implode("', '", $potentialSons)."')";
          $oldSons = array();
@@ -195,7 +195,7 @@ class CommonImplicitTreeDropdown extends CommonTreeDropdown {
             $oldSons[] = $oldSon["id"];
          }
          if (count($oldSons) > 0) { // Then make them pointing to old parent
-            $query = "UPDATE `".$this::getTable()."`
+            $query = "UPDATE `".$static::getTable()."`
                       SET `".$this->getForeignKeyField()."` = '$oldParent'
                       WHERE `id` IN ('".implode("', '", $oldSons)."')";
             $DB->query($query);
@@ -209,7 +209,7 @@ class CommonImplicitTreeDropdown extends CommonTreeDropdown {
          // And, get all direct sons of my new Father that must be attached to me (ie : that are
          // potential sons
          $query = "SELECT `id`
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `".$this->getForeignKeyField()."` = '$newParent'
                          AND `id` IN ('".implode("', '", $potentialSons)."')";
          $newSons = array();
@@ -217,7 +217,7 @@ class CommonImplicitTreeDropdown extends CommonTreeDropdown {
             $newSons[] = $newSon["id"];
          }
          if (count($newSons) > 0) { // Then make them pointing to me
-            $query = "UPDATE `".$this::getTable()."`
+            $query = "UPDATE `".$static::getTable()."`
                       SET `".$this->getForeignKeyField()."` = '".$this->getID()."'
                       WHERE `id` IN ('".implode("', '", $newSons)."')";
             $DB->query($query);

--- a/inc/commonimplicittreedropdown.class.php
+++ b/inc/commonimplicittreedropdown.class.php
@@ -187,7 +187,7 @@ class CommonImplicitTreeDropdown extends CommonTreeDropdown {
       if ($step != "add") { // Because there is no old sons of new node
          // First, get all my current direct sons (old ones) that are not new potential sons
          $query = "SELECT `id`
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `".$this->getForeignKeyField()."` = '".$this->getID()."'
                          AND `id` NOT IN ('".implode("', '", $potentialSons)."')";
          $oldSons = array();
@@ -195,7 +195,7 @@ class CommonImplicitTreeDropdown extends CommonTreeDropdown {
             $oldSons[] = $oldSon["id"];
          }
          if (count($oldSons) > 0) { // Then make them pointing to old parent
-            $query = "UPDATE `".$this->getTable()."`
+            $query = "UPDATE `".$this::getTable()."`
                       SET `".$this->getForeignKeyField()."` = '$oldParent'
                       WHERE `id` IN ('".implode("', '", $oldSons)."')";
             $DB->query($query);
@@ -209,7 +209,7 @@ class CommonImplicitTreeDropdown extends CommonTreeDropdown {
          // And, get all direct sons of my new Father that must be attached to me (ie : that are
          // potential sons
          $query = "SELECT `id`
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `".$this->getForeignKeyField()."` = '$newParent'
                          AND `id` IN ('".implode("', '", $potentialSons)."')";
          $newSons = array();
@@ -217,7 +217,7 @@ class CommonImplicitTreeDropdown extends CommonTreeDropdown {
             $newSons[] = $newSon["id"];
          }
          if (count($newSons) > 0) { // Then make them pointing to me
-            $query = "UPDATE `".$this->getTable()."`
+            $query = "UPDATE `".$this::getTable()."`
                       SET `".$this->getForeignKeyField()."` = '".$this->getID()."'
                       WHERE `id` IN ('".implode("', '", $newSons)."')";
             $DB->query($query);

--- a/inc/commonimplicittreedropdown.class.php
+++ b/inc/commonimplicittreedropdown.class.php
@@ -187,7 +187,7 @@ class CommonImplicitTreeDropdown extends CommonTreeDropdown {
       if ($step != "add") { // Because there is no old sons of new node
          // First, get all my current direct sons (old ones) that are not new potential sons
          $query = "SELECT `id`
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `".$this->getForeignKeyField()."` = '".$this->getID()."'
                          AND `id` NOT IN ('".implode("', '", $potentialSons)."')";
          $oldSons = array();
@@ -195,7 +195,7 @@ class CommonImplicitTreeDropdown extends CommonTreeDropdown {
             $oldSons[] = $oldSon["id"];
          }
          if (count($oldSons) > 0) { // Then make them pointing to old parent
-            $query = "UPDATE `".$static::getTable()."`
+            $query = "UPDATE `".static::getTable()."`
                       SET `".$this->getForeignKeyField()."` = '$oldParent'
                       WHERE `id` IN ('".implode("', '", $oldSons)."')";
             $DB->query($query);
@@ -209,7 +209,7 @@ class CommonImplicitTreeDropdown extends CommonTreeDropdown {
          // And, get all direct sons of my new Father that must be attached to me (ie : that are
          // potential sons
          $query = "SELECT `id`
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `".$this->getForeignKeyField()."` = '$newParent'
                          AND `id` IN ('".implode("', '", $potentialSons)."')";
          $newSons = array();
@@ -217,7 +217,7 @@ class CommonImplicitTreeDropdown extends CommonTreeDropdown {
             $newSons[] = $newSon["id"];
          }
          if (count($newSons) > 0) { // Then make them pointing to me
-            $query = "UPDATE `".$static::getTable()."`
+            $query = "UPDATE `".static::getTable()."`
                       SET `".$this->getForeignKeyField()."` = '".$this->getID()."'
                       WHERE `id` IN ('".implode("', '", $newSons)."')";
             $DB->query($query);

--- a/inc/commonitilactor.class.php
+++ b/inc/commonitilactor.class.php
@@ -93,8 +93,8 @@ abstract class CommonITILActor extends CommonDBRelation {
       global $DB;
 
       $users = array();
-      $query = "SELECT `".$this->getTable()."`.*
-                FROM `".$this->getTable()."`
+      $query = "SELECT `".$this::getTable()."`.*
+                FROM `".$this::getTable()."`
                 WHERE `".static::getItilObjectForeignKey()."` = '$items_id'";
 
       foreach ($DB->request($query) as $data) {
@@ -111,8 +111,8 @@ abstract class CommonITILActor extends CommonDBRelation {
    function isAlternateEmailForITILObject($items_id, $email) {
       global $DB;
 
-      $query = "SELECT `".$this->getTable()."`.*
-                FROM `".$this->getTable()."`
+      $query = "SELECT `".$this::getTable()."`.*
+                FROM `".$this::getTable()."`
                 WHERE `".static::getItilObjectForeignKey()."` = '$items_id'
                   AND `alternative_email` = '$email'";
 

--- a/inc/commonitilactor.class.php
+++ b/inc/commonitilactor.class.php
@@ -93,8 +93,8 @@ abstract class CommonITILActor extends CommonDBRelation {
       global $DB;
 
       $users = array();
-      $query = "SELECT `".$this::getTable()."`.*
-                FROM `".$this::getTable()."`
+      $query = "SELECT `".$static::getTable()."`.*
+                FROM `".$static::getTable()."`
                 WHERE `".static::getItilObjectForeignKey()."` = '$items_id'";
 
       foreach ($DB->request($query) as $data) {
@@ -111,8 +111,8 @@ abstract class CommonITILActor extends CommonDBRelation {
    function isAlternateEmailForITILObject($items_id, $email) {
       global $DB;
 
-      $query = "SELECT `".$this::getTable()."`.*
-                FROM `".$this::getTable()."`
+      $query = "SELECT `".$static::getTable()."`.*
+                FROM `".$static::getTable()."`
                 WHERE `".static::getItilObjectForeignKey()."` = '$items_id'
                   AND `alternative_email` = '$email'";
 

--- a/inc/commonitilactor.class.php
+++ b/inc/commonitilactor.class.php
@@ -93,8 +93,8 @@ abstract class CommonITILActor extends CommonDBRelation {
       global $DB;
 
       $users = array();
-      $query = "SELECT `".$static::getTable()."`.*
-                FROM `".$static::getTable()."`
+      $query = "SELECT `".static::getTable()."`.*
+                FROM `".static::getTable()."`
                 WHERE `".static::getItilObjectForeignKey()."` = '$items_id'";
 
       foreach ($DB->request($query) as $data) {
@@ -111,8 +111,8 @@ abstract class CommonITILActor extends CommonDBRelation {
    function isAlternateEmailForITILObject($items_id, $email) {
       global $DB;
 
-      $query = "SELECT `".$static::getTable()."`.*
-                FROM `".$static::getTable()."`
+      $query = "SELECT `".static::getTable()."`.*
+                FROM `".static::getTable()."`
                 WHERE `".static::getItilObjectForeignKey()."` = '$items_id'
                   AND `alternative_email` = '$email'";
 

--- a/inc/commonitilcost.class.php
+++ b/inc/commonitilcost.class.php
@@ -68,7 +68,7 @@ abstract class CommonITILCost extends CommonDBChild {
           && static::canView()) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($static::getTable(),
+            $nb = countElementsInTable(static::getTable(),
                                        [$item->getForeignKeyField() => $item->getID()]);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
@@ -99,7 +99,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'searchtype'         => 'contains',
@@ -109,7 +109,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -118,7 +118,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -126,7 +126,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Begin date'),
          'datatype'           => 'datetime'
@@ -134,7 +134,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'
@@ -142,7 +142,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'actiontime',
          'name'               => __('Duration'),
          'datatype'           => 'timestamp'
@@ -150,7 +150,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'cost_time',
          'name'               => __('Time cost'),
          'datatype'           => 'decimal'
@@ -158,7 +158,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'cost_fixed',
          'name'               => __('Fixed cost'),
          'datatype'           => 'decimal'
@@ -166,7 +166,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'cost_material',
          'name'               => __('Material cost'),
          'datatype'           => 'decimal'
@@ -333,7 +333,7 @@ abstract class CommonITILCost extends CommonDBChild {
       global $DB;
 
       $query = "SELECT SUM(`actiontime`)
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `".static::$items_id."` = '$items_id'";
 
       if ($result = $DB->query($query)) {
@@ -353,7 +353,7 @@ abstract class CommonITILCost extends CommonDBChild {
       global $DB;
 
       $query = "SELECT *
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `".static::$items_id."` = '$items_id'
                 ORDER BY 'end_date' DESC, `id` DESC";
 

--- a/inc/commonitilcost.class.php
+++ b/inc/commonitilcost.class.php
@@ -68,7 +68,7 @@ abstract class CommonITILCost extends CommonDBChild {
           && static::canView()) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($this::getTable(),
+            $nb = countElementsInTable($static::getTable(),
                                        [$item->getForeignKeyField() => $item->getID()]);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
@@ -99,7 +99,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'searchtype'         => 'contains',
@@ -109,7 +109,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -118,7 +118,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -126,7 +126,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Begin date'),
          'datatype'           => 'datetime'
@@ -134,7 +134,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'
@@ -142,7 +142,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'actiontime',
          'name'               => __('Duration'),
          'datatype'           => 'timestamp'
@@ -150,7 +150,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'cost_time',
          'name'               => __('Time cost'),
          'datatype'           => 'decimal'
@@ -158,7 +158,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'cost_fixed',
          'name'               => __('Fixed cost'),
          'datatype'           => 'decimal'
@@ -166,7 +166,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'cost_material',
          'name'               => __('Material cost'),
          'datatype'           => 'decimal'
@@ -333,7 +333,7 @@ abstract class CommonITILCost extends CommonDBChild {
       global $DB;
 
       $query = "SELECT SUM(`actiontime`)
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `".static::$items_id."` = '$items_id'";
 
       if ($result = $DB->query($query)) {
@@ -353,7 +353,7 @@ abstract class CommonITILCost extends CommonDBChild {
       global $DB;
 
       $query = "SELECT *
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `".static::$items_id."` = '$items_id'
                 ORDER BY 'end_date' DESC, `id` DESC";
 

--- a/inc/commonitilcost.class.php
+++ b/inc/commonitilcost.class.php
@@ -68,7 +68,7 @@ abstract class CommonITILCost extends CommonDBChild {
           && static::canView()) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($this->getTable(),
+            $nb = countElementsInTable($this::getTable(),
                                        [$item->getForeignKeyField() => $item->getID()]);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
@@ -99,7 +99,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'searchtype'         => 'contains',
@@ -109,7 +109,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -118,7 +118,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -126,7 +126,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Begin date'),
          'datatype'           => 'datetime'
@@ -134,7 +134,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'
@@ -142,7 +142,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'actiontime',
          'name'               => __('Duration'),
          'datatype'           => 'timestamp'
@@ -150,7 +150,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'cost_time',
          'name'               => __('Time cost'),
          'datatype'           => 'decimal'
@@ -158,7 +158,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'cost_fixed',
          'name'               => __('Fixed cost'),
          'datatype'           => 'decimal'
@@ -166,7 +166,7 @@ abstract class CommonITILCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'cost_material',
          'name'               => __('Material cost'),
          'datatype'           => 'decimal'
@@ -333,7 +333,7 @@ abstract class CommonITILCost extends CommonDBChild {
       global $DB;
 
       $query = "SELECT SUM(`actiontime`)
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `".static::$items_id."` = '$items_id'";
 
       if ($result = $DB->query($query)) {
@@ -353,7 +353,7 @@ abstract class CommonITILCost extends CommonDBChild {
       global $DB;
 
       $query = "SELECT *
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `".static::$items_id."` = '$items_id'
                 ORDER BY 'end_date' DESC, `id` DESC";
 

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -446,10 +446,10 @@ abstract class CommonITILObject extends CommonDBTM {
    function countActiveObjectsForUser($users_id) {
 
       $linkclass = new $this->userlinkclass();
-      $itemtable = $this->getTable();
+      $itemtable = $this::getTable();
       $itemtype  = $this->getType();
       $itemfk    = $this->getForeignKeyField();
-      $linktable = $linkclass->getTable();
+      $linktable = $linkclass::getTable();
 
       return countElementsInTable(array($itemtable,$linktable),
                                   getEntitiesRestrictRequest("", $itemtable)."
@@ -477,10 +477,10 @@ abstract class CommonITILObject extends CommonDBTM {
    function countActiveObjectsForTech($users_id) {
 
       $linkclass = new $this->userlinkclass();
-      $itemtable = $this->getTable();
+      $itemtable = $this::getTable();
       $itemtype  = $this->getType();
       $itemfk    = $this->getForeignKeyField();
-      $linktable = $linkclass->getTable();
+      $linktable = $linkclass::getTable();
 
       return countElementsInTable(array($itemtable,$linktable),
                                   getEntitiesRestrictRequest("", $itemtable)."
@@ -508,10 +508,10 @@ abstract class CommonITILObject extends CommonDBTM {
    function countActiveObjectsForTechGroup($groups_id) {
 
       $linkclass = new $this->grouplinkclass();
-      $itemtable = $this->getTable();
+      $itemtable = $this::getTable();
       $itemtype  = $this->getType();
       $itemfk    = $this->getForeignKeyField();
-      $linktable = $linkclass->getTable();
+      $linktable = $linkclass::getTable();
 
       return countElementsInTable(array($itemtable,$linktable),
                                   getEntitiesRestrictRequest("", $itemtable)."
@@ -539,10 +539,10 @@ abstract class CommonITILObject extends CommonDBTM {
    function countActiveObjectsForSupplier($suppliers_id) {
 
       $linkclass = new $this->supplierlinkclass();
-      $itemtable = $this->getTable();
+      $itemtable = $this::getTable();
       $itemtype  = $this->getType();
       $itemfk    = $this->getForeignKeyField();
-      $linktable = $linkclass->getTable();
+      $linktable = $linkclass::getTable();
 
       return countElementsInTable(array($itemtable,$linktable),
                                   getEntitiesRestrictRequest("", $itemtable)."
@@ -2316,7 +2316,7 @@ abstract class CommonITILObject extends CommonDBTM {
             if ($supplier->getFromDB($k)) {
                echo $supplier->getLink(array('comments' => $showsupplierlink));
                echo "&nbsp;";
-               $tmpname = Dropdown::getDropdownName($supplier->getTable(), $k, 1);
+               $tmpname = Dropdown::getDropdownName($supplier::getTable(), $k, 1);
                Html::showToolTip($tmpname['comment']);
 
                if ($CFG_GLPI['use_mailing']) {
@@ -2595,7 +2595,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'datatype'           => 'itemlink',
@@ -2606,7 +2606,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $newtab = [
          'id'                 => '21',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'massiveaction'      => false,
@@ -2620,7 +2620,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -2629,7 +2629,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'status',
          'name'               => __('Status'),
          'searchtype'         => 'equals',
@@ -2638,7 +2638,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'urgency',
          'name'               => __('Urgency'),
          'searchtype'         => 'equals',
@@ -2647,7 +2647,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'impact',
          'name'               => __('Impact'),
          'searchtype'         => 'equals',
@@ -2656,7 +2656,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'priority',
          'name'               => __('Priority'),
          'searchtype'         => 'equals',
@@ -2665,7 +2665,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date',
          'name'               => __('Opening date'),
          'datatype'           => 'datetime',
@@ -2674,7 +2674,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'closedate',
          'name'               => __('Closing date'),
          'datatype'           => 'datetime',
@@ -2683,7 +2683,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'due_date',
          'name'               => __('Time to resolve'),
          'datatype'           => 'datetime',
@@ -2694,7 +2694,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '151',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'due_date',
          'name'               => __('Time to resolve + Progress'),
          'massiveaction'      => false,
@@ -2704,7 +2704,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_late',
          'name'               => __('Time to resolve exceedeed'),
          'datatype'           => 'bool',
@@ -2719,7 +2719,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'solvedate',
          'name'               => __('Resolution date'),
          'datatype'           => 'datetime',
@@ -2728,7 +2728,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -2761,7 +2761,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '45',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'actiontime',
          'name'               => __('Total duration'),
          'datatype'           => 'timestamp',
@@ -2815,7 +2815,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'solution',
          'name'               => _n('Solution', 'Solutions', 1),
          'datatype'           => 'text',
@@ -2837,7 +2837,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '154',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'solve_delay_stat',
          'name'               => __('Resolution time'),
          'datatype'           => 'timestamp',
@@ -2847,7 +2847,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '152',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'close_delay_stat',
          'name'               => __('Closing time'),
          'datatype'           => 'timestamp',
@@ -2857,7 +2857,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '153',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'waiting_duration',
          'name'               => __('Waiting time'),
          'datatype'           => 'timestamp',
@@ -4265,7 +4265,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       if ($this->getFromDB($ID)) {
          // Force date mod and lastupdater
-         $query = "UPDATE `".$this->getTable()."`
+         $query = "UPDATE `".$this::getTable()."`
                    SET `date_mod` = '".$_SESSION["glpi_currenttime"]."'";
 
          // set last updater if interactive user
@@ -4304,7 +4304,7 @@ abstract class CommonITILObject extends CommonDBTM {
             $tot += $sum;
          }
       }
-      $query2 = "UPDATE `".$this->getTable()."`
+      $query2 = "UPDATE `".$this::getTable()."`
                  SET `actiontime` = '$tot'
                  WHERE `id` = '$ID'";
 
@@ -4530,22 +4530,22 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $linkclass = new $this->userlinkclass();
-      $linktable = $linkclass->getTable();
+      $linktable = $linkclass::getTable();
 
       $query = "SELECT DISTINCT `glpi_users`.`id` AS users_id, `glpi_users`.`name` AS name,
                                 `glpi_users`.`realname` AS realname,
                                 `glpi_users`.`firstname` AS firstname
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this->getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::REQUESTER."')
                 INNER JOIN `glpi_users` ON (`glpi_users`.`id` = `$linktable`.`users_id`)
-                WHERE NOT `".$this->getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this->getTable());
+                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $this::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this->getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this->getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY realname, firstname, name";
@@ -4578,15 +4578,15 @@ abstract class CommonITILObject extends CommonDBTM {
                                 `glpi_users`.`name` AS name,
                                 `glpi_users`.`realname` AS realname,
                                 `glpi_users`.`firstname` AS firstname
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 LEFT JOIN `glpi_users`
-                     ON (`glpi_users`.`id` = `".$this->getTable()."`.`users_id_recipient`)
-                WHERE NOT `".$this->getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this->getTable());
+                     ON (`glpi_users`.`id` = `".$this::getTable()."`.`users_id_recipient`)
+                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $this::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this->getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this->getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY realname, firstname, name";
@@ -4617,20 +4617,20 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $linkclass = new $this->grouplinkclass();
-      $linktable = $linkclass->getTable();
+      $linktable = $linkclass::getTable();
 
       $query = "SELECT DISTINCT `glpi_groups`.`id`, `glpi_groups`.`completename`
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this->getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::REQUESTER."')
                 LEFT JOIN `glpi_groups` ON (`$linktable`.`groups_id` = `glpi_groups`.`id`)
-                WHERE NOT `".$this->getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this->getTable());
+                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $this::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this->getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this->getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `glpi_groups`.`completename`";
@@ -4661,7 +4661,7 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $linkclass = new $this->userlinkclass();
-      $linktable = $linkclass->getTable();
+      $linktable = $linkclass::getTable();
 
       if ($title) {
          $table = "glpi_usertitles";
@@ -4672,17 +4672,17 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       $query = "SELECT DISTINCT `glpi_users`.`$field`
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 INNER JOIN `$linktable`
-                  ON (`".$this->getTable()."`.`id` = `$linktable`.`".$this->getForeignKeyField()."`)
+                  ON (`".$this::getTable()."`.`id` = `$linktable`.`".$this->getForeignKeyField()."`)
                 INNER JOIN `glpi_users` ON (`glpi_users`.`id` = `$linktable`.`users_id`)
                 LEFT JOIN `$table` ON (`$table`.`id` = `glpi_users`.`$field`)
-                WHERE NOT `".$this->getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this->getTable());
+                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $this::getTable());
 
       if (!empty($date1)||!empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this->getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this->getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .=" ORDER BY `glpi_users`.`$field`";
@@ -4712,13 +4712,13 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `priority`
-                FROM `".$this->getTable()."`
-                WHERE NOT `".$this->getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this->getTable());
+                FROM `".$this::getTable()."`
+                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $this::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this->getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this->getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `priority`";
@@ -4749,13 +4749,13 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `urgency`
-                FROM `".$this->getTable()."`
-                WHERE NOT `".$this->getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this->getTable());
+                FROM `".$this::getTable()."`
+                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $this::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this->getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this->getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `urgency`";
@@ -4787,13 +4787,13 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `impact`
-                FROM `".$this->getTable()."`
-                WHERE NOT `".$this->getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this->getTable());
+                FROM `".$this::getTable()."`
+                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $this::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this->getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this->getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `impact`";
@@ -4824,14 +4824,14 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `requesttypes_id`
-                FROM `".$this->getTable()."`
-                WHERE NOT `".$this->getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this->getTable());
+                FROM `".$this::getTable()."`
+                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $this::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this->getTable()."`.`date`",
+         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`",
                                            $date1, $date2)."
-                          OR ".getDateRequest("`".$this->getTable()."`.`closedate`",
+                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`",
                                               $date1, $date2).") ";
       }
       $query .= " ORDER BY `requesttypes_id`";
@@ -4862,13 +4862,13 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `solutiontypes_id`
-                FROM `".$this->getTable()."`
-                WHERE NOT `".$this->getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this->getTable());
+                FROM `".$this::getTable()."`
+                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $this::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this->getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this->getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `solutiontypes_id`";
@@ -4898,25 +4898,25 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $linkclass = new $this->userlinkclass();
-      $linktable = $linkclass->getTable();
+      $linktable = $linkclass::getTable();
       $showlink = User::canView();
 
       $query = "SELECT DISTINCT `glpi_users`.`id` AS users_id,
                                 `glpi_users`.`name` AS name,
                                 `glpi_users`.`realname` AS realname,
                                 `glpi_users`.`firstname` AS firstname
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this->getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::ASSIGN."')
                 LEFT JOIN `glpi_users` ON (`glpi_users`.`id` = `$linktable`.`users_id`)
-                WHERE NOT `".$this->getTable()."`.`is_deleted` ".
-                getEntitiesRestrictRequest("AND", $this->getTable());
+                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
+                getEntitiesRestrictRequest("AND", $this::getTable());
 
       if (!empty($date1)||!empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this->getTable()."`.`date`",
+         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`",
                                            $date1, $date2)."
-                          OR ".getDateRequest("`".$this->getTable()."`.`closedate`",
+                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`",
                                               $date1, $date2).") ";
       }
       $query .= " ORDER BY realname, firstname, name";
@@ -4954,9 +4954,9 @@ abstract class CommonITILObject extends CommonDBTM {
                                 `glpi_users`.`name` AS name,
                                 `glpi_users`.`realname` AS realname,
                                 `glpi_users`.`firstname` AS firstname
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 LEFT JOIN `$tasktable`
-                  ON (`".$this->getTable()."`.`id` = `$tasktable`.`".$this->getForeignKeyField()."`)
+                  ON (`".$this::getTable()."`.`id` = `$tasktable`.`".$this->getForeignKeyField()."`)
                 LEFT JOIN `glpi_users` ON (`glpi_users`.`id` = `$tasktable`.`users_id`)
                 LEFT JOIN `glpi_profiles_users`
                   ON (`glpi_users`.`id` = `glpi_profiles_users`.`users_id`)
@@ -4964,13 +4964,13 @@ abstract class CommonITILObject extends CommonDBTM {
                   ON (`glpi_profiles`.`id` = `glpi_profiles_users`.`profiles_id`)
                 LEFT JOIN `glpi_profilerights`
                   ON (`glpi_profiles`.`id` = `glpi_profilerights`.`profiles_id`)
-                WHERE NOT `".$this->getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this->getTable());
+                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $this::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this->getTable()."`.`date`",
+         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`",
                                            $date1, $date2)."
-                          OR ".getDateRequest("`".$this->getTable()."`.`closedate`",
+                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`",
                                               $date1, $date2).") ";
       }
       $query .="     AND `glpi_profilerights`.`name` = 'ticket'
@@ -5006,23 +5006,23 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB,$CFG_GLPI;
 
       $linkclass = new $this->supplierlinkclass();
-      $linktable = $linkclass->getTable();
+      $linktable = $linkclass::getTable();
 
       $query = "SELECT DISTINCT `glpi_suppliers`.`id` AS suppliers_id_assign,
                                 `glpi_suppliers`.`name` AS name
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this->getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::ASSIGN."')
                 LEFT JOIN `glpi_suppliers`
                      ON (`glpi_suppliers`.`id` = `$linktable`.`suppliers_id`)
-                WHERE NOT `".$this->getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this->getTable());
+                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $this::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this->getTable()."`.`date`",
+         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`",
                                            $date1, $date2)."
-                          OR ".getDateRequest("`".$this->getTable()."`.`closedate`",
+                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`",
                                               $date1, $date2).") ";
       }
       $query .= " ORDER BY name";
@@ -5052,20 +5052,20 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $linkclass = new $this->grouplinkclass();
-      $linktable = $linkclass->getTable();
+      $linktable = $linkclass::getTable();
 
       $query = "SELECT DISTINCT `glpi_groups`.`id`, `glpi_groups`.`completename`
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this->getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::ASSIGN."')
                 LEFT JOIN `glpi_groups` ON (`$linktable`.`groups_id` = `glpi_groups`.`id`)
-                WHERE NOT `".$this->getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this->getTable());
+                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $this::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this->getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this->getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `glpi_groups`.`completename`";
@@ -5336,7 +5336,7 @@ abstract class CommonITILObject extends CommonDBTM {
          $plan          = new $tasktype();
          $items         = array();
 
-         foreach ($DB->request($plan->getTable(),
+         foreach ($DB->request($plan::getTable(),
                                array($item->getForeignKeyField() => $item->fields['id'])) as $plan) {
 
             if (isset($plan['begin']) && $plan['begin']) {

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -446,7 +446,7 @@ abstract class CommonITILObject extends CommonDBTM {
    function countActiveObjectsForUser($users_id) {
 
       $linkclass = new $this->userlinkclass();
-      $itemtable = $static::getTable();
+      $itemtable = static::getTable();
       $itemtype  = $this->getType();
       $itemfk    = $this->getForeignKeyField();
       $linktable = $linkclass::getTable();
@@ -477,7 +477,7 @@ abstract class CommonITILObject extends CommonDBTM {
    function countActiveObjectsForTech($users_id) {
 
       $linkclass = new $this->userlinkclass();
-      $itemtable = $static::getTable();
+      $itemtable = static::getTable();
       $itemtype  = $this->getType();
       $itemfk    = $this->getForeignKeyField();
       $linktable = $linkclass::getTable();
@@ -508,7 +508,7 @@ abstract class CommonITILObject extends CommonDBTM {
    function countActiveObjectsForTechGroup($groups_id) {
 
       $linkclass = new $this->grouplinkclass();
-      $itemtable = $static::getTable();
+      $itemtable = static::getTable();
       $itemtype  = $this->getType();
       $itemfk    = $this->getForeignKeyField();
       $linktable = $linkclass::getTable();
@@ -539,7 +539,7 @@ abstract class CommonITILObject extends CommonDBTM {
    function countActiveObjectsForSupplier($suppliers_id) {
 
       $linkclass = new $this->supplierlinkclass();
-      $itemtable = $static::getTable();
+      $itemtable = static::getTable();
       $itemtype  = $this->getType();
       $itemfk    = $this->getForeignKeyField();
       $linktable = $linkclass::getTable();
@@ -2595,7 +2595,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'datatype'           => 'itemlink',
@@ -2606,7 +2606,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $newtab = [
          'id'                 => '21',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'massiveaction'      => false,
@@ -2620,7 +2620,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -2629,7 +2629,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'status',
          'name'               => __('Status'),
          'searchtype'         => 'equals',
@@ -2638,7 +2638,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'urgency',
          'name'               => __('Urgency'),
          'searchtype'         => 'equals',
@@ -2647,7 +2647,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'impact',
          'name'               => __('Impact'),
          'searchtype'         => 'equals',
@@ -2656,7 +2656,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'priority',
          'name'               => __('Priority'),
          'searchtype'         => 'equals',
@@ -2665,7 +2665,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date',
          'name'               => __('Opening date'),
          'datatype'           => 'datetime',
@@ -2674,7 +2674,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'closedate',
          'name'               => __('Closing date'),
          'datatype'           => 'datetime',
@@ -2683,7 +2683,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'due_date',
          'name'               => __('Time to resolve'),
          'datatype'           => 'datetime',
@@ -2694,7 +2694,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '151',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'due_date',
          'name'               => __('Time to resolve + Progress'),
          'massiveaction'      => false,
@@ -2704,7 +2704,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_late',
          'name'               => __('Time to resolve exceedeed'),
          'datatype'           => 'bool',
@@ -2719,7 +2719,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'solvedate',
          'name'               => __('Resolution date'),
          'datatype'           => 'datetime',
@@ -2728,7 +2728,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -2761,7 +2761,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '45',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'actiontime',
          'name'               => __('Total duration'),
          'datatype'           => 'timestamp',
@@ -2815,7 +2815,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'solution',
          'name'               => _n('Solution', 'Solutions', 1),
          'datatype'           => 'text',
@@ -2837,7 +2837,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '154',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'solve_delay_stat',
          'name'               => __('Resolution time'),
          'datatype'           => 'timestamp',
@@ -2847,7 +2847,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '152',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'close_delay_stat',
          'name'               => __('Closing time'),
          'datatype'           => 'timestamp',
@@ -2857,7 +2857,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '153',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'waiting_duration',
          'name'               => __('Waiting time'),
          'datatype'           => 'timestamp',
@@ -4265,7 +4265,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       if ($this->getFromDB($ID)) {
          // Force date mod and lastupdater
-         $query = "UPDATE `".$static::getTable()."`
+         $query = "UPDATE `".static::getTable()."`
                    SET `date_mod` = '".$_SESSION["glpi_currenttime"]."'";
 
          // set last updater if interactive user
@@ -4304,7 +4304,7 @@ abstract class CommonITILObject extends CommonDBTM {
             $tot += $sum;
          }
       }
-      $query2 = "UPDATE `".$static::getTable()."`
+      $query2 = "UPDATE `".static::getTable()."`
                  SET `actiontime` = '$tot'
                  WHERE `id` = '$ID'";
 
@@ -4535,17 +4535,17 @@ abstract class CommonITILObject extends CommonDBTM {
       $query = "SELECT DISTINCT `glpi_users`.`id` AS users_id, `glpi_users`.`name` AS name,
                                 `glpi_users`.`realname` AS realname,
                                 `glpi_users`.`firstname` AS firstname
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$static::getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".static::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::REQUESTER."')
                 INNER JOIN `glpi_users` ON (`glpi_users`.`id` = `$linktable`.`users_id`)
-                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $static::getTable());
+                WHERE NOT `".static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY realname, firstname, name";
@@ -4578,15 +4578,15 @@ abstract class CommonITILObject extends CommonDBTM {
                                 `glpi_users`.`name` AS name,
                                 `glpi_users`.`realname` AS realname,
                                 `glpi_users`.`firstname` AS firstname
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 LEFT JOIN `glpi_users`
-                     ON (`glpi_users`.`id` = `".$static::getTable()."`.`users_id_recipient`)
-                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $static::getTable());
+                     ON (`glpi_users`.`id` = `".static::getTable()."`.`users_id_recipient`)
+                WHERE NOT `".static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY realname, firstname, name";
@@ -4620,17 +4620,17 @@ abstract class CommonITILObject extends CommonDBTM {
       $linktable = $linkclass::getTable();
 
       $query = "SELECT DISTINCT `glpi_groups`.`id`, `glpi_groups`.`completename`
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$static::getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".static::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::REQUESTER."')
                 LEFT JOIN `glpi_groups` ON (`$linktable`.`groups_id` = `glpi_groups`.`id`)
-                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $static::getTable());
+                WHERE NOT `".static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `glpi_groups`.`completename`";
@@ -4672,17 +4672,17 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       $query = "SELECT DISTINCT `glpi_users`.`$field`
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 INNER JOIN `$linktable`
-                  ON (`".$static::getTable()."`.`id` = `$linktable`.`".$this->getForeignKeyField()."`)
+                  ON (`".static::getTable()."`.`id` = `$linktable`.`".$this->getForeignKeyField()."`)
                 INNER JOIN `glpi_users` ON (`glpi_users`.`id` = `$linktable`.`users_id`)
                 LEFT JOIN `$table` ON (`$table`.`id` = `glpi_users`.`$field`)
-                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $static::getTable());
+                WHERE NOT `".static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", static::getTable());
 
       if (!empty($date1)||!empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .=" ORDER BY `glpi_users`.`$field`";
@@ -4712,13 +4712,13 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `priority`
-                FROM `".$static::getTable()."`
-                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $static::getTable());
+                FROM `".static::getTable()."`
+                WHERE NOT `".static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `priority`";
@@ -4749,13 +4749,13 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `urgency`
-                FROM `".$static::getTable()."`
-                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $static::getTable());
+                FROM `".static::getTable()."`
+                WHERE NOT `".static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `urgency`";
@@ -4787,13 +4787,13 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `impact`
-                FROM `".$static::getTable()."`
-                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $static::getTable());
+                FROM `".static::getTable()."`
+                WHERE NOT `".static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `impact`";
@@ -4824,14 +4824,14 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `requesttypes_id`
-                FROM `".$static::getTable()."`
-                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $static::getTable());
+                FROM `".static::getTable()."`
+                WHERE NOT `".static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`",
+         $query .= " AND (".getDateRequest("`".static::getTable()."`.`date`",
                                            $date1, $date2)."
-                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`",
+                          OR ".getDateRequest("`".static::getTable()."`.`closedate`",
                                               $date1, $date2).") ";
       }
       $query .= " ORDER BY `requesttypes_id`";
@@ -4862,13 +4862,13 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `solutiontypes_id`
-                FROM `".$static::getTable()."`
-                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $static::getTable());
+                FROM `".static::getTable()."`
+                WHERE NOT `".static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `solutiontypes_id`";
@@ -4905,18 +4905,18 @@ abstract class CommonITILObject extends CommonDBTM {
                                 `glpi_users`.`name` AS name,
                                 `glpi_users`.`realname` AS realname,
                                 `glpi_users`.`firstname` AS firstname
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$static::getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".static::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::ASSIGN."')
                 LEFT JOIN `glpi_users` ON (`glpi_users`.`id` = `$linktable`.`users_id`)
-                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
-                getEntitiesRestrictRequest("AND", $static::getTable());
+                WHERE NOT `".static::getTable()."`.`is_deleted` ".
+                getEntitiesRestrictRequest("AND", static::getTable());
 
       if (!empty($date1)||!empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`",
+         $query .= " AND (".getDateRequest("`".static::getTable()."`.`date`",
                                            $date1, $date2)."
-                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`",
+                          OR ".getDateRequest("`".static::getTable()."`.`closedate`",
                                               $date1, $date2).") ";
       }
       $query .= " ORDER BY realname, firstname, name";
@@ -4954,9 +4954,9 @@ abstract class CommonITILObject extends CommonDBTM {
                                 `glpi_users`.`name` AS name,
                                 `glpi_users`.`realname` AS realname,
                                 `glpi_users`.`firstname` AS firstname
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 LEFT JOIN `$tasktable`
-                  ON (`".$static::getTable()."`.`id` = `$tasktable`.`".$this->getForeignKeyField()."`)
+                  ON (`".static::getTable()."`.`id` = `$tasktable`.`".$this->getForeignKeyField()."`)
                 LEFT JOIN `glpi_users` ON (`glpi_users`.`id` = `$tasktable`.`users_id`)
                 LEFT JOIN `glpi_profiles_users`
                   ON (`glpi_users`.`id` = `glpi_profiles_users`.`users_id`)
@@ -4964,13 +4964,13 @@ abstract class CommonITILObject extends CommonDBTM {
                   ON (`glpi_profiles`.`id` = `glpi_profiles_users`.`profiles_id`)
                 LEFT JOIN `glpi_profilerights`
                   ON (`glpi_profiles`.`id` = `glpi_profilerights`.`profiles_id`)
-                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $static::getTable());
+                WHERE NOT `".static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`",
+         $query .= " AND (".getDateRequest("`".static::getTable()."`.`date`",
                                            $date1, $date2)."
-                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`",
+                          OR ".getDateRequest("`".static::getTable()."`.`closedate`",
                                               $date1, $date2).") ";
       }
       $query .="     AND `glpi_profilerights`.`name` = 'ticket'
@@ -5010,19 +5010,19 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $query = "SELECT DISTINCT `glpi_suppliers`.`id` AS suppliers_id_assign,
                                 `glpi_suppliers`.`name` AS name
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$static::getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".static::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::ASSIGN."')
                 LEFT JOIN `glpi_suppliers`
                      ON (`glpi_suppliers`.`id` = `$linktable`.`suppliers_id`)
-                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $static::getTable());
+                WHERE NOT `".static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`",
+         $query .= " AND (".getDateRequest("`".static::getTable()."`.`date`",
                                            $date1, $date2)."
-                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`",
+                          OR ".getDateRequest("`".static::getTable()."`.`closedate`",
                                               $date1, $date2).") ";
       }
       $query .= " ORDER BY name";
@@ -5055,17 +5055,17 @@ abstract class CommonITILObject extends CommonDBTM {
       $linktable = $linkclass::getTable();
 
       $query = "SELECT DISTINCT `glpi_groups`.`id`, `glpi_groups`.`completename`
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$static::getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".static::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::ASSIGN."')
                 LEFT JOIN `glpi_groups` ON (`$linktable`.`groups_id` = `glpi_groups`.`id`)
-                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $static::getTable());
+                WHERE NOT `".static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `glpi_groups`.`completename`";

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -446,7 +446,7 @@ abstract class CommonITILObject extends CommonDBTM {
    function countActiveObjectsForUser($users_id) {
 
       $linkclass = new $this->userlinkclass();
-      $itemtable = $this::getTable();
+      $itemtable = $static::getTable();
       $itemtype  = $this->getType();
       $itemfk    = $this->getForeignKeyField();
       $linktable = $linkclass::getTable();
@@ -477,7 +477,7 @@ abstract class CommonITILObject extends CommonDBTM {
    function countActiveObjectsForTech($users_id) {
 
       $linkclass = new $this->userlinkclass();
-      $itemtable = $this::getTable();
+      $itemtable = $static::getTable();
       $itemtype  = $this->getType();
       $itemfk    = $this->getForeignKeyField();
       $linktable = $linkclass::getTable();
@@ -508,7 +508,7 @@ abstract class CommonITILObject extends CommonDBTM {
    function countActiveObjectsForTechGroup($groups_id) {
 
       $linkclass = new $this->grouplinkclass();
-      $itemtable = $this::getTable();
+      $itemtable = $static::getTable();
       $itemtype  = $this->getType();
       $itemfk    = $this->getForeignKeyField();
       $linktable = $linkclass::getTable();
@@ -539,7 +539,7 @@ abstract class CommonITILObject extends CommonDBTM {
    function countActiveObjectsForSupplier($suppliers_id) {
 
       $linkclass = new $this->supplierlinkclass();
-      $itemtable = $this::getTable();
+      $itemtable = $static::getTable();
       $itemtype  = $this->getType();
       $itemfk    = $this->getForeignKeyField();
       $linktable = $linkclass::getTable();
@@ -2595,7 +2595,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'datatype'           => 'itemlink',
@@ -2606,7 +2606,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $newtab = [
          'id'                 => '21',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'massiveaction'      => false,
@@ -2620,7 +2620,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -2629,7 +2629,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'status',
          'name'               => __('Status'),
          'searchtype'         => 'equals',
@@ -2638,7 +2638,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'urgency',
          'name'               => __('Urgency'),
          'searchtype'         => 'equals',
@@ -2647,7 +2647,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'impact',
          'name'               => __('Impact'),
          'searchtype'         => 'equals',
@@ -2656,7 +2656,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'priority',
          'name'               => __('Priority'),
          'searchtype'         => 'equals',
@@ -2665,7 +2665,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date',
          'name'               => __('Opening date'),
          'datatype'           => 'datetime',
@@ -2674,7 +2674,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'closedate',
          'name'               => __('Closing date'),
          'datatype'           => 'datetime',
@@ -2683,7 +2683,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'due_date',
          'name'               => __('Time to resolve'),
          'datatype'           => 'datetime',
@@ -2694,7 +2694,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '151',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'due_date',
          'name'               => __('Time to resolve + Progress'),
          'massiveaction'      => false,
@@ -2704,7 +2704,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_late',
          'name'               => __('Time to resolve exceedeed'),
          'datatype'           => 'bool',
@@ -2719,7 +2719,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'solvedate',
          'name'               => __('Resolution date'),
          'datatype'           => 'datetime',
@@ -2728,7 +2728,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -2761,7 +2761,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '45',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'actiontime',
          'name'               => __('Total duration'),
          'datatype'           => 'timestamp',
@@ -2815,7 +2815,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'solution',
          'name'               => _n('Solution', 'Solutions', 1),
          'datatype'           => 'text',
@@ -2837,7 +2837,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '154',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'solve_delay_stat',
          'name'               => __('Resolution time'),
          'datatype'           => 'timestamp',
@@ -2847,7 +2847,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '152',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'close_delay_stat',
          'name'               => __('Closing time'),
          'datatype'           => 'timestamp',
@@ -2857,7 +2857,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '153',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'waiting_duration',
          'name'               => __('Waiting time'),
          'datatype'           => 'timestamp',
@@ -4265,7 +4265,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       if ($this->getFromDB($ID)) {
          // Force date mod and lastupdater
-         $query = "UPDATE `".$this::getTable()."`
+         $query = "UPDATE `".$static::getTable()."`
                    SET `date_mod` = '".$_SESSION["glpi_currenttime"]."'";
 
          // set last updater if interactive user
@@ -4304,7 +4304,7 @@ abstract class CommonITILObject extends CommonDBTM {
             $tot += $sum;
          }
       }
-      $query2 = "UPDATE `".$this::getTable()."`
+      $query2 = "UPDATE `".$static::getTable()."`
                  SET `actiontime` = '$tot'
                  WHERE `id` = '$ID'";
 
@@ -4535,17 +4535,17 @@ abstract class CommonITILObject extends CommonDBTM {
       $query = "SELECT DISTINCT `glpi_users`.`id` AS users_id, `glpi_users`.`name` AS name,
                                 `glpi_users`.`realname` AS realname,
                                 `glpi_users`.`firstname` AS firstname
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this::getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$static::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::REQUESTER."')
                 INNER JOIN `glpi_users` ON (`glpi_users`.`id` = `$linktable`.`users_id`)
-                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this::getTable());
+                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY realname, firstname, name";
@@ -4578,15 +4578,15 @@ abstract class CommonITILObject extends CommonDBTM {
                                 `glpi_users`.`name` AS name,
                                 `glpi_users`.`realname` AS realname,
                                 `glpi_users`.`firstname` AS firstname
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 LEFT JOIN `glpi_users`
-                     ON (`glpi_users`.`id` = `".$this::getTable()."`.`users_id_recipient`)
-                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this::getTable());
+                     ON (`glpi_users`.`id` = `".$static::getTable()."`.`users_id_recipient`)
+                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY realname, firstname, name";
@@ -4620,17 +4620,17 @@ abstract class CommonITILObject extends CommonDBTM {
       $linktable = $linkclass::getTable();
 
       $query = "SELECT DISTINCT `glpi_groups`.`id`, `glpi_groups`.`completename`
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this::getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$static::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::REQUESTER."')
                 LEFT JOIN `glpi_groups` ON (`$linktable`.`groups_id` = `glpi_groups`.`id`)
-                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this::getTable());
+                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `glpi_groups`.`completename`";
@@ -4672,17 +4672,17 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       $query = "SELECT DISTINCT `glpi_users`.`$field`
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 INNER JOIN `$linktable`
-                  ON (`".$this::getTable()."`.`id` = `$linktable`.`".$this->getForeignKeyField()."`)
+                  ON (`".$static::getTable()."`.`id` = `$linktable`.`".$this->getForeignKeyField()."`)
                 INNER JOIN `glpi_users` ON (`glpi_users`.`id` = `$linktable`.`users_id`)
                 LEFT JOIN `$table` ON (`$table`.`id` = `glpi_users`.`$field`)
-                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this::getTable());
+                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $static::getTable());
 
       if (!empty($date1)||!empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .=" ORDER BY `glpi_users`.`$field`";
@@ -4712,13 +4712,13 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `priority`
-                FROM `".$this::getTable()."`
-                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this::getTable());
+                FROM `".$static::getTable()."`
+                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `priority`";
@@ -4749,13 +4749,13 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `urgency`
-                FROM `".$this::getTable()."`
-                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this::getTable());
+                FROM `".$static::getTable()."`
+                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `urgency`";
@@ -4787,13 +4787,13 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `impact`
-                FROM `".$this::getTable()."`
-                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this::getTable());
+                FROM `".$static::getTable()."`
+                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `impact`";
@@ -4824,14 +4824,14 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `requesttypes_id`
-                FROM `".$this::getTable()."`
-                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this::getTable());
+                FROM `".$static::getTable()."`
+                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`",
+         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`",
                                            $date1, $date2)."
-                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`",
+                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`",
                                               $date1, $date2).") ";
       }
       $query .= " ORDER BY `requesttypes_id`";
@@ -4862,13 +4862,13 @@ abstract class CommonITILObject extends CommonDBTM {
       global $DB;
 
       $query = "SELECT DISTINCT `solutiontypes_id`
-                FROM `".$this::getTable()."`
-                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this::getTable());
+                FROM `".$static::getTable()."`
+                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `solutiontypes_id`";
@@ -4905,18 +4905,18 @@ abstract class CommonITILObject extends CommonDBTM {
                                 `glpi_users`.`name` AS name,
                                 `glpi_users`.`realname` AS realname,
                                 `glpi_users`.`firstname` AS firstname
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this::getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$static::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::ASSIGN."')
                 LEFT JOIN `glpi_users` ON (`glpi_users`.`id` = `$linktable`.`users_id`)
-                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
-                getEntitiesRestrictRequest("AND", $this::getTable());
+                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
+                getEntitiesRestrictRequest("AND", $static::getTable());
 
       if (!empty($date1)||!empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`",
+         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`",
                                            $date1, $date2)."
-                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`",
+                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`",
                                               $date1, $date2).") ";
       }
       $query .= " ORDER BY realname, firstname, name";
@@ -4954,9 +4954,9 @@ abstract class CommonITILObject extends CommonDBTM {
                                 `glpi_users`.`name` AS name,
                                 `glpi_users`.`realname` AS realname,
                                 `glpi_users`.`firstname` AS firstname
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 LEFT JOIN `$tasktable`
-                  ON (`".$this::getTable()."`.`id` = `$tasktable`.`".$this->getForeignKeyField()."`)
+                  ON (`".$static::getTable()."`.`id` = `$tasktable`.`".$this->getForeignKeyField()."`)
                 LEFT JOIN `glpi_users` ON (`glpi_users`.`id` = `$tasktable`.`users_id`)
                 LEFT JOIN `glpi_profiles_users`
                   ON (`glpi_users`.`id` = `glpi_profiles_users`.`users_id`)
@@ -4964,13 +4964,13 @@ abstract class CommonITILObject extends CommonDBTM {
                   ON (`glpi_profiles`.`id` = `glpi_profiles_users`.`profiles_id`)
                 LEFT JOIN `glpi_profilerights`
                   ON (`glpi_profiles`.`id` = `glpi_profilerights`.`profiles_id`)
-                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this::getTable());
+                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`",
+         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`",
                                            $date1, $date2)."
-                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`",
+                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`",
                                               $date1, $date2).") ";
       }
       $query .="     AND `glpi_profilerights`.`name` = 'ticket'
@@ -5010,19 +5010,19 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $query = "SELECT DISTINCT `glpi_suppliers`.`id` AS suppliers_id_assign,
                                 `glpi_suppliers`.`name` AS name
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this::getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$static::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::ASSIGN."')
                 LEFT JOIN `glpi_suppliers`
                      ON (`glpi_suppliers`.`id` = `$linktable`.`suppliers_id`)
-                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this::getTable());
+                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`",
+         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`",
                                            $date1, $date2)."
-                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`",
+                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`",
                                               $date1, $date2).") ";
       }
       $query .= " ORDER BY name";
@@ -5055,17 +5055,17 @@ abstract class CommonITILObject extends CommonDBTM {
       $linktable = $linkclass::getTable();
 
       $query = "SELECT DISTINCT `glpi_groups`.`id`, `glpi_groups`.`completename`
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 LEFT JOIN `$linktable`
-                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$this::getTable()."`.`id`
+                  ON (`$linktable`.`".$this->getForeignKeyField()."` = `".$static::getTable()."`.`id`
                       AND `$linktable`.`type` = '".CommonITILActor::ASSIGN."')
                 LEFT JOIN `glpi_groups` ON (`$linktable`.`groups_id` = `glpi_groups`.`id`)
-                WHERE NOT `".$this::getTable()."`.`is_deleted` ".
-                      getEntitiesRestrictRequest("AND", $this::getTable());
+                WHERE NOT `".$static::getTable()."`.`is_deleted` ".
+                      getEntitiesRestrictRequest("AND", $static::getTable());
 
       if (!empty($date1) || !empty($date2)) {
-         $query .= " AND (".getDateRequest("`".$this::getTable()."`.`date`", $date1, $date2)."
-                          OR ".getDateRequest("`".$this::getTable()."`.`closedate`", $date1,
+         $query .= " AND (".getDateRequest("`".$static::getTable()."`.`date`", $date1, $date2)."
+                          OR ".getDateRequest("`".$static::getTable()."`.`closedate`", $date1,
                                               $date2).") ";
       }
       $query .= " ORDER BY `glpi_groups`.`completename`";

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -190,7 +190,7 @@ abstract class CommonITILTask  extends CommonDBTM {
                $restrict .= " AND (`is_private` = '0'
                                    OR `users_id` = '" . Session::getLoginUserID() . "') ";
             }
-            $nb = countElementsInTable($this->getTable(), $restrict);
+            $nb = countElementsInTable($this::getTable(), $restrict);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
       }
@@ -550,7 +550,7 @@ abstract class CommonITILTask  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'datatype'           => 'text'
@@ -567,7 +567,7 @@ abstract class CommonITILTask  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'datetime'
@@ -576,7 +576,7 @@ abstract class CommonITILTask  extends CommonDBTM {
       if ($this->maybePrivate()) {
          $tab[] = [
             'id'                 => '4',
-            'table'              => $this->getTable(),
+            'table'              => $this::getTable(),
             'field'              => 'is_private',
             'name'               => __('Public followup'),
             'datatype'           => 'bool'
@@ -594,7 +594,7 @@ abstract class CommonITILTask  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'actiontime',
          'name'               => __('Total duration'),
          'datatype'           => 'actiontime',
@@ -603,7 +603,7 @@ abstract class CommonITILTask  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'state',
          'name'               => __('Status'),
          'datatype'           => 'specific'
@@ -915,7 +915,7 @@ abstract class CommonITILTask  extends CommonDBTM {
          if (!$options['genical']
              && count($_SESSION["glpigroups"])) {
             $groups = implode("','", $_SESSION['glpigroups']);
-            $ASSIGN = "`".$item->getTable()."`.`users_id_tech`
+            $ASSIGN = "`".$item::getTable()."`.`users_id_tech`
                            IN (SELECT DISTINCT `users_id`
                                FROM `glpi_groups_users`
                                INNER JOIN `glpi_groups`
@@ -924,29 +924,29 @@ abstract class CommonITILTask  extends CommonDBTM {
                                      AND `glpi_groups`.`is_assign`)
                                      AND ";
          } else { // Only personal ones
-            $ASSIGN = "`".$item->getTable()."`.`users_id_tech` = '$who'
+            $ASSIGN = "`".$item::getTable()."`.`users_id_tech` = '$who'
                        AND ";
          }
 
       } else {
          if ($who > 0) {
-            $ASSIGN = "`".$item->getTable()."`.`users_id_tech` = '$who'
+            $ASSIGN = "`".$item::getTable()."`.`users_id_tech` = '$who'
                        AND ";
          }
          if ($who_group > 0) {
-            $ASSIGN = "`".$item->getTable()."`.`users_id_tech` IN (SELECT `users_id`
+            $ASSIGN = "`".$item::getTable()."`.`users_id_tech` IN (SELECT `users_id`
                                                                    FROM `glpi_groups_users`
                                                                    WHERE `groups_id` = '$who_group')
                                                                          AND ";
          }
          if ($whogroup > 0) {
-            $ASSIGN = "`".$item->getTable()."`.`groups_id_tech` = '$whogroup'
+            $ASSIGN = "`".$item::getTable()."`.`groups_id_tech` = '$whogroup'
                        AND ";
          }
 
       }
       if (empty($ASSIGN)) {
-         $ASSIGN = "`".$item->getTable()."`.`users_id_tech`
+         $ASSIGN = "`".$item::getTable()."`.`users_id_tech`
                         IN (SELECT DISTINCT `glpi_profiles_users`.`users_id`
                             FROM `glpi_profiles`
                             LEFT JOIN `glpi_profiles_users`
@@ -959,27 +959,27 @@ abstract class CommonITILTask  extends CommonDBTM {
 
       $DONE_EVENTS = '';
       if (!$options['display_done_events']) {
-         $DONE_EVENTS = "(`".$item->getTable()."`.`state` = ".Planning::TODO."
-                          OR (`".$item->getTable()."`.`state` = ".Planning::INFO."
-                              AND `".$item->getTable()."`.`end` > NOW()))
+         $DONE_EVENTS = "(`".$item::getTable()."`.`state` = ".Planning::TODO."
+                          OR (`".$item::getTable()."`.`state` = ".Planning::INFO."
+                              AND `".$item::getTable()."`.`end` > NOW()))
                          AND ";
       }
 
       $addrestrict = '';
       if ($parentitem->maybeDeleted()) {
-         $addrestrict = 'AND NOT `'.$parentitem->getTable().'`.`is_deleted`';
+         $addrestrict = 'AND NOT `'.$parentitem::getTable().'`.`is_deleted`';
       }
 
-      $query = "SELECT `".$item->getTable()."`.*
-                FROM `".$item->getTable()."`
-                INNER JOIN `".$parentitem->getTable()."`
-                  ON (`".$parentitem->getTable()."`.`id` = `".$item->getTable()."`.`".$parentitem->getForeignKeyField()."`)
+      $query = "SELECT `".$item::getTable()."`.*
+                FROM `".$item::getTable()."`
+                INNER JOIN `".$parentitem::getTable()."`
+                  ON (`".$parentitem::getTable()."`.`id` = `".$item::getTable()."`.`".$parentitem->getForeignKeyField()."`)
                 WHERE $ASSIGN
                       $DONE_EVENTS
-                      '$begin' < `".$item->getTable()."`.`end`
-                      AND '$end' > `".$item->getTable()."`.`begin`
+                      '$begin' < `".$item::getTable()."`.`end`
+                      AND '$end' > `".$item::getTable()."`.`begin`
                       $addrestrict
-                ORDER BY `".$item->getTable()."`.`begin`";
+                ORDER BY `".$item::getTable()."`.`begin`";
 
       $result = $DB->query($query);
 
@@ -1636,7 +1636,7 @@ abstract class CommonITILTask  extends CommonDBTM {
       }
 
       $query = "SELECT `id`, `date`
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `".$item->getForeignKeyField()."` = '$tID'
                       $RESTRICT
                 ORDER BY `date` DESC";

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -190,7 +190,7 @@ abstract class CommonITILTask  extends CommonDBTM {
                $restrict .= " AND (`is_private` = '0'
                                    OR `users_id` = '" . Session::getLoginUserID() . "') ";
             }
-            $nb = countElementsInTable($static::getTable(), $restrict);
+            $nb = countElementsInTable(static::getTable(), $restrict);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
       }
@@ -550,7 +550,7 @@ abstract class CommonITILTask  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'datatype'           => 'text'
@@ -567,7 +567,7 @@ abstract class CommonITILTask  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'datetime'
@@ -576,7 +576,7 @@ abstract class CommonITILTask  extends CommonDBTM {
       if ($this->maybePrivate()) {
          $tab[] = [
             'id'                 => '4',
-            'table'              => $static::getTable(),
+            'table'              => static::getTable(),
             'field'              => 'is_private',
             'name'               => __('Public followup'),
             'datatype'           => 'bool'
@@ -594,7 +594,7 @@ abstract class CommonITILTask  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'actiontime',
          'name'               => __('Total duration'),
          'datatype'           => 'actiontime',
@@ -603,7 +603,7 @@ abstract class CommonITILTask  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'state',
          'name'               => __('Status'),
          'datatype'           => 'specific'
@@ -1636,7 +1636,7 @@ abstract class CommonITILTask  extends CommonDBTM {
       }
 
       $query = "SELECT `id`, `date`
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `".$item->getForeignKeyField()."` = '$tID'
                       $RESTRICT
                 ORDER BY `date` DESC";

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -190,7 +190,7 @@ abstract class CommonITILTask  extends CommonDBTM {
                $restrict .= " AND (`is_private` = '0'
                                    OR `users_id` = '" . Session::getLoginUserID() . "') ";
             }
-            $nb = countElementsInTable($this::getTable(), $restrict);
+            $nb = countElementsInTable($static::getTable(), $restrict);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
       }
@@ -550,7 +550,7 @@ abstract class CommonITILTask  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'datatype'           => 'text'
@@ -567,7 +567,7 @@ abstract class CommonITILTask  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'datetime'
@@ -576,7 +576,7 @@ abstract class CommonITILTask  extends CommonDBTM {
       if ($this->maybePrivate()) {
          $tab[] = [
             'id'                 => '4',
-            'table'              => $this::getTable(),
+            'table'              => $static::getTable(),
             'field'              => 'is_private',
             'name'               => __('Public followup'),
             'datatype'           => 'bool'
@@ -594,7 +594,7 @@ abstract class CommonITILTask  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'actiontime',
          'name'               => __('Total duration'),
          'datatype'           => 'actiontime',
@@ -603,7 +603,7 @@ abstract class CommonITILTask  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'state',
          'name'               => __('Status'),
          'datatype'           => 'specific'
@@ -1636,7 +1636,7 @@ abstract class CommonITILTask  extends CommonDBTM {
       }
 
       $query = "SELECT `id`, `date`
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `".$item->getForeignKeyField()."` = '$tID'
                       $RESTRICT
                 ORDER BY `date` DESC";

--- a/inc/commonitilvalidation.class.php
+++ b/inc/commonitilvalidation.class.php
@@ -794,7 +794,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
       }
 
       $query = "SELECT *
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `".static::$items_id."` = '".$item->getField('id')."'";
 
       $query .= " ORDER BY submission_date DESC";
@@ -1011,7 +1011,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment_submission',
          'name'               => __('Request comments'),
          'datatype'           => 'text'
@@ -1019,7 +1019,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment_validation',
          'name'               => __('Approval comments'),
          'datatype'           => 'text'
@@ -1027,7 +1027,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'status',
          'name'               => __('Status'),
          'searchtype'         => 'equals',
@@ -1036,7 +1036,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'submission_date',
          'name'               => __('Request date'),
          'datatype'           => 'datetime'
@@ -1044,7 +1044,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'validation_date',
          'name'               => __('Approval date'),
          'datatype'           => 'datetime'

--- a/inc/commonitilvalidation.class.php
+++ b/inc/commonitilvalidation.class.php
@@ -794,7 +794,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
       }
 
       $query = "SELECT *
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `".static::$items_id."` = '".$item->getField('id')."'";
 
       $query .= " ORDER BY submission_date DESC";
@@ -1011,7 +1011,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment_submission',
          'name'               => __('Request comments'),
          'datatype'           => 'text'
@@ -1019,7 +1019,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment_validation',
          'name'               => __('Approval comments'),
          'datatype'           => 'text'
@@ -1027,7 +1027,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'status',
          'name'               => __('Status'),
          'searchtype'         => 'equals',
@@ -1036,7 +1036,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'submission_date',
          'name'               => __('Request date'),
          'datatype'           => 'datetime'
@@ -1044,7 +1044,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'validation_date',
          'name'               => __('Approval date'),
          'datatype'           => 'datetime'

--- a/inc/commonitilvalidation.class.php
+++ b/inc/commonitilvalidation.class.php
@@ -794,7 +794,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
       }
 
       $query = "SELECT *
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `".static::$items_id."` = '".$item->getField('id')."'";
 
       $query .= " ORDER BY submission_date DESC";
@@ -1011,7 +1011,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment_submission',
          'name'               => __('Request comments'),
          'datatype'           => 'text'
@@ -1019,7 +1019,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment_validation',
          'name'               => __('Approval comments'),
          'datatype'           => 'text'
@@ -1027,7 +1027,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'status',
          'name'               => __('Status'),
          'searchtype'         => 'equals',
@@ -1036,7 +1036,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'submission_date',
          'name'               => __('Request date'),
          'datatype'           => 'datetime'
@@ -1044,7 +1044,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'validation_date',
          'name'               => __('Approval date'),
          'datatype'           => 'datetime'

--- a/inc/commontreedropdown.class.php
+++ b/inc/commontreedropdown.class.php
@@ -84,7 +84,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
           && ($item->getType() == $this->getType())) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($static::getTable(),
+            $nb = countElementsInTable(static::getTable(),
                                       [$this->getForeignKeyField() => $item->getID()]);
          }
          return self::createTabEntry($this->getTypeName(Session::getPluralNumber()), $nb);
@@ -166,7 +166,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       $crit = array('FIELDS'                    => 'id',
                     $this->getForeignKeyField() => $this->fields["id"]);
 
-      foreach ($DB->request($static::getTable(), $crit) as $data) {
+      foreach ($DB->request(static::getTable(), $crit) as $data) {
          $data[$this->getForeignKeyField()] = $parent;
          $tmp->update($data);
       }
@@ -180,7 +180,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       if (isset($input[$this->getForeignKeyField()])) {
          // Can't move a parent under a child
          if (in_array($input[$this->getForeignKeyField()],
-             getSonsOf($static::getTable(), $input['id']))) {
+             getSonsOf(static::getTable(), $input['id']))) {
              return false;
          }
          // Parent changes => clear ancestors and update its level and completename
@@ -217,14 +217,14 @@ abstract class CommonTreeDropdown extends CommonDropdown {
          }
 
          $query = "SELECT `id`, `name`
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `".$this->getForeignKeyField()."` = '$ID'";
          if (Session::haveTranslations($this->getType(), 'completename')) {
             DropdownTranslation::regenerateAllCompletenameTranslationsFor($this->getType(), $ID);
          }
 
          foreach ($DB->request($query) as $data) {
-            $query = "UPDATE `".$static::getTable()."`
+            $query = "UPDATE `".static::getTable()."`
                       SET ";
             $fieldsToUpdate = array();
 
@@ -264,7 +264,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       global $DB;
 
       if ($ID > 0) {
-         $query = "UPDATE `".$static::getTable()."`
+         $query = "UPDATE `".static::getTable()."`
                     SET `sons_cache` = NULL
                     WHERE `id` = '$ID'";
          $DB->query($query);
@@ -453,7 +453,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
          }
       }
       $nb = 0;
-      foreach ($DB->request($static::getTable(), $crit) as $data) {
+      foreach ($DB->request(static::getTable(), $crit) as $data) {
          $nb++;
          echo "<tr class='tab_bg_1'>";
          echo "<td><a href='".$this->getFormURL();
@@ -601,7 +601,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'completename',
          'name'               => __('Complete name'),
          'datatype'           => 'itemlink',
@@ -610,7 +610,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -619,7 +619,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '14',
-         'table'             => $static::getTable(),
+         'table'             => static::getTable(),
          'field'             => 'name',
          'name'              => __('Name'),
          'datatype'          => 'itemlink'
@@ -627,7 +627,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '13',
-         'table'             => $static::getTable(),
+         'table'             => static::getTable(),
          'field'             => 'completename',
          'name'              => __('Father'),
          'datatype'          => 'dropdown',
@@ -638,7 +638,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '16',
-         'table'             => $static::getTable(),
+         'table'             => static::getTable(),
          'field'             => 'comment',
          'name'              => __('Comments'),
          'datatype'          => 'text'
@@ -658,7 +658,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       if ($this->maybeRecursive()) {
          $tab[] = [
             'id'             => '86',
-            'table'          => $static::getTable(),
+            'table'          => static::getTable(),
             'field'          => 'is_recursive',
             'name'           => __('Child entities'),
             'datatype'       => 'bool'
@@ -668,7 +668,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       if ($this->isField('date_mod')) {
          $tab[] = [
             'id'             => '19',
-            'table'          => $static::getTable(),
+            'table'          => static::getTable(),
             'field'          => 'date_mod',
             'name'           => __('Last update'),
             'datatype'       => 'datetime',
@@ -679,7 +679,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       if ($this->isField('date_creation')) {
          $tab[] = [
             'id'             => '121',
-            'table'          => $static::getTable(),
+            'table'          => static::getTable(),
             'field'          => 'date_creation',
             'name'           => __('Creation date'),
             'datatype'       => 'datetime',
@@ -703,7 +703,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       $fk = $this->getForeignKeyField();
       $id = $this->fields['id'];
 
-      return (countElementsInTable($static::getTable(), [$fk => $id]) > 0);
+      return (countElementsInTable(static::getTable(), [$fk => $id]) > 0);
    }
 
 
@@ -746,10 +746,10 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       if (isset($input['completename']) && !empty($input['completename'])) {
          $query = "SELECT `id`
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `completename` = '".$input['completename']."'";
          if ($this->isEntityAssign()) {
-            $query .= getEntitiesRestrictRequest(' AND ', $static::getTable(), '',
+            $query .= getEntitiesRestrictRequest(' AND ', static::getTable(), '',
                                                  $input['entities_id'], $this->maybeRecursive());
          }
          // Check twin :
@@ -763,12 +763,12 @@ abstract class CommonTreeDropdown extends CommonDropdown {
          $fk = $this->getForeignKeyField();
 
          $query = "SELECT `id`
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `name` = '".$input["name"]."'
                          AND `$fk` = '".(isset($input[$fk]) ? $input[$fk] : 0)."'";
 
          if ($this->isEntityAssign()) {
-            $query .= getEntitiesRestrictRequest(' AND ', $static::getTable(), '',
+            $query .= getEntitiesRestrictRequest(' AND ', static::getTable(), '',
                                                  $input['entities_id'], $this->maybeRecursive());
          }
 

--- a/inc/commontreedropdown.class.php
+++ b/inc/commontreedropdown.class.php
@@ -84,7 +84,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
           && ($item->getType() == $this->getType())) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($this::getTable(),
+            $nb = countElementsInTable($static::getTable(),
                                       [$this->getForeignKeyField() => $item->getID()]);
          }
          return self::createTabEntry($this->getTypeName(Session::getPluralNumber()), $nb);
@@ -166,7 +166,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       $crit = array('FIELDS'                    => 'id',
                     $this->getForeignKeyField() => $this->fields["id"]);
 
-      foreach ($DB->request($this::getTable(), $crit) as $data) {
+      foreach ($DB->request($static::getTable(), $crit) as $data) {
          $data[$this->getForeignKeyField()] = $parent;
          $tmp->update($data);
       }
@@ -180,7 +180,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       if (isset($input[$this->getForeignKeyField()])) {
          // Can't move a parent under a child
          if (in_array($input[$this->getForeignKeyField()],
-             getSonsOf($this::getTable(), $input['id']))) {
+             getSonsOf($static::getTable(), $input['id']))) {
              return false;
          }
          // Parent changes => clear ancestors and update its level and completename
@@ -217,14 +217,14 @@ abstract class CommonTreeDropdown extends CommonDropdown {
          }
 
          $query = "SELECT `id`, `name`
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `".$this->getForeignKeyField()."` = '$ID'";
          if (Session::haveTranslations($this->getType(), 'completename')) {
             DropdownTranslation::regenerateAllCompletenameTranslationsFor($this->getType(), $ID);
          }
 
          foreach ($DB->request($query) as $data) {
-            $query = "UPDATE `".$this::getTable()."`
+            $query = "UPDATE `".$static::getTable()."`
                       SET ";
             $fieldsToUpdate = array();
 
@@ -264,7 +264,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       global $DB;
 
       if ($ID > 0) {
-         $query = "UPDATE `".$this::getTable()."`
+         $query = "UPDATE `".$static::getTable()."`
                     SET `sons_cache` = NULL
                     WHERE `id` = '$ID'";
          $DB->query($query);
@@ -453,7 +453,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
          }
       }
       $nb = 0;
-      foreach ($DB->request($this::getTable(), $crit) as $data) {
+      foreach ($DB->request($static::getTable(), $crit) as $data) {
          $nb++;
          echo "<tr class='tab_bg_1'>";
          echo "<td><a href='".$this->getFormURL();
@@ -601,7 +601,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'completename',
          'name'               => __('Complete name'),
          'datatype'           => 'itemlink',
@@ -610,7 +610,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -619,7 +619,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '14',
-         'table'             => $this::getTable(),
+         'table'             => $static::getTable(),
          'field'             => 'name',
          'name'              => __('Name'),
          'datatype'          => 'itemlink'
@@ -627,7 +627,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '13',
-         'table'             => $this::getTable(),
+         'table'             => $static::getTable(),
          'field'             => 'completename',
          'name'              => __('Father'),
          'datatype'          => 'dropdown',
@@ -638,7 +638,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '16',
-         'table'             => $this::getTable(),
+         'table'             => $static::getTable(),
          'field'             => 'comment',
          'name'              => __('Comments'),
          'datatype'          => 'text'
@@ -658,7 +658,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       if ($this->maybeRecursive()) {
          $tab[] = [
             'id'             => '86',
-            'table'          => $this::getTable(),
+            'table'          => $static::getTable(),
             'field'          => 'is_recursive',
             'name'           => __('Child entities'),
             'datatype'       => 'bool'
@@ -668,7 +668,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       if ($this->isField('date_mod')) {
          $tab[] = [
             'id'             => '19',
-            'table'          => $this::getTable(),
+            'table'          => $static::getTable(),
             'field'          => 'date_mod',
             'name'           => __('Last update'),
             'datatype'       => 'datetime',
@@ -679,7 +679,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       if ($this->isField('date_creation')) {
          $tab[] = [
             'id'             => '121',
-            'table'          => $this::getTable(),
+            'table'          => $static::getTable(),
             'field'          => 'date_creation',
             'name'           => __('Creation date'),
             'datatype'       => 'datetime',
@@ -703,7 +703,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       $fk = $this->getForeignKeyField();
       $id = $this->fields['id'];
 
-      return (countElementsInTable($this::getTable(), [$fk => $id]) > 0);
+      return (countElementsInTable($static::getTable(), [$fk => $id]) > 0);
    }
 
 
@@ -746,10 +746,10 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       if (isset($input['completename']) && !empty($input['completename'])) {
          $query = "SELECT `id`
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `completename` = '".$input['completename']."'";
          if ($this->isEntityAssign()) {
-            $query .= getEntitiesRestrictRequest(' AND ', $this::getTable(), '',
+            $query .= getEntitiesRestrictRequest(' AND ', $static::getTable(), '',
                                                  $input['entities_id'], $this->maybeRecursive());
          }
          // Check twin :
@@ -763,12 +763,12 @@ abstract class CommonTreeDropdown extends CommonDropdown {
          $fk = $this->getForeignKeyField();
 
          $query = "SELECT `id`
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `name` = '".$input["name"]."'
                          AND `$fk` = '".(isset($input[$fk]) ? $input[$fk] : 0)."'";
 
          if ($this->isEntityAssign()) {
-            $query .= getEntitiesRestrictRequest(' AND ', $this::getTable(), '',
+            $query .= getEntitiesRestrictRequest(' AND ', $static::getTable(), '',
                                                  $input['entities_id'], $this->maybeRecursive());
          }
 

--- a/inc/commontreedropdown.class.php
+++ b/inc/commontreedropdown.class.php
@@ -84,7 +84,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
           && ($item->getType() == $this->getType())) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($this->getTable(),
+            $nb = countElementsInTable($this::getTable(),
                                       [$this->getForeignKeyField() => $item->getID()]);
          }
          return self::createTabEntry($this->getTypeName(Session::getPluralNumber()), $nb);
@@ -166,7 +166,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       $crit = array('FIELDS'                    => 'id',
                     $this->getForeignKeyField() => $this->fields["id"]);
 
-      foreach ($DB->request($this->getTable(), $crit) as $data) {
+      foreach ($DB->request($this::getTable(), $crit) as $data) {
          $data[$this->getForeignKeyField()] = $parent;
          $tmp->update($data);
       }
@@ -180,7 +180,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       if (isset($input[$this->getForeignKeyField()])) {
          // Can't move a parent under a child
          if (in_array($input[$this->getForeignKeyField()],
-             getSonsOf($this->getTable(), $input['id']))) {
+             getSonsOf($this::getTable(), $input['id']))) {
              return false;
          }
          // Parent changes => clear ancestors and update its level and completename
@@ -217,14 +217,14 @@ abstract class CommonTreeDropdown extends CommonDropdown {
          }
 
          $query = "SELECT `id`, `name`
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `".$this->getForeignKeyField()."` = '$ID'";
          if (Session::haveTranslations($this->getType(), 'completename')) {
             DropdownTranslation::regenerateAllCompletenameTranslationsFor($this->getType(), $ID);
          }
 
          foreach ($DB->request($query) as $data) {
-            $query = "UPDATE `".$this->getTable()."`
+            $query = "UPDATE `".$this::getTable()."`
                       SET ";
             $fieldsToUpdate = array();
 
@@ -264,7 +264,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       global $DB;
 
       if ($ID > 0) {
-         $query = "UPDATE `".$this->getTable()."`
+         $query = "UPDATE `".$this::getTable()."`
                     SET `sons_cache` = NULL
                     WHERE `id` = '$ID'";
          $DB->query($query);
@@ -453,7 +453,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
          }
       }
       $nb = 0;
-      foreach ($DB->request($this->getTable(), $crit) as $data) {
+      foreach ($DB->request($this::getTable(), $crit) as $data) {
          $nb++;
          echo "<tr class='tab_bg_1'>";
          echo "<td><a href='".$this->getFormURL();
@@ -558,7 +558,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
                foreach ($ids as $id) {
                   if ($item->can($id, UPDATE)) {
                      // Check if parent is not a child of the original one
-                     if (!in_array($parent->getID(), getSonsOf($item->getTable(),
+                     if (!in_array($parent->getID(), getSonsOf($item::getTable(),
                                                                $item->getID()))) {
                         if ($item->update(array('id' => $id,
                                                 $fk  => $parent->getID()))) {
@@ -601,7 +601,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'completename',
          'name'               => __('Complete name'),
          'datatype'           => 'itemlink',
@@ -610,7 +610,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -619,7 +619,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '14',
-         'table'             => $this->getTable(),
+         'table'             => $this::getTable(),
          'field'             => 'name',
          'name'              => __('Name'),
          'datatype'          => 'itemlink'
@@ -627,7 +627,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '13',
-         'table'             => $this->getTable(),
+         'table'             => $this::getTable(),
          'field'             => 'completename',
          'name'              => __('Father'),
          'datatype'          => 'dropdown',
@@ -638,7 +638,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       $tab[] = [
          'id'                => '16',
-         'table'             => $this->getTable(),
+         'table'             => $this::getTable(),
          'field'             => 'comment',
          'name'              => __('Comments'),
          'datatype'          => 'text'
@@ -658,7 +658,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       if ($this->maybeRecursive()) {
          $tab[] = [
             'id'             => '86',
-            'table'          => $this->getTable(),
+            'table'          => $this::getTable(),
             'field'          => 'is_recursive',
             'name'           => __('Child entities'),
             'datatype'       => 'bool'
@@ -668,7 +668,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       if ($this->isField('date_mod')) {
          $tab[] = [
             'id'             => '19',
-            'table'          => $this->getTable(),
+            'table'          => $this::getTable(),
             'field'          => 'date_mod',
             'name'           => __('Last update'),
             'datatype'       => 'datetime',
@@ -679,7 +679,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       if ($this->isField('date_creation')) {
          $tab[] = [
             'id'             => '121',
-            'table'          => $this->getTable(),
+            'table'          => $this::getTable(),
             'field'          => 'date_creation',
             'name'           => __('Creation date'),
             'datatype'       => 'datetime',
@@ -703,7 +703,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       $fk = $this->getForeignKeyField();
       $id = $this->fields['id'];
 
-      return (countElementsInTable($this->getTable(), [$fk => $id]) > 0);
+      return (countElementsInTable($this::getTable(), [$fk => $id]) > 0);
    }
 
 
@@ -746,10 +746,10 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       if (isset($input['completename']) && !empty($input['completename'])) {
          $query = "SELECT `id`
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `completename` = '".$input['completename']."'";
          if ($this->isEntityAssign()) {
-            $query .= getEntitiesRestrictRequest(' AND ', $this->getTable(), '',
+            $query .= getEntitiesRestrictRequest(' AND ', $this::getTable(), '',
                                                  $input['entities_id'], $this->maybeRecursive());
          }
          // Check twin :
@@ -763,12 +763,12 @@ abstract class CommonTreeDropdown extends CommonDropdown {
          $fk = $this->getForeignKeyField();
 
          $query = "SELECT `id`
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `name` = '".$input["name"]."'
                          AND `$fk` = '".(isset($input[$fk]) ? $input[$fk] : 0)."'";
 
          if ($this->isEntityAssign()) {
-            $query .= getEntitiesRestrictRequest(' AND ', $this->getTable(), '',
+            $query .= getEntitiesRestrictRequest(' AND ', $this::getTable(), '',
                                                  $input['entities_id'], $this->maybeRecursive());
          }
 

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -647,7 +647,7 @@ class Computer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -656,7 +656,7 @@ class Computer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false, // implicit field is id

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -647,7 +647,7 @@ class Computer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -656,7 +656,7 @@ class Computer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false, // implicit field is id

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -647,7 +647,7 @@ class Computer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -656,7 +656,7 @@ class Computer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false, // implicit field is id

--- a/inc/computer_softwarelicense.class.php
+++ b/inc/computer_softwarelicense.class.php
@@ -78,7 +78,7 @@ class Computer_SoftwareLicense extends CommonDBRelation {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,

--- a/inc/computer_softwarelicense.class.php
+++ b/inc/computer_softwarelicense.class.php
@@ -78,7 +78,7 @@ class Computer_SoftwareLicense extends CommonDBRelation {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,

--- a/inc/computer_softwarelicense.class.php
+++ b/inc/computer_softwarelicense.class.php
@@ -78,7 +78,7 @@ class Computer_SoftwareLicense extends CommonDBRelation {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,

--- a/inc/computer_softwareversion.class.php
+++ b/inc/computer_softwareversion.class.php
@@ -204,7 +204,7 @@ class Computer_SoftwareVersion extends CommonDBRelation {
 
       $comp = new Computer();
       if ($comp->getFromDB($computers_id)) {
-         $query = "UPDATE `".$this::getTable()."`
+         $query = "UPDATE `".$static::getTable()."`
                    SET `is_template_computer` = '".$comp->getField('is_template')."',
                        `is_deleted_computer` = '".$comp->getField('is_deleted')."'
                    WHERE `computers_id` = '$computers_id';";

--- a/inc/computer_softwareversion.class.php
+++ b/inc/computer_softwareversion.class.php
@@ -204,7 +204,7 @@ class Computer_SoftwareVersion extends CommonDBRelation {
 
       $comp = new Computer();
       if ($comp->getFromDB($computers_id)) {
-         $query = "UPDATE `".$this->getTable()."`
+         $query = "UPDATE `".$this::getTable()."`
                    SET `is_template_computer` = '".$comp->getField('is_template')."',
                        `is_deleted_computer` = '".$comp->getField('is_deleted')."'
                    WHERE `computers_id` = '$computers_id';";

--- a/inc/computer_softwareversion.class.php
+++ b/inc/computer_softwareversion.class.php
@@ -204,7 +204,7 @@ class Computer_SoftwareVersion extends CommonDBRelation {
 
       $comp = new Computer();
       if ($comp->getFromDB($computers_id)) {
-         $query = "UPDATE `".$static::getTable()."`
+         $query = "UPDATE `".static::getTable()."`
                    SET `is_template_computer` = '".$comp->getField('is_template')."',
                        `is_deleted_computer` = '".$comp->getField('is_deleted')."'
                    WHERE `computers_id` = '$computers_id';";

--- a/inc/consumable.class.php
+++ b/inc/consumable.class.php
@@ -119,7 +119,7 @@ class Consumable extends CommonDBChild {
    function backToStock(array $input, $history=1) {
       global $DB;
 
-      $query = "UPDATE `".$this::getTable()."`
+      $query = "UPDATE `".$static::getTable()."`
                 SET `date_out` = NULL
                 WHERE `id` = '".$input["id"]."'";
 
@@ -162,7 +162,7 @@ class Consumable extends CommonDBChild {
       if (!empty($itemtype)
           && ($items_id > 0)) {
 
-         $query = "UPDATE `".$this::getTable()."`
+         $query = "UPDATE `".$static::getTable()."`
                    SET `date_out` = '".date("Y-m-d")."',
                        `itemtype` = '$itemtype',
                        `items_id` = '$items_id'

--- a/inc/consumable.class.php
+++ b/inc/consumable.class.php
@@ -119,7 +119,7 @@ class Consumable extends CommonDBChild {
    function backToStock(array $input, $history=1) {
       global $DB;
 
-      $query = "UPDATE `".$static::getTable()."`
+      $query = "UPDATE `".static::getTable()."`
                 SET `date_out` = NULL
                 WHERE `id` = '".$input["id"]."'";
 
@@ -162,7 +162,7 @@ class Consumable extends CommonDBChild {
       if (!empty($itemtype)
           && ($items_id > 0)) {
 
-         $query = "UPDATE `".$static::getTable()."`
+         $query = "UPDATE `".static::getTable()."`
                    SET `date_out` = '".date("Y-m-d")."',
                        `itemtype` = '$itemtype',
                        `items_id` = '$items_id'

--- a/inc/consumable.class.php
+++ b/inc/consumable.class.php
@@ -119,7 +119,7 @@ class Consumable extends CommonDBChild {
    function backToStock(array $input, $history=1) {
       global $DB;
 
-      $query = "UPDATE `".$this->getTable()."`
+      $query = "UPDATE `".$this::getTable()."`
                 SET `date_out` = NULL
                 WHERE `id` = '".$input["id"]."'";
 
@@ -162,7 +162,7 @@ class Consumable extends CommonDBChild {
       if (!empty($itemtype)
           && ($items_id > 0)) {
 
-         $query = "UPDATE `".$this->getTable()."`
+         $query = "UPDATE `".$this::getTable()."`
                    SET `date_out` = '".date("Y-m-d")."',
                        `itemtype` = '$itemtype',
                        `items_id` = '$items_id'

--- a/inc/consumableitem.class.php
+++ b/inc/consumableitem.class.php
@@ -236,7 +236,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -245,7 +245,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'datatype'           => 'number',
@@ -254,7 +254,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '34',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'ref',
          'name'               => __('Reference'),
          'datatype'           => 'string'
@@ -278,7 +278,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => '_virtual',
          'linkfield'          => '_virtual',
          'name'               => _n('Consumable', 'Consumables', Session::getPluralNumber()),
@@ -343,7 +343,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'alarm_threshold',
          'name'               => __('Alert threshold'),
          'datatype'           => 'number',
@@ -354,7 +354,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/consumableitem.class.php
+++ b/inc/consumableitem.class.php
@@ -236,7 +236,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -245,7 +245,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'datatype'           => 'number',
@@ -254,7 +254,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '34',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'ref',
          'name'               => __('Reference'),
          'datatype'           => 'string'
@@ -278,7 +278,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => '_virtual',
          'linkfield'          => '_virtual',
          'name'               => _n('Consumable', 'Consumables', Session::getPluralNumber()),
@@ -343,7 +343,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'alarm_threshold',
          'name'               => __('Alert threshold'),
          'datatype'           => 'number',
@@ -354,7 +354,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/consumableitem.class.php
+++ b/inc/consumableitem.class.php
@@ -236,7 +236,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -245,7 +245,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'datatype'           => 'number',
@@ -254,7 +254,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '34',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'ref',
          'name'               => __('Reference'),
          'datatype'           => 'string'
@@ -278,7 +278,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => '_virtual',
          'linkfield'          => '_virtual',
          'name'               => _n('Consumable', 'Consumables', Session::getPluralNumber()),
@@ -343,7 +343,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'alarm_threshold',
          'name'               => __('Alert threshold'),
          'datatype'           => 'number',
@@ -354,7 +354,7 @@ class ConsumableItem extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/contact.class.php
+++ b/inc/contact.class.php
@@ -288,7 +288,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Last Name'),
          'datatype'           => 'itemlink',
@@ -297,7 +297,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'firstname',
          'name'               => __('First Name'),
          'datatype'           => 'string'
@@ -305,7 +305,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -314,7 +314,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'phone',
          'name'               => __('Phone'),
          'datatype'           => 'string'
@@ -322,7 +322,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'phone2',
          'name'               => __('Phone 2'),
          'datatype'           => 'string'
@@ -330,7 +330,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mobile',
          'name'               => __('Mobile phone'),
          'datatype'           => 'string'
@@ -338,7 +338,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'fax',
          'name'               => __('Fax'),
          'datatype'           => 'string'
@@ -346,7 +346,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'email',
          'name'               => _n('Email', 'Emails', 1),
          'datatype'           => 'email'
@@ -354,7 +354,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'address',
          'name'               => __('Address')
       ];
@@ -362,14 +362,14 @@ class Contact extends CommonDBTM{
       $tab[] = [
          'id'                 => '83',
          'datatype'           => 'string',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'postcode',
          'name'               => __('Postal code')
       ];
 
       $tab[] = [
          'id'                 => '84',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'town',
          'name'               => __('City'),
          'datatype'           => 'string'
@@ -377,7 +377,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '85',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'state',
          'name'               => __('State'),
          'datatype'           => 'string'
@@ -385,7 +385,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '87',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'country',
          'name'               => __('Country'),
          'datatype'           => 'string'
@@ -426,7 +426,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -443,7 +443,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -451,7 +451,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -460,7 +460,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/contact.class.php
+++ b/inc/contact.class.php
@@ -288,7 +288,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Last Name'),
          'datatype'           => 'itemlink',
@@ -297,7 +297,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'firstname',
          'name'               => __('First Name'),
          'datatype'           => 'string'
@@ -305,7 +305,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -314,7 +314,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'phone',
          'name'               => __('Phone'),
          'datatype'           => 'string'
@@ -322,7 +322,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'phone2',
          'name'               => __('Phone 2'),
          'datatype'           => 'string'
@@ -330,7 +330,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mobile',
          'name'               => __('Mobile phone'),
          'datatype'           => 'string'
@@ -338,7 +338,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'fax',
          'name'               => __('Fax'),
          'datatype'           => 'string'
@@ -346,7 +346,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'email',
          'name'               => _n('Email', 'Emails', 1),
          'datatype'           => 'email'
@@ -354,7 +354,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'address',
          'name'               => __('Address')
       ];
@@ -362,14 +362,14 @@ class Contact extends CommonDBTM{
       $tab[] = [
          'id'                 => '83',
          'datatype'           => 'string',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'postcode',
          'name'               => __('Postal code')
       ];
 
       $tab[] = [
          'id'                 => '84',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'town',
          'name'               => __('City'),
          'datatype'           => 'string'
@@ -377,7 +377,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '85',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'state',
          'name'               => __('State'),
          'datatype'           => 'string'
@@ -385,7 +385,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '87',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'country',
          'name'               => __('Country'),
          'datatype'           => 'string'
@@ -426,7 +426,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -443,7 +443,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -451,7 +451,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -460,7 +460,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/contact.class.php
+++ b/inc/contact.class.php
@@ -288,7 +288,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Last Name'),
          'datatype'           => 'itemlink',
@@ -297,7 +297,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'firstname',
          'name'               => __('First Name'),
          'datatype'           => 'string'
@@ -305,7 +305,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -314,7 +314,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'phone',
          'name'               => __('Phone'),
          'datatype'           => 'string'
@@ -322,7 +322,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'phone2',
          'name'               => __('Phone 2'),
          'datatype'           => 'string'
@@ -330,7 +330,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mobile',
          'name'               => __('Mobile phone'),
          'datatype'           => 'string'
@@ -338,7 +338,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'fax',
          'name'               => __('Fax'),
          'datatype'           => 'string'
@@ -346,7 +346,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'email',
          'name'               => _n('Email', 'Emails', 1),
          'datatype'           => 'email'
@@ -354,7 +354,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'address',
          'name'               => __('Address')
       ];
@@ -362,14 +362,14 @@ class Contact extends CommonDBTM{
       $tab[] = [
          'id'                 => '83',
          'datatype'           => 'string',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'postcode',
          'name'               => __('Postal code')
       ];
 
       $tab[] = [
          'id'                 => '84',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'town',
          'name'               => __('City'),
          'datatype'           => 'string'
@@ -377,7 +377,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '85',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'state',
          'name'               => __('State'),
          'datatype'           => 'string'
@@ -385,7 +385,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '87',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'country',
          'name'               => __('Country'),
          'datatype'           => 'string'
@@ -426,7 +426,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -443,7 +443,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -451,7 +451,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -460,7 +460,7 @@ class Contact extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/contract.class.php
+++ b/inc/contract.class.php
@@ -636,7 +636,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -645,7 +645,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -654,7 +654,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'num',
          'name'               => _x('phone', 'Number'),
          'datatype'           => 'string'
@@ -670,7 +670,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Start date'),
          'datatype'           => 'date',
@@ -679,7 +679,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'duration',
          'name'               => __('Duration'),
          'datatype'           => 'number',
@@ -689,7 +689,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -698,7 +698,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -707,7 +707,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'date_delay',
@@ -723,7 +723,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'notice',
          'name'               => __('Notice'),
          'datatype'           => 'number',
@@ -733,7 +733,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'periodicity',
          'name'               => __('Periodicity'),
          'massiveaction'      => false,
@@ -753,7 +753,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'billing',
          'name'               => __('Invoice period'),
          'massiveaction'      => false,
@@ -773,7 +773,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'accounting_number',
          'name'               => __('Account number'),
          'datatype'           => 'string'
@@ -781,7 +781,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'renewal',
          'name'               => __('Renewal'),
          'massiveaction'      => false,
@@ -791,7 +791,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'expire',
          'name'               => __('Expiration'),
          'datatype'           => 'date_delay',
@@ -807,7 +807,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'expire_notice',
          'name'               => __('Expiration date + notice'),
          'datatype'           => 'date_delay',
@@ -824,7 +824,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -841,7 +841,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '59',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'alert',
          'name'               => __('Email alarms'),
          'datatype'           => 'specific',
@@ -850,7 +850,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/contract.class.php
+++ b/inc/contract.class.php
@@ -636,7 +636,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -645,7 +645,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -654,7 +654,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'num',
          'name'               => _x('phone', 'Number'),
          'datatype'           => 'string'
@@ -670,7 +670,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Start date'),
          'datatype'           => 'date',
@@ -679,7 +679,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'duration',
          'name'               => __('Duration'),
          'datatype'           => 'number',
@@ -689,7 +689,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -698,7 +698,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -707,7 +707,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'date_delay',
@@ -723,7 +723,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'notice',
          'name'               => __('Notice'),
          'datatype'           => 'number',
@@ -733,7 +733,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'periodicity',
          'name'               => __('Periodicity'),
          'massiveaction'      => false,
@@ -753,7 +753,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'billing',
          'name'               => __('Invoice period'),
          'massiveaction'      => false,
@@ -773,7 +773,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'accounting_number',
          'name'               => __('Account number'),
          'datatype'           => 'string'
@@ -781,7 +781,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'renewal',
          'name'               => __('Renewal'),
          'massiveaction'      => false,
@@ -791,7 +791,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'expire',
          'name'               => __('Expiration'),
          'datatype'           => 'date_delay',
@@ -807,7 +807,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'expire_notice',
          'name'               => __('Expiration date + notice'),
          'datatype'           => 'date_delay',
@@ -824,7 +824,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -841,7 +841,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '59',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'alert',
          'name'               => __('Email alarms'),
          'datatype'           => 'specific',
@@ -850,7 +850,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/contract.class.php
+++ b/inc/contract.class.php
@@ -636,7 +636,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -645,7 +645,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -654,7 +654,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'num',
          'name'               => _x('phone', 'Number'),
          'datatype'           => 'string'
@@ -670,7 +670,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Start date'),
          'datatype'           => 'date',
@@ -679,7 +679,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'duration',
          'name'               => __('Duration'),
          'datatype'           => 'number',
@@ -689,7 +689,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -698,7 +698,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -707,7 +707,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'date_delay',
@@ -723,7 +723,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'notice',
          'name'               => __('Notice'),
          'datatype'           => 'number',
@@ -733,7 +733,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'periodicity',
          'name'               => __('Periodicity'),
          'massiveaction'      => false,
@@ -753,7 +753,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'billing',
          'name'               => __('Invoice period'),
          'massiveaction'      => false,
@@ -773,7 +773,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'accounting_number',
          'name'               => __('Account number'),
          'datatype'           => 'string'
@@ -781,7 +781,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'renewal',
          'name'               => __('Renewal'),
          'massiveaction'      => false,
@@ -791,7 +791,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'expire',
          'name'               => __('Expiration'),
          'datatype'           => 'date_delay',
@@ -807,7 +807,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'expire_notice',
          'name'               => __('Expiration date + notice'),
          'datatype'           => 'date_delay',
@@ -824,7 +824,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -841,7 +841,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '59',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'alert',
          'name'               => __('Email alarms'),
          'datatype'           => 'specific',
@@ -850,7 +850,7 @@ class Contract extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/contract_item.class.php
+++ b/inc/contract_item.class.php
@@ -81,7 +81,7 @@ class Contract_Item extends CommonDBRelation{
          return false;
       }
       if (($contract->fields['max_links_allowed'] > 0)
-          && (countElementsInTable($this->getTable(),
+          && (countElementsInTable($this::getTable(),
                                   ['contracts_id'=> $this->input['contracts_id']])
                 >= $contract->fields['max_links_allowed'])) {
          return false;
@@ -151,7 +151,7 @@ class Contract_Item extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -160,7 +160,7 @@ class Contract_Item extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'items_id',
          'name'               => __('Associated item ID'),
          'massiveaction'      => false,
@@ -170,7 +170,7 @@ class Contract_Item extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'massiveaction'      => false,
@@ -208,13 +208,13 @@ class Contract_Item extends CommonDBRelation{
          $itemt = getItemForItemtype($data['itemtype']);
 
          $query = "SELECT COUNT(*) AS cpt
-                   FROM `glpi_contracts_items`, `".$itemt->getTable()."`
+                   FROM `glpi_contracts_items`, `".$itemt::getTable()."`
                    WHERE `glpi_contracts_items`.`contracts_id` = '".$item->getField('id')."'
                          AND `glpi_contracts_items`.`itemtype` = '".$data['itemtype']."'
-                         AND `".$itemt->getTable()."`.`id` = `glpi_contracts_items`.`items_id`";
+                         AND `".$itemt::getTable()."`.`id` = `glpi_contracts_items`.`items_id`";
 
          if ($itemt->maybeTemplate()) {
-            $query .= " AND NOT `".$itemt->getTable()."`.`is_template`";
+            $query .= " AND NOT `".$itemt::getTable()."`.`is_template`";
          }
 
          foreach ($DB->request($query) as $row) {

--- a/inc/contract_item.class.php
+++ b/inc/contract_item.class.php
@@ -81,7 +81,7 @@ class Contract_Item extends CommonDBRelation{
          return false;
       }
       if (($contract->fields['max_links_allowed'] > 0)
-          && (countElementsInTable($static::getTable(),
+          && (countElementsInTable(static::getTable(),
                                   ['contracts_id'=> $this->input['contracts_id']])
                 >= $contract->fields['max_links_allowed'])) {
          return false;
@@ -151,7 +151,7 @@ class Contract_Item extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -160,7 +160,7 @@ class Contract_Item extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'items_id',
          'name'               => __('Associated item ID'),
          'massiveaction'      => false,
@@ -170,7 +170,7 @@ class Contract_Item extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'massiveaction'      => false,

--- a/inc/contract_item.class.php
+++ b/inc/contract_item.class.php
@@ -81,7 +81,7 @@ class Contract_Item extends CommonDBRelation{
          return false;
       }
       if (($contract->fields['max_links_allowed'] > 0)
-          && (countElementsInTable($this::getTable(),
+          && (countElementsInTable($static::getTable(),
                                   ['contracts_id'=> $this->input['contracts_id']])
                 >= $contract->fields['max_links_allowed'])) {
          return false;
@@ -151,7 +151,7 @@ class Contract_Item extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -160,7 +160,7 @@ class Contract_Item extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'items_id',
          'name'               => __('Associated item ID'),
          'massiveaction'      => false,
@@ -170,7 +170,7 @@ class Contract_Item extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'massiveaction'      => false,

--- a/inc/contractcost.class.php
+++ b/inc/contractcost.class.php
@@ -127,7 +127,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'searchtype'         => 'contains',
@@ -137,7 +137,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -146,7 +146,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -154,7 +154,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Begin date'),
          'datatype'           => 'datetime'
@@ -162,7 +162,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'
@@ -170,7 +170,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'cost',
          'name'               => __('Cost'),
          'datatype'           => 'decimal'
@@ -257,7 +257,7 @@ class ContractCost extends CommonDBChild {
       global $DB;
 
       $query = "SELECT *
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `contracts_id` = '$contracts_id'
                 ORDER BY 'end_date' DESC, `id` DESC";
 

--- a/inc/contractcost.class.php
+++ b/inc/contractcost.class.php
@@ -127,7 +127,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'searchtype'         => 'contains',
@@ -137,7 +137,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -146,7 +146,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -154,7 +154,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Begin date'),
          'datatype'           => 'datetime'
@@ -162,7 +162,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'
@@ -170,7 +170,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'cost',
          'name'               => __('Cost'),
          'datatype'           => 'decimal'
@@ -257,7 +257,7 @@ class ContractCost extends CommonDBChild {
       global $DB;
 
       $query = "SELECT *
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `contracts_id` = '$contracts_id'
                 ORDER BY 'end_date' DESC, `id` DESC";
 

--- a/inc/contractcost.class.php
+++ b/inc/contractcost.class.php
@@ -127,7 +127,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'searchtype'         => 'contains',
@@ -137,7 +137,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -146,7 +146,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -154,7 +154,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Begin date'),
          'datatype'           => 'datetime'
@@ -162,7 +162,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'
@@ -170,7 +170,7 @@ class ContractCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'cost',
          'name'               => __('Cost'),
          'datatype'           => 'decimal'
@@ -257,7 +257,7 @@ class ContractCost extends CommonDBChild {
       global $DB;
 
       $query = "SELECT *
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `contracts_id` = '$contracts_id'
                 ORDER BY 'end_date' DESC, `id` DESC";
 

--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -132,8 +132,8 @@ class CronTask extends CommonDBTM{
    **/
    function getFromDBbyName($itemtype, $name) {
 
-      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`name` = '$name'
-                                            AND `".$this::getTable()."`.`itemtype` = '$itemtype'");
+      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`name` = '$name'
+                                            AND `".$static::getTable()."`.`itemtype` = '$itemtype'");
    }
 
 
@@ -219,7 +219,7 @@ class CronTask extends CommonDBTM{
          pcntl_signal(SIGTERM, [$this, 'signal']);
       }
 
-      $query = "UPDATE `".$this::getTable()."`
+      $query = "UPDATE `".$static::getTable()."`
                 SET `state` = '".self::STATE_RUNNING."',
                     `lastrun` = DATE_FORMAT(NOW(),'%Y-%m-%d %H:%i:00')
                 WHERE `id` = '".$this->fields['id']."'
@@ -281,7 +281,7 @@ class CronTask extends CommonDBTM{
       if (!isset($this->fields['id'])) {
          return false;
       }
-      $query = "UPDATE `".$this::getTable()."`
+      $query = "UPDATE `".$static::getTable()."`
                 SET `state` = '".$this->fields['state']."'
                 WHERE `id` = '".$this->fields['id']."'
                       AND `state` = '".self::STATE_RUNNING."'";
@@ -358,7 +358,7 @@ class CronTask extends CommonDBTM{
       // First core ones
       $query = "SELECT *,
                        LOCATE('Plugin',itemtype) AS ISPLUGIN
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE (`itemtype` NOT LIKE 'Plugin%'";
 
       if (count($_SESSION['glpi_plugins'])) {
@@ -1314,7 +1314,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -1323,7 +1323,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -1332,7 +1332,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'description',
          'name'               => __('Description'),
          'nosearch'           => true,
@@ -1344,7 +1344,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'state',
          'name'               => __('Status'),
          'searchtype'         => ['equals', 'notequals'],
@@ -1354,7 +1354,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mode',
          'name'               => __('Run mode'),
          'datatype'           => 'specific',
@@ -1363,7 +1363,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'frequency',
          'name'               => __('Run frequency'),
          'datatype'           => 'timestamp',
@@ -1372,7 +1372,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'lastrun',
          'name'               => __('Last run'),
          'datatype'           => 'datetime',
@@ -1381,7 +1381,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Item type'),
          'massiveaction'      => false,
@@ -1391,7 +1391,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -1399,7 +1399,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'hourmin',
          'name'               => __('Begin hour of run period'),
          'datatype'           => 'integer',
@@ -1409,7 +1409,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'hourmax',
          'name'               => __('End hour of run period'),
          'datatype'           => 'integer',
@@ -1419,7 +1419,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'logs_lifetime',
          'name'               => __('Number of days this action logs are stored'),
          'datatype'           => 'integer',
@@ -1433,7 +1433,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -1442,7 +1442,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -132,8 +132,8 @@ class CronTask extends CommonDBTM{
    **/
    function getFromDBbyName($itemtype, $name) {
 
-      return $this->getFromDBByQuery("WHERE `".$this->getTable()."`.`name` = '$name'
-                                            AND `".$this->getTable()."`.`itemtype` = '$itemtype'");
+      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`name` = '$name'
+                                            AND `".$this::getTable()."`.`itemtype` = '$itemtype'");
    }
 
 
@@ -219,7 +219,7 @@ class CronTask extends CommonDBTM{
          pcntl_signal(SIGTERM, [$this, 'signal']);
       }
 
-      $query = "UPDATE `".$this->getTable()."`
+      $query = "UPDATE `".$this::getTable()."`
                 SET `state` = '".self::STATE_RUNNING."',
                     `lastrun` = DATE_FORMAT(NOW(),'%Y-%m-%d %H:%i:00')
                 WHERE `id` = '".$this->fields['id']."'
@@ -281,7 +281,7 @@ class CronTask extends CommonDBTM{
       if (!isset($this->fields['id'])) {
          return false;
       }
-      $query = "UPDATE `".$this->getTable()."`
+      $query = "UPDATE `".$this::getTable()."`
                 SET `state` = '".$this->fields['state']."'
                 WHERE `id` = '".$this->fields['id']."'
                       AND `state` = '".self::STATE_RUNNING."'";
@@ -358,7 +358,7 @@ class CronTask extends CommonDBTM{
       // First core ones
       $query = "SELECT *,
                        LOCATE('Plugin',itemtype) AS ISPLUGIN
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE (`itemtype` NOT LIKE 'Plugin%'";
 
       if (count($_SESSION['glpi_plugins'])) {
@@ -801,7 +801,7 @@ class CronTask extends CommonDBTM{
             Toolbox::logInFile('cron', __('A minimum of 64 Mio is commonly required for GLPI.')."\n");
          }
          // If no task in CLI mode, call cron.php from command line is not really usefull ;)
-         if (!countElementsInTable($crontask->getTable(), ['mode' => abs($mode)])) {
+         if (!countElementsInTable($crontask::getTable(), ['mode' => abs($mode)])) {
             Toolbox::logInFile('cron',
                                __('No task with Run mode = CLI, fix your tasks configuration')."\n");
          }
@@ -1314,7 +1314,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -1323,7 +1323,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -1332,7 +1332,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'description',
          'name'               => __('Description'),
          'nosearch'           => true,
@@ -1344,7 +1344,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'state',
          'name'               => __('Status'),
          'searchtype'         => ['equals', 'notequals'],
@@ -1354,7 +1354,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mode',
          'name'               => __('Run mode'),
          'datatype'           => 'specific',
@@ -1363,7 +1363,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'frequency',
          'name'               => __('Run frequency'),
          'datatype'           => 'timestamp',
@@ -1372,7 +1372,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'lastrun',
          'name'               => __('Last run'),
          'datatype'           => 'datetime',
@@ -1381,7 +1381,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Item type'),
          'massiveaction'      => false,
@@ -1391,7 +1391,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -1399,7 +1399,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'hourmin',
          'name'               => __('Begin hour of run period'),
          'datatype'           => 'integer',
@@ -1409,7 +1409,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'hourmax',
          'name'               => __('End hour of run period'),
          'datatype'           => 'integer',
@@ -1419,7 +1419,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'logs_lifetime',
          'name'               => __('Number of days this action logs are stored'),
          'datatype'           => 'integer',
@@ -1433,7 +1433,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -1442,7 +1442,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -132,8 +132,8 @@ class CronTask extends CommonDBTM{
    **/
    function getFromDBbyName($itemtype, $name) {
 
-      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`name` = '$name'
-                                            AND `".$static::getTable()."`.`itemtype` = '$itemtype'");
+      return $this->getFromDBByQuery("WHERE `".static::getTable()."`.`name` = '$name'
+                                            AND `".static::getTable()."`.`itemtype` = '$itemtype'");
    }
 
 
@@ -219,7 +219,7 @@ class CronTask extends CommonDBTM{
          pcntl_signal(SIGTERM, [$this, 'signal']);
       }
 
-      $query = "UPDATE `".$static::getTable()."`
+      $query = "UPDATE `".static::getTable()."`
                 SET `state` = '".self::STATE_RUNNING."',
                     `lastrun` = DATE_FORMAT(NOW(),'%Y-%m-%d %H:%i:00')
                 WHERE `id` = '".$this->fields['id']."'
@@ -281,7 +281,7 @@ class CronTask extends CommonDBTM{
       if (!isset($this->fields['id'])) {
          return false;
       }
-      $query = "UPDATE `".$static::getTable()."`
+      $query = "UPDATE `".static::getTable()."`
                 SET `state` = '".$this->fields['state']."'
                 WHERE `id` = '".$this->fields['id']."'
                       AND `state` = '".self::STATE_RUNNING."'";
@@ -358,7 +358,7 @@ class CronTask extends CommonDBTM{
       // First core ones
       $query = "SELECT *,
                        LOCATE('Plugin',itemtype) AS ISPLUGIN
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE (`itemtype` NOT LIKE 'Plugin%'";
 
       if (count($_SESSION['glpi_plugins'])) {
@@ -1314,7 +1314,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -1323,7 +1323,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -1332,7 +1332,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'description',
          'name'               => __('Description'),
          'nosearch'           => true,
@@ -1344,7 +1344,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'state',
          'name'               => __('Status'),
          'searchtype'         => ['equals', 'notequals'],
@@ -1354,7 +1354,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mode',
          'name'               => __('Run mode'),
          'datatype'           => 'specific',
@@ -1363,7 +1363,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'frequency',
          'name'               => __('Run frequency'),
          'datatype'           => 'timestamp',
@@ -1372,7 +1372,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'lastrun',
          'name'               => __('Last run'),
          'datatype'           => 'datetime',
@@ -1381,7 +1381,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Item type'),
          'massiveaction'      => false,
@@ -1391,7 +1391,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -1399,7 +1399,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'hourmin',
          'name'               => __('Begin hour of run period'),
          'datatype'           => 'integer',
@@ -1409,7 +1409,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'hourmax',
          'name'               => __('End hour of run period'),
          'datatype'           => 'integer',
@@ -1419,7 +1419,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'logs_lifetime',
          'name'               => __('Number of days this action logs are stored'),
          'datatype'           => 'integer',
@@ -1433,7 +1433,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -1442,7 +1442,7 @@ class CronTask extends CommonDBTM{
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/crontasklog.class.php
+++ b/inc/crontasklog.class.php
@@ -81,7 +81,7 @@ class CronTaskLog extends CommonDBTM{
                $ong    = array();
                $ong[1] = __('Statistics');
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb =  countElementsInTable($this::getTable(),
+                  $nb =  countElementsInTable($static::getTable(),
                                               ['crontasks_id' => $item->getID(),
                                                'state'        => self::STATE_STOP ]);
                }

--- a/inc/crontasklog.class.php
+++ b/inc/crontasklog.class.php
@@ -81,7 +81,7 @@ class CronTaskLog extends CommonDBTM{
                $ong    = array();
                $ong[1] = __('Statistics');
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb =  countElementsInTable($this->getTable(),
+                  $nb =  countElementsInTable($this::getTable(),
                                               ['crontasks_id' => $item->getID(),
                                                'state'        => self::STATE_STOP ]);
                }

--- a/inc/crontasklog.class.php
+++ b/inc/crontasklog.class.php
@@ -81,7 +81,7 @@ class CronTaskLog extends CommonDBTM{
                $ong    = array();
                $ong[1] = __('Statistics');
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb =  countElementsInTable($static::getTable(),
+                  $nb =  countElementsInTable(static::getTable(),
                                               ['crontasks_id' => $item->getID(),
                                                'state'        => self::STATE_STOP ]);
                }

--- a/inc/devicebattery.class.php
+++ b/inc/devicebattery.class.php
@@ -74,7 +74,7 @@ class DeviceBattery extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'capacity',
          'name'               => __('Capacity'),
          'datatype'           => 'string'
@@ -82,7 +82,7 @@ class DeviceBattery extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'voltage',
          'name'               => __('Voltage'),
          'datatype'           => 'string'

--- a/inc/devicebattery.class.php
+++ b/inc/devicebattery.class.php
@@ -74,7 +74,7 @@ class DeviceBattery extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'capacity',
          'name'               => __('Capacity'),
          'datatype'           => 'string'
@@ -82,7 +82,7 @@ class DeviceBattery extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'voltage',
          'name'               => __('Voltage'),
          'datatype'           => 'string'

--- a/inc/devicebattery.class.php
+++ b/inc/devicebattery.class.php
@@ -74,7 +74,7 @@ class DeviceBattery extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'capacity',
          'name'               => __('Capacity'),
          'datatype'           => 'string'
@@ -82,7 +82,7 @@ class DeviceBattery extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'voltage',
          'name'               => __('Voltage'),
          'datatype'           => 'string'

--- a/inc/devicecontrol.class.php
+++ b/inc/devicecontrol.class.php
@@ -76,7 +76,7 @@ class DeviceControl extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_raid',
          'name'               => __('RAID'),
          'datatype'           => 'bool'

--- a/inc/devicecontrol.class.php
+++ b/inc/devicecontrol.class.php
@@ -76,7 +76,7 @@ class DeviceControl extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_raid',
          'name'               => __('RAID'),
          'datatype'           => 'bool'

--- a/inc/devicecontrol.class.php
+++ b/inc/devicecontrol.class.php
@@ -76,7 +76,7 @@ class DeviceControl extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_raid',
          'name'               => __('RAID'),
          'datatype'           => 'bool'

--- a/inc/devicedrive.class.php
+++ b/inc/devicedrive.class.php
@@ -71,7 +71,7 @@ class DeviceDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_writer',
          'name'               => __('Writing ability'),
          'datatype'           => 'bool'
@@ -79,7 +79,7 @@ class DeviceDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'speed',
          'name'               => __('Speed'),
          'datatype'           => 'string'

--- a/inc/devicedrive.class.php
+++ b/inc/devicedrive.class.php
@@ -71,7 +71,7 @@ class DeviceDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_writer',
          'name'               => __('Writing ability'),
          'datatype'           => 'bool'
@@ -79,7 +79,7 @@ class DeviceDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'speed',
          'name'               => __('Speed'),
          'datatype'           => 'string'

--- a/inc/devicedrive.class.php
+++ b/inc/devicedrive.class.php
@@ -71,7 +71,7 @@ class DeviceDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_writer',
          'name'               => __('Writing ability'),
          'datatype'           => 'bool'
@@ -79,7 +79,7 @@ class DeviceDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'speed',
          'name'               => __('Speed'),
          'datatype'           => 'string'

--- a/inc/devicefirmware.class.php
+++ b/inc/devicefirmware.class.php
@@ -78,7 +78,7 @@ class DeviceFirmware extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'date'

--- a/inc/devicefirmware.class.php
+++ b/inc/devicefirmware.class.php
@@ -78,7 +78,7 @@ class DeviceFirmware extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'date'

--- a/inc/devicefirmware.class.php
+++ b/inc/devicefirmware.class.php
@@ -78,7 +78,7 @@ class DeviceFirmware extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'date'

--- a/inc/devicegraphiccard.class.php
+++ b/inc/devicegraphiccard.class.php
@@ -78,7 +78,7 @@ class DeviceGraphicCard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'memory_default',
          'name'               => __('Memory by default'),
          'datatype'           => 'string'

--- a/inc/devicegraphiccard.class.php
+++ b/inc/devicegraphiccard.class.php
@@ -78,7 +78,7 @@ class DeviceGraphicCard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'memory_default',
          'name'               => __('Memory by default'),
          'datatype'           => 'string'

--- a/inc/devicegraphiccard.class.php
+++ b/inc/devicegraphiccard.class.php
@@ -78,7 +78,7 @@ class DeviceGraphicCard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'memory_default',
          'name'               => __('Memory by default'),
          'datatype'           => 'string'

--- a/inc/deviceharddrive.class.php
+++ b/inc/deviceharddrive.class.php
@@ -76,7 +76,7 @@ class DeviceHardDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'capacity_default',
          'name'               => __('Capacity by default'),
          'datatype'           => 'string'
@@ -84,7 +84,7 @@ class DeviceHardDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'rpm',
          'name'               => __('Rpm'),
          'datatype'           => 'string'
@@ -92,7 +92,7 @@ class DeviceHardDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'cache',
          'name'               => __('Cache'),
          'datatype'           => 'string'

--- a/inc/deviceharddrive.class.php
+++ b/inc/deviceharddrive.class.php
@@ -76,7 +76,7 @@ class DeviceHardDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'capacity_default',
          'name'               => __('Capacity by default'),
          'datatype'           => 'string'
@@ -84,7 +84,7 @@ class DeviceHardDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'rpm',
          'name'               => __('Rpm'),
          'datatype'           => 'string'
@@ -92,7 +92,7 @@ class DeviceHardDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'cache',
          'name'               => __('Cache'),
          'datatype'           => 'string'

--- a/inc/deviceharddrive.class.php
+++ b/inc/deviceharddrive.class.php
@@ -76,7 +76,7 @@ class DeviceHardDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'capacity_default',
          'name'               => __('Capacity by default'),
          'datatype'           => 'string'
@@ -84,7 +84,7 @@ class DeviceHardDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'rpm',
          'name'               => __('Rpm'),
          'datatype'           => 'string'
@@ -92,7 +92,7 @@ class DeviceHardDrive extends CommonDevice {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'cache',
          'name'               => __('Cache'),
          'datatype'           => 'string'

--- a/inc/devicememory.class.php
+++ b/inc/devicememory.class.php
@@ -73,7 +73,7 @@ class DeviceMemory extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'size_default',
          'name'               => __('Size by default'),
          'datatype'           => 'string'
@@ -81,7 +81,7 @@ class DeviceMemory extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'frequence',
          'name'               => __('Frequency'),
          'datatype'           => 'string'

--- a/inc/devicememory.class.php
+++ b/inc/devicememory.class.php
@@ -73,7 +73,7 @@ class DeviceMemory extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'size_default',
          'name'               => __('Size by default'),
          'datatype'           => 'string'
@@ -81,7 +81,7 @@ class DeviceMemory extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'frequence',
          'name'               => __('Frequency'),
          'datatype'           => 'string'

--- a/inc/devicememory.class.php
+++ b/inc/devicememory.class.php
@@ -73,7 +73,7 @@ class DeviceMemory extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'size_default',
          'name'               => __('Size by default'),
          'datatype'           => 'string'
@@ -81,7 +81,7 @@ class DeviceMemory extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'frequence',
          'name'               => __('Frequency'),
          'datatype'           => 'string'

--- a/inc/devicemotherboard.class.php
+++ b/inc/devicemotherboard.class.php
@@ -65,7 +65,7 @@ class DeviceMotherboard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'chipset',
          'name'               => __('Chipset'),
          'datatype'           => 'string'

--- a/inc/devicemotherboard.class.php
+++ b/inc/devicemotherboard.class.php
@@ -65,7 +65,7 @@ class DeviceMotherboard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'chipset',
          'name'               => __('Chipset'),
          'datatype'           => 'string'

--- a/inc/devicemotherboard.class.php
+++ b/inc/devicemotherboard.class.php
@@ -65,7 +65,7 @@ class DeviceMotherboard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'chipset',
          'name'               => __('Chipset'),
          'datatype'           => 'string'

--- a/inc/devicenetworkcard.class.php
+++ b/inc/devicenetworkcard.class.php
@@ -89,7 +89,7 @@ class DeviceNetworkCard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mac_default',
          'name'               => __('MAC address by default'),
          'datatype'           => 'mac'
@@ -97,7 +97,7 @@ class DeviceNetworkCard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'bandwidth',
          'name'               => __('Flow'),
          'datatype'           => 'string'
@@ -130,7 +130,7 @@ class DeviceNetworkCard extends CommonDevice {
       }
 
       $query = "SELECT `id`
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `designation` = '" . $input['designation'] . "'";
 
       if (isset($input["bandwidth"])) {

--- a/inc/devicenetworkcard.class.php
+++ b/inc/devicenetworkcard.class.php
@@ -89,7 +89,7 @@ class DeviceNetworkCard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mac_default',
          'name'               => __('MAC address by default'),
          'datatype'           => 'mac'
@@ -97,7 +97,7 @@ class DeviceNetworkCard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'bandwidth',
          'name'               => __('Flow'),
          'datatype'           => 'string'
@@ -130,7 +130,7 @@ class DeviceNetworkCard extends CommonDevice {
       }
 
       $query = "SELECT `id`
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `designation` = '" . $input['designation'] . "'";
 
       if (isset($input["bandwidth"])) {

--- a/inc/devicenetworkcard.class.php
+++ b/inc/devicenetworkcard.class.php
@@ -89,7 +89,7 @@ class DeviceNetworkCard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mac_default',
          'name'               => __('MAC address by default'),
          'datatype'           => 'mac'
@@ -97,7 +97,7 @@ class DeviceNetworkCard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'bandwidth',
          'name'               => __('Flow'),
          'datatype'           => 'string'
@@ -130,7 +130,7 @@ class DeviceNetworkCard extends CommonDevice {
       }
 
       $query = "SELECT `id`
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `designation` = '" . $input['designation'] . "'";
 
       if (isset($input["bandwidth"])) {

--- a/inc/devicepowersupply.class.php
+++ b/inc/devicepowersupply.class.php
@@ -68,7 +68,7 @@ class DevicePowerSupply extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_atx',
          'name'               => __('ATX'),
          'datatype'           => 'bool'
@@ -76,7 +76,7 @@ class DevicePowerSupply extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'power',
          'name'               => __('Power'),
          'datatype'           => 'string'

--- a/inc/devicepowersupply.class.php
+++ b/inc/devicepowersupply.class.php
@@ -68,7 +68,7 @@ class DevicePowerSupply extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_atx',
          'name'               => __('ATX'),
          'datatype'           => 'bool'
@@ -76,7 +76,7 @@ class DevicePowerSupply extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'power',
          'name'               => __('Power'),
          'datatype'           => 'string'

--- a/inc/devicepowersupply.class.php
+++ b/inc/devicepowersupply.class.php
@@ -68,7 +68,7 @@ class DevicePowerSupply extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_atx',
          'name'               => __('ATX'),
          'datatype'           => 'bool'
@@ -76,7 +76,7 @@ class DevicePowerSupply extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'power',
          'name'               => __('Power'),
          'datatype'           => 'string'

--- a/inc/deviceprocessor.class.php
+++ b/inc/deviceprocessor.class.php
@@ -77,7 +77,7 @@ class DeviceProcessor extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'frequency_default',
          'name'               => __('Frequency by default'),
          'datatype'           => 'string'
@@ -85,7 +85,7 @@ class DeviceProcessor extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'frequence',
          'name'               => __('Frequency'),
          'datatype'           => 'string'
@@ -93,7 +93,7 @@ class DeviceProcessor extends CommonDevice {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'nbcores_default',
          'name'               => __('Number of cores'),
          'datatype'           => 'integer'
@@ -101,7 +101,7 @@ class DeviceProcessor extends CommonDevice {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'nbthreads_default',
          'name'               => __('Number of threads'),
          'datatype'           => 'integer'

--- a/inc/deviceprocessor.class.php
+++ b/inc/deviceprocessor.class.php
@@ -77,7 +77,7 @@ class DeviceProcessor extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'frequency_default',
          'name'               => __('Frequency by default'),
          'datatype'           => 'string'
@@ -85,7 +85,7 @@ class DeviceProcessor extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'frequence',
          'name'               => __('Frequency'),
          'datatype'           => 'string'
@@ -93,7 +93,7 @@ class DeviceProcessor extends CommonDevice {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'nbcores_default',
          'name'               => __('Number of cores'),
          'datatype'           => 'integer'
@@ -101,7 +101,7 @@ class DeviceProcessor extends CommonDevice {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'nbthreads_default',
          'name'               => __('Number of threads'),
          'datatype'           => 'integer'

--- a/inc/deviceprocessor.class.php
+++ b/inc/deviceprocessor.class.php
@@ -77,7 +77,7 @@ class DeviceProcessor extends CommonDevice {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'frequency_default',
          'name'               => __('Frequency by default'),
          'datatype'           => 'string'
@@ -85,7 +85,7 @@ class DeviceProcessor extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'frequence',
          'name'               => __('Frequency'),
          'datatype'           => 'string'
@@ -93,7 +93,7 @@ class DeviceProcessor extends CommonDevice {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'nbcores_default',
          'name'               => __('Number of cores'),
          'datatype'           => 'integer'
@@ -101,7 +101,7 @@ class DeviceProcessor extends CommonDevice {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'nbthreads_default',
          'name'               => __('Number of threads'),
          'datatype'           => 'integer'

--- a/inc/devicesoundcard.class.php
+++ b/inc/devicesoundcard.class.php
@@ -73,7 +73,7 @@ class DeviceSoundCard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'type',
          'name'               => __('Type'),
          'datatype'           => 'string'

--- a/inc/devicesoundcard.class.php
+++ b/inc/devicesoundcard.class.php
@@ -73,7 +73,7 @@ class DeviceSoundCard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'type',
          'name'               => __('Type'),
          'datatype'           => 'string'

--- a/inc/devicesoundcard.class.php
+++ b/inc/devicesoundcard.class.php
@@ -73,7 +73,7 @@ class DeviceSoundCard extends CommonDevice {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'type',
          'name'               => __('Type'),
          'datatype'           => 'string'

--- a/inc/displaypreference.class.php
+++ b/inc/displaypreference.class.php
@@ -64,7 +64,7 @@ class DisplayPreference extends CommonDBTM {
       global $DB;
 
       $query = "SELECT MAX(`rank`)
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `itemtype` = '".$input["itemtype"]."'
                       AND `users_id` = '".$input["users_id"]."'";
       $result = $DB->query($query);
@@ -156,7 +156,7 @@ class DisplayPreference extends CommonDBTM {
       }
 
       $query = "SELECT *
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `itemtype` = '".$input["itemtype"]."'
                       AND `users_id` = '0'";
       $result = $DB->query($query);
@@ -205,14 +205,14 @@ class DisplayPreference extends CommonDBTM {
 
       // Get current item
       $query = "SELECT `rank`
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `id` = '".$input['id']."'";
       $result = $DB->query($query);
       $rank1  = $DB->result($result, 0, 0);
 
       // Get previous or next item
       $query = "SELECT `id`, `rank`
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `itemtype` = '".$input['itemtype']."'
                       AND `users_id` = '".$input["users_id"]."'";
 
@@ -236,12 +236,12 @@ class DisplayPreference extends CommonDBTM {
       $ID2    = $DB->result($result, 0, "id");
 
       // Update items
-      $query = "UPDATE `".$this::getTable()."`
+      $query = "UPDATE `".$static::getTable()."`
                 SET `rank` = '$rank2'
                 WHERE `id` = '".$input['id']."'";
       $DB->query($query);
 
-      $query = "UPDATE `".$this::getTable()."`
+      $query = "UPDATE `".$static::getTable()."`
                 SET `rank` = '$rank1'
                 WHERE `id` = '$ID2'";
       $DB->query($query);
@@ -274,7 +274,7 @@ class DisplayPreference extends CommonDBTM {
       echo "<div class='center' id='tabsbody' >";
       // Defined items
       $query = "SELECT *
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `itemtype` = '$itemtype'
                       AND `users_id` = '$IDuser'
                 ORDER BY `rank`";
@@ -443,7 +443,7 @@ class DisplayPreference extends CommonDBTM {
       echo "<div class='center' id='tabsbody' >";
       // Defined items
       $query = "SELECT *
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `itemtype` = '$itemtype'
                       AND `users_id` = '$IDuser'
                 ORDER BY `rank`";

--- a/inc/displaypreference.class.php
+++ b/inc/displaypreference.class.php
@@ -64,7 +64,7 @@ class DisplayPreference extends CommonDBTM {
       global $DB;
 
       $query = "SELECT MAX(`rank`)
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `itemtype` = '".$input["itemtype"]."'
                       AND `users_id` = '".$input["users_id"]."'";
       $result = $DB->query($query);
@@ -156,7 +156,7 @@ class DisplayPreference extends CommonDBTM {
       }
 
       $query = "SELECT *
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `itemtype` = '".$input["itemtype"]."'
                       AND `users_id` = '0'";
       $result = $DB->query($query);
@@ -205,14 +205,14 @@ class DisplayPreference extends CommonDBTM {
 
       // Get current item
       $query = "SELECT `rank`
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `id` = '".$input['id']."'";
       $result = $DB->query($query);
       $rank1  = $DB->result($result, 0, 0);
 
       // Get previous or next item
       $query = "SELECT `id`, `rank`
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `itemtype` = '".$input['itemtype']."'
                       AND `users_id` = '".$input["users_id"]."'";
 
@@ -236,12 +236,12 @@ class DisplayPreference extends CommonDBTM {
       $ID2    = $DB->result($result, 0, "id");
 
       // Update items
-      $query = "UPDATE `".$this->getTable()."`
+      $query = "UPDATE `".$this::getTable()."`
                 SET `rank` = '$rank2'
                 WHERE `id` = '".$input['id']."'";
       $DB->query($query);
 
-      $query = "UPDATE `".$this->getTable()."`
+      $query = "UPDATE `".$this::getTable()."`
                 SET `rank` = '$rank1'
                 WHERE `id` = '$ID2'";
       $DB->query($query);
@@ -274,7 +274,7 @@ class DisplayPreference extends CommonDBTM {
       echo "<div class='center' id='tabsbody' >";
       // Defined items
       $query = "SELECT *
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `itemtype` = '$itemtype'
                       AND `users_id` = '$IDuser'
                 ORDER BY `rank`";
@@ -443,7 +443,7 @@ class DisplayPreference extends CommonDBTM {
       echo "<div class='center' id='tabsbody' >";
       // Defined items
       $query = "SELECT *
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `itemtype` = '$itemtype'
                       AND `users_id` = '$IDuser'
                 ORDER BY `rank`";

--- a/inc/displaypreference.class.php
+++ b/inc/displaypreference.class.php
@@ -64,7 +64,7 @@ class DisplayPreference extends CommonDBTM {
       global $DB;
 
       $query = "SELECT MAX(`rank`)
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `itemtype` = '".$input["itemtype"]."'
                       AND `users_id` = '".$input["users_id"]."'";
       $result = $DB->query($query);
@@ -156,7 +156,7 @@ class DisplayPreference extends CommonDBTM {
       }
 
       $query = "SELECT *
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `itemtype` = '".$input["itemtype"]."'
                       AND `users_id` = '0'";
       $result = $DB->query($query);
@@ -205,14 +205,14 @@ class DisplayPreference extends CommonDBTM {
 
       // Get current item
       $query = "SELECT `rank`
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `id` = '".$input['id']."'";
       $result = $DB->query($query);
       $rank1  = $DB->result($result, 0, 0);
 
       // Get previous or next item
       $query = "SELECT `id`, `rank`
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `itemtype` = '".$input['itemtype']."'
                       AND `users_id` = '".$input["users_id"]."'";
 
@@ -236,12 +236,12 @@ class DisplayPreference extends CommonDBTM {
       $ID2    = $DB->result($result, 0, "id");
 
       // Update items
-      $query = "UPDATE `".$static::getTable()."`
+      $query = "UPDATE `".static::getTable()."`
                 SET `rank` = '$rank2'
                 WHERE `id` = '".$input['id']."'";
       $DB->query($query);
 
-      $query = "UPDATE `".$static::getTable()."`
+      $query = "UPDATE `".static::getTable()."`
                 SET `rank` = '$rank1'
                 WHERE `id` = '$ID2'";
       $DB->query($query);
@@ -274,7 +274,7 @@ class DisplayPreference extends CommonDBTM {
       echo "<div class='center' id='tabsbody' >";
       // Defined items
       $query = "SELECT *
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `itemtype` = '$itemtype'
                       AND `users_id` = '$IDuser'
                 ORDER BY `rank`";
@@ -443,7 +443,7 @@ class DisplayPreference extends CommonDBTM {
       echo "<div class='center' id='tabsbody' >";
       // Defined items
       $query = "SELECT *
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `itemtype` = '$itemtype'
                       AND `users_id` = '$IDuser'
                 ORDER BY `rank`";

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -161,7 +161,7 @@ class Document extends CommonDBTM {
       if (!empty($this->fields["filepath"])) {
          if (is_file(GLPI_DOC_DIR."/".$this->fields["filepath"])
              && !is_dir(GLPI_DOC_DIR."/".$this->fields["filepath"])
-             && (countElementsInTable($this->getTable(),
+             && (countElementsInTable($this::getTable(),
                                      ['sha1sum' => $this->fields["sha1sum"] ]) <= 1)) {
 
             if (unlink(GLPI_DOC_DIR."/".$this->fields["filepath"])) {
@@ -271,7 +271,7 @@ class Document extends CommonDBTM {
          // Check if already upload in the current entity
          $crit = array('sha1sum'=>$input['sha1sum'],
                        'entities_id'=>$input['entities_id']);
-         foreach ($DB->request($this->getTable(), $crit) as $data) {
+         foreach ($DB->request($this::getTable(), $crit) as $data) {
             $link=$this->getFormURL();
             Session::addMessageAfterRedirect(__('"A document with that filename has already been attached to another record.').
                "&nbsp;: <a href=\"".$link."?id=".
@@ -539,8 +539,8 @@ class Document extends CommonDBTM {
          return false;
       }
 
-      return $this->getFromDBByQuery("WHERE `".$this->getTable()."`.`sha1sum` = '$sum'
-                                     AND `".$this->getTable()."`.`entities_id` = '$entity'");
+      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`sha1sum` = '$sum'
+                                     AND `".$this::getTable()."`.`entities_id` = '$entity'");
    }
 
 
@@ -763,7 +763,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -772,7 +772,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -781,7 +781,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'filename',
          'name'               => __('File'),
          'massiveaction'      => false,
@@ -790,7 +790,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'link',
          'name'               => __('Web Link'),
          'datatype'           => 'weblink'
@@ -798,7 +798,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mime',
          'name'               => __('MIME type'),
          'datatype'           => 'string'
@@ -807,7 +807,7 @@ class Document extends CommonDBTM {
       if ($CFG_GLPI['use_rich_text']) {
          $tab[] = [
             'id'                 => '6',
-            'table'              => $this->getTable(),
+            'table'              => $this::getTable(),
             'field'              => 'tag',
             'name'               => __('Tag'),
             'datatype'           => 'text',
@@ -834,7 +834,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -842,7 +842,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -851,7 +851,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -860,7 +860,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'sha1sum',
          'name'               => sprintf(__('%1$s (%2$s)'), __('Checksum'), __('SHA1')),
          'massiveaction'      => false,
@@ -869,7 +869,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -161,7 +161,7 @@ class Document extends CommonDBTM {
       if (!empty($this->fields["filepath"])) {
          if (is_file(GLPI_DOC_DIR."/".$this->fields["filepath"])
              && !is_dir(GLPI_DOC_DIR."/".$this->fields["filepath"])
-             && (countElementsInTable($this::getTable(),
+             && (countElementsInTable($static::getTable(),
                                      ['sha1sum' => $this->fields["sha1sum"] ]) <= 1)) {
 
             if (unlink(GLPI_DOC_DIR."/".$this->fields["filepath"])) {
@@ -271,7 +271,7 @@ class Document extends CommonDBTM {
          // Check if already upload in the current entity
          $crit = array('sha1sum'=>$input['sha1sum'],
                        'entities_id'=>$input['entities_id']);
-         foreach ($DB->request($this::getTable(), $crit) as $data) {
+         foreach ($DB->request($static::getTable(), $crit) as $data) {
             $link=$this->getFormURL();
             Session::addMessageAfterRedirect(__('"A document with that filename has already been attached to another record.').
                "&nbsp;: <a href=\"".$link."?id=".
@@ -539,8 +539,8 @@ class Document extends CommonDBTM {
          return false;
       }
 
-      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`sha1sum` = '$sum'
-                                     AND `".$this::getTable()."`.`entities_id` = '$entity'");
+      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`sha1sum` = '$sum'
+                                     AND `".$static::getTable()."`.`entities_id` = '$entity'");
    }
 
 
@@ -763,7 +763,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -772,7 +772,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -781,7 +781,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'filename',
          'name'               => __('File'),
          'massiveaction'      => false,
@@ -790,7 +790,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'link',
          'name'               => __('Web Link'),
          'datatype'           => 'weblink'
@@ -798,7 +798,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mime',
          'name'               => __('MIME type'),
          'datatype'           => 'string'
@@ -807,7 +807,7 @@ class Document extends CommonDBTM {
       if ($CFG_GLPI['use_rich_text']) {
          $tab[] = [
             'id'                 => '6',
-            'table'              => $this::getTable(),
+            'table'              => $static::getTable(),
             'field'              => 'tag',
             'name'               => __('Tag'),
             'datatype'           => 'text',
@@ -834,7 +834,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -842,7 +842,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -851,7 +851,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -860,7 +860,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'sha1sum',
          'name'               => sprintf(__('%1$s (%2$s)'), __('Checksum'), __('SHA1')),
          'massiveaction'      => false,
@@ -869,7 +869,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -161,7 +161,7 @@ class Document extends CommonDBTM {
       if (!empty($this->fields["filepath"])) {
          if (is_file(GLPI_DOC_DIR."/".$this->fields["filepath"])
              && !is_dir(GLPI_DOC_DIR."/".$this->fields["filepath"])
-             && (countElementsInTable($static::getTable(),
+             && (countElementsInTable(static::getTable(),
                                      ['sha1sum' => $this->fields["sha1sum"] ]) <= 1)) {
 
             if (unlink(GLPI_DOC_DIR."/".$this->fields["filepath"])) {
@@ -271,7 +271,7 @@ class Document extends CommonDBTM {
          // Check if already upload in the current entity
          $crit = array('sha1sum'=>$input['sha1sum'],
                        'entities_id'=>$input['entities_id']);
-         foreach ($DB->request($static::getTable(), $crit) as $data) {
+         foreach ($DB->request(static::getTable(), $crit) as $data) {
             $link=$this->getFormURL();
             Session::addMessageAfterRedirect(__('"A document with that filename has already been attached to another record.').
                "&nbsp;: <a href=\"".$link."?id=".
@@ -539,8 +539,8 @@ class Document extends CommonDBTM {
          return false;
       }
 
-      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`sha1sum` = '$sum'
-                                     AND `".$static::getTable()."`.`entities_id` = '$entity'");
+      return $this->getFromDBByQuery("WHERE `".static::getTable()."`.`sha1sum` = '$sum'
+                                     AND `".static::getTable()."`.`entities_id` = '$entity'");
    }
 
 
@@ -763,7 +763,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -772,7 +772,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -781,7 +781,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'filename',
          'name'               => __('File'),
          'massiveaction'      => false,
@@ -790,7 +790,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'link',
          'name'               => __('Web Link'),
          'datatype'           => 'weblink'
@@ -798,7 +798,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mime',
          'name'               => __('MIME type'),
          'datatype'           => 'string'
@@ -807,7 +807,7 @@ class Document extends CommonDBTM {
       if ($CFG_GLPI['use_rich_text']) {
          $tab[] = [
             'id'                 => '6',
-            'table'              => $static::getTable(),
+            'table'              => static::getTable(),
             'field'              => 'tag',
             'name'               => __('Tag'),
             'datatype'           => 'text',
@@ -834,7 +834,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -842,7 +842,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -851,7 +851,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -860,7 +860,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'sha1sum',
          'name'               => sprintf(__('%1$s (%2$s)'), __('Checksum'), __('SHA1')),
          'massiveaction'      => false,
@@ -869,7 +869,7 @@ class Document extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -101,7 +101,7 @@ class Document_Item extends CommonDBRelation{
       }
 
       // Avoid duplicate entry
-      if (countElementsInTable($this::getTable(),
+      if (countElementsInTable($static::getTable(),
                               ['documents_id' => $input['documents_id'],
                                'itemtype'     => $input['itemtype'],
                                'items_id'     => $input['items_id']]) > 0) {
@@ -137,7 +137,7 @@ class Document_Item extends CommonDBRelation{
 
          if (isset($tt->mandatory['_documents_id'])) {
             // refuse delete if only one document
-            if (countElementsInTable($this::getTable(),
+            if (countElementsInTable($static::getTable(),
                                     ['items_id' => $this->fields['items_id'],
                                      'itemtype' => 'Ticket' ]) == 1) {
                $message = sprintf(__('Mandatory fields are not filled. Please correct: %s'),

--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -101,7 +101,7 @@ class Document_Item extends CommonDBRelation{
       }
 
       // Avoid duplicate entry
-      if (countElementsInTable($this->getTable(),
+      if (countElementsInTable($this::getTable(),
                               ['documents_id' => $input['documents_id'],
                                'itemtype'     => $input['itemtype'],
                                'items_id'     => $input['items_id']]) > 0) {
@@ -137,7 +137,7 @@ class Document_Item extends CommonDBRelation{
 
          if (isset($tt->mandatory['_documents_id'])) {
             // refuse delete if only one document
-            if (countElementsInTable($this->getTable(),
+            if (countElementsInTable($this::getTable(),
                                     ['items_id' => $this->fields['items_id'],
                                      'itemtype' => 'Ticket' ]) == 1) {
                $message = sprintf(__('Mandatory fields are not filled. Please correct: %s'),

--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -101,7 +101,7 @@ class Document_Item extends CommonDBRelation{
       }
 
       // Avoid duplicate entry
-      if (countElementsInTable($static::getTable(),
+      if (countElementsInTable(static::getTable(),
                               ['documents_id' => $input['documents_id'],
                                'itemtype'     => $input['itemtype'],
                                'items_id'     => $input['items_id']]) > 0) {
@@ -137,7 +137,7 @@ class Document_Item extends CommonDBRelation{
 
          if (isset($tt->mandatory['_documents_id'])) {
             // refuse delete if only one document
-            if (countElementsInTable($static::getTable(),
+            if (countElementsInTable(static::getTable(),
                                     ['items_id' => $this->fields['items_id'],
                                      'itemtype' => 'Ticket' ]) == 1) {
                $message = sprintf(__('Mandatory fields are not filled. Please correct: %s'),

--- a/inc/documenttype.class.php
+++ b/inc/documenttype.class.php
@@ -79,7 +79,7 @@ class DocumentType  extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'ext',
          'name'               => __('Extension'),
          'datatype'           => 'string'
@@ -87,7 +87,7 @@ class DocumentType  extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'icon',
          'name'               => __('Icon'),
          'massiveaction'      => false,
@@ -96,7 +96,7 @@ class DocumentType  extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mime',
          'name'               => __('MIME type'),
          'datatype'           => 'string'
@@ -104,7 +104,7 @@ class DocumentType  extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_uploadable',
          'name'               => __('Authorized upload'),
          'datatype'           => 'bool'

--- a/inc/documenttype.class.php
+++ b/inc/documenttype.class.php
@@ -79,7 +79,7 @@ class DocumentType  extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'ext',
          'name'               => __('Extension'),
          'datatype'           => 'string'
@@ -87,7 +87,7 @@ class DocumentType  extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'icon',
          'name'               => __('Icon'),
          'massiveaction'      => false,
@@ -96,7 +96,7 @@ class DocumentType  extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mime',
          'name'               => __('MIME type'),
          'datatype'           => 'string'
@@ -104,7 +104,7 @@ class DocumentType  extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_uploadable',
          'name'               => __('Authorized upload'),
          'datatype'           => 'bool'

--- a/inc/documenttype.class.php
+++ b/inc/documenttype.class.php
@@ -79,7 +79,7 @@ class DocumentType  extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'ext',
          'name'               => __('Extension'),
          'datatype'           => 'string'
@@ -87,7 +87,7 @@ class DocumentType  extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'icon',
          'name'               => __('Icon'),
          'massiveaction'      => false,
@@ -96,7 +96,7 @@ class DocumentType  extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mime',
          'name'               => __('MIME type'),
          'datatype'           => 'string'
@@ -104,7 +104,7 @@ class DocumentType  extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_uploadable',
          'name'               => __('Authorized upload'),
          'datatype'           => 'bool'

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -86,7 +86,7 @@ class Dropdown {
          return false;
       }
 
-      $table = $item->getTable();
+      $table = $item::getTable();
 
       $params['name']                 = $item->getForeignKeyField();
       $params['value']                = (($itemtype == 'Entity') ? $_SESSION['glpiactive_entity'] : '');

--- a/inc/dropdowntranslation.class.php
+++ b/inc/dropdowntranslation.class.php
@@ -295,7 +295,7 @@ class DropdownTranslation extends CommonDBChild {
          }
 
          $query = "SELECT `id`
-                   FROM `".$item->getTable()."`
+                   FROM `".$item::getTable()."`
                    WHERE `$foreignKey` = '".$item->getID()."'";
 
          foreach ($DB->request($query) as $tmp) {

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -454,7 +454,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'completename',
          'name'               => __('Complete name'),
          'datatype'           => 'itemlink',
@@ -463,7 +463,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -472,7 +472,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -481,7 +481,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'address',
          'name'               => __('Address'),
          'massiveaction'      => false,
@@ -490,7 +490,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'website',
          'name'               => __('Website'),
          'massiveaction'      => false,
@@ -499,7 +499,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'phonenumber',
          'name'               => __('Phone'),
          'massiveaction'      => false,
@@ -508,7 +508,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'email',
          'name'               => _n('Email', 'Emails', 1),
          'datatype'           => 'email',
@@ -517,7 +517,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'fax',
          'name'               => __('Fax'),
          'massiveaction'      => false,
@@ -526,7 +526,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '25',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'postcode',
          'name'               => __('Postal code'),
          'datatype'           => 'string'
@@ -534,7 +534,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'town',
          'name'               => __('City'),
          'massiveaction'      => false,
@@ -543,7 +543,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'state',
          'name'               => _x('location', 'State'),
          'massiveaction'      => false,
@@ -552,7 +552,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'country',
          'name'               => __('Country'),
          'massiveaction'      => false,
@@ -561,7 +561,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -569,7 +569,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '122',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -578,7 +578,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -597,7 +597,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'ldap_dn',
          'name'               => __('LDAP directory information attribute representing the entity'),
          'massiveaction'      => false,
@@ -606,7 +606,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'tag',
          'name'               => __('Information in inventory tool (TAG) representing the entity'),
          'massiveaction'      => false,
@@ -624,7 +624,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'entity_ldapfilter',
          'name'               => __('Search filter (if needed)'),
          'massiveaction'      => false,
@@ -633,7 +633,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mail_domain',
          'name'               => __('Mail domain'),
          'massiveaction'      => false,
@@ -647,7 +647,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '60',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'delay_send_emails',
          'name'               => __('Delay to send email notifications'),
          'massiveaction'      => false,
@@ -662,7 +662,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '61',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_notif_enable_default',
          'name'               => __('Enable notifications by default'),
          'massiveaction'      => false,
@@ -672,7 +672,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'admin_email',
          'name'               => __('Administrator email'),
          'massiveaction'      => false,
@@ -681,7 +681,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'admin_reply',
          'name'               => __('Administrator reply-to email (if needed)'),
          'massiveaction'      => false,
@@ -690,7 +690,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'notification_subject_tag',
          'name'               => __('Prefix for notifications'),
          'datatype'           => 'string'
@@ -698,7 +698,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'admin_email_name',
          'name'               => __('Administrator name'),
          'datatype'           => 'string'
@@ -706,7 +706,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'admin_reply_name',
          'name'               => __('Response address (if needed)'),
          'datatype'           => 'string'
@@ -714,7 +714,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mailing_signature',
          'name'               => __('Email signature'),
          'datatype'           => 'text'
@@ -722,7 +722,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '26',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'cartridges_alert_repeat',
          'name'               => __('Alarms on cartridges'),
          'massiveaction'      => false,
@@ -732,7 +732,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '27',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'consumables_alert_repeat',
          'name'               => __('Alarms on consumables'),
          'massiveaction'      => false,
@@ -742,7 +742,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '29',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'use_licenses_alert',
          'name'               => __('Alarms on expired licenses'),
          'massiveaction'      => false,
@@ -752,7 +752,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '53',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'send_licenses_alert_before_delay',
          'name'               => __('Send license alarms before'),
          'massiveaction'      => false,
@@ -762,7 +762,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '30',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'use_contracts_alert',
          'name'               => __('Alarms on contracts'),
          'massiveaction'      => false,
@@ -772,7 +772,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '54',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'send_contracts_alert_before_delay',
          'name'               => __('Send contract alarms before'),
          'massiveaction'      => false,
@@ -782,7 +782,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '31',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'use_infocoms_alert',
          'name'               => __('Alarms on financial and administrative information'),
          'massiveaction'      => false,
@@ -792,7 +792,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '55',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'send_infocoms_alert_before_delay',
          'name'               => __('Send financial and administrative information alarms before'),
          'massiveaction'      => false,
@@ -802,7 +802,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '32',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'use_reservations_alert',
          'name'               => __('Alerts on reservations'),
          'massiveaction'      => false,
@@ -812,7 +812,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '48',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'default_contract_alert',
          'name'               => __('Default value for alarms on contracts'),
          'massiveaction'      => false,
@@ -822,7 +822,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '49',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'default_infocom_alert',
          'name'               => __('Default value for alarms on financial and administrative information'),
          'massiveaction'      => false,
@@ -832,7 +832,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '50',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'default_cartridges_alarm_threshold',
          'name'               => __('Default threshold for cartridges count'),
          'massiveaction'      => false,
@@ -842,7 +842,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '52',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'default_consumables_alarm_threshold',
          'name'               => __('Default threshold for consumables count'),
          'massiveaction'      => false,
@@ -857,7 +857,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '47',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'tickettemplates_id', // not a dropdown because of special value
          'name'               => _n('Ticket template', 'Ticket templates', 1),
          'massiveaction'      => false,
@@ -867,7 +867,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '33',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'autoclose_delay',
          'name'               => __('Automatic closing of solved tickets after'),
          'massiveaction'      => false,
@@ -886,7 +886,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '34',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'notclosed_delay',
          'name'               => __('Alerts on tickets which are not solved'),
          'massiveaction'      => false,
@@ -896,7 +896,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '35',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'auto_assign_mode',
          'name'               => __('Automatic assignment of tickets'),
          'massiveaction'      => false,
@@ -906,7 +906,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '36',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'calendars_id',// not a dropdown because of special valu
          'name'               => __('Calendar'),
          'massiveaction'      => false,
@@ -916,7 +916,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '37',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'tickettype',
          'name'               => __('Tickets default type'),
          'massiveaction'      => false,
@@ -931,7 +931,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '38',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'autofill_buy_date',
          'name'               => __('Date of purchase'),
          'massiveaction'      => false,
@@ -941,7 +941,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '39',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'autofill_order_date',
          'name'               => __('Order date'),
          'massiveaction'      => false,
@@ -951,7 +951,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '40',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'autofill_delivery_date',
          'name'               => __('Delivery date'),
          'massiveaction'      => false,
@@ -961,7 +961,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '41',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'autofill_use_date',
          'name'               => __('Startup date'),
          'massiveaction'      => false,
@@ -971,7 +971,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '42',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'autofill_warranty_date',
          'name'               => __('Start date of warranty'),
          'massiveaction'      => false,
@@ -981,7 +981,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '43',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'inquest_config',
          'name'               => __('Satisfaction survey configuration'),
          'massiveaction'      => false,
@@ -991,7 +991,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '44',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'inquest_rate',
          'name'               => __('Satisfaction survey trigger rate'),
          'massiveaction'      => false,
@@ -1000,7 +1000,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '45',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'inquest_delay',
          'name'               => __('Create survey after'),
          'massiveaction'      => false,
@@ -1009,7 +1009,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '46',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'inquest_URL',
          'name'               => __('URL'),
          'massiveaction'      => false,
@@ -1018,7 +1018,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '51',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'entities_id_software', // not a dropdown because of special value
                                  //TRANS: software in plural
          'name'               => __('Entity for software creation'),
@@ -1029,7 +1029,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '56',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'autofill_decommission_date',
          'name'               => __('Decommission date'),
          'massiveaction'      => false,

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -454,7 +454,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'completename',
          'name'               => __('Complete name'),
          'datatype'           => 'itemlink',
@@ -463,7 +463,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -472,7 +472,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -481,7 +481,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'address',
          'name'               => __('Address'),
          'massiveaction'      => false,
@@ -490,7 +490,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'website',
          'name'               => __('Website'),
          'massiveaction'      => false,
@@ -499,7 +499,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'phonenumber',
          'name'               => __('Phone'),
          'massiveaction'      => false,
@@ -508,7 +508,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'email',
          'name'               => _n('Email', 'Emails', 1),
          'datatype'           => 'email',
@@ -517,7 +517,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'fax',
          'name'               => __('Fax'),
          'massiveaction'      => false,
@@ -526,7 +526,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '25',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'postcode',
          'name'               => __('Postal code'),
          'datatype'           => 'string'
@@ -534,7 +534,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'town',
          'name'               => __('City'),
          'massiveaction'      => false,
@@ -543,7 +543,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'state',
          'name'               => _x('location', 'State'),
          'massiveaction'      => false,
@@ -552,7 +552,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'country',
          'name'               => __('Country'),
          'massiveaction'      => false,
@@ -561,7 +561,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -569,7 +569,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '122',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -578,7 +578,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -597,7 +597,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'ldap_dn',
          'name'               => __('LDAP directory information attribute representing the entity'),
          'massiveaction'      => false,
@@ -606,7 +606,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'tag',
          'name'               => __('Information in inventory tool (TAG) representing the entity'),
          'massiveaction'      => false,
@@ -624,7 +624,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'entity_ldapfilter',
          'name'               => __('Search filter (if needed)'),
          'massiveaction'      => false,
@@ -633,7 +633,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mail_domain',
          'name'               => __('Mail domain'),
          'massiveaction'      => false,
@@ -647,7 +647,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '60',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'delay_send_emails',
          'name'               => __('Delay to send email notifications'),
          'massiveaction'      => false,
@@ -662,7 +662,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '61',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_notif_enable_default',
          'name'               => __('Enable notifications by default'),
          'massiveaction'      => false,
@@ -672,7 +672,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'admin_email',
          'name'               => __('Administrator email'),
          'massiveaction'      => false,
@@ -681,7 +681,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'admin_reply',
          'name'               => __('Administrator reply-to email (if needed)'),
          'massiveaction'      => false,
@@ -690,7 +690,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'notification_subject_tag',
          'name'               => __('Prefix for notifications'),
          'datatype'           => 'string'
@@ -698,7 +698,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'admin_email_name',
          'name'               => __('Administrator name'),
          'datatype'           => 'string'
@@ -706,7 +706,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'admin_reply_name',
          'name'               => __('Response address (if needed)'),
          'datatype'           => 'string'
@@ -714,7 +714,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mailing_signature',
          'name'               => __('Email signature'),
          'datatype'           => 'text'
@@ -722,7 +722,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '26',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'cartridges_alert_repeat',
          'name'               => __('Alarms on cartridges'),
          'massiveaction'      => false,
@@ -732,7 +732,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '27',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'consumables_alert_repeat',
          'name'               => __('Alarms on consumables'),
          'massiveaction'      => false,
@@ -742,7 +742,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '29',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'use_licenses_alert',
          'name'               => __('Alarms on expired licenses'),
          'massiveaction'      => false,
@@ -752,7 +752,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '53',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'send_licenses_alert_before_delay',
          'name'               => __('Send license alarms before'),
          'massiveaction'      => false,
@@ -762,7 +762,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '30',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'use_contracts_alert',
          'name'               => __('Alarms on contracts'),
          'massiveaction'      => false,
@@ -772,7 +772,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '54',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'send_contracts_alert_before_delay',
          'name'               => __('Send contract alarms before'),
          'massiveaction'      => false,
@@ -782,7 +782,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '31',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'use_infocoms_alert',
          'name'               => __('Alarms on financial and administrative information'),
          'massiveaction'      => false,
@@ -792,7 +792,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '55',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'send_infocoms_alert_before_delay',
          'name'               => __('Send financial and administrative information alarms before'),
          'massiveaction'      => false,
@@ -802,7 +802,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '32',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'use_reservations_alert',
          'name'               => __('Alerts on reservations'),
          'massiveaction'      => false,
@@ -812,7 +812,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '48',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'default_contract_alert',
          'name'               => __('Default value for alarms on contracts'),
          'massiveaction'      => false,
@@ -822,7 +822,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '49',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'default_infocom_alert',
          'name'               => __('Default value for alarms on financial and administrative information'),
          'massiveaction'      => false,
@@ -832,7 +832,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '50',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'default_cartridges_alarm_threshold',
          'name'               => __('Default threshold for cartridges count'),
          'massiveaction'      => false,
@@ -842,7 +842,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '52',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'default_consumables_alarm_threshold',
          'name'               => __('Default threshold for consumables count'),
          'massiveaction'      => false,
@@ -857,7 +857,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '47',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'tickettemplates_id', // not a dropdown because of special value
          'name'               => _n('Ticket template', 'Ticket templates', 1),
          'massiveaction'      => false,
@@ -867,7 +867,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '33',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'autoclose_delay',
          'name'               => __('Automatic closing of solved tickets after'),
          'massiveaction'      => false,
@@ -886,7 +886,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '34',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'notclosed_delay',
          'name'               => __('Alerts on tickets which are not solved'),
          'massiveaction'      => false,
@@ -896,7 +896,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '35',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'auto_assign_mode',
          'name'               => __('Automatic assignment of tickets'),
          'massiveaction'      => false,
@@ -906,7 +906,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '36',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'calendars_id',// not a dropdown because of special valu
          'name'               => __('Calendar'),
          'massiveaction'      => false,
@@ -916,7 +916,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '37',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'tickettype',
          'name'               => __('Tickets default type'),
          'massiveaction'      => false,
@@ -931,7 +931,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '38',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'autofill_buy_date',
          'name'               => __('Date of purchase'),
          'massiveaction'      => false,
@@ -941,7 +941,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '39',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'autofill_order_date',
          'name'               => __('Order date'),
          'massiveaction'      => false,
@@ -951,7 +951,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '40',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'autofill_delivery_date',
          'name'               => __('Delivery date'),
          'massiveaction'      => false,
@@ -961,7 +961,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '41',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'autofill_use_date',
          'name'               => __('Startup date'),
          'massiveaction'      => false,
@@ -971,7 +971,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '42',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'autofill_warranty_date',
          'name'               => __('Start date of warranty'),
          'massiveaction'      => false,
@@ -981,7 +981,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '43',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'inquest_config',
          'name'               => __('Satisfaction survey configuration'),
          'massiveaction'      => false,
@@ -991,7 +991,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '44',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'inquest_rate',
          'name'               => __('Satisfaction survey trigger rate'),
          'massiveaction'      => false,
@@ -1000,7 +1000,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '45',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'inquest_delay',
          'name'               => __('Create survey after'),
          'massiveaction'      => false,
@@ -1009,7 +1009,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '46',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'inquest_URL',
          'name'               => __('URL'),
          'massiveaction'      => false,
@@ -1018,7 +1018,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '51',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'entities_id_software', // not a dropdown because of special value
                                  //TRANS: software in plural
          'name'               => __('Entity for software creation'),
@@ -1029,7 +1029,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '56',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'autofill_decommission_date',
          'name'               => __('Decommission date'),
          'massiveaction'      => false,

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -454,7 +454,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'completename',
          'name'               => __('Complete name'),
          'datatype'           => 'itemlink',
@@ -463,7 +463,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -472,7 +472,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -481,7 +481,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'address',
          'name'               => __('Address'),
          'massiveaction'      => false,
@@ -490,7 +490,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'website',
          'name'               => __('Website'),
          'massiveaction'      => false,
@@ -499,7 +499,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'phonenumber',
          'name'               => __('Phone'),
          'massiveaction'      => false,
@@ -508,7 +508,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'email',
          'name'               => _n('Email', 'Emails', 1),
          'datatype'           => 'email',
@@ -517,7 +517,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'fax',
          'name'               => __('Fax'),
          'massiveaction'      => false,
@@ -526,7 +526,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '25',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'postcode',
          'name'               => __('Postal code'),
          'datatype'           => 'string'
@@ -534,7 +534,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'town',
          'name'               => __('City'),
          'massiveaction'      => false,
@@ -543,7 +543,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'state',
          'name'               => _x('location', 'State'),
          'massiveaction'      => false,
@@ -552,7 +552,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'country',
          'name'               => __('Country'),
          'massiveaction'      => false,
@@ -561,7 +561,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -569,7 +569,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '122',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -578,7 +578,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -597,7 +597,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'ldap_dn',
          'name'               => __('LDAP directory information attribute representing the entity'),
          'massiveaction'      => false,
@@ -606,7 +606,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'tag',
          'name'               => __('Information in inventory tool (TAG) representing the entity'),
          'massiveaction'      => false,
@@ -624,7 +624,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'entity_ldapfilter',
          'name'               => __('Search filter (if needed)'),
          'massiveaction'      => false,
@@ -633,7 +633,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mail_domain',
          'name'               => __('Mail domain'),
          'massiveaction'      => false,
@@ -647,7 +647,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '60',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'delay_send_emails',
          'name'               => __('Delay to send email notifications'),
          'massiveaction'      => false,
@@ -662,7 +662,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '61',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_notif_enable_default',
          'name'               => __('Enable notifications by default'),
          'massiveaction'      => false,
@@ -672,7 +672,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'admin_email',
          'name'               => __('Administrator email'),
          'massiveaction'      => false,
@@ -681,7 +681,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'admin_reply',
          'name'               => __('Administrator reply-to email (if needed)'),
          'massiveaction'      => false,
@@ -690,7 +690,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'notification_subject_tag',
          'name'               => __('Prefix for notifications'),
          'datatype'           => 'string'
@@ -698,7 +698,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'admin_email_name',
          'name'               => __('Administrator name'),
          'datatype'           => 'string'
@@ -706,7 +706,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'admin_reply_name',
          'name'               => __('Response address (if needed)'),
          'datatype'           => 'string'
@@ -714,7 +714,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mailing_signature',
          'name'               => __('Email signature'),
          'datatype'           => 'text'
@@ -722,7 +722,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '26',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'cartridges_alert_repeat',
          'name'               => __('Alarms on cartridges'),
          'massiveaction'      => false,
@@ -732,7 +732,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '27',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'consumables_alert_repeat',
          'name'               => __('Alarms on consumables'),
          'massiveaction'      => false,
@@ -742,7 +742,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '29',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'use_licenses_alert',
          'name'               => __('Alarms on expired licenses'),
          'massiveaction'      => false,
@@ -752,7 +752,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '53',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'send_licenses_alert_before_delay',
          'name'               => __('Send license alarms before'),
          'massiveaction'      => false,
@@ -762,7 +762,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '30',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'use_contracts_alert',
          'name'               => __('Alarms on contracts'),
          'massiveaction'      => false,
@@ -772,7 +772,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '54',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'send_contracts_alert_before_delay',
          'name'               => __('Send contract alarms before'),
          'massiveaction'      => false,
@@ -782,7 +782,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '31',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'use_infocoms_alert',
          'name'               => __('Alarms on financial and administrative information'),
          'massiveaction'      => false,
@@ -792,7 +792,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '55',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'send_infocoms_alert_before_delay',
          'name'               => __('Send financial and administrative information alarms before'),
          'massiveaction'      => false,
@@ -802,7 +802,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '32',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'use_reservations_alert',
          'name'               => __('Alerts on reservations'),
          'massiveaction'      => false,
@@ -812,7 +812,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '48',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'default_contract_alert',
          'name'               => __('Default value for alarms on contracts'),
          'massiveaction'      => false,
@@ -822,7 +822,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '49',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'default_infocom_alert',
          'name'               => __('Default value for alarms on financial and administrative information'),
          'massiveaction'      => false,
@@ -832,7 +832,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '50',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'default_cartridges_alarm_threshold',
          'name'               => __('Default threshold for cartridges count'),
          'massiveaction'      => false,
@@ -842,7 +842,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '52',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'default_consumables_alarm_threshold',
          'name'               => __('Default threshold for consumables count'),
          'massiveaction'      => false,
@@ -857,7 +857,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '47',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'tickettemplates_id', // not a dropdown because of special value
          'name'               => _n('Ticket template', 'Ticket templates', 1),
          'massiveaction'      => false,
@@ -867,7 +867,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '33',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'autoclose_delay',
          'name'               => __('Automatic closing of solved tickets after'),
          'massiveaction'      => false,
@@ -886,7 +886,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '34',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'notclosed_delay',
          'name'               => __('Alerts on tickets which are not solved'),
          'massiveaction'      => false,
@@ -896,7 +896,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '35',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'auto_assign_mode',
          'name'               => __('Automatic assignment of tickets'),
          'massiveaction'      => false,
@@ -906,7 +906,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '36',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'calendars_id',// not a dropdown because of special valu
          'name'               => __('Calendar'),
          'massiveaction'      => false,
@@ -916,7 +916,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '37',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'tickettype',
          'name'               => __('Tickets default type'),
          'massiveaction'      => false,
@@ -931,7 +931,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '38',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'autofill_buy_date',
          'name'               => __('Date of purchase'),
          'massiveaction'      => false,
@@ -941,7 +941,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '39',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'autofill_order_date',
          'name'               => __('Order date'),
          'massiveaction'      => false,
@@ -951,7 +951,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '40',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'autofill_delivery_date',
          'name'               => __('Delivery date'),
          'massiveaction'      => false,
@@ -961,7 +961,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '41',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'autofill_use_date',
          'name'               => __('Startup date'),
          'massiveaction'      => false,
@@ -971,7 +971,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '42',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'autofill_warranty_date',
          'name'               => __('Start date of warranty'),
          'massiveaction'      => false,
@@ -981,7 +981,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '43',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'inquest_config',
          'name'               => __('Satisfaction survey configuration'),
          'massiveaction'      => false,
@@ -991,7 +991,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '44',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'inquest_rate',
          'name'               => __('Satisfaction survey trigger rate'),
          'massiveaction'      => false,
@@ -1000,7 +1000,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '45',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'inquest_delay',
          'name'               => __('Create survey after'),
          'massiveaction'      => false,
@@ -1009,7 +1009,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '46',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'inquest_URL',
          'name'               => __('URL'),
          'massiveaction'      => false,
@@ -1018,7 +1018,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '51',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'entities_id_software', // not a dropdown because of special value
                                  //TRANS: software in plural
          'name'               => __('Entity for software creation'),
@@ -1029,7 +1029,7 @@ class Entity extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '56',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'autofill_decommission_date',
          'name'               => __('Decommission date'),
          'massiveaction'      => false,

--- a/inc/fieldblacklist.class.php
+++ b/inc/fieldblacklist.class.php
@@ -90,7 +90,7 @@ class Fieldblacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'massiveaction'      => false,
@@ -100,7 +100,7 @@ class Fieldblacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'field',
          'name'               => __('Field'),
          'massiveaction'      => false,
@@ -112,7 +112,7 @@ class Fieldblacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'value',
          'name'               => __('Value'),
          'datatype'           => 'specific',

--- a/inc/fieldblacklist.class.php
+++ b/inc/fieldblacklist.class.php
@@ -90,7 +90,7 @@ class Fieldblacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'massiveaction'      => false,
@@ -100,7 +100,7 @@ class Fieldblacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'field',
          'name'               => __('Field'),
          'massiveaction'      => false,
@@ -112,7 +112,7 @@ class Fieldblacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'value',
          'name'               => __('Value'),
          'datatype'           => 'specific',

--- a/inc/fieldblacklist.class.php
+++ b/inc/fieldblacklist.class.php
@@ -90,7 +90,7 @@ class Fieldblacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'massiveaction'      => false,
@@ -100,7 +100,7 @@ class Fieldblacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'field',
          'name'               => __('Field'),
          'massiveaction'      => false,
@@ -112,7 +112,7 @@ class Fieldblacklist extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'value',
          'name'               => __('Value'),
          'datatype'           => 'specific',
@@ -325,7 +325,7 @@ class Fieldblacklist extends CommonDropdown {
 
       if ($target = getItemForItemtype($itemtype)) {
          $criteria = array();
-         foreach ($DB->list_fields($target->getTable()) as $field) {
+         foreach ($DB->list_fields($target::getTable()) as $field) {
             $searchOption = $target->getSearchOptionByField('field', $field['Field']);
 
             // MoYo : do not know why  this part ?

--- a/inc/fieldunicity.class.php
+++ b/inc/fieldunicity.class.php
@@ -312,7 +312,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -321,7 +321,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'datatype'           => 'number',
@@ -330,7 +330,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'fields',
          'name'               => __('Unique fields'),
          'massiveaction'      => false,
@@ -340,7 +340,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'massiveaction'      => false,
@@ -350,7 +350,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'action_refuse',
          'name'               => __('Record into the database denied'),
          'datatype'           => 'bool'
@@ -358,7 +358,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'action_notify',
          'name'               => __('Send a notification'),
          'datatype'           => 'bool'
@@ -366,7 +366,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -374,7 +374,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -382,7 +382,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '30',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool',

--- a/inc/fieldunicity.class.php
+++ b/inc/fieldunicity.class.php
@@ -312,7 +312,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -321,7 +321,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'datatype'           => 'number',
@@ -330,7 +330,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'fields',
          'name'               => __('Unique fields'),
          'massiveaction'      => false,
@@ -340,7 +340,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'massiveaction'      => false,
@@ -350,7 +350,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'action_refuse',
          'name'               => __('Record into the database denied'),
          'datatype'           => 'bool'
@@ -358,7 +358,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'action_notify',
          'name'               => __('Send a notification'),
          'datatype'           => 'bool'
@@ -366,7 +366,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -374,7 +374,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -382,7 +382,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '30',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool',

--- a/inc/fieldunicity.class.php
+++ b/inc/fieldunicity.class.php
@@ -312,7 +312,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -321,7 +321,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'datatype'           => 'number',
@@ -330,7 +330,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'fields',
          'name'               => __('Unique fields'),
          'massiveaction'      => false,
@@ -340,7 +340,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'massiveaction'      => false,
@@ -350,7 +350,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'action_refuse',
          'name'               => __('Record into the database denied'),
          'datatype'           => 'bool'
@@ -358,7 +358,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'action_notify',
          'name'               => __('Send a notification'),
          'datatype'           => 'bool'
@@ -366,7 +366,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -374,7 +374,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -382,7 +382,7 @@ class FieldUnicity extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '30',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool',
@@ -550,7 +550,7 @@ class FieldUnicity extends CommonDropdown {
          $fields_string = implode(',', $fields);
 
          if ($item->maybeTemplate()) {
-            $where_template = " AND `".$item->getTable()."`.`is_template` = '0'";
+            $where_template = " AND `".$item::getTable()."`.`is_template` = '0'";
          } else {
             $where_template = "";
          }
@@ -565,8 +565,8 @@ class FieldUnicity extends CommonDropdown {
          }
          $query = "SELECT $fields_string,
                           COUNT(*) AS cpt
-                   FROM `".$item->getTable()."`
-                   WHERE `".$item->getTable()."`.`entities_id` IN (".implode(',', $entities).")
+                   FROM `".$item::getTable()."`
+                   WHERE `".$item::getTable()."`.`entities_id` IN (".implode(',', $entities).")
                          $where_template
                          $where_fields_string
                    GROUP BY $fields_string

--- a/inc/fqdn.class.php
+++ b/inc/fqdn.class.php
@@ -200,7 +200,7 @@ class FQDN extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'fqdn',
          'name'               => __('FQDN'),
          'datatype'           => 'string'

--- a/inc/fqdn.class.php
+++ b/inc/fqdn.class.php
@@ -200,7 +200,7 @@ class FQDN extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'fqdn',
          'name'               => __('FQDN'),
          'datatype'           => 'string'

--- a/inc/fqdn.class.php
+++ b/inc/fqdn.class.php
@@ -200,7 +200,7 @@ class FQDN extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'fqdn',
          'name'               => __('FQDN'),
          'datatype'           => 'string'

--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -148,7 +148,7 @@ class Group extends CommonTreeDropdown {
             case 'Group' :
                $ong = array();
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this->getTable(),
+                  $nb = countElementsInTable($this::getTable(),
                                              ['groups_id' => $item->getID()]);
                }
                $ong[4] = self::createTabEntry(__('Child groups'), $nb);
@@ -255,7 +255,7 @@ class Group extends CommonTreeDropdown {
       self::dropdown(array('value'  => $this->fields['groups_id'],
                            'name'   => 'groups_id',
                            'entity' => $this->fields['entities_id'],
-                           'used'   => (($ID > 0) ? getSonsOf($this->getTable(), $ID) : array())));
+                           'used'   => (($ID > 0) ? getSonsOf($this::getTable(), $ID) : array())));
       echo "</td></tr>";
 
       echo "<tr class='tab_bg_1'>";
@@ -440,7 +440,7 @@ class Group extends CommonTreeDropdown {
       if (AuthLdap::useAuthLdap()) {
          $tab[] = [
             'id'                 => '3',
-            'table'              => $this->getTable(),
+            'table'              => $this::getTable(),
             'field'              => 'ldap_field',
             'name'               => __('Attribute of the user containing its groups'),
             'datatype'           => 'string'
@@ -448,7 +448,7 @@ class Group extends CommonTreeDropdown {
 
          $tab[] = [
             'id'                 => '4',
-            'table'              => $this->getTable(),
+            'table'              => $this::getTable(),
             'field'              => 'ldap_value',
             'name'               => __('Attribute value'),
             'datatype'           => 'text'
@@ -456,7 +456,7 @@ class Group extends CommonTreeDropdown {
 
          $tab[] = [
             'id'                 => '5',
-            'table'              => $this->getTable(),
+            'table'              => $this::getTable(),
             'field'              => 'ldap_group_dn',
             'name'               => __('Group DN'),
             'datatype'           => 'text'
@@ -465,7 +465,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_requester',
          'name'               => __('Requester'),
          'datatype'           => 'bool'
@@ -473,7 +473,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_assign',
          'name'               => __('Assigned to'),
          'datatype'           => 'bool'
@@ -481,7 +481,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_manager',
          'name'               => __('Can be manager'),
          'datatype'           => 'bool'
@@ -489,7 +489,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_notify',
          'name'               => __('Can be notified'),
          'datatype'           => 'bool'
@@ -497,7 +497,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_itemgroup',
          'name'               => sprintf(__('%1$s %2$s'), __('Can contain'), _n('Item', 'Items', Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -505,7 +505,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_usergroup',
          'name'               => sprintf(__('%1$s %2$s'), __('Can contain'), User::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -553,7 +553,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '72',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_task',
          'name'               => __('Can be in charge of a task'),
          'datatype'           => 'bool'
@@ -662,7 +662,7 @@ class Group extends CommonTreeDropdown {
 
          if ($item->isEntityAssign()) {
             if ($itemtype != 'Consumable') {
-               $restrict[$itemtype] .= getEntitiesRestrictRequest(" AND ", $item->getTable(), '', '',
+               $restrict[$itemtype] .= getEntitiesRestrictRequest(" AND ", $item::getTable(), '', '',
                                                                   $item->maybeRecursive());
             }
          }
@@ -684,7 +684,7 @@ class Group extends CommonTreeDropdown {
                                                                            "glpi_consumableitems", '', '', true).")";
          }
 
-         $tot += $nb[$itemtype] = countElementsInTable($item->getTable(), $restrict[$itemtype]);
+         $tot += $nb[$itemtype] = countElementsInTable($item::getTable(), $restrict[$itemtype]);
       }
       $max = $_SESSION['glpilist_limit'];
       if ($start >= $tot) {
@@ -701,7 +701,7 @@ class Group extends CommonTreeDropdown {
          } else {
 
             $query = "SELECT $select`id`
-                      FROM `".$item->getTable()."`
+                      FROM `".$item::getTable()."`
                       $join
                       WHERE ".$restrict[$itemtype]."
                       ORDER BY `name`

--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -148,7 +148,7 @@ class Group extends CommonTreeDropdown {
             case 'Group' :
                $ong = array();
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($static::getTable(),
+                  $nb = countElementsInTable(static::getTable(),
                                              ['groups_id' => $item->getID()]);
                }
                $ong[4] = self::createTabEntry(__('Child groups'), $nb);
@@ -255,7 +255,7 @@ class Group extends CommonTreeDropdown {
       self::dropdown(array('value'  => $this->fields['groups_id'],
                            'name'   => 'groups_id',
                            'entity' => $this->fields['entities_id'],
-                           'used'   => (($ID > 0) ? getSonsOf($static::getTable(), $ID) : array())));
+                           'used'   => (($ID > 0) ? getSonsOf(static::getTable(), $ID) : array())));
       echo "</td></tr>";
 
       echo "<tr class='tab_bg_1'>";
@@ -440,7 +440,7 @@ class Group extends CommonTreeDropdown {
       if (AuthLdap::useAuthLdap()) {
          $tab[] = [
             'id'                 => '3',
-            'table'              => $static::getTable(),
+            'table'              => static::getTable(),
             'field'              => 'ldap_field',
             'name'               => __('Attribute of the user containing its groups'),
             'datatype'           => 'string'
@@ -448,7 +448,7 @@ class Group extends CommonTreeDropdown {
 
          $tab[] = [
             'id'                 => '4',
-            'table'              => $static::getTable(),
+            'table'              => static::getTable(),
             'field'              => 'ldap_value',
             'name'               => __('Attribute value'),
             'datatype'           => 'text'
@@ -456,7 +456,7 @@ class Group extends CommonTreeDropdown {
 
          $tab[] = [
             'id'                 => '5',
-            'table'              => $static::getTable(),
+            'table'              => static::getTable(),
             'field'              => 'ldap_group_dn',
             'name'               => __('Group DN'),
             'datatype'           => 'text'
@@ -465,7 +465,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_requester',
          'name'               => __('Requester'),
          'datatype'           => 'bool'
@@ -473,7 +473,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_assign',
          'name'               => __('Assigned to'),
          'datatype'           => 'bool'
@@ -481,7 +481,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_manager',
          'name'               => __('Can be manager'),
          'datatype'           => 'bool'
@@ -489,7 +489,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_notify',
          'name'               => __('Can be notified'),
          'datatype'           => 'bool'
@@ -497,7 +497,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_itemgroup',
          'name'               => sprintf(__('%1$s %2$s'), __('Can contain'), _n('Item', 'Items', Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -505,7 +505,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_usergroup',
          'name'               => sprintf(__('%1$s %2$s'), __('Can contain'), User::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -553,7 +553,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '72',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_task',
          'name'               => __('Can be in charge of a task'),
          'datatype'           => 'bool'

--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -148,7 +148,7 @@ class Group extends CommonTreeDropdown {
             case 'Group' :
                $ong = array();
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this::getTable(),
+                  $nb = countElementsInTable($static::getTable(),
                                              ['groups_id' => $item->getID()]);
                }
                $ong[4] = self::createTabEntry(__('Child groups'), $nb);
@@ -255,7 +255,7 @@ class Group extends CommonTreeDropdown {
       self::dropdown(array('value'  => $this->fields['groups_id'],
                            'name'   => 'groups_id',
                            'entity' => $this->fields['entities_id'],
-                           'used'   => (($ID > 0) ? getSonsOf($this::getTable(), $ID) : array())));
+                           'used'   => (($ID > 0) ? getSonsOf($static::getTable(), $ID) : array())));
       echo "</td></tr>";
 
       echo "<tr class='tab_bg_1'>";
@@ -440,7 +440,7 @@ class Group extends CommonTreeDropdown {
       if (AuthLdap::useAuthLdap()) {
          $tab[] = [
             'id'                 => '3',
-            'table'              => $this::getTable(),
+            'table'              => $static::getTable(),
             'field'              => 'ldap_field',
             'name'               => __('Attribute of the user containing its groups'),
             'datatype'           => 'string'
@@ -448,7 +448,7 @@ class Group extends CommonTreeDropdown {
 
          $tab[] = [
             'id'                 => '4',
-            'table'              => $this::getTable(),
+            'table'              => $static::getTable(),
             'field'              => 'ldap_value',
             'name'               => __('Attribute value'),
             'datatype'           => 'text'
@@ -456,7 +456,7 @@ class Group extends CommonTreeDropdown {
 
          $tab[] = [
             'id'                 => '5',
-            'table'              => $this::getTable(),
+            'table'              => $static::getTable(),
             'field'              => 'ldap_group_dn',
             'name'               => __('Group DN'),
             'datatype'           => 'text'
@@ -465,7 +465,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_requester',
          'name'               => __('Requester'),
          'datatype'           => 'bool'
@@ -473,7 +473,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_assign',
          'name'               => __('Assigned to'),
          'datatype'           => 'bool'
@@ -481,7 +481,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_manager',
          'name'               => __('Can be manager'),
          'datatype'           => 'bool'
@@ -489,7 +489,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_notify',
          'name'               => __('Can be notified'),
          'datatype'           => 'bool'
@@ -497,7 +497,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_itemgroup',
          'name'               => sprintf(__('%1$s %2$s'), __('Can contain'), _n('Item', 'Items', Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -505,7 +505,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_usergroup',
          'name'               => sprintf(__('%1$s %2$s'), __('Can contain'), User::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -553,7 +553,7 @@ class Group extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '72',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_task',
          'name'               => __('Can be in charge of a task'),
          'datatype'           => 'bool'

--- a/inc/group_user.class.php
+++ b/inc/group_user.class.php
@@ -614,7 +614,7 @@ class Group_User extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -623,7 +623,7 @@ class Group_User extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_dynamic',
          'name'               => __('Dynamic'),
          'datatype'           => 'bool',
@@ -651,7 +651,7 @@ class Group_User extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_manager',
          'name'               => __('Manager'),
          'datatype'           => 'bool'
@@ -659,7 +659,7 @@ class Group_User extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_userdelegate',
          'name'               => __('Delegatee'),
          'datatype'           => 'bool'
@@ -693,7 +693,7 @@ class Group_User extends CommonDBRelation{
             case 'User' :
                if (Group::canView()) {
                   if ($_SESSION['glpishow_count_on_tabs']) {
-                     $nb = countElementsInTable($this->getTable(),
+                     $nb = countElementsInTable($this::getTable(),
                                                ['users_id' => $item->getID()]);
                   }
                   return self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/group_user.class.php
+++ b/inc/group_user.class.php
@@ -614,7 +614,7 @@ class Group_User extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -623,7 +623,7 @@ class Group_User extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_dynamic',
          'name'               => __('Dynamic'),
          'datatype'           => 'bool',
@@ -651,7 +651,7 @@ class Group_User extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_manager',
          'name'               => __('Manager'),
          'datatype'           => 'bool'
@@ -659,7 +659,7 @@ class Group_User extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_userdelegate',
          'name'               => __('Delegatee'),
          'datatype'           => 'bool'
@@ -693,7 +693,7 @@ class Group_User extends CommonDBRelation{
             case 'User' :
                if (Group::canView()) {
                   if ($_SESSION['glpishow_count_on_tabs']) {
-                     $nb = countElementsInTable($this::getTable(),
+                     $nb = countElementsInTable($static::getTable(),
                                                ['users_id' => $item->getID()]);
                   }
                   return self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/group_user.class.php
+++ b/inc/group_user.class.php
@@ -614,7 +614,7 @@ class Group_User extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -623,7 +623,7 @@ class Group_User extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_dynamic',
          'name'               => __('Dynamic'),
          'datatype'           => 'bool',
@@ -651,7 +651,7 @@ class Group_User extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_manager',
          'name'               => __('Manager'),
          'datatype'           => 'bool'
@@ -659,7 +659,7 @@ class Group_User extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_userdelegate',
          'name'               => __('Delegatee'),
          'datatype'           => 'bool'
@@ -693,7 +693,7 @@ class Group_User extends CommonDBRelation{
             case 'User' :
                if (Group::canView()) {
                   if ($_SESSION['glpishow_count_on_tabs']) {
-                     $nb = countElementsInTable($static::getTable(),
+                     $nb = countElementsInTable(static::getTable(),
                                                ['users_id' => $item->getID()]);
                   }
                   return self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/holiday.class.php
+++ b/inc/holiday.class.php
@@ -72,7 +72,7 @@ class Holiday extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Start'),
          'datatype'           => 'date'
@@ -80,7 +80,7 @@ class Holiday extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'end_date',
          'name'               => __('End'),
          'datatype'           => 'date'
@@ -88,7 +88,7 @@ class Holiday extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_perpetual',
          'name'               => __('Recurrent'),
          'datatype'           => 'bool'

--- a/inc/holiday.class.php
+++ b/inc/holiday.class.php
@@ -72,7 +72,7 @@ class Holiday extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Start'),
          'datatype'           => 'date'
@@ -80,7 +80,7 @@ class Holiday extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End'),
          'datatype'           => 'date'
@@ -88,7 +88,7 @@ class Holiday extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_perpetual',
          'name'               => __('Recurrent'),
          'datatype'           => 'bool'

--- a/inc/holiday.class.php
+++ b/inc/holiday.class.php
@@ -72,7 +72,7 @@ class Holiday extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Start'),
          'datatype'           => 'date'
@@ -80,7 +80,7 @@ class Holiday extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End'),
          'datatype'           => 'date'
@@ -88,7 +88,7 @@ class Holiday extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_perpetual',
          'name'               => __('Recurrent'),
          'datatype'           => 'bool'

--- a/inc/htmltableheader.class.php
+++ b/inc/htmltableheader.class.php
@@ -114,7 +114,7 @@ abstract class HTMLTableHeader extends HTMLTableEntity {
          if (!isset($this->itemtypes[$item->getType()])) {
             throw new Exception('Implementation error: type mismatch between header and cell');
          }
-         $this::getTable()->addItemType($item->getType(), $this->itemtypes[$item->getType()]);
+         $static::getTable()->addItemType($item->getType(), $this->itemtypes[$item->getType()]);
       }
    }
 

--- a/inc/htmltableheader.class.php
+++ b/inc/htmltableheader.class.php
@@ -114,7 +114,7 @@ abstract class HTMLTableHeader extends HTMLTableEntity {
          if (!isset($this->itemtypes[$item->getType()])) {
             throw new Exception('Implementation error: type mismatch between header and cell');
          }
-         $static::getTable()->addItemType($item->getType(), $this->itemtypes[$item->getType()]);
+         static::getTable()->addItemType($item->getType(), $this->itemtypes[$item->getType()]);
       }
    }
 

--- a/inc/htmltableheader.class.php
+++ b/inc/htmltableheader.class.php
@@ -114,7 +114,7 @@ abstract class HTMLTableHeader extends HTMLTableEntity {
          if (!isset($this->itemtypes[$item->getType()])) {
             throw new Exception('Implementation error: type mismatch between header and cell');
          }
-         $this->getTable()->addItemType($item->getType(), $this->itemtypes[$item->getType()]);
+         $this::getTable()->addItemType($item->getType(), $this->itemtypes[$item->getType()]);
       }
    }
 

--- a/inc/htmltablesubheader.class.php
+++ b/inc/htmltablesubheader.class.php
@@ -81,7 +81,8 @@ class HTMLTableSubHeader extends HTMLTableHeader {
 
 
    protected function getTable() {
-      return $this->header::getTable();
+      $header = $this->header;
+      return $header::getTable();
    }
 
 

--- a/inc/htmltablesubheader.class.php
+++ b/inc/htmltablesubheader.class.php
@@ -81,7 +81,7 @@ class HTMLTableSubHeader extends HTMLTableHeader {
 
 
    protected function getTable() {
-      return $this->header->getTable();
+      return $this->header::getTable();
    }
 
 

--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -240,8 +240,8 @@ class Infocom extends CommonDBChild {
    **/
    function getFromDBforDevice ($itemtype, $ID) {
 
-      if ($this->getFromDBByQuery("WHERE `".$this::getTable()."`.`items_id` = '$ID'
-                                  AND `".$this::getTable()."`.`itemtype` = '$itemtype'")) {
+      if ($this->getFromDBByQuery("WHERE `".$static::getTable()."`.`items_id` = '$ID'
+                                  AND `".$static::getTable()."`.`itemtype` = '$itemtype'")) {
          return true;
       }
       $this->getEmpty();
@@ -1542,7 +1542,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -1551,7 +1551,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'buy_date',
          'name'               => __('Date of purchase'),
          'datatype'           => 'date'
@@ -1559,7 +1559,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'use_date',
          'name'               => __('Startup date'),
          'datatype'           => 'date'
@@ -1567,7 +1567,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'delivery_date',
          'name'               => __('Delivery date'),
          'datatype'           => 'date',
@@ -1576,7 +1576,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'order_date',
          'name'               => __('Order date'),
          'datatype'           => 'date',
@@ -1585,7 +1585,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '25',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'warranty_date',
          'name'               => __('Start date of warranty'),
          'datatype'           => 'date',
@@ -1594,7 +1594,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '27',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'inventory_date',
          'name'               => __('Date of last physical inventory'),
          'datatype'           => 'date',
@@ -1603,7 +1603,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '28',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'decommission_date',
          'name'               => __('Decommission date'),
          'datatype'           => 'date',
@@ -1612,7 +1612,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'warranty_duration',
          'name'               => __('Warranty duration'),
          'datatype'           => 'number',
@@ -1625,7 +1625,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'warranty_info',
          'name'               => __('Warranty information'),
          'datatype'           => 'string'
@@ -1633,7 +1633,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'warranty_value',
          'name'               => __('Warranty extension value'),
          'datatype'           => 'decimal'
@@ -1649,7 +1649,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'order_number',
          'name'               => __('Order number'),
          'datatype'           => 'string'
@@ -1657,7 +1657,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'delivery_number',
          'name'               => __('Delivery form'),
          'datatype'           => 'string'
@@ -1665,7 +1665,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'immo_number',
          'name'               => __('Immobilization number'),
          'datatype'           => 'string'
@@ -1673,7 +1673,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'value',
          'name'               => _x('price', 'Value'),
          'datatype'           => 'decimal'
@@ -1681,7 +1681,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'sink_time',
          'name'               => __('Amortization duration'),
          'datatype'           => 'number',
@@ -1691,7 +1691,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'sink_type',
          'name'               => __('Amortization type'),
          'datatype'           => 'specific',
@@ -1700,7 +1700,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -1708,7 +1708,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'sink_coeff',
          'name'               => __('Amortization coefficient'),
          'datatype'           => 'decimal'
@@ -1716,7 +1716,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'bill',
          'name'               => __('Invoice number'),
          'datatype'           => 'string'
@@ -1732,7 +1732,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtype',
@@ -1741,7 +1741,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'items_id',
          'name'               => __('ID'),
          'datatype'           => 'integer',
@@ -1750,7 +1750,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'alert',
          'name'               => __('Alarms on financial and administrative information'),
          'datatype'           => 'integer'
@@ -1767,7 +1767,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -240,8 +240,8 @@ class Infocom extends CommonDBChild {
    **/
    function getFromDBforDevice ($itemtype, $ID) {
 
-      if ($this->getFromDBByQuery("WHERE `".$static::getTable()."`.`items_id` = '$ID'
-                                  AND `".$static::getTable()."`.`itemtype` = '$itemtype'")) {
+      if ($this->getFromDBByQuery("WHERE `".static::getTable()."`.`items_id` = '$ID'
+                                  AND `".static::getTable()."`.`itemtype` = '$itemtype'")) {
          return true;
       }
       $this->getEmpty();
@@ -1542,7 +1542,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -1551,7 +1551,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'buy_date',
          'name'               => __('Date of purchase'),
          'datatype'           => 'date'
@@ -1559,7 +1559,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'use_date',
          'name'               => __('Startup date'),
          'datatype'           => 'date'
@@ -1567,7 +1567,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'delivery_date',
          'name'               => __('Delivery date'),
          'datatype'           => 'date',
@@ -1576,7 +1576,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'order_date',
          'name'               => __('Order date'),
          'datatype'           => 'date',
@@ -1585,7 +1585,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '25',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'warranty_date',
          'name'               => __('Start date of warranty'),
          'datatype'           => 'date',
@@ -1594,7 +1594,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '27',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'inventory_date',
          'name'               => __('Date of last physical inventory'),
          'datatype'           => 'date',
@@ -1603,7 +1603,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '28',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'decommission_date',
          'name'               => __('Decommission date'),
          'datatype'           => 'date',
@@ -1612,7 +1612,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'warranty_duration',
          'name'               => __('Warranty duration'),
          'datatype'           => 'number',
@@ -1625,7 +1625,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'warranty_info',
          'name'               => __('Warranty information'),
          'datatype'           => 'string'
@@ -1633,7 +1633,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'warranty_value',
          'name'               => __('Warranty extension value'),
          'datatype'           => 'decimal'
@@ -1649,7 +1649,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'order_number',
          'name'               => __('Order number'),
          'datatype'           => 'string'
@@ -1657,7 +1657,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'delivery_number',
          'name'               => __('Delivery form'),
          'datatype'           => 'string'
@@ -1665,7 +1665,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'immo_number',
          'name'               => __('Immobilization number'),
          'datatype'           => 'string'
@@ -1673,7 +1673,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'value',
          'name'               => _x('price', 'Value'),
          'datatype'           => 'decimal'
@@ -1681,7 +1681,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'sink_time',
          'name'               => __('Amortization duration'),
          'datatype'           => 'number',
@@ -1691,7 +1691,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'sink_type',
          'name'               => __('Amortization type'),
          'datatype'           => 'specific',
@@ -1700,7 +1700,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -1708,7 +1708,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'sink_coeff',
          'name'               => __('Amortization coefficient'),
          'datatype'           => 'decimal'
@@ -1716,7 +1716,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'bill',
          'name'               => __('Invoice number'),
          'datatype'           => 'string'
@@ -1732,7 +1732,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtype',
@@ -1741,7 +1741,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'items_id',
          'name'               => __('ID'),
          'datatype'           => 'integer',
@@ -1750,7 +1750,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'alert',
          'name'               => __('Alarms on financial and administrative information'),
          'datatype'           => 'integer'
@@ -1767,7 +1767,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -240,8 +240,8 @@ class Infocom extends CommonDBChild {
    **/
    function getFromDBforDevice ($itemtype, $ID) {
 
-      if ($this->getFromDBByQuery("WHERE `".$this->getTable()."`.`items_id` = '$ID'
-                                  AND `".$this->getTable()."`.`itemtype` = '$itemtype'")) {
+      if ($this->getFromDBByQuery("WHERE `".$this::getTable()."`.`items_id` = '$ID'
+                                  AND `".$this::getTable()."`.`itemtype` = '$itemtype'")) {
          return true;
       }
       $this->getEmpty();
@@ -1542,7 +1542,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -1551,7 +1551,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'buy_date',
          'name'               => __('Date of purchase'),
          'datatype'           => 'date'
@@ -1559,7 +1559,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'use_date',
          'name'               => __('Startup date'),
          'datatype'           => 'date'
@@ -1567,7 +1567,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'delivery_date',
          'name'               => __('Delivery date'),
          'datatype'           => 'date',
@@ -1576,7 +1576,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'order_date',
          'name'               => __('Order date'),
          'datatype'           => 'date',
@@ -1585,7 +1585,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '25',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'warranty_date',
          'name'               => __('Start date of warranty'),
          'datatype'           => 'date',
@@ -1594,7 +1594,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '27',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'inventory_date',
          'name'               => __('Date of last physical inventory'),
          'datatype'           => 'date',
@@ -1603,7 +1603,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '28',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'decommission_date',
          'name'               => __('Decommission date'),
          'datatype'           => 'date',
@@ -1612,7 +1612,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'warranty_duration',
          'name'               => __('Warranty duration'),
          'datatype'           => 'number',
@@ -1625,7 +1625,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'warranty_info',
          'name'               => __('Warranty information'),
          'datatype'           => 'string'
@@ -1633,7 +1633,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'warranty_value',
          'name'               => __('Warranty extension value'),
          'datatype'           => 'decimal'
@@ -1649,7 +1649,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'order_number',
          'name'               => __('Order number'),
          'datatype'           => 'string'
@@ -1657,7 +1657,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'delivery_number',
          'name'               => __('Delivery form'),
          'datatype'           => 'string'
@@ -1665,7 +1665,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'immo_number',
          'name'               => __('Immobilization number'),
          'datatype'           => 'string'
@@ -1673,7 +1673,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'value',
          'name'               => _x('price', 'Value'),
          'datatype'           => 'decimal'
@@ -1681,7 +1681,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'sink_time',
          'name'               => __('Amortization duration'),
          'datatype'           => 'number',
@@ -1691,7 +1691,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'sink_type',
          'name'               => __('Amortization type'),
          'datatype'           => 'specific',
@@ -1700,7 +1700,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -1708,7 +1708,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'sink_coeff',
          'name'               => __('Amortization coefficient'),
          'datatype'           => 'decimal'
@@ -1716,7 +1716,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'bill',
          'name'               => __('Invoice number'),
          'datatype'           => 'string'
@@ -1732,7 +1732,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtype',
@@ -1741,7 +1741,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'items_id',
          'name'               => __('ID'),
          'datatype'           => 'integer',
@@ -1750,7 +1750,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'alert',
          'name'               => __('Alarms on financial and administrative information'),
          'datatype'           => 'integer'
@@ -1767,7 +1767,7 @@ class Infocom extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/ipaddress.class.php
+++ b/inc/ipaddress.class.php
@@ -568,7 +568,7 @@ class IPAddress extends CommonDBChild {
       if (!empty($itemtype)
           && ($items_id > 0)) {
          $query = "SELECT `id`
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `items_id` = '$items_id'
                          AND `itemtype` = '$itemtype'
                          AND `name` = '$address'";
@@ -731,7 +731,7 @@ class IPAddress extends CommonDBChild {
       if (!empty($itemtype)
           && ($items_id > 0)) {
          $query = "SELECT `id`
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `items_id` = '$items_id'
                          AND `itemtype` = '$itemtype'";
 

--- a/inc/ipaddress.class.php
+++ b/inc/ipaddress.class.php
@@ -568,7 +568,7 @@ class IPAddress extends CommonDBChild {
       if (!empty($itemtype)
           && ($items_id > 0)) {
          $query = "SELECT `id`
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `items_id` = '$items_id'
                          AND `itemtype` = '$itemtype'
                          AND `name` = '$address'";
@@ -731,7 +731,7 @@ class IPAddress extends CommonDBChild {
       if (!empty($itemtype)
           && ($items_id > 0)) {
          $query = "SELECT `id`
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `items_id` = '$items_id'
                          AND `itemtype` = '$itemtype'";
 

--- a/inc/ipaddress.class.php
+++ b/inc/ipaddress.class.php
@@ -568,7 +568,7 @@ class IPAddress extends CommonDBChild {
       if (!empty($itemtype)
           && ($items_id > 0)) {
          $query = "SELECT `id`
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `items_id` = '$items_id'
                          AND `itemtype` = '$itemtype'
                          AND `name` = '$address'";
@@ -731,7 +731,7 @@ class IPAddress extends CommonDBChild {
       if (!empty($itemtype)
           && ($items_id > 0)) {
          $query = "SELECT `id`
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `items_id` = '$items_id'
                          AND `itemtype` = '$itemtype'";
 

--- a/inc/ipaddress_ipnetwork.class.php
+++ b/inc/ipaddress_ipnetwork.class.php
@@ -62,7 +62,7 @@ class IPAddress_IPNetwork extends CommonDBRelation {
       global $DB;
 
       $linkObject    = new self();
-      $linkTable     = $linkObject->getTable();
+      $linkTable     = $linkObject::getTable();
       $ipnetworks_id = $network->getID();
 
       // First, remove all links of the current Network

--- a/inc/ipnetwork.class.php
+++ b/inc/ipnetwork.class.php
@@ -65,7 +65,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'version',
          'name'               => __('IP version'),
          'massiveaction'      => false,
@@ -74,7 +74,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'address',
          'name'               => IPAddress::getTypeName(1),
          'massiveaction'      => false,
@@ -83,7 +83,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'netmask',
          'name'               => IPNetmask::getTypeName(1),
          'massiveaction'      => false,
@@ -92,7 +92,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'gateway',
          'name'               => __('Gateway'),
          'massiveaction'      => false,
@@ -101,7 +101,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'addressable',
          'name'               => __('Addressable network'),
          'datatype'           => 'bool'

--- a/inc/ipnetwork.class.php
+++ b/inc/ipnetwork.class.php
@@ -65,7 +65,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'version',
          'name'               => __('IP version'),
          'massiveaction'      => false,
@@ -74,7 +74,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'address',
          'name'               => IPAddress::getTypeName(1),
          'massiveaction'      => false,
@@ -83,7 +83,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'netmask',
          'name'               => IPNetmask::getTypeName(1),
          'massiveaction'      => false,
@@ -92,7 +92,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'gateway',
          'name'               => __('Gateway'),
          'massiveaction'      => false,
@@ -101,7 +101,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'addressable',
          'name'               => __('Addressable network'),
          'datatype'           => 'bool'

--- a/inc/ipnetwork.class.php
+++ b/inc/ipnetwork.class.php
@@ -65,7 +65,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'version',
          'name'               => __('IP version'),
          'massiveaction'      => false,
@@ -74,7 +74,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'address',
          'name'               => IPAddress::getTypeName(1),
          'massiveaction'      => false,
@@ -83,7 +83,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'netmask',
          'name'               => IPNetmask::getTypeName(1),
          'massiveaction'      => false,
@@ -92,7 +92,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'gateway',
          'name'               => __('Gateway'),
          'massiveaction'      => false,
@@ -101,7 +101,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'addressable',
          'name'               => __('Addressable network'),
          'datatype'           => 'bool'

--- a/inc/ipnetwork_vlan.class.php
+++ b/inc/ipnetwork_vlan.class.php
@@ -220,7 +220,7 @@ class IPNetwork_Vlan extends CommonDBRelation {
          switch ($item->getType()) {
             case 'IPNetwork' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb =  countElementsInTable($this::getTable(),
+                  $nb =  countElementsInTable($static::getTable(),
                                               ['ipnetworks_id' => $item->getID()]);
                }
                return self::createTabEntry(Vlan::getTypeName(), $nb);

--- a/inc/ipnetwork_vlan.class.php
+++ b/inc/ipnetwork_vlan.class.php
@@ -220,7 +220,7 @@ class IPNetwork_Vlan extends CommonDBRelation {
          switch ($item->getType()) {
             case 'IPNetwork' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb =  countElementsInTable($this->getTable(),
+                  $nb =  countElementsInTable($this::getTable(),
                                               ['ipnetworks_id' => $item->getID()]);
                }
                return self::createTabEntry(Vlan::getTypeName(), $nb);

--- a/inc/ipnetwork_vlan.class.php
+++ b/inc/ipnetwork_vlan.class.php
@@ -220,7 +220,7 @@ class IPNetwork_Vlan extends CommonDBRelation {
          switch ($item->getType()) {
             case 'IPNetwork' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb =  countElementsInTable($static::getTable(),
+                  $nb =  countElementsInTable(static::getTable(),
                                               ['ipnetworks_id' => $item->getID()]);
                }
                return self::createTabEntry(Vlan::getTypeName(), $nb);

--- a/inc/item_devices.class.php
+++ b/inc/item_devices.class.php
@@ -118,7 +118,7 @@ class Item_Devices extends CommonDBRelation {
                $table = 'glpi_locations';
                break;
             default:
-               $table = $this->getTable();
+               $table = $this::getTable();
          }
 
          $newtab = [
@@ -612,25 +612,25 @@ class Item_Devices extends CommonDBRelation {
          $where = "";
          if (!empty($peer_type)) {
             $leftjoin = "LEFT JOIN `".getTableForItemType($peer_type)."`
-                        ON (`".$this->getTable()."`.`items_id` = `".getTableForItemType($peer_type)."`.`id`
-                            AND `".$this->getTable()."`.`itemtype` = '$peer_type')";
+                        ON (`".$this::getTable()."`.`items_id` = `".getTableForItemType($peer_type)."`.`id`
+                            AND `".$this::getTable()."`.`itemtype` = '$peer_type')";
             $where = getEntitiesRestrictRequest(" AND", getTableForItemType($peer_type));
          }
 
-         $query = "SELECT `".$this->getTable()."`.*
-                   FROM `".$this->getTable()."`
+         $query = "SELECT `".$this::getTable()."`.*
+                   FROM `".$this::getTable()."`
                    $leftjoin
                    WHERE `".$this->getDeviceForeignKey()."` = '".$item->getID()."'
-                         AND `".$this->getTable()."`.`itemtype` = '$peer_type'
-                         AND `".$this->getTable()."`.`is_deleted` = '0'
+                         AND `".$this::getTable()."`.`itemtype` = '$peer_type'
+                         AND `".$this::getTable()."`.`is_deleted` = '0'
                          $where
-                   ORDER BY `".$this->getTable()."`.`itemtype`, `".$this->getTable()."`.`$fk`";
+                   ORDER BY `".$this::getTable()."`.`itemtype`, `".$this::getTable()."`.`$fk`";
 
       } else {
          $fk = $this->getDeviceForeignKey();
 
          $query = "SELECT *
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `itemtype` = '".$item->getType()."'
                          AND `items_id` = '".$item->getID()."'
                          AND `is_deleted` = '0'
@@ -943,7 +943,7 @@ class Item_Devices extends CommonDBRelation {
          if ($link) {
             if ($unaffect) {
                $query = "SELECT `id`
-                         FROM `".$link->getTable()."`
+                         FROM `".$link::getTable()."`
                          WHERE `itemtype` = '$itemtype'
                                AND `items_id` = '$items_id'";
                $input = array('items_id' => 0,

--- a/inc/item_devices.class.php
+++ b/inc/item_devices.class.php
@@ -118,7 +118,7 @@ class Item_Devices extends CommonDBRelation {
                $table = 'glpi_locations';
                break;
             default:
-               $table = $this::getTable();
+               $table = $static::getTable();
          }
 
          $newtab = [
@@ -612,25 +612,25 @@ class Item_Devices extends CommonDBRelation {
          $where = "";
          if (!empty($peer_type)) {
             $leftjoin = "LEFT JOIN `".getTableForItemType($peer_type)."`
-                        ON (`".$this::getTable()."`.`items_id` = `".getTableForItemType($peer_type)."`.`id`
-                            AND `".$this::getTable()."`.`itemtype` = '$peer_type')";
+                        ON (`".$static::getTable()."`.`items_id` = `".getTableForItemType($peer_type)."`.`id`
+                            AND `".$static::getTable()."`.`itemtype` = '$peer_type')";
             $where = getEntitiesRestrictRequest(" AND", getTableForItemType($peer_type));
          }
 
-         $query = "SELECT `".$this::getTable()."`.*
-                   FROM `".$this::getTable()."`
+         $query = "SELECT `".$static::getTable()."`.*
+                   FROM `".$static::getTable()."`
                    $leftjoin
                    WHERE `".$this->getDeviceForeignKey()."` = '".$item->getID()."'
-                         AND `".$this::getTable()."`.`itemtype` = '$peer_type'
-                         AND `".$this::getTable()."`.`is_deleted` = '0'
+                         AND `".$static::getTable()."`.`itemtype` = '$peer_type'
+                         AND `".$static::getTable()."`.`is_deleted` = '0'
                          $where
-                   ORDER BY `".$this::getTable()."`.`itemtype`, `".$this::getTable()."`.`$fk`";
+                   ORDER BY `".$static::getTable()."`.`itemtype`, `".$static::getTable()."`.`$fk`";
 
       } else {
          $fk = $this->getDeviceForeignKey();
 
          $query = "SELECT *
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `itemtype` = '".$item->getType()."'
                          AND `items_id` = '".$item->getID()."'
                          AND `is_deleted` = '0'

--- a/inc/item_devices.class.php
+++ b/inc/item_devices.class.php
@@ -118,7 +118,7 @@ class Item_Devices extends CommonDBRelation {
                $table = 'glpi_locations';
                break;
             default:
-               $table = $static::getTable();
+               $table = static::getTable();
          }
 
          $newtab = [
@@ -612,25 +612,25 @@ class Item_Devices extends CommonDBRelation {
          $where = "";
          if (!empty($peer_type)) {
             $leftjoin = "LEFT JOIN `".getTableForItemType($peer_type)."`
-                        ON (`".$static::getTable()."`.`items_id` = `".getTableForItemType($peer_type)."`.`id`
-                            AND `".$static::getTable()."`.`itemtype` = '$peer_type')";
+                        ON (`".static::getTable()."`.`items_id` = `".getTableForItemType($peer_type)."`.`id`
+                            AND `".static::getTable()."`.`itemtype` = '$peer_type')";
             $where = getEntitiesRestrictRequest(" AND", getTableForItemType($peer_type));
          }
 
-         $query = "SELECT `".$static::getTable()."`.*
-                   FROM `".$static::getTable()."`
+         $query = "SELECT `".static::getTable()."`.*
+                   FROM `".static::getTable()."`
                    $leftjoin
                    WHERE `".$this->getDeviceForeignKey()."` = '".$item->getID()."'
-                         AND `".$static::getTable()."`.`itemtype` = '$peer_type'
-                         AND `".$static::getTable()."`.`is_deleted` = '0'
+                         AND `".static::getTable()."`.`itemtype` = '$peer_type'
+                         AND `".static::getTable()."`.`is_deleted` = '0'
                          $where
-                   ORDER BY `".$static::getTable()."`.`itemtype`, `".$static::getTable()."`.`$fk`";
+                   ORDER BY `".static::getTable()."`.`itemtype`, `".static::getTable()."`.`$fk`";
 
       } else {
          $fk = $this->getDeviceForeignKey();
 
          $query = "SELECT *
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `itemtype` = '".$item->getType()."'
                          AND `items_id` = '".$item->getID()."'
                          AND `is_deleted` = '0'

--- a/inc/item_problem.class.php
+++ b/inc/item_problem.class.php
@@ -73,7 +73,7 @@ class Item_Problem extends CommonDBRelation{
    function prepareInputForAdd($input) {
 
       // Avoid duplicate entry
-      if (countElementsInTable($static::getTable(), ['problems_id' => $input['problems_id'],
+      if (countElementsInTable(static::getTable(), ['problems_id' => $input['problems_id'],
                                                   'itemtype'    => $input['itemtype'],
                                                   'items_id'    => $input['items_id']])>0) {
          return false;

--- a/inc/item_problem.class.php
+++ b/inc/item_problem.class.php
@@ -73,7 +73,7 @@ class Item_Problem extends CommonDBRelation{
    function prepareInputForAdd($input) {
 
       // Avoid duplicate entry
-      if (countElementsInTable($this::getTable(), ['problems_id' => $input['problems_id'],
+      if (countElementsInTable($static::getTable(), ['problems_id' => $input['problems_id'],
                                                   'itemtype'    => $input['itemtype'],
                                                   'items_id'    => $input['items_id']])>0) {
          return false;

--- a/inc/item_problem.class.php
+++ b/inc/item_problem.class.php
@@ -73,7 +73,7 @@ class Item_Problem extends CommonDBRelation{
    function prepareInputForAdd($input) {
 
       // Avoid duplicate entry
-      if (countElementsInTable($this->getTable(), ['problems_id' => $input['problems_id'],
+      if (countElementsInTable($this::getTable(), ['problems_id' => $input['problems_id'],
                                                   'itemtype'    => $input['itemtype'],
                                                   'items_id'    => $input['items_id']])>0) {
          return false;

--- a/inc/item_project.class.php
+++ b/inc/item_project.class.php
@@ -73,7 +73,7 @@ class Item_Project extends CommonDBRelation{
    function prepareInputForAdd($input) {
 
       // Avoid duplicate entry
-      if (countElementsInTable($this::getTable(), ['projects_id' => $input['projects_id'],
+      if (countElementsInTable($static::getTable(), ['projects_id' => $input['projects_id'],
                                                    'itemtype'    => $input['itemtype'],
                                                    'items_id'    => $input['items_id']]) > 0) {
          return false;

--- a/inc/item_project.class.php
+++ b/inc/item_project.class.php
@@ -73,7 +73,7 @@ class Item_Project extends CommonDBRelation{
    function prepareInputForAdd($input) {
 
       // Avoid duplicate entry
-      if (countElementsInTable($static::getTable(), ['projects_id' => $input['projects_id'],
+      if (countElementsInTable(static::getTable(), ['projects_id' => $input['projects_id'],
                                                    'itemtype'    => $input['itemtype'],
                                                    'items_id'    => $input['items_id']]) > 0) {
          return false;

--- a/inc/item_project.class.php
+++ b/inc/item_project.class.php
@@ -73,7 +73,7 @@ class Item_Project extends CommonDBRelation{
    function prepareInputForAdd($input) {
 
       // Avoid duplicate entry
-      if (countElementsInTable($this->getTable(), ['projects_id' => $input['projects_id'],
+      if (countElementsInTable($this::getTable(), ['projects_id' => $input['projects_id'],
                                                    'itemtype'    => $input['itemtype'],
                                                    'items_id'    => $input['items_id']]) > 0) {
          return false;

--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -125,7 +125,7 @@ class Item_Ticket extends CommonDBRelation{
    function prepareInputForAdd($input) {
 
       // Avoid duplicate entry
-      if (countElementsInTable($this->getTable(), ['tickets_id' => $input['tickets_id'],
+      if (countElementsInTable($this::getTable(), ['tickets_id' => $input['tickets_id'],
                                                    'itemtype'   => $input['itemtype'],
                                                    'items_id'   => $input['items_id']]) > 0) {
          return false;
@@ -1195,7 +1195,7 @@ class Item_Ticket extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'items_id',
          'name'               => _n('Associated element', 'Associated elements', 2),
          'datatype'           => 'specific',
@@ -1206,7 +1206,7 @@ class Item_Ticket extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '131',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'itemtype',
          'name'               => _n('Associated item type', 'Associated item types', 2),
          'datatype'           => 'itemtypename',

--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -125,7 +125,7 @@ class Item_Ticket extends CommonDBRelation{
    function prepareInputForAdd($input) {
 
       // Avoid duplicate entry
-      if (countElementsInTable($static::getTable(), ['tickets_id' => $input['tickets_id'],
+      if (countElementsInTable(static::getTable(), ['tickets_id' => $input['tickets_id'],
                                                    'itemtype'   => $input['itemtype'],
                                                    'items_id'   => $input['items_id']]) > 0) {
          return false;
@@ -1195,7 +1195,7 @@ class Item_Ticket extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'items_id',
          'name'               => _n('Associated element', 'Associated elements', 2),
          'datatype'           => 'specific',
@@ -1206,7 +1206,7 @@ class Item_Ticket extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '131',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'itemtype',
          'name'               => _n('Associated item type', 'Associated item types', 2),
          'datatype'           => 'itemtypename',

--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -125,7 +125,7 @@ class Item_Ticket extends CommonDBRelation{
    function prepareInputForAdd($input) {
 
       // Avoid duplicate entry
-      if (countElementsInTable($this::getTable(), ['tickets_id' => $input['tickets_id'],
+      if (countElementsInTable($static::getTable(), ['tickets_id' => $input['tickets_id'],
                                                    'itemtype'   => $input['itemtype'],
                                                    'items_id'   => $input['items_id']]) > 0) {
          return false;
@@ -1195,7 +1195,7 @@ class Item_Ticket extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'items_id',
          'name'               => _n('Associated element', 'Associated elements', 2),
          'datatype'           => 'specific',
@@ -1206,7 +1206,7 @@ class Item_Ticket extends CommonDBRelation{
 
       $tab[] = [
          'id'                 => '131',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'itemtype',
          'name'               => _n('Associated item type', 'Associated item types', 2),
          'datatype'           => 'itemtypename',

--- a/inc/itilcategory.class.php
+++ b/inc/itilcategory.class.php
@@ -151,7 +151,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '74',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_incident',
          'name'               => __('Visible for an incident'),
          'datatype'           => 'bool'
@@ -159,7 +159,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '75',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_request',
          'name'               => __('Visible for a request'),
          'datatype'           => 'bool'
@@ -167,7 +167,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '76',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_problem',
          'name'               => __('Visible for a problem'),
          'datatype'           => 'bool'
@@ -175,7 +175,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '85',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_change',
          'name'               => __('Visible for a change'),
          'datatype'           => 'bool'
@@ -183,7 +183,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_helpdeskvisible',
          'name'               => __('Visible in the simplified interface'),
          'datatype'           => 'bool'

--- a/inc/itilcategory.class.php
+++ b/inc/itilcategory.class.php
@@ -151,7 +151,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '74',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_incident',
          'name'               => __('Visible for an incident'),
          'datatype'           => 'bool'
@@ -159,7 +159,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '75',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_request',
          'name'               => __('Visible for a request'),
          'datatype'           => 'bool'
@@ -167,7 +167,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '76',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_problem',
          'name'               => __('Visible for a problem'),
          'datatype'           => 'bool'
@@ -175,7 +175,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '85',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_change',
          'name'               => __('Visible for a change'),
          'datatype'           => 'bool'
@@ -183,7 +183,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_helpdeskvisible',
          'name'               => __('Visible in the simplified interface'),
          'datatype'           => 'bool'

--- a/inc/itilcategory.class.php
+++ b/inc/itilcategory.class.php
@@ -151,7 +151,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '74',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_incident',
          'name'               => __('Visible for an incident'),
          'datatype'           => 'bool'
@@ -159,7 +159,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '75',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_request',
          'name'               => __('Visible for a request'),
          'datatype'           => 'bool'
@@ -167,7 +167,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '76',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_problem',
          'name'               => __('Visible for a problem'),
          'datatype'           => 'bool'
@@ -175,7 +175,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '85',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_change',
          'name'               => __('Visible for a change'),
          'datatype'           => 'bool'
@@ -183,7 +183,7 @@ class ITILCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_helpdeskvisible',
          'name'               => __('Visible in the simplified interface'),
          'datatype'           => 'bool'

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -796,7 +796,7 @@ class KnowbaseItem extends CommonDBVisible {
    function addToFaq() {
       global $DB;
 
-      $DB->query("UPDATE `".$this->getTable()."`
+      $DB->query("UPDATE `".$this::getTable()."`
                   SET `is_faq` = '1'
                   WHERE `id` = '".$this->fields['id']."'");
 
@@ -1599,7 +1599,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -1616,7 +1616,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'datetime',
@@ -1625,7 +1625,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Subject'),
          'datatype'           => 'text'
@@ -1633,7 +1633,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'answer',
          'name'               => __('Content'),
          'datatype'           => 'text',
@@ -1642,7 +1642,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_faq',
          'name'               => __('FAQ item'),
          'datatype'           => 'bool'
@@ -1650,7 +1650,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'view',
          'name'               => _n('View', 'Views', Session::getPluralNumber()),
          'datatype'           => 'integer',
@@ -1659,7 +1659,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Visibility start date'),
          'datatype'           => 'datetime'
@@ -1667,7 +1667,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'end_date',
          'name'               => __('Visibility end date'),
          'datatype'           => 'datetime'
@@ -1675,7 +1675,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -1703,7 +1703,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -796,7 +796,7 @@ class KnowbaseItem extends CommonDBVisible {
    function addToFaq() {
       global $DB;
 
-      $DB->query("UPDATE `".$static::getTable()."`
+      $DB->query("UPDATE `".static::getTable()."`
                   SET `is_faq` = '1'
                   WHERE `id` = '".$this->fields['id']."'");
 
@@ -1599,7 +1599,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -1616,7 +1616,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'datetime',
@@ -1625,7 +1625,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Subject'),
          'datatype'           => 'text'
@@ -1633,7 +1633,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'answer',
          'name'               => __('Content'),
          'datatype'           => 'text',
@@ -1642,7 +1642,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_faq',
          'name'               => __('FAQ item'),
          'datatype'           => 'bool'
@@ -1650,7 +1650,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'view',
          'name'               => _n('View', 'Views', Session::getPluralNumber()),
          'datatype'           => 'integer',
@@ -1659,7 +1659,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Visibility start date'),
          'datatype'           => 'datetime'
@@ -1667,7 +1667,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'end_date',
          'name'               => __('Visibility end date'),
          'datatype'           => 'datetime'
@@ -1675,7 +1675,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -1703,7 +1703,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -796,7 +796,7 @@ class KnowbaseItem extends CommonDBVisible {
    function addToFaq() {
       global $DB;
 
-      $DB->query("UPDATE `".$this::getTable()."`
+      $DB->query("UPDATE `".$static::getTable()."`
                   SET `is_faq` = '1'
                   WHERE `id` = '".$this->fields['id']."'");
 
@@ -1599,7 +1599,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -1616,7 +1616,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'datetime',
@@ -1625,7 +1625,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Subject'),
          'datatype'           => 'text'
@@ -1633,7 +1633,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'answer',
          'name'               => __('Content'),
          'datatype'           => 'text',
@@ -1642,7 +1642,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_faq',
          'name'               => __('FAQ item'),
          'datatype'           => 'bool'
@@ -1650,7 +1650,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'view',
          'name'               => _n('View', 'Views', Session::getPluralNumber()),
          'datatype'           => 'integer',
@@ -1659,7 +1659,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Visibility start date'),
          'datatype'           => 'datetime'
@@ -1667,7 +1667,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'end_date',
          'name'               => __('Visibility end date'),
          'datatype'           => 'datetime'
@@ -1675,7 +1675,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -1703,7 +1703,7 @@ class KnowbaseItem extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/knowbaseitem_item.class.php
+++ b/inc/knowbaseitem_item.class.php
@@ -317,7 +317,7 @@ class KnowbaseItem_Item extends CommonDBRelation {
 
       $itemtype  = $item->getType();
       $items_id  = $item->getField('id');
-      $itemtable = $item->getTable();
+      $itemtable = $item::getTable();
 
       if ($item::getType() == KnowbaseItem::getType()) {
          $id_field = 'glpi_knowbaseitems_items.knowbaseitems_id';
@@ -330,11 +330,11 @@ class KnowbaseItem_Item extends CommonDBRelation {
          }
       } else {
          $id_field = 'glpi_knowbaseitems_items.items_id';
-         $where = getEntitiesRestrictCriteria($item->getTable(), '', '', $item->maybeRecursive());
+         $where = getEntitiesRestrictCriteria($item::getTable(), '', '', $item->maybeRecursive());
          $where[] = ['glpi_knowbaseitems_items.itemtype' => $item::getType()];
          if (count($where)) {
-            $options['FROM'][] = $item->getTable();
-            $where[] = ['glpi_knowbaseitems_items.items_id' => '`' . $item->getTable() . '`.`id`'];
+            $options['FROM'][] = $item::getTable();
+            $where[] = ['glpi_knowbaseitems_items.items_id' => '`' . $item::getTable() . '`.`id`'];
          }
       }
 

--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -205,7 +205,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -214,7 +214,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -223,7 +223,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'link',
          'name'               => __('Link or filename'),
          'datatype'           => 'string'
@@ -231,7 +231,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -240,7 +240,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -205,7 +205,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -214,7 +214,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -223,7 +223,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'link',
          'name'               => __('Link or filename'),
          'datatype'           => 'string'
@@ -231,7 +231,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -240,7 +240,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -205,7 +205,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -214,7 +214,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -223,7 +223,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'link',
          'name'               => __('Link or filename'),
          'datatype'           => 'string'
@@ -231,7 +231,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -240,7 +240,7 @@ class Link extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/link_itemtype.class.php
+++ b/inc/link_itemtype.class.php
@@ -163,7 +163,7 @@ class Link_Itemtype extends CommonDBChild {
          switch ($item->getType()) {
             case 'Link' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this::getTable(),
+                  $nb = countElementsInTable($static::getTable(),
                                              ['links_id' => $item->getID()]);
                }
                return self::createTabEntry(_n('Associated item type', 'Associated item types',

--- a/inc/link_itemtype.class.php
+++ b/inc/link_itemtype.class.php
@@ -163,7 +163,7 @@ class Link_Itemtype extends CommonDBChild {
          switch ($item->getType()) {
             case 'Link' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this->getTable(),
+                  $nb = countElementsInTable($this::getTable(),
                                              ['links_id' => $item->getID()]);
                }
                return self::createTabEntry(_n('Associated item type', 'Associated item types',

--- a/inc/link_itemtype.class.php
+++ b/inc/link_itemtype.class.php
@@ -163,7 +163,7 @@ class Link_Itemtype extends CommonDBChild {
          switch ($item->getType()) {
             case 'Link' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($static::getTable(),
+                  $nb = countElementsInTable(static::getTable(),
                                              ['links_id' => $item->getID()]);
                }
                return self::createTabEntry(_n('Associated item type', 'Associated item types',

--- a/inc/log.class.php
+++ b/inc/log.class.php
@@ -149,11 +149,11 @@ class Log extends CommonDBTM {
 
             } else if (($val2['linkfield'] == $key)
                 || (($key == $val2['field'])
-                    && ($val2['table'] == $item->getTable()))) {
+                    && ($val2['table'] == $item::getTable()))) {
                // Linkfield or standard field not massive action enable
                $id_search_option = $key2; // Give ID of the $SEARCHOPTION
 
-               if ($val2['table'] == $item->getTable()) {
+               if ($val2['table'] == $item::getTable()) {
                   $changes = array($id_search_option, addslashes($oldval), $values[$key]);
                } else {
                   // other cases; link field -> get data from dropdown
@@ -323,7 +323,7 @@ class Log extends CommonDBTM {
 
       $itemtype  = $item->getType();
       $items_id  = $item->getField('id');
-      $itemtable = $item->getTable();
+      $itemtable = $item::getTable();
 
       $SEARCHOPTION = Search::getOptions($itemtype);
 

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -339,7 +339,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -348,7 +348,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -356,7 +356,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'host',
          'name'               => __('Connection string'),
          'massiveaction'      => false,
@@ -365,7 +365,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'login',
          'name'               => __('Login'),
          'massiveaction'      => false,
@@ -374,7 +374,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'filesize_max',
          'name'               => __('Maximum size of each file imported by the mails receiver'),
          'datatype'           => 'integer'
@@ -382,7 +382,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -390,7 +390,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -399,7 +399,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'accepted',
          'name'               => __('Accepted mail archive folder (optional)'),
          'datatype'           => 'string'
@@ -407,7 +407,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'refused',
          'name'               => __('Refused mail archive folder (optional)'),
          'datatype'           => 'string'
@@ -415,7 +415,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'errors',
          'name'               => __('Connection errors'),
          'datatype'           => 'integer'
@@ -1769,11 +1769,11 @@ class MailCollector  extends CommonDBTM {
       global $CFG_GLPI;
 
       $buttons = array();
-      if (countElementsInTable($static::getTable())) {
+      if (countElementsInTable(static::getTable())) {
          $buttons["notimportedemail.php"] = __('List of not imported emails');
       }
 
-      $errors  = getAllDatasFromTable($static::getTable(), '`errors` > 0');
+      $errors  = getAllDatasFromTable(static::getTable(), '`errors` > 0');
       $message = '';
       if (count($errors)) {
          $servers = array();

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -339,7 +339,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -348,7 +348,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -356,7 +356,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'host',
          'name'               => __('Connection string'),
          'massiveaction'      => false,
@@ -365,7 +365,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'login',
          'name'               => __('Login'),
          'massiveaction'      => false,
@@ -374,7 +374,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'filesize_max',
          'name'               => __('Maximum size of each file imported by the mails receiver'),
          'datatype'           => 'integer'
@@ -382,7 +382,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -390,7 +390,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -399,7 +399,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'accepted',
          'name'               => __('Accepted mail archive folder (optional)'),
          'datatype'           => 'string'
@@ -407,7 +407,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'refused',
          'name'               => __('Refused mail archive folder (optional)'),
          'datatype'           => 'string'
@@ -415,7 +415,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'errors',
          'name'               => __('Connection errors'),
          'datatype'           => 'integer'
@@ -1769,11 +1769,11 @@ class MailCollector  extends CommonDBTM {
       global $CFG_GLPI;
 
       $buttons = array();
-      if (countElementsInTable($this->getTable())) {
+      if (countElementsInTable($this::getTable())) {
          $buttons["notimportedemail.php"] = __('List of not imported emails');
       }
 
-      $errors  = getAllDatasFromTable($this->getTable(), '`errors` > 0');
+      $errors  = getAllDatasFromTable($this::getTable(), '`errors` > 0');
       $message = '';
       if (count($errors)) {
          $servers = array();

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -339,7 +339,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -348,7 +348,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -356,7 +356,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'host',
          'name'               => __('Connection string'),
          'massiveaction'      => false,
@@ -365,7 +365,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'login',
          'name'               => __('Login'),
          'massiveaction'      => false,
@@ -374,7 +374,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'filesize_max',
          'name'               => __('Maximum size of each file imported by the mails receiver'),
          'datatype'           => 'integer'
@@ -382,7 +382,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -390,7 +390,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -399,7 +399,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'accepted',
          'name'               => __('Accepted mail archive folder (optional)'),
          'datatype'           => 'string'
@@ -407,7 +407,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'refused',
          'name'               => __('Refused mail archive folder (optional)'),
          'datatype'           => 'string'
@@ -415,7 +415,7 @@ class MailCollector  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'errors',
          'name'               => __('Connection errors'),
          'datatype'           => 'integer'
@@ -1769,11 +1769,11 @@ class MailCollector  extends CommonDBTM {
       global $CFG_GLPI;
 
       $buttons = array();
-      if (countElementsInTable($this::getTable())) {
+      if (countElementsInTable($static::getTable())) {
          $buttons["notimportedemail.php"] = __('List of not imported emails');
       }
 
-      $errors  = getAllDatasFromTable($this::getTable(), '`errors` > 0');
+      $errors  = getAllDatasFromTable($static::getTable(), '`errors` > 0');
       $message = '';
       if (count($errors)) {
          $servers = array();

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -388,7 +388,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -397,7 +397,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -433,7 +433,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -441,7 +441,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -449,7 +449,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -457,7 +457,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -483,7 +483,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -492,7 +492,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -501,7 +501,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -509,7 +509,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'size',
          'name'               => __('Size'),
          'datatype'           => 'decimal'
@@ -517,7 +517,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '41',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_micro',
          'name'               => __('Microphone'),
          'datatype'           => 'bool'
@@ -525,7 +525,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '42',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_speaker',
          'name'               => __('Speakers'),
          'datatype'           => 'bool'
@@ -533,7 +533,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '43',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_subd',
          'name'               => __('Sub-D'),
          'datatype'           => 'bool'
@@ -541,7 +541,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '44',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_bnc',
          'name'               => __('BNC'),
          'datatype'           => 'bool'
@@ -549,7 +549,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '45',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_dvi',
          'name'               => __('DVI'),
          'datatype'           => 'bool'
@@ -557,7 +557,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '46',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_pivot',
          'name'               => __('Pivot'),
          'datatype'           => 'bool'
@@ -565,7 +565,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '47',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_hdmi',
          'name'               => __('HDMI'),
          'datatype'           => 'bool'
@@ -573,7 +573,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '48',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_displayport',
          'name'               => __('DisplayPort'),
          'datatype'           => 'bool'
@@ -618,7 +618,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_global',
          'name'               => __('Global management'),
          'datatype'           => 'bool',

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -388,7 +388,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -397,7 +397,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -433,7 +433,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -441,7 +441,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -449,7 +449,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -457,7 +457,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -483,7 +483,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -492,7 +492,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -501,7 +501,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -509,7 +509,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'size',
          'name'               => __('Size'),
          'datatype'           => 'decimal'
@@ -517,7 +517,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '41',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_micro',
          'name'               => __('Microphone'),
          'datatype'           => 'bool'
@@ -525,7 +525,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '42',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_speaker',
          'name'               => __('Speakers'),
          'datatype'           => 'bool'
@@ -533,7 +533,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '43',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_subd',
          'name'               => __('Sub-D'),
          'datatype'           => 'bool'
@@ -541,7 +541,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '44',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_bnc',
          'name'               => __('BNC'),
          'datatype'           => 'bool'
@@ -549,7 +549,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '45',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_dvi',
          'name'               => __('DVI'),
          'datatype'           => 'bool'
@@ -557,7 +557,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '46',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_pivot',
          'name'               => __('Pivot'),
          'datatype'           => 'bool'
@@ -565,7 +565,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '47',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_hdmi',
          'name'               => __('HDMI'),
          'datatype'           => 'bool'
@@ -573,7 +573,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '48',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_displayport',
          'name'               => __('DisplayPort'),
          'datatype'           => 'bool'
@@ -618,7 +618,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_global',
          'name'               => __('Global management'),
          'datatype'           => 'bool',

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -388,7 +388,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -397,7 +397,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -433,7 +433,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -441,7 +441,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -449,7 +449,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -457,7 +457,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -483,7 +483,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -492,7 +492,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -501,7 +501,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -509,7 +509,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'size',
          'name'               => __('Size'),
          'datatype'           => 'decimal'
@@ -517,7 +517,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '41',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_micro',
          'name'               => __('Microphone'),
          'datatype'           => 'bool'
@@ -525,7 +525,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '42',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_speaker',
          'name'               => __('Speakers'),
          'datatype'           => 'bool'
@@ -533,7 +533,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '43',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_subd',
          'name'               => __('Sub-D'),
          'datatype'           => 'bool'
@@ -541,7 +541,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '44',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_bnc',
          'name'               => __('BNC'),
          'datatype'           => 'bool'
@@ -549,7 +549,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '45',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_dvi',
          'name'               => __('DVI'),
          'datatype'           => 'bool'
@@ -557,7 +557,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '46',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_pivot',
          'name'               => __('Pivot'),
          'datatype'           => 'bool'
@@ -565,7 +565,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '47',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_hdmi',
          'name'               => __('HDMI'),
          'datatype'           => 'bool'
@@ -573,7 +573,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '48',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_displayport',
          'name'               => __('DisplayPort'),
          'datatype'           => 'bool'
@@ -618,7 +618,7 @@ class Monitor extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_global',
          'name'               => __('Global management'),
          'datatype'           => 'bool',

--- a/inc/netpoint.class.php
+++ b/inc/netpoint.class.php
@@ -176,11 +176,11 @@ class Netpoint extends CommonDropdown {
 
       if (!empty($input["name"])) {
          $query = "SELECT `id`
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `name` = '".$input["name"]."'
                          AND `locations_id` = '".(isset($input["locations_id"])
                                                       ?$input["locations_id"]:0)."'".
-                         getEntitiesRestrictRequest(' AND ', $this::getTable(), '',
+                         getEntitiesRestrictRequest(' AND ', $static::getTable(), '',
                                                     $input['entities_id'], $this->maybeRecursive());
 
          // Check twin :
@@ -225,7 +225,7 @@ class Netpoint extends CommonDropdown {
          switch ($item->getType()) {
             case 'Location' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb =  countElementsInTable($this::getTable(),
+                  $nb =  countElementsInTable($static::getTable(),
                                               ['locations_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/netpoint.class.php
+++ b/inc/netpoint.class.php
@@ -176,11 +176,11 @@ class Netpoint extends CommonDropdown {
 
       if (!empty($input["name"])) {
          $query = "SELECT `id`
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `name` = '".$input["name"]."'
                          AND `locations_id` = '".(isset($input["locations_id"])
                                                       ?$input["locations_id"]:0)."'".
-                         getEntitiesRestrictRequest(' AND ', $this->getTable(), '',
+                         getEntitiesRestrictRequest(' AND ', $this::getTable(), '',
                                                     $input['entities_id'], $this->maybeRecursive());
 
          // Check twin :
@@ -225,7 +225,7 @@ class Netpoint extends CommonDropdown {
          switch ($item->getType()) {
             case 'Location' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb =  countElementsInTable($this->getTable(),
+                  $nb =  countElementsInTable($this::getTable(),
                                               ['locations_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/netpoint.class.php
+++ b/inc/netpoint.class.php
@@ -176,11 +176,11 @@ class Netpoint extends CommonDropdown {
 
       if (!empty($input["name"])) {
          $query = "SELECT `id`
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `name` = '".$input["name"]."'
                          AND `locations_id` = '".(isset($input["locations_id"])
                                                       ?$input["locations_id"]:0)."'".
-                         getEntitiesRestrictRequest(' AND ', $static::getTable(), '',
+                         getEntitiesRestrictRequest(' AND ', static::getTable(), '',
                                                     $input['entities_id'], $this->maybeRecursive());
 
          // Check twin :
@@ -225,7 +225,7 @@ class Netpoint extends CommonDropdown {
          switch ($item->getType()) {
             case 'Location' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb =  countElementsInTable($static::getTable(),
+                  $nb =  countElementsInTable(static::getTable(),
                                               ['locations_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/networkalias.class.php
+++ b/inc/networkalias.class.php
@@ -466,12 +466,12 @@ class NetworkAlias extends FQDNLabel {
          if ($_SESSION['glpishow_count_on_tabs']) {
             switch ($item->getType()) {
                case 'NetworkName' :
-                  $nb = countElementsInTable($this::getTable(),
+                  $nb = countElementsInTable($static::getTable(),
                                             ['networknames_id' => $item->getID() ]);
                   break;
 
                case 'FQDN' :
-                  $nb = countElementsInTable($this::getTable(),
+                  $nb = countElementsInTable($static::getTable(),
                                             ['fqdns_id' => $item->getID() ]);
             }
          }

--- a/inc/networkalias.class.php
+++ b/inc/networkalias.class.php
@@ -466,12 +466,12 @@ class NetworkAlias extends FQDNLabel {
          if ($_SESSION['glpishow_count_on_tabs']) {
             switch ($item->getType()) {
                case 'NetworkName' :
-                  $nb = countElementsInTable($static::getTable(),
+                  $nb = countElementsInTable(static::getTable(),
                                             ['networknames_id' => $item->getID() ]);
                   break;
 
                case 'FQDN' :
-                  $nb = countElementsInTable($static::getTable(),
+                  $nb = countElementsInTable(static::getTable(),
                                             ['fqdns_id' => $item->getID() ]);
             }
          }

--- a/inc/networkalias.class.php
+++ b/inc/networkalias.class.php
@@ -387,7 +387,7 @@ class NetworkAlias extends FQDNLabel {
          $order = "alias";
       }
 
-      $number = countElementsInTable($alias->getTable(), ['fqdns_id' => $item->getID() ]);
+      $number = countElementsInTable($alias::getTable(), ['fqdns_id' => $item->getID() ]);
 
       echo "<br><div class='center'>";
 
@@ -466,12 +466,12 @@ class NetworkAlias extends FQDNLabel {
          if ($_SESSION['glpishow_count_on_tabs']) {
             switch ($item->getType()) {
                case 'NetworkName' :
-                  $nb = countElementsInTable($this->getTable(),
+                  $nb = countElementsInTable($this::getTable(),
                                             ['networknames_id' => $item->getID() ]);
                   break;
 
                case 'FQDN' :
-                  $nb = countElementsInTable($this->getTable(),
+                  $nb = countElementsInTable($this::getTable(),
                                             ['fqdns_id' => $item->getID() ]);
             }
          }

--- a/inc/networkequipment.class.php
+++ b/inc/networkequipment.class.php
@@ -433,7 +433,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -442,7 +442,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -478,7 +478,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -486,7 +486,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -494,7 +494,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -502,7 +502,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -528,7 +528,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -537,7 +537,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -546,7 +546,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -562,7 +562,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'ram',
          'name'               => sprintf(__('%1$s (%2$s)'), __('Memory'), __('Mio')),
          'datatype'           => 'number'
@@ -623,7 +623,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/networkequipment.class.php
+++ b/inc/networkequipment.class.php
@@ -433,7 +433,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -442,7 +442,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -478,7 +478,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -486,7 +486,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -494,7 +494,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -502,7 +502,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -528,7 +528,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -537,7 +537,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -546,7 +546,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -562,7 +562,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'ram',
          'name'               => sprintf(__('%1$s (%2$s)'), __('Memory'), __('Mio')),
          'datatype'           => 'number'
@@ -623,7 +623,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/networkequipment.class.php
+++ b/inc/networkequipment.class.php
@@ -433,7 +433,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -442,7 +442,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -478,7 +478,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -486,7 +486,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -494,7 +494,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -502,7 +502,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -528,7 +528,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -537,7 +537,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -546,7 +546,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -562,7 +562,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'ram',
          'name'               => sprintf(__('%1$s (%2$s)'), __('Memory'), __('Mio')),
          'datatype'           => 'number'
@@ -623,7 +623,7 @@ class NetworkEquipment extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/networkname.class.php
+++ b/inc/networkname.class.php
@@ -190,7 +190,7 @@ class NetworkName extends FQDNLabel {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtype',
@@ -199,7 +199,7 @@ class NetworkName extends FQDNLabel {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'items_id',
          'name'               => __('ID'),
          'datatype'           => 'integer',

--- a/inc/networkname.class.php
+++ b/inc/networkname.class.php
@@ -190,7 +190,7 @@ class NetworkName extends FQDNLabel {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtype',
@@ -199,7 +199,7 @@ class NetworkName extends FQDNLabel {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'items_id',
          'name'               => __('ID'),
          'datatype'           => 'integer',
@@ -408,7 +408,7 @@ class NetworkName extends FQDNLabel {
 
       if ($networkPortID > 0) {
          $query = "SELECT `id`
-                   FROM `".$name->getTable()."`
+                   FROM `".$name::getTable()."`
                    WHERE `itemtype` = 'NetworkPort'
                    AND `items_id` = '$networkPortID'
                    AND `is_deleted` = '0'";

--- a/inc/networkname.class.php
+++ b/inc/networkname.class.php
@@ -190,7 +190,7 @@ class NetworkName extends FQDNLabel {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtype',
@@ -199,7 +199,7 @@ class NetworkName extends FQDNLabel {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'items_id',
          'name'               => __('ID'),
          'datatype'           => 'integer',

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -1008,7 +1008,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'type'               => 'text',
@@ -1018,7 +1018,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -1027,7 +1027,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'logical_number',
          'name'               => __('Port number'),
          'datatype'           => 'integer'
@@ -1035,7 +1035,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mac',
          'name'               => __('MAC address'),
          'datatype'           => 'mac'
@@ -1043,7 +1043,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'instantiation_type',
          'name'               => __('Network port type'),
          'datatype'           => 'itemtypename',
@@ -1061,7 +1061,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -1069,7 +1069,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtype',
@@ -1078,7 +1078,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'items_id',
          'name'               => __('ID'),
          'datatype'           => 'integer',

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -1008,7 +1008,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'type'               => 'text',
@@ -1018,7 +1018,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -1027,7 +1027,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'logical_number',
          'name'               => __('Port number'),
          'datatype'           => 'integer'
@@ -1035,7 +1035,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mac',
          'name'               => __('MAC address'),
          'datatype'           => 'mac'
@@ -1043,7 +1043,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'instantiation_type',
          'name'               => __('Network port type'),
          'datatype'           => 'itemtypename',
@@ -1061,7 +1061,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -1069,7 +1069,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtype',
@@ -1078,7 +1078,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'items_id',
          'name'               => __('ID'),
          'datatype'           => 'integer',
@@ -1128,7 +1128,7 @@ class NetworkPort extends CommonDBChild {
          }
 
          $npv = new NetworkPort_Vlan();
-         foreach ($DB->request($npv->getTable(),
+         foreach ($DB->request($npv::getTable(),
                                array($npv::$items_id_1 => $data["id"])) as $vlan) {
 
             $input = array($npv::$items_id_1 => $portid,

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -1008,7 +1008,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'type'               => 'text',
@@ -1018,7 +1018,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -1027,7 +1027,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'logical_number',
          'name'               => __('Port number'),
          'datatype'           => 'integer'
@@ -1035,7 +1035,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mac',
          'name'               => __('MAC address'),
          'datatype'           => 'mac'
@@ -1043,7 +1043,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'instantiation_type',
          'name'               => __('Network port type'),
          'datatype'           => 'itemtypename',
@@ -1061,7 +1061,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -1069,7 +1069,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtype',
@@ -1078,7 +1078,7 @@ class NetworkPort extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'items_id',
          'name'               => __('ID'),
          'datatype'           => 'integer',

--- a/inc/networkport_networkport.class.php
+++ b/inc/networkport_networkport.class.php
@@ -63,8 +63,8 @@ class NetworkPort_NetworkPort extends CommonDBRelation {
    **/
    function getFromDBForNetworkPort($ID) {
 
-      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`networkports_id_1` = '$ID'
-                                            OR `".$static::getTable()."`.`networkports_id_2` = '$ID'");
+      return $this->getFromDBByQuery("WHERE `".static::getTable()."`.`networkports_id_1` = '$ID'
+                                            OR `".static::getTable()."`.`networkports_id_2` = '$ID'");
    }
 
 

--- a/inc/networkport_networkport.class.php
+++ b/inc/networkport_networkport.class.php
@@ -63,8 +63,8 @@ class NetworkPort_NetworkPort extends CommonDBRelation {
    **/
    function getFromDBForNetworkPort($ID) {
 
-      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`networkports_id_1` = '$ID'
-                                            OR `".$this::getTable()."`.`networkports_id_2` = '$ID'");
+      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`networkports_id_1` = '$ID'
+                                            OR `".$static::getTable()."`.`networkports_id_2` = '$ID'");
    }
 
 

--- a/inc/networkport_networkport.class.php
+++ b/inc/networkport_networkport.class.php
@@ -63,8 +63,8 @@ class NetworkPort_NetworkPort extends CommonDBRelation {
    **/
    function getFromDBForNetworkPort($ID) {
 
-      return $this->getFromDBByQuery("WHERE `".$this->getTable()."`.`networkports_id_1` = '$ID'
-                                            OR `".$this->getTable()."`.`networkports_id_2` = '$ID'");
+      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`networkports_id_1` = '$ID'
+                                            OR `".$this::getTable()."`.`networkports_id_2` = '$ID'");
    }
 
 

--- a/inc/networkport_vlan.class.php
+++ b/inc/networkport_vlan.class.php
@@ -226,7 +226,7 @@ class NetworkPort_Vlan extends CommonDBRelation {
          switch ($item->getType()) {
             case 'NetworkPort' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($static::getTable(),
+                  $nb = countElementsInTable(static::getTable(),
                                              ["networkports_id" => $item->getID()]);
                }
                return self::createTabEntry(Vlan::getTypeName(), $nb);

--- a/inc/networkport_vlan.class.php
+++ b/inc/networkport_vlan.class.php
@@ -226,7 +226,7 @@ class NetworkPort_Vlan extends CommonDBRelation {
          switch ($item->getType()) {
             case 'NetworkPort' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this->getTable(),
+                  $nb = countElementsInTable($this::getTable(),
                                              ["networkports_id" => $item->getID()]);
                }
                return self::createTabEntry(Vlan::getTypeName(), $nb);

--- a/inc/networkport_vlan.class.php
+++ b/inc/networkport_vlan.class.php
@@ -226,7 +226,7 @@ class NetworkPort_Vlan extends CommonDBRelation {
          switch ($item->getType()) {
             case 'NetworkPort' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this::getTable(),
+                  $nb = countElementsInTable($static::getTable(),
                                              ["networkports_id" => $item->getID()]);
                }
                return self::createTabEntry(Vlan::getTypeName(), $nb);

--- a/inc/networkportethernet.class.php
+++ b/inc/networkportethernet.class.php
@@ -189,7 +189,7 @@ class NetworkPortEthernet extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mac',
          'datatype'           => 'mac',
          'name'               => __('MAC'),
@@ -198,7 +198,7 @@ class NetworkPortEthernet extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'type',
          'name'               => __('Ethernet port type'),
          'massiveaction'      => false,
@@ -207,7 +207,7 @@ class NetworkPortEthernet extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'speed',
          'name'               => __('Ethernet port speed'),
          'massiveaction'      => false,

--- a/inc/networkportethernet.class.php
+++ b/inc/networkportethernet.class.php
@@ -189,7 +189,7 @@ class NetworkPortEthernet extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mac',
          'datatype'           => 'mac',
          'name'               => __('MAC'),
@@ -198,7 +198,7 @@ class NetworkPortEthernet extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'type',
          'name'               => __('Ethernet port type'),
          'massiveaction'      => false,
@@ -207,7 +207,7 @@ class NetworkPortEthernet extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'speed',
          'name'               => __('Ethernet port speed'),
          'massiveaction'      => false,

--- a/inc/networkportethernet.class.php
+++ b/inc/networkportethernet.class.php
@@ -189,7 +189,7 @@ class NetworkPortEthernet extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mac',
          'datatype'           => 'mac',
          'name'               => __('MAC'),
@@ -198,7 +198,7 @@ class NetworkPortEthernet extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'type',
          'name'               => __('Ethernet port type'),
          'massiveaction'      => false,
@@ -207,7 +207,7 @@ class NetworkPortEthernet extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'speed',
          'name'               => __('Ethernet port speed'),
          'massiveaction'      => false,

--- a/inc/networkportfiberchannel.class.php
+++ b/inc/networkportfiberchannel.class.php
@@ -189,7 +189,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mac',
          'datatype'           => 'mac',
          'name'               => __('MAC'),
@@ -198,7 +198,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'wwn',
          'name'               => __('World Wide Name'),
          'massiveaction'      => false
@@ -206,7 +206,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'speed',
          'name'               => __('Fiber channel port speed'),
          'massiveaction'      => false,

--- a/inc/networkportfiberchannel.class.php
+++ b/inc/networkportfiberchannel.class.php
@@ -189,7 +189,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mac',
          'datatype'           => 'mac',
          'name'               => __('MAC'),
@@ -198,7 +198,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'wwn',
          'name'               => __('World Wide Name'),
          'massiveaction'      => false
@@ -206,7 +206,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'speed',
          'name'               => __('Fiber channel port speed'),
          'massiveaction'      => false,

--- a/inc/networkportfiberchannel.class.php
+++ b/inc/networkportfiberchannel.class.php
@@ -189,7 +189,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mac',
          'datatype'           => 'mac',
          'name'               => __('MAC'),
@@ -198,7 +198,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'wwn',
          'name'               => __('World Wide Name'),
          'massiveaction'      => false
@@ -206,7 +206,7 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'speed',
          'name'               => __('Fiber channel port speed'),
          'massiveaction'      => false,

--- a/inc/networkportinstantiation.class.php
+++ b/inc/networkportinstantiation.class.php
@@ -371,7 +371,7 @@ class NetworkPortInstantiation extends CommonDBChild {
          $netport = new $netporttype();
 
          $query = "SELECT `id`
-                   FROM `".$netport->getTable()."`
+                   FROM `".$netport::getTable()."`
                    WHERE `mac` $relation ";
 
          foreach ($DB->request($query) as $element) {

--- a/inc/networkportmigration.class.php
+++ b/inc/networkportmigration.class.php
@@ -75,8 +75,8 @@ class NetworkPortMigration extends CommonDBChild {
          }
       }
 
-      if (countElementsInTable($static::getTable()) == 0) {
-         $query = "DROP TABLE `".$static::getTable()."`";
+      if (countElementsInTable(static::getTable()) == 0) {
+         $query = "DROP TABLE `".static::getTable()."`";
          $DB->query($query);
       }
 
@@ -412,7 +412,7 @@ class NetworkPortMigration extends CommonDBChild {
       foreach (self::getMotives() as $motive => $name) {
          $tab[] = [
             'id'                 => $optionIndex,
-            'table'              => $static::getTable(),
+            'table'              => static::getTable(),
             'field'              => $motive,
             'name'               => $name,
             'datatype'           => 'bool'
@@ -423,7 +423,7 @@ class NetworkPortMigration extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'ip',
          'datatype'           => 'ip',
          'name'               => IPAddress::getTypeName(1)
@@ -431,7 +431,7 @@ class NetworkPortMigration extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'netmask',
          'datatype'           => 'string',
          'name'               => IPNetmask::getTypeName(1)
@@ -439,7 +439,7 @@ class NetworkPortMigration extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'subnet',
          'datatype'           => 'string',
          'name'               => __('Network address')
@@ -447,7 +447,7 @@ class NetworkPortMigration extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'gateway',
          'datatype'           => 'string',
          'name'               => IPAddress::getTypeName(1)

--- a/inc/networkportmigration.class.php
+++ b/inc/networkportmigration.class.php
@@ -75,8 +75,8 @@ class NetworkPortMigration extends CommonDBChild {
          }
       }
 
-      if (countElementsInTable($this::getTable()) == 0) {
-         $query = "DROP TABLE `".$this::getTable()."`";
+      if (countElementsInTable($static::getTable()) == 0) {
+         $query = "DROP TABLE `".$static::getTable()."`";
          $DB->query($query);
       }
 
@@ -412,7 +412,7 @@ class NetworkPortMigration extends CommonDBChild {
       foreach (self::getMotives() as $motive => $name) {
          $tab[] = [
             'id'                 => $optionIndex,
-            'table'              => $this::getTable(),
+            'table'              => $static::getTable(),
             'field'              => $motive,
             'name'               => $name,
             'datatype'           => 'bool'
@@ -423,7 +423,7 @@ class NetworkPortMigration extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'ip',
          'datatype'           => 'ip',
          'name'               => IPAddress::getTypeName(1)
@@ -431,7 +431,7 @@ class NetworkPortMigration extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'netmask',
          'datatype'           => 'string',
          'name'               => IPNetmask::getTypeName(1)
@@ -439,7 +439,7 @@ class NetworkPortMigration extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'subnet',
          'datatype'           => 'string',
          'name'               => __('Network address')
@@ -447,7 +447,7 @@ class NetworkPortMigration extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'gateway',
          'datatype'           => 'string',
          'name'               => IPAddress::getTypeName(1)

--- a/inc/networkportmigration.class.php
+++ b/inc/networkportmigration.class.php
@@ -75,8 +75,8 @@ class NetworkPortMigration extends CommonDBChild {
          }
       }
 
-      if (countElementsInTable($this->getTable()) == 0) {
-         $query = "DROP TABLE `".$this->getTable()."`";
+      if (countElementsInTable($this::getTable()) == 0) {
+         $query = "DROP TABLE `".$this::getTable()."`";
          $DB->query($query);
       }
 
@@ -412,7 +412,7 @@ class NetworkPortMigration extends CommonDBChild {
       foreach (self::getMotives() as $motive => $name) {
          $tab[] = [
             'id'                 => $optionIndex,
-            'table'              => $this->getTable(),
+            'table'              => $this::getTable(),
             'field'              => $motive,
             'name'               => $name,
             'datatype'           => 'bool'
@@ -423,7 +423,7 @@ class NetworkPortMigration extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'ip',
          'datatype'           => 'ip',
          'name'               => IPAddress::getTypeName(1)
@@ -431,7 +431,7 @@ class NetworkPortMigration extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'netmask',
          'datatype'           => 'string',
          'name'               => IPNetmask::getTypeName(1)
@@ -439,7 +439,7 @@ class NetworkPortMigration extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'subnet',
          'datatype'           => 'string',
          'name'               => __('Network address')
@@ -447,7 +447,7 @@ class NetworkPortMigration extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'gateway',
          'datatype'           => 'string',
          'name'               => IPAddress::getTypeName(1)

--- a/inc/networkportwifi.class.php
+++ b/inc/networkportwifi.class.php
@@ -140,7 +140,7 @@ class NetworkPortWifi extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mac',
          'name'               => __('MAC'),
          'massiveaction'      => false,
@@ -149,7 +149,7 @@ class NetworkPortWifi extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mode',
          'name'               => __('Wifi mode'),
          'massiveaction'      => false,
@@ -158,7 +158,7 @@ class NetworkPortWifi extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'version',
          'name'               => __('Wifi protocol version'),
          'massiveaction'      => false

--- a/inc/networkportwifi.class.php
+++ b/inc/networkportwifi.class.php
@@ -140,7 +140,7 @@ class NetworkPortWifi extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mac',
          'name'               => __('MAC'),
          'massiveaction'      => false,
@@ -149,7 +149,7 @@ class NetworkPortWifi extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mode',
          'name'               => __('Wifi mode'),
          'massiveaction'      => false,
@@ -158,7 +158,7 @@ class NetworkPortWifi extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'version',
          'name'               => __('Wifi protocol version'),
          'massiveaction'      => false

--- a/inc/networkportwifi.class.php
+++ b/inc/networkportwifi.class.php
@@ -140,7 +140,7 @@ class NetworkPortWifi extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mac',
          'name'               => __('MAC'),
          'massiveaction'      => false,
@@ -149,7 +149,7 @@ class NetworkPortWifi extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mode',
          'name'               => __('Wifi mode'),
          'massiveaction'      => false,
@@ -158,7 +158,7 @@ class NetworkPortWifi extends NetworkPortInstantiation {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'version',
          'name'               => __('Wifi protocol version'),
          'massiveaction'      => false

--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -334,7 +334,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -343,7 +343,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'event',
          'name'               => _n('Event', 'Events', 1),
          'massiveaction'      => false,
@@ -355,7 +355,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mode',
          'name'               => __('Notification method'),
          'massiveaction'      => false,
@@ -376,7 +376,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtypename',
@@ -386,7 +386,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -394,7 +394,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -411,7 +411,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -334,7 +334,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -343,7 +343,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'event',
          'name'               => _n('Event', 'Events', 1),
          'massiveaction'      => false,
@@ -355,7 +355,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mode',
          'name'               => __('Notification method'),
          'massiveaction'      => false,
@@ -376,7 +376,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtypename',
@@ -386,7 +386,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -394,7 +394,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -411,7 +411,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -334,7 +334,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -343,7 +343,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'event',
          'name'               => _n('Event', 'Events', 1),
          'massiveaction'      => false,
@@ -355,7 +355,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mode',
          'name'               => __('Notification method'),
          'massiveaction'      => false,
@@ -376,7 +376,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtypename',
@@ -386,7 +386,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -394,7 +394,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -411,7 +411,7 @@ class Notification extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -139,9 +139,9 @@ class NotificationTarget extends CommonDBChild {
    **/
    function getFromDBForTarget($notifications_id, $type, $ID) {
 
-      if ($this->getFromDBByQuery("WHERE `".$this->getTable()."`.`notifications_id` = '$notifications_id'
-                                  AND `".$this->getTable()."`.`items_id` = '$ID'
-                                  AND `".$this->getTable()."`.`type` = '$type'")) {
+      if ($this->getFromDBByQuery("WHERE `".$this::getTable()."`.`notifications_id` = '$notifications_id'
+                                  AND `".$this::getTable()."`.`items_id` = '$ID'
+                                  AND `".$this::getTable()."`.`type` = '$type'")) {
          return true;
       }
       return false;
@@ -1144,7 +1144,7 @@ class NotificationTarget extends CommonDBChild {
 
             case 'Notification' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this->getTable(),
+                  $nb = countElementsInTable($this::getTable(),
                                              ['notifications_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -139,9 +139,9 @@ class NotificationTarget extends CommonDBChild {
    **/
    function getFromDBForTarget($notifications_id, $type, $ID) {
 
-      if ($this->getFromDBByQuery("WHERE `".$this::getTable()."`.`notifications_id` = '$notifications_id'
-                                  AND `".$this::getTable()."`.`items_id` = '$ID'
-                                  AND `".$this::getTable()."`.`type` = '$type'")) {
+      if ($this->getFromDBByQuery("WHERE `".$static::getTable()."`.`notifications_id` = '$notifications_id'
+                                  AND `".$static::getTable()."`.`items_id` = '$ID'
+                                  AND `".$static::getTable()."`.`type` = '$type'")) {
          return true;
       }
       return false;
@@ -1144,7 +1144,7 @@ class NotificationTarget extends CommonDBChild {
 
             case 'Notification' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this::getTable(),
+                  $nb = countElementsInTable($static::getTable(),
                                              ['notifications_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -139,9 +139,9 @@ class NotificationTarget extends CommonDBChild {
    **/
    function getFromDBForTarget($notifications_id, $type, $ID) {
 
-      if ($this->getFromDBByQuery("WHERE `".$static::getTable()."`.`notifications_id` = '$notifications_id'
-                                  AND `".$static::getTable()."`.`items_id` = '$ID'
-                                  AND `".$static::getTable()."`.`type` = '$type'")) {
+      if ($this->getFromDBByQuery("WHERE `".static::getTable()."`.`notifications_id` = '$notifications_id'
+                                  AND `".static::getTable()."`.`items_id` = '$ID'
+                                  AND `".static::getTable()."`.`type` = '$type'")) {
          return true;
       }
       return false;
@@ -1144,7 +1144,7 @@ class NotificationTarget extends CommonDBChild {
 
             case 'Notification' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($static::getTable(),
+                  $nb = countElementsInTable(static::getTable(),
                                              ['notifications_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/notificationtargetchange.class.php
+++ b/inc/notificationtargetchange.class.php
@@ -192,7 +192,7 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject {
                                                                    $item2->getField('groups_id'));
                      }
 
-                     $modeltable = getSingular($item2->getTable())."models";
+                     $modeltable = getSingular($item2::getTable())."models";
                      $modelfield = getForeignKeyFieldForTable($modeltable);
 
                      if ($item2->isField($modelfield)) {

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -940,18 +940,18 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
          $datas["##$objettype.numberoflogs##"] = count($datas['log']);
 
          // Get unresolved items
-         $restrict = "`".$item->getTable()."`.`status`
+         $restrict = "`".$item::getTable()."`.`status`
                         NOT IN ('".implode("', '", array_merge($item->getSolvedStatusArray(),
                                                                $item->getClosedStatusArray())
                                           )."'
                                )";
 
          if ($item->maybeDeleted()) {
-            $restrict .= " AND `".$item->getTable()."`.`is_deleted` = '0' ";
+            $restrict .= " AND `".$item::getTable()."`.`is_deleted` = '0' ";
          }
 
          $datas["##$objettype.numberofunresolved##"]
-               = countElementsInTableForEntity($item->getTable(), $this->getEntity(), $restrict);
+               = countElementsInTableForEntity($item::getTable(), $this->getEntity(), $restrict);
 
          // Document
          $query = "SELECT `glpi_documents`.*
@@ -1045,7 +1045,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
          }
          $restrict .= " ORDER BY `date_mod` DESC, `id` ASC";
 
-         $tasks          = getAllDatasFromTable($taskobj->getTable(), $restrict);
+         $tasks          = getAllDatasFromTable($taskobj::getTable(), $restrict);
          $datas['tasks'] = array();
          foreach ($tasks as $task) {
             $tmp                          = array();

--- a/inc/notificationtargetproblem.class.php
+++ b/inc/notificationtargetproblem.class.php
@@ -181,7 +181,7 @@ class NotificationTargetProblem extends NotificationTargetCommonITILObject {
                                                                    $item2->getField('groups_id'));
                      }
 
-                     $modeltable = getSingular($item2->getTable())."models";
+                     $modeltable = getSingular($item2::getTable())."models";
                      $modelfield = getForeignKeyFieldForTable($modeltable);
 
                      if ($item2->isField($modelfield)) {

--- a/inc/notificationtargetproject.class.php
+++ b/inc/notificationtargetproject.class.php
@@ -527,7 +527,7 @@ class NotificationTargetProject extends NotificationTarget {
                                                                   $item2->getField('groups_id'));
                   }
 
-                  $modeltable = getSingular($item2->getTable())."models";
+                  $modeltable = getSingular($item2::getTable())."models";
                   $modelfield = getForeignKeyFieldForTable($modeltable);
 
                   if ($item2->isField($modelfield)) {

--- a/inc/notificationtargetticket.class.php
+++ b/inc/notificationtargetticket.class.php
@@ -458,7 +458,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject {
                               = Dropdown::getDropdownName('glpi_groups', $hardware->getField('groups_id'));
                }
 
-               $modeltable = getSingular($hardware->getTable())."models";
+               $modeltable = getSingular($hardware::getTable())."models";
                $modelfield = getForeignKeyFieldForTable($modeltable);
 
                if ($hardware->isField($modelfield)) {

--- a/inc/notificationtemplate.class.php
+++ b/inc/notificationtemplate.class.php
@@ -150,7 +150,7 @@ class NotificationTemplate extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -159,7 +159,7 @@ class NotificationTemplate extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtypename',
@@ -169,7 +169,7 @@ class NotificationTemplate extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/notificationtemplate.class.php
+++ b/inc/notificationtemplate.class.php
@@ -150,7 +150,7 @@ class NotificationTemplate extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -159,7 +159,7 @@ class NotificationTemplate extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtypename',
@@ -169,7 +169,7 @@ class NotificationTemplate extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/notificationtemplate.class.php
+++ b/inc/notificationtemplate.class.php
@@ -150,7 +150,7 @@ class NotificationTemplate extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -159,7 +159,7 @@ class NotificationTemplate extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtypename',
@@ -169,7 +169,7 @@ class NotificationTemplate extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/notificationtemplatetranslation.class.php
+++ b/inc/notificationtemplatetranslation.class.php
@@ -284,7 +284,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'language',
          'name'               => __('Language'),
          'datatype'           => 'language',
@@ -293,7 +293,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'subject',
          'name'               => __('Subject'),
          'massiveaction'      => false,
@@ -302,7 +302,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'content_html',
          'name'               => __('Email HTML body'),
          'datatype'           => 'text',
@@ -312,7 +312,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'content_text',
          'name'               => __('Email text body'),
          'datatype'           => 'text',
@@ -411,7 +411,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
          switch ($item->getType()) {
             case 'NotificationTemplate' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this::getTable(),
+                  $nb = countElementsInTable($static::getTable(),
                                              ['notificationtemplates_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/notificationtemplatetranslation.class.php
+++ b/inc/notificationtemplatetranslation.class.php
@@ -284,7 +284,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'language',
          'name'               => __('Language'),
          'datatype'           => 'language',
@@ -293,7 +293,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'subject',
          'name'               => __('Subject'),
          'massiveaction'      => false,
@@ -302,7 +302,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'content_html',
          'name'               => __('Email HTML body'),
          'datatype'           => 'text',
@@ -312,7 +312,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'content_text',
          'name'               => __('Email text body'),
          'datatype'           => 'text',
@@ -411,7 +411,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
          switch ($item->getType()) {
             case 'NotificationTemplate' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($static::getTable(),
+                  $nb = countElementsInTable(static::getTable(),
                                              ['notificationtemplates_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/notificationtemplatetranslation.class.php
+++ b/inc/notificationtemplatetranslation.class.php
@@ -284,7 +284,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'language',
          'name'               => __('Language'),
          'datatype'           => 'language',
@@ -293,7 +293,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'subject',
          'name'               => __('Subject'),
          'massiveaction'      => false,
@@ -302,7 +302,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'content_html',
          'name'               => __('Email HTML body'),
          'datatype'           => 'text',
@@ -312,7 +312,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'content_text',
          'name'               => __('Email text body'),
          'datatype'           => 'text',
@@ -411,7 +411,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
          switch ($item->getType()) {
             case 'NotificationTemplate' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this->getTable(),
+                  $nb = countElementsInTable($this::getTable(),
                                              ['notificationtemplates_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/notimportedemail.class.php
+++ b/inc/notimportedemail.class.php
@@ -135,7 +135,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'from',
          'name'               => __('From email header'),
          'massiveaction'      => false,
@@ -144,7 +144,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'to',
          'name'               => __('To email header'),
          'massiveaction'      => false,
@@ -153,7 +153,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'subject',
          'name'               => __('Subject email header'),
          'massiveaction'      => false,
@@ -170,7 +170,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'messageid',
          'name'               => __('Message-ID email header'),
          'massiveaction'      => false,
@@ -188,7 +188,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'reason',
          'name'               => __('Reason of rejection'),
          'datatype'           => 'specific',
@@ -197,7 +197,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'datetime',

--- a/inc/notimportedemail.class.php
+++ b/inc/notimportedemail.class.php
@@ -135,7 +135,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'from',
          'name'               => __('From email header'),
          'massiveaction'      => false,
@@ -144,7 +144,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'to',
          'name'               => __('To email header'),
          'massiveaction'      => false,
@@ -153,7 +153,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'subject',
          'name'               => __('Subject email header'),
          'massiveaction'      => false,
@@ -170,7 +170,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'messageid',
          'name'               => __('Message-ID email header'),
          'massiveaction'      => false,
@@ -188,7 +188,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'reason',
          'name'               => __('Reason of rejection'),
          'datatype'           => 'specific',
@@ -197,7 +197,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'datetime',

--- a/inc/notimportedemail.class.php
+++ b/inc/notimportedemail.class.php
@@ -135,7 +135,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'from',
          'name'               => __('From email header'),
          'massiveaction'      => false,
@@ -144,7 +144,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'to',
          'name'               => __('To email header'),
          'massiveaction'      => false,
@@ -153,7 +153,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'subject',
          'name'               => __('Subject email header'),
          'massiveaction'      => false,
@@ -170,7 +170,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'messageid',
          'name'               => __('Message-ID email header'),
          'massiveaction'      => false,
@@ -188,7 +188,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'reason',
          'name'               => __('Reason of rejection'),
          'datatype'           => 'specific',
@@ -197,7 +197,7 @@ class NotImportedEmail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'datetime',

--- a/inc/peripheral.class.php
+++ b/inc/peripheral.class.php
@@ -357,7 +357,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -366,7 +366,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -402,7 +402,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -410,7 +410,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -418,7 +418,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -426,7 +426,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -452,7 +452,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -461,7 +461,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -470,7 +470,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -478,7 +478,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'brand',
          'name'               => __('Brand'),
          'datatype'           => 'string'
@@ -523,7 +523,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_global',
          'name'               => __('Global management'),
          'datatype'           => 'bool',

--- a/inc/peripheral.class.php
+++ b/inc/peripheral.class.php
@@ -357,7 +357,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -366,7 +366,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -402,7 +402,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -410,7 +410,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -418,7 +418,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -426,7 +426,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -452,7 +452,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -461,7 +461,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -470,7 +470,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -478,7 +478,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'brand',
          'name'               => __('Brand'),
          'datatype'           => 'string'
@@ -523,7 +523,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_global',
          'name'               => __('Global management'),
          'datatype'           => 'bool',

--- a/inc/peripheral.class.php
+++ b/inc/peripheral.class.php
@@ -357,7 +357,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -366,7 +366,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -402,7 +402,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -410,7 +410,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -418,7 +418,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -426,7 +426,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -452,7 +452,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -461,7 +461,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -470,7 +470,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -478,7 +478,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'brand',
          'name'               => __('Brand'),
          'datatype'           => 'string'
@@ -523,7 +523,7 @@ class Peripheral extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_global',
          'name'               => __('Global management'),
          'datatype'           => 'bool',

--- a/inc/phone.class.php
+++ b/inc/phone.class.php
@@ -386,7 +386,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -395,7 +395,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -431,7 +431,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -439,7 +439,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -447,7 +447,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -455,7 +455,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -463,7 +463,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'number_line',
          'name'               => _x('quantity', 'Number of lines'),
          'datatype'           => 'string'
@@ -489,7 +489,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -498,7 +498,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -507,7 +507,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -515,7 +515,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'brand',
          'name'               => __('Brand'),
          'datatype'           => 'string'
@@ -531,7 +531,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '32',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'firmware',
          'name'               => __('Firmware'),
          'datatype'           => 'string'
@@ -567,7 +567,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '43',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_headset',
          'name'               => __('Headset'),
          'datatype'           => 'bool'
@@ -575,7 +575,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '44',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_hp',
          'name'               => __('Speaker'),
          'datatype'           => 'bool'
@@ -592,7 +592,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_global',
          'name'               => __('Global management'),
          'datatype'           => 'bool',

--- a/inc/phone.class.php
+++ b/inc/phone.class.php
@@ -386,7 +386,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -395,7 +395,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -431,7 +431,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -439,7 +439,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -447,7 +447,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -455,7 +455,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -463,7 +463,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'number_line',
          'name'               => _x('quantity', 'Number of lines'),
          'datatype'           => 'string'
@@ -489,7 +489,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -498,7 +498,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -507,7 +507,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -515,7 +515,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'brand',
          'name'               => __('Brand'),
          'datatype'           => 'string'
@@ -531,7 +531,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '32',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'firmware',
          'name'               => __('Firmware'),
          'datatype'           => 'string'
@@ -567,7 +567,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '43',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_headset',
          'name'               => __('Headset'),
          'datatype'           => 'bool'
@@ -575,7 +575,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '44',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_hp',
          'name'               => __('Speaker'),
          'datatype'           => 'bool'
@@ -592,7 +592,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_global',
          'name'               => __('Global management'),
          'datatype'           => 'bool',

--- a/inc/phone.class.php
+++ b/inc/phone.class.php
@@ -386,7 +386,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -395,7 +395,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -431,7 +431,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -439,7 +439,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -447,7 +447,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -455,7 +455,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -463,7 +463,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'number_line',
          'name'               => _x('quantity', 'Number of lines'),
          'datatype'           => 'string'
@@ -489,7 +489,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -498,7 +498,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -507,7 +507,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -515,7 +515,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'brand',
          'name'               => __('Brand'),
          'datatype'           => 'string'
@@ -531,7 +531,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '32',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'firmware',
          'name'               => __('Firmware'),
          'datatype'           => 'string'
@@ -567,7 +567,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '43',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_headset',
          'name'               => __('Headset'),
          'datatype'           => 'bool'
@@ -575,7 +575,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '44',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_hp',
          'name'               => __('Speaker'),
          'datatype'           => 'bool'
@@ -592,7 +592,7 @@ class Phone extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_global',
          'name'               => __('Global management'),
          'datatype'           => 'bool',

--- a/inc/planningrecall.class.php
+++ b/inc/planningrecall.class.php
@@ -105,9 +105,9 @@ class PlanningRecall extends CommonDBChild {
    **/
    function getFromDBForItemAndUser($itemtype, $items_id, $users_id) {
 
-      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`itemtype` = '$itemtype'
-                                             AND `".$this::getTable()."`.`items_id` = '$items_id'
-                                             AND `".$this::getTable()."`.`users_id` = '$users_id'");
+      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`itemtype` = '$itemtype'
+                                             AND `".$static::getTable()."`.`items_id` = '$items_id'
+                                             AND `".$static::getTable()."`.`users_id` = '$users_id'");
    }
 
 

--- a/inc/planningrecall.class.php
+++ b/inc/planningrecall.class.php
@@ -105,9 +105,9 @@ class PlanningRecall extends CommonDBChild {
    **/
    function getFromDBForItemAndUser($itemtype, $items_id, $users_id) {
 
-      return $this->getFromDBByQuery("WHERE `".$this->getTable()."`.`itemtype` = '$itemtype'
-                                             AND `".$this->getTable()."`.`items_id` = '$items_id'
-                                             AND `".$this->getTable()."`.`users_id` = '$users_id'");
+      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`itemtype` = '$itemtype'
+                                             AND `".$this::getTable()."`.`items_id` = '$items_id'
+                                             AND `".$this::getTable()."`.`users_id` = '$users_id'");
    }
 
 

--- a/inc/planningrecall.class.php
+++ b/inc/planningrecall.class.php
@@ -105,9 +105,9 @@ class PlanningRecall extends CommonDBChild {
    **/
    function getFromDBForItemAndUser($itemtype, $items_id, $users_id) {
 
-      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`itemtype` = '$itemtype'
-                                             AND `".$static::getTable()."`.`items_id` = '$items_id'
-                                             AND `".$static::getTable()."`.`users_id` = '$users_id'");
+      return $this->getFromDBByQuery("WHERE `".static::getTable()."`.`itemtype` = '$itemtype'
+                                             AND `".static::getTable()."`.`items_id` = '$items_id'
+                                             AND `".static::getTable()."`.`users_id` = '$users_id'");
    }
 
 

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -100,7 +100,7 @@ class Plugin extends CommonDBTM {
     * @return true if succeed else false
    **/
    function getFromDBbyDir($dir) {
-      return $this->getFromDBByQuery("WHERE `".$this->getTable()."`.`directory` = '$dir'");
+      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`directory` = '$dir'");
    }
 
 
@@ -855,7 +855,7 @@ class Plugin extends CommonDBTM {
    function unactivateAll() {
       global $DB;
 
-      $query = "UPDATE `".$this->getTable()."`
+      $query = "UPDATE `".$this::getTable()."`
                 SET `state` = ".self::NOTACTIVATED."
                 WHERE `state` = ".self::ACTIVATED;
       $DB->query($query);

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -100,7 +100,7 @@ class Plugin extends CommonDBTM {
     * @return true if succeed else false
    **/
    function getFromDBbyDir($dir) {
-      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`directory` = '$dir'");
+      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`directory` = '$dir'");
    }
 
 
@@ -855,7 +855,7 @@ class Plugin extends CommonDBTM {
    function unactivateAll() {
       global $DB;
 
-      $query = "UPDATE `".$this::getTable()."`
+      $query = "UPDATE `".$static::getTable()."`
                 SET `state` = ".self::NOTACTIVATED."
                 WHERE `state` = ".self::ACTIVATED;
       $DB->query($query);

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -100,7 +100,7 @@ class Plugin extends CommonDBTM {
     * @return true if succeed else false
    **/
    function getFromDBbyDir($dir) {
-      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`directory` = '$dir'");
+      return $this->getFromDBByQuery("WHERE `".static::getTable()."`.`directory` = '$dir'");
    }
 
 
@@ -855,7 +855,7 @@ class Plugin extends CommonDBTM {
    function unactivateAll() {
       global $DB;
 
-      $query = "UPDATE `".$static::getTable()."`
+      $query = "UPDATE `".static::getTable()."`
                 SET `state` = ".self::NOTACTIVATED."
                 WHERE `state` = ".self::ACTIVATED;
       $DB->query($query);

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -503,7 +503,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -512,7 +512,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -548,7 +548,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -556,7 +556,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -564,7 +564,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -572,7 +572,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -598,7 +598,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -607,7 +607,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -616,7 +616,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -624,7 +624,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '42',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_serial',
          'name'               => __('Serial'),
          'datatype'           => 'bool'
@@ -632,7 +632,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '43',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_parallel',
          'name'               => __('Parallel'),
          'datatype'           => 'bool'
@@ -640,7 +640,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '44',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_usb',
          'name'               => __('USB'),
          'datatype'           => 'bool'
@@ -648,7 +648,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '45',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_ethernet',
          'name'               => __('Ethernet'),
          'datatype'           => 'bool'
@@ -656,7 +656,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '46',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_wifi',
          'name'               => __('Wifi'),
          'datatype'           => 'bool'
@@ -664,7 +664,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'memory_size',
          'name'               => __('Memory'),
          'datatype'           => 'string'
@@ -672,7 +672,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'init_pages_counter',
          'name'               => __('Initial page counter'),
          'datatype'           => 'number',
@@ -681,7 +681,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'last_pages_counter',
          'name'               => __('Current counter of pages'),
          'datatype'           => 'number'
@@ -689,7 +689,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => '_virtual',
          'linkfield'          => '_virtual',
          'name'               => _n('Cartridge', 'Cartridges', Session::getPluralNumber()),
@@ -785,7 +785,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_global',
          'name'               => __('Global management'),
          'datatype'           => 'bool',
@@ -794,7 +794,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -503,7 +503,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -512,7 +512,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -548,7 +548,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -556,7 +556,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -564,7 +564,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -572,7 +572,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -598,7 +598,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -607,7 +607,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -616,7 +616,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -624,7 +624,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '42',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_serial',
          'name'               => __('Serial'),
          'datatype'           => 'bool'
@@ -632,7 +632,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '43',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_parallel',
          'name'               => __('Parallel'),
          'datatype'           => 'bool'
@@ -640,7 +640,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '44',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_usb',
          'name'               => __('USB'),
          'datatype'           => 'bool'
@@ -648,7 +648,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '45',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_ethernet',
          'name'               => __('Ethernet'),
          'datatype'           => 'bool'
@@ -656,7 +656,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '46',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_wifi',
          'name'               => __('Wifi'),
          'datatype'           => 'bool'
@@ -664,7 +664,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'memory_size',
          'name'               => __('Memory'),
          'datatype'           => 'string'
@@ -672,7 +672,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'init_pages_counter',
          'name'               => __('Initial page counter'),
          'datatype'           => 'number',
@@ -681,7 +681,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'last_pages_counter',
          'name'               => __('Current counter of pages'),
          'datatype'           => 'number'
@@ -689,7 +689,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => '_virtual',
          'linkfield'          => '_virtual',
          'name'               => _n('Cartridge', 'Cartridges', Session::getPluralNumber()),
@@ -785,7 +785,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_global',
          'name'               => __('Global management'),
          'datatype'           => 'bool',
@@ -794,7 +794,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -503,7 +503,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -512,7 +512,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -548,7 +548,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -556,7 +556,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'datatype'           => 'string'
@@ -564,7 +564,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'contact',
          'name'               => __('Alternate username'),
          'datatype'           => 'string'
@@ -572,7 +572,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'contact_num',
          'name'               => __('Alternate username number'),
          'datatype'           => 'string'
@@ -598,7 +598,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -607,7 +607,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -616,7 +616,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -624,7 +624,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '42',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_serial',
          'name'               => __('Serial'),
          'datatype'           => 'bool'
@@ -632,7 +632,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '43',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_parallel',
          'name'               => __('Parallel'),
          'datatype'           => 'bool'
@@ -640,7 +640,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '44',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_usb',
          'name'               => __('USB'),
          'datatype'           => 'bool'
@@ -648,7 +648,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '45',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_ethernet',
          'name'               => __('Ethernet'),
          'datatype'           => 'bool'
@@ -656,7 +656,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '46',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_wifi',
          'name'               => __('Wifi'),
          'datatype'           => 'bool'
@@ -664,7 +664,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'memory_size',
          'name'               => __('Memory'),
          'datatype'           => 'string'
@@ -672,7 +672,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'init_pages_counter',
          'name'               => __('Initial page counter'),
          'datatype'           => 'number',
@@ -681,7 +681,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'last_pages_counter',
          'name'               => __('Current counter of pages'),
          'datatype'           => 'number'
@@ -689,7 +689,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => '_virtual',
          'linkfield'          => '_virtual',
          'name'               => _n('Cartridge', 'Cartridges', Session::getPluralNumber()),
@@ -785,7 +785,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '82',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_global',
          'name'               => __('Global management'),
          'datatype'           => 'bool',
@@ -794,7 +794,7 @@ class Printer  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -477,7 +477,7 @@ class Problem extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '60',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'impactcontent',
          'name'               => __('Impacts'),
          'massiveaction'      => false,
@@ -486,7 +486,7 @@ class Problem extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '61',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'causecontent',
          'name'               => __('Causes'),
          'massiveaction'      => false,
@@ -495,7 +495,7 @@ class Problem extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '62',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'symptomcontent',
          'name'               => __('Symptoms'),
          'massiveaction'      => false,

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -477,7 +477,7 @@ class Problem extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '60',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'impactcontent',
          'name'               => __('Impacts'),
          'massiveaction'      => false,
@@ -486,7 +486,7 @@ class Problem extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '61',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'causecontent',
          'name'               => __('Causes'),
          'massiveaction'      => false,
@@ -495,7 +495,7 @@ class Problem extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '62',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'symptomcontent',
          'name'               => __('Symptoms'),
          'massiveaction'      => false,

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -477,7 +477,7 @@ class Problem extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '60',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'impactcontent',
          'name'               => __('Impacts'),
          'massiveaction'      => false,
@@ -486,7 +486,7 @@ class Problem extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '61',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'causecontent',
          'name'               => __('Causes'),
          'massiveaction'      => false,
@@ -495,7 +495,7 @@ class Problem extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '62',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'symptomcontent',
          'name'               => __('Symptoms'),
          'massiveaction'      => false,

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -173,7 +173,7 @@ class Profile extends CommonDBTM {
       }
 
       if (in_array('is_default', $this->updates) && ($this->input["is_default"] == 1)) {
-         $query = "UPDATE ". $this->getTable()."
+         $query = "UPDATE ". $this::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->input['id']."'";
          $DB->query($query);
@@ -199,7 +199,7 @@ class Profile extends CommonDBTM {
       unset($this->profileRight);
 
       if (isset($this->fields['is_default']) && ($this->fields["is_default"] == 1)) {
-         $query = "UPDATE ". $this->getTable()."
+         $query = "UPDATE ". $this::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
@@ -1480,7 +1480,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -1489,7 +1489,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -1498,7 +1498,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -1507,7 +1507,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'interface',
          'name'               => __("Profile's interface"),
          'massiveaction'      => false,
@@ -1517,7 +1517,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_default',
          'name'               => __('Default profile'),
          'datatype'           => 'bool',
@@ -1526,7 +1526,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '118',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'create_ticket_on_login',
          'name'               => __('Ticket creation form on login'),
          'datatype'           => 'bool'
@@ -1534,7 +1534,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -2226,7 +2226,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'helpdesk_hardware',
          'name'               => __('Link with items for the creation of tickets'),
          'massiveaction'      => false,
@@ -2235,7 +2235,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '87',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'helpdesk_item_type',
          'name'               => __('Associable items to a ticket'),
          'massiveaction'      => false,
@@ -2256,7 +2256,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '100',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'ticket_status',
          'name'               => __('Life cycle of tickets'),
          'nosearch'           => true,
@@ -2266,7 +2266,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '110',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'problem_status',
          'name'               => __('Life cycle of problems'),
          'nosearch'           => true,
@@ -2290,7 +2290,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '111',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'change_status',
          'name'               => __('Life cycle of changes'),
          'nosearch'           => true,

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -173,7 +173,7 @@ class Profile extends CommonDBTM {
       }
 
       if (in_array('is_default', $this->updates) && ($this->input["is_default"] == 1)) {
-         $query = "UPDATE ". $static::getTable()."
+         $query = "UPDATE ". static::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->input['id']."'";
          $DB->query($query);
@@ -199,7 +199,7 @@ class Profile extends CommonDBTM {
       unset($this->profileRight);
 
       if (isset($this->fields['is_default']) && ($this->fields["is_default"] == 1)) {
-         $query = "UPDATE ". $static::getTable()."
+         $query = "UPDATE ". static::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
@@ -1480,7 +1480,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -1489,7 +1489,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -1498,7 +1498,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -1507,7 +1507,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'interface',
          'name'               => __("Profile's interface"),
          'massiveaction'      => false,
@@ -1517,7 +1517,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_default',
          'name'               => __('Default profile'),
          'datatype'           => 'bool',
@@ -1526,7 +1526,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '118',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'create_ticket_on_login',
          'name'               => __('Ticket creation form on login'),
          'datatype'           => 'bool'
@@ -1534,7 +1534,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -2226,7 +2226,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'helpdesk_hardware',
          'name'               => __('Link with items for the creation of tickets'),
          'massiveaction'      => false,
@@ -2235,7 +2235,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '87',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'helpdesk_item_type',
          'name'               => __('Associable items to a ticket'),
          'massiveaction'      => false,
@@ -2256,7 +2256,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '100',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'ticket_status',
          'name'               => __('Life cycle of tickets'),
          'nosearch'           => true,
@@ -2266,7 +2266,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '110',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'problem_status',
          'name'               => __('Life cycle of problems'),
          'nosearch'           => true,
@@ -2290,7 +2290,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '111',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'change_status',
          'name'               => __('Life cycle of changes'),
          'nosearch'           => true,

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -173,7 +173,7 @@ class Profile extends CommonDBTM {
       }
 
       if (in_array('is_default', $this->updates) && ($this->input["is_default"] == 1)) {
-         $query = "UPDATE ". $this::getTable()."
+         $query = "UPDATE ". $static::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->input['id']."'";
          $DB->query($query);
@@ -199,7 +199,7 @@ class Profile extends CommonDBTM {
       unset($this->profileRight);
 
       if (isset($this->fields['is_default']) && ($this->fields["is_default"] == 1)) {
-         $query = "UPDATE ". $this::getTable()."
+         $query = "UPDATE ". $static::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
@@ -1480,7 +1480,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -1489,7 +1489,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -1498,7 +1498,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -1507,7 +1507,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'interface',
          'name'               => __("Profile's interface"),
          'massiveaction'      => false,
@@ -1517,7 +1517,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_default',
          'name'               => __('Default profile'),
          'datatype'           => 'bool',
@@ -1526,7 +1526,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '118',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'create_ticket_on_login',
          'name'               => __('Ticket creation form on login'),
          'datatype'           => 'bool'
@@ -1534,7 +1534,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -2226,7 +2226,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'helpdesk_hardware',
          'name'               => __('Link with items for the creation of tickets'),
          'massiveaction'      => false,
@@ -2235,7 +2235,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '87',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'helpdesk_item_type',
          'name'               => __('Associable items to a ticket'),
          'massiveaction'      => false,
@@ -2256,7 +2256,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '100',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'ticket_status',
          'name'               => __('Life cycle of tickets'),
          'nosearch'           => true,
@@ -2266,7 +2266,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '110',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'problem_status',
          'name'               => __('Life cycle of problems'),
          'nosearch'           => true,
@@ -2290,7 +2290,7 @@ class Profile extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '111',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'change_status',
          'name'               => __('Life cycle of changes'),
          'nosearch'           => true,

--- a/inc/profile_user.class.php
+++ b/inc/profile_user.class.php
@@ -849,7 +849,7 @@ class Profile_User extends CommonDBRelation {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -858,7 +858,7 @@ class Profile_User extends CommonDBRelation {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_dynamic',
          'name'               => __('Dynamic'),
          'datatype'           => 'bool',
@@ -895,7 +895,7 @@ class Profile_User extends CommonDBRelation {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool',
@@ -940,7 +940,7 @@ class Profile_User extends CommonDBRelation {
       if (!$withtemplate) {
          $nb = 0;
          $query_nb = "SELECT COUNT(*) as cpt
-                      FROM `".$static::getTable()."`
+                      FROM `".static::getTable()."`
                       LEFT JOIN glpi_users
                         ON (`glpi_users`.`id` = `glpi_profiles_users`.`users_id`)
                       WHERE `glpi_users`.`is_deleted` = '0' ";
@@ -976,7 +976,7 @@ class Profile_User extends CommonDBRelation {
 
             case 'User' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($static::getTable(),
+                  $nb = countElementsInTable(static::getTable(),
                                              ['users_id' => $item->getID()]);
                }
                return self::createTabEntry(_n('Authorization', 'Authorizations',

--- a/inc/profile_user.class.php
+++ b/inc/profile_user.class.php
@@ -849,7 +849,7 @@ class Profile_User extends CommonDBRelation {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -858,7 +858,7 @@ class Profile_User extends CommonDBRelation {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_dynamic',
          'name'               => __('Dynamic'),
          'datatype'           => 'bool',
@@ -895,7 +895,7 @@ class Profile_User extends CommonDBRelation {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool',
@@ -940,7 +940,7 @@ class Profile_User extends CommonDBRelation {
       if (!$withtemplate) {
          $nb = 0;
          $query_nb = "SELECT COUNT(*) as cpt
-                      FROM `".$this::getTable()."`
+                      FROM `".$static::getTable()."`
                       LEFT JOIN glpi_users
                         ON (`glpi_users`.`id` = `glpi_profiles_users`.`users_id`)
                       WHERE `glpi_users`.`is_deleted` = '0' ";
@@ -976,7 +976,7 @@ class Profile_User extends CommonDBRelation {
 
             case 'User' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this::getTable(),
+                  $nb = countElementsInTable($static::getTable(),
                                              ['users_id' => $item->getID()]);
                }
                return self::createTabEntry(_n('Authorization', 'Authorizations',

--- a/inc/profile_user.class.php
+++ b/inc/profile_user.class.php
@@ -849,7 +849,7 @@ class Profile_User extends CommonDBRelation {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -858,7 +858,7 @@ class Profile_User extends CommonDBRelation {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_dynamic',
          'name'               => __('Dynamic'),
          'datatype'           => 'bool',
@@ -895,7 +895,7 @@ class Profile_User extends CommonDBRelation {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool',
@@ -940,7 +940,7 @@ class Profile_User extends CommonDBRelation {
       if (!$withtemplate) {
          $nb = 0;
          $query_nb = "SELECT COUNT(*) as cpt
-                      FROM `".$this->getTable()."`
+                      FROM `".$this::getTable()."`
                       LEFT JOIN glpi_users
                         ON (`glpi_users`.`id` = `glpi_profiles_users`.`users_id`)
                       WHERE `glpi_users`.`is_deleted` = '0' ";
@@ -976,7 +976,7 @@ class Profile_User extends CommonDBRelation {
 
             case 'User' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this->getTable(),
+                  $nb = countElementsInTable($this::getTable(),
                                              ['users_id' => $item->getID()]);
                }
                return self::createTabEntry(_n('Authorization', 'Authorizations',

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -131,7 +131,7 @@ class Project extends CommonDBTM {
             case __CLASS__ :
                $ong    = array();
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this::getTable(),
+                  $nb = countElementsInTable($static::getTable(),
                                              [$this->getForeignKeyField() => $item->getID()]);
                }
                $ong[1] = self::createTabEntry($this->getTypeName(Session::getPluralNumber()), $nb);
@@ -379,7 +379,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -389,7 +389,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -398,7 +398,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'code',
          'name'               => __('Code'),
          'massiveaction'      => false,
@@ -407,7 +407,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Father'),
          'datatype'           => 'itemlink',
@@ -419,7 +419,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'massiveaction'      => false,
@@ -428,7 +428,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'priority',
          'name'               => __('Priority'),
          'searchtype'         => 'equals',
@@ -453,7 +453,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -462,7 +462,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'percent_done',
          'name'               => __('Percent done'),
          'datatype'           => 'number',
@@ -474,7 +474,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'show_on_global_gantt',
          'name'               => __('Show on global GANTT'),
          'datatype'           => 'bool'
@@ -502,7 +502,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'plan_start_date',
          'name'               => __('Planned start date'),
          'datatype'           => 'datetime'
@@ -510,7 +510,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'plan_end_date',
          'name'               => __('Planned end date'),
          'datatype'           => 'datetime'
@@ -518,7 +518,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => '_virtual_planned_duration',
          'name'               => __('Planned duration'),
          'datatype'           => 'specific',
@@ -529,7 +529,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'real_start_date',
          'name'               => __('Real start date'),
          'datatype'           => 'datetime'
@@ -537,7 +537,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'real_end_date',
          'name'               => __('Real end date'),
          'datatype'           => 'datetime'
@@ -545,7 +545,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => '_virtual_effective_duration',
          'name'               => __('Effective duration'),
          'datatype'           => 'specific',
@@ -556,7 +556,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -564,7 +564,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -573,7 +573,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -590,7 +590,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -842,7 +842,7 @@ class Project extends CommonDBTM {
       $rand = mt_rand();
 
       $query = "SELECT *
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `".$this->getForeignKeyField()."` = '$ID'";
       if ($result = $DB->query($query)) {
          $numrows = $DB->numrows($result);

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -131,7 +131,7 @@ class Project extends CommonDBTM {
             case __CLASS__ :
                $ong    = array();
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($static::getTable(),
+                  $nb = countElementsInTable(static::getTable(),
                                              [$this->getForeignKeyField() => $item->getID()]);
                }
                $ong[1] = self::createTabEntry($this->getTypeName(Session::getPluralNumber()), $nb);
@@ -379,7 +379,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -389,7 +389,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -398,7 +398,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'code',
          'name'               => __('Code'),
          'massiveaction'      => false,
@@ -407,7 +407,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Father'),
          'datatype'           => 'itemlink',
@@ -419,7 +419,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'massiveaction'      => false,
@@ -428,7 +428,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'priority',
          'name'               => __('Priority'),
          'searchtype'         => 'equals',
@@ -453,7 +453,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -462,7 +462,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'percent_done',
          'name'               => __('Percent done'),
          'datatype'           => 'number',
@@ -474,7 +474,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'show_on_global_gantt',
          'name'               => __('Show on global GANTT'),
          'datatype'           => 'bool'
@@ -502,7 +502,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'plan_start_date',
          'name'               => __('Planned start date'),
          'datatype'           => 'datetime'
@@ -510,7 +510,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'plan_end_date',
          'name'               => __('Planned end date'),
          'datatype'           => 'datetime'
@@ -518,7 +518,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => '_virtual_planned_duration',
          'name'               => __('Planned duration'),
          'datatype'           => 'specific',
@@ -529,7 +529,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'real_start_date',
          'name'               => __('Real start date'),
          'datatype'           => 'datetime'
@@ -537,7 +537,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'real_end_date',
          'name'               => __('Real end date'),
          'datatype'           => 'datetime'
@@ -545,7 +545,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => '_virtual_effective_duration',
          'name'               => __('Effective duration'),
          'datatype'           => 'specific',
@@ -556,7 +556,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -564,7 +564,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -573,7 +573,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -590,7 +590,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -842,7 +842,7 @@ class Project extends CommonDBTM {
       $rand = mt_rand();
 
       $query = "SELECT *
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `".$this->getForeignKeyField()."` = '$ID'";
       if ($result = $DB->query($query)) {
          $numrows = $DB->numrows($result);

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -131,7 +131,7 @@ class Project extends CommonDBTM {
             case __CLASS__ :
                $ong    = array();
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this->getTable(),
+                  $nb = countElementsInTable($this::getTable(),
                                              [$this->getForeignKeyField() => $item->getID()]);
                }
                $ong[1] = self::createTabEntry($this->getTypeName(Session::getPluralNumber()), $nb);
@@ -379,7 +379,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -389,7 +389,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -398,7 +398,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'code',
          'name'               => __('Code'),
          'massiveaction'      => false,
@@ -407,7 +407,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Father'),
          'datatype'           => 'itemlink',
@@ -419,7 +419,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'massiveaction'      => false,
@@ -428,7 +428,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'priority',
          'name'               => __('Priority'),
          'searchtype'         => 'equals',
@@ -453,7 +453,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -462,7 +462,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'percent_done',
          'name'               => __('Percent done'),
          'datatype'           => 'number',
@@ -474,7 +474,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'show_on_global_gantt',
          'name'               => __('Show on global GANTT'),
          'datatype'           => 'bool'
@@ -502,7 +502,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'plan_start_date',
          'name'               => __('Planned start date'),
          'datatype'           => 'datetime'
@@ -510,7 +510,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'plan_end_date',
          'name'               => __('Planned end date'),
          'datatype'           => 'datetime'
@@ -518,7 +518,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => '_virtual_planned_duration',
          'name'               => __('Planned duration'),
          'datatype'           => 'specific',
@@ -529,7 +529,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'real_start_date',
          'name'               => __('Real start date'),
          'datatype'           => 'datetime'
@@ -537,7 +537,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'real_end_date',
          'name'               => __('Real end date'),
          'datatype'           => 'datetime'
@@ -545,7 +545,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => '_virtual_effective_duration',
          'name'               => __('Effective duration'),
          'datatype'           => 'specific',
@@ -556,7 +556,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -564,7 +564,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -573,7 +573,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -590,7 +590,7 @@ class Project extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -842,7 +842,7 @@ class Project extends CommonDBTM {
       $rand = mt_rand();
 
       $query = "SELECT *
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `".$this->getForeignKeyField()."` = '$ID'";
       if ($result = $DB->query($query)) {
          $numrows = $DB->numrows($result);

--- a/inc/projectcost.class.php
+++ b/inc/projectcost.class.php
@@ -124,7 +124,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'searchtype'         => 'contains',
@@ -134,7 +134,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -143,7 +143,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -151,7 +151,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Begin date'),
          'datatype'           => 'datetime'
@@ -159,7 +159,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'
@@ -167,7 +167,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'cost',
          'name'               => __('Cost'),
          'datatype'           => 'decimal'
@@ -254,7 +254,7 @@ class ProjectCost extends CommonDBChild {
       global $DB;
 
       $query = "SELECT *
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `projects_id` = '$projects_id'
                 ORDER BY 'end_date' DESC, `id` DESC";
 

--- a/inc/projectcost.class.php
+++ b/inc/projectcost.class.php
@@ -124,7 +124,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'searchtype'         => 'contains',
@@ -134,7 +134,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -143,7 +143,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -151,7 +151,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Begin date'),
          'datatype'           => 'datetime'
@@ -159,7 +159,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'
@@ -167,7 +167,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'cost',
          'name'               => __('Cost'),
          'datatype'           => 'decimal'
@@ -254,7 +254,7 @@ class ProjectCost extends CommonDBChild {
       global $DB;
 
       $query = "SELECT *
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `projects_id` = '$projects_id'
                 ORDER BY 'end_date' DESC, `id` DESC";
 

--- a/inc/projectcost.class.php
+++ b/inc/projectcost.class.php
@@ -124,7 +124,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'searchtype'         => 'contains',
@@ -134,7 +134,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -143,7 +143,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -151,7 +151,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Begin date'),
          'datatype'           => 'datetime'
@@ -159,7 +159,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'
@@ -167,7 +167,7 @@ class ProjectCost extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'cost',
          'name'               => __('Cost'),
          'datatype'           => 'decimal'
@@ -254,7 +254,7 @@ class ProjectCost extends CommonDBChild {
       global $DB;
 
       $query = "SELECT *
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `projects_id` = '$projects_id'
                 ORDER BY 'end_date' DESC, `id` DESC";
 

--- a/inc/projectstate.class.php
+++ b/inc/projectstate.class.php
@@ -74,7 +74,7 @@ class ProjectState extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'color',
          'name'               => __('Color'),
          'datatype'           => 'color'
@@ -82,7 +82,7 @@ class ProjectState extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_finished',
          'name'               => __('Finished state'),
          'datatype'           => 'bool'

--- a/inc/projectstate.class.php
+++ b/inc/projectstate.class.php
@@ -74,7 +74,7 @@ class ProjectState extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'color',
          'name'               => __('Color'),
          'datatype'           => 'color'
@@ -82,7 +82,7 @@ class ProjectState extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_finished',
          'name'               => __('Finished state'),
          'datatype'           => 'bool'

--- a/inc/projectstate.class.php
+++ b/inc/projectstate.class.php
@@ -74,7 +74,7 @@ class ProjectState extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'color',
          'name'               => __('Color'),
          'datatype'           => 'color'
@@ -82,7 +82,7 @@ class ProjectState extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_finished',
          'name'               => __('Finished state'),
          'datatype'           => 'bool'

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -599,7 +599,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -617,7 +617,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Father'),
          'datatype'           => 'dropdown',
@@ -630,7 +630,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'massiveaction'      => false,
@@ -655,7 +655,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date',
          'name'               => __('Opening date'),
          'datatype'           => 'datetime',
@@ -664,7 +664,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -673,7 +673,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'percent_done',
          'name'               => __('Percent done'),
          'datatype'           => 'number',
@@ -694,7 +694,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'plan_start_date',
          'name'               => __('Planned start date'),
          'datatype'           => 'datetime'
@@ -702,7 +702,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'plan_end_date',
          'name'               => __('Planned end date'),
          'datatype'           => 'datetime'
@@ -710,7 +710,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'real_start_date',
          'name'               => __('Real start date'),
          'datatype'           => 'datetime'
@@ -718,7 +718,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'real_end_date',
          'name'               => __('Real end date'),
          'datatype'           => 'datetime'
@@ -726,7 +726,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'planned_duration',
          'name'               => __('Planned duration'),
          'datatype'           => 'timestamp',
@@ -739,7 +739,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'effective_duration',
          'name'               => __('Effective duration'),
          'datatype'           => 'timestamp',
@@ -752,7 +752,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -760,7 +760,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_milestone',
          'name'               => __('Milestone'),
          'datatype'           => 'bool'
@@ -776,7 +776,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -993,14 +993,14 @@ class ProjectTask extends CommonDBChild {
          switch ($item->getType()) {
             case 'Project' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($static::getTable(),
+                  $nb = countElementsInTable(static::getTable(),
                                             ['projects_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
 
             case __CLASS__ :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($static::getTable(),
+                  $nb = countElementsInTable(static::getTable(),
                                             ['projecttasks_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -599,7 +599,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -617,7 +617,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Father'),
          'datatype'           => 'dropdown',
@@ -630,7 +630,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'massiveaction'      => false,
@@ -655,7 +655,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date',
          'name'               => __('Opening date'),
          'datatype'           => 'datetime',
@@ -664,7 +664,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -673,7 +673,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'percent_done',
          'name'               => __('Percent done'),
          'datatype'           => 'number',
@@ -694,7 +694,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'plan_start_date',
          'name'               => __('Planned start date'),
          'datatype'           => 'datetime'
@@ -702,7 +702,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'plan_end_date',
          'name'               => __('Planned end date'),
          'datatype'           => 'datetime'
@@ -710,7 +710,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'real_start_date',
          'name'               => __('Real start date'),
          'datatype'           => 'datetime'
@@ -718,7 +718,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'real_end_date',
          'name'               => __('Real end date'),
          'datatype'           => 'datetime'
@@ -726,7 +726,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'planned_duration',
          'name'               => __('Planned duration'),
          'datatype'           => 'timestamp',
@@ -739,7 +739,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'effective_duration',
          'name'               => __('Effective duration'),
          'datatype'           => 'timestamp',
@@ -752,7 +752,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -760,7 +760,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_milestone',
          'name'               => __('Milestone'),
          'datatype'           => 'bool'
@@ -776,7 +776,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -993,14 +993,14 @@ class ProjectTask extends CommonDBChild {
          switch ($item->getType()) {
             case 'Project' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this::getTable(),
+                  $nb = countElementsInTable($static::getTable(),
                                             ['projects_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
 
             case __CLASS__ :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this::getTable(),
+                  $nb = countElementsInTable($static::getTable(),
                                             ['projecttasks_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -599,7 +599,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -617,7 +617,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Father'),
          'datatype'           => 'dropdown',
@@ -630,7 +630,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'massiveaction'      => false,
@@ -655,7 +655,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date',
          'name'               => __('Opening date'),
          'datatype'           => 'datetime',
@@ -664,7 +664,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -673,7 +673,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'percent_done',
          'name'               => __('Percent done'),
          'datatype'           => 'number',
@@ -694,7 +694,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'plan_start_date',
          'name'               => __('Planned start date'),
          'datatype'           => 'datetime'
@@ -702,7 +702,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'plan_end_date',
          'name'               => __('Planned end date'),
          'datatype'           => 'datetime'
@@ -710,7 +710,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'real_start_date',
          'name'               => __('Real start date'),
          'datatype'           => 'datetime'
@@ -718,7 +718,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'real_end_date',
          'name'               => __('Real end date'),
          'datatype'           => 'datetime'
@@ -726,7 +726,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'planned_duration',
          'name'               => __('Planned duration'),
          'datatype'           => 'timestamp',
@@ -739,7 +739,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'effective_duration',
          'name'               => __('Effective duration'),
          'datatype'           => 'timestamp',
@@ -752,7 +752,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -760,7 +760,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '18',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_milestone',
          'name'               => __('Milestone'),
          'datatype'           => 'bool'
@@ -776,7 +776,7 @@ class ProjectTask extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -993,14 +993,14 @@ class ProjectTask extends CommonDBChild {
          switch ($item->getType()) {
             case 'Project' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this->getTable(),
+                  $nb = countElementsInTable($this::getTable(),
                                             ['projects_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
 
             case __CLASS__ :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this->getTable(),
+                  $nb = countElementsInTable($this::getTable(),
                                             ['projecttasks_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/queuedmail.class.php
+++ b/inc/queuedmail.class.php
@@ -161,7 +161,7 @@ class QueuedMail extends CommonDBTM {
                    AND `entities_id` = '".$input['entities_id']."'
                    AND `notificationtemplates_id` = '".$input['notificationtemplates_id']."'
                    AND `recipient` = '".$input['recipient']."'";
-         foreach ($DB->request($this->getTable(), $query) as $data) {
+         foreach ($DB->request($this::getTable(), $query) as $data) {
             $this->delete(array('id' => $data['id']), 1);
          }
       }
@@ -180,7 +180,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Subject'),
          'datatype'           => 'itemlink',
@@ -189,7 +189,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -198,7 +198,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'create_time',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -207,7 +207,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'send_time',
          'name'               => __('Expected send date'),
          'datatype'           => 'datetime',
@@ -216,7 +216,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'sent_time',
          'name'               => __('Send date'),
          'datatype'           => 'datetime',
@@ -225,7 +225,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'sender',
          'name'               => __('Sender email'),
          'datatype'           => 'text',
@@ -234,7 +234,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'sendername',
          'name'               => __('Sender name'),
          'datatype'           => 'string',
@@ -243,7 +243,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'recipient',
          'name'               => __('Recipient email'),
          'datatype'           => 'string',
@@ -252,7 +252,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'recipientname',
          'name'               => __('Recipient name'),
          'datatype'           => 'string',
@@ -261,7 +261,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'replyto',
          'name'               => __('Reply-to email'),
          'datatype'           => 'string',
@@ -270,7 +270,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'replytoname',
          'name'               => __('Reply-to name'),
          'datatype'           => 'string',
@@ -279,7 +279,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'headers',
          'name'               => __('Additional headers'),
          'datatype'           => 'specific',
@@ -288,7 +288,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'body_html',
          'name'               => __('Email HTML body'),
          'datatype'           => 'text',
@@ -298,7 +298,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'body_text',
          'name'               => __('Email text body'),
          'datatype'           => 'text',
@@ -307,7 +307,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'messageid',
          'name'               => __('Message ID'),
          'datatype'           => 'string',
@@ -316,7 +316,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'sent_try',
          'name'               => __('Number of tries of sent'),
          'datatype'           => 'integer',
@@ -325,7 +325,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtype',
@@ -334,7 +334,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'items_id',
          'name'               => __('Associated item ID'),
          'massiveaction'      => false,

--- a/inc/queuedmail.class.php
+++ b/inc/queuedmail.class.php
@@ -161,7 +161,7 @@ class QueuedMail extends CommonDBTM {
                    AND `entities_id` = '".$input['entities_id']."'
                    AND `notificationtemplates_id` = '".$input['notificationtemplates_id']."'
                    AND `recipient` = '".$input['recipient']."'";
-         foreach ($DB->request($static::getTable(), $query) as $data) {
+         foreach ($DB->request(static::getTable(), $query) as $data) {
             $this->delete(array('id' => $data['id']), 1);
          }
       }
@@ -180,7 +180,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Subject'),
          'datatype'           => 'itemlink',
@@ -189,7 +189,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -198,7 +198,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'create_time',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -207,7 +207,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'send_time',
          'name'               => __('Expected send date'),
          'datatype'           => 'datetime',
@@ -216,7 +216,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'sent_time',
          'name'               => __('Send date'),
          'datatype'           => 'datetime',
@@ -225,7 +225,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'sender',
          'name'               => __('Sender email'),
          'datatype'           => 'text',
@@ -234,7 +234,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'sendername',
          'name'               => __('Sender name'),
          'datatype'           => 'string',
@@ -243,7 +243,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'recipient',
          'name'               => __('Recipient email'),
          'datatype'           => 'string',
@@ -252,7 +252,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'recipientname',
          'name'               => __('Recipient name'),
          'datatype'           => 'string',
@@ -261,7 +261,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'replyto',
          'name'               => __('Reply-to email'),
          'datatype'           => 'string',
@@ -270,7 +270,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'replytoname',
          'name'               => __('Reply-to name'),
          'datatype'           => 'string',
@@ -279,7 +279,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'headers',
          'name'               => __('Additional headers'),
          'datatype'           => 'specific',
@@ -288,7 +288,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'body_html',
          'name'               => __('Email HTML body'),
          'datatype'           => 'text',
@@ -298,7 +298,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'body_text',
          'name'               => __('Email text body'),
          'datatype'           => 'text',
@@ -307,7 +307,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'messageid',
          'name'               => __('Message ID'),
          'datatype'           => 'string',
@@ -316,7 +316,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'sent_try',
          'name'               => __('Number of tries of sent'),
          'datatype'           => 'integer',
@@ -325,7 +325,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtype',
@@ -334,7 +334,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'items_id',
          'name'               => __('Associated item ID'),
          'massiveaction'      => false,

--- a/inc/queuedmail.class.php
+++ b/inc/queuedmail.class.php
@@ -161,7 +161,7 @@ class QueuedMail extends CommonDBTM {
                    AND `entities_id` = '".$input['entities_id']."'
                    AND `notificationtemplates_id` = '".$input['notificationtemplates_id']."'
                    AND `recipient` = '".$input['recipient']."'";
-         foreach ($DB->request($this::getTable(), $query) as $data) {
+         foreach ($DB->request($static::getTable(), $query) as $data) {
             $this->delete(array('id' => $data['id']), 1);
          }
       }
@@ -180,7 +180,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Subject'),
          'datatype'           => 'itemlink',
@@ -189,7 +189,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -198,7 +198,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'create_time',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -207,7 +207,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'send_time',
          'name'               => __('Expected send date'),
          'datatype'           => 'datetime',
@@ -216,7 +216,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'sent_time',
          'name'               => __('Send date'),
          'datatype'           => 'datetime',
@@ -225,7 +225,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'sender',
          'name'               => __('Sender email'),
          'datatype'           => 'text',
@@ -234,7 +234,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'sendername',
          'name'               => __('Sender name'),
          'datatype'           => 'string',
@@ -243,7 +243,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'recipient',
          'name'               => __('Recipient email'),
          'datatype'           => 'string',
@@ -252,7 +252,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'recipientname',
          'name'               => __('Recipient name'),
          'datatype'           => 'string',
@@ -261,7 +261,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'replyto',
          'name'               => __('Reply-to email'),
          'datatype'           => 'string',
@@ -270,7 +270,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'replytoname',
          'name'               => __('Reply-to name'),
          'datatype'           => 'string',
@@ -279,7 +279,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'headers',
          'name'               => __('Additional headers'),
          'datatype'           => 'specific',
@@ -288,7 +288,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'body_html',
          'name'               => __('Email HTML body'),
          'datatype'           => 'text',
@@ -298,7 +298,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'body_text',
          'name'               => __('Email text body'),
          'datatype'           => 'text',
@@ -307,7 +307,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'messageid',
          'name'               => __('Message ID'),
          'datatype'           => 'string',
@@ -316,7 +316,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'sent_try',
          'name'               => __('Number of tries of sent'),
          'datatype'           => 'integer',
@@ -325,7 +325,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '20',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'itemtype',
          'name'               => __('Type'),
          'datatype'           => 'itemtype',
@@ -334,7 +334,7 @@ class QueuedMail extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'items_id',
          'name'               => __('Associated item ID'),
          'massiveaction'      => false,

--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -311,7 +311,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'datatype'           => 'itemlink',
@@ -331,7 +331,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'state',
          'name'               => __('Status'),
          'datatype'           => 'specific',
@@ -341,7 +341,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'text',
          'name'               => __('Description'),
          'massiveaction'      => false,
@@ -351,7 +351,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'begin_view_date',
          'name'               => __('Visibility start date'),
          'datatype'           => 'datetime'
@@ -359,7 +359,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'end_view_date',
          'name'               => __('Visibility end date'),
          'datatype'           => 'datetime'
@@ -367,7 +367,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_planned',
          'name'               => __('Planning'),
          'datatype'           => 'bool',
@@ -376,7 +376,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'begin',
          'name'               => __('Planning start date'),
          'datatype'           => 'datetime'
@@ -384,7 +384,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'end',
          'name'               => __('Planning end date'),
          'datatype'           => 'datetime'
@@ -392,7 +392,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -401,7 +401,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -311,7 +311,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'datatype'           => 'itemlink',
@@ -331,7 +331,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'state',
          'name'               => __('Status'),
          'datatype'           => 'specific',
@@ -341,7 +341,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'text',
          'name'               => __('Description'),
          'massiveaction'      => false,
@@ -351,7 +351,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'begin_view_date',
          'name'               => __('Visibility start date'),
          'datatype'           => 'datetime'
@@ -359,7 +359,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'end_view_date',
          'name'               => __('Visibility end date'),
          'datatype'           => 'datetime'
@@ -367,7 +367,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_planned',
          'name'               => __('Planning'),
          'datatype'           => 'bool',
@@ -376,7 +376,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'begin',
          'name'               => __('Planning start date'),
          'datatype'           => 'datetime'
@@ -384,7 +384,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'end',
          'name'               => __('Planning end date'),
          'datatype'           => 'datetime'
@@ -392,7 +392,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -401,7 +401,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -311,7 +311,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Title'),
          'datatype'           => 'itemlink',
@@ -331,7 +331,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'state',
          'name'               => __('Status'),
          'datatype'           => 'specific',
@@ -341,7 +341,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'text',
          'name'               => __('Description'),
          'massiveaction'      => false,
@@ -351,7 +351,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'begin_view_date',
          'name'               => __('Visibility start date'),
          'datatype'           => 'datetime'
@@ -359,7 +359,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'end_view_date',
          'name'               => __('Visibility end date'),
          'datatype'           => 'datetime'
@@ -367,7 +367,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_planned',
          'name'               => __('Planning'),
          'datatype'           => 'bool',
@@ -376,7 +376,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'begin',
          'name'               => __('Planning start date'),
          'datatype'           => 'datetime'
@@ -384,7 +384,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'end',
          'name'               => __('Planning end date'),
          'datatype'           => 'datetime'
@@ -392,7 +392,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -401,7 +401,7 @@ class Reminder extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/requesttype.class.php
+++ b/inc/requesttype.class.php
@@ -79,7 +79,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_helpdesk_default',
          'name'               => __('Default for tickets'),
          'datatype'           => 'bool',
@@ -88,7 +88,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '182',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_followup_default',
          'name'               => __('Default for followups'),
          'datatype'           => 'bool',
@@ -97,7 +97,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_mail_default',
          'name'               => __('Default for mail recipients'),
          'datatype'           => 'bool',
@@ -106,7 +106,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '183',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_mailfollowup_default',
          'name'               => __('Default for followup mail recipients'),
          'datatype'           => 'bool',
@@ -115,7 +115,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -123,7 +123,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '180',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_ticketheader',
          'name'               => __('Request source visible for tickets'),
          'datatype'           => 'bool'
@@ -131,7 +131,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '181',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_ticketfollowup',
          'name'               => __('Request source visible for followups'),
          'datatype'           => 'bool'
@@ -145,28 +145,28 @@ class RequestType extends CommonDropdown {
       global $DB;
 
       if (isset($this->input["is_helpdesk_default"]) && $this->input["is_helpdesk_default"]) {
-         $query = "UPDATE `".$static::getTable()."`
+         $query = "UPDATE `".static::getTable()."`
                    SET `is_helpdesk_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
       }
 
       if (isset($this->input["is_followup_default"]) && $this->input["is_followup_default"]) {
-         $query = "UPDATE `".$static::getTable()."`
+         $query = "UPDATE `".static::getTable()."`
                    SET `is_followup_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
       }
 
       if (isset($this->input["is_mail_default"]) && $this->input["is_mail_default"]) {
-         $query = "UPDATE `".$static::getTable()."`
+         $query = "UPDATE `".static::getTable()."`
                    SET `is_mail_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
       }
 
       if (isset($this->input["is_mailfollowup_default"]) && $this->input["is_mailfollowup_default"]) {
-         $query = "UPDATE `".$static::getTable()."`
+         $query = "UPDATE `".static::getTable()."`
                    SET `is_mailfollowup_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
@@ -183,7 +183,7 @@ class RequestType extends CommonDropdown {
       if (in_array('is_helpdesk_default', $this->updates)) {
 
          if ($this->input["is_helpdesk_default"]) {
-            $query = "UPDATE `".$static::getTable()."`
+            $query = "UPDATE `".static::getTable()."`
                       SET `is_helpdesk_default` = '0'
                       WHERE `id` <> '".$this->input['id']."'";
             $DB->query($query);
@@ -196,7 +196,7 @@ class RequestType extends CommonDropdown {
       if (in_array('is_followup_default', $this->updates)) {
 
          if ($this->input["is_followup_default"]) {
-            $query = "UPDATE `".$static::getTable()."`
+            $query = "UPDATE `".static::getTable()."`
                       SET `is_followup_default` = '0'
                       WHERE `id` <> '".$this->input['id']."'";
             $DB->query($query);
@@ -209,7 +209,7 @@ class RequestType extends CommonDropdown {
       if (in_array('is_mail_default', $this->updates)) {
 
          if ($this->input["is_mail_default"]) {
-            $query = "UPDATE `".$static::getTable()."`
+            $query = "UPDATE `".static::getTable()."`
                       SET `is_mail_default` = '0'
                       WHERE `id` <> '".$this->input['id']."'";
             $DB->query($query);
@@ -222,7 +222,7 @@ class RequestType extends CommonDropdown {
       if (in_array('is_mailfollowup_default', $this->updates)) {
 
          if ($this->input["is_mailfollowup_default"]) {
-            $query = "UPDATE `".$static::getTable()."`
+            $query = "UPDATE `".static::getTable()."`
                       SET `is_mailfollowup_default` = '0'
                       WHERE `id` <> '".$this->input['id']."'";
             $DB->query($query);

--- a/inc/requesttype.class.php
+++ b/inc/requesttype.class.php
@@ -79,7 +79,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_helpdesk_default',
          'name'               => __('Default for tickets'),
          'datatype'           => 'bool',
@@ -88,7 +88,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '182',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_followup_default',
          'name'               => __('Default for followups'),
          'datatype'           => 'bool',
@@ -97,7 +97,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_mail_default',
          'name'               => __('Default for mail recipients'),
          'datatype'           => 'bool',
@@ -106,7 +106,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '183',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_mailfollowup_default',
          'name'               => __('Default for followup mail recipients'),
          'datatype'           => 'bool',
@@ -115,7 +115,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -123,7 +123,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '180',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_ticketheader',
          'name'               => __('Request source visible for tickets'),
          'datatype'           => 'bool'
@@ -131,7 +131,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '181',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_ticketfollowup',
          'name'               => __('Request source visible for followups'),
          'datatype'           => 'bool'
@@ -145,28 +145,28 @@ class RequestType extends CommonDropdown {
       global $DB;
 
       if (isset($this->input["is_helpdesk_default"]) && $this->input["is_helpdesk_default"]) {
-         $query = "UPDATE `".$this::getTable()."`
+         $query = "UPDATE `".$static::getTable()."`
                    SET `is_helpdesk_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
       }
 
       if (isset($this->input["is_followup_default"]) && $this->input["is_followup_default"]) {
-         $query = "UPDATE `".$this::getTable()."`
+         $query = "UPDATE `".$static::getTable()."`
                    SET `is_followup_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
       }
 
       if (isset($this->input["is_mail_default"]) && $this->input["is_mail_default"]) {
-         $query = "UPDATE `".$this::getTable()."`
+         $query = "UPDATE `".$static::getTable()."`
                    SET `is_mail_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
       }
 
       if (isset($this->input["is_mailfollowup_default"]) && $this->input["is_mailfollowup_default"]) {
-         $query = "UPDATE `".$this::getTable()."`
+         $query = "UPDATE `".$static::getTable()."`
                    SET `is_mailfollowup_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
@@ -183,7 +183,7 @@ class RequestType extends CommonDropdown {
       if (in_array('is_helpdesk_default', $this->updates)) {
 
          if ($this->input["is_helpdesk_default"]) {
-            $query = "UPDATE `".$this::getTable()."`
+            $query = "UPDATE `".$static::getTable()."`
                       SET `is_helpdesk_default` = '0'
                       WHERE `id` <> '".$this->input['id']."'";
             $DB->query($query);
@@ -196,7 +196,7 @@ class RequestType extends CommonDropdown {
       if (in_array('is_followup_default', $this->updates)) {
 
          if ($this->input["is_followup_default"]) {
-            $query = "UPDATE `".$this::getTable()."`
+            $query = "UPDATE `".$static::getTable()."`
                       SET `is_followup_default` = '0'
                       WHERE `id` <> '".$this->input['id']."'";
             $DB->query($query);
@@ -209,7 +209,7 @@ class RequestType extends CommonDropdown {
       if (in_array('is_mail_default', $this->updates)) {
 
          if ($this->input["is_mail_default"]) {
-            $query = "UPDATE `".$this::getTable()."`
+            $query = "UPDATE `".$static::getTable()."`
                       SET `is_mail_default` = '0'
                       WHERE `id` <> '".$this->input['id']."'";
             $DB->query($query);
@@ -222,7 +222,7 @@ class RequestType extends CommonDropdown {
       if (in_array('is_mailfollowup_default', $this->updates)) {
 
          if ($this->input["is_mailfollowup_default"]) {
-            $query = "UPDATE `".$this::getTable()."`
+            $query = "UPDATE `".$static::getTable()."`
                       SET `is_mailfollowup_default` = '0'
                       WHERE `id` <> '".$this->input['id']."'";
             $DB->query($query);

--- a/inc/requesttype.class.php
+++ b/inc/requesttype.class.php
@@ -79,7 +79,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_helpdesk_default',
          'name'               => __('Default for tickets'),
          'datatype'           => 'bool',
@@ -88,7 +88,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '182',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_followup_default',
          'name'               => __('Default for followups'),
          'datatype'           => 'bool',
@@ -97,7 +97,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_mail_default',
          'name'               => __('Default for mail recipients'),
          'datatype'           => 'bool',
@@ -106,7 +106,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '183',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_mailfollowup_default',
          'name'               => __('Default for followup mail recipients'),
          'datatype'           => 'bool',
@@ -115,7 +115,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -123,7 +123,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '180',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_ticketheader',
          'name'               => __('Request source visible for tickets'),
          'datatype'           => 'bool'
@@ -131,7 +131,7 @@ class RequestType extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '181',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_ticketfollowup',
          'name'               => __('Request source visible for followups'),
          'datatype'           => 'bool'
@@ -145,28 +145,28 @@ class RequestType extends CommonDropdown {
       global $DB;
 
       if (isset($this->input["is_helpdesk_default"]) && $this->input["is_helpdesk_default"]) {
-         $query = "UPDATE `".$this->getTable()."`
+         $query = "UPDATE `".$this::getTable()."`
                    SET `is_helpdesk_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
       }
 
       if (isset($this->input["is_followup_default"]) && $this->input["is_followup_default"]) {
-         $query = "UPDATE `".$this->getTable()."`
+         $query = "UPDATE `".$this::getTable()."`
                    SET `is_followup_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
       }
 
       if (isset($this->input["is_mail_default"]) && $this->input["is_mail_default"]) {
-         $query = "UPDATE `".$this->getTable()."`
+         $query = "UPDATE `".$this::getTable()."`
                    SET `is_mail_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
       }
 
       if (isset($this->input["is_mailfollowup_default"]) && $this->input["is_mailfollowup_default"]) {
-         $query = "UPDATE `".$this->getTable()."`
+         $query = "UPDATE `".$this::getTable()."`
                    SET `is_mailfollowup_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'";
          $DB->query($query);
@@ -183,7 +183,7 @@ class RequestType extends CommonDropdown {
       if (in_array('is_helpdesk_default', $this->updates)) {
 
          if ($this->input["is_helpdesk_default"]) {
-            $query = "UPDATE `".$this->getTable()."`
+            $query = "UPDATE `".$this::getTable()."`
                       SET `is_helpdesk_default` = '0'
                       WHERE `id` <> '".$this->input['id']."'";
             $DB->query($query);
@@ -196,7 +196,7 @@ class RequestType extends CommonDropdown {
       if (in_array('is_followup_default', $this->updates)) {
 
          if ($this->input["is_followup_default"]) {
-            $query = "UPDATE `".$this->getTable()."`
+            $query = "UPDATE `".$this::getTable()."`
                       SET `is_followup_default` = '0'
                       WHERE `id` <> '".$this->input['id']."'";
             $DB->query($query);
@@ -209,7 +209,7 @@ class RequestType extends CommonDropdown {
       if (in_array('is_mail_default', $this->updates)) {
 
          if ($this->input["is_mail_default"]) {
-            $query = "UPDATE `".$this->getTable()."`
+            $query = "UPDATE `".$this::getTable()."`
                       SET `is_mail_default` = '0'
                       WHERE `id` <> '".$this->input['id']."'";
             $DB->query($query);
@@ -222,7 +222,7 @@ class RequestType extends CommonDropdown {
       if (in_array('is_mailfollowup_default', $this->updates)) {
 
          if ($this->input["is_mailfollowup_default"]) {
-            $query = "UPDATE `".$this->getTable()."`
+            $query = "UPDATE `".$this::getTable()."`
                       SET `is_mailfollowup_default` = '0'
                       WHERE `id` <> '".$this->input['id']."'";
             $DB->query($query);

--- a/inc/reservation.class.php
+++ b/inc/reservation.class.php
@@ -240,7 +240,7 @@ class Reservation extends CommonDBChild {
          $ID_where = " `id` <> '".$this->fields["id"]."' AND ";
       }
       $query = "SELECT *
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE $ID_where
                       `reservationitems_id` = '".$this->fields["reservationitems_id"]."'
                       AND '".$this->fields["begin"]."' < `end`

--- a/inc/reservation.class.php
+++ b/inc/reservation.class.php
@@ -240,7 +240,7 @@ class Reservation extends CommonDBChild {
          $ID_where = " `id` <> '".$this->fields["id"]."' AND ";
       }
       $query = "SELECT *
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE $ID_where
                       `reservationitems_id` = '".$this->fields["reservationitems_id"]."'
                       AND '".$this->fields["begin"]."' < `end`

--- a/inc/reservation.class.php
+++ b/inc/reservation.class.php
@@ -240,7 +240,7 @@ class Reservation extends CommonDBChild {
          $ID_where = " `id` <> '".$this->fields["id"]."' AND ";
       }
       $query = "SELECT *
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE $ID_where
                       `reservationitems_id` = '".$this->fields["reservationitems_id"]."'
                       AND '".$this->fields["begin"]."' < `end`

--- a/inc/reservationitem.class.php
+++ b/inc/reservationitem.class.php
@@ -117,8 +117,8 @@ class ReservationItem extends CommonDBChild {
    **/
    function getFromDBbyItem($itemtype, $ID) {
 
-      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`itemtype` = '$itemtype'
-                                            AND `".$this::getTable()."`.`items_id` = '$ID'");
+      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`itemtype` = '$itemtype'
+                                            AND `".$static::getTable()."`.`items_id` = '$ID'");
    }
 
 
@@ -138,7 +138,7 @@ class ReservationItem extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -146,7 +146,7 @@ class ReservationItem extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -180,7 +180,7 @@ class ReservationItem extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => '_virtual',
          'name'               => __('Planning'),
          'datatype'           => 'specific',

--- a/inc/reservationitem.class.php
+++ b/inc/reservationitem.class.php
@@ -117,8 +117,8 @@ class ReservationItem extends CommonDBChild {
    **/
    function getFromDBbyItem($itemtype, $ID) {
 
-      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`itemtype` = '$itemtype'
-                                            AND `".$static::getTable()."`.`items_id` = '$ID'");
+      return $this->getFromDBByQuery("WHERE `".static::getTable()."`.`itemtype` = '$itemtype'
+                                            AND `".static::getTable()."`.`items_id` = '$ID'");
    }
 
 
@@ -138,7 +138,7 @@ class ReservationItem extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -146,7 +146,7 @@ class ReservationItem extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -180,7 +180,7 @@ class ReservationItem extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => '_virtual',
          'name'               => __('Planning'),
          'datatype'           => 'specific',

--- a/inc/reservationitem.class.php
+++ b/inc/reservationitem.class.php
@@ -117,8 +117,8 @@ class ReservationItem extends CommonDBChild {
    **/
    function getFromDBbyItem($itemtype, $ID) {
 
-      return $this->getFromDBByQuery("WHERE `".$this->getTable()."`.`itemtype` = '$itemtype'
-                                            AND `".$this->getTable()."`.`items_id` = '$ID'");
+      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`itemtype` = '$itemtype'
+                                            AND `".$this::getTable()."`.`items_id` = '$ID'");
    }
 
 
@@ -138,7 +138,7 @@ class ReservationItem extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -146,7 +146,7 @@ class ReservationItem extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -180,7 +180,7 @@ class ReservationItem extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => '_virtual',
          'name'               => __('Planning'),
          'datatype'           => 'specific',

--- a/inc/rssfeed.class.php
+++ b/inc/rssfeed.class.php
@@ -331,7 +331,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -351,7 +351,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'url',
          'name'               => __('URL'),
          'datatype'           => 'string',
@@ -360,7 +360,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool',
@@ -369,7 +369,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'have_error',
          'name'               => __('Error'),
          'datatype'           => 'bool',
@@ -378,7 +378,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'max_items',
          'name'               => __('Number of items displayed'),
          'datatype'           => 'number',
@@ -391,7 +391,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -399,7 +399,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'refresh_rate',
          'name'               => __('Refresh rate'),
          'datatype'           => 'timestamp',
@@ -419,7 +419,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -428,7 +428,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/rssfeed.class.php
+++ b/inc/rssfeed.class.php
@@ -331,7 +331,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -351,7 +351,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'url',
          'name'               => __('URL'),
          'datatype'           => 'string',
@@ -360,7 +360,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool',
@@ -369,7 +369,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'have_error',
          'name'               => __('Error'),
          'datatype'           => 'bool',
@@ -378,7 +378,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'max_items',
          'name'               => __('Number of items displayed'),
          'datatype'           => 'number',
@@ -391,7 +391,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -399,7 +399,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'refresh_rate',
          'name'               => __('Refresh rate'),
          'datatype'           => 'timestamp',
@@ -419,7 +419,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -428,7 +428,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/rssfeed.class.php
+++ b/inc/rssfeed.class.php
@@ -331,7 +331,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -351,7 +351,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'url',
          'name'               => __('URL'),
          'datatype'           => 'string',
@@ -360,7 +360,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool',
@@ -369,7 +369,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'have_error',
          'name'               => __('Error'),
          'datatype'           => 'bool',
@@ -378,7 +378,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'max_items',
          'name'               => __('Number of items displayed'),
          'datatype'           => 'number',
@@ -391,7 +391,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -399,7 +399,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'refresh_rate',
          'name'               => __('Refresh rate'),
          'datatype'           => 'timestamp',
@@ -419,7 +419,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -428,7 +428,7 @@ class RSSFeed extends CommonDBVisible {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -691,7 +691,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -700,7 +700,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'ranking',
          'name'               => __('Position'),
          'datatype'           => 'number',
@@ -709,7 +709,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'description',
          'name'               => __('Description'),
          'datatype'           => 'text'
@@ -717,7 +717,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'match',
          'name'               => __('Logical operator'),
          'datatype'           => 'specific',
@@ -726,7 +726,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -734,7 +734,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -751,7 +751,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool',
@@ -760,7 +760,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -769,7 +769,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -2693,12 +2693,12 @@ class Rule extends CommonDBTM {
       /// TODO : not working for SLALevels : no sub_type
 
       //Get all the rules whose sub_type is $sub_type and entity is $ID
-      $query = "SELECT `".$this::getTable()."`.`id`
+      $query = "SELECT `".$static::getTable()."`.`id`
                 FROM `".getTableForItemType($this->ruleactionclass)."`,
-                     `".$this::getTable()."`
+                     `".$static::getTable()."`
                 WHERE `".getTableForItemType($this->ruleactionclass)."`.".$this->rules_id_field."
-                           = `".$this::getTable()."`.`id`
-                      AND `".$this::getTable()."`.`sub_type` = '".get_class($this)."'";
+                           = `".$static::getTable()."`.`id`
+                      AND `".$static::getTable()."`.`sub_type` = '".get_class($this)."'";
 
       foreach ($crit as $field => $value) {
          $query .= " AND `".getTableForItemType($this->ruleactionclass)."`.`$field` = '$value'";

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -691,7 +691,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -700,7 +700,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'ranking',
          'name'               => __('Position'),
          'datatype'           => 'number',
@@ -709,7 +709,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'description',
          'name'               => __('Description'),
          'datatype'           => 'text'
@@ -717,7 +717,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'match',
          'name'               => __('Logical operator'),
          'datatype'           => 'specific',
@@ -726,7 +726,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -734,7 +734,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -751,7 +751,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool',
@@ -760,7 +760,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -769,7 +769,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -2693,12 +2693,12 @@ class Rule extends CommonDBTM {
       /// TODO : not working for SLALevels : no sub_type
 
       //Get all the rules whose sub_type is $sub_type and entity is $ID
-      $query = "SELECT `".$static::getTable()."`.`id`
+      $query = "SELECT `".static::getTable()."`.`id`
                 FROM `".getTableForItemType($this->ruleactionclass)."`,
-                     `".$static::getTable()."`
+                     `".static::getTable()."`
                 WHERE `".getTableForItemType($this->ruleactionclass)."`.".$this->rules_id_field."
-                           = `".$static::getTable()."`.`id`
-                      AND `".$static::getTable()."`.`sub_type` = '".get_class($this)."'";
+                           = `".static::getTable()."`.`id`
+                      AND `".static::getTable()."`.`sub_type` = '".get_class($this)."'";
 
       foreach ($crit as $field => $value) {
          $query .= " AND `".getTableForItemType($this->ruleactionclass)."`.`$field` = '$value'";

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -691,7 +691,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -700,7 +700,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'ranking',
          'name'               => __('Position'),
          'datatype'           => 'number',
@@ -709,7 +709,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'description',
          'name'               => __('Description'),
          'datatype'           => 'text'
@@ -717,7 +717,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'match',
          'name'               => __('Logical operator'),
          'datatype'           => 'specific',
@@ -726,7 +726,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -734,7 +734,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -751,7 +751,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool',
@@ -760,7 +760,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -769,7 +769,7 @@ class Rule extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -2693,12 +2693,12 @@ class Rule extends CommonDBTM {
       /// TODO : not working for SLALevels : no sub_type
 
       //Get all the rules whose sub_type is $sub_type and entity is $ID
-      $query = "SELECT `".$this->getTable()."`.`id`
+      $query = "SELECT `".$this::getTable()."`.`id`
                 FROM `".getTableForItemType($this->ruleactionclass)."`,
-                     `".$this->getTable()."`
+                     `".$this::getTable()."`
                 WHERE `".getTableForItemType($this->ruleactionclass)."`.".$this->rules_id_field."
-                           = `".$this->getTable()."`.`id`
-                      AND `".$this->getTable()."`.`sub_type` = '".get_class($this)."'";
+                           = `".$this::getTable()."`.`id`
+                      AND `".$this::getTable()."`.`sub_type` = '".get_class($this)."'";
 
       foreach ($crit as $field => $value) {
          $query .= " AND `".getTableForItemType($this->ruleactionclass)."`.`$field` = '$value'";
@@ -2756,7 +2756,7 @@ class Rule extends CommonDBTM {
       }
 
          //Get all rules and actions
-      $crit = array('field' => getForeignKeyFieldForTable($item->getTable()),
+      $crit = array('field' => getForeignKeyFieldForTable($item::getTable()),
                     'value' => $item->getField('id'));
 
       $rules = $this->getRulesForCriteria($crit);
@@ -2904,10 +2904,10 @@ class Rule extends CommonDBTM {
                                                         $valfield, $fieldfield) {
       global $DB;
 
-      $fieldid = getForeignKeyFieldForTable($ruleitem->getTable());
+      $fieldid = getForeignKeyFieldForTable($ruleitem::getTable());
 
       if (empty($field)) {
-         $field = getForeignKeyFieldForTable($item->getTable());
+         $field = getForeignKeyFieldForTable($item::getTable());
       }
 
       if (isset($item->input['_replace_by']) && ($item->input['_replace_by'] > 0)) {

--- a/inc/ruleaction.class.php
+++ b/inc/ruleaction.class.php
@@ -153,7 +153,7 @@ class RuleAction extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'action_type',
          'name'               => self::getTypeName(1),
          'massiveaction'      => false,
@@ -163,7 +163,7 @@ class RuleAction extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'field',
          'name'               => _n('Field', 'Fields', Session::getPluralNumber()),
          'massiveaction'      => false,
@@ -173,7 +173,7 @@ class RuleAction extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'value',
          'name'               => __('Value'),
          'massiveaction'      => false,
@@ -303,7 +303,7 @@ class RuleAction extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$static::getTable()."`
+              FROM `".static::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
       $result = $DB->query($sql);
@@ -453,7 +453,7 @@ class RuleAction extends CommonDBChild {
 
          $actions = array();
          $res     = $DB->query("SELECT `field`
-                                FROM `".$static::getTable()."`
+                                FROM `".static::getTable()."`
                                 WHERE `".static::$items_id."` = '".$rules_id."'");
 
          while ($action = $DB->fetch_assoc($res)) {

--- a/inc/ruleaction.class.php
+++ b/inc/ruleaction.class.php
@@ -153,7 +153,7 @@ class RuleAction extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'action_type',
          'name'               => self::getTypeName(1),
          'massiveaction'      => false,
@@ -163,7 +163,7 @@ class RuleAction extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'field',
          'name'               => _n('Field', 'Fields', Session::getPluralNumber()),
          'massiveaction'      => false,
@@ -173,7 +173,7 @@ class RuleAction extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'value',
          'name'               => __('Value'),
          'massiveaction'      => false,
@@ -303,7 +303,7 @@ class RuleAction extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$this::getTable()."`
+              FROM `".$static::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
       $result = $DB->query($sql);
@@ -453,7 +453,7 @@ class RuleAction extends CommonDBChild {
 
          $actions = array();
          $res     = $DB->query("SELECT `field`
-                                FROM `".$this::getTable()."`
+                                FROM `".$static::getTable()."`
                                 WHERE `".static::$items_id."` = '".$rules_id."'");
 
          while ($action = $DB->fetch_assoc($res)) {

--- a/inc/ruleaction.class.php
+++ b/inc/ruleaction.class.php
@@ -153,7 +153,7 @@ class RuleAction extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'action_type',
          'name'               => self::getTypeName(1),
          'massiveaction'      => false,
@@ -163,7 +163,7 @@ class RuleAction extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'field',
          'name'               => _n('Field', 'Fields', Session::getPluralNumber()),
          'massiveaction'      => false,
@@ -173,7 +173,7 @@ class RuleAction extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'value',
          'name'               => __('Value'),
          'massiveaction'      => false,
@@ -303,7 +303,7 @@ class RuleAction extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$this->getTable()."`
+              FROM `".$this::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
       $result = $DB->query($sql);
@@ -453,7 +453,7 @@ class RuleAction extends CommonDBChild {
 
          $actions = array();
          $res     = $DB->query("SELECT `field`
-                                FROM `".$this->getTable()."`
+                                FROM `".$this::getTable()."`
                                 WHERE `".static::$items_id."` = '".$rules_id."'");
 
          while ($action = $DB->fetch_assoc($res)) {

--- a/inc/rulecriteria.class.php
+++ b/inc/rulecriteria.class.php
@@ -156,7 +156,7 @@ class RuleCriteria extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'criteria',
          'name'               => __('Name'),
          'massiveaction'      => false,
@@ -166,7 +166,7 @@ class RuleCriteria extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'condition',
          'name'               => __('Condition'),
          'massiveaction'      => false,
@@ -176,7 +176,7 @@ class RuleCriteria extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'pattern',
          'name'               => __('Reason'),
          'massiveaction'      => false,
@@ -317,7 +317,7 @@ class RuleCriteria extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$this->getTable()."`
+              FROM `".$this::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
 

--- a/inc/rulecriteria.class.php
+++ b/inc/rulecriteria.class.php
@@ -156,7 +156,7 @@ class RuleCriteria extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'criteria',
          'name'               => __('Name'),
          'massiveaction'      => false,
@@ -166,7 +166,7 @@ class RuleCriteria extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'condition',
          'name'               => __('Condition'),
          'massiveaction'      => false,
@@ -176,7 +176,7 @@ class RuleCriteria extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'pattern',
          'name'               => __('Reason'),
          'massiveaction'      => false,
@@ -317,7 +317,7 @@ class RuleCriteria extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$this::getTable()."`
+              FROM `".$static::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
 

--- a/inc/rulecriteria.class.php
+++ b/inc/rulecriteria.class.php
@@ -156,7 +156,7 @@ class RuleCriteria extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'criteria',
          'name'               => __('Name'),
          'massiveaction'      => false,
@@ -166,7 +166,7 @@ class RuleCriteria extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'condition',
          'name'               => __('Condition'),
          'massiveaction'      => false,
@@ -176,7 +176,7 @@ class RuleCriteria extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'pattern',
          'name'               => __('Reason'),
          'massiveaction'      => false,
@@ -317,7 +317,7 @@ class RuleCriteria extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$static::getTable()."`
+              FROM `".static::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
 

--- a/inc/rulerightparameter.class.php
+++ b/inc/rulerightparameter.class.php
@@ -71,7 +71,7 @@ class RuleRightParameter extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'value',
          'name'               => _n('Criterion', 'Criteria', 1),
          'datatype'           => 'string'

--- a/inc/rulerightparameter.class.php
+++ b/inc/rulerightparameter.class.php
@@ -71,7 +71,7 @@ class RuleRightParameter extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'value',
          'name'               => _n('Criterion', 'Criteria', 1),
          'datatype'           => 'string'

--- a/inc/rulerightparameter.class.php
+++ b/inc/rulerightparameter.class.php
@@ -71,7 +71,7 @@ class RuleRightParameter extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'value',
          'name'               => _n('Criterion', 'Criteria', 1),
          'datatype'           => 'string'

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5454,7 +5454,7 @@ class Search {
             $itemtable = $CFG_GLPI['union_search_type'][$itemtype];
          } else {
             if ($item = getItemForItemtype($itemtype)) {
-               $itemtable = $item->getTable();
+               $itemtable = $item::getTable();
             }
          }
 

--- a/inc/sla.class.php
+++ b/inc/sla.class.php
@@ -132,7 +132,7 @@ class SLA extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -141,7 +141,7 @@ class SLA extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,

--- a/inc/sla.class.php
+++ b/inc/sla.class.php
@@ -132,7 +132,7 @@ class SLA extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -141,7 +141,7 @@ class SLA extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,

--- a/inc/sla.class.php
+++ b/inc/sla.class.php
@@ -132,7 +132,7 @@ class SLA extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -141,7 +141,7 @@ class SLA extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,

--- a/inc/slalevel.class.php
+++ b/inc/slalevel.class.php
@@ -490,7 +490,7 @@ class SlaLevel extends RuleTicket {
          switch ($item->getType()) {
             case 'SLT' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb =  countElementsInTable($this->getTable(), ['slts_id' => $item->getID()]);
+                  $nb =  countElementsInTable($this::getTable(), ['slts_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
          }

--- a/inc/slalevel.class.php
+++ b/inc/slalevel.class.php
@@ -490,7 +490,7 @@ class SlaLevel extends RuleTicket {
          switch ($item->getType()) {
             case 'SLT' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb =  countElementsInTable($static::getTable(), ['slts_id' => $item->getID()]);
+                  $nb =  countElementsInTable(static::getTable(), ['slts_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
          }

--- a/inc/slalevel.class.php
+++ b/inc/slalevel.class.php
@@ -490,7 +490,7 @@ class SlaLevel extends RuleTicket {
          switch ($item->getType()) {
             case 'SLT' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb =  countElementsInTable($this::getTable(), ['slts_id' => $item->getID()]);
+                  $nb =  countElementsInTable($static::getTable(), ['slts_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
          }

--- a/inc/slalevel_ticket.class.php
+++ b/inc/slalevel_ticket.class.php
@@ -57,7 +57,7 @@ class SlaLevel_Ticket extends CommonDBTM {
       $query = "LEFT JOIN `glpi_slalevels`
                      ON (`glpi_slalevels_tickets`.`slalevels_id` = `glpi_slalevels`.`id`)
                 LEFT JOIN `glpi_slts` ON (`glpi_slalevels`.`slts_id` = `glpi_slts`.`id`)
-                WHERE `".$this->getTable()."`.`tickets_id` = '$ID'
+                WHERE `".$this::getTable()."`.`tickets_id` = '$ID'
                       AND `glpi_slts`.`type` = '$sltType'
                 LIMIT 1";
 

--- a/inc/slalevel_ticket.class.php
+++ b/inc/slalevel_ticket.class.php
@@ -57,7 +57,7 @@ class SlaLevel_Ticket extends CommonDBTM {
       $query = "LEFT JOIN `glpi_slalevels`
                      ON (`glpi_slalevels_tickets`.`slalevels_id` = `glpi_slalevels`.`id`)
                 LEFT JOIN `glpi_slts` ON (`glpi_slalevels`.`slts_id` = `glpi_slts`.`id`)
-                WHERE `".$static::getTable()."`.`tickets_id` = '$ID'
+                WHERE `".static::getTable()."`.`tickets_id` = '$ID'
                       AND `glpi_slts`.`type` = '$sltType'
                 LIMIT 1";
 

--- a/inc/slalevel_ticket.class.php
+++ b/inc/slalevel_ticket.class.php
@@ -57,7 +57,7 @@ class SlaLevel_Ticket extends CommonDBTM {
       $query = "LEFT JOIN `glpi_slalevels`
                      ON (`glpi_slalevels_tickets`.`slalevels_id` = `glpi_slalevels`.`id`)
                 LEFT JOIN `glpi_slts` ON (`glpi_slalevels`.`slts_id` = `glpi_slts`.`id`)
-                WHERE `".$this::getTable()."`.`tickets_id` = '$ID'
+                WHERE `".$static::getTable()."`.`tickets_id` = '$ID'
                       AND `glpi_slts`.`type` = '$sltType'
                 LIMIT 1";
 

--- a/inc/slt.class.php
+++ b/inc/slt.class.php
@@ -435,7 +435,7 @@ class SLT extends CommonDBChild {
             $field = 'slts_tto_id';
             break;
       }
-      return $this->getFromDBByQuery("INNER JOIN `glpi_tickets` ON (`glpi_tickets`.`$field` = `".$this->getTable()."`.`id`) WHERE `glpi_tickets`.`id` = '".$tickets_id."' LIMIT 1");
+      return $this->getFromDBByQuery("INNER JOIN `glpi_tickets` ON (`glpi_tickets`.`$field` = `".$this::getTable()."`.`id`) WHERE `glpi_tickets`.`id` = '".$tickets_id."' LIMIT 1");
    }
 
 
@@ -676,7 +676,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -685,7 +685,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -694,7 +694,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'number_time',
          'name'               => __('Time'),
          'datatype'           => 'specific',
@@ -705,7 +705,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'end_of_working_day',
          'name'               => __('End of working day'),
          'datatype'           => 'bool',
@@ -714,7 +714,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'type',
          'name'               => __('Type'),
          'datatype'           => 'specific'
@@ -730,7 +730,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/slt.class.php
+++ b/inc/slt.class.php
@@ -435,7 +435,7 @@ class SLT extends CommonDBChild {
             $field = 'slts_tto_id';
             break;
       }
-      return $this->getFromDBByQuery("INNER JOIN `glpi_tickets` ON (`glpi_tickets`.`$field` = `".$static::getTable()."`.`id`) WHERE `glpi_tickets`.`id` = '".$tickets_id."' LIMIT 1");
+      return $this->getFromDBByQuery("INNER JOIN `glpi_tickets` ON (`glpi_tickets`.`$field` = `".static::getTable()."`.`id`) WHERE `glpi_tickets`.`id` = '".$tickets_id."' LIMIT 1");
    }
 
 
@@ -676,7 +676,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -685,7 +685,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -694,7 +694,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'number_time',
          'name'               => __('Time'),
          'datatype'           => 'specific',
@@ -705,7 +705,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'end_of_working_day',
          'name'               => __('End of working day'),
          'datatype'           => 'bool',
@@ -714,7 +714,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'type',
          'name'               => __('Type'),
          'datatype'           => 'specific'
@@ -730,7 +730,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/slt.class.php
+++ b/inc/slt.class.php
@@ -435,7 +435,7 @@ class SLT extends CommonDBChild {
             $field = 'slts_tto_id';
             break;
       }
-      return $this->getFromDBByQuery("INNER JOIN `glpi_tickets` ON (`glpi_tickets`.`$field` = `".$this::getTable()."`.`id`) WHERE `glpi_tickets`.`id` = '".$tickets_id."' LIMIT 1");
+      return $this->getFromDBByQuery("INNER JOIN `glpi_tickets` ON (`glpi_tickets`.`$field` = `".$static::getTable()."`.`id`) WHERE `glpi_tickets`.`id` = '".$tickets_id."' LIMIT 1");
    }
 
 
@@ -676,7 +676,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -685,7 +685,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -694,7 +694,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'number_time',
          'name'               => __('Time'),
          'datatype'           => 'specific',
@@ -705,7 +705,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'end_of_working_day',
          'name'               => __('End of working day'),
          'datatype'           => 'bool',
@@ -714,7 +714,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '7',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'type',
          'name'               => __('Type'),
          'datatype'           => 'specific'
@@ -730,7 +730,7 @@ class SLT extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -456,7 +456,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -465,7 +465,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -476,7 +476,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -492,7 +492,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -501,7 +501,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -556,7 +556,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '61',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_helpdesk_visible',
          'name'               => __('Associable to a ticket'),
          'datatype'           => 'bool'
@@ -564,7 +564,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '63',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_valid',
                               //TRANS: Indicator to know is all licenses of the software are valids
          'name'               => __('Valid licenses'),
@@ -609,7 +609,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool',

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -456,7 +456,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -465,7 +465,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -476,7 +476,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -492,7 +492,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -501,7 +501,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -556,7 +556,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '61',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_helpdesk_visible',
          'name'               => __('Associable to a ticket'),
          'datatype'           => 'bool'
@@ -564,7 +564,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '63',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_valid',
                               //TRANS: Indicator to know is all licenses of the software are valids
          'name'               => __('Valid licenses'),
@@ -609,7 +609,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool',

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -456,7 +456,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -465,7 +465,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -476,7 +476,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -492,7 +492,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -501,7 +501,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -556,7 +556,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '61',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_helpdesk_visible',
          'name'               => __('Associable to a ticket'),
          'datatype'           => 'bool'
@@ -564,7 +564,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '63',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_valid',
                               //TRANS: Indicator to know is all licenses of the software are valids
          'name'               => __('Valid licenses'),
@@ -609,7 +609,7 @@ class Software extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool',

--- a/inc/softwarelicense.class.php
+++ b/inc/softwarelicense.class.php
@@ -490,7 +490,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -500,7 +500,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -512,7 +512,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -520,7 +520,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'number',
          'name'               => __('Number'),
          'datatype'           => 'number',
@@ -564,7 +564,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'expire',
          'name'               => __('Expiration'),
          'datatype'           => 'date'
@@ -572,7 +572,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_valid',
          'name'               => __('Valid'),
          'datatype'           => 'bool'
@@ -598,7 +598,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -661,7 +661,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -669,7 +669,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '162',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'massiveaction'      => false,

--- a/inc/softwarelicense.class.php
+++ b/inc/softwarelicense.class.php
@@ -490,7 +490,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -500,7 +500,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -512,7 +512,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -520,7 +520,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'number',
          'name'               => __('Number'),
          'datatype'           => 'number',
@@ -564,7 +564,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'expire',
          'name'               => __('Expiration'),
          'datatype'           => 'date'
@@ -572,7 +572,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_valid',
          'name'               => __('Valid'),
          'datatype'           => 'bool'
@@ -598,7 +598,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -661,7 +661,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -669,7 +669,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '162',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'massiveaction'      => false,

--- a/inc/softwarelicense.class.php
+++ b/inc/softwarelicense.class.php
@@ -490,7 +490,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -500,7 +500,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -512,7 +512,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'serial',
          'name'               => __('Serial number'),
          'datatype'           => 'string'
@@ -520,7 +520,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'number',
          'name'               => __('Number'),
          'datatype'           => 'number',
@@ -564,7 +564,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'expire',
          'name'               => __('Expiration'),
          'datatype'           => 'date'
@@ -572,7 +572,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_valid',
          'name'               => __('Valid'),
          'datatype'           => 'bool'
@@ -598,7 +598,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -661,7 +661,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'
@@ -669,7 +669,7 @@ class SoftwareLicense extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '162',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'otherserial',
          'name'               => __('Inventory number'),
          'massiveaction'      => false,

--- a/inc/softwareversion.class.php
+++ b/inc/softwareversion.class.php
@@ -164,7 +164,7 @@ class SoftwareVersion extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'string'
@@ -180,7 +180,7 @@ class SoftwareVersion extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -197,7 +197,7 @@ class SoftwareVersion extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -355,7 +355,7 @@ class SoftwareVersion extends CommonDBChild {
          switch ($item->getType()) {
             case 'Software' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this->getTable(), ['softwares_id' => $item->getID()]);
+                  $nb = countElementsInTable($this::getTable(), ['softwares_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
          }

--- a/inc/softwareversion.class.php
+++ b/inc/softwareversion.class.php
@@ -164,7 +164,7 @@ class SoftwareVersion extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'string'
@@ -180,7 +180,7 @@ class SoftwareVersion extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -197,7 +197,7 @@ class SoftwareVersion extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -355,7 +355,7 @@ class SoftwareVersion extends CommonDBChild {
          switch ($item->getType()) {
             case 'Software' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($static::getTable(), ['softwares_id' => $item->getID()]);
+                  $nb = countElementsInTable(static::getTable(), ['softwares_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
          }

--- a/inc/softwareversion.class.php
+++ b/inc/softwareversion.class.php
@@ -164,7 +164,7 @@ class SoftwareVersion extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'string'
@@ -180,7 +180,7 @@ class SoftwareVersion extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -197,7 +197,7 @@ class SoftwareVersion extends CommonDBChild {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -355,7 +355,7 @@ class SoftwareVersion extends CommonDBChild {
          switch ($item->getType()) {
             case 'Software' :
                if ($_SESSION['glpishow_count_on_tabs']) {
-                  $nb = countElementsInTable($this::getTable(), ['softwares_id' => $item->getID()]);
+                  $nb = countElementsInTable($static::getTable(), ['softwares_id' => $item->getID()]);
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
          }

--- a/inc/solutiontemplate.class.php
+++ b/inc/solutiontemplate.class.php
@@ -75,7 +75,7 @@ class SolutionTemplate extends CommonDropdown {
          'id'                 => '4',
          'name'               => __('Content'),
          'field'              => 'content',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'datatype'           => 'text',
          'htmltext'           => true
       ];

--- a/inc/solutiontemplate.class.php
+++ b/inc/solutiontemplate.class.php
@@ -75,7 +75,7 @@ class SolutionTemplate extends CommonDropdown {
          'id'                 => '4',
          'name'               => __('Content'),
          'field'              => 'content',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'datatype'           => 'text',
          'htmltext'           => true
       ];

--- a/inc/solutiontemplate.class.php
+++ b/inc/solutiontemplate.class.php
@@ -75,7 +75,7 @@ class SolutionTemplate extends CommonDropdown {
          'id'                 => '4',
          'name'               => __('Content'),
          'field'              => 'content',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'datatype'           => 'text',
          'htmltext'           => true
       ];

--- a/inc/stat.class.php
+++ b/inc/stat.class.php
@@ -224,7 +224,7 @@ class Stat extends CommonGLPI {
          default :
             if (($item = getItemForItemtype($type))
                 && ($item instanceof CommonDevice)) {
-               $device_table = $item->getTable();
+               $device_table = $item::getTable();
 
                //select devices IDs (table row)
                $query = "SELECT `id`, `designation`
@@ -698,22 +698,22 @@ class Stat extends CommonGLPI {
       if (!$item = getItemForItemtype($itemtype)) {
          return;
       }
-      $table          = $item->getTable();
+      $table          = $item::getTable();
       $fkfield        = $item->getForeignKeyField();
 
       if (!($userlinkclass = getItemForItemtype($item->userlinkclass))) {
          return;
       }
-      $userlinktable  = $userlinkclass->getTable();
+      $userlinktable  = $userlinkclass::getTable();
       if (!$grouplinkclass = getItemForItemtype($item->grouplinkclass)) {
          return;
       }
-      $grouplinktable = $grouplinkclass->getTable();
+      $grouplinktable = $grouplinkclass::getTable();
 
       if (!($supplierlinkclass = getItemForItemtype($item->supplierlinkclass))) {
          return;
       }
-      $supplierlinktable = $supplierlinkclass->getTable();
+      $supplierlinktable = $supplierlinkclass::getTable();
 
       $tasktable      = getTableForItemType($item->getType().'Task');
 

--- a/inc/state.class.php
+++ b/inc/state.class.php
@@ -279,7 +279,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_visible_computer',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Computer::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -287,7 +287,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_visible_softwareversion',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'),
                                      SoftwareVersion::getTypeName(Session::getPluralNumber())),
@@ -296,7 +296,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_visible_monitor',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Monitor::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -304,7 +304,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_visible_printer',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Printer::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -312,7 +312,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '25',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_visible_peripheral',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Peripheral::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -320,7 +320,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '26',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_visible_phone',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Phone::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -328,7 +328,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '27',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_visible_networkequipment',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'),
                                      NetworkEquipment::getTypeName(Session::getPluralNumber())),
@@ -337,7 +337,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '28',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_visible_softwarelicense',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'),
                                      SoftwareLicense::getTypeName(Session::getPluralNumber())),

--- a/inc/state.class.php
+++ b/inc/state.class.php
@@ -279,7 +279,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_visible_computer',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Computer::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -287,7 +287,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_visible_softwareversion',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'),
                                      SoftwareVersion::getTypeName(Session::getPluralNumber())),
@@ -296,7 +296,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_visible_monitor',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Monitor::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -304,7 +304,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_visible_printer',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Printer::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -312,7 +312,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '25',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_visible_peripheral',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Peripheral::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -320,7 +320,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '26',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_visible_phone',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Phone::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -328,7 +328,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '27',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_visible_networkequipment',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'),
                                      NetworkEquipment::getTypeName(Session::getPluralNumber())),
@@ -337,7 +337,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '28',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_visible_softwarelicense',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'),
                                      SoftwareLicense::getTypeName(Session::getPluralNumber())),

--- a/inc/state.class.php
+++ b/inc/state.class.php
@@ -279,7 +279,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_visible_computer',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Computer::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -287,7 +287,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_visible_softwareversion',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'),
                                      SoftwareVersion::getTypeName(Session::getPluralNumber())),
@@ -296,7 +296,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_visible_monitor',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Monitor::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -304,7 +304,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_visible_printer',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Printer::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -312,7 +312,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '25',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_visible_peripheral',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Peripheral::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -320,7 +320,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '26',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_visible_phone',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'), Phone::getTypeName(Session::getPluralNumber())),
          'datatype'           => 'bool'
@@ -328,7 +328,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '27',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_visible_networkequipment',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'),
                                      NetworkEquipment::getTypeName(Session::getPluralNumber())),
@@ -337,7 +337,7 @@ class State extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '28',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_visible_softwarelicense',
          'name'               => sprintf(__('%1$s - %2$s'), __('Visibility'),
                                      SoftwareLicense::getTypeName(Session::getPluralNumber())),

--- a/inc/supplier.class.php
+++ b/inc/supplier.class.php
@@ -228,7 +228,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -237,7 +237,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -246,7 +246,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'address',
          'name'               => __('Address'),
          'datatype'           => 'text'
@@ -254,7 +254,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'fax',
          'name'               => __('Fax'),
          'datatype'           => 'string'
@@ -262,7 +262,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'town',
          'name'               => __('City'),
          'datatype'           => 'string'
@@ -270,7 +270,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'postcode',
          'name'               => __('Postal code'),
          'datatype'           => 'string'
@@ -278,7 +278,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'state',
          'name'               => _x('location', 'State'),
          'datatype'           => 'string'
@@ -286,7 +286,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'country',
          'name'               => __('Country'),
          'datatype'           => 'string'
@@ -294,7 +294,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'website',
          'name'               => __('Website'),
          'datatype'           => 'weblink'
@@ -302,7 +302,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'phonenumber',
          'name'               => __('Phone'),
          'datatype'           => 'string'
@@ -310,7 +310,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'email',
          'name'               => _n('Email', 'Emails', 1),
          'datatype'           => 'email'
@@ -326,7 +326,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -335,7 +335,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -372,7 +372,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -389,7 +389,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/supplier.class.php
+++ b/inc/supplier.class.php
@@ -228,7 +228,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -237,7 +237,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -246,7 +246,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'address',
          'name'               => __('Address'),
          'datatype'           => 'text'
@@ -254,7 +254,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'fax',
          'name'               => __('Fax'),
          'datatype'           => 'string'
@@ -262,7 +262,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'town',
          'name'               => __('City'),
          'datatype'           => 'string'
@@ -270,7 +270,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'postcode',
          'name'               => __('Postal code'),
          'datatype'           => 'string'
@@ -278,7 +278,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'state',
          'name'               => _x('location', 'State'),
          'datatype'           => 'string'
@@ -286,7 +286,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'country',
          'name'               => __('Country'),
          'datatype'           => 'string'
@@ -294,7 +294,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'website',
          'name'               => __('Website'),
          'datatype'           => 'weblink'
@@ -302,7 +302,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'phonenumber',
          'name'               => __('Phone'),
          'datatype'           => 'string'
@@ -310,7 +310,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'email',
          'name'               => _n('Email', 'Emails', 1),
          'datatype'           => 'email'
@@ -326,7 +326,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -335,7 +335,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -372,7 +372,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -389,7 +389,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/supplier.class.php
+++ b/inc/supplier.class.php
@@ -228,7 +228,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -237,7 +237,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -246,7 +246,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'address',
          'name'               => __('Address'),
          'datatype'           => 'text'
@@ -254,7 +254,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'fax',
          'name'               => __('Fax'),
          'datatype'           => 'string'
@@ -262,7 +262,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'town',
          'name'               => __('City'),
          'datatype'           => 'string'
@@ -270,7 +270,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'postcode',
          'name'               => __('Postal code'),
          'datatype'           => 'string'
@@ -278,7 +278,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '12',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'state',
          'name'               => _x('location', 'State'),
          'datatype'           => 'string'
@@ -286,7 +286,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'country',
          'name'               => __('Country'),
          'datatype'           => 'string'
@@ -294,7 +294,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'website',
          'name'               => __('Website'),
          'datatype'           => 'weblink'
@@ -302,7 +302,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '5',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'phonenumber',
          'name'               => __('Phone'),
          'datatype'           => 'string'
@@ -310,7 +310,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'email',
          'name'               => _n('Email', 'Emails', 1),
          'datatype'           => 'email'
@@ -326,7 +326,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -335,7 +335,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -372,7 +372,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -389,7 +389,7 @@ class Supplier extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '86',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool'

--- a/inc/supplier_ticket.class.php
+++ b/inc/supplier_ticket.class.php
@@ -62,10 +62,10 @@ class Supplier_Ticket extends CommonITILActor {
       global $DB;
 
       $query = "SELECT *
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 LEFT JOIN `glpi_suppliers`
-                      ON (`".$this->getTable()."`.`suppliers_id` = `glpi_suppliers`.`id`)
-                WHERE `".$this->getTable()."`.`tickets_id` = '".$items_id."'
+                      ON (`".$this::getTable()."`.`suppliers_id` = `glpi_suppliers`.`id`)
+                WHERE `".$this::getTable()."`.`tickets_id` = '".$items_id."'
                       AND `glpi_suppliers`.`email` = '$email'";
 
       foreach ($DB->request($query) as $data) {

--- a/inc/supplier_ticket.class.php
+++ b/inc/supplier_ticket.class.php
@@ -62,10 +62,10 @@ class Supplier_Ticket extends CommonITILActor {
       global $DB;
 
       $query = "SELECT *
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 LEFT JOIN `glpi_suppliers`
-                      ON (`".$static::getTable()."`.`suppliers_id` = `glpi_suppliers`.`id`)
-                WHERE `".$static::getTable()."`.`tickets_id` = '".$items_id."'
+                      ON (`".static::getTable()."`.`suppliers_id` = `glpi_suppliers`.`id`)
+                WHERE `".static::getTable()."`.`tickets_id` = '".$items_id."'
                       AND `glpi_suppliers`.`email` = '$email'";
 
       foreach ($DB->request($query) as $data) {

--- a/inc/supplier_ticket.class.php
+++ b/inc/supplier_ticket.class.php
@@ -62,10 +62,10 @@ class Supplier_Ticket extends CommonITILActor {
       global $DB;
 
       $query = "SELECT *
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 LEFT JOIN `glpi_suppliers`
-                      ON (`".$this::getTable()."`.`suppliers_id` = `glpi_suppliers`.`id`)
-                WHERE `".$this::getTable()."`.`tickets_id` = '".$items_id."'
+                      ON (`".$static::getTable()."`.`suppliers_id` = `glpi_suppliers`.`id`)
+                WHERE `".$static::getTable()."`.`tickets_id` = '".$items_id."'
                       AND `glpi_suppliers`.`email` = '$email'";
 
       foreach ($DB->request($query) as $data) {

--- a/inc/taskcategory.class.php
+++ b/inc/taskcategory.class.php
@@ -71,7 +71,7 @@ class TaskCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'

--- a/inc/taskcategory.class.php
+++ b/inc/taskcategory.class.php
@@ -71,7 +71,7 @@ class TaskCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'

--- a/inc/taskcategory.class.php
+++ b/inc/taskcategory.class.php
@@ -71,7 +71,7 @@ class TaskCategory extends CommonTreeDropdown {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'

--- a/inc/tasktemplate.class.php
+++ b/inc/tasktemplate.class.php
@@ -92,7 +92,7 @@ class TaskTemplate extends CommonDropdown {
          'id'                 => '4',
          'name'               => __('Content'),
          'field'              => 'content',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'datatype'           => 'text',
          'htmltext'           => true
       ];

--- a/inc/tasktemplate.class.php
+++ b/inc/tasktemplate.class.php
@@ -92,7 +92,7 @@ class TaskTemplate extends CommonDropdown {
          'id'                 => '4',
          'name'               => __('Content'),
          'field'              => 'content',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'datatype'           => 'text',
          'htmltext'           => true
       ];

--- a/inc/tasktemplate.class.php
+++ b/inc/tasktemplate.class.php
@@ -92,7 +92,7 @@ class TaskTemplate extends CommonDropdown {
          'id'                 => '4',
          'name'               => __('Content'),
          'field'              => 'content',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'datatype'           => 'text',
          'htmltext'           => true
       ];

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2030,17 +2030,17 @@ class Ticket extends CommonITILObject {
       $result = array();
 
       $query = "SELECT *
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 LEFT JOIN `glpi_items_tickets`
-                  ON (`".$this::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
+                  ON (`".$static::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
                 WHERE `glpi_items_tickets`.`itemtype` = '$itemtype'
                       AND `glpi_items_tickets`.`items_id` = '$items_id'
-                      AND (`".$this::getTable()."`.`status`
+                      AND (`".$static::getTable()."`.`status`
                               NOT IN ('".implode("', '", array_merge($this->getSolvedStatusArray(),
                                                                      $this->getClosedStatusArray())
                                                 )."')
-                            OR (`".$this::getTable()."`.`solvedate` IS NOT NULL
-                                AND ADDDATE(`".$this::getTable()."`.`solvedate`, INTERVAL $days DAY)
+                            OR (`".$static::getTable()."`.`solvedate` IS NOT NULL
+                                AND ADDDATE(`".$static::getTable()."`.`solvedate`, INTERVAL $days DAY)
                                             > NOW()))";
 
       foreach ($DB->request($query) as $tick) {
@@ -2065,12 +2065,12 @@ class Ticket extends CommonITILObject {
       global $DB;
 
       $query = "SELECT COUNT(*) AS cpt
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 LEFT JOIN `glpi_items_tickets`
-                   ON (`".$this::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
+                   ON (`".$static::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
                 WHERE `glpi_items_tickets`.`itemtype` = '$itemtype'
                 AND `glpi_items_tickets`.`items_id` = '$items_id'
-                AND `".$this::getTable()."`.`status`
+                AND `".$static::getTable()."`.`status`
                    NOT IN ('".implode("', '",
                             array_merge($this->getSolvedStatusArray(),
                                         $this->getClosedStatusArray())
@@ -2098,15 +2098,15 @@ class Ticket extends CommonITILObject {
       global $DB;
 
       $query = "SELECT COUNT(*) AS cpt
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 LEFT JOIN `glpi_items_tickets`
-                   ON (`".$this::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
+                   ON (`".$static::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
                 WHERE `glpi_items_tickets`.`itemtype` = '$itemtype'
                 AND `glpi_items_tickets`.`items_id` = '$items_id'
-                AND `".$this::getTable()."`.`solvedate` IS NOT NULL
-                AND ADDDATE(`".$this::getTable()."`.`solvedate`,
+                AND `".$static::getTable()."`.`solvedate` IS NOT NULL
+                AND ADDDATE(`".$static::getTable()."`.`solvedate`,
                            INTERVAL $days DAY) > NOW()
-                AND `".$this::getTable()."`.`status`
+                AND `".$static::getTable()."`.`status`
                      IN ('".implode("', '",
                                     array_merge($this->getSolvedStatusArray(),
                                                 $this->getClosedStatusArray())
@@ -2275,7 +2275,7 @@ class Ticket extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '155',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'time_to_own',
          'name'               => __('Time to own'),
          'datatype'           => 'datetime',
@@ -2286,7 +2286,7 @@ class Ticket extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '158',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'time_to_own',
          'name'               => __('Time to own + Progress'),
          'massiveaction'      => false,
@@ -2313,7 +2313,7 @@ class Ticket extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'type',
          'name'               => __('Type'),
          'searchtype'         => 'equals',
@@ -2628,7 +2628,7 @@ class Ticket extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '150',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'takeintoaccount_delay_stat',
          'name'               => __('Take into account time'),
          'datatype'           => 'timestamp',

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2030,17 +2030,17 @@ class Ticket extends CommonITILObject {
       $result = array();
 
       $query = "SELECT *
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 LEFT JOIN `glpi_items_tickets`
-                  ON (`".$static::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
+                  ON (`".static::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
                 WHERE `glpi_items_tickets`.`itemtype` = '$itemtype'
                       AND `glpi_items_tickets`.`items_id` = '$items_id'
-                      AND (`".$static::getTable()."`.`status`
+                      AND (`".static::getTable()."`.`status`
                               NOT IN ('".implode("', '", array_merge($this->getSolvedStatusArray(),
                                                                      $this->getClosedStatusArray())
                                                 )."')
-                            OR (`".$static::getTable()."`.`solvedate` IS NOT NULL
-                                AND ADDDATE(`".$static::getTable()."`.`solvedate`, INTERVAL $days DAY)
+                            OR (`".static::getTable()."`.`solvedate` IS NOT NULL
+                                AND ADDDATE(`".static::getTable()."`.`solvedate`, INTERVAL $days DAY)
                                             > NOW()))";
 
       foreach ($DB->request($query) as $tick) {
@@ -2065,12 +2065,12 @@ class Ticket extends CommonITILObject {
       global $DB;
 
       $query = "SELECT COUNT(*) AS cpt
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 LEFT JOIN `glpi_items_tickets`
-                   ON (`".$static::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
+                   ON (`".static::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
                 WHERE `glpi_items_tickets`.`itemtype` = '$itemtype'
                 AND `glpi_items_tickets`.`items_id` = '$items_id'
-                AND `".$static::getTable()."`.`status`
+                AND `".static::getTable()."`.`status`
                    NOT IN ('".implode("', '",
                             array_merge($this->getSolvedStatusArray(),
                                         $this->getClosedStatusArray())
@@ -2098,15 +2098,15 @@ class Ticket extends CommonITILObject {
       global $DB;
 
       $query = "SELECT COUNT(*) AS cpt
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 LEFT JOIN `glpi_items_tickets`
-                   ON (`".$static::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
+                   ON (`".static::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
                 WHERE `glpi_items_tickets`.`itemtype` = '$itemtype'
                 AND `glpi_items_tickets`.`items_id` = '$items_id'
-                AND `".$static::getTable()."`.`solvedate` IS NOT NULL
-                AND ADDDATE(`".$static::getTable()."`.`solvedate`,
+                AND `".static::getTable()."`.`solvedate` IS NOT NULL
+                AND ADDDATE(`".static::getTable()."`.`solvedate`,
                            INTERVAL $days DAY) > NOW()
-                AND `".$static::getTable()."`.`status`
+                AND `".static::getTable()."`.`status`
                      IN ('".implode("', '",
                                     array_merge($this->getSolvedStatusArray(),
                                                 $this->getClosedStatusArray())
@@ -2275,7 +2275,7 @@ class Ticket extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '155',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'time_to_own',
          'name'               => __('Time to own'),
          'datatype'           => 'datetime',
@@ -2286,7 +2286,7 @@ class Ticket extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '158',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'time_to_own',
          'name'               => __('Time to own + Progress'),
          'massiveaction'      => false,
@@ -2313,7 +2313,7 @@ class Ticket extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'type',
          'name'               => __('Type'),
          'searchtype'         => 'equals',
@@ -2628,7 +2628,7 @@ class Ticket extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '150',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'takeintoaccount_delay_stat',
          'name'               => __('Take into account time'),
          'datatype'           => 'timestamp',

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2030,17 +2030,17 @@ class Ticket extends CommonITILObject {
       $result = array();
 
       $query = "SELECT *
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 LEFT JOIN `glpi_items_tickets`
-                  ON (`".$this->getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
+                  ON (`".$this::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
                 WHERE `glpi_items_tickets`.`itemtype` = '$itemtype'
                       AND `glpi_items_tickets`.`items_id` = '$items_id'
-                      AND (`".$this->getTable()."`.`status`
+                      AND (`".$this::getTable()."`.`status`
                               NOT IN ('".implode("', '", array_merge($this->getSolvedStatusArray(),
                                                                      $this->getClosedStatusArray())
                                                 )."')
-                            OR (`".$this->getTable()."`.`solvedate` IS NOT NULL
-                                AND ADDDATE(`".$this->getTable()."`.`solvedate`, INTERVAL $days DAY)
+                            OR (`".$this::getTable()."`.`solvedate` IS NOT NULL
+                                AND ADDDATE(`".$this::getTable()."`.`solvedate`, INTERVAL $days DAY)
                                             > NOW()))";
 
       foreach ($DB->request($query) as $tick) {
@@ -2065,12 +2065,12 @@ class Ticket extends CommonITILObject {
       global $DB;
 
       $query = "SELECT COUNT(*) AS cpt
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 LEFT JOIN `glpi_items_tickets`
-                   ON (`".$this->getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
+                   ON (`".$this::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
                 WHERE `glpi_items_tickets`.`itemtype` = '$itemtype'
                 AND `glpi_items_tickets`.`items_id` = '$items_id'
-                AND `".$this->getTable()."`.`status`
+                AND `".$this::getTable()."`.`status`
                    NOT IN ('".implode("', '",
                             array_merge($this->getSolvedStatusArray(),
                                         $this->getClosedStatusArray())
@@ -2098,15 +2098,15 @@ class Ticket extends CommonITILObject {
       global $DB;
 
       $query = "SELECT COUNT(*) AS cpt
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 LEFT JOIN `glpi_items_tickets`
-                   ON (`".$this->getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
+                   ON (`".$this::getTable()."`.`id` = `glpi_items_tickets`.`tickets_id`)
                 WHERE `glpi_items_tickets`.`itemtype` = '$itemtype'
                 AND `glpi_items_tickets`.`items_id` = '$items_id'
-                AND `".$this->getTable()."`.`solvedate` IS NOT NULL
-                AND ADDDATE(`".$this->getTable()."`.`solvedate`,
+                AND `".$this::getTable()."`.`solvedate` IS NOT NULL
+                AND ADDDATE(`".$this::getTable()."`.`solvedate`,
                            INTERVAL $days DAY) > NOW()
-                AND `".$this->getTable()."`.`status`
+                AND `".$this::getTable()."`.`status`
                      IN ('".implode("', '",
                                     array_merge($this->getSolvedStatusArray(),
                                                 $this->getClosedStatusArray())
@@ -2275,7 +2275,7 @@ class Ticket extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '155',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'time_to_own',
          'name'               => __('Time to own'),
          'datatype'           => 'datetime',
@@ -2286,7 +2286,7 @@ class Ticket extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '158',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'time_to_own',
          'name'               => __('Time to own + Progress'),
          'massiveaction'      => false,
@@ -2313,7 +2313,7 @@ class Ticket extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'type',
          'name'               => __('Type'),
          'searchtype'         => 'equals',
@@ -2628,7 +2628,7 @@ class Ticket extends CommonITILObject {
 
       $tab[] = [
          'id'                 => '150',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'takeintoaccount_delay_stat',
          'name'               => __('Take into account time'),
          'datatype'           => 'timestamp',

--- a/inc/ticketfollowup.class.php
+++ b/inc/ticketfollowup.class.php
@@ -1132,7 +1132,7 @@ class TicketFollowup  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'datatype'           => 'text'
@@ -1149,7 +1149,7 @@ class TicketFollowup  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'datetime'
@@ -1157,7 +1157,7 @@ class TicketFollowup  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_private',
          'name'               => __('Private'),
          'datatype'           => 'bool'

--- a/inc/ticketfollowup.class.php
+++ b/inc/ticketfollowup.class.php
@@ -1132,7 +1132,7 @@ class TicketFollowup  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'datatype'           => 'text'
@@ -1149,7 +1149,7 @@ class TicketFollowup  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'datetime'
@@ -1157,7 +1157,7 @@ class TicketFollowup  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_private',
          'name'               => __('Private'),
          'datatype'           => 'bool'

--- a/inc/ticketfollowup.class.php
+++ b/inc/ticketfollowup.class.php
@@ -1132,7 +1132,7 @@ class TicketFollowup  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'content',
          'name'               => __('Description'),
          'datatype'           => 'text'
@@ -1149,7 +1149,7 @@ class TicketFollowup  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date',
          'name'               => __('Date'),
          'datatype'           => 'datetime'
@@ -1157,7 +1157,7 @@ class TicketFollowup  extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '4',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_private',
          'name'               => __('Private'),
          'datatype'           => 'bool'

--- a/inc/ticketrecurrent.class.php
+++ b/inc/ticketrecurrent.class.php
@@ -235,7 +235,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -251,7 +251,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Start date'),
          'datatype'           => 'datetime'
@@ -259,7 +259,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'
@@ -267,7 +267,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'periodicity',
          'name'               => __('Periodicity'),
          'datatype'           => 'specific'
@@ -275,7 +275,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'create_before',
          'name'               => __('Preliminary creation'),
          'datatype'           => 'timestamp'

--- a/inc/ticketrecurrent.class.php
+++ b/inc/ticketrecurrent.class.php
@@ -235,7 +235,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -251,7 +251,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Start date'),
          'datatype'           => 'datetime'
@@ -259,7 +259,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'
@@ -267,7 +267,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'periodicity',
          'name'               => __('Periodicity'),
          'datatype'           => 'specific'
@@ -275,7 +275,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'create_before',
          'name'               => __('Preliminary creation'),
          'datatype'           => 'timestamp'

--- a/inc/ticketrecurrent.class.php
+++ b/inc/ticketrecurrent.class.php
@@ -235,7 +235,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -251,7 +251,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '13',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Start date'),
          'datatype'           => 'datetime'
@@ -259,7 +259,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'
@@ -267,7 +267,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'periodicity',
          'name'               => __('Periodicity'),
          'datatype'           => 'specific'
@@ -275,7 +275,7 @@ class TicketRecurrent extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'create_before',
          'name'               => __('Preliminary creation'),
          'datatype'           => 'timestamp'

--- a/inc/tickettemplatehiddenfield.class.php
+++ b/inc/tickettemplatehiddenfield.class.php
@@ -89,7 +89,7 @@ class TicketTemplateHiddenField extends CommonDBChild {
           && Session::haveRight("tickettemplate", READ)) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($this::getTable(),
+            $nb = countElementsInTable($static::getTable(),
                                        ['tickettemplates_id' => $item->getID()]);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
@@ -116,7 +116,7 @@ class TicketTemplateHiddenField extends CommonDBChild {
       // Try to delete itemtype -> delete items_id
       if ($this->fields['num'] == $itemtype_id) {
          $query = "SELECT `id`
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `".static::$items_id."` = '".$this->fields['tickettemplates_id']."'
                          AND `num` = '$items_id_id'";
 
@@ -144,7 +144,7 @@ class TicketTemplateHiddenField extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$this::getTable()."`
+              FROM `".$static::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
       $result = $DB->query($sql);

--- a/inc/tickettemplatehiddenfield.class.php
+++ b/inc/tickettemplatehiddenfield.class.php
@@ -89,7 +89,7 @@ class TicketTemplateHiddenField extends CommonDBChild {
           && Session::haveRight("tickettemplate", READ)) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($static::getTable(),
+            $nb = countElementsInTable(static::getTable(),
                                        ['tickettemplates_id' => $item->getID()]);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
@@ -116,7 +116,7 @@ class TicketTemplateHiddenField extends CommonDBChild {
       // Try to delete itemtype -> delete items_id
       if ($this->fields['num'] == $itemtype_id) {
          $query = "SELECT `id`
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `".static::$items_id."` = '".$this->fields['tickettemplates_id']."'
                          AND `num` = '$items_id_id'";
 
@@ -144,7 +144,7 @@ class TicketTemplateHiddenField extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$static::getTable()."`
+              FROM `".static::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
       $result = $DB->query($sql);

--- a/inc/tickettemplatehiddenfield.class.php
+++ b/inc/tickettemplatehiddenfield.class.php
@@ -89,7 +89,7 @@ class TicketTemplateHiddenField extends CommonDBChild {
           && Session::haveRight("tickettemplate", READ)) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($this->getTable(),
+            $nb = countElementsInTable($this::getTable(),
                                        ['tickettemplates_id' => $item->getID()]);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
@@ -116,7 +116,7 @@ class TicketTemplateHiddenField extends CommonDBChild {
       // Try to delete itemtype -> delete items_id
       if ($this->fields['num'] == $itemtype_id) {
          $query = "SELECT `id`
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `".static::$items_id."` = '".$this->fields['tickettemplates_id']."'
                          AND `num` = '$items_id_id'";
 
@@ -144,7 +144,7 @@ class TicketTemplateHiddenField extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$this->getTable()."`
+              FROM `".$this::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
       $result = $DB->query($sql);

--- a/inc/tickettemplatemandatoryfield.class.php
+++ b/inc/tickettemplatemandatoryfield.class.php
@@ -88,7 +88,7 @@ class TicketTemplateMandatoryField extends CommonDBChild {
           && Session::haveRight("tickettemplate", READ)) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($this->getTable(),
+            $nb = countElementsInTable($this::getTable(),
                                        ['tickettemplates_id' => $item->getID()]);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
@@ -116,7 +116,7 @@ class TicketTemplateMandatoryField extends CommonDBChild {
       // Try to delete itemtype -> delete items_id
       if ($this->fields['num'] == $itemtype_id) {
          $query = "SELECT `id`
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `".static::$items_id."` = '".$this->fields['tickettemplates_id']."'
                          AND `num` = '$items_id_id'";
 
@@ -144,7 +144,7 @@ class TicketTemplateMandatoryField extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$this->getTable()."`
+              FROM `".$this::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
       $result = $DB->query($sql);

--- a/inc/tickettemplatemandatoryfield.class.php
+++ b/inc/tickettemplatemandatoryfield.class.php
@@ -88,7 +88,7 @@ class TicketTemplateMandatoryField extends CommonDBChild {
           && Session::haveRight("tickettemplate", READ)) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($this::getTable(),
+            $nb = countElementsInTable($static::getTable(),
                                        ['tickettemplates_id' => $item->getID()]);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
@@ -116,7 +116,7 @@ class TicketTemplateMandatoryField extends CommonDBChild {
       // Try to delete itemtype -> delete items_id
       if ($this->fields['num'] == $itemtype_id) {
          $query = "SELECT `id`
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `".static::$items_id."` = '".$this->fields['tickettemplates_id']."'
                          AND `num` = '$items_id_id'";
 
@@ -144,7 +144,7 @@ class TicketTemplateMandatoryField extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$this::getTable()."`
+              FROM `".$static::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
       $result = $DB->query($sql);

--- a/inc/tickettemplatemandatoryfield.class.php
+++ b/inc/tickettemplatemandatoryfield.class.php
@@ -88,7 +88,7 @@ class TicketTemplateMandatoryField extends CommonDBChild {
           && Session::haveRight("tickettemplate", READ)) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($static::getTable(),
+            $nb = countElementsInTable(static::getTable(),
                                        ['tickettemplates_id' => $item->getID()]);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
@@ -116,7 +116,7 @@ class TicketTemplateMandatoryField extends CommonDBChild {
       // Try to delete itemtype -> delete items_id
       if ($this->fields['num'] == $itemtype_id) {
          $query = "SELECT `id`
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `".static::$items_id."` = '".$this->fields['tickettemplates_id']."'
                          AND `num` = '$items_id_id'";
 
@@ -144,7 +144,7 @@ class TicketTemplateMandatoryField extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$static::getTable()."`
+              FROM `".static::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
       $result = $DB->query($sql);

--- a/inc/tickettemplatepredefinedfield.class.php
+++ b/inc/tickettemplatepredefinedfield.class.php
@@ -114,7 +114,7 @@ class TicketTemplatePredefinedField extends CommonDBChild {
       // Try to delete itemtype -> delete items_id
       if ($this->fields['num'] == $itemtype_id) {
          $query = "SELECT `id`
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `".static::$items_id."` = '".$this->fields['tickettemplates_id']."'
                          AND `num` = '$items_id_id'";
 
@@ -135,7 +135,7 @@ class TicketTemplatePredefinedField extends CommonDBChild {
           && Session::haveRight("tickettemplate", READ)) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($static::getTable(),
+            $nb = countElementsInTable(static::getTable(),
                                        ['tickettemplates_id' => $item->getID()]);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
@@ -165,7 +165,7 @@ class TicketTemplatePredefinedField extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$static::getTable()."`
+              FROM `".static::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
       $result = $DB->query($sql);

--- a/inc/tickettemplatepredefinedfield.class.php
+++ b/inc/tickettemplatepredefinedfield.class.php
@@ -114,7 +114,7 @@ class TicketTemplatePredefinedField extends CommonDBChild {
       // Try to delete itemtype -> delete items_id
       if ($this->fields['num'] == $itemtype_id) {
          $query = "SELECT `id`
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `".static::$items_id."` = '".$this->fields['tickettemplates_id']."'
                          AND `num` = '$items_id_id'";
 
@@ -135,7 +135,7 @@ class TicketTemplatePredefinedField extends CommonDBChild {
           && Session::haveRight("tickettemplate", READ)) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($this->getTable(),
+            $nb = countElementsInTable($this::getTable(),
                                        ['tickettemplates_id' => $item->getID()]);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
@@ -165,7 +165,7 @@ class TicketTemplatePredefinedField extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$this->getTable()."`
+              FROM `".$this::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
       $result = $DB->query($sql);

--- a/inc/tickettemplatepredefinedfield.class.php
+++ b/inc/tickettemplatepredefinedfield.class.php
@@ -114,7 +114,7 @@ class TicketTemplatePredefinedField extends CommonDBChild {
       // Try to delete itemtype -> delete items_id
       if ($this->fields['num'] == $itemtype_id) {
          $query = "SELECT `id`
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `".static::$items_id."` = '".$this->fields['tickettemplates_id']."'
                          AND `num` = '$items_id_id'";
 
@@ -135,7 +135,7 @@ class TicketTemplatePredefinedField extends CommonDBChild {
           && Session::haveRight("tickettemplate", READ)) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $nb = countElementsInTable($this::getTable(),
+            $nb = countElementsInTable($static::getTable(),
                                        ['tickettemplates_id' => $item->getID()]);
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
@@ -165,7 +165,7 @@ class TicketTemplatePredefinedField extends CommonDBChild {
       global $DB;
 
       $sql = "SELECT *
-              FROM `".$this::getTable()."`
+              FROM `".$static::getTable()."`
               WHERE `".static::$items_id."` = '$ID'
               ORDER BY `id`";
       $result = $DB->query($sql);

--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -86,7 +86,7 @@ class Transfer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -95,7 +95,7 @@ class Transfer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -104,7 +104,7 @@ class Transfer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -86,7 +86,7 @@ class Transfer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -95,7 +95,7 @@ class Transfer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -104,7 +104,7 @@ class Transfer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -86,7 +86,7 @@ class Transfer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Name'),
          'datatype'           => 'itemlink',
@@ -95,7 +95,7 @@ class Transfer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -104,7 +104,7 @@ class Transfer extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -409,7 +409,7 @@ class User extends CommonDBTM {
     * @return true if succeed else false
    **/
    function getFromDBbyName($name) {
-      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`name` = '$name'");
+      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`name` = '$name'");
    }
 
 
@@ -423,7 +423,7 @@ class User extends CommonDBTM {
     * @return true if succeed else false
    **/
    function getFromDBbyDn($user_dn) {
-      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`user_dn` = '$user_dn'");
+      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`user_dn` = '$user_dn'");
    }
 
 
@@ -438,7 +438,7 @@ class User extends CommonDBTM {
    function getFromDBbyEmail($email, $condition) {
 
       $request = "LEFT JOIN `glpi_useremails`
-                     ON (`glpi_useremails`.`users_id` = `".$this::getTable()."`.`id`)
+                     ON (`glpi_useremails`.`users_id` = `".$static::getTable()."`.`id`)
                   WHERE `glpi_useremails`.`email` = '$email'";
 
       if (!empty($condition)) {
@@ -501,7 +501,7 @@ class User extends CommonDBTM {
     * @return true if succeed else false
    **/
    function getFromDBbyToken($token) {
-      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`personal_token` = '$token'");
+      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`personal_token` = '$token'");
    }
 
 
@@ -520,7 +520,7 @@ class User extends CommonDBTM {
 
       // Check if user does not exists
       $query = "SELECT *
-                FROM `".$this::getTable()."`
+                FROM `".$static::getTable()."`
                 WHERE `name` = '".$input['name']."'";
       $result = $DB->query($query);
 
@@ -1768,7 +1768,7 @@ class User extends CommonDBTM {
       global $DB;
 
       if (!empty($this->fields["name"])) {
-         $query = "UPDATE `".$this::getTable()."`
+         $query = "UPDATE `".$static::getTable()."`
                    SET `password` = ''
                    WHERE `name` = '" . $this->fields["name"] . "'";
          $DB->query($query);
@@ -2380,7 +2380,7 @@ class User extends CommonDBTM {
       if (($key = array_search('name', $this->updates)) !== false) {
          /// Check if user does not exists
          $query = "SELECT *
-                   FROM `".$this::getTable()."`
+                   FROM `".$static::getTable()."`
                    WHERE `name` = '".$this->input['name']."'
                          AND `id` <> '".$this->input['id']."';";
          $result = $DB->query($query);
@@ -2572,7 +2572,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'name',
          'name'               => __('Login'),
          'datatype'           => 'itemlink',
@@ -2582,7 +2582,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -2591,7 +2591,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '34',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'realname',
          'name'               => __('Last Name'),
          'datatype'           => 'string'
@@ -2599,7 +2599,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'firstname',
          'name'               => __('First Name'),
          'datatype'           => 'string'
@@ -2622,7 +2622,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -2630,7 +2630,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'phone',
          'name'               => __('Phone'),
          'datatype'           => 'string'
@@ -2638,7 +2638,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'phone2',
          'name'               => __('Phone 2'),
          'datatype'           => 'string'
@@ -2646,7 +2646,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'mobile',
          'name'               => __('Mobile phone'),
          'datatype'           => 'string'
@@ -2672,7 +2672,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'last_login',
          'name'               => __('Last login'),
          'datatype'           => 'datetime',
@@ -2681,7 +2681,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'authtype',
          'name'               => __('Authentication'),
          'massiveaction'      => false,
@@ -2720,7 +2720,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -2728,7 +2728,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'language',
          'name'               => __('Language'),
          'datatype'           => 'language',
@@ -2738,7 +2738,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -2747,7 +2747,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -2775,7 +2775,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'user_dn',
          'name'               => __('User DN'),
          'massiveaction'      => false,
@@ -2784,7 +2784,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'registration_number',
          'name'               => __('Administrative number'),
          'datatype'           => 'string'
@@ -2792,7 +2792,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'date_sync',
          'datatype'           => 'datetime',
          'name'               => __('Last synchronization'),
@@ -2801,7 +2801,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'is_deleted_ldap',
          'name'               => __('Deleted user in LDAP directory'),
          'datatype'           => 'bool',
@@ -2863,7 +2863,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '62',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Begin date'),
          'datatype'           => 'datetime'
@@ -2871,7 +2871,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '63',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -409,7 +409,7 @@ class User extends CommonDBTM {
     * @return true if succeed else false
    **/
    function getFromDBbyName($name) {
-      return $this->getFromDBByQuery("WHERE `".$this->getTable()."`.`name` = '$name'");
+      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`name` = '$name'");
    }
 
 
@@ -423,7 +423,7 @@ class User extends CommonDBTM {
     * @return true if succeed else false
    **/
    function getFromDBbyDn($user_dn) {
-      return $this->getFromDBByQuery("WHERE `".$this->getTable()."`.`user_dn` = '$user_dn'");
+      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`user_dn` = '$user_dn'");
    }
 
 
@@ -438,7 +438,7 @@ class User extends CommonDBTM {
    function getFromDBbyEmail($email, $condition) {
 
       $request = "LEFT JOIN `glpi_useremails`
-                     ON (`glpi_useremails`.`users_id` = `".$this->getTable()."`.`id`)
+                     ON (`glpi_useremails`.`users_id` = `".$this::getTable()."`.`id`)
                   WHERE `glpi_useremails`.`email` = '$email'";
 
       if (!empty($condition)) {
@@ -501,7 +501,7 @@ class User extends CommonDBTM {
     * @return true if succeed else false
    **/
    function getFromDBbyToken($token) {
-      return $this->getFromDBByQuery("WHERE `".$this->getTable()."`.`personal_token` = '$token'");
+      return $this->getFromDBByQuery("WHERE `".$this::getTable()."`.`personal_token` = '$token'");
    }
 
 
@@ -520,7 +520,7 @@ class User extends CommonDBTM {
 
       // Check if user does not exists
       $query = "SELECT *
-                FROM `".$this->getTable()."`
+                FROM `".$this::getTable()."`
                 WHERE `name` = '".$input['name']."'";
       $result = $DB->query($query);
 
@@ -1768,7 +1768,7 @@ class User extends CommonDBTM {
       global $DB;
 
       if (!empty($this->fields["name"])) {
-         $query = "UPDATE `".$this->getTable()."`
+         $query = "UPDATE `".$this::getTable()."`
                    SET `password` = ''
                    WHERE `name` = '" . $this->fields["name"] . "'";
          $DB->query($query);
@@ -2380,7 +2380,7 @@ class User extends CommonDBTM {
       if (($key = array_search('name', $this->updates)) !== false) {
          /// Check if user does not exists
          $query = "SELECT *
-                   FROM `".$this->getTable()."`
+                   FROM `".$this::getTable()."`
                    WHERE `name` = '".$this->input['name']."'
                          AND `id` <> '".$this->input['id']."';";
          $result = $DB->query($query);
@@ -2572,7 +2572,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'name',
          'name'               => __('Login'),
          'datatype'           => 'itemlink',
@@ -2582,7 +2582,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -2591,7 +2591,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '34',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'realname',
          'name'               => __('Last Name'),
          'datatype'           => 'string'
@@ -2599,7 +2599,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'firstname',
          'name'               => __('First Name'),
          'datatype'           => 'string'
@@ -2622,7 +2622,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -2630,7 +2630,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'phone',
          'name'               => __('Phone'),
          'datatype'           => 'string'
@@ -2638,7 +2638,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'phone2',
          'name'               => __('Phone 2'),
          'datatype'           => 'string'
@@ -2646,7 +2646,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'mobile',
          'name'               => __('Mobile phone'),
          'datatype'           => 'string'
@@ -2672,7 +2672,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'last_login',
          'name'               => __('Last login'),
          'datatype'           => 'datetime',
@@ -2681,7 +2681,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'authtype',
          'name'               => __('Authentication'),
          'massiveaction'      => false,
@@ -2720,7 +2720,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -2728,7 +2728,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'language',
          'name'               => __('Language'),
          'datatype'           => 'language',
@@ -2738,7 +2738,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -2747,7 +2747,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -2775,7 +2775,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'user_dn',
          'name'               => __('User DN'),
          'massiveaction'      => false,
@@ -2784,7 +2784,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'registration_number',
          'name'               => __('Administrative number'),
          'datatype'           => 'string'
@@ -2792,7 +2792,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'date_sync',
          'datatype'           => 'datetime',
          'name'               => __('Last synchronization'),
@@ -2801,7 +2801,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'is_deleted_ldap',
          'name'               => __('Deleted user in LDAP directory'),
          'datatype'           => 'bool',
@@ -2863,7 +2863,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '62',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Begin date'),
          'datatype'           => 'datetime'
@@ -2871,7 +2871,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '63',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -409,7 +409,7 @@ class User extends CommonDBTM {
     * @return true if succeed else false
    **/
    function getFromDBbyName($name) {
-      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`name` = '$name'");
+      return $this->getFromDBByQuery("WHERE `".static::getTable()."`.`name` = '$name'");
    }
 
 
@@ -423,7 +423,7 @@ class User extends CommonDBTM {
     * @return true if succeed else false
    **/
    function getFromDBbyDn($user_dn) {
-      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`user_dn` = '$user_dn'");
+      return $this->getFromDBByQuery("WHERE `".static::getTable()."`.`user_dn` = '$user_dn'");
    }
 
 
@@ -438,7 +438,7 @@ class User extends CommonDBTM {
    function getFromDBbyEmail($email, $condition) {
 
       $request = "LEFT JOIN `glpi_useremails`
-                     ON (`glpi_useremails`.`users_id` = `".$static::getTable()."`.`id`)
+                     ON (`glpi_useremails`.`users_id` = `".static::getTable()."`.`id`)
                   WHERE `glpi_useremails`.`email` = '$email'";
 
       if (!empty($condition)) {
@@ -501,7 +501,7 @@ class User extends CommonDBTM {
     * @return true if succeed else false
    **/
    function getFromDBbyToken($token) {
-      return $this->getFromDBByQuery("WHERE `".$static::getTable()."`.`personal_token` = '$token'");
+      return $this->getFromDBByQuery("WHERE `".static::getTable()."`.`personal_token` = '$token'");
    }
 
 
@@ -520,7 +520,7 @@ class User extends CommonDBTM {
 
       // Check if user does not exists
       $query = "SELECT *
-                FROM `".$static::getTable()."`
+                FROM `".static::getTable()."`
                 WHERE `name` = '".$input['name']."'";
       $result = $DB->query($query);
 
@@ -1768,7 +1768,7 @@ class User extends CommonDBTM {
       global $DB;
 
       if (!empty($this->fields["name"])) {
-         $query = "UPDATE `".$static::getTable()."`
+         $query = "UPDATE `".static::getTable()."`
                    SET `password` = ''
                    WHERE `name` = '" . $this->fields["name"] . "'";
          $DB->query($query);
@@ -2380,7 +2380,7 @@ class User extends CommonDBTM {
       if (($key = array_search('name', $this->updates)) !== false) {
          /// Check if user does not exists
          $query = "SELECT *
-                   FROM `".$static::getTable()."`
+                   FROM `".static::getTable()."`
                    WHERE `name` = '".$this->input['name']."'
                          AND `id` <> '".$this->input['id']."';";
          $result = $DB->query($query);
@@ -2572,7 +2572,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'name',
          'name'               => __('Login'),
          'datatype'           => 'itemlink',
@@ -2582,7 +2582,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '2',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'id',
          'name'               => __('ID'),
          'massiveaction'      => false,
@@ -2591,7 +2591,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '34',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'realname',
          'name'               => __('Last Name'),
          'datatype'           => 'string'
@@ -2599,7 +2599,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '9',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'firstname',
          'name'               => __('First Name'),
          'datatype'           => 'string'
@@ -2622,7 +2622,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '8',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_active',
          'name'               => __('Active'),
          'datatype'           => 'bool'
@@ -2630,7 +2630,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'phone',
          'name'               => __('Phone'),
          'datatype'           => 'string'
@@ -2638,7 +2638,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'phone2',
          'name'               => __('Phone 2'),
          'datatype'           => 'string'
@@ -2646,7 +2646,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'mobile',
          'name'               => __('Mobile phone'),
          'datatype'           => 'string'
@@ -2672,7 +2672,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '14',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'last_login',
          'name'               => __('Last login'),
          'datatype'           => 'datetime',
@@ -2681,7 +2681,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '15',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'authtype',
          'name'               => __('Authentication'),
          'massiveaction'      => false,
@@ -2720,7 +2720,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '16',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'comment',
          'name'               => __('Comments'),
          'datatype'           => 'text'
@@ -2728,7 +2728,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '17',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'language',
          'name'               => __('Language'),
          'datatype'           => 'language',
@@ -2738,7 +2738,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '19',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
          'datatype'           => 'datetime',
@@ -2747,7 +2747,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '121',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
@@ -2775,7 +2775,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '21',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'user_dn',
          'name'               => __('User DN'),
          'massiveaction'      => false,
@@ -2784,7 +2784,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '22',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'registration_number',
          'name'               => __('Administrative number'),
          'datatype'           => 'string'
@@ -2792,7 +2792,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '23',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'date_sync',
          'datatype'           => 'datetime',
          'name'               => __('Last synchronization'),
@@ -2801,7 +2801,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '24',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'is_deleted_ldap',
          'name'               => __('Deleted user in LDAP directory'),
          'datatype'           => 'bool',
@@ -2863,7 +2863,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '62',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'begin_date',
          'name'               => __('Begin date'),
          'datatype'           => 'datetime'
@@ -2871,7 +2871,7 @@ class User extends CommonDBTM {
 
       $tab[] = [
          'id'                 => '63',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'end_date',
          'name'               => __('End date'),
          'datatype'           => 'datetime'

--- a/inc/useremail.class.php
+++ b/inc/useremail.class.php
@@ -220,7 +220,7 @@ class UserEmail  extends CommonDBChild {
       }
 
       // First email is default
-      if (countElementsInTable($static::getTable(), ['users_id' => $input['users_id']]) == 0) {
+      if (countElementsInTable(static::getTable(), ['users_id' => $input['users_id']]) == 0) {
          $input['is_default'] = 1;
       }
 
@@ -246,7 +246,7 @@ class UserEmail  extends CommonDBChild {
       // if default is set : unsed others for the users
       if (in_array('is_default', $this->updates)
           && ($this->input["is_default"] == 1)) {
-         $query = "UPDATE ". $static::getTable()."
+         $query = "UPDATE ". static::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->input['id']."'
                          AND `users_id` = '".$this->fields['users_id']."'";
@@ -262,7 +262,7 @@ class UserEmail  extends CommonDBChild {
 
       // if default is set : unset others for the users
       if (isset($this->fields['is_default']) && ($this->fields["is_default"] == 1)) {
-         $query = "UPDATE ". $static::getTable()."
+         $query = "UPDATE ". static::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'
                          AND `users_id` = '".$this->fields['users_id']."'";
@@ -279,7 +279,7 @@ class UserEmail  extends CommonDBChild {
 
       // if default is set : set default to another one
       if ($this->fields["is_default"] == 1) {
-         $query = "UPDATE `". $static::getTable()."`
+         $query = "UPDATE `". static::getTable()."`
                    SET `is_default` = '1'
                    WHERE `id` <> '".$this->fields['id']."'
                          AND `users_id` = '".$this->fields['users_id']."'

--- a/inc/useremail.class.php
+++ b/inc/useremail.class.php
@@ -220,7 +220,7 @@ class UserEmail  extends CommonDBChild {
       }
 
       // First email is default
-      if (countElementsInTable($this::getTable(), ['users_id' => $input['users_id']]) == 0) {
+      if (countElementsInTable($static::getTable(), ['users_id' => $input['users_id']]) == 0) {
          $input['is_default'] = 1;
       }
 
@@ -246,7 +246,7 @@ class UserEmail  extends CommonDBChild {
       // if default is set : unsed others for the users
       if (in_array('is_default', $this->updates)
           && ($this->input["is_default"] == 1)) {
-         $query = "UPDATE ". $this::getTable()."
+         $query = "UPDATE ". $static::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->input['id']."'
                          AND `users_id` = '".$this->fields['users_id']."'";
@@ -262,7 +262,7 @@ class UserEmail  extends CommonDBChild {
 
       // if default is set : unset others for the users
       if (isset($this->fields['is_default']) && ($this->fields["is_default"] == 1)) {
-         $query = "UPDATE ". $this::getTable()."
+         $query = "UPDATE ". $static::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'
                          AND `users_id` = '".$this->fields['users_id']."'";
@@ -279,7 +279,7 @@ class UserEmail  extends CommonDBChild {
 
       // if default is set : set default to another one
       if ($this->fields["is_default"] == 1) {
-         $query = "UPDATE `". $this::getTable()."`
+         $query = "UPDATE `". $static::getTable()."`
                    SET `is_default` = '1'
                    WHERE `id` <> '".$this->fields['id']."'
                          AND `users_id` = '".$this->fields['users_id']."'

--- a/inc/useremail.class.php
+++ b/inc/useremail.class.php
@@ -220,7 +220,7 @@ class UserEmail  extends CommonDBChild {
       }
 
       // First email is default
-      if (countElementsInTable($this->getTable(), ['users_id' => $input['users_id']]) == 0) {
+      if (countElementsInTable($this::getTable(), ['users_id' => $input['users_id']]) == 0) {
          $input['is_default'] = 1;
       }
 
@@ -246,7 +246,7 @@ class UserEmail  extends CommonDBChild {
       // if default is set : unsed others for the users
       if (in_array('is_default', $this->updates)
           && ($this->input["is_default"] == 1)) {
-         $query = "UPDATE ". $this->getTable()."
+         $query = "UPDATE ". $this::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->input['id']."'
                          AND `users_id` = '".$this->fields['users_id']."'";
@@ -262,7 +262,7 @@ class UserEmail  extends CommonDBChild {
 
       // if default is set : unset others for the users
       if (isset($this->fields['is_default']) && ($this->fields["is_default"] == 1)) {
-         $query = "UPDATE ". $this->getTable()."
+         $query = "UPDATE ". $this::getTable()."
                    SET `is_default` = '0'
                    WHERE `id` <> '".$this->fields['id']."'
                          AND `users_id` = '".$this->fields['users_id']."'";
@@ -279,7 +279,7 @@ class UserEmail  extends CommonDBChild {
 
       // if default is set : set default to another one
       if ($this->fields["is_default"] == 1) {
-         $query = "UPDATE `". $this->getTable()."`
+         $query = "UPDATE `". $this::getTable()."`
                    SET `is_default` = '1'
                    WHERE `id` <> '".$this->fields['id']."'
                          AND `users_id` = '".$this->fields['users_id']."'

--- a/inc/vlan.class.php
+++ b/inc/vlan.class.php
@@ -78,7 +78,7 @@ class Vlan extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'tag',
          'name'               => __('ID TAG'),
          'datatype'           => 'number',

--- a/inc/vlan.class.php
+++ b/inc/vlan.class.php
@@ -78,7 +78,7 @@ class Vlan extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'tag',
          'name'               => __('ID TAG'),
          'datatype'           => 'number',

--- a/inc/vlan.class.php
+++ b/inc/vlan.class.php
@@ -78,7 +78,7 @@ class Vlan extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '11',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'tag',
          'name'               => __('ID TAG'),
          'datatype'           => 'number',

--- a/inc/wifinetwork.class.php
+++ b/inc/wifinetwork.class.php
@@ -123,7 +123,7 @@ class WifiNetwork extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this->getTable(),
+         'table'              => $this::getTable(),
          'field'              => 'essid',
          'name'               => __('ESSID'),
          'datatype'           => 'string'

--- a/inc/wifinetwork.class.php
+++ b/inc/wifinetwork.class.php
@@ -123,7 +123,7 @@ class WifiNetwork extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $this::getTable(),
+         'table'              => $static::getTable(),
          'field'              => 'essid',
          'name'               => __('ESSID'),
          'datatype'           => 'string'

--- a/inc/wifinetwork.class.php
+++ b/inc/wifinetwork.class.php
@@ -123,7 +123,7 @@ class WifiNetwork extends CommonDropdown {
 
       $tab[] = [
          'id'                 => '10',
-         'table'              => $static::getTable(),
+         'table'              => static::getTable(),
          'field'              => 'essid',
          'name'               => __('ESSID'),
          'datatype'           => 'string'

--- a/install/update_0831_084.php
+++ b/install/update_0831_084.php
@@ -1632,7 +1632,7 @@ function createNetworkNameFromItem($itemtype, $items_id, $main_items_id, $main_i
                                                      'items_id'      => $networknames_id),
                                                "version", "name", "binary");
 
-      $migration->insertInTable($IPaddress->getTable(), $input);
+      $migration->insertInTable($IPaddress::getTable(), $input);
 
    } else { // Don't add the NetworkName if the address is not valid
       addNetworkPortMigrationError($items_id, 'invalid_address');
@@ -1715,7 +1715,7 @@ function updateNetworkPortInstantiation($port, $fields, $setNetworkCard) {
             }
          }
       }
-      $migration->insertInTable($port->getTable(), $input);
+      $migration->insertInTable($port::getTable(), $input);
    }
 }
 
@@ -1847,7 +1847,7 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
          $domainName = $domain['name'];
          // We ensure that domains have at least 1 dote to be sure it is not a Windows workgroup
          if ((strpos($domainName, '.') !== false) && (FQDN::checkFQDN($domainName))) {
-            $migration->insertInTable($fqdn->getTable(),
+            $migration->insertInTable($fqdn::getTable(),
                                       array('entities_id' => 0,
                                             'name'        => $domainName,
                                             'fqdn'        => $domainName,
@@ -2000,7 +2000,7 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
                                       $data['items_id'], $preparedInput['error']);
                }
             }
-            $migration->insertInTable($network->getTable(), $input);
+            $migration->insertInTable($network::getTable(), $input);
          } else if (isset($preparedInput['error'])) {
             $query = "SELECT id, items_id, itemtype
                       FROM origin_glpi_networkports

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -37,7 +37,7 @@ class AlertTest extends DbTestCase {
    public function testAddDelete() {
 
       $alert = new Alert();
-      $nb    = countElementsInTable($alert->getTable());
+      $nb    = countElementsInTable($alert::getTable());
       $comp  = getItemByTypeName('Computer', '_test_pc01');
       $date  = '2016-09-01 12:34:56';
 
@@ -49,7 +49,7 @@ class AlertTest extends DbTestCase {
          'date'     => $date,
       ]);
       $this->assertGreaterThan(0, $id);
-      $this->assertGreaterThan($nb, countElementsInTable($alert->getTable()));
+      $this->assertGreaterThan($nb, countElementsInTable($alert::getTable()));
 
       // Getters
       $this->assertFalse(Alert::alertExists($comp->getType(), $comp->getID(), Alert::NOTICE));
@@ -62,7 +62,7 @@ class AlertTest extends DbTestCase {
 
       // Delete
       $this->assertTrue($alert->clear($comp->getType(), $comp->getID(), Alert::END));
-      $this->assertEquals($nb, countElementsInTable($alert->getTable()));
+      $this->assertEquals($nb, countElementsInTable($alert::getTable()));
 
       // Still true, nothing to delete but no error
       $this->assertTrue($alert->clear($comp->getType(), $comp->getID(), Alert::END));

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -217,7 +217,7 @@ class SearchTest extends DbTestCase {
 
       $displaypref = new DisplayPreference();
       // save table glpi_displaypreferences
-      $dp = getAllDatasFromTable($displaypref->getTable());
+      $dp = getAllDatasFromTable($displaypref::getTable());
       foreach ($dp as $line) {
          $displaypref->delete($line, true);
       }
@@ -260,7 +260,7 @@ class SearchTest extends DbTestCase {
                $number++;
             }
          }
-         $this->assertEquals($number, countElementsInTable($displaypref->getTable(),
+         $this->assertEquals($number, countElementsInTable($displaypref::getTable(),
                  "`itemtype`='".$itemtype."' AND `users_id`=0"));
 
          // do a search query
@@ -275,10 +275,10 @@ class SearchTest extends DbTestCase {
       }
       // restore displaypreference table
       /// TODO: review, this can't work.
-      foreach (getAllDatasFromTable($displaypref->getTable()) as $line) {
+      foreach (getAllDatasFromTable($displaypref::getTable()) as $line) {
          $displaypref->delete($line, true);
       }
-      $this->assertEquals(0, countElementsInTable($displaypref->getTable()));
+      $this->assertEquals(0, countElementsInTable($displaypref::getTable()));
       foreach ($dp as $input) {
          $displaypref->add($input);
       }

--- a/tools/convert_search_options.php
+++ b/tools/convert_search_options.php
@@ -101,7 +101,7 @@ function display($array, $table, $pad = 20, $tab = '         ') {
          switch ($k) {
             case 'table':
                if ($v == $table) {
-                  $v = '$this->getTable()';
+                  $v = '$this::getTable()';
                } else {
                   $v = "'$v'";
                }
@@ -138,14 +138,14 @@ $commonopts = $commondbtm->getSearchOptions();
 $item = new $itemtype();
 $opts = $item->getSearchOptions();
 
-$commonopts[1]['table'] = $item->getTable();
+$commonopts[1]['table'] = $item::getTable();
 //do not proceed if item class does not define its own getSearchOptions method
 if ($opts != $commonopts) {
-   convert($opts, $item->getTable());
+   convert($opts, $item::getTable());
 }
 
 //handle getSearchOptionsToAdd
 if (method_exists($item, 'getSearchOptionsToAdd')) {
    echo "\n\nFOR GETSEARCHOPTIONSTOADD\n\n";
-   convert($item->getSearchOptionsToAdd(), $item->getTable());
+   convert($item->getSearchOptionsToAdd(), $item::getTable());
 }

--- a/tools/convert_search_options.php
+++ b/tools/convert_search_options.php
@@ -101,7 +101,7 @@ function display($array, $table, $pad = 20, $tab = '         ') {
          switch ($k) {
             case 'table':
                if ($v == $table) {
-                  $v = '$static::getTable()';
+                  $v = 'static::getTable()';
                } else {
                   $v = "'$v'";
                }

--- a/tools/convert_search_options.php
+++ b/tools/convert_search_options.php
@@ -101,7 +101,7 @@ function display($array, $table, $pad = 20, $tab = '         ') {
          switch ($k) {
             case 'table':
                if ($v == $table) {
-                  $v = '$this::getTable()';
+                  $v = '$static::getTable()';
                } else {
                   $v = "'$v'";
                }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

a static method should be called statically, even if PHP does not complains doing call other ways.