### PR TITLE
[9.2] Error display planning when plugin not installed Fix #2775

### DIFF
--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -1247,8 +1247,9 @@ class Planning extends CommonGLPI {
          $group->getFromDB($actor[1]);
          $title = $group->getName();
       } else if ($filter_data['type'] == 'event_filter') {
-         if (!$filter_key::canView()
-               || !($item = getItemForItemtype($filter_key))) {
+         if (!($item = getItemForItemtype($filter_key))) {
+            return false;
+         } else if (!$filter_key::canView()) {
             return false;
          }
          $title = $filter_key::getTypeName();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2775