### PR TITLE
permit to add items in self-service; fix #876

### DIFF
--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -80,6 +80,10 @@ class Item_Ticket extends CommonDBRelation{
         return false;
       }
 
+      if ($ticket->canUpdateItem()) {
+         return true;
+      }
+
       return parent::canCreateItem();
    }
 
@@ -281,7 +285,7 @@ class Item_Ticket extends CommonDBRelation{
 
       if (!empty($params['items_id'])) {
          // No delete if mandatory and only one item
-         $delete = true;
+         $delete = $ticket->canUpdateItem();
          $cpt = 0;
          foreach ($params['items_id'] as $itemtype => $items) {
             foreach ($items as $items_id) {
@@ -377,9 +381,7 @@ class Item_Ticket extends CommonDBRelation{
          return false;
       }
 
-      $canedit = ($ticket->canAddItem($instID)
-                  && isset($_SESSION["glpiactiveprofile"])
-                  && $_SESSION["glpiactiveprofile"]["interface"] == "central");
+      $canedit = $ticket->canAddItem($instID) && $ticket->canUpdateItem();
       $rand    = mt_rand();
 
       $query = "SELECT DISTINCT `itemtype`

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -432,11 +432,14 @@ class Ticket extends CommonITILObject {
          return false;
       }
 
-      if (($this->numberOfFollowups() == 0)
-          && ($this->numberOfTasks() == 0)
+      if ($_SESSION["glpiactiveprofile"]["interface"] == "helpdesk"
+          && ($this->fields['status'] != self::INCOMING
+            || $this->numberOfFollowups() > 0
+            || $this->numberOfTasks() > 0
+          )
           && ($this->isUser(CommonITILActor::REQUESTER,Session::getLoginUserID())
-              || ($this->fields["users_id_recipient"] === Session::getLoginUserID()))) {
-         return true;
+              || $this->fields["users_id_recipient"] === Session::getLoginUserID())) {
+         return false;
       }
 
       return static::canUpdate();
@@ -884,14 +887,13 @@ class Ticket extends CommonITILObject {
             }
 
             // Can only update initial fields if no followup or task already added
-            if (($this->numberOfFollowups() == 0)
-                && ($this->numberOfTasks() == 0)
-                && $this->isUser(CommonITILActor::REQUESTER, Session::getLoginUserID())) {
+            if ($this->canUpdateItem()) {
                 $allowed_fields[] = 'content';
                 $allowed_fields[] = 'urgency';
                 $allowed_fields[] = 'priority'; // automatic recalculate if user changes urgence
                 $allowed_fields[] = 'itilcategories_id';
                 $allowed_fields[] = 'name';
+                $allowed_fields[] = 'items_id';
             }
 
             if ($this->canSolve()) {
@@ -3881,11 +3883,7 @@ class Ticket extends CommonITILObject {
       $colsize3 = '13';
       $colsize4 = '45';
 
-      $canupdate_descr = $canupdate
-                         || (($this->fields['status'] == self::INCOMING)
-                             && $this->isUser(CommonITILActor::REQUESTER, Session::getLoginUserID())
-                             && ($this->numberOfFollowups() == 0)
-                             && ($this->numberOfTasks() == 0));
+      $canupdate_descr = $canupdate || $this->canUpdateItem();
 
       if (!$options['template_preview']) {
          echo "<form method='post' name='form_ticket' enctype='multipart/form-data' action='".


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #876

It seems the problem mentioned in #876 is already fixed but i found that i can save the choice of item with saving the ticket, so here is an additional correction