### PR TITLE
Check recursively for UPDATE right

### DIFF
--- a/inc/consumable.class.php
+++ b/inc/consumable.class.php
@@ -495,9 +495,13 @@ class Consumable extends CommonDBChild {
 
       if ($canedit && $number) {
          Html::openMassiveActionsForm('mass'.__CLASS__.$rand);
-         $actions = array('delete' => _x('button', 'Delete permanently'),
-                          'Infocom'.MassiveAction::CLASS_ACTION_SEPARATOR.'activate'
-                                   => __('Enable the financial and administrative information'));
+         $actions = [];
+         if ($consitem->can($tID, PURGE)) {
+            $actions['delete'] = _x('button', 'Delete permanently');
+         }
+         $actions['Infocom'.MassiveAction::CLASS_ACTION_SEPARATOR.'activate']
+            = __('Enable the financial and administrative information');
+
          if ($show_old) {
             $actions['Consumable'.MassiveAction::CLASS_ACTION_SEPARATOR.'backtostock']
                      = __('Back to stock');

--- a/inc/consumableitem.class.php
+++ b/inc/consumableitem.class.php
@@ -458,5 +458,24 @@ class ConsumableItem extends CommonDBTM {
       NotificationEvent::debugEvent($this, $options);
    }
 
+
+   /**
+    * Have I the right to "update" the Object
+    *
+    * Default is true and check entity if the objet is entity assign
+    *
+    * May be overloaded if needed
+    *
+    * Overriden here to check entities recursively
+    *
+    * @return booleen
+   **/
+   function canUpdateItem() {
+
+      if (!$this->checkEntity(true)) {
+         return false;
+      }
+      return true;
+   }
 }
-?>
+


### PR DESCRIPTION
Fixes #1780

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1780

Default behavior in GLPI for `can*Item()` is to check only current entity; without recursivity.

I've overridden the `canUpdateItem()` to display massive actions; so it is now possible to "give" items and "enable infocom". 