### PR TITLE
fix manual update

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2589,4 +2589,26 @@ class Config extends CommonDBTM {
       return $values;
    }
 
+   /**
+    * Get message that informs the user he's using a development version
+    *
+    * @param boolean $bg Display a background
+    *
+    * @return void
+    */
+   public static function agreeDevMessage($bg = false) {
+      $msg = '<p class="'.($bg ? 'mig' : '') .'red"><strong>' . __('You are using a development version, be careful!') . '</strong><br/>';
+      $msg .= "<input type='checkbox' required='required' id='agree_dev' name='agree_dev'/><label for='agree_dev'>" . __('I know I am using a unstable version.') . "</label></p>";
+      $msg .= "<script type=text/javascript>
+            $(function() {
+               $('[name=from_update]').on('click', function(event){
+                  if(!$('#agree_dev').is(':checked')) {
+                     event.preventDefault();
+                     alert('" . __('Please check the unstable version checkbox.') . "');
+                  }
+               });
+            });
+            </script>";
+      return $msg;
+   }
 }

--- a/inc/config.php
+++ b/inc/config.php
@@ -264,18 +264,7 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
             if ($older === true) {
                echo "<form method='post' action='".$CFG_GLPI["root_doc"]."/install/update.php'>";
                if ($dev === true) {
-                  echo '<p class="red"><strong>' . __('You are using a development version, be careful!') . '</strong><br/>';
-                  echo "<input type='checkbox' required='required' id='agree_dev' name='agree_dev'/><label for='agree_dev'>" . __('I know I am using a unstable version.') . "</label></p>";
-                  echo "<script type=text/javascript>
-                        $(function() {
-                           $('[name=from_update]').on('click', function(event){
-                              if(!$('#agree_dev').is(':checked')) {
-                                 event.preventDefault();
-                                 alert('" . __('Please check the unstable version checkbox.') . "');
-                              }
-                           });
-                        });
-                        </script>";
+                  echo Config::agreeDevMessage();
                }
                echo "<p class='red'>";
                echo __('The version of the database is not compatible with the version of the installed files. An update is necessary.')."</p>";

--- a/install/update.php
+++ b/install/update.php
@@ -536,6 +536,7 @@ if (empty($_POST["continuer"]) && empty($_POST["from_update"])) {
       echo "<h3><span class='migred'>".sprintf(__('Caution! You will update the GLPI database named: %s'), $DB->dbdefault) ."</h3>";
 
       echo "<form action='update.php' method='post'>";
+      echo Config::agreeDevMessage();
       echo "<input type='submit' class='submit' name='continuer' value=\"".__('Continue')."\">";
       Html::closeForm();
       echo "</div>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

with the introduction of upgrade from stable to dev, manual upgrade (config/config.db.php absent) didn't work anymore.
I am forcing the missing parameter in hidden, because the code of detection of old and new version seems complex to factorize, your thoughts ?