### PR TITLE
avoid double clean on slk export

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5873,14 +5873,14 @@ class Search {
             // Header
             foreach ($SYLK_HEADER as $num => $val) {
                $out .= "F;SDM4;FG0C;".($num == 1 ? "Y1;" : "")."X$num\n";
-               $out .= "C;N;K\"".self::sylk_clean($val)."\"\n";
+               $out .= "C;N;K\"$val\"\n";
                $out .= "\n";
             }
             // Datas
             foreach ($SYLK_ARRAY as $row => $tab) {
                foreach ($tab as $num => $val) {
                   $out .= "F;P3;FG0L;".($num == 1 ? "Y".$row.";" : "")."X$num\n";
-                  $out .= "C;N;K\"".self::sylk_clean($val)."\"\n";
+                  $out .= "C;N;K\"$val\"\n";
                }
             }
             $out.= "E\n";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Explanation:

in case of slk export, the output is not directly computed. We pass in 3 steps:
- [showHeaderItem function](https://github.com/glpi-project/glpi/blob/master/inc/search.class.php#L5684) does a sylk_clean and append the value to $SYLK_HEADER
- [showItem function](https://github.com/glpi-project/glpi/blob/master/inc/search.class.php#L5743) does a sylk_clean and append value to $SYLK_ARRAY
- [showFooter function](https://github.com/glpi-project/glpi/blob/master/inc/search.class.php#L5865) parse each value in $SYLK_HEADER and $SYLK_ARRAY, sylk_clean them and finally output 

So, for each value in the displayed tab, we have double sylk_clean call.
In a windows env, i encounter some strange behavior with encoding and missing char.

This pr remove one of the double clean.