### PR TITLE
Feature/fix simcard ui

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -650,23 +650,16 @@ input.submit[type=reset] {
    padding-right: 50px;
 }
 
-/* #page .fa.disclose {
+#page .disclosablefield {
    position: relative;
-   left: -40px;
-   top: 2px
 }
- */
- 
- #page .disclosablefield {
- 	position: relative;
- }
- 
- #page .disclosablefield span {
- 	position: absolute;
- 	right: 0;
- 	top: 0;
- }
- 
+
+#page .disclosablefield span {
+   position: absolute;
+   right: 0;
+   top: 0;
+}
+
 /* ################--------------- Layout  ---------------#################### */
 .layout_classic.form div.navigationheader,
 .layout_vsplit.form div.navigationheader {

--- a/css/styles.css
+++ b/css/styles.css
@@ -650,12 +650,23 @@ input.submit[type=reset] {
    padding-right: 50px;
 }
 
-#page .fa.disclose {
+/* #page .fa.disclose {
    position: relative;
    left: -40px;
    top: 2px
 }
-
+ */
+ 
+ #page .disclosablefield {
+ 	position: relative;
+ }
+ 
+ #page .disclosablefield span {
+ 	position: absolute;
+ 	right: 0;
+ 	top: 0;
+ }
+ 
 /* ################--------------- Layout  ---------------#################### */
 .layout_classic.form div.navigationheader,
 .layout_vsplit.form div.navigationheader {

--- a/inc/item_devices.class.php
+++ b/inc/item_devices.class.php
@@ -1101,6 +1101,7 @@ class Item_Devices extends CommonDBRelation {
          }
          echo "<td>".$attributs['long name']."</td>";
          echo "<td>";
+         $out = '';
 
          // Can the user view the value of the field ?
          if (!isset($attributs['right'])) {
@@ -1112,6 +1113,7 @@ class Item_Devices extends CommonDBRelation {
          // Do the field needs a user action to display ?
          if (isset($attributs['protected']) && $attributs['protected']) {
             $protected = true;
+            $out.= '<span class="disclosablefield">';
          } else {
             $protected = false;
          }
@@ -1126,28 +1128,29 @@ class Item_Devices extends CommonDBRelation {
             switch ($attributs['datatype']) {
                case 'dropdown':
                   $dropdownType = getItemtypeForForeignKeyField($field);
-                  $out = $dropdownType::dropdown(['value'    => $value,
+                  $out.= $dropdownType::dropdown(['value'    => $value,
                                                   'rand'     => $rand,
                                                   'entity'   => $this->fields["entities_id"],
                                                   'display'  => false]);
                   break;
                default:
                   if (!$protected) {
-                     $out = Html::autocompletionTextField($this, $field, ['value'    => $value,
+                     $out.= Html::autocompletionTextField($this, $field, ['value'    => $value,
                                                                           'rand'     => $rand,
                                                                           'size'     => $attributs['size'],
                                                                           'display'  => false]);
                   } else {
-                     $out = '<input class="protected" type="password" autocomplete="off" name="' . $field . '" ';
+                     $out.= '<input class="protected" type="password" autocomplete="off" name="' . $field . '" ';
                      $out.= 'id="' . $field . $rand . '" value="' . $value . '">';
                   }
             }
             if ($protected) {
-               $out.= '<i class="fa fa-eye pointer disclose" ';
+               $out.= '<span><i class="fa fa-eye pointer" ';
                $out.= 'onmousedown="showField(\'' . $field . $rand . '\')" ';
                $out.= 'onmouseup="hideField(\'' . $field . $rand . '\')"></i>';
-               $out.= '<i class="fa fa-clipboard pointer disclose" ';
-               $out.= 'onclick="copyToClipboard(\'' . $field . $rand . '\')"></i>';
+               $out.= '<i class="fa fa-clipboard pointer" ';
+               $out.= 'onclick="copyToClipboard(\'' . $field . $rand . '\')"></i></span>';
+               $out.= '</span>';
             }
             echo $out;
          } else {

--- a/inc/item_devices.class.php
+++ b/inc/item_devices.class.php
@@ -1147,7 +1147,7 @@ class Item_Devices extends CommonDBRelation {
             if ($protected) {
                $out.= '<span><i class="fa fa-eye pointer" ';
                $out.= 'onmousedown="showField(\'' . $field . $rand . '\')" ';
-               $out.= 'onmouseup="hideField(\'' . $field . $rand . '\')"></i>';
+               $out.= 'onmouseup="hideField(\'' . $field . $rand . '\')" onmouseout="hideField(\'' . $field . $rand . '\')"></i>';
                $out.= '<i class="fa fa-clipboard pointer" ';
                $out.= 'onclick="copyToClipboard(\'' . $field . $rand . '\')"></i></span>';
                $out.= '</span>';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Fixed tickets | none

2 fixes
- when the browser is not wide enough, the eye button and the copy button go out of their expected place.
- when one click on the eye and goes out of it while pressing the mouse button, the field still shows its content.

## before
![image](https://user-images.githubusercontent.com/14139801/32133526-049905ec-bbda-11e7-9038-311eda5e350a.png)

![image](https://user-images.githubusercontent.com/14139801/32133527-0fd489f4-bbda-11e7-8ed3-ebf7780b5492.png)

## after

![image](https://user-images.githubusercontent.com/14139801/32133536-3579cf16-bbda-11e7-83f8-303f87bd8a67.png)

![image](https://user-images.githubusercontent.com/14139801/32133537-3d04201a-bbda-11e7-8d56-42e8dccdff3e.png)
