### PR TITLE
Add translation; fixes #2314

### DIFF
--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -859,8 +859,13 @@ class Migration {
          // rename new tables if exists ?
          if (TableExists($table)) {
             $this->dropTable("backup_$table");
-            $this->displayWarning("$table table already exists. ".
-                                       "A backup have been done to backup_$table.");
+            $this->displayWarning(
+               sprintf(
+                  __('%1$s table already exists. A backup have been done to %2$s'),
+                  $table,
+                  "backup_$table"
+               )
+            );
             $backup_tables = true;
             $this->renameTable("$table", "backup_$table");
          }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2314 

Add translation for backup tables. I wonder if this should be changed as well in all update_*.php files.