### PR TITLE
Dynamically load tinymce from ajax calls; fixes #2799

### DIFF
--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -525,8 +525,6 @@ class Planning extends CommonGLPI {
          return false;
       }
 
-      Html::requireJs('tinymce');
-
       $fullview_str = $fullview?"true":"false";
 
       $pl_height = "function() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2799 

Trying to load TinyMCE from an ajax tab will fail; JS scripts are only loadable from the main page.

The goal of the new method is to load dynamically the lib is this is not already; and then make initialization. If the lib has already been loaded, just init the editor. 