### PR TITLE
To permit children classes to rewrite logInFile

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -571,7 +571,7 @@ class Toolbox {
       $err .= self::backtrace(false, $hide, $skip);
 
       // Save error
-      self::logInFile("php-errors", $err);
+      static::logInFile("php-errors", $err);
 
       return $errortype[$errno];
    }


### PR DESCRIPTION
If a class 'PluginPlugnameToolbox' extends Toolbox in order to rewrite logInFile
And if the plugin uses `set_error_handler(array('PluginPlugnameToolbox', 'userErrorHandlerNormal'));` then the new logInFile method will not be called as self points to `Toolbox` and not to `PluginPlugnameToolbox`.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes


