### PR TITLE
There is no is_template field for OS

### DIFF
--- a/inc/report.class.php
+++ b/inc/report.class.php
@@ -217,8 +217,7 @@ class Report extends CommonGLPI{
 
       // 2. Get some more number data (operating systems per computer)
 
-      $where = "WHERE `is_deleted` = '0'
-                      AND `is_template` = '0' ";
+      $where = "WHERE `is_deleted` = '0' ";
 
       $query = "SELECT COUNT(*) AS count, `glpi_operatingsystems`.`name` AS name
                 FROM `glpi_items_operatingsystems`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

From Tools/Reports, with default report, errors were:
```
2017-10-27 14:59:59 [2@LF014]
  *** MySQL query error:
  SQL: SELECT COUNT(*) AS count, `glpi_operatingsystems`.`name` AS name
                FROM `glpi_items_operatingsystems`
                LEFT JOIN `glpi_operatingsystems`
                   ON (`glpi_items_operatingsystems`.`operatingsystems_id` = `glpi_operatingsystems`.`id`)
                WHERE `is_deleted` = '0'
                      AND `is_template` = '0' 
                GROUP BY `glpi_operatingsystems`.`name`
  Error: Unknown column 'is_template' in 'where clause'
  Backtrace :
  inc/report.class.php:229                           
  front/report.default.php:45                        Report::showDefaultReport()

[27-Oct-2017 14:59:59 UTC] PHP Fatal error:  Uncaught Error: Call to a member function fetch_assoc() on boolean in /var/www/webapps/glpi/inc/dbmysql.class.php:311
Stack trace:
#0 /var/www/webapps/glpi/inc/report.class.php(231): DBmysql->fetch_assoc(false)
#1 /var/www/webapps/glpi/front/report.default.php(45): Report::showDefaultReport()
#2 {main}
  thrown in /var/www/webapps/glpi/inc/dbmysql.class.php on line 311

```