### PR TITLE
add missing MSIN field to simcards

### DIFF
--- a/inc/item_devices.class.php
+++ b/inc/item_devices.class.php
@@ -1099,8 +1099,6 @@ class Item_Devices extends CommonDBRelation {
          if (($even % 2) == 0) {
             echo "<tr class='tab_bg_1'>";
          }
-         echo "<td>".$attributs['long name']."</td>";
-         echo "<td>";
          $out = '';
 
          // Can the user view the value of the field ?
@@ -1110,6 +1108,27 @@ class Item_Devices extends CommonDBRelation {
             $canRead = (Session::haveRightsOr($attributs['right'], [READ, UPDATE]));
          }
 
+         if (!isset($attributs['datatype'])) {
+            $attributs['datatype'] = 'text';
+         }
+
+         $rand = mt_rand();
+         echo "<td>";
+         if ($canRead) {
+            switch ($attributs['datatype']) {
+               case 'dropdown':
+                  $fieldType = 'dropdown';
+                  break;
+
+               default:
+                  $fieldType = 'textfield';
+            }
+            echo "<label for='${fieldType}_$field$rand'>".$attributs['long name']."</label>";
+         } else {
+            echo $attributs['long name'];
+         }
+         echo "</td><td>";
+
          // Do the field needs a user action to display ?
          if (isset($attributs['protected']) && $attributs['protected']) {
             $protected = true;
@@ -1118,13 +1137,14 @@ class Item_Devices extends CommonDBRelation {
             $protected = false;
          }
 
-         if (!isset($attributs['datatype'])) {
-            $attributs['datatype'] = 'text';
+         if (isset($attributs['tooltip']) && strlen($attributs['tooltip']) > 0) {
+            $tooltip = $attributs['tooltip'];
+         } else {
+            $tooltip = null;
          }
 
          if ($canRead) {
             $value = $this->fields[$field];
-            $rand = mt_rand();
             switch ($attributs['datatype']) {
                case 'dropdown':
                   $dropdownType = getItemtypeForForeignKeyField($field);
@@ -1144,12 +1164,21 @@ class Item_Devices extends CommonDBRelation {
                      $out.= 'id="' . $field . $rand . '" value="' . $value . '">';
                   }
             }
+            if ($tooltip !== null) {
+               $comment_id      = Html::cleanId("comment_".$field.$rand);
+               $link_id         = Html::cleanId("comment_link_".$field.$rand);
+               $options_tooltip = ['contentid' => $comment_id,
+                  'linkid'    => $link_id,
+                  'display'   => false];
+               $out.= '&nbsp;'.Html::showToolTip($tooltip, $options_tooltip);
+            }
             if ($protected) {
-               $out.= '<span><i class="fa fa-eye pointer" ';
+               $out.= '<span><i class="fa fa-eye pointer disclose" ';
                $out.= 'onmousedown="showField(\'' . $field . $rand . '\')" ';
-               $out.= 'onmouseup="hideField(\'' . $field . $rand . '\')" onmouseout="hideField(\'' . $field . $rand . '\')"></i>';
-               $out.= '<i class="fa fa-clipboard pointer" ';
-               $out.= 'onclick="copyToClipboard(\'' . $field . $rand . '\')"></i></span>';
+               $out.= 'onmouseup="hideField(\'' . $field . $rand . '\')" ';
+               $out.= 'onmouseout="hideField(\'' . $field . $rand . '\')"></i>';
+               $out.= '<i class="fa fa-clipboard pointer disclose" ';
+               $out.= 'onclick="copyToClipboard(\'' . $field . $rand . '\')"></i>';
                $out.= '</span>';
             }
             echo $out;

--- a/inc/item_devicesimcard.class.php
+++ b/inc/item_devicesimcard.class.php
@@ -101,6 +101,12 @@ class Item_DeviceSimcard extends Item_Devices {
                                   'size'       => 20,
                                   'id'         => 19,
                                   'datatype'   => 'dropdown'],
+             'msin'           => ['long name'  => __('Mobile Subscriber Identification Number'),
+                                  'short name' => __('MSIN'),
+                                  'size'       => 20,
+                                  'id'         => 20,
+                                  'datatype'   => 'string',
+                                  'tooltip'    => __('MSIN is the last 8 or 10 digits of IMSI')],
       ];
    }
 }

--- a/inc/line.class.php
+++ b/inc/line.class.php
@@ -38,7 +38,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
-class Line extends CommonDBTM {
+class Line extends CommonDropdown {
    // From CommonDBTM
    public $dohistory                   = true;
 
@@ -179,24 +179,7 @@ class Line extends CommonDBTM {
    function getSearchOptionsNew() {
       $tab = parent::getSearchOptionsNew();
 
-      $tab[] = [
-            'id'                 => '2',
-            'table'              => $this->getTable(),
-            'field'              => 'id',
-            'name'               => __('ID'),
-            'massiveaction'      => false,
-            'datatype'           => 'number'
-      ];
-
       $tab = array_merge($tab, Location::getSearchOptionsToAddNew());
-
-      $tab[] = [
-            'id'                 => '16',
-            'table'              => $this->getTable(),
-            'field'              => 'comment',
-            'name'               => __('Comments'),
-            'datatype'           => 'text'
-      ];
 
       $tab[] = [
             'id'                 => '31',
@@ -223,33 +206,6 @@ class Line extends CommonDBTM {
             'name'               => __('Group'),
             'condition'          => '`is_itemgroup`',
             'datatype'           => 'dropdown'
-      ];
-
-      $tab[] = [
-            'id'                 => '80',
-            'table'              => 'glpi_entities',
-            'field'              => 'completename',
-            'name'               => __('Entity'),
-            'massiveaction'      => false,
-            'datatype'           => 'dropdown'
-      ];
-
-      $tab[] = [
-            'id'                 => '19',
-            'table'              => $this->getTable(),
-            'field'              => 'date_mod',
-            'name'               => __('Last update'),
-            'datatype'           => 'datetime',
-            'massiveaction'      => false
-      ];
-
-      $tab[] = [
-            'id'                 => '121',
-            'table'              => $this->getTable(),
-            'field'              => 'date_creation',
-            'name'               => __('Creation date'),
-            'datatype'           => 'datetime',
-            'massiveaction'      => false
       ];
 
       $tab[] = [

--- a/inc/update.class.php
+++ b/inc/update.class.php
@@ -398,6 +398,7 @@ class Update extends CommonGLPI {
             update92to921();
             break;
 
+         case "9.2.1":
          case GLPI_VERSION:
          case GLPI_SCHEMA_VERSION:
             break;

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -2322,6 +2322,7 @@ CREATE TABLE IF NOT EXISTS `glpi_items_devicesimcards` (
   `pin2` varchar(255) NOT NULL DEFAULT '',
   `puk` varchar(255) NOT NULL DEFAULT '',
   `puk2` varchar(255) NOT NULL DEFAULT '',
+  `msin` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `devicesimcards_id` (`devicesimcards_id`),

--- a/install/update_92_921.php
+++ b/install/update_92_921.php
@@ -283,6 +283,9 @@ function update92to921() {
 
    // end fix 9.2 migration
 
+   //add MSIN to simcard component
+   $migration->addField('glpi_items_devicesimcards', 'msin', 'string', ['after' => 'puk2', 'value' => '']);
+
    // ************ Keep it at the end **************
    $migration->executeMigration();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Fixed tickets |

MSIN is the last 8 or 10 digits of IMSI
IMSI is the concatenation of:
- MCC (Mobile Country Code) (3 digits)
- MNC (Mobile Network Code) (2 or 3 digits)
- MSIN (Mobile Subscriber Identification Number) (8 or 10 digits)

Having 3 digits length MCC and 3 digits length MNC and 10 digits length MSIN is not allowed
because the full length is at most 15 digits.

Possible combinations are:
3 digits MCC + 2 digits MNC + 10 igits MSIN = 15 digits
3 digits MCC + 3 ditigs MNC + 8 digits MSIN = 14 digits
3 digits MCC + 2 digits MNC + 8 digits MSIN = 13 digits

MCC and MNC are stored in the line operator itemtype
MSIN is stored in a items_simcards itemtype. To save the full IMSI, one must
create a simcard component, instanciate it, fill its MSIN field and associate it to a line, associate the line to an operator with MCC and MNC fields populated.

Also fix wrong base class for line itemtype, preventing to create a line from items_simcards form