### PR TITLE
onClick was duplicated in the $search_config_bottom

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1221,7 +1221,6 @@ class Search {
 
                $search_config_top    .= Html::jsGetElementbyID('search_config_top').
                                                       ".dialog('open');\"";
-               $search_config_bottom .= " onClick=\"";
                $search_config_bottom .= Html::jsGetElementbyID('search_config_bottom').
                                                       ".dialog('open');\"";
 


### PR DESCRIPTION
Got a javascript error when viewing user list (for example).
Was due to duplicated 'onClick' in the $search_config_bottom
fixes #2560 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixes issue | #2560 
