### PR TITLE
Fix 9.1 possible migration issues; fixes #1296

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - php -S localhost:8088 tests/router.php &>/dev/null &
   # LDAP stuff
   - phpenv config-add tests/enable-ldap.ini
-  - ./tests/LDAP/ldap_fixtures.sh
+  - ./tests/LDAP/ldap_fixtures.sh > /dev/null
   #APCu
   - phpenv config-add tests/enable-apcu.ini
 script:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1296 

Too many changes were relying on the presence of a single table; causing hard to reproduce issues during migration (without any errors).