### PR TITLE
Feature/phpmailer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-curl": "*",
         "jasig/phpcas": "~1.3.0",
         "iamcal/lib_autolink": "~1.7",
-        "phpmailer/phpmailer": "~5.2",
+        "phpmailer/phpmailer": "~6.0",
         "sabre/vobject": "~4.1",
         "simplepie/simplepie": "^1.5",
         "tecnickcom/tcpdf": "~6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa5efb0cc8aba67554f24991f0a3fedf",
+    "content-hash": "f4b644d3da2884dd7dc19c6835ff5a02",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -224,56 +224,44 @@
         },
         {
             "name": "phpmailer/phpmailer",
-            "version": "v5.2.26",
+            "version": "v6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPMailer/PHPMailer.git",
-                "reference": "70362997bda4376378be7d92d81e2200550923f7"
+                "reference": "992392437c2e2784e0dc41446024fe411d293c96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/70362997bda4376378be7d92d81e2200550923f7",
-                "reference": "70362997bda4376378be7d92d81e2200550923f7",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/992392437c2e2784e0dc41446024fe411d293c96",
+                "reference": "992392437c2e2784e0dc41446024fe411d293c96",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
-                "php": ">=5.0.0"
+                "php": ">=5.5.0"
             },
             "require-dev": {
                 "doctrine/annotations": "1.2.*",
-                "jms/serializer": "0.16.*",
+                "friendsofphp/php-cs-fixer": "^2.2",
                 "phpdocumentor/phpdocumentor": "2.*",
-                "phpunit/phpunit": "4.8.*",
-                "symfony/debug": "2.8.*",
-                "symfony/filesystem": "2.8.*",
-                "symfony/translation": "2.8.*",
-                "symfony/yaml": "2.8.*",
-                "zendframework/zend-cache": "2.5.1",
-                "zendframework/zend-config": "2.5.1",
-                "zendframework/zend-eventmanager": "2.5.1",
-                "zendframework/zend-filter": "2.5.1",
-                "zendframework/zend-i18n": "2.5.1",
-                "zendframework/zend-json": "2.5.1",
-                "zendframework/zend-math": "2.5.1",
-                "zendframework/zend-serializer": "2.5.*",
-                "zendframework/zend-servicemanager": "2.5.*",
-                "zendframework/zend-stdlib": "2.5.1"
+                "phpunit/phpunit": "^4.8 || ^5.7",
+                "zendframework/zend-eventmanager": "3.0.*",
+                "zendframework/zend-i18n": "2.7.3",
+                "zendframework/zend-serializer": "2.7.*"
             },
             "suggest": {
-                "league/oauth2-google": "Needed for Google XOAUTH2 authentication"
+                "ext-mbstring": "Needed to send email in multibyte encoding charset",
+                "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
+                "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
+                "psr/log": "For optional PSR-3 debug logging",
+                "stevenmaguire/oauth2-microsoft": "Needed for Microsoft XOAUTH2 authentication",
+                "symfony/polyfill-mbstring": "To support UTF-8 if the Mbstring PHP extension is not enabled (^1.2)"
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "class.phpmailer.php",
-                    "class.phpmaileroauth.php",
-                    "class.phpmaileroauthgoogle.php",
-                    "class.smtp.php",
-                    "class.pop3.php",
-                    "extras/EasyPeasyICS.php",
-                    "extras/ntlm_sasl_client.php"
-                ]
+                "psr-4": {
+                    "PHPMailer\\PHPMailer\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -297,7 +285,7 @@
                 }
             ],
             "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
-            "time": "2017-11-04T09:26:05+00:00"
+            "time": "2017-09-14T16:47:12+00:00"
         },
         {
             "name": "psr/container",

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -38,6 +38,7 @@ use Glpi\Exception\PasswordTooWeakException;
 use Zend\Cache\Storage\AvailableSpaceCapableInterface;
 use Zend\Cache\Storage\TotalSpaceCapableInterface;
 use Zend\Cache\Storage\FlushableInterface;
+use PHPMailer\PHPMailer\PHPMailer;
 
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");

--- a/inc/glpimailer.class.php
+++ b/inc/glpimailer.class.php
@@ -34,6 +34,8 @@
 * @brief
 */
 
+use PHPMailer\PHPMailer\PHPMailer;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }

--- a/inc/glpimailer.class.php
+++ b/inc/glpimailer.class.php
@@ -100,4 +100,13 @@ class GLPIMailer extends PHPMailer {
       }
    }
 
+   public function setLanguage($langcode = 'en', $lang_path = '') {
+      if ($lang_path == '') {
+         $local_path = dirname(Config::getLibraryDir('PHPMailer\PHPMailer\PHPMailer'))  . '/language/';
+         if (is_dir($local_path)) {
+            $lang_path = $local_path;
+         }
+      }
+      parent::setLanguage($langcode, $lang_path);
+   }
 }

--- a/inc/glpimailer.class.php
+++ b/inc/glpimailer.class.php
@@ -35,6 +35,7 @@
 */
 
 use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
 
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
@@ -98,6 +99,15 @@ class GLPIMailer extends PHPMailer {
             );
          };
       }
