### PR TITLE
Feature/mutualize remote ip

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -101,8 +101,7 @@ abstract class API extends CommonGLPI {
       }
 
       // retrieve ip of client
-      $this->iptxt = (isset($_SERVER["HTTP_X_FORWARDED_FOR"]) ? $_SERVER["HTTP_X_FORWARDED_FOR"]
-                                                              : $_SERVER["REMOTE_ADDR"]);
+      $this->iptxt = Toolbox::getRemoteIpAddress();
       $this->ipnum = (strstr($this->iptxt, ':')===false ? ip2long($this->iptxt) : '');
 
       // check ip access

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2698,4 +2698,16 @@ class Toolbox {
       $length = strlen($needle);
       return (substr($haystack, 0, $length) === $needle);
    }
+
+   /**
+    * gets the IP address of the client
+    *
+    * @since 9.2
+    *
+    * @return string the IP address
+    */
+   public static function getRemoteIpAddress() {
+      return (isset($_SERVER["HTTP_X_FORWARDED_FOR"]) ? $_SERVER["HTTP_X_FORWARDED_FOR"]
+                                                      : $_SERVER["REMOTE_ADDR"]);
+   }
 }

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -84,4 +84,23 @@ class Toolbox extends atoum {
    public function testGetSize($input, $expected) {
       $this->string(\Toolbox::getSize($input))->isIdenticalTo($expected);
    }
+
+   public function testGetIPAddress() {
+      // Save values
+      $saveServer = $_SERVER;
+
+      // Test REMOTE_ADDR
+      unset($_SERVER['HTTP_X_FORWARDED_FOR']);
+      $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
+      $ip = \Toolbox::getRemoteIpAddress();
+      $this->variable($ip)->isEqualTo('123.123.123.123');
+
+      // Test HTTP_X_FORWARDED_FOR takes precedence over REMOTE_ADDR
+      $_SERVER['HTTP_X_FORWARDED_FOR'] = '231.231.231.231';
+      $ip = \Toolbox::getRemoteIpAddress();
+      $this->variable($ip)->isEqualTo('231.231.231.231');
+
+      // Restore values
+      $_SERVER = $saveServer;
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | will see
| Fixed tickets | none

I noticed FormCreator does not support proxy when retrieving IP address of a remote (see its IP address field). I also need to get IP address for Flyve MDM.

The REST / XML API retrieves the IP address and handles proxies, so I think it should be provided through its API to plugins.

