### PR TITLE
fix disabled addDefaultWhere

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2784,7 +2784,6 @@ class Search {
                   }
                }
             }
-            return "";
       }
       list($itemtype, $condition) = Plugin::doHookFunction('add_default_where', [$itemtype, $condition]);
       return $condition;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

this return "" disables the hook. 

No cherry-pick needed.