### PR TITLE
specify table when inserting SELECT criteria in deleteByCriteria

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -4021,7 +4021,7 @@ class CommonDBTM extends CommonGLPI {
 
       $ok = false;
       if (is_array($crit) && (count($crit) > 0)) {
-         $crit['FIELDS'] = 'id';
+         $crit['FIELDS'] = [$this::getTable() => 'id'];
          $ok = true;
          foreach ($DB->request($this->getTable(), $crit) as $row) {
             if (!$this->delete($row, $force, $history)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

If using deleteByCtriteria with a JOIN expression, we need to specify the table if he ID field to select