### PR TITLE
MediumStrenght generator rely on deprecated mcrypt extension

### DIFF
--- a/inc/apiclient.class.php
+++ b/inc/apiclient.class.php
@@ -300,7 +300,7 @@ class APIClient extends CommonDBTM {
 
       $ok = false;
       do {
-         $key    = Toolbox::getRandomString(40, true);
+         $key    = Toolbox::getRandomString(40);
          if (countElementsInTable(self::getTable(), ['app_token' => $key]) == 0) {
             return $key;
          }

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -1477,20 +1477,15 @@ class Toolbox {
     * Get a random string
     *
     * @param integer $length of the random string
-    * @param boolean $high strength of the random source (since 9.2)
     *
     * @return random string
    **/
-   static function getRandomString($length, $high = false) {
+   static function getRandomString($length) {
 
       $factory = new RandomLib\Factory();
-      if ($high) {
-         /* Notice "High" imply mcrypt extension, unwanted for now
-            See https://github.com/ircmaxell/RandomLib/issues/57 */
-         $generator = $factory->getMediumStrengthGenerator();
-      } else {
-         $generator = $factory->getLowStrengthGenerator();
-      }
+      /* "High" (and apparently "Medium") imply mcrypt extension, unwanted for now:
+         https://github.com/ircmaxell/RandomLib/issues/57 */
+      $generator = $factory->getLowStrengthGenerator();
 
       return $generator->generateString($length, RandomLib\Generator::CHAR_LOWER + RandomLib\Generator::CHAR_DIGITS);
    }

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -40,14 +40,9 @@ class Toolbox extends atoum {
 
    public function testGetRandomString() {
       for ($len = 20; $len < 50; $len += 5) {
-         // Low strength
          $str = \Toolbox::getRandomString($len);
          $this->integer(strlen($str))->isIdenticalTo($len);
          $this->boolean(ctype_alnum($str))->isTrue();
-         // High strength
-         $str = \Toolbox::getRandomString($len, true);
-         $this->integer(strlen($str))->isIdenticalTo($len);
-         $this->boolean(ctype_alnum ($str))->isTrue();
       }
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes (maybe -- partial 9.2 only)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2393 