### PR TITLE
avoid changeActiveProfile to silently fail

### DIFF
--- a/apirest.md
+++ b/apirest.md
@@ -247,6 +247,7 @@ $ curl -X GET \
 * **Returns**:
   * 200 (OK).
   * 400 (Bad Request) with a message indicating an error in input parameter.
+  * 404 (Not found) with a message indicating an error ig the profile does not exists or usable.
 
 Example usage (CURL):
 

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -358,10 +358,16 @@ abstract class API extends CommonGLPI {
 
       $this->initEndpoint();
 
+      if (!isset($params['profiles_id'])) {
+         $this->returnError();
+      }
+
       $profiles_id = intval($params['profiles_id']);
       if (isset($_SESSION['glpiprofiles'][$profiles_id])) {
          return Session::changeProfile($profiles_id);
       }
+
+      $this->messageNotfoundError();
    }
 
 

--- a/tests/APIBaseClass.php
+++ b/tests/APIBaseClass.php
@@ -127,10 +127,27 @@ abstract class APIBaseClass extends atoum {
     * @covers  API::changeActiveProfile
     */
    public function testChangeActiveProfile() {
+      // test change to an existing and available profile
       $data = $this->query('changeActiveProfile',
                            ['verb'    => 'POST',
                             'headers' => ['Session-Token' => $this->session_token],
                             'json'    => ['profiles_id'   => 4]]);
+
+      // test change to a non existing profile
+      $data = $this->query('changeActiveProfile',
+                           ['verb'    => 'POST',
+                            'headers' => ['Session-Token' => $this->session_token],
+                            'json'    => ['profiles_id'   => 9999]],
+                           404,
+                           'ERROR_ITEM_NOT_FOUND');
+
+      // test a bad request
+      $data = $this->query('changeActiveProfile',
+                           ['verb'    => 'POST',
+                            'headers' => ['Session-Token' => $this->session_token],
+                            'json'    => ['something_bad' => 4]],
+                           400,
+                           'ERROR');
    }
 
    /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | will see
| Fixed tickets | none

a request to the API endpoint changeActiveProfile may silently fail, sending HTTP 200:
- when profiles_id parameter does not exists
- when the target profile is not available
