### PR TITLE
fix dropdowns while editing a computer

### DIFF
--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -473,7 +473,7 @@ class Computer extends CommonDBTM {
       State::dropdown(array('value'     => $this->fields["states_id"],
                             'entity'    => $this->fields["entities_id"],
                             'condition' => "`is_visible_computer`",
-            'rand'      => $randDropdown));
+                            'rand'      => $randDropdown));
       echo "</td></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
@@ -482,7 +482,7 @@ class Computer extends CommonDBTM {
       echo "<td>";
       Location::dropdown(array('value'  => $this->fields["locations_id"],
                                'entity' => $this->fields["entities_id"],
-            'rand' => $randDropdown));
+                               'rand' => $randDropdown));
       echo "</td>";
       $randDropdown = mt_rand();
       echo "<td><label for='dropdown_computertypes_id$randDropdown'>".__('Type')."</label></td>";
@@ -514,7 +514,7 @@ class Computer extends CommonDBTM {
                             'value'     => $this->fields['groups_id_tech'],
                             'entity'    => $this->fields['entities_id'],
                             'condition' => '`is_assign`',
-            'rand' => $randDropdown));
+                            'rand' => $randDropdown));
 
       echo "</td>";
       $randDropdown = mt_rand();

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -467,53 +467,60 @@ class Computer extends CommonDBTM {
          ]
       );
       echo "</td>";
-      echo "<td><label for='dropdown_states_id$rand'>".__('Status')."</label></td>";
+      $randDropdown = mt_rand();
+      echo "<td><label for='dropdown_states_id$randDropdown'>".__('Status')."</label></td>";
       echo "<td>";
       State::dropdown(array('value'     => $this->fields["states_id"],
                             'entity'    => $this->fields["entities_id"],
                             'condition' => "`is_visible_computer`",
-                            'rand'      => $rand));
+            'rand'      => $randDropdown));
       echo "</td></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
-      echo "<td><label for='dropdown_locations_id$rand'>".__('Location')."</label></td>";
+      $randDropdown = mt_rand();
+      echo "<td><label for='dropdown_locations_id$randDropdown'>".__('Location')."</label></td>";
       echo "<td>";
       Location::dropdown(array('value'  => $this->fields["locations_id"],
                                'entity' => $this->fields["entities_id"],
-                               'rand' => $rand));
+            'rand' => $randDropdown));
       echo "</td>";
-      echo "<td><label for='dropdown_computertypes_id$rand'>".__('Type')."</label></td>";
+      $randDropdown = mt_rand();
+      echo "<td><label for='dropdown_computertypes_id$randDropdown'>".__('Type')."</label></td>";
       echo "<td>";
-      ComputerType::dropdown(array('value' => $this->fields["computertypes_id"], 'rand' => $rand));
+      ComputerType::dropdown(array('value' => $this->fields["computertypes_id"], 'rand' => $randDropdown));
       echo "</td></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
-      echo "<td><label for='dropdown_users_id_tech$rand'>".__('Technician in charge of the hardware')."</label></td>";
+      $randDropdown = mt_rand();
+      echo "<td><label for='dropdown_users_id_tech$randDropdown'>".__('Technician in charge of the hardware')."</label></td>";
       echo "<td>";
       User::dropdown(array('name'   => 'users_id_tech',
                            'value'  => $this->fields["users_id_tech"],
                            'right'  => 'own_ticket',
                            'entity' => $this->fields["entities_id"],
-                           'rand'   => $rand));
+                           'rand'   => $randDropdown));
       echo "</td>";
-      echo "<td><label for='dropdown_manufacturers_id$rand'>".__('Manufacturer')."</label></td>";
+      $randDropdown = mt_rand();
+      echo "<td><label for='dropdown_manufacturers_id$randDropdown'>".__('Manufacturer')."</label></td>";
       echo "<td>";
-      Manufacturer::dropdown(array('value' => $this->fields["manufacturers_id"], 'rand' => $rand));
+      Manufacturer::dropdown(array('value' => $this->fields["manufacturers_id"], 'rand' => $randDropdown));
       echo "</td></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
