### PR TITLE
Issue wddxdeprecated

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -506,9 +506,8 @@ class Toolbox {
     * @param $errmsg    string   error message.
     * @param $filename  string   filename that the error was raised in.
     * @param $linenum   integer  line number the error was raised at.
-    * @param $vars      array    that points to the active symbol table at the point the error occurred.
    **/
-   static function userErrorHandlerNormal($errno, $errmsg, $filename, $linenum, $vars) {
+   static function userErrorHandlerNormal($errno, $errmsg, $filename, $linenum) {
 
       // Date et heure de l'erreur
       $errortype = [E_ERROR             => 'Error',
@@ -530,9 +529,6 @@ class Toolbox {
       $user_errors = [E_USER_ERROR, E_USER_NOTICE, E_USER_WARNING];
 
       $err = '  *** PHP '.$errortype[$errno] . "($errno): $errmsg\n";
-      if (in_array($errno, $user_errors) && function_exists('wddx_serialize_value')) {
-         $err .= "Variables:".wddx_serialize_value($vars, "Variables")."\n";
-      }
 
       $skip = ['Toolbox::backtrace()'];
       if (isset($_SESSION['glpi_use_mode']) && $_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
@@ -573,12 +569,11 @@ class Toolbox {
     * @param $errmsg    string   error message.
     * @param $filename  string   filename that the error was raised in.
     * @param $linenum   integer  line number the error was raised at.
-    * @param $vars      array    that points to the active symbol table at the point the error occurred.
    **/
-   static function userErrorHandlerDebug($errno, $errmsg, $filename, $linenum, $vars) {
+   static function userErrorHandlerDebug($errno, $errmsg, $filename, $linenum) {
 
       // For file record
-      $type = self::userErrorHandlerNormal($errno, $errmsg, $filename, $linenum, $vars);
+      $type = self::userErrorHandlerNormal($errno, $errmsg, $filename, $linenum);
 
       // Display
       if (!isCommandLine()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |o
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | don't know yet
| Fixed tickets | no


See http://php.net/manual/en/function.set-error-handler.php
The 5th parameter ($errcontext) is deprecated (7.2)
More **wddx** is unsecure, and will probably be deprecated / removed in a near future.
