### PR TITLE
Feature - anonymous endpoint and extra (not itemtypes) endpoints for plugins

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -41,10 +41,11 @@ abstract class API extends CommonGLPI {
 
    static $api_url = "";
    protected $format;
-   protected $iptxt         = "";
-   protected $ipnum         = "";
-   protected $app_tokens    = array();
-   protected $apiclients_id = 0;
+   protected $iptxt           = "";
+   protected $ipnum           = "";
+   protected $app_tokens      = array();
+   protected $apiclients_id   = 0;
+   protected $extraEndpoints  = [];
 
    /**
     * First function used on api call
@@ -1289,6 +1290,25 @@ abstract class API extends CommonGLPI {
       }
 
       return $uid_parts;
+   }
+
+   /**
+    * return additional endpoints provided by plugins
+    */
+   protected function getExtraEndpoints() {
+      global $PLUGIN_HOOKS;
+
+      $pluginEndpoints = [];
+      foreach ($PLUGIN_HOOKS['api_endpoint'] as $plugin => $endpoints) {
+         if (!is_array($endpoints)) {
+            // Ignore invalid endpoint definition
+            continue;
+         }
+         foreach ($endpoints as $name => $function) {
+            $pluginEndpoints[$name] = $function;
+         }
+      }
+      return $pluginEndpoints;
    }
 
 

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1294,6 +1294,8 @@ abstract class API extends CommonGLPI {
 
    /**
     * return additional endpoints provided by plugins
+    *
+    * @return array endpointName => callable function or method
     */
    protected function getExtraEndpoints() {
       global $PLUGIN_HOOKS;
@@ -1305,7 +1307,10 @@ abstract class API extends CommonGLPI {
             continue;
          }
          foreach ($endpoints as $name => $function) {
-            $pluginEndpoints[$name] = $function;
+            $pluginEndpoints[$name] = [
+                  'callable' => $function,
+                  'plugin'   => $plugin
+            ];
          }
       }
       return $pluginEndpoints;

--- a/inc/apirest.class.php
+++ b/inc/apirest.class.php
@@ -68,7 +68,6 @@ class APIRest extends API {
     * @return mixed json with response or error
     */
    public function call() {
-
       //parse http request and find parts
       $this->request_uri  = $_SERVER['REQUEST_URI'];
       $this->verb         = $_SERVER['REQUEST_METHOD'];
@@ -104,6 +103,8 @@ class APIRest extends API {
       if (isset($this->parameters['session_write'])) {
          $this->session_write = (bool)$this->parameters['session_write'];
       }
+
+      $this->extraEndpoints = $this->getExtraEndpoints();
 
       // inline documentation (api/)
       if ($is_inline_doc) {
@@ -188,6 +189,8 @@ class APIRest extends API {
          }
 
          return $this->returnResponse($response, $code, $additionalheaders);
+      } else if (isset($this->extraEndpoints[$resource]) && is_callable($this->extraEndpoints[$resource])) {
+         return call_user_func($this->extraEndpoints[$resource], $this->parameters);
 
       } else {
          // commonDBTM manipulation

--- a/inc/apirest.class.php
+++ b/inc/apirest.class.php
@@ -189,8 +189,13 @@ class APIRest extends API {
          }
 
          return $this->returnResponse($response, $code, $additionalheaders);
-      } else if (isset($this->extraEndpoints[$resource]) && is_callable($this->extraEndpoints[$resource])) {
-         return call_user_func($this->extraEndpoints[$resource], $this->parameters);
+      } else if (isset($this->extraEndpoints[$resource]) && is_callable($this->extraEndpoints[$resource]['callable'])) {
+         $plug = $this->extraEndpoints[$resource]['plugin'];
+         if (file_exists(GLPI_ROOT . "/plugins/$plug/hook.php")) {
+            include_once(GLPI_ROOT . "/plugins/$plug/hook.php");
+         }
+         $response = call_user_func($this->extraEndpoints[$resource]['callable'], $this, $this->parameters);
+         $this->returnResponse($response);
 
       } else {
          // commonDBTM manipulation
@@ -488,7 +493,7 @@ class APIRest extends API {
     *
     * @return void
     */
-   public function returnResponse($response, $httpcode=200, $additionalheaders=array()) {
+   protected function returnResponse($response, $httpcode=200, $additionalheaders=array()) {
 
       if (empty($httpcode)) {
          $httpcode = 200;

--- a/inc/apixmlrpc.class.php
+++ b/inc/apixmlrpc.class.php
@@ -66,6 +66,8 @@ class APIXmlrpc extends API {
       // retrieve session (if exist)
       $this->retrieveSession();
 
+      $this->extraEndpoints = $this->getExtraEndpoints();
+
       $code = 200;
 
       if ($resource === "initSession") {
@@ -129,6 +131,9 @@ class APIXmlrpc extends API {
          }
 
          return $this->returnResponse($response, $code, $additionalheaders);
+
+      } else if (isset($this->extraEndpoints[$resource]) && is_callable($this->extraEndpoints[$resource])) {
+         return call_user_func($this->extraEndpoints[$resource], $this->parameters);
 
       } else if (in_array($resource,
                           array("getItem", "getItems", "createItems", "updateItems", "deleteItems"))) {

--- a/inc/apixmlrpc.class.php
+++ b/inc/apixmlrpc.class.php
@@ -132,8 +132,13 @@ class APIXmlrpc extends API {
 
          return $this->returnResponse($response, $code, $additionalheaders);
 
-      } else if (isset($this->extraEndpoints[$resource]) && is_callable($this->extraEndpoints[$resource])) {
-         return call_user_func($this->extraEndpoints[$resource], $this->parameters);
+      } else if (isset($this->extraEndpoints[$resource]) && is_callable($this->extraEndpoints[$resource]['callable'])) {
+         $plug = $this->extraEndpoints[$resource]['plugin'];
+         if (file_exists(GLPI_ROOT . "/plugins/$plug/hook.php")) {
+            include_once(GLPI_ROOT . "/plugins/$plug/hook.php");
+         }
+         $response = call_user_func($this->extraEndpoints[$resource]['callable'], $this, $this->parameters);
+         $this->returnResponse($response);
 
       } else if (in_array($resource,
                           array("getItem", "getItems", "createItems", "updateItems", "deleteItems"))) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | PoC for now
| Fixed tickets | 

For FlyveMDM: ability to handle endpoints not matching an itemtype.

Solves the need to have endpoints useable without authentication (depends on the implementation of the hook function in the plugin), and also solves the need to have endpoints which are not handled as an itemtype.

However, this feature allows potentially very big power. Plugin is responsible for proper implementation.

One problem I wish to sholve though: the endpoints are available without authnetication. The implementation is in charge to verify the session if needed. Thus the API cannot check if the plugin is enabled. Plugins may need to implement the callee function in setup.php or use post_init hook to ensure hooks.php is included.

Moreover, to check the session, the callee needs the instance if the API class (not implemented yet)