### PR TITLE
Rename new hook

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -2484,7 +2484,7 @@ class CommonDBTM extends CommonGLPI {
       }
     
       $this->right = $right;
-      plugin::doHook('can', $this);
+      plugin::doHook('item_can', $this);
       switch ($this->right) {
          case READ :
             // Personnal item


### PR DESCRIPTION
Hook already exists with another name in the master branch. Since this one is new, it has to be renamed. See https://github.com/glpi-project/glpi/pull/2304/commits/4958e8be79f5deef6bb8e55b54095e6284cc920d 

@yllen take care if you already used 'can' hook ;)