### PR TITLE
handle plugins CSS requirements

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1152,7 +1152,11 @@ class Html {
                   $jslibs = $CFG_GLPI['javascript'][$sector][$item];
                }
             } else {
-               $jslibs = $CFG_GLPI['javascript'][$sector];
+               if (isset($CFG_GLPI['javascript']['plugins'][$item][$option])) {
+                  $jslibs = $CFG_GLPI['javascript']['plugins'][$item][$option];
+               } else {
+                  $jslibs = $CFG_GLPI['javascript'][$sector];
+               }
             }
          }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | wait and see
| Fixed tickets | 

If a plugin requires a library provided by GLPI, and this library requires an additional CSS, GLPI does not adds the CSS in the HEAD tag of the HTML.

Example:

The following loads chartist library, but the CSS included in Chartist is not added.

 ```php
// setup.php of a plugin
function plugin_init_flyvemdm() {
   // ...
   $CFG_GLPI['javascript']['plugins']['pluginflyvemdmmenu']['Menu'] = ['charts'];
   // ...
}
```

```php
// front/menu.php of the plugin

Html::header(PluginFlyvemdmMenu::getTypeName(Session::getPluralNumber()), '', 'admin', 'PluginFlyvemdmMenu', 'Menu');

```