+   }
+
+   public static function validateAddress($address, $patternselect = null) {
+      $isValid = parent::validateAddress($address, $patternselect);
+      if (!$isValid && Toolbox::endsWith($address, '@localhost')) {
+         //since phpmailer6, @localhost address are no longer valid...
+         $isValid = parent::ValidateAddress($address . '.me');
+      }
+      return $isValid;
    }
 
    public function setLanguage($langcode = 'en', $lang_path = '') {

--- a/inc/notificationmailing.class.php
+++ b/inc/notificationmailing.class.php
@@ -34,8 +34,6 @@
 * @brief
 */
 
-use PHPMailer\PHPMailer\PHPMailer;
-
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -69,11 +67,7 @@ class NotificationMailing implements NotificationInterface {
    static function isUserAddressValid($address, $options = ['checkdns'=>false]) {
       //drop sanitize...
       $address = Toolbox::stripslashes_deep($address);
-      $isValid = PHPMailer::ValidateAddress($address);
-      if (!$isValid && Toolbox::endsWith($address, '@localhost')) {
-         //since phpmailer6, @localhost address are no longer valid...
-         $isValid = PHPMailer::ValidateAddress($address . '.me');
-      }
+      $isValid = GLPIMailer::ValidateAddress($address);
 
       $checkdns = (isset($options['checkdns']) ? $options['checkdns'] :  false);
       if ($checkdns) {

--- a/inc/notificationmailing.class.php
+++ b/inc/notificationmailing.class.php
@@ -34,6 +34,8 @@
 * @brief
 */
 
+use PHPMailer\PHPMailer\PHPMailer;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -67,7 +69,7 @@ class NotificationMailing implements NotificationInterface {
    static function isUserAddressValid($address, $options = ['checkdns'=>false]) {
       //drop sanitize...
       $address = Toolbox::stripslashes_deep($address);
-      $isValid = \PHPMailer::ValidateAddress($address);
+      $isValid = PHPMailer::ValidateAddress($address);
 
       $checkdns = (isset($options['checkdns']) ? $options['checkdns'] :  false);
       if ($checkdns) {

--- a/inc/notificationmailing.class.php
+++ b/inc/notificationmailing.class.php
@@ -70,6 +70,10 @@ class NotificationMailing implements NotificationInterface {
       //drop sanitize...
       $address = Toolbox::stripslashes_deep($address);
       $isValid = PHPMailer::ValidateAddress($address);
+      if (!$isValid && Toolbox::endsWith($address, '@localhost')) {
+         //since phpmailer6, @localhost address are no longer valid...
+         $isValid = PHPMailer::ValidateAddress($address . '.me');
+      }
 
       $checkdns = (isset($options['checkdns']) ? $options['checkdns'] :  false);
       if ($checkdns) {

--- a/tests/units/Config.php
+++ b/tests/units/Config.php
@@ -32,6 +32,7 @@
 
 namespace tests\units;
 
+use PHPMailer\PHPMailer\PHPMailer;
 use \DbTestCase;
 
 /* Test for inc/config.class.php */
@@ -246,11 +247,11 @@ class Config extends DbTestCase {
       $this->boolean(\Config::getLibraryDir(''))->isFalse();
       $this->boolean(\Config::getLibraryDir('abcde'))->isFalse();
 
-      $expected = realpath(__DIR__ . '/../../vendor/phpmailer/phpmailer');
+      $expected = realpath(__DIR__ . '/../../vendor/phpmailer/phpmailer/src');
       if (is_dir($expected)) { // skip when system library is used
-         $this->string(\Config::getLibraryDir('PHPMailer'))->isIdenticalTo($expected);
+         $this->string(\Config::getLibraryDir('PHPMailer\PHPMailer\PHPMailer'))->isIdenticalTo($expected);
 
-         $mailer = new \PHPMailer();
+         $mailer = new PHPMailer();
          $this->string(\Config::getLibraryDir($mailer))->isIdenticalTo($expected);
       }
 

--- a/tests/units/GLPIMailer.php
+++ b/tests/units/GLPIMailer.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2017 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+*/
+
+namespace tests\units;
+
+use \DbTestCase;
+
+/* Test for inc/notificationmailing.class.php .class.php */
+
+class GLPIMailer extends DbTestCase {
+
+   public function testPhpMailerLang() {
+      $mailer = new \GLPIMailer;
+
+      $mailer->setLanguage();
+      $tr = $mailer->getTranslations();
+      $this->string($tr['empty_message'])->isIdenticalTo('Message body empty');
+
+      $mailer->setLanguage('fr');
+      $tr = $mailer->getTranslations();
+      $this->string($tr['empty_message'])->isIdenticalTo('Corps du message vide.');
+   }
+}

--- a/tests/units/GLPIMailer.php
+++ b/tests/units/GLPIMailer.php
@@ -38,6 +38,14 @@ use \DbTestCase;
 
 class GLPIMailer extends DbTestCase {
 
+   public function testValidateAddress() {
+      $mailer = new \GLPIMailer;
+
+      $this->boolean($mailer->validateAddress('user'))->isFalse();
+      $this->boolean($mailer->validateAddress('user@localhost'))->isTrue();
+      $this->boolean($mailer->validateAddress('user@localhost.dot'))->isTrue();
+   }
+
    public function testPhpMailerLang() {
       $mailer = new \GLPIMailer;
 

--- a/tests/units/NotificationMailing.php
+++ b/tests/units/NotificationMailing.php
@@ -101,16 +101,4 @@ class NotificationMailing extends DbTestCase {
             'mode'                     => 'mailing'
          ]);
    }
-
-   public function testPhpMailerLang() {
-      $mailer = new \PHPMailer();
-
-      $mailer->setLanguage();
-      $tr = $mailer->getTranslations();
-      $this->string($tr['empty_message'])->isIdenticalTo('Message body empty');
-
-      $mailer->setLanguage('fr');
-      $tr = $mailer->getTranslations();
-      $this->string($tr['empty_message'])->isIdenticalTo('Corps du message vide.');
-   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3020

It seems we did not use any deprecated that has been dropped, nor any method that signature has changed.

The only thing I've seen is that `user@localhost` is no longer valid; and will not be. So, I've provided a workaround.