### PR TITLE
Changed 'Ticket recall' text into 'Ticket# %s description' and %s 

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -7089,7 +7089,7 @@ class Ticket extends CommonITILObject {
 
          echo "<div class='h_content TicketContent'>";
 
-         echo "<div class='b_right'>".__("Ticket recall")."</div>";
+         echo "<div class='b_right'>".sprintf(__("Ticket# %s description"), $this->getID())."</div>";
 
          echo "<div class='ticket_title'>";
          echo Html::setSimpleTextContent($this->fields['name']);


### PR DESCRIPTION
Changed 'Ticket recall' text into 'Ticket# %s description' and %s willl take the ticket ID.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Partially fixed ticket | #1918 

This new text has been approved by our US service-desk colleagues.
