### PR TITLE
in case of required ticket description, ensure tinymce reflect its co…

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3904,6 +3904,13 @@ class Html {
             menubar: false,
             statusbar: false,
             skin: 'light',
+            setup: function(editor) {
+               if ($('#$name').attr('required') == 'required') {
+                  $('#$name').closest('form').find('input[type=submit]').click(function() {
+                     editor.save();
+                  });
+               }
+            },
             plugins: [
                'table directionality searchreplace',
                'tabfocus autoresize link image paste',

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3908,6 +3908,9 @@ class Html {
                if ($('#$name').attr('required') == 'required') {
                   $('#$name').closest('form').find('input[type=submit]').click(function() {
                      editor.save();
+                     if ($('#$name').val() == '') {
+                        alert('".__('The description field is mandatory')."');
+                     }
                   });
                }
             },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

ATM, force save of tinymce on edition.
It avoids to have the required attribute not verified.

We have still the issue with browser tooltips not displayed on the field