### PR TITLE
Provide missing interface that has been removed for some plugins

### DIFF
--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -310,6 +310,7 @@ function glpi_autoload($classname) {
    //hack for \Zend\Loader\SplAutoloader :(
    //@since 9.2 -- WILL BE REMOVED IN FUTURE RELEASE
    if ($classname === 'Zend\\Loader\\SplAutoloader') {
+      Toolbox::deprecated('Zend\Loader\SplAutoloader has been dropped from GLPI.');
       require_once GLPI_ROOT . '/lib/zend-splautoloader.class.php';
       return true;
    }

--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -307,6 +307,13 @@ function glpi_autoload($classname) {
       die("Security die. trying to load a forbidden class name");
    }
 
+   //hack for \Zend\Loader\SplAutoloader :(
+   //@since 9.2 -- WILL BE REMOVED IN FUTURE RELEASE
+   if ($classname === 'Zend\\Loader\\SplAutoloader') {
+      require_once GLPI_ROOT . '/lib/zend-splautoloader.class.php';
+      return true;
+   }
+
    $dir = GLPI_ROOT . "/inc/";
 
    if ($plug = isPluginItemType($classname)) {

--- a/lib/zend-splautoloader.class.php
+++ b/lib/zend-splautoloader.class.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2017 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Zend\Loader;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ * Fake SplAutoloader class to prevent plugin issues when upgrading to 9.2
+ *
+ * @deprecated 9.2
+**/
+interface SplAutoloader {
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Some plugins used `Zend\Loader\SplAutoloader` that was previously provided from GLPI dependencies but has been removed.
Such plugins may cause fatal errors when GLPI is upgraded to 9.2 and plugins are still present.