### PR TITLE
fix small ui misalignment

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -833,7 +833,8 @@ input.submit[type=reset] {
 
    .layout_vsplit.form table.tab_cadre_pager,
    .layout_vsplit.form table.tab_cadre_fixe,
-   .layout_vsplit.form table.tab_cadre_fixehov {
+   .layout_vsplit.form table.tab_cadre_fixehov,
+   .layout_vsplit.form .dates_timelines {
       width: 100%;
       margin: 0;
    }

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -4531,10 +4531,8 @@ abstract class CommonITILObject extends CommonDBTM {
          return false;
       }
 
-      echo "<div class='center'>";
       $this->showStatsDates();
       $this->showStatsTimes();
-      echo "</div>";
    }
 
    function showStatsDates() {

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -4561,6 +4561,7 @@ abstract class CommonITILObject extends CommonDBTM {
    }
 
    function showStatsTimes() {
+      echo "<div class='dates_timelines'>";
       echo "<table class='tab_cadre_fixe'>";
       echo "<tr><th colspan='2'>"._n('Time', 'Times', Session::getPluralNumber())."</th></tr>";
 
@@ -4605,6 +4606,7 @@ abstract class CommonITILObject extends CommonDBTM {
       echo "</td></tr>";
 
       echo "</table>";
+      echo "</div>";
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

I noticed a small vertical misalignment un GLPI

before fix
![image](https://user-images.githubusercontent.com/14139801/31881232-387abd7e-b7e3-11e7-8bae-b7bc02301635.png)

after fix
![image](https://user-images.githubusercontent.com/14139801/31881248-48ead59a-b7e3-11e7-8c47-5603e273038e.png)

This issue impacts formcreator's service catalog with vertical split layout, with a much bigger difference.

![image](https://user-images.githubusercontent.com/14139801/31881437-c970f4d8-b7e3-11e7-92dd-4ee258a94699.png)
