### PR TITLE
[9.2-RC1]fix url of natives notifications

### DIFF
--- a/inc/notificationajax.class.php
+++ b/inc/notificationajax.class.php
@@ -126,7 +126,7 @@ class NotificationAjax implements NotificationInterface {
                   method_exists($row['itemtype'], 'getFormURL')
                ) {
                   $item = new $row['itemtype'];
-                  $url = $item->getFormURL()."?id={$row['items_id']}";
+                  $url = $item->getFormURL(false)."?id={$row['items_id']}";
                }
 
                $return[] = [

--- a/tests/units/NotificationAjax.php
+++ b/tests/units/NotificationAjax.php
@@ -113,7 +113,7 @@ class NotificationAjax extends DbTestCase {
       $notifs = \NotificationAjax::getMyNotifications();
       $this->array($notifs)->hasSize(1);
       $this->string($notifs[0]['url'])
-         ->isIdenticalTo($computer->getFormURL() . '?id=' . $computer->getID());
+         ->isIdenticalTo($computer->getFormURL(false) . '?id=' . $computer->getID());
 
       //reset
       $CFG_GLPI['notifications_ajax'] = 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

When clicking the native notification we have a bad url