### PR TITLE
use strict in_array

### DIFF
--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -329,7 +329,7 @@ class DBmysqlIterator implements Iterator, Countable {
             }
 
          } else if (is_array($value)) {
-            if (count($value) == 2 && in_array($value[0], $operators)) {
+            if (count($value) == 2 && in_array($value[0], $operators, true)) {
                if (is_numeric($value[1]) || preg_match("/^`.*?`$/", $value[1])) {
                   $ret .= self::quoteName($name) . " {$value[0]} {$value[1]}";
                } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | will see
| Fixed tickets | #2485

The bug occurs in the following scenario
$value[0] = 0

```php
$operators = ['=', '<', '<=', '>', '>=', 'LIKE', 'REGEXP', 'NOT LIKE', 'NOT REGEX'];
$needle = 0;
var_dump(in_array($needle, $operators));
bool(true)
```

With the fix:
```php
var_dump(in_array($needle, $operators, true));
bool(false)
```