### PR TITLE
fix bad header

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -682,7 +682,7 @@ class Toolbox {
          if (isset($mimeTypeMap[$ext])) {
             $mime = $mimeTypeMap[$ext];
          } else {
-            $mime = 'application/octetstream';
+            $mime = 'application/octet-stream';
          }
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | certainly
| Fixed tickets | 

when GLPI sends a file, a header **Accept: application/octetstream** is sent. This header should be **Accept: application/octet-stream**