### PR TITLE
Added support to autogrow in simplified interface

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -4076,6 +4076,11 @@ class Ticket extends CommonITILObject {
          echo "<textarea id='$content_id' name='content' cols='$cols' rows='$rows'
                " . ($tt->isMandatoryField('content') ? " required='required'" : '') .">".
                 $content."</textarea></div>";
+
+         if (!$CFG_GLPI["use_rich_text"]) {
+            echo Html::scriptBlock("$(document).ready(function() { $('#$content_id').autogrow(); });");
+         }
+
          Html::file(['editor_id' => $content_id,
                           'showtitle' => false,
                           'multiple' => true]);


### PR DESCRIPTION
If the user is using the simplified interface, the description field does not increase as the text size.

With autogrow, the field increases as the user enters the text.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
