### PR TITLE
avoid to throw warning on inexistant hosts in telemetry

### DIFF
--- a/inc/telemetry.class.php
+++ b/inc/telemetry.class.php
@@ -136,22 +136,29 @@ class Telemetry extends CommonGLPI {
    static public function grabWebserverInfos() {
       global $CFG_GLPI;
 
-      $headers = get_headers($CFG_GLPI['url_base']);
-
-      //BEGIN EXTRACTING SERVER DETAILS
-      $pattern = '#^Server:*#i';
-      $matches = preg_grep($pattern, $headers);
-
+      $headers = false;
       $engine  = '';
       $version = '';
 
-      if (count($matches)) {
-         $infos = current($matches);
-         $pattern = '#Server: ([^ ]+)/([^ ]+)#i';
-         preg_match($pattern, $infos, $srv_infos);
-         if (count($srv_infos) == 3) {
-            $engine  = $srv_infos[1];
-            $version = $srv_infos[2];
+      // check if host is present (do no throw php warning in contrary of get_headers)
+      if (filter_var(gethostbyname(parse_url($CFG_GLPI['url_base'], PHP_URL_HOST)),
+          FILTER_VALIDATE_IP)) {
+         $headers = get_headers($CFG_GLPI['url_base']);
+      }
+
+      if (is_array($headers)) {
+         //BEGIN EXTRACTING SERVER DETAILS
+         $pattern = '#^Server:*#i';
+         $matches = preg_grep($pattern, $headers);
+
+         if (count($matches)) {
+            $infos = current($matches);
+            $pattern = '#Server: ([^ ]+)/([^ ]+)#i';
+            preg_match($pattern, $infos, $srv_infos);
+            if (count($srv_infos) == 3) {
+               $engine  = $srv_infos[1];
+               $version = $srv_infos[2];
+            }
          }
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

fix some warnings:
```
2017-09-07 13:57:45 [@LU002]
  *** PHP Warning(2): get_headers(): php_network_getaddresses: getaddrinfo failed: Name or service not known
  Backtrace :
  :                                                  
  inc/telemetry.class.php:139                        get_headers()
  inc/telemetry.class.php:49                         Telemetry::grabWebserverInfos()
  inc/telemetry.class.php:252                        Telemetry::getTelemetryInfos()
  inc/crontask.class.php:832                         Telemetry::cronTelemetry()
  front/cron.php:65                                  CronTask::launch()
2017-09-07 13:57:45 [@LU002]
  *** PHP Warning(2): get_headers(...): failed to open stream: php_network_getaddresses: getaddrinfo failed: Name or service not known
  Backtrace :
  :                                                  
  inc/telemetry.class.php:139                        get_headers()
  inc/telemetry.class.php:49                         Telemetry::grabWebserverInfos()
  inc/telemetry.class.php:252                        Telemetry::getTelemetryInfos()
  inc/crontask.class.php:832                         Telemetry::cronTelemetry()
  front/cron.php:65                                  CronTask::launch()
2017-09-07 13:57:45 [@LU002]
  *** PHP Warning(2): preg_grep() expects parameter 2 to be array, boolean given
  Backtrace :
  :                                                  
  inc/telemetry.class.php:143                        preg_grep()
  inc/telemetry.class.php:49                         Telemetry::grabWebserverInfos()
  inc/telemetry.class.php:252                        Telemetry::getTelemetryInfos()
  inc/crontask.class.php:832                         Telemetry::cronTelemetry()
  front/cron.php:65    
```