### PR TITLE
fix #2075 No change of validation status when deleting a validation request

### DIFF
--- a/inc/commonitilvalidation.class.php
+++ b/inc/commonitilvalidation.class.php
@@ -363,6 +363,20 @@ abstract class CommonITILValidation  extends CommonDBChild {
       parent::post_updateItem($history);
    }
 
+   function pre_deleteItem() {
+
+      $item    = new static::$itemtype();
+      if ($item->getFromDB($this->fields[static::$items_id])) {
+         if (($item->fields['global_validation'] == self::WAITING)) {
+
+            $input['id']                = $this->fields[static::$items_id];
+            $input['global_validation'] = self::NONE;
+            $item->update($input);
+         }
+      }
+      return true;
+   }
+
 
    /**
     * @see CommonDBConnexity::getHistoryChangeWhenUpdateField


### PR DESCRIPTION
No change of validation status when deleting a validation request

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2075 

*Please update this template with something that matches your PR*