### PR TITLE
fix background on login page (when scrolling)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -42,7 +42,9 @@ body {
    margin: 0;
    padding: 0;
    background:  #f8f7f3;
-
+   height: auto;
+   min-height: 100%;
+   position: relative;
 }
 
 body.iframed {
@@ -2007,10 +2009,9 @@ a.icon_nav_move:hover img {
 /* ################--------------- Login Null Header  ---------------#################### */
 
 #firstboxlogin {
-   position: absolute;
-   top: 0;
-   bottom: 0;
    width: 100%;
+   min-height: 100%;
+   min-height: 100vh;
 }
 
 #logo_login {
@@ -3493,7 +3494,6 @@ input[type=checkbox]:not(:disabled) ~ .lever:active:after {
    }
 
    #firstboxlogin {
-      position: fixed;
       overflow-y: auto;
    }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -2011,7 +2011,7 @@ a.icon_nav_move:hover img {
 #firstboxlogin {
    width: 100%;
    min-height: 100%;
-   min-height: 100vh;
+   min-height: 100vh; /* double min-height, some old browser don't have vh units support*/
 }
 
 #logo_login {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Before:
![image](https://cloud.githubusercontent.com/assets/418844/25854717/49ba1732-34d1-11e7-8209-3202619b9331.png)


After
![image](https://cloud.githubusercontent.com/assets/418844/25854731/560c1076-34d1-11e7-91a9-3bcb424f9e79.png)

on \#firstboxlogin, double ```min-height``` definition is here for old browsers which doesn't support vh unit (hello safari)