### PR TITLE
prevent sql error if user has no group

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -5990,8 +5990,11 @@ class Ticket extends CommonITILObject {
                $restrict .= " AND (`glpi_tickets`.`users_id_recipient` = '".Session::getLoginUserID()."'
                                    OR (`glpi_tickets_users`.`tickets_id` = `glpi_tickets`.`id`
                                        AND `glpi_tickets_users`.`users_id`
-                                            = '".Session::getLoginUserID()."')
-                                   OR `glpi_groups_tickets`.`groups_id` IN (".implode(",", $_SESSION['glpigroups'])."))";
+                                            = '".Session::getLoginUserID()."')";
+               if (count($_SESSION['glpigroups'])) {
+                  $restrict .= " OR `glpi_groups_tickets`.`groups_id` IN (".implode(",", $_SESSION['glpigroups']).")";
+               }
+               $restrict .= ")";
             }
 
             $order    = '`glpi_tickets`.`date_mod` DESC';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes (in Formcreator, maybe elsewhere)
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | will see
| Fixed tickets | https://github.com/pluginsGLPI/formcreator/issues/759

See the issue in Formcreator