### PR TITLE
Fix lock objects

### DIFF
--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -690,6 +690,10 @@ class CommonGLPI {
          if ($this->getType() == 'Ticket') {
             $this->input = $cleaned_options;
             $this->saveInput();
+            if (isset($cleaned_options['locked'])) {
+               $extraparamhtml = "&amp;".Toolbox::append_params(['locked' => $cleaned_options['locked']],
+                                                                '&amp;');
+            }
          } else {
             $extraparamhtml = "&amp;".Toolbox::append_params($cleaned_options, '&amp;');
          }

--- a/inc/objectlock.class.php
+++ b/inc/objectlock.class.php
@@ -173,8 +173,8 @@ class ObjectLock extends CommonDBTM {
 
       $msg = "<table><tr><td class=red>";
       $msg .= __("Locked by you!")."</td>";
-      $msg .= "<td><a class='vsubmit' onclick='javascript:unlockIt(this);'>".__('Unlock ').
-               $this->itemtypename." #".$this->itemid."</a>";
+      $msg .= "<td><a class='vsubmit' onclick='javascript:unlockIt(this);'>"
+              .sprintf(__('Unlock %1s #%2s'), $this->itemtypename, $this->itemid)."</a>";
       $msg .="</td></tr></table>";
 
       $this->displayLockMessage($msg);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

* 1st commit is just to have a space between "Unlock" and the itemtype
* 2nd one is a fix for regression added by https://github.com/glpi-project/glpi/commit/ea2d6c52998f250d21c8ef59cd8a82cb9661eb80#diff-0ea1de57520847d97d3ea2579cbdd928R690, param is_locked is not passed to the tab anymore due to the removal of $extraparamhtml. The regression results in a locked object, the lock message appears correctly, but fields are not set in readonly
