### PR TITLE
collect mails with uid instead index

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -55,8 +55,8 @@ class MailCollector  extends CommonDBTM {
    public $charset         = "";
    /// IMAP / POP connection
    public $marubox         = '';
-   /// ID of the current message
-   public $mid             = -1;
+   /// UID of the current message
+   public $uid             = -1;
    /// structure used to store the mail structure
    public $structure       = false;
    /// structure used to store files attached to a mail
@@ -71,6 +71,8 @@ class MailCollector  extends CommonDBTM {
    public $fetch_emails    = 0;
    /// Maximum number of emails to fetch : default to 10
    public $maxfetch_emails = 10;
+   /// array of indexes -> uid for messages
+   public $messages_uid    = [];
    /// Max size for attached files
    public $filesize_max    = 0;
    /// Body converted
@@ -422,7 +424,7 @@ class MailCollector  extends CommonDBTM {
       $ticket = new Ticket();
       foreach ($todelete as $mailcollector_id => $rejected) {
          if ($this->getFromDB($mailcollector_id)) {
-            $this->mid          = -1;
+            $this->uid          = -1;
             $this->fetch_emails = 0;
             //Connect to the Mail Box
             $this->connect();
@@ -487,7 +489,7 @@ class MailCollector  extends CommonDBTM {
       global $CFG_GLPI;
 
       if ($this->getFromDB($mailgateID)) {
-         $this->mid          = -1;
+         $this->uid          = -1;
          $this->fetch_emails = 0;
          //Connect to the Mail Box
          $this->connect();
@@ -503,9 +505,15 @@ class MailCollector  extends CommonDBTM {
             $refused     = 0;
             $blacklisted = 0;
 
+            //get messages id
+            for ($i=1 ; ($i <= $tot); $i++) {
+               $this->messages_uid[$i] = imap_uid($this->marubox, $i);
+            }
+
             for ($i=1 ; ($i <= $tot) && ($this->fetch_emails < $this->maxfetch_emails) ; $i++) {
-               $tkt = $this->buildTicket($i, array('mailgates_id' => $mailgateID,
-                                                   'play_rules'   => true));
+               $uid = $this->messages_uid[$i];
+               $tkt = $this->buildTicket($uid, array('mailgates_id' => $mailgateID,
+                                                     'play_rules'   => true));
 
                //Indicates that the mail must be deleted from the mailbox
                $delete_mail = false;
@@ -530,7 +538,7 @@ class MailCollector  extends CommonDBTM {
 
                // Manage blacklisted emails
                if (isset($tkt['_blacklisted']) && $tkt['_blacklisted']) {
-                  $this->deleteMails($i, self::REFUSED_FOLDER);
+                  $this->deleteMails($uid, self::REFUSED_FOLDER);
                   $blacklisted++;
                // entities_id set when new ticket / tickets_id when new followup
                } else if (((isset($tkt['entities_id']) || isset($tkt['tickets_id']))
@@ -577,7 +585,7 @@ class MailCollector  extends CommonDBTM {
                   }
                   //Delete Mail from Mail box if ticket is added successfully
                   if ($delete_mail) {
-                     $this->deleteMails($i, $delete_mail);
+                     $this->deleteMails($uid, $delete_mail);
                   }
 
                } else {
@@ -589,7 +597,7 @@ class MailCollector  extends CommonDBTM {
                   }
                   $refused++;
                   $rejected->add($rejinput);
-                  $this->deleteMails($i, self::REFUSED_FOLDER);
+                  $this->deleteMails($uid, self::REFUSED_FOLDER);
                }
                $this->fetch_emails++;
             }
@@ -628,16 +636,16 @@ class MailCollector  extends CommonDBTM {
 
    /** function buildTicket - Builds,and returns, the major structure of the ticket to be entered.
     *
-    * @param $i                  mail ID
+    * @param @param $uid UID of the message
     * @param $options   array    of possible options
     *
     * @return ticket fields array
     */
-   function buildTicket($i, $options=array()) {
+   function buildTicket($uid, $options=array()) {
       global $CFG_GLPI;
 
       $play_rules = (isset($options['play_rules']) && $options['play_rules']);
-      $head       = $this->getHeaders($i); // Get Header Info Return Array Of Headers
+      $head       = $this->getHeaders($uid); // Get Header Info Return Array Of Headers
                                            // **Key Are (subject,to,toOth,toNameOth,from,fromName)
       $tkt                 = array();
       $tkt['_blacklisted'] = false;
@@ -670,7 +678,7 @@ class MailCollector  extends CommonDBTM {
       // max size = 0 : no import attachments
       if ($this->fields['filesize_max'] > 0) {
          if (is_writable(GLPI_TMP_DIR)) {
-            $tkt['_filename'] = $this->getAttached($i, GLPI_TMP_DIR."/", $this->fields['filesize_max']);
+            $tkt['_filename'] = $this->getAttached($uid, GLPI_TMP_DIR."/", $this->fields['filesize_max']);
             $tkt['_tag']      = $this->tags;
          } else {
             //TRANS: %s is a directory
@@ -716,7 +724,7 @@ class MailCollector  extends CommonDBTM {
       $tkt['_auto_import']           = 1;
       // For followup : do not check users_id = login user
       $tkt['_do_not_check_users_id'] = 1;
-      $body                          = $this->getBody($i);
+      $body                          = $this->getBody($uid);
 
       // Do it before using charset variable
       $head['subject']               = $this->decodeMimeString($head['subject']);
@@ -1106,26 +1114,26 @@ class MailCollector  extends CommonDBTM {
     *
     * @param $mid : Message ID.
    **/
-    function getStructure ($mid) {
+    function getStructure ($uid) {
 
-      if (($mid != $this->mid)
+      if (($uid != $this->uid)
           || !$this->structure) {
-         $this->structure = imap_fetchstructure($this->marubox,$mid);
+         $this->structure = imap_fetchstructure($this->marubox, $uid, FT_UID);
 
          if ($this->structure) {
-            $this->mid = $mid;
+            $this->uid = $uid;
          }
       }
    }
 
 
    /**
-    * @param $mid
+    * @param $uid UID of the message
    **/
-   function getAdditionnalHeaders($mid) {
+   function getAdditionnalHeaders($uid) {
 
       $head   = array();
-      $header = explode("\n", imap_fetchheader($this->marubox, $mid));
+      $header = explode("\n", imap_fetchheader($this->marubox, $uid, FT_UID));
 
       if (is_array($header) && count($header)) {
          foreach ($header as $line) {
@@ -1155,7 +1163,7 @@ class MailCollector  extends CommonDBTM {
    /**
     * This function is use full to Get Header info from particular mail
     *
-    * @param $mid               = Mail Id of a Mailbox
+    * @param $uid UID of the message
     *
     * @return Return Associative array with following keys
     * subject   => Subject of Mail
@@ -1165,9 +1173,10 @@ class MailCollector  extends CommonDBTM {
     * from      => From address of mail
     * fromName  => Form Name of Mail
    **/
-   function getHeaders($mid) { // Get Header info
+   function getHeaders($uid) { // Get Header info
+      //$mail_header  = imap_header($this->marubox, $mid);
+      $mail_header = imap_rfc822_parse_headers(imap_fetchheader($this->marubox, $uid, FT_UID));
 
-      $mail_header  = imap_header($this->marubox, $mid);
       $sender       = $mail_header->from[0];
       $to           = $mail_header->to[0];
       $date         = date("Y-m-d H:i:s", strtotime($mail_header->date));
@@ -1217,7 +1226,7 @@ class MailCollector  extends CommonDBTM {
          }
 
          //Add additional headers in X-
-         foreach ($this->getAdditionnalHeaders($mid) as $header => $value) {
+         foreach ($this->getAdditionnalHeaders($uid) as $header => $value) {
             $mail_details[$header] = $value;
          }
       }
@@ -1250,14 +1259,14 @@ class MailCollector  extends CommonDBTM {
     * Get Part Of Message Internal Private Use
     *
     * @param $stream       An IMAP stream returned by imap_open
-    * @param $msg_number   The message number
+    * @param $uid          The message UID
     * @param $mime_type    mime type of the mail
     * @param $structure    structure of the mail (false by default)
     * @param $part_number  The part number (false by default)
     *
     * @return data of false if error
    **/
-   function get_part($stream, $msg_number, $mime_type, $structure=false, $part_number=false) {
+   function get_part($stream, $uid, $mime_type, $structure=false, $part_number=false) {
 
       if ($structure) {
          if ($mime_type == $this->get_mime_type($structure)) {
@@ -1266,7 +1275,7 @@ class MailCollector  extends CommonDBTM {
                $part_number = "1";
             }
 
-            $text = imap_fetchbody($stream, $msg_number, $part_number);
+            $text = imap_fetchbody($stream, $uid, $part_number, FT_UID);
 
             if ($structure->encoding == 3) {
                $text =  imap_base64($text);
@@ -1302,7 +1311,7 @@ class MailCollector  extends CommonDBTM {
                if ($part_number) {
                   $prefix = $part_number . '.';
                }
-               $data = $this->get_part($stream, $msg_number, $mime_type, $sub_structure,
+               $data = $this->get_part($stream, $uid, $mime_type, $sub_structure,
                                        $prefix . ($index + 1));
                if ($data) {
                   return $data;
@@ -1332,14 +1341,14 @@ class MailCollector  extends CommonDBTM {
     *
     * @since version 0.90.2
     * @param $structure
-    * @param $mid
+    * @param $uid
     * @param $part
     *
     * @return bool|string
    **/
-   private function getDecodedFetchbody($structure, $mid, $part) {
+   private function getDecodedFetchbody($structure, $uid, $part) {
 
-      if ($message = imap_fetchbody($this->marubox, $mid, $part)) {
+      if ($message = imap_fetchbody($this->marubox, $uid, $part, FT_UID)) {
          switch ($structure->encoding) {
             case 1 :
                $message = imap_8bit($message);
@@ -1367,7 +1376,7 @@ class MailCollector  extends CommonDBTM {
    /**
     * Private function : Recursivly get attached documents
     *
-    * @param $mid          message id
+    * @param $uid          message uid
     * @param $path         temporary path
     * @param $maxsize      of document to be retrieved
     * @param $structure    of the message or part
@@ -1375,12 +1384,12 @@ class MailCollector  extends CommonDBTM {
     *
     * Result is stored in $this->files
    **/
-   function getRecursiveAttached($mid, $path, $maxsize, $structure, $part="") {
+   function getRecursiveAttached($uid, $path, $maxsize, $structure, $part="") {
 
       if ($structure->type == 1) { // multipart
          reset($structure->parts);
          while (list($index, $sub) = each($structure->parts)) {
-            $this->getRecursiveAttached($mid, $path, $maxsize, $sub,
+            $this->getRecursiveAttached($uid, $path, $maxsize, $sub,
                                         ($part ? $part.".".($index+1) : ($index+1)));
          }
 
@@ -1430,7 +1439,7 @@ class MailCollector  extends CommonDBTM {
                     && $structure->subtype) {
              // Embeded email comes without filename - try to get "Subject:" or generate trivial one
              $filename = "msg_$part.EML"; // default trivial one :)!
-             if (($message = $this->getDecodedFetchbody($structure, $mid, $part))
+             if (($message = $this->getDecodedFetchbody($structure, $uid, $part))
                  && (preg_match( "/Subject: *([^\r\n]*)/i",  $message,  $matches))) {
                  $filename = "msg_".$part."_".$this->decodeMimeString($matches[1]).".EML";
                 $filename = preg_replace( "#[<>:\"\\\\/|?*]#u", "_", $filename) ;
@@ -1474,7 +1483,7 @@ class MailCollector  extends CommonDBTM {
          }
 
          if ((($structure->type == 2) && $structure->subtype)
-             || ($message = $this->getDecodedFetchbody($structure, $mid, $part))) {
+             || ($message = $this->getDecodedFetchbody($structure, $uid, $part))) {
             if (file_put_contents($path.$filename, $message)) {
                $this->files[$filename] = $filename;
                // If embeded image, we add a tag
@@ -1502,19 +1511,19 @@ class MailCollector  extends CommonDBTM {
    /**
     * Public function : get attached documents in a mail
     *
-    * @param $mid       message id
+    * @param $uid       UID of the message
     * @param $path      temporary path
     * @param $maxsize   of document to be retrieved
     *
     * @return array containing extracted filenames in file/_tmp
    **/
-   function getAttached($mid, $path, $maxsize) {
+   function getAttached($uid, $path, $maxsize) {
 
-      $this->getStructure($mid);
+      $this->getStructure($uid);
       $this->files     = array();
       $this->altfiles  = array();
       $this->addtobody = "";
-      $this->getRecursiveAttached($mid, $path, $maxsize, $this->structure);
+      $this->getRecursiveAttached($uid, $path, $maxsize, $this->structure);
 
       return ($this->files);
    }
@@ -1523,15 +1532,15 @@ class MailCollector  extends CommonDBTM {
    /**
     * Get The actual mail content from this mail
     *
-    * @param $mid : mail Id
+    * @param $uid : mail UID
    **/
-   function getBody($mid) {// Get Message Body
+   function getBody($uid) {// Get Message Body
 
-      $this->getStructure($mid);
-      $body = $this->get_part($this->marubox, $mid, "TEXT/HTML", $this->structure);
+      $this->getStructure($uid);
+      $body = $this->get_part($this->marubox, $uid, "TEXT/HTML", $this->structure);
 
       if ($body == "") {
-         $body = $this->get_part($this->marubox, $mid, "TEXT/PLAIN", $this->structure);
+         $body = $this->get_part($this->marubox, $uid, "TEXT/PLAIN", $this->structure);
       }
 
       if ($body == "") {
@@ -1545,15 +1554,15 @@ class MailCollector  extends CommonDBTM {
    /**
     * Delete mail from that mail box
     *
-    * @param $mid       String    mail Id
+    * @param $uid       String    mail UID
     * @param $folder    String   folder to move (delete if empty) (default '')
     *
     * @return Boolean
    **/
-   function deleteMails($mid, $folder='') {
+   function deleteMails($uid, $folder='') {
       if (!empty($folder) && isset($this->fields[$folder]) && !empty($this->fields[$folder])) {
          $name = mb_convert_encoding($this->fields[$folder], "UTF7-IMAP","UTF-8");
-         if (imap_mail_move($this->marubox, $mid, $name)) {
+         if (imap_mail_move($this->marubox, $uid, $name, CP_UID)) {
             return true;
          }
          // raise an error and fallback to delete
@@ -1561,7 +1570,7 @@ class MailCollector  extends CommonDBTM {
          trigger_error(sprintf(__('Invalid configuration for %1$s folder in receiver %2$s'),
                                $folder, $this->getName()));
       }
-      return imap_delete($this->marubox, $mid);
+      return imap_delete($this->marubox, $uid, FT_UID);
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | to fill (need check backlog)

Ok this is change which can finish all random issues with mail receiver.
Here is the scenario which needed this change.
- it a connection on gmail with imap
- on imap_delete, classic imap server (not gmail) will only mark the message for deletion, an imap_expunge will be necessary for real deletion. Gmail remove the message from INBOX (or any collected folder/label) directly on imap_delete and so on the next loop of message fetching, all emails have their index decreased).
- with this behavior, we have some warnings on imap_header and the current message is not parsed.
- additionally, on the next receiver fetch, a message already computed in ticket could be done again.

So i changed all imap_ functions that handles a message. They now use the message UID instead of the index in the folder.
