### PR TITLE
telemetry: retrieve plugin key instead translated name

### DIFF
--- a/inc/telemetry.class.php
+++ b/inc/telemetry.class.php
@@ -85,9 +85,9 @@ class Telemetry extends CommonGLPI {
       ];
 
       $plugins = new Plugin();
-      foreach ($plugins->getList(['name', 'version']) as $plugin) {
+      foreach ($plugins->getList(['directory', 'version']) as $plugin) {
          $glpi['plugins'][] = [
-            'key'       => $plugin['name'],
+            'key'       => $plugin['directory'],
             'version'   => $plugin['version']
          ];
       }

--- a/tests/units/Telemetry.php
+++ b/tests/units/Telemetry.php
@@ -69,11 +69,13 @@ class Telemetry extends DbTestCase {
       $this->array($result)->isIdenticalTo($expected);
 
       $plugins = new \Plugin();
-      $this->integer((int)$plugins->add(['name' => 'test plugin', 'version' => '0.x.z']))
+      $this->integer((int)$plugins->add(['directory' => 'testplugin',
+                                         'name'      => 'test plugin',
+                                         'version'   => '0.x.z']))
          ->isGreaterThan(0);
 
       $expected['plugins'][] = [
-         'key'       => 'test plugin',
+         'key'       => 'testplugin',
          'version'   => '0.x.z'
       ];
       $this->array(\Telemetry::grabGlpiInfos())->isIdenticalTo($expected);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

In http://glpi-project.org/telemetry/, submitted plugins are translated