### PR TITLE
Feature/api searck sanity check for 9.2

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1347,8 +1347,8 @@ abstract class API extends CommonGLPI {
                return $this->returnError(__("Malformed search criteria"));
             }
 
-            if (!ctype_digit($criteria['field'])
-                || !array_key_exists($criteria['field'], $soptions)) {
+            if (!ctype_digit((string) $criteria['field'])
+                  || !array_key_exists($criteria['field'], $soptions)) {
                return $this->returnError(__("Bad field ID in search criteria"));
             }
          }

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1342,9 +1342,13 @@ abstract class API extends CommonGLPI {
       // Check the criterias are valid
       if (isset($params['criteria']) && is_array($params['criteria'])) {
          foreach ($params['criteria'] as $criteria) {
-            if (isset($criteria['field'])
-                  && ctype_digit($criteria['field'])
-                  && !array_key_exists($criteria['field'], $soptions)) {
+            if (!isset($criteria['field']) || !isset($criteria['searchtype'])
+                || !isset($criteria['value'])) {
+               return $this->returnError(__("Malformed search criteria"));
+            }
+
+            if (!ctype_digit($criteria['field'])
+                || !array_key_exists($criteria['field'], $soptions)) {
                return $this->returnError(__("Bad field ID in search criteria"));
             }
          }

--- a/tests/API/APIBaseClass.php
+++ b/tests/API/APIBaseClass.php
@@ -363,29 +363,29 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
 
       // test a non numeric search option ID
       $data = $this->query('search',
-                           ['itemtype' => 'User',
-                            'headers'  => ['Session-Token' => $session_token],
-                            'query'    => [
+                            ['itemtype' => 'User',
+                             'headers'  => ['Session-Token' => $session_token],
+                             'query'    => [
                               'reset'    => 'reset',
                               'criteria' => [[
                                  'field'      => '\134343',
                                  'searchtype' => 'contains',
                                  'value'      => 'dsadasd',
                               ]]
-                           ]],
-                          400,   // 400 code expected (error, bad request)
-                          'ERROR');
+                            ]],
+                           400,   // 400 code expected (error, bad request)
+                           'ERROR');
 
-     // test an incomplete criteria
-     $data = $this->query('search',
-                          ['itemtype' => 'User',
-                           'headers'  => ['Session-Token' => $session_token],
-                           'query'    => [
+      // test an incomplete criteria
+      $data = $this->query('search',
+                           ['itemtype' => 'User',
+                            'headers'  => ['Session-Token' => $session_token],
+                            'query'    => [
                              'reset'    => 'reset',
                              'criteria' => [[
                                 'field'      => '134343',
                                 'searchtype' => 'contains',
-                             ]]
+                            ]]
                           ]],
                          400,  // 400 code expected (error, bad request)
                          'ERROR');

--- a/tests/API/APIBaseClass.php
+++ b/tests/API/APIBaseClass.php
@@ -319,7 +319,7 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
                               'rawdata'       => true,
                               'criteria'      => [
                                  [
-                                    'field'      => '1',
+                                    'field'      => 1,
                                     'searchtype' => 'contains',
                                     'value'      => 'nonexistent',
                                  ]

--- a/tests/API/APIBaseClass.php
+++ b/tests/API/APIBaseClass.php
@@ -40,21 +40,6 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
                             'enable_api_login_external_token' => true));
    }
 
-   /**
-    * @group  api
-    * @covers API::initSession
-    */
-   public function testInitSessionCredentials() {
-      $data = $this->query('initSession',
-                           ['query' => [
-                              'login'    => TU_USER,
-                              'password' => TU_PASS]]);
-
-      $this->assertNotEquals(false, $data);
-      $this->assertArrayHasKey('session_token', $data);
-      return $data['session_token'];
-   }
-
 
    /**
     * @group  api
@@ -334,7 +319,7 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
                               'rawdata'       => true,
                               'criteria'      => [
                                  [
-                                    'field'      => 1,
+                                    'field'      => '1',
                                     'searchtype' => 'contains',
                                     'value'      => 'nonexistent',
                                  ]
@@ -360,6 +345,8 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
    public function testSearchWithBadCriteria($session_token) {
       // test retrieve all users
       // multidimensional array of vars in query string not supported ?
+
+      // test a non existing search option ID
       $data = $this->query('search',
                            ['itemtype' => 'User',
                             'headers'  => ['Session-Token' => $session_token],
@@ -371,18 +358,48 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
                                  'value'      => 'dsadasd',
                               ]]
                             ]],
-                           400); // 400 code expected (error, bad request)
+                           400,   // 400 code expected (error, bad request)
+                           'ERROR');
+
+      $data = $this->query('search',
+                           ['itemtype' => 'User',
+                            'headers'  => ['Session-Token' => $session_token],
+                            'query'    => [
+                              'reset'    => 'reset',
+                              'criteria' => [[
+                                 'field'      => '\134343',
+                                 'searchtype' => 'contains',
+                                 'value'      => 'dsadasd',
+                              ]]
+                           ]],
+                          400,   // 400 code expected (error, bad request)
+                          'ERROR');
+
+     // test an incomplete criteria
+     $data = $this->query('search',
+                          ['itemtype' => 'User',
+                           'headers'  => ['Session-Token' => $session_token],
+                           'query'    => [
+                             'reset'    => 'reset',
+                             'criteria' => [[
+                                'field'      => '134343',
+                                'searchtype' => 'contains',
+                             ]]
+                          ]],
+                         400,  // 400 code expected (error, bad request)
+                         'ERROR');
    }
 
    /**
     * @group   api
     * @depends testInitSessionCredentials
     */
-   public function testBadEndpoint($session_token, $expected_code = 405) {
+   public function testBadEndpoint($session_token, $expected_code = null, $expected_symbol = null) {
       $data = $this->query('badEndpoint',
                            ['headers' => [
                             'Session-Token' => $session_token]],
-                           $expected_code);
+                           $expected_code,
+                           $expected_symbol);
    }
 
 
@@ -676,7 +693,8 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
                             'query'    => [
                                'range' => '100-105',
                                'expand_dropdowns' => true]],
