### PR TITLE
Missing $DB->escape on addToDB and updateInDB

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -425,7 +425,7 @@ class CommonDBTM extends CommonGLPI {
                $query .= " = ".$this->fields[$field];
 
             } else {
-               $query .= " = '". $DB->escape($this->fields[$field])."'";
+               $query .= ' = "'.$DB->escape($this->fields[$field]).'"';
             }
 
             $query .= " WHERE `id` ='".$this->fields["id"]."'";
@@ -491,7 +491,7 @@ class CommonDBTM extends CommonGLPI {
                if (($this->getType() == 'ProfileRight') && ($values[$i] == '')) {
                   $values[$i] = 0;
                }
-               $query .= "'".$DB->escape($values[$i])."'";
+               $query .= '"'.$DB->escape($values[$i]).'"';
             }
 
             if ($i != ($nb_fields-1)) {

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -425,7 +425,7 @@ class CommonDBTM extends CommonGLPI {
                $query .= " = ".$this->fields[$field];
 
             } else {
-               $query .= " = '".$this->fields[$field]."'";
+               $query .= " = '".$DB->escape($this->fields[$field])."'";
             }
 
             $query .= " WHERE `id` ='".$this->fields["id"]."'";
@@ -491,7 +491,7 @@ class CommonDBTM extends CommonGLPI {
                if (($this->getType() == 'ProfileRight') && ($values[$i] == '')) {
                   $values[$i] = 0;
                }
-               $query .= "'".$values[$i]."'";
+               $query .= "'".$DB->escape($values[$i])."'";
             }
 
             if ($i != ($nb_fields-1)) {

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -425,7 +425,7 @@ class CommonDBTM extends CommonGLPI {
                $query .= " = ".$this->fields[$field];
 
             } else {
-               $query .= " = '".$DB->escape($this->fields[$field])."'";
+               $query .= " = '". $DB->escape($this->fields[$field])."'";
             }
 
             $query .= " WHERE `id` ='".$this->fields["id"]."'";

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -425,7 +425,7 @@ class CommonDBTM extends CommonGLPI {
                $query .= " = ".$this->fields[$field];
 
             } else {
-               $query .= ' = "'.$DB->escape($this->fields[$field]).'"';
+               $query .= ' = \''.$DB->escape($this->fields[$field]).'\'';
             }
 
             $query .= " WHERE `id` ='".$this->fields["id"]."'";
@@ -491,7 +491,7 @@ class CommonDBTM extends CommonGLPI {
                if (($this->getType() == 'ProfileRight') && ($values[$i] == '')) {
                   $values[$i] = 0;
                }
-               $query .= '"'.$DB->escape($values[$i]).'"';
+               $query .= '\''.$DB->escape($values[$i]).'\'';
             }
 
             if ($i != ($nb_fields-1)) {

--- a/tests/units/NotificationEventAjax.php
+++ b/tests/units/NotificationEventAjax.php
@@ -146,7 +146,7 @@ class NotificationEventAjax extends DbTestCase {
       unset($data['send_time']);
       unset($data['messageid']);
       $data['body_text'] = preg_replace(
-         '/(Opening date).+/m',
+         '/Opening date\s+:\s+[-0-9]+\s[:0-9]+/m',
          '$1 OPENING',
          $data['body_text']
       );


### PR DESCRIPTION
On file `commondbtm.class.php`, missing use of `$DB->escape($this->fields[$field])` on addToDB and updateInDB functions.
Code should be modified to use $DB->escape function, otherwise values like "Alex's field" generate an error (and allowing SQL injection).

```php
 $query .= "'".$DB->escape($values[$i])."'";
```

Sample error :
```
  SQL: INSERT
                   INTO `glpi_plugin_fields_labeltranslations` (`plugin_fields_itemtype`,`plugin_fields_items_id`,`language`,`label`) VALUES (\'PluginFieldsContainer\',\'3\',\'en_GB\',\'Alex\'s fields\')
  Error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 's fields')' at line 2
  Backtrace :
  inc\commondbtm.class.php:436                       
  inc\commondbtm.class.php:852                       CommonDBTM->addToDB()
  plugins\fields\inc\labeltranslation.class.php:64   CommonDBTM->add()
  plugins\fields\inc\container.class.php:300         PluginFieldsLabelTranslation::createForItem()
  plugins\fields\hook.php:159                        PluginFieldsContainer->post_addItem()
  plugins\fields\front\regenerate_files.php:7        regenerateFiles()
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #number

Tests on going, Travis reports NotificationEventAjax failing. Since this PR is on common DB lib checks are on going to see if it has some issues on a separate branch/repo.

*Please update this template with something that matches your PR*