### PR TITLE
Prevent planned task to be stored whenit overlaps

### DIFF
--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -276,8 +276,11 @@ abstract class CommonITILTask  extends CommonDBTM {
                                              false, ERROR);
             return false;
          }
-         Planning::checkAlreadyPlanned($input["users_id_tech"], $input["begin"], $input["end"],
-                                       array($this->getType() => array($input["id"])));
+
+         if (Planning::checkAlreadyPlanned($input["users_id_tech"], $input["begin"], $input["end"],
+                                       array($this->getType() => array($input["id"])))) {
+            return false;
+         }
 
          $calendars_id = Entity::getUsedConfig('calendars_id', $input["_job"]->fields['entities_id']);
          $calendar     = new Calendar();
@@ -399,6 +402,10 @@ abstract class CommonITILTask  extends CommonDBTM {
                                              false, ERROR);
             return false;
          }
+
+         if (Planning::checkAlreadyPlanned($input["users_id_tech"], $input["begin"], $input["end"])) {
+            return false;
+         }
       }
 
       $input["_job"] = new $itemtype();
@@ -447,9 +454,6 @@ abstract class CommonITILTask  extends CommonDBTM {
       $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_mailing"];
 
       if (isset($this->fields["begin"]) && !empty($this->fields["begin"])) {
-         Planning::checkAlreadyPlanned($this->fields["users_id_tech"], $this->fields["begin"],
-                                       $this->fields["end"],
-                                       array($this->getType() => array($this->fields["id"])));
 
          $calendars_id = Entity::getUsedConfig('calendars_id', $this->input["_job"]->fields['entities_id']);
          $calendar     = new Calendar();


### PR DESCRIPTION
fixes #2114

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2114

With this change, task is not stored when an overlap is detected.
An alternative would be not to store plan, but keep storing task. 

The problem is that nothing will be stored, and all entered data will be lost :/ Reopening task form populated with posted data would be great; but I'm affraid this will be difficult to achieve.