### PR TITLE
Deleted not used variable $extraparam and Fixed #2031 and #2553 

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -760,7 +760,7 @@ class CommonDBTM extends CommonGLPI {
          $saved = Html::cleanPostForTextArea($_SESSION['saveInput'][$this->getType()]);
 
          // clear saved data when restored (only need once)
-         unset($_SESSION['saveInput'][$this->getType()]);
+         $this->clearSavedInput();
 
          return $saved;
       }

--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -685,7 +685,6 @@ class CommonGLPI {
 
       $target         = $_SERVER['PHP_SELF'];
       $extraparamhtml = "";
-      $extraparam     = "";
       $withtemplate   = "";
       if (is_array($options) && count($options)) {
          if (isset($options['withtemplate'])) {
@@ -699,7 +698,6 @@ class CommonGLPI {
             unset($cleaned_options['stock_image']);
          }
          $extraparamhtml = "&amp;".Toolbox::append_params($cleaned_options,'&amp;');
-         $extraparam     = "&".Toolbox::append_params($cleaned_options);
       }
       echo "<div class='glpi_tabs ".($this->isNewID($ID)?"new_form_tabs":"")."'>";
       echo "<div id='tabspanel' class='center-h'></div>";
@@ -762,7 +760,6 @@ class CommonGLPI {
       }
       $target         = $_SERVER['PHP_SELF'];
       $extraparamhtml = "";
-      $extraparam     = "";
       $withtemplate   = "";
 
       if (is_array($options) && count($options)) {
@@ -778,7 +775,6 @@ class CommonGLPI {
             }
          }
          $extraparamhtml = "&amp;".Toolbox::append_params($cleanoptions,'&amp;');
-         $extraparam     = "&".Toolbox::append_params($cleanoptions);
       }
 
       if (empty($withtemplate)
@@ -940,7 +936,6 @@ class CommonGLPI {
       }
       $target         = $_SERVER['PHP_SELF'];
       $extraparamhtml = "";
-      $extraparam     = "";
       $withtemplate   = "";
 
       if (is_array($options) && count($options)) {
@@ -951,7 +946,6 @@ class CommonGLPI {
             // Do not include id options
             if (($key[0] != '_') && ($key != 'id')) {
                $extraparamhtml .= "&amp;$key=$val";
-               $extraparam     .= "&$key=$val";
             }
          }
       }

--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -697,7 +697,12 @@ class CommonGLPI {
          if (isset($cleaned_options['stock_image'])) {
             unset($cleaned_options['stock_image']);
          }
-         $extraparamhtml = "&amp;".Toolbox::append_params($cleaned_options,'&amp;');
+         if ($this->getType() == 'Ticket') {
+            $this->input = $cleaned_options;
+            $this->saveInput();
+         } else {
+            $extraparamhtml = "&amp;".Toolbox::append_params($cleaned_options,'&amp;');
+         }
       }
       echo "<div class='glpi_tabs ".($this->isNewID($ID)?"new_form_tabs":"")."'>";
       echo "<div id='tabspanel' class='center-h'></div>";

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -3767,17 +3767,6 @@ class Ticket extends CommonITILObject {
          }
       }
 
-      if (isset($options['content'])) {
-         // Clean new lines to be fix encoding
-         $order            = array('\\r', '\\n', "\\");
-         $replace          = array("", "", "");
-
-         $options['content'] = str_replace($order,$replace,$options['content']);
-      }
-      if (isset($options['name'])) {
-         $options['name'] = str_replace("\\", "", $options['name']);
-      }
-
       if (!$ID) {
          // Override defaut values from projecttask if needed
          if (isset($options['_projecttasks_id'])) {


### PR DESCRIPTION
$extraparam was not used at all, so I deleted it and I deleted the line that assigned a value to it.
Also fixed #2031 and #2553
Moved for Ticket type only the $extraparamhtml mechanism to saveInput() and restoreInput()
Added a new filter for \\\\n to be converted into \n in cleanPostForTextArea
Added a test for this new filter in testCleanPostForTextArea() test method.
Deleted in ticket::showForm() the section that was doing replace of "\\r", "\\n" and "\\" by "" (is done by cleanPostForTextArea)
Changed restoreInput so that it wall call clearSavedInput.

regards,
Tomolimo

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
