### PR TITLE
load more in session when retrieve ical planning; fix #1448

### DIFF
--- a/front/planning.php
+++ b/front/planning.php
@@ -72,6 +72,17 @@ if (isset($_GET['checkavailability'])) {
       if ($user->getFromDBByToken($_GET['token'])) {
          if (isset($_GET['entities_id']) && isset($_GET['is_recursive'])) {
             $user->loadMinimalSession($_GET['entities_id'], $_GET['is_recursive']);
+
+            // load entities & profiles
+            // needed to pass canViewItem() in populatePlanning functions in case of ical export
+            $_SESSION["glpidefault_entity"]  = $user->fields['entities_id'];
+            Session::initEntityProfiles($user->getID());
+            if (isset($_SESSION['glpiprofiles'][$user->fields['profiles_id']])) {
+               Session::changeProfile($user->fields['profiles_id']);
+
+            } else {
+               Session::changeProfile(key($_SESSION['glpiprofiles']));
+            }
          }
          //// check if the request is valid: rights on uID / gID
          // First check mine : user then groups


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1448