### PR TITLE
Use CommonDBTM::getLinkURL() instead of manual concatenation

### DIFF
--- a/front/authmail.form.php
+++ b/front/authmail.form.php
@@ -55,7 +55,7 @@ if (isset($_POST["update"])) {
    if ($_POST["name"] != "") {
       if (($newID = $config_mail->add($_POST))
           && $_SESSION['glpibackcreated']) {
-         Html::redirect($config_mail->getFormURL()."?id=".$newID);
+         Html::redirect($config_mail->getLinkURL());
       }
    }
    Html::back();

--- a/front/budget.form.php
+++ b/front/budget.form.php
@@ -54,7 +54,7 @@ if (isset($_POST["add"])) {
                   //TRANS: %1$s is the user login, %2$s is the name of the item to add
                   sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($budget->getFormURL()."?id=".$newID);
+         Html::redirect($budget->getLinkURL());
       }
    }
    Html::back();

--- a/front/cartridgeitem.form.php
+++ b/front/cartridgeitem.form.php
@@ -52,7 +52,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "cartridgeitems", 4, "inventory",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($cartype->getFormURL()."?id=".$newID);
+         Html::redirect($cartype->getLinkURL());
       }
    }
    Html::back();

--- a/front/change.form.php
+++ b/front/change.form.php
@@ -52,7 +52,7 @@ if (isset($_POST["add"])) {
               //TRANS: %1$s is the user login, %2$s is the name of the item
               sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
    if ($_SESSION['glpibackcreated']) {
-      Html::redirect($change->getFormURL()."?id=".$newID);
+      Html::redirect($change->getLinkURL());
    } else {
       Html::back();
    }

--- a/front/computer.form.php
+++ b/front/computer.form.php
@@ -56,7 +56,7 @@ if (isset($_POST["add"])) {
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
 
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($computer->getFormURL()."?id=".$newID);
+         Html::redirect($computer->getLinkURL());
       }
    }
    Html::back();

--- a/front/computerantivirus.form.php
+++ b/front/computerantivirus.form.php
@@ -56,7 +56,7 @@ if (isset($_POST["add"])) {
                  //TRANS: %s is the user login
                  sprintf(__('%s adds an antivirus'), $_SESSION["glpiname"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($antivirus->getFormURL()."?id=".$newID);
+         Html::redirect($antivirus->getLinkURL());
       }
    }
    Html::back();

--- a/front/computerdisk.form.php
+++ b/front/computerdisk.form.php
@@ -56,7 +56,7 @@ if (isset($_POST["add"])) {
                  //TRANS: %s is the user login
                  sprintf(__('%s adds a volume'), $_SESSION["glpiname"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($disk->getFormURL()."?id=".$newID);
+         Html::redirect($disk->getFormURL());
       }
    }
    Html::back();

--- a/front/computervirtualmachine.form.php
+++ b/front/computervirtualmachine.form.php
@@ -56,7 +56,7 @@ if (isset($_POST["add"])) {
                  //TRANS: %s is the user login
                  sprintf(__('%s adds a virtual machine'), $_SESSION["glpiname"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect(Toolbox::getItemTypeFormURL('ComputerVirtualMachine')."?id=".$newID);
+         Html::redirect($dis->getLinkURL());
       }
    }
    Html::back();

--- a/front/consumableitem.form.php
+++ b/front/consumableitem.form.php
@@ -53,7 +53,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "consumableitems", 4, "inventory",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($constype->getFormURL()."?id=".$newID);
+         Html::redirect($constype->getLinkURL());
       }
    }
    Html::back();

--- a/front/contact.form.php
+++ b/front/contact.form.php
@@ -60,7 +60,7 @@ if (isset($_GET['getvcard'])) {
       Event::log($newID, "contacts", 4, "financial",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($contact->getFormURL()."?id=".$newID);
+         Html::redirect($contact->getLinkURL());
       }
    }
    Html::back();

--- a/front/contract.form.php
+++ b/front/contract.form.php
@@ -58,7 +58,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "contracts", 4, "financial",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($contract->getFormURL()."?id=".$newID);
+         Html::redirect($contract->getLinkURL());
       }
 
    }

--- a/front/document.form.php
+++ b/front/document.form.php
@@ -60,14 +60,14 @@ if (isset($_POST["add"])) {
          }
       }
       if ($_SESSION['glpibackcreated'] && (!isset($_POST['itemtype']) || !isset($_POST['items_id']))) {
-         Html::redirect($doc->getFormURL()."?id=".$newID);
+         Html::redirect($doc->getLinkURL());
       }
    } else if ($newID = $doc->add($_POST)) {
       Event::log($newID, "documents", 4, "login",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $doc->fields["name"]));
       // Not from item tab
       if ($_SESSION['glpibackcreated'] && (!isset($_POST['itemtype']) || !isset($_POST['items_id']))) {
-         Html::redirect($doc->getFormURL()."?id=".$newID);
+         Html::redirect($doc->getLinkURL());
       }
    }
 

--- a/front/dropdown.common.form.php
+++ b/front/dropdown.common.form.php
@@ -63,7 +63,7 @@ if (isset($_POST["add"])) {
                     sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       }
       if ($_SESSION['glpibackcreated']) {
-        $url = $dropdown->getFormURLWithID($newID);
+        $url = $dropdown->getLinkURL();
         if (isset($_REQUEST['_in_modal'])) {
           $url.="&_in_modal=1";
         }

--- a/front/group.form.php
+++ b/front/group.form.php
@@ -51,7 +51,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "groups", 4, "setup",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($group->getFormURL()."?id=".$newID);
+         Html::redirect($group->getLinkURL());
       }
    }
    Html::back();

--- a/front/mailcollector.form.php
+++ b/front/mailcollector.form.php
@@ -52,7 +52,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "mailcollector", 4, "setup",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($mailgate->getFormURL()."?id=".$newID);
+         Html::redirect($mailgate->getLinkURL());
       }
    }
    Html::back();

--- a/front/monitor.form.php
+++ b/front/monitor.form.php
@@ -55,7 +55,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "monitors", 4, "inventory",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($monitor->getFormURL()."?id=".$newID);
+         Html::redirect($monitor->getLinkURL());
       }
    }
    Html::back();

--- a/front/networkalias.form.php
+++ b/front/networkalias.form.php
@@ -53,7 +53,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, $alias->getType(), 4, "setup",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($alias->getFormURL()."?id=".$newID);
+         Html::redirect($alias->getLinkURL());
       }
    }
    Html::back();

--- a/front/networkequipment.form.php
+++ b/front/networkequipment.form.php
@@ -54,7 +54,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "networkequipment", 4, "inventory",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($netdevice->getFormURL()."?id=".$newID);
+         Html::redirect($netdevice->getLinkURL());
       }
    }
    Html::back();

--- a/front/networkname.form.php
+++ b/front/networkname.form.php
@@ -47,7 +47,7 @@ if (isset($_POST["add"])) {
                  //TRANS: %s is the user login
                  sprintf(__('%s adds an item'), $_SESSION["glpiname"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($nn->getFormURL()."?id=".$newID);
+         Html::redirect($nn->getLinkURL());
       }
    }
    Html::back();

--- a/front/peripheral.form.php
+++ b/front/peripheral.form.php
@@ -55,7 +55,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "peripherals", 4, "inventory",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($peripheral->getFormURL()."?id=".$newID);
+         Html::redirect($peripheral->getLinkURL());
       }
    }
    Html::back();

--- a/front/phone.form.php
+++ b/front/phone.form.php
@@ -55,7 +55,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "phones", 4, "inventory",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($phone->getFormURL()."?id=".$newID);
+         Html::redirect($phone->getLinkURL());
       }
    }
    Html::back();

--- a/front/printer.form.php
+++ b/front/printer.form.php
@@ -54,7 +54,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "printers", 4, "inventory",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($print->getFormURL()."?id=".$newID);
+         Html::redirect($print->getLinkURL());
       }
    }
    Html::back();

--- a/front/problem.form.php
+++ b/front/problem.form.php
@@ -51,7 +51,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "problem", 4, "maintain",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($problem->getFormURL()."?id=".$newID);
+         Html::redirect($problem->getLinkURL());
       }
    }
    Html::back();

--- a/front/project.form.php
+++ b/front/project.form.php
@@ -53,7 +53,7 @@ if (isset($_POST["add"])) {
               //TRANS: %1$s is the user login, %2$s is the name of the item
               sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
    if ($_SESSION['glpibackcreated']) {
-      Html::redirect($project->getFormURL()."?id=".$newID);
+      Html::redirect($project->getLinkURL());
    } else {
       Html::back();
    }

--- a/front/projecttask.form.php
+++ b/front/projecttask.form.php
@@ -59,7 +59,7 @@ if (isset($_POST["add"])) {
               //TRANS: %s is the user login
               sprintf(__('%s adds a task'), $_SESSION["glpiname"]));
    if ($_SESSION['glpibackcreated']) {
-      Html::redirect($task->getFormURL()."?id=".$newID);
+      Html::redirect($task->getLinkURL());
    } else {
       Html::redirect(ProjectTask::getFormURL()."?projects_id=".$task->fields['projects_id']);
    }

--- a/front/reminder.form.php
+++ b/front/reminder.form.php
@@ -50,7 +50,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "reminder", 4, "tools",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($remind->getFormURL()."?id=".$newID);
+         Html::redirect($remind->getLinkURL());
       }
    }
    Html::back();

