### PR TITLE
Fixes #1996

### DIFF
--- a/inc/slalevel_ticket.class.php
+++ b/inc/slalevel_ticket.class.php
@@ -214,7 +214,8 @@ class SlaLevel_Ticket extends CommonDBTM {
                   // Put next level in todo list
                   $next = $slalevel->getNextSltLevel($ticket->fields[$sltField],
                                                      $data['slalevels_id']);
-                  $slt->addLevelToDo($ticket, $next);
+                  $current = $data['slalevels_id'];
+                  $slt->addLevelToDo($ticket, $next, $current);
                   // Action done : drop the line
                   $slalevelticket->delete(array('id' => $data['id']));
 

--- a/inc/slt.class.php
+++ b/inc/slt.class.php
@@ -914,8 +914,9 @@ class SLT extends CommonDBChild {
    **/
    function addLevelToDo(Ticket $ticket, $slalevels_id = 0) {
 
-      $slalevels_id = ($slalevels_id ? $slalevels_id
-                                     : $ticket->fields["ttr_slalevels_id"]);
+      if ( !$slalevels_id and !$current ){
+         $slalevels_id = $ticket->fields["ttr_slalevels_id"];
+      }
       if ($slalevels_id > 0) {
          $toadd = array();
          $date = $this->computeExecutionDate($ticket->fields['date'], $slalevels_id,

--- a/inc/slt.class.php
+++ b/inc/slt.class.php
@@ -912,7 +912,7 @@ class SLT extends CommonDBChild {
     *
     * @return execution date time (NULL if sla not exists)
    **/
-   function addLevelToDo(Ticket $ticket, $slalevels_id = 0, $current) {
+   function addLevelToDo(Ticket $ticket, $slalevels_id = 0, $current = 0) {
 
       if ( !$slalevels_id and !$current ){
          $slalevels_id = $ticket->fields["ttr_slalevels_id"];

--- a/inc/slt.class.php
+++ b/inc/slt.class.php
@@ -912,7 +912,7 @@ class SLT extends CommonDBChild {
     *
     * @return execution date time (NULL if sla not exists)
    **/
-   function addLevelToDo(Ticket $ticket, $slalevels_id = 0) {
+   function addLevelToDo(Ticket $ticket, $slalevels_id = 0, $current) {
 
       if ( !$slalevels_id and !$current ){
          $slalevels_id = $ticket->fields["ttr_slalevels_id"];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Fixed tickets | #1996

Fixing slt excalation infinite loop

Set first esc level from fields["ttr_slalevels_id"] 
only if $slalevels_id and $current are 0

Note that if ticket status gets changed 
(eg. processing to pending and back to 
processing), escalation chain gets reset.
