### PR TITLE
add api_token and api_token_date after personnal_token_date

### DIFF
--- a/install/update_91_92.php
+++ b/install/update_91_92.php
@@ -774,8 +774,8 @@ Regards,',
 
    // Create a dedicated token for api
    if (!FieldExists('glpi_users', 'api_token')) {
-      $migration->addField('glpi_users', 'api_token', 'string');
-      $migration->addField('glpi_users', 'api_token_date', 'datetime');
+      $migration->addField('glpi_users', 'api_token', 'string', ['after' => 'personal_token_date']);
+      $migration->addField('glpi_users', 'api_token_date', 'datetime', ['after' => 'api_token']);
       $migration->displayWarning("Api users tokens has been reset, if you use REST/XMLRPC api with personal token for authentication, please reset your user's token.",
                                  true);
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | none
| Fixed tickets | none

when upgrading to GLPI 9.2, add api_token and api_token_date after personal_token_date instead if the end of the table.

THis ensure the table is closer to the original in empty.sql