### PR TITLE
Drop hardcoded get table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ new whole window
 
 ### API changes
 
+#### Changes
+
+- `CommonDBTM::getTable()` signature has changed
+
 #### Deprecated
 
 The following methods have been deprecated:

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -105,20 +105,26 @@ class CommonDBTM extends CommonGLPI {
 
 
    /**
-    * Return the table used to stor this object
+    * Return the table used to store this object
+    *
+    * @param string $classname Force class (to avoid late_binding on inheritance)
     *
     * @return string
    **/
-   static function getTable() {
+   static function getTable($classname = null) {
       if (static::$notable) {
          return '';
       }
 
-      if (empty($_SESSION['glpi_table_of'][get_called_class()])) {
-         $_SESSION['glpi_table_of'][get_called_class()] = getTableForItemType(get_called_class());
+      if ($classname === null) {
+         $classname = get_called_class();
       }
 
-      return $_SESSION['glpi_table_of'][get_called_class()];
+      if (empty($_SESSION['glpi_table_of'][$classname])) {
+         $_SESSION['glpi_table_of'][$classname] = getTableForItemType($classname);
+      }
+
+      return $_SESSION['glpi_table_of'][$classname];
    }
 
 

--- a/inc/notificationmailsetting.class.php
+++ b/inc/notificationmailsetting.class.php
@@ -51,9 +51,8 @@ class NotificationMailSetting extends CommonDBTM {
 
 
 
-   // Temproray hack for this class in 0.84
-   static function getTable() {
-      return 'glpi_configs';
+   static function getTable($classname = null) {
+      return parent::getTable('Config');
    }
 
 

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -148,12 +148,6 @@ class NotificationTarget extends CommonDBChild {
    }
 
 
-   // Temporary hack for this class since 0.84
-   static function getTable() {
-      return 'glpi_notificationtargets';
-   }
-
-
    /**
     * Validate send before doing it (may be overloaded : exemple for private tasks or followups)
     *

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -98,8 +98,8 @@ class Rule extends CommonDBTM {
 
 
    // Temproray hack for this class
-   static function getTable() {
-      return 'glpi_rules';
+   static function getTable($classname = null) {
+      return parent::getTable(__CLASS__);
    }
 
 

--- a/inc/rulecollection.class.php
+++ b/inc/rulecollection.class.php
@@ -68,8 +68,8 @@ class RuleCollection extends CommonDBTM {
    public $taborientation = 'horizontal';
 
    // Temproray hack for this class
-   static function getTable() {
-      return 'glpi_rules';
+   static function getTable($classname = null) {
+      return parent::getTable('Rule');
    }
 
 

--- a/inc/rulemailcollector.class.php
+++ b/inc/rulemailcollector.class.php
@@ -46,12 +46,6 @@ class RuleMailCollector extends Rule {
    public $can_sort  = true;
 
 
-   // Temproray hack for this class in 0.84
-   static function getTable() {
-      return 'glpi_rules';
-   }
-
-
    /**
     * @see Rule::maxActionsCount()
    **/

--- a/inc/ruleright.class.php
+++ b/inc/ruleright.class.php
@@ -50,13 +50,6 @@ class RuleRight extends Rule {
    public $specific_parameters = true;
 
 
-   // Temproray hack for this class in 0.84
-   static function getTable() {
-      return 'glpi_rules';
-   }
-
-
-
    /**
     * @see Rule::maxActionsCount()
    **/

--- a/inc/slalevel.class.php
+++ b/inc/slalevel.class.php
@@ -58,11 +58,6 @@ class SlaLevel extends RuleTicket {
       // Override in order not to use glpi_rules table.
    }
 
-   // Temporary hack for this class in 0.84
-   static function getTable() {
-      return 'glpi_slalevels';
-   }
-
 
    /**
     * @since version 0.85


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes

In order to remove hardcoded table names from getTable method.