-      echo "<td><label for='dropdown_groups_id_tech$rand'>".__('Group in charge of the hardware')."</label></td>";
+      $randDropdown = mt_rand();
+      echo "<td><label for='dropdown_groups_id_tech$randDropdown'>".__('Group in charge of the hardware')."</label></td>";
       echo "<td>";
       Group::dropdown(array('name'      => 'groups_id_tech',
                             'value'     => $this->fields['groups_id_tech'],
                             'entity'    => $this->fields['entities_id'],
                             'condition' => '`is_assign`',
-                            'rand' => $rand));
+            'rand' => $randDropdown));
 
       echo "</td>";
-      echo "<td><label for='dropdown_computermodels_id$rand'>".__('Model')."</label></td>";
+      $randDropdown = mt_rand();
+      echo "<td><label for='dropdown_computermodels_id$randDropdown'>".__('Model')."</label></td>";
       echo "<td>";
-      ComputerModel::dropdown(array('value' => $this->fields["computermodels_id"], 'rand' => $rand));
+      ComputerModel::dropdown(array('value' => $this->fields["computermodels_id"], 'rand' => $randDropdown));
       echo "</td></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
@@ -552,25 +559,28 @@ class Computer extends CommonDBTM {
       echo "</td></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
-      echo "<td><label for='dropdown_users_id$rand'>".__('User')."</label></td>";
+      $randDropdown = mt_rand();
+      echo "<td><label for='dropdown_users_id$randDropdown'>".__('User')."</label></td>";
       echo "<td>";
       User::dropdown(array('value'  => $this->fields["users_id"],
                            'entity' => $this->fields["entities_id"],
                            'right'  => 'all',
-                           'rand'   => $rand));
+                           'rand'   => $randDropdown));
       echo "</td>";
-      echo "<td><label for='dropdown_networks_id$rand'>".__('Network')."</label></td>";
+      $randDropdown = mt_rand();
+      echo "<td><label for='dropdown_networks_id$randDropdown'>".__('Network')."</label></td>";
       echo "<td>";
-      Network::dropdown(array('value' => $this->fields["networks_id"], 'rand' => $rand));
+      Network::dropdown(array('value' => $this->fields["networks_id"], 'rand' => $randDropdown));
       echo "</td></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
-      echo "<td><label for='dropdown_groups_id$rand'>".__('Group')."</label></td>";
+      $randDropdown = mt_rand();
+      echo "<td><label for='dropdown_groups_id$randDropdown'>".__('Group')."</label></td>";
       echo "<td>";
       Group::dropdown(array('value'     => $this->fields["groups_id"],
                             'entity'    => $this->fields["entities_id"],
                             'condition' => '`is_itemgroup`',
-                            'rand'      => $rand));
+                            'rand'      => $randDropdown));
 
       echo "</td>";
 
@@ -585,11 +595,12 @@ class Computer extends CommonDBTM {
       echo "</textarea></td></tr>";
 
       echo "<tr class='tab_bg_1'>";
-      echo "<td><label for='dropdown_domains_id$rand'>".__('Domain')."</label></td>";
+      $randDropdown = mt_rand();
+      echo "<td><label for='dropdown_domains_id$randDropdown'>".__('Domain')."</label></td>";
       echo "<td >";
       Domain::dropdown(array('value'  => $this->fields["domains_id"],
                              'entity' => $this->fields["entities_id"],
-                             'rand'   => $rand));
+                             'rand'   => $randDropdown));
       echo "</td></tr>";
 
       echo "<tr class='tab_bg_1'>";
@@ -600,9 +611,10 @@ class Computer extends CommonDBTM {
       echo "</tr>\n";
 
       echo "<tr class='tab_bg_1'>";
-      echo "<td><label for='dropdown_autoupdatesystems_id$rand'>".__('Update Source')."</label></td>";
+      $randDropdown = mt_rand();
+      echo "<td><label for='dropdown_autoupdatesystems_id$randDropdown'>".__('Update Source')."</label></td>";
       echo "<td >";
-      AutoUpdateSystem::dropdown(array('value' => $this->fields["autoupdatesystems_id"], 'rand' => $rand));
+      AutoUpdateSystem::dropdown(array('value' => $this->fields["autoupdatesystems_id"], 'rand' => $randDropdown));
       echo "</td></tr>";
       // Display auto inventory informations
       if (!empty($ID)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

If a user creates or edit a computer, for all dropdowns except the "status" field, we cannot add a new item. the modal form displayed is for status instead of lcoation, domain, network, ....

