### PR TITLE
Use ZendCache everywhere

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2258,7 +2258,7 @@ class Config extends CommonDBTM {
                'required'  => false
             ],
             //to enhance perfs
-            'APCu'       => [
+            'APCu'      => [
                'required'  => false,
                'function'  => 'apcu_fetch'
             ],
@@ -2282,7 +2282,9 @@ class Config extends CommonDBTM {
       foreach ($extensions_to_check as $ext => $params) {
          $success = true;
 
-         if (isset($params['function'])) {
+         if (isset($params['call'])) {
+            $success = call_user_func($params['call']);
+         } else if (isset($params['function'])) {
             if (!function_exists($params['function'])) {
                 $success = false;
             }

--- a/inc/config.php
+++ b/inc/config.php
@@ -45,6 +45,26 @@ include_once (GLPI_ROOT."/inc/dbconnection.class.php");
 Session::setPath();
 Session::start();
 
+//init cache
+$GLPI_CACHE = false;
+try {
+   if (function_exists('apcu_fetch') && (!defined('TU_USER') || defined('CACHED_TESTS'))) {
+      //ZendCache does not works with PHP5 acpu...
+      $adapter = (version_compare(PHP_VERSION, '7.0.0') >= 0) ? 'apcu' : 'apc';
+      $GLPI_CACHE = Zend\Cache\StorageFactory::factory([
+         'adapter'   => $adapter,
+         'options'   => [
+            'namespace' => 'glpicache' . GLPI_VERSION
+         ]
+      ]);
+   }
+} catch (Exception $e) {
+   $GLPI_CACHE = false;
+   if (Session::DEBUG_MODE == $_SESSION['glpi_use_mode']) {
+      Toolbox::logDebug($e->getMessage());
+   }
+}
+
 Config::detectRootDoc();
 
 

--- a/inc/dbutils.class.php
+++ b/inc/dbutils.class.php
@@ -670,14 +670,14 @@ final class DbUtils {
     * @return array of IDs of the sons
     */
    public function getSonsOf($table, $IDf) {
-      global $DB;
+      global $DB, $GLPI_CACHE;
 
       $ckey = $table . '_sons_cache_' . $IDf;
       $sons = [];
 
       if (Toolbox::useCache()) {
-         if (apcu_exists($ckey)) {
-            $sons = apcu_fetch($ckey);
+         if ($GLPI_CACHE->hasItem($ckey)) {
+            $sons = $GLPI_CACHE->getItem($ckey);
             if ($sons) {
                return $sons;
             }
@@ -759,7 +759,7 @@ final class DbUtils {
       }
 
       if (Toolbox::useCache()) {
-         apcu_store($ckey, $sons);
+         $GLPI_CACHE->addItem($ckey, $sons);
       }
 
       return $sons;
@@ -774,7 +774,7 @@ final class DbUtils {
     * @return array of IDs of the ancestors
     */
    public function getAncestorsOf($table, $items_id) {
-      global $DB;
+      global $DB, $GLPI_CACHE;
 
       $ckey = $table . '_ancestors_cache_';
       if (is_array($items_id)) {
@@ -785,8 +785,8 @@ final class DbUtils {
       $ancestors = [];
 
       if (Toolbox::useCache()) {
-         if (apcu_exists($ckey)) {
-            $ancestors = apcu_fetch($ckey);
+         if ($GLPI_CACHE->hasItem($ckey)) {
+            $ancestors = $GLPI_CACHE->getItem($ckey);
             if ($ancestors) {
                return $ancestors;
             }
@@ -871,7 +871,7 @@ final class DbUtils {
       }
 
       if (Toolbox::useCache()) {
-         apcu_store($ckey, $ancestors);
+         $GLPI_CACHE->addItem($ckey, $ancestors);
       }
 
       return $ancestors;

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -125,6 +125,7 @@ class Entity extends CommonTreeDropdown {
     * @since version 0.84
    **/
    function pre_deleteItem() {
+      global $GLPI_CACHE;
 
       // Security do not delete root entity
       if ($this->input['id'] == 0) {
@@ -135,8 +136,8 @@ class Entity extends CommonTreeDropdown {
       $this->cleanParentsSons();
       if (Toolbox::useCache()) {
          $ckey = $this->getTable() . '_ancestors_cache_' . $this->getID();
-         if (apcu_exists($ckey)) {
-            apcu_delete($ckey);
+         if ($GLPI_CACHE->hasItem($ckey)) {
+            $GLPI_CACHE->removeItem($ckey);
          }
       }
       return true;

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -541,7 +541,7 @@ class Session {
     * @return nothing (make an include)
    **/
    static function loadLanguage($forcelang = '') {
-      global $LANG, $CFG_GLPI, $TRANSLATE;
+      global $LANG, $CFG_GLPI, $TRANSLATE, $GLPI_CACHE;
 
       $file = "";
 
@@ -580,14 +580,9 @@ class Session {
       if (isset($CFG_GLPI["languages"][$trytoload][5])) {
          $_SESSION['glpipluralnumber'] = $CFG_GLPI["languages"][$trytoload][5];
       }
-      try {
-         $TRANSLATE = new Zend\I18n\Translator\Translator;
-         $cache = Zend\Cache\StorageFactory::factory(['adapter' => 'apcu']);
-         $TRANSLATE->setCache($cache);
-      } catch (Exception $e) {
-         $TRANSLATE = new Zend\I18n\Translator\Translator;
-         // ignore when APC not available
-         // toolbox::logDebug($e->getMessage());
+      $TRANSLATE = new Zend\I18n\Translator\Translator;
+      if ($GLPI_CACHE !== false) {
+         $TRANSLATE->setCache($GLPI_CACHE);
       }
       $TRANSLATE->addTranslationFile('gettext', GLPI_ROOT.$newfile, 'glpi', $trytoload);
 

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2820,14 +2820,16 @@ class Toolbox {
    }
 
    /**
-    * Should APCu cache be used
+    * Should cache be used
     *
     * @since 9.2
     *
     * @return boolean
     */
    public static function useCache() {
-      return function_exists('apcu_exists') && (!defined('TU_USER') || defined('CACHED_TESTS'));
+      global $GLPI_CACHE;
+      return $GLPI_CACHE instanceof Zend\Cache\Storage\Adapter\AbstractAdapter
+         && (!defined('TU_USER') || defined('CACHED_TESTS'));
    }
 
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,6 +35,8 @@ error_reporting(E_ALL);
 define('GLPI_CONFIG_DIR', __DIR__);
 define('GLPI_LOG_DIR', __DIR__ . '/files/_log');
 define('GLPI_URI', 'http://localhost:8088');
+define('TU_USER', '_test_user');
+define('TU_PASS', 'PhpUnit_4');
 
 if (!file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {
    die("\nConfiguration file for tests not found\n\nrun: php tools/cliinstall.php --tests ...\n\n");
@@ -49,9 +51,6 @@ include_once __DIR__ . '/APIBaseClass.php';
 if (file_exists(__DIR__ . '/../vendor/autoload.php') && !file_exists(__DIR__ . '/../vendor/guzzlehttp/guzzle')) {
    die("\nDevelopment dependencies not found\n\nrun: composer install -o\n\n");
 }
-
-define('TU_USER', '_test_user');
-define('TU_PASS', 'PhpUnit_4');
 
 class GlpitestPHPerror extends Exception
 {

--- a/tests/units/DbUtils.php
+++ b/tests/units/DbUtils.php
@@ -37,6 +37,10 @@ use \DbTestCase;
 /* Test for inc/dbutils.class.php */
 
 class DbUtils extends DbTestCase {
+   protected $cached_methods = [
+      'testGetAncestorsOfCached',
+      'testGetSonsOfCached'
+   ];
 
    public function setUp() {
       global $CFG_GLPI;
@@ -684,7 +688,7 @@ class DbUtils extends DbTestCase {
       //- if $cache === 1; we expect cache to be empty before call, and populated after
       //- if $hit   === 1; we expect cache to be populated
 
-      $ckey = 'glpi_entities_ancestors_cache_';
+      $ckey = $this->nscache . ':glpi_entities_ancestors_cache_';
 
       //test on ent0
       $expected = [0 => '0'];
@@ -811,7 +815,6 @@ class DbUtils extends DbTestCase {
     */
    public function testGetAncestorsOfCached() {
       //run with cache
-      define('CACHED_TESTS', true);
       //first run: no cache hit expected
       $this->runGetAncestorsOf(true);
       //second run: cache hit expected
@@ -838,7 +841,7 @@ class DbUtils extends DbTestCase {
       //- if $cache === 1; we expect cache to be empty before call, and populated after
       //- if $hit   === 1; we expect cache to be populated
 
-      $ckey = 'glpi_entities_sons_cache_';
+      $ckey = $this->nscache . ':glpi_entities_sons_cache_';
 
       //test on ent0
       $expected = [$ent0 => "$ent0", $ent1 => "$ent1", $ent2 => "$ent2"];
@@ -963,7 +966,6 @@ class DbUtils extends DbTestCase {
     */
    public function testGetSonsOfCached() {
       //run with cache
-      define('CACHED_TESTS', true);
       //first run: no cache hit expected
       $this->runGetSonsOf(true);
       //second run: cache hit expected

--- a/tests/units/Entity.php
+++ b/tests/units/Entity.php
@@ -37,6 +37,9 @@ use \DbTestCase;
 /* Test for inc/entity.class.php */
 
 class Entity extends DbTestCase {
+   protected $cached_methods = [
+      'testChangeEntityParentCached'
+   ];
 
    public function testSonsAncestors() {
       $ent0 = getItemByTypeName('Entity', '_test_root_entity');
@@ -118,8 +121,8 @@ class Entity extends DbTestCase {
       $ent1 = getItemByTypeName('Entity', '_test_child_1', true);
       $ent2 = getItemByTypeName('Entity', '_test_child_2', true);
 
-      $ackey = 'glpi_entities_ancestors_cache_';
-      $sckey = 'glpi_entities_sons_cache_';
+      $ackey = $this->nscache . ':glpi_entities_ancestors_cache_';
+      $sckey = $this->nscache . ':glpi_entities_sons_cache_';
 
       $entity = new \Entity();
       $new_id = (int)$entity->add([
@@ -228,7 +231,6 @@ class Entity extends DbTestCase {
     */
    public function testChangeEntityParentCached() {
       //run with cache
-      define('CACHED_TESTS', true);
       //first run: no cache hit expected
       $this->runChangeEntityParent(true);
       //reset cache (checking for expected defaults) then run a second time: cache hit expected


### PR DESCRIPTION
Store overridable configuration; fixes #2712
Change cache prefix

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2712

Still use APCu per default, but along with Zend Cache.