### PR TITLE
sanity check before searches; see #2071

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1292,9 +1292,13 @@ abstract class API extends CommonGLPI {
       // Check the criterias are valid
       if (isset($params['criteria']) && is_array($params['criteria'])) {
          foreach ($params['criteria'] as $criteria) {
-            if (isset($criteria['field'])
-                  && ctype_digit($criteria['field'])
-                  && !array_key_exists($criteria['field'], $soptions)) {
+            if (!isset($criteria['field']) || !isset($criteria['searchtype'])
+                || !isset($criteria['value'])) {
+               return $this->returnError(__("Malformed search criteria"));
+            }
+
+            if (!ctype_digit($criteria['field']) 
+                  || !array_key_exists($criteria['field'], $soptions)) {
                return $this->returnError(__("Bad field ID in search criteria"));
             }
          }

--- a/tests/API/APIRestTest.php
+++ b/tests/API/APIRestTest.php
@@ -381,6 +381,8 @@ class APIRestTest extends PHPUnit\Framework\TestCase {
    public function testSearchWithBadCriteria($session_token) {
       // test retrieve all users
       // multidimensional array of vars in query string not supported ? 
+
+      // test a non existing search option ID
       try {
          $res = $this->doHttpRequest('GET', 'search/User/?criteria[0][field]=134343&criteria[0][searchtype]=contains&criteria[0][value]=dsadasd',
                                              ['headers' => [
@@ -388,6 +390,35 @@ class APIRestTest extends PHPUnit\Framework\TestCase {
          $this->assertGreaterThanOrEqual(400, $res->getStatusCode());
       } catch (ClientException $e) {
          $this->assertEquals(400, $this->last_error->getStatusCode());
+         $body = json_decode($e->getResponse()->getBody());
+         $this->assertArrayHasKey('0', $body);
+         $this->assertEquals('ERROR', $body[0]);
+      }
+
+      // test a non numeric search option ID
+      try {
+         $res = $this->doHttpRequest('GET', 'search/User/?criteria[0][field]=\134343&criteria[0][searchtype]=contains&criteria[0][value]=dsadasd',
+               ['headers' => [
+                     'Session-Token' => $session_token]]);
+               $this->assertGreaterThanOrEqual(400, $res->getStatusCode());
+      } catch (ClientException $e) {
+         $this->assertEquals(400, $this->last_error->getStatusCode());
+         $body = json_decode($e->getResponse()->getBody());
+         $this->assertArrayHasKey('0', $body);
+         $this->assertEquals('ERROR', $body[0]);
+      }
+
+      // test an incomplete criteria
+      try {
+         $res = $this->doHttpRequest('GET', 'search/User/?criteria[0][field]=\134343&criteria[0][searchtype]=contains',
+               ['headers' => [
+                     'Session-Token' => $session_token]]);
+               $this->assertGreaterThanOrEqual(400, $res->getStatusCode());
+      } catch (ClientException $e) {
+         $this->assertEquals(400, $this->last_error->getStatusCode());
+         $body = json_decode($e->getResponse()->getBody());
+         $this->assertArrayHasKey('0', $body);
+         $this->assertEquals('ERROR', $body[0]);
       }
    }
 
@@ -1143,7 +1174,7 @@ class APIRestTest extends PHPUnit\Framework\TestCase {
       $criteria = array();
       $queryString = "";
       foreach ($rows as $row) {
-         $queryString = "&criteria[][link]=or&criteria[][field]=1&criteria[][searchtype]=equals&criteria[][value]=" . $row['name'];
+         $queryString = "&criteria[0][link]=or&criteria[0][field]=1&criteria[0][searchtype]=equals&criteria[0][value]=" . $row['name'];
       }
 
       $res = $this->doHttpRequest('GET', "search/Config" . "?$queryString",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2071 

Detects malformed searches to avoid SQL errors.

