### PR TITLE
don't forget PARENT_OF

### DIFF
--- a/inc/ticket_ticket.class.php
+++ b/inc/ticket_ticket.class.php
@@ -233,10 +233,12 @@ class Ticket_Ticket extends CommonDBRelation {
          $tmp[self::LINK_TO]        = __('Linked to');
          $tmp[self::DUPLICATE_WITH] = __('Duplicates');
          $tmp[self::SON_OF]         = __('Son of');
+         $tmp[self::PARENT_OF]      = __('Parent of');
       } else {
          $tmp[self::LINK_TO]        = __('Linked to');
          $tmp[self::DUPLICATE_WITH] = __('Duplicated by');
          $tmp[self::SON_OF]         = __('Parent of');
+         $tmp[self::PARENT_OF]      = __('Son of');
       }
 
       if (isset($tmp[$value])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

for Formcreator I need to manage relation between tickets. They may be already created, or to be created when a user fils a form. Because of this, I cannot implement the same trick GLPI does to not need to translate PARENT_OF. Also, if we allow translation of a constant into a localised string, I think it is better to translate all constants related to the same feature, isntean of cheating to not handle some of them.