-                           400);
+                           400,
+                           'ERROR_RANGE_EXCEED_TOTAL');
    }
 
    /**
@@ -707,7 +725,8 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
                     'id'       => $tickets_id,
                     'headers'  => [
                         'Session-Token' => $data['session_token']]],
-                   401);
+                   401,
+                   'ERROR_RIGHT_MISSING');
 
       // try to access ticket list (we should get empty return)
       $data = $this->query('getItems',
@@ -749,14 +768,6 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
       $computers_exist = $computer->getFromDB($computers_id);
       $this->assertEquals(true, (bool) $computers_exist);
       $this->assertEquals("abcdef", $computer->fields['serial']);
-
-      //try to update an item without input
-      $data = $this->query('updateItems',
-                           ['itemtype' => 'Computer',
-                            'verb'     => 'PUT',
-                            'headers'  => ['Session-Token' => $session_token],
-                            'json'     => []],
-                            400);
    }
 
    /**
@@ -964,7 +975,7 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
       $criteria = array();
       $queryString = "";
       foreach ($rows as $row) {
-         $queryString = "&criteria[][link]=or&criteria[][field]=1&criteria[][searchtype]=equals&criteria[][value]=".$row['name'];
+         $queryString = "&criteria[0][link]=or&criteria[0][field]=1&criteria[0][searchtype]=equals&criteria[0][value]=".$row['name'];
       }
 
       $data = $this->query('search',
@@ -1012,7 +1023,8 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
                           ['headers' => ['Session-Token' => $session_token]]);
       $res = $this->query('getFullSession',
                           ['headers' => ['Session-Token' => $session_token]],
-                          401);
+                          401,
+                          'ERROR_SESSION_TOKEN_INVALID');
    }
 
    /**

--- a/tests/API/APIBaseClass.php
+++ b/tests/API/APIBaseClass.php
@@ -372,7 +372,7 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
                                  'searchtype' => 'contains',
                                  'value'      => 'dsadasd',
                               ]]
-                            ]],
+                             ]],
                            400,   // 400 code expected (error, bad request)
                            'ERROR');
 
@@ -385,8 +385,8 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
                              'criteria' => [[
                                 'field'      => '134343',
                                 'searchtype' => 'contains',
-                            ]]
-                          ]],
+                             ]]
+                            ]],
                          400,  // 400 code expected (error, bad request)
                          'ERROR');
    }

--- a/tests/API/APIBaseClass.php
+++ b/tests/API/APIBaseClass.php
@@ -31,6 +31,8 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
                                      $params        = [],
                                      $expected_code = 200);
 
+   abstract public function testInitSessionCredentials();
+
    public static function setUpBeforeClass() {
       // enable api config
       $config = new Config;

--- a/tests/API/APIBaseClass.php
+++ b/tests/API/APIBaseClass.php
@@ -361,6 +361,7 @@ abstract class APIBaseClass extends PHPUnit\Framework\TestCase {
                            400,   // 400 code expected (error, bad request)
                            'ERROR');
 
+      // test a non numeric search option ID
       $data = $this->query('search',
                            ['itemtype' => 'User',
                             'headers'  => ['Session-Token' => $session_token],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2071 #2095 

The fix of the issue for 9.1/bugfix cannit be cherry picked to master because the tests are too different.

This PR requires a global enhancement on tests to check the symbol returned by the API when an error occurs. I also had to specialize some more parts of the unit tests previously common to rest and xmlrpc.

