### PR TITLE
Feature/improve mail config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ new whole window
 - `NotificationTemplate::getDataToSend()` signature has changed
 - `QueuedMail` has been renamed to `QueuedNotification`
 - `CommonDBTM::mailqueueonaction` has been renamed to `CommonDBTM::notificationqueueonaction`
+- `NotificationTarget::getSender()` no longer takes any parameters (was not used)
 - `TableExists` has been moved to `DBMysql::tableExists`
 - `FieldExists` has been moved to `DBMysql::fieldExists`
 

--- a/inc/define.php
+++ b/inc/define.php
@@ -163,10 +163,6 @@ define("MAIL_SMTP", 1);
 define("MAIL_SMTPSSL", 2);
 define("MAIL_SMTPTLS", 3);
 
-if (!isset($CFG_GLPI['smtp_max_retries'])) {
-   $CFG_GLPI['smtp_max_retries'] = 5;
-}
-
 // MESSAGE TYPE
 define("INFO", 0);
 define("ERROR", 1);

--- a/inc/glpimailer.class.php
+++ b/inc/glpimailer.class.php
@@ -79,13 +79,22 @@ class GLPIMailer extends PHPMailer {
 
          if (!$CFG_GLPI['smtp_check_certificate']) {
             $this->SMTPOptions = ['ssl' => ['verify_peer'       => false,
-                                                      'verify_peer_name'  => false,
-                                                      'allow_self_signed' => true]];
+                                            'verify_peer_name'  => false,
+                                            'allow_self_signed' => true]];
+         }
+         if ($CFG_GLPI['smtp_sender'] != '') {
+            $this->Sender = $CFG_GLPI['smtp_sender'];
          }
       }
 
       if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
-         $this->do_debug = 3;
+         $this->SMTPDebug = SMTP::DEBUG_CONNECTION;
+         $this->Debugoutput = function ($message, $level) {
+            Toolbox::logInFile(
+               'mail-debug',
+               "$level - $message"
+            );
+         };
       }
    }
 

