### PR TITLE
prevent task list on central to differs from real search

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -2113,6 +2113,30 @@ abstract class CommonITILObject extends CommonDBTM {
       return $tab;
    }
 
+   /**
+    * Get the ITIL object all status list without solved and closed status
+    *
+    * @since version 9.2.1
+    *
+    * @return array
+   **/
+   static function getNotSolvedStatusArray() {
+      $all = static::getAllStatusArray();
+      foreach (static::getSolvedStatusArray() as $status) {
+         if (isset($all[$status])) {
+            unset($all[$status]);
+         }
+      }
+      foreach (static::getClosedStatusArray() as $status) {
+         if (isset($all[$status])) {
+            unset($all[$status]);
+         }
+      }
+      $nosolved = array_keys($all);
+
+      return $nosolved;
+   }
+
 
    /**
     * Get the ITIL object new status list

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1778,7 +1778,7 @@ abstract class CommonITILTask  extends CommonDBTM {
          ]
       ];
 
-      $prep_req['WHERE'] = [];
+      $prep_req['WHERE'] = [$fk_table.".status" => $itemtype::getNotSolvedStatusArray()];
       switch ($status) {
          case "todo" : // we display the task with the status `todo`
             $prep_req['WHERE'][self::getTable() . '.state'] = Planning::TODO;

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3105,18 +3105,7 @@ class Search {
                      break;
 
                   case 'notold' :
-                     $tocheck = $item->getAllStatusArray();
-                     foreach ($item->getSolvedStatusArray() as $status) {
-                        if (isset($tocheck[$status])) {
-                           unset($tocheck[$status]);
-                        }
-                     }
-                     foreach ($item->getClosedStatusArray() as $status) {
-                        if (isset($tocheck[$status])) {
-                           unset($tocheck[$status]);
-                        }
-                     }
-                     $tocheck = array_keys($tocheck);
+                     $tocheck = $item::getNotSolvedStatusArray();
                      break;
                }
             }

--- a/tests/units/TicketTask.php
+++ b/tests/units/TicketTask.php
@@ -81,7 +81,7 @@ class TicketTask extends DbTestCase {
 
       $iterator = $task::getTaskList('todo', false);
       $this->string($iterator->getSql())->isIdenticalTo(
-         'SELECT `glpi_tickettasks`.`id` FROM `glpi_tickettasks` INNER JOIN `glpi_tickets` ON (`glpi_tickettasks`.`tickets_id` = `glpi_tickets`.`id`) WHERE `glpi_tickettasks`.`state` = 1 AND `glpi_tickettasks`.`users_id_tech` = ' . $uid . ' ORDER BY `glpi_tickettasks`.`date_mod` DESC'
+         'SELECT `glpi_tickettasks`.`id` FROM `glpi_tickettasks` INNER JOIN `glpi_tickets` ON (`glpi_tickettasks`.`tickets_id` = `glpi_tickets`.`id`) WHERE `glpi_tickets`.`status` IN (1, 2, 3, 4) AND `glpi_tickettasks`.`state` = 1 AND `glpi_tickettasks`.`users_id_tech` = ' . $uid . ' ORDER BY `glpi_tickettasks`.`date_mod` DESC'
       );
       //we create two ones plus the one in bootstrap data
       $this->integer(count($iterator))->isIdenticalTo(3);
@@ -92,7 +92,7 @@ class TicketTask extends DbTestCase {
       $_SESSION['glpigroups'] = [42, 157];
       $iterator = $task::getTaskList('todo', true);
       $this->string($iterator->getSql())->isIdenticalTo(
-         'SELECT `glpi_tickettasks`.`id` FROM `glpi_tickettasks` INNER JOIN `glpi_tickets` ON (`glpi_tickettasks`.`tickets_id` = `glpi_tickets`.`id`) WHERE `glpi_tickettasks`.`state` = 1 AND `glpi_tickettasks`.`groups_id_tech` IN (42, 157) ORDER BY `glpi_tickettasks`.`date_mod` DESC'
+         'SELECT `glpi_tickettasks`.`id` FROM `glpi_tickettasks` INNER JOIN `glpi_tickets` ON (`glpi_tickettasks`.`tickets_id` = `glpi_tickets`.`id`) WHERE `glpi_tickets`.`status` IN (1, 2, 3, 4) AND `glpi_tickettasks`.`state` = 1 AND `glpi_tickettasks`.`groups_id_tech` IN (42, 157) ORDER BY `glpi_tickettasks`.`date_mod` DESC'
       );
       //no task for those groups
       $this->integer(count($iterator))->isIdenticalTo(0);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Also, i add a new static method in CommonITILObject to prevent code duplication

For the original issue:
- on central (bottom of the page)
![image](https://user-images.githubusercontent.com/418844/31828571-eed3ae94-b5ba-11e7-9a3f-e9da6c79cd19.png)

- ticket list
![image](https://user-images.githubusercontent.com/418844/31828587-f59a654c-b5ba-11e7-81dd-48073f651755.png)
