### PR TITLE
Replace ">" with "-" for [LOCATION]

### DIFF
--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -299,6 +299,7 @@ class Link extends CommonDBTM {
             $link = str_replace("[LOCATION]",
                                 Dropdown::getDropdownName("glpi_locations",
                                                           $item->getField('locations_id')), $link);
+            $link = str_replace(">", "-", $link);
       }
       if (strstr($link, "[NETWORK]")
           && $item->isField('networks_id')) {


### PR DESCRIPTION
When using [LOCATION] for directory it does work with sub directory because ">" is not allowed in directory name in Windows.
(example: file:///X:/APP/[LOCATION]/[NAME])

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | ?
| Deprecations? | ?
| Tests pass?   | yes
| Fixed tickets |