### PR TITLE
rewrite manageRefreshPage function

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -6119,11 +6119,9 @@ class Html {
          $timer = $timer * MINUTE_TIMESTAMP * 1000;
          
          // call callback function to $timer interval
-         echo self::scriptBlock("
-            window.setInterval(function() {
+         echo self::scriptBlock("window.setInterval(function() {
                $callback
-            }, $timer);
-         ");
+            }, $timer);");
       }
 
       return $text;

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -6119,7 +6119,7 @@ class Html {
          $timer = $timer * MINUTE_TIMESTAMP * 1000;
          
          // call callback function to $timer interval
-         echo self::scriptBlock("window.setInterval(function() {
+         $text = self::scriptBlock("window.setInterval(function() {
                $callback
             }, $timer);");
       }

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -6117,7 +6117,7 @@ class Html {
       if ($timer > 0) {
          // set timer to millisecond from minutes
          $timer = $timer * MINUTE_TIMESTAMP * 1000;
-         
+
          // call callback function to $timer interval
          $text = self::scriptBlock("window.setInterval(function() {
                $callback

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -6115,11 +6115,15 @@ class Html {
 
       $text = "";
       if ($timer > 0) {
-         // Refresh automatique  sur tracking.php
-         $text.="<script type=\"text/javascript\">\n";
-         $text.="setInterval($callback,".
-               (60000 * $timer).");\n";
-         $text.="</script>\n";
+         // set timer to millisecond from minutes
+         $timer = $timer * MINUTE_TIMESTAMP * 1000;
+         
+         // call callback function to $timer interval
+         echo self::scriptBlock("
+            window.setInterval(function() {
+               $callback
+            }, $timer);
+         ");
       }
 
       return $text;

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -645,9 +645,9 @@ class HtmlTest extends PHPUnit\Framework\TestCase {
          unset($_SESSION['glpirefresh_ticket_list']);
       }
 
-      $base_script = "window.setInterval(function() {
+      $base_script = Html::scriptBlock("window.setInterval(function() {
                ##CALLBACK##
-            }, ##TIMER##);";
+            }, ##TIMER##);");
 
       $expected = '';
       $message = Html::manageRefreshPage();

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -645,42 +645,34 @@ class HtmlTest extends PHPUnit\Framework\TestCase {
          unset($_SESSION['glpirefresh_ticket_list']);
       }
 
+      $base_script = "window.setInterval(function() {
+               ##CALLBACK##
+            }, ##TIMER##);";
+
       $expected = '';
       $message = Html::manageRefreshPage();
       $this->assertEquals($expected, $message, 'Timer empty');
 
       //Set session refresh to one minute
       $_SESSION['glpirefresh_ticket_list'] = 1;
-      $expected = "<script type=\"text/javascript\">\n";
-      $expected .= "setInterval(window.location.reload(),".
-            (60000 * $_SESSION['glpirefresh_ticket_list']).");\n";
-      $expected .= "</script>\n";
+      $expected = str_replace("##CALLBACK##", "window.location.reload()", $base_script);
+      $expected = str_replace("##TIMER##", 1 * MINUTE_TIMESTAMP * 1000, $expected);
       $message = Html::manageRefreshPage();
-
       $this->assertEquals($expected, $message, 'Timer set to one minute from session');
 
-      $expected = "<script type=\"text/javascript\">\n";
-      $expected .= "setInterval(function() {\$('#mydiv').remove();},".
-            (60000 * $_SESSION['glpirefresh_ticket_list']).");\n";
-      $expected .= "</script>\n";
-      $message = Html::manageRefreshPage(false, 'function() {$(\'#mydiv\').remove();}');
-
+      $expected = str_replace("##CALLBACK##", '$(\'#mydiv\').remove();', $base_script);
+      $expected = str_replace("##TIMER##", 1 * MINUTE_TIMESTAMP * 1000, $expected);
+      $message = Html::manageRefreshPage(false, '$(\'#mydiv\').remove();');
       $this->assertEquals($expected, $message, 'Timer set to one minute from session with callback');
 
-      $expected ="<script type=\"text/javascript\">\n";
-      $expected .= "setInterval(window.location.reload(),".
-            (60000 * 3).");\n";
-      $expected .= "</script>\n";
+      $expected = str_replace("##CALLBACK##", "window.location.reload()", $base_script);
+      $expected = str_replace("##TIMER##", 3 * MINUTE_TIMESTAMP * 1000, $expected);
       $message = Html::manageRefreshPage(3);
-
       $this->assertEquals($expected, $message, 'Timer set to 3 minutes from args');
 
-      $expected = "<script type=\"text/javascript\">\n";
-      $expected .= "setInterval(function() {\$('#mydiv').remove();},".
-            (60000 * 3).");\n";
-      $expected .= "</script>\n";
-      $message = Html::manageRefreshPage(3, 'function() {$(\'#mydiv\').remove();}');
-
+      $expected = str_replace("##CALLBACK##", '$(\'#mydiv\').remove();', $base_script);
+      $expected = str_replace("##TIMER##", 3 * MINUTE_TIMESTAMP * 1000, $expected);
+      $message = Html::manageRefreshPage(3, '$(\'#mydiv\').remove();');
       $this->assertEquals($expected, $message, 'Timer set to 3 minutes from args minute with callback');
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Current master.

In previous implementation, the function didn't set the ```window.location.reload()``` part into a isolated function.
It results in an instant refresh.
I rewrite also code to enhance readability.