### PR TITLE
fix getTable() issues when 2 an itemtype inherits from an other (and so

### DIFF
--- a/inc/slalevel.class.php
+++ b/inc/slalevel.class.php
@@ -59,6 +59,11 @@ class SlaLevel extends RuleTicket {
    }
 
 
+   static function getTable($classname = null) {
+      return CommonDBTM::getTable(__CLASS__);
+   }
+
+
    /**
     * @since version 0.85
    **/


### PR DESCRIPTION
on for slalevel)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

FlyveMDM unit tests failed today with the following backtrace and similar others ones.
```
+'2017-03-24 15:55:57 [2@workstation-sid]
+  *** MySQL query error:
+  SQL: SELECT `rules_id`
+                   FROM `glpi_slalevelactions`
+                   WHERE `value` = \'1\'
+                         AND `field` LIKE \'%entities_id\'
+  Error: Unknown column 'rules_id' in 'field list'
+  Backtrace :
+  inc/rule.class.php:2925                            
+  inc/rule.class.php:2953                            Rule::cleanForItemActionOrCriteria()
+  inc/entity.class.php:437                           Rule::cleanForItemAction()
+  inc/commondbtm.class.php:504                       Entity->cleanDBonPurge()
+  inc/commondbtm.class.php:1396                      CommonDBTM->deleteFromDB()
+  inc/api.class.php:1764                             CommonDBTM->delete()
+  inc/apirest.class.php:272                          API->deleteItems()
+  ...-mdm/test/src/Glpi/Test/ApiRestTestCase.php:133 APIRest->call()
+  ...-mdm/test/src/Glpi/Test/ApiRestTestCase.php:264 Glpi\Test\ApiRestTestCase->emulateRestRequest()
+  ...tests/0010_Integration/DeleteEntityTest.php:190 Glpi\Test\ApiRestTestCase->entity()
+  :                                                  DeleteEntityTest->testDeleteEntity()
+  ...phpunit/phpunit/src/Framework/TestCase.php:1053 ReflectionMethod->invokeArgs()
+  .../phpunit/phpunit/src/Framework/TestCase.php:912 PHPUnit\Framework\TestCase->runTest()
+  ...hpunit/phpunit/src/Framework/TestResult.php:688 PHPUnit\Framework\TestCase->runBare()
+  .../phpunit/phpunit/src/Framework/TestCase.php:867 PHPUnit\Framework\TestResult->run()
+  ...phpunit/phpunit/src/Framework/TestSuite.php:739 PHPUnit\Framework\TestCase->run()
+  ...r/phpunit/phpunit/src/TextUI/TestRunner.php:514 PHPUnit\Framework\TestSuite->run()
+  ...ndor/phpunit/phpunit/src/TextUI/Command.php:207 PHPUnit\TextUI\TestRunner->doRun()
+  ...ndor/phpunit/phpunit/src/TextUI/Command.php:136 PHPUnit\TextUI\Command->run()
+  plugins/flyvemdm/vendor/phpunit/phpunit/phpunit:53 PHPUnit\TextUI\Command::main()
+'
```

The computation of the slalevel table failed because getTAble() was removed for this itemtype. Adding in slalevel.class.php
```
   static function getTable($classname = null) {
      return parent::getTable(__CLASS__);
   }
```
was not sufficient, because the parent implementation of the method for slalevel is in Rule, and it does not takes into account the argument **$classname**

I think it is more robust to explicitly call CommonDBTM::getTable() when a an itemtype inherits from an other. That's why I also changed rule.class.php and notificationtarget.class.php