### PR TITLE
Fix migration on some cases

### DIFF
--- a/install/update_91_92.php
+++ b/install/update_91_92.php
@@ -1046,9 +1046,14 @@ function update91to92() {
       $DB->queryOrDie($query, "9.2 Add saved search alerts notification template");
       $nottid = $DB->insert_id();
 
-      $query = "INSERT INTO `glpi_notifications_notificationtemplates`
-                VALUES (null, $notid, '".Notification_NotificationTemplate::MODE_MAIL."', $nottid);";
-      $DB->queryOrDie($query, "9.2 Add saved search alerts notification");
+      $where =  "`notifications_id`='$notid' AND `mode`='" .
+         Notification_NotificationTemplate::MODE_MAIL.
+         "' AND `notificationtemplates_id`='$nottid'";
+      if (countElementsInTable('glpi_notifications_notificationtemplates', $where)) {
+         $query = "INSERT INTO `glpi_notifications_notificationtemplates`
+                   VALUES (null, $notid, '".Notification_NotificationTemplate::MODE_MAIL."', $nottid);";
+         $DB->queryOrDie($query, "9.2 Add saved search alerts notification");
+      }
 
       $query = "INSERT INTO `glpi_notificationtargets`
                 VALUES (null,'19','1','$notid');";
@@ -1353,9 +1358,14 @@ Regards,',
       $DB->queryOrDie($query, "9.2 Add certifcate alerts notification template");
       $nottid = $DB->insert_id();
 
-      $query = "INSERT INTO `glpi_notifications_notificationtemplates`
-                VALUES (null, $notid, '".Notification_NotificationTemplate::MODE_MAIL."', $nottid);";
-      $DB->queryOrDie($query, "9.2 Add scertificates alerts notification templates");
+      $where =  "`notifications_id`='$notid' AND `mode`='" .
+         Notification_NotificationTemplate::MODE_MAIL.
+         "' AND `notificationtemplates_id`='$nottid'";
+      if (!countElementsInTable('glpi_notifications_notificationtemplates', $where)) {
+         $query = "INSERT INTO `glpi_notifications_notificationtemplates`
+                   VALUES (null, $notid, '".Notification_NotificationTemplate::MODE_MAIL."', $nottid);";
+         $DB->queryOrDie($query, "9.2 Add certificates alerts notification templates");
+      }
 
       $query = "INSERT INTO `glpi_notificationtemplatetranslations`
                   (`notificationtemplates_id`, `language`, `subject`, `content_text`, `content_html`)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

To reproduce the original issue:
- install a 9.2 DB,
- switch to 9.1/bf branch, and cliinstall,
- switch back to 9.2/bf and try to update.

You'll get something like:
```
 * MySQL query error: SQL: INSERT INTO glpi_notifications_notificationtemplates VALUES (null, 67, \'mailing\', 25); Error: Duplicate entry '67-mailing-25' for key 'unicity'
```

This happens because templates and notifications tables are reset from the 9.1 cliinstall; but  glpi_notifications_notificationtemplates remains the same (exists only on 9.2); that lands to this unicity issue.