### PR TITLE
Add user anonymous can fill dropdown with data

### DIFF
--- a/ajax/getDropdownValue.php
+++ b/ajax/getDropdownValue.php
@@ -44,9 +44,9 @@ if (strpos($_SERVER['PHP_SELF'], "getDropdownValue.php")) {
    die("Sorry. You can't access this file directly");
 }
 
-if(!isset($_POST['allow_anonymous'])){
+if (!isset($_POST['allow_anonymous'])) {
    Session::checkLoginUser();
-}else if(!$_POST['allow_anonymous']){
+} else if(!$_POST['allow_anonymous']) {
    Session::checkLoginUser();
 }
 

--- a/ajax/getDropdownValue.php
+++ b/ajax/getDropdownValue.php
@@ -44,7 +44,11 @@ if (strpos($_SERVER['PHP_SELF'], "getDropdownValue.php")) {
    die("Sorry. You can't access this file directly");
 }
 
-Session::checkLoginUser();
+if(!isset($_POST['allow_anonymous'])){
+   Session::checkLoginUser();
+}else if(!$_POST['allow_anonymous']){
+   Session::checkLoginUser();
+}
 
 if (isset($_POST["entity_restrict"])
     && !is_array($_POST["entity_restrict"])

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -3524,7 +3524,7 @@ class CommonDBTM extends CommonGLPI {
     *                   (need value_fieldname, to_update, url (see Ajax::updateItemOnSelectEvent for information)
     *                   and may have moreparams)
     *    - used : array / Already used items ID: not to display in dropdown (default empty)
-	*	 - allow_anonymous: allow get data even if user is not logged
+    *    - allow_anonymous: allow get data even if user is not logged
     *
     * @return void display the dropdown
    **/

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -3524,6 +3524,7 @@ class CommonDBTM extends CommonGLPI {
     *                   (need value_fieldname, to_update, url (see Ajax::updateItemOnSelectEvent for information)
     *                   and may have moreparams)
     *    - used : array / Already used items ID: not to display in dropdown (default empty)
+	*	 - allow_anonymous: allow get data even if user is not logged
     *
     * @return void display the dropdown
    **/

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -76,6 +76,7 @@ class Dropdown {
     *    - specific_tags        : array of HTML5 tags to add the the field
     *    - url                  : url of the ajax php code which should return the json data to show in
     *                                       the dropdown
+	*	 - allow_anonymous	    : allow get data even if user is not logged
     *
     * @return boolean : false if error and random id if OK
    **/
@@ -111,6 +112,7 @@ class Dropdown {
       $params['addicon']              = true;
       $params['specific_tags']        = array();
       $params['url']                  = $CFG_GLPI['root_doc']."/ajax/getDropdownValue.php";
+	  $params['allow_anonymous']      = false;
 
       if (is_array($options) && count($options)) {
          foreach ($options as $key => $val) {
@@ -174,6 +176,7 @@ class Dropdown {
                  'on_change'            => $params['on_change'],
                  'permit_select_parent' => $params['permit_select_parent'],
                  'specific_tags'        => $params['specific_tags'],
+				 'allow_anonymous'		=> $params['allow_anonymous'],
                 );
 
       $output = "<span class='no-wrap'>";

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -76,7 +76,7 @@ class Dropdown {
     *    - specific_tags        : array of HTML5 tags to add the the field
     *    - url                  : url of the ajax php code which should return the json data to show in
     *                                       the dropdown
-	*	 - allow_anonymous	    : allow get data even if user is not logged
+    *    - allow_anonymous      : allow get data even if user is not logged
     *
     * @return boolean : false if error and random id if OK
    **/
@@ -112,7 +112,7 @@ class Dropdown {
       $params['addicon']              = true;
       $params['specific_tags']        = array();
       $params['url']                  = $CFG_GLPI['root_doc']."/ajax/getDropdownValue.php";
-	  $params['allow_anonymous']      = false;
+      $params['allow_anonymous']      = false;
 
       if (is_array($options) && count($options)) {
          foreach ($options as $key => $val) {


### PR DESCRIPTION
When we're with the anonymous user and we're in the helpdesk.php we're not able to fill a dropdown with data (i.e: categories) because of we're not logged. Adding a new parameter.
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
