### PR TITLE
Prevent to load extra not needed data for bookmarks count

### DIFF
--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -857,7 +857,7 @@ class SavedSearch extends CommonDBTM {
                   $data = $search->prepareDatasForSearch($current_type, $params);
                   $data['search']['sort'] = null;
                   $search->constructSQL($data);
-                  $search->constructDatas($data);
+                  $search->constructDatas($data, true);
                   $count = $data['data']['totalcount'];
                }
             } else {

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -886,11 +886,12 @@ class Search {
     *
     * @since version 0.85
     *
-    * @param $data array of search datas prepared to get datas
+    * @param array   $data      array of search data prepared to get data
+    * @param boolean $onlycount If we just want to count results
     *
     * @return nothing
    **/
-   static function constructDatas(array &$data) {
+   static function constructDatas(array &$data, $onlycount = false) {
       global $CFG_GLPI;
 
       if (!isset($data['sql']) || !isset($data['sql']['search'])) {
@@ -954,6 +955,11 @@ class Search {
                   $data['data']['totalcount'] += $DBread->result($result_num, 0, 0);
                }
             }
+         }
+
+         if ($onlycount) {
+            //we just want to coutn results; no need to continue process
+            return;
          }
 
          // Search case


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

This avoid loading not relevant data counting saved searches. On a test database, with ~100 saved searches:

Before:
- panel load time : ~7s
-  mysqli->query calls : ~4000

After:
- panel load time : ~2s
-  mysqli->query calls : ~400