### PR TITLE
Added colorpicker to admin config

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -456,7 +456,7 @@ $CFG_GLPI['javascript'] = [
          'notificationtemplate' => ['tinymce']
       ]
    ],
-   'admin'     => ['clipboard'],
+   'admin'     => ['colorpicker', 'clipboard'],
    'preference'=> ['colorpicker', 'clipboard'],
 ];
 


### PR DESCRIPTION
In order to load colorpicker jquery plugin when viewing settings of a user

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2563 

