### PR TITLE
Fix warnings in notifications

### DIFF
--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -198,7 +198,7 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                                           sprintf(__('Fatal error: giving up delivery of email to %s'),
                                                 $current->fields['recipient']),
                                           $current->fields['name']."\n"));
-               $current->delete(array('id' => $curent->fields['id']));
+               $current->delete(array('id' => $current->fields['id']));
             }
 
             $mmail->ClearAddresses();

--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -145,7 +145,9 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
             $current->fields['body_html'] = Html::entity_decode_deep($current->fields['body_html']);
             $documents = importArrayFromDB($current->fields['documents']);
             if (is_array($documents) && count($documents)) {
-               $doc = new Document();
+               if (!$doc = new Document()) {
+                  continue;
+               }
                foreach ($documents as $docID) {
                   $doc->getFromDB($docID);
                   // Add embeded image if tag present in ticket content


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2301 

Should solve this warning
```
2017-06-15 15:41:38 [2@workstation-sid]
  *** PHP Notice(8): Undefined variable: curent
  Backtrace :
  inc/notificationeventmailing.class.php:201         
  inc/queuednotification.class.php:578               NotificationEventMailing::send()
  inc/crontask.class.php:832                         QueuedNotification::cronQueuedNotification()
  front/cron.php:65                                  CronTask::launch()
```