--- a/inc/notificationmailingsetting.class.php
+++ b/inc/notificationmailingsetting.class.php
@@ -75,39 +75,42 @@ class NotificationMailingSetting extends NotificationSetting {
 
       if ($CFG_GLPI['notifications_mailing']) {
          $out .= "<tr class='tab_bg_2'>";
-         $out .= "<td>" . __('Administrator email') . "</td>";
-         $out .= "<td><input type='text' name='admin_email' size='40' value='".
+         $out .= "<td><label for='admin_email'>" . __('Administrator email') . "</label></td>";
+         $out .= "<td><input type='text' name='admin_email' id='admin_email' size='40' value='".
                     $CFG_GLPI["admin_email"]."'>";
          if (!NotificationMailing::isUserAddressValid($CFG_GLPI["admin_email"])) {
              $out .= "<br/><span class='red'>&nbsp;".__('Invalid email address')."</span>";
          }
          $out .= "</td>";
-         $out .= "<td >" . __('Administrator name') . "</td>";
-         $out .= "<td><input type='text' name='admin_email_name' size='40' value='" .
+         $out .= "<td><label for='admin_email_name'>" . __('Administrator name') . "</label></td>";
+         $out .= "<td><input type='text' name='admin_email_name' id='admin_email_name' size='40' value='" .
                     $CFG_GLPI["admin_email_name"] . "'>";
          $out .= " </td></tr>";
 
          $out .= "<tr class='tab_bg_2'>";
-         $out .= "<td >" . __('Administrator reply-to email (if needed)') . "</td>";
-         $out .= "<td><input type='text' name='admin_reply' size='40' value='" .
+         $out .= "<td><label for='admin_reply'>" . __('Reply-to address') . " <i class='pointer fa fa-info' title='" .
+            __('Optionnal reply to address.') . "\n" . __('If not set, main administrator email will be used.') . "'></i></label></td>";
+         $out .= "<td><input type='text' name='admin_reply' id='admin_reply' size='40' value='" .
                     $CFG_GLPI["admin_reply"] . "'>";
          if (!empty($CFG_GLPI['admin_reply'])
              && !NotificationMailing::isUserAddressValid($CFG_GLPI["admin_reply"])) {
             $out .= "<br/><span class='red'>&nbsp;".__('Invalid email address')."</span>";
          }
          $out .= " </td>";
-         $out .= "<td >" . __('Response name (if needed)') . "</td>";
-         $out .= "<td><input type='text' name='admin_reply_name' size='40' value='" .
+         $out .= "<td><label for='admin_reply_name'>" . __('Reply-to name') . " <i class='pointer fa fa-info' title='" .
+            _('Optionnal reply to name.') . "\n" . __('If not set, main administrator name will be used.'). "'></i></label></td>";
+         $out .= "<td><input type='text' name='admin_reply_name' id='admin_reply_name' size='40' value='" .
                     $CFG_GLPI["admin_reply_name"] . "'>";
          $out .= " </td></tr>";
 
          $out .= "<tr class='tab_bg_2'>";
-         $out .= "<td>" . __('Add documents into ticket notifications') . "</td><td>";
+         $attachrand = mt_rand();
+         $out .= "<td><label for='dropdown_attach_ticket_documents_to_mail$attachrand'>" . __('Add documents into ticket notifications') . "</label></td><td>";
          $out .= Dropdown::showYesNo(
             "attach_ticket_documents_to_mail",
             $CFG_GLPI["attach_ticket_documents_to_mail"],
             -1,
-            ['display' => false]
+            ['display' => false, 'rand' => $attachrand]
          );
          $out .= "</td>";
          $out .= "<td colspan='2'></td></tr>";
@@ -120,12 +123,13 @@ class NotificationMailingSetting extends NotificationSetting {
          }
 
          $out .= "<tr class='tab_bg_2'>";
-         $out .= "<td>" . __('Email signature') . "</td>";
-         $out .= "<td colspan='3'><textarea cols='60' rows='3' name='mailing_signature'>".
+         $out .= "<td><label for='mailing_signature'>" . __('Email signature') . "</label></td>";
+         $out .= "<td colspan='3'><textarea cols='60' rows='3' name='mailing_signature' id='mailing_signature'>".
                                 $CFG_GLPI["mailing_signature"]."</textarea></td></tr>";
 
          $out .= "<tr class='tab_bg_1'><th colspan='4'>".__('Mail server')."</th></tr>";
-         $out .= "<tr class='tab_bg_2'><td>" . __('Way of sending emails') . "</td><td>";
+         $methodrand = mt_rand();
+         $out .= "<tr class='tab_bg_2'><td><label for='dropdown_smtp_mode$methodrand'>" . __('Way of sending emails') . "<label></td><td>";
          $mail_methods = [MAIL_MAIL    => __('PHP'),
                                MAIL_SMTP    => __('SMTP'),
                                MAIL_SMTPSSL => __('SMTP+SSL'),
@@ -135,44 +139,46 @@ class NotificationMailingSetting extends NotificationSetting {
             $mail_methods,
             [
                'value'     => $CFG_GLPI["smtp_mode"],
-               'display'   => false
+               'display'   => false,
+               'rand'      => $methodrand
             ]
          );
          $out .= "</td>";
-         $out .= "<td >" . __("Check certificate") . "</td>";
+         $certrand = mt_rand();
+         $out .= "<td><label for='dropdown_smtp_check_certificate$certrand'>" . __("Check certificate") . "</label></td>";
          $out .= "<td>";
          $out .= Dropdown::showYesNo(
             'smtp_check_certificate',
             $CFG_GLPI["smtp_check_certificate"],
             -1,
-            ['display' => false]
+            ['display' => false, 'rand' => $certrand]
          );
          $out .= "</td>";
          $out .= "</tr>";
 
-         $out .= "<tr class='tab_bg_2'><td >" . __('SMTP host') . "</td>";
-         $out .= "<td><input type='text' name='smtp_host' size='40' value='".$CFG_GLPI["smtp_host"]."'>";
+         $out .= "<tr class='tab_bg_2'><td><label for='smtp_host'>" . __('SMTP host') . "</label></td>";
+         $out .= "<td><input type='text' name='smtp_host' id='smtp_host' size='40' value='".$CFG_GLPI["smtp_host"]."'>";
          $out.= "</td>";
          //TRANS: SMTP port
-         $out .= "<td >" . __('Port') . "</td>";
-         $out .= "<td><input type='text' name='smtp_port' size='5' value='".$CFG_GLPI["smtp_port"]."'>";
+         $out .= "<td><label for='smtp_port'>" . __('Port') . "</label></td>";
+         $out .= "<td><input type='text' name='smtp_port' id='smtp_port' size='5' value='".$CFG_GLPI["smtp_port"]."'>";
          $out .= "</td>";
          $out .= "</tr>";
 
          $out .= "<tr class='tab_bg_2'>";
-         $out .= "<td >" . __('SMTP login (optional)') . "</td>";
-         $out .= "<td><input type='text' name='smtp_username' size='40' value='" .
+         $out .= "<td><label for='smtp_username'>" . __('SMTP login (optional)') . "</label></td>";
+         $out .= "<td><input type='text' name='smtp_username' id='smtp_username' size='40' value='" .
                     $CFG_GLPI["smtp_username"] . "'></td>";
 
-         $out .= "<td >" . __('SMTP password (optional)') . "</td>";
-         $out .= "<td><input type='password' name='smtp_passwd' size='40' value='' autocomplete='off'>";
-         $out .= "<br><input type='checkbox' name='_blank_smtp_passwd'>&nbsp;".__('Clear');
+         $out .= "<td><label for='smtp_passwd'>" . __('SMTP password (optional)') . "</label></td>";
+         $out .= "<td><input type='password' name='smtp_passwd' id='smtp_passwd' size='40' value='' autocomplete='off'>";
+         $out .= "<br><input type='checkbox' name='_blank_smtp_passwd'i id='_blank_smtp_passwd'>&nbsp;<label for='_blank_smtp_passwd'>".__('Clear') . "</label>";
 
          $out .= "</td></tr>";
 
          $out .= "<tr class='tab_bg_2'>";
-         $out .= "<td >" . __('SMTP max. delivery retries') . "</td>";
-         $out .= "<td><input type='text' name='smtp_max_retries' size='5' value='" .
+         $out .= "<td><label for='smtp_max_retries'>" . __('SMTP max. delivery retries') . "</label></td>";
+         $out .= "<td><input type='text' name='smtp_max_retries' id='smtp_max_retries' size='5' value='" .
                        $CFG_GLPI["smtp_max_retries"] . "'></td>";
 
          $out .= "</tr>";

--- a/inc/notificationtargetobjectlock.class.php
+++ b/inc/notificationtargetobjectlock.class.php
@@ -135,7 +135,7 @@ class NotificationTargetObjectLock extends NotificationTarget {
    }
 
 
-   function getSender($options = []) {
+   function getSender() {
 
       $mails = new UserEmail();
       if (isset( $_SESSION['glpiID']) && ($_SESSION['glpiID'] > 0)
@@ -145,10 +145,10 @@ class NotificationTargetObjectLock extends NotificationTarget {
                                               AND is_default = 1 " )) {
 
             $ret = ['email' => $mails->fields['email'],
-                         'name'  => formatUserName(0, $_SESSION["glpiname"], $_SESSION["glpirealname"],
-                                                   $_SESSION["glpifirstname"])];
+                    'name'  => formatUserName(0, $_SESSION["glpiname"], $_SESSION["glpirealname"],
+                                              $_SESSION["glpifirstname"])];
       } else {
-         $ret = parent::getSender($options);
+         $ret = parent::getSender();
       }
 
       return $ret;

--- a/inc/notificationtemplate.class.php
+++ b/inc/notificationtemplate.class.php
@@ -519,7 +519,7 @@ class NotificationTemplate extends CommonDBTM {
       $language   = $user_infos['language'];
       $user_name  = $user_infos['username'];
 
-      $sender     = $target->getSender($options);
+      $sender     = $target->getSender();
       $replyto    = $target->getReplyTo($options);
 
       $mailing_options['to']          = $to;

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -1246,6 +1246,10 @@ INSERT INTO `glpi_configs` VALUES ('175','core','notifications_ajax_check_interv
 INSERT INTO `glpi_configs` VALUES ('176','core','notifications_ajax_sound', NULL);
 INSERT INTO `glpi_configs` VALUES ('177','core','notifications_ajax_icon_url', '/pics/glpi.png');
 INSERT INTO `glpi_configs` VALUES ('178','core','dbversion','9.2-dev');
+INSERT INTO `glpi_configs` VALUES ('179','core','smtp_max_retries','5');
+INSERT INTO `glpi_configs` VALUES ('180','core','smtp_sender', NULL);
+INSERT INTO `glpi_configs` VALUES ('181','core','from_email', NULL);
+INSERT INTO `glpi_configs` VALUES ('182','core','from_email_name', NULL);
 
 
 ### Dump table glpi_consumableitems

--- a/install/update_91_92.php
+++ b/install/update_91_92.php
@@ -1317,6 +1317,13 @@ Regards,',
       $migration->addKey("glpi_problemtasks", "users_id_editor");
    }
 
+   $migration->addConfig([
+      'smtp_max_retries'   => 5,
+      'smtp_sender'        => 'NULL',
+      'from_email'         => 'NULL',
+      'from_email_name'    => 'NULL'
+   ]);
+
    // ************ Keep it at the end **************
    $migration->executeMigration();
 

--- a/tests/units/Config.php
+++ b/tests/units/Config.php
@@ -335,7 +335,7 @@ class Config extends DbTestCase {
    public function testGetConfigurationValues() {
       $conf = \Config::getConfigurationValues('core');
       $this->array($conf)
-         ->hasSize(172)
+         ->hasSize(176)
          ->hasKeys(['version', 'dbversion']);
 
       $conf = \Config::getConfigurationValues('core', ['version', 'dbversion']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1967

Several changes in this proposal:
- add a global from email and names to be used on each send, instead of admin or entity admin infos,
- add a smtp_sender that seems to be required from some providers (it uses the "from" field is fnot set),
- rework debug (not sure it was OK) and log in a specific file,
- rework config form:
   - add html labels,
   - hide smtp configuration when not needed,
   - move some fields from "smtp config" that are not SMTP specific (so they're not hidden)
- drop empty and unused `$options` parameter for ` getSender()` method.