### PR TITLE
use rich file upload 'field' for user picture

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -685,15 +685,13 @@ class User extends CommonDBTM {
          $input['picture'] = 'NULL';
       } else {
          $newPicture = false;
-         if (isAPI()) {
-            if (isset($input["_picture"]) && !empty($input["_picture"]) == 1) {
-               $newPicture = true;
-            }
-         } else {
+         if (!isAPI()) {
             if (isset($input["_picture"][0]) && !empty($input["_picture"][0]) == 1) {
                $input["_picture"] = $input["_picture"][0];
-               $newPicture = true;
             }
+         }
+         if (isset($input["_picture"]) && !empty($input["_picture"]) == 1) {
+            $newPicture = true;
          }
          if ($newPicture) {
             $fullpath = GLPI_TMP_DIR."/".$input["_picture"];

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -686,11 +686,11 @@ class User extends CommonDBTM {
       } else {
          $newPicture = false;
          if (!isAPI()) {
-            if (isset($input["_picture"][0]) && !empty($input["_picture"][0]) == 1) {
+            if (isset($input["_picture"][0]) && !empty($input["_picture"][0])) {
                $input["_picture"] = $input["_picture"][0];
             }
          }
-         if (isset($input["_picture"]) && !empty($input["_picture"]) == 1) {
+         if (isset($input["_picture"]) && !empty($input["_picture"])) {
             $newPicture = true;
          }
          if ($newPicture) {
@@ -707,7 +707,7 @@ class User extends CommonDBTM {
                $picture_path = GLPI_PICTURE_DIR  . "/$sub/${filename}.$extension";
                self::dropPictureFiles($filename.".".$extension);
 
-               if (Document::isImage($_FILES['picture']['name'])
+               if (Document::isImage($input["_picture"])
                    && Document::renameForce($fullpath, $picture_path)) {
                   Session::addMessageAfterRedirect(__('The file is valid. Upload is successful.'));
                   // For display
@@ -2306,7 +2306,7 @@ class User extends CommonDBTM {
             $full_picture .= "</div>";
 
             Html::showTooltip($full_picture, ['applyto' => "picture$rand"]);
-            echo "<input type='file' name='picture' accept='image/*'>";
+            echo Html::file(['name' => 'picture', 'display' => false, 'onlyimages' => true]);
 
             echo "&nbsp;";
             Html::showCheckbox(['name' => '_blank_picture', 'title' => __('Clear')]);

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -684,15 +684,26 @@ class User extends CommonDBTM {
          self::dropPictureFiles($this->fields['picture']);
          $input['picture'] = 'NULL';
       } else {
-         if (isset($input["_picture"][0]) && !empty($input["_picture"][0]) == 1) {
-            $fullpath = GLPI_TMP_DIR."/".$input["_picture"][0];
+         $newPicture = false;
+         if (isAPI()) {
+            if (isset($input["_picture"]) && !empty($input["_picture"]) == 1) {
+               $newPicture = true;
+            }
+         } else {
+            if (isset($input["_picture"][0]) && !empty($input["_picture"][0]) == 1) {
+               $input["_picture"] = $input["_picture"][0];
+               $newPicture = true;
+            }
+         }
+         if ($newPicture) {
+            $fullpath = GLPI_TMP_DIR."/".$input["_picture"];
             if (toolbox::getMime($fullpath, 'image')) {
                // Unlink old picture (clean on changing format)
                self::dropPictureFiles($this->fields['picture']);
                // Move uploaded file
                $filename     = uniqid($this->fields['id'].'_');
                $sub          = substr($filename, -2); /* 2 hex digit */
-               $tmp          = explode(".", $input["_picture"][0]);
+               $tmp          = explode(".", $input["_picture"]);
                $extension    = Toolbox::strtolower(array_pop($tmp));
                @mkdir(GLPI_PICTURE_DIR . "/$sub");
                $picture_path = GLPI_PICTURE_DIR  . "/$sub/${filename}.$extension";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

The main purpose of this PR is to allow update of user picture from the API by removing the need tu handle a file upload with the HTTP PUT verb.

This also allows to drag / drop a picture in GLPI's UI and unifies the interface between User and Document.

To update the picture of a user from the API, the API consumer needs to upload a file with the endpoint ajax/fileUpload.php, then send a HTTP PUT request on the user object with a additional property **_picture** containing the filename as answered in JSON after a successful upload.

```json
{
  "input": {
    "id": 9,
    "_picture": "my_picture.jpg"
  }
}
````

