### PR TITLE
prevent notice when using Ticket::canUpdate without session

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -299,7 +299,8 @@ class Ticket extends CommonITILObject {
    static function canUpdate() {
 
       // To allow update of urgency and category for post-only
-      if ($_SESSION["glpiactiveprofile"]["interface"] == "helpdesk") {
+      if (isset($_SESSION["glpiactiveprofile"]["interface"])
+          && $_SESSION["glpiactiveprofile"]["interface"] == "helpdesk") {
          return Session::haveRight(self::$rightname, CREATE);
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Example:
```
2017-11-15 14:24:34 [@bwgpidev]
   *** PHP Notice(8): Undefined index: glpiactiveprofile
   Backtrace :
   inc/ticket.class.php:302
   plugins/behaviors/inc/common.class.php:86          Ticket::canUpdate()
   inc/commonglpi.class.php:206                       PluginBehaviorsCommon->getTabNameForItem()
   inc/commonglpi.class.php:169                       CommonGLPI->addStandardTab()
   ajax/updatecurrenttab.php:50                       CommonGLPI->defineAllTabs()
```