### PR TITLE
Rotate e-mail queue for not sended e-mails

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -35,7 +35,7 @@
 */
 
 // Current version of GLPI
-define('GLPI_VERSION', '9.2.1');
+define('GLPI_VERSION', '9.2.2');
 if (substr(GLPI_VERSION, -4) === '-dev') {
    //for dev version
    define('GLPI_PREVER', str_replace('-dev', '', GLPI_VERSION));
@@ -45,7 +45,7 @@ if (substr(GLPI_VERSION, -4) === '-dev') {
    );
 } else {
    //for stable version
-   define("GLPI_SCHEMA_VERSION", '9.2.1');
+   define("GLPI_SCHEMA_VERSION", '9.2.2');
 }
 define('GLPI_MIN_PHP', '5.6.0'); // Must also be changed in top of index.php
 define('GLPI_YEAR', '2017');

--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -285,8 +285,15 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
             }
 
             $mmail->ClearAddresses();
-            $current->update(['id'        => $current->fields['id'],
-                                'sent_try' => $current->fields['sent_try']+1]);
+            $input = [
+                'id'        => $current->fields['id'],
+                'sent_try'  => $current->fields['sent_try'] + 1
+            ];
+
+            if ($CFG_GLPI["smtp_retry_time"] > 0) {
+               $input['send_time'] = date("Y-m-d H:i:s", strtotime('+' . $CFG_GLPI["smtp_retry_time"] . ' minutes')); //Delay X minutes to try again
+            }
+            $current->update($input);
          } else {
             //TRANS to be written in logs %1$s is the to email / %2$s is the subject of the mail
             Toolbox::logInFile("mail",

--- a/inc/notificationmailingsetting.class.php
+++ b/inc/notificationmailingsetting.class.php
@@ -178,6 +178,19 @@ class NotificationMailingSetting extends NotificationSetting {
          $out .= "<td><label for='smtp_max_retries'>" . __('Max. delivery retries') . "</label></td>";
          $out .= "<td><input type='text' name='smtp_max_retries' id='smtp_max_retries' size='5' value='" .
                        $CFG_GLPI["smtp_max_retries"] . "'></td>";
+         $out .= "</tr>";
+
+         $out .= "<tr class='tab_bg_2'>";
+         $out .= "<td><label for='smtp_max_retries'>" . __('Try to deliver again in (minutes)') . "</label></td>";
+         $out .= "<td>";
+         $out .= Dropdown::showNumber('smtp_retry_time', [
+                     'value'    => $CFG_GLPI["smtp_retry_time"],
+                     'min'      => 0,
+                     'max'      => 60,
+                     'step'     => 1,
+                     'display'  => false,
+                 ]);
+         $out .= "</td>";
 
          $out .= "</table>";
 

--- a/inc/update.class.php
+++ b/inc/update.class.php
@@ -403,6 +403,8 @@ class Update extends CommonGLPI {
          case "9.2.1":
          case GLPI_VERSION:
          case GLPI_SCHEMA_VERSION:
+            include_once("{$updir}update_921_922.php");
+            update921to922();
             break;
 
          default :

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -1348,13 +1348,14 @@ INSERT INTO `glpi_configs` VALUES ('174','core','notifications_ajax','0');
 INSERT INTO `glpi_configs` VALUES ('175','core','notifications_ajax_check_interval', '5');
 INSERT INTO `glpi_configs` VALUES ('176','core','notifications_ajax_sound', NULL);
 INSERT INTO `glpi_configs` VALUES ('177','core','notifications_ajax_icon_url', '/pics/glpi.png');
-INSERT INTO `glpi_configs` VALUES ('178','core','dbversion','9.2');
+INSERT INTO `glpi_configs` VALUES ('178','core','dbversion','9.2.2');
 INSERT INTO `glpi_configs` VALUES ('179','core','smtp_max_retries','5');
 INSERT INTO `glpi_configs` VALUES ('180','core','smtp_sender', NULL);
 INSERT INTO `glpi_configs` VALUES ('181','core','from_email', NULL);
 INSERT INTO `glpi_configs` VALUES ('182','core','from_email_name', NULL);
 INSERT INTO `glpi_configs` VALUES ('183','core','instance_uuid', NULL);
 INSERT INTO `glpi_configs` VALUES ('184','core','registration_uuid', NULL);
+INSERT INTO `glpi_configs` VALUES ('185','core','smtp_retry_time','5');
 
 
 ### Dump table glpi_consumableitems

--- a/install/update_921_922.php
+++ b/install/update_921_922.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2017 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+/** @file
+* @brief
+*/
+
+/**
+ * Update from 9.2.1 to 9.2.2
+ *
+ * @return bool for success (will die for most error)
+**/
+function update921to922() {
+   global $DB, $migration, $CFG_GLPI;
+
+   $current_config   = Config::getConfigurationValues('core');
+   $updateresult     = true;
+   $ADDTODISPLAYPREF = [];
+
+   //TRANS: %s is the number of new version
+   $migration->displayTitle(sprintf(__('Update to %s'), '9.2.2'));
+   $migration->setVersion('9.2.2');
+
+   $migration->addConfig([
+      'smtp_retry_time' => 5,
+   ]);
+
+   // ************ Keep it at the end **************
+   $migration->executeMigration();
+
+   return $updateresult;
+}

--- a/tools/cliupdate.php
+++ b/tools/cliupdate.php
@@ -151,8 +151,8 @@ if (version_compare($current_db_version, GLPI_SCHEMA_VERSION, 'ne')) {
    $migration->displayWarning("\nMigration Done.");
 } else if (isset($args['force']) || $current_db_version != GLPI_SCHEMA_VERSION && isset($args['dev'])) {
 
-   include_once("../install/update_92_921.php");
-   update92to921();
+   include_once("../install/update_921_922.php");
+   update921to922();
 
    $migration->displayWarning((isset($args['force']) ? "\nForced" : "\nDevelopment") . " migration Done.");
 } else {


### PR DESCRIPTION
For environments with high volume of emails, unsent emails delay other sent.

Example: If I have 40 unsent emails (Example: Invalid address), the cron need executate 5 (minimal 5 minutes) times to send the others emails.

With the pull request, unsent emails try again later, allowing new emails to sent.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3130 
