### PR TITLE
handle config relocated in /etc

### DIFF
--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -47,7 +47,9 @@ if (!empty($tz)) {
 }
 
 // If this file exists, it is load
-if (file_exists(GLPI_ROOT. '/config/local_define.php')) {
+if (!is_dir(GLPI_ROOT. '/config') && file_exists('/etc/glpi/local_define.php')) { // Relocated (Linux only)
+   require_once '/etc/glpi/local_define.php';
+} else if (file_exists(GLPI_ROOT. '/config/local_define.php')) {
    require_once GLPI_ROOT. '/config/local_define.php';
 }
 


### PR DESCRIPTION
As this happens only when `config` directory is moved, it allow multiple instance of GLPI (common dev configuration) to ignore `/etc/glpi/local_define.php`, and thus, it  will only be used by default instance  (stable version).

P.S. this PR will allow to drop patch from downstream, such as https://src.fedoraproject.org/cgit/rpms/glpi.git/plain/glpi-localdef.patch and will (try to) make local_define usage more consistent