--- a/front/sla.form.php
+++ b/front/sla.form.php
@@ -52,7 +52,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "slas", 4, "setup",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($sla->getFormURL()."?id=".$newID);
+         Html::redirect($sla->getLinkURL());
       }
    }
    Html::redirect($CFG_GLPI["root_doc"]."/front/sla.php");

--- a/front/slalevel.form.php
+++ b/front/slalevel.form.php
@@ -59,7 +59,7 @@ if (isset($_POST["update"])) {
                  //TRANS: %s is the user login
                  sprintf(__('%s adds a link with an item'), $_SESSION["glpiname"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($item->getFormURL()."?id=".$newID);
+         Html::redirect($item->getLinkURL());
       }
    }
    Html::back();

--- a/front/slt.form.php
+++ b/front/slt.form.php
@@ -52,7 +52,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "slts", 4, "setup",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($slt->getFormURL()."?id=".$newID);
+         Html::redirect($slt->getLinkURL());
       }
    }
    Html::back();

--- a/front/software.form.php
+++ b/front/software.form.php
@@ -54,7 +54,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "software", 4, "inventory",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($soft->getFormURL()."?id=".$newID);
+         Html::redirect($soft->getLinkURL());
       }
    }
    Html::back();

--- a/front/softwarelicense.form.php
+++ b/front/softwarelicense.form.php
@@ -57,7 +57,7 @@ if (isset($_POST["add"])) {
                  //TRANS: %s is the user login, %2$s is the license id
                  sprintf(__('%1$s adds the license %2$s'), $_SESSION["glpiname"], $newID));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($license->getFormURL()."?id=".$newID);
+         Html::redirect($license->getLinkURL());
       }
    }
    Html::back();

--- a/front/supplier.form.php
+++ b/front/supplier.form.php
@@ -53,7 +53,7 @@ if (isset($_POST["add"])) {
       Event::log($newID, "suppliers", 4, "financial",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($ent->getFormURL()."?id=".$newID);
+         Html::redirect($ent->getLinkURL());
       }
    }
    Html::back();

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -65,7 +65,7 @@ if (isset($_POST["add"])) {
 
    if ($id = $track->add($_POST)) {
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($track->getFormURL()."?id=".$id);
+         Html::redirect($track->getLinkURL());
       }
    }
    Html::back();

--- a/front/tracking.injector.php
+++ b/front/tracking.injector.php
@@ -69,7 +69,7 @@ if (isset($_POST['add'])) {
    }
    if ($newID = $track->add($_POST)) {
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($track->getFormURL()."?id=".$newID);
+         Html::redirect($track->getLinkURL());
       }
       if (isset($_POST["_type"]) && ($_POST["_type"] == "Helpdesk")) {
          echo "<div class='center spaced'>".

--- a/front/user.form.php
+++ b/front/user.form.php
@@ -70,7 +70,7 @@ if (isset($_GET['getvcard'])) {
       Event::log($newID, "users", 4, "setup",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {
-         Html::redirect($user->getFormURL()."?id=".$newID);
+         Html::redirect($user->getLinkURL());
       }
    }
    Html::back();

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -945,14 +945,13 @@ class CommonDBTM extends CommonGLPI {
     * @return string : HTML link
    **/
    function getLinkURL() {
-      global $CFG_GLPI;
 
       if (!isset($this->fields['id'])) {
          return '';
       }
 
       $link  = $this->getFormURLWithID($this->getID());
-      $link .= ($this->isTemplate() ? "&amp;withtemplate=1" : "");
+      $link .= ($this->isTemplate() ? "&withtemplate=1" : "");
 
       return $link;
    }
@@ -962,7 +961,6 @@ class CommonDBTM extends CommonGLPI {
     * Add a message on add action
    **/
    function addMessageOnAddAction() {
-      global $CFG_GLPI;
 
       $addMessAfterRedirect = false;
       if (isset($this->input['_add'])) {


### PR DESCRIPTION
This fixes #2332 (templates are automatically handled from getLinkURL())

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2332