### PR TITLE
fix count of associated items

### DIFF
--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -585,7 +585,9 @@ class Item_Ticket extends CommonDBRelation{
                    && (count($_SESSION["glpiactiveprofile"]["helpdesk_item_type"]) > 0)) {
                   if ($_SESSION['glpishow_count_on_tabs']) {
                      $nb = countElementsInTable('glpi_items_tickets',
-                                                ['tickets_id' => $item->getID() ]);
+                                                ['AND' => ['tickets_id' => $item->getID() ],
+                                                   ['itemtype' => $_SESSION["glpiactiveprofile"]["helpdesk_item_type"]]
+                                                ]);
                   }
                   return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb);
                }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2813

take into account the profile settings when counting aassociated elemetns of a ticket.

(Also fix a deprecation issue)