### PR TITLE
Add an option to disabled html progressbar for software merge (intere…

### DIFF
--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -1096,7 +1096,7 @@ class Software extends CommonDBTM {
          }
       }
       if ($html) {
-         Html::changeProgressBarPosition($i, $nb+1, __('Task completed.'));         
+         Html::changeProgressBarPosition($i, $nb+1, __('Task completed.'));
       }
       return $i == ($nb+1);
    }

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -1008,19 +1008,22 @@ class Software extends CommonDBTM {
     * Merge softwares with current
     *
     * @param $item array of software ID to be merged
+    * @param boolean display html progress bar
     *
     * @return boolean about success
    **/
-   function merge($item) {
+   function merge($item, $html = true) {
       global $DB;
 
       $ID = $this->getField('id');
 
-      echo "<div class='center'>";
-      echo "<table class='tab_cadrehov'><tr><th>".__('Merging')."</th></tr>";
-      echo "<tr class='tab_bg_2'><td>";
-      Html::createProgressBar(__('Work in progress...'));
-      echo "</td></tr></table></div>\n";
+      if ($html) {
+         echo "<div class='center'>";
+         echo "<table class='tab_cadrehov'><tr><th>".__('Merging')."</th></tr>";
+         echo "<tr class='tab_bg_2'><td>";
+         Html::createProgressBar(__('Work in progress...'));
+         echo "</td></tr></table></div>\n";
+      }
 
       $item = array_keys($item);
 
@@ -1070,7 +1073,9 @@ class Software extends CommonDBTM {
             if ($DB->query($sql)) {
                $i++;
             }
-            Html::changeProgressBarPosition($i, $nb+1);
+            if ($html) {
+               Html::changeProgressBarPosition($i, $nb+1);
+            }
          }
       }
 
@@ -1090,7 +1095,9 @@ class Software extends CommonDBTM {
             $soft->putInTrash($old, __('Software deleted after merging'));
          }
       }
-      Html::changeProgressBarPosition($i, $nb+1, __('Task completed.'));
+      if ($html) {
+         Html::changeProgressBarPosition($i, $nb+1, __('Task completed.'));         
+      }
       return $i == ($nb+1);
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

This PR adds a new parameter to disable HTML progress bar during software merge.
This allows software merging by script, without displaying progress bar infos in the console.
