### PR TITLE
Add a class to display warngins on central page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -4363,6 +4363,29 @@ button.unstyled {
    margin: none;
 }
 
+.warning {
+   padding: .5em;
+   cursor:pointer;
+   font: bold 12px Arial, Helvetica;
+   color: #8f5a0a;
+   background-color: #FEC95C;
+   border: 0;
+   text-align: center;
+}
+
+.warning li {
+   margin-bottom: .5em;
+}
+.warning li:last-child {
+   margin-bottom: 0;
+}
+
+.warning .fa {
+   color: white;
+   float:left;
+   margin-right: .2em;
+}
+
 @media screen and (max-width: 900px) {
    .documentation {
       margin-left: 0 !important;

--- a/inc/central.class.php
+++ b/inc/central.class.php
@@ -203,11 +203,11 @@ class Central extends CommonGLPI {
 
       if (count($warnings)) {
          echo "<tr><th colspan='2'>";
-         Html::displayTitle(
-            $CFG_GLPI['root_doc']."/pics/warning.png",
-            '',
-            "<ul><li>" . implode('</li><li>', $warnings) . "</li></ul>"
-         );
+         echo "<div class='warning'>";
+         echo "<i class='fa fa-exclamation-triangle fa-5x'></i>";
+         echo "<ul><li>" . implode('</li><li>', $warnings) . "</li></ul>";
+         echo "<div class='sep'></div";
+         echo "</div>";
          echo "</th></tr>";
       }
 


### PR DESCRIPTION
Drop nowrap to prevent overflow on small screens with long texts

![warningbox](https://cloud.githubusercontent.com/assets/224733/24740594/38f6a292-1aa2-11e7-8354-d7053d1030a7.png)
