### PR TITLE
Don't use filename

### DIFF
--- a/front/fileupload.php
+++ b/front/fileupload.php
@@ -71,8 +71,13 @@ $errors =  array(
 
 $upload_dir = GLPI_TMP_DIR.'/';
 
+$pname = $_GET['name'];
+$rand_name = uniqid('', true);
+foreach ($_FILES[$pname]['name'] as &$name) {
+   $name = $rand_name . $name;
+}
 $upload_handler = new UploadHandler(array('upload_dir'        => $upload_dir,
-                                          'param_name'        => $_GET['name'],
+                                          'param_name'        => $pname,
                                           'orient_image'      => false,
                                           'image_versions'    => array()),
                                     false, $errors);
@@ -80,13 +85,14 @@ $response = $upload_handler->post(false);
 
 
 // clean compute display filesize
-if (isset($response[$_GET['name']]) && is_array($response[$_GET['name']])) {
+if (isset($response[$pname]) && is_array($response[$pname])) {
 
 
-   foreach ($response[$_GET['name']] as $key => &$val) {
+   foreach ($response[$pname] as $key => &$val) {
       if (Document::isValidDoc(addslashes($val->name))) {
+         $val->prefix = $rand_name;
          if (isset($val->name)) {
-            $val->display = $val->name;
+            $val->display = str_replace($rand_name, '', $val->name);
          }
          if (isset($val->size)) {
             $val->filesize = Toolbox::getSize($val->size);
@@ -96,7 +102,7 @@ if (isset($response[$_GET['name']]) && is_array($response[$_GET['name']])) {
          }
       } else { // Unlink file
          $val->error = $errors['accept_file_types'];
-	 if (file_exists($upload_dir.$val->name)) {
+         if (file_exists($upload_dir.$val->name)) {
             @unlink($upload_dir.$val->name);
          }
       }

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -1750,6 +1750,9 @@ abstract class CommonITILObject extends CommonDBTM {
             $input2["_only_if_upload_succeed"] = 1;
             $input2["entities_id"]             = $this->fields["entities_id"];
             $input2["_filename"]               = array($file);
+            if (isset($this->input['_prefix_filename'][$key])) {
+               $input2["_prefix_filename"]  = [$this->input['_prefix_filename'][$key]];
+            }
             $docID = $doc->add($input2);
          }
 

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -900,7 +900,13 @@ class Document extends CommonDBTM {
    static function moveUploadedDocument(array &$input, $filename) {
       global $CFG_GLPI;
 
-      $fullpath = GLPI_UPLOAD_DIR."/".$filename;
+      $prefix = '';
+      if (isset($input['_prefix_filename'])) {
+         $prefix = array_shift($input['_prefix_filename']);
+      }
+
+      $fullpath = GLPI_TMP_DIR."/".$filename;
+      $filename = str_replace($prefix, '', $filename);
 
       if (!is_dir(GLPI_UPLOAD_DIR)) {
          Session::addMessageAfterRedirect(__("Upload directory doesn't exist"), false, ERROR);
@@ -982,7 +988,13 @@ class Document extends CommonDBTM {
    static function moveDocument(array &$input, $filename) {
       global $CFG_GLPI;
 
+      $prefix = '';
+      if (isset($input['_prefix_filename'])) {
+         $prefix = array_shift($input['_prefix_filename']);
+      }
+
       $fullpath = GLPI_TMP_DIR."/".$filename;
+      $filename = str_replace($prefix, '', $filename);
       if (!is_dir(GLPI_TMP_DIR)) {
          Session::addMessageAfterRedirect(__("Temporary directory doesn't exist"), false, ERROR);
          return false;

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -5322,6 +5322,7 @@ class Html {
 
             // File
             $('<input/>').attr('type', 'hidden').attr('name', '_".$p['name']."['+fileindex".$p['rand']."+']').attr('value',file.name).appendTo(p);\n
+            $('<input/>').attr('type', 'hidden').attr('name', '_prefix_".$p['name']."['+fileindex".$p['rand']."+']').attr('value',file.prefix).appendTo(p);\n
 
             // Tag
             $('<input/>').attr('type', 'hidden').attr('name', '_tag_".$p['name']."['+fileindex".$p['rand']."+']').attr('value', tag.name).appendTo(p);\n


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

The goal is not to use the real filename, this would prevent rejected file to be accessed while they're still in temporay directory.