### PR TITLE
fix uncleaned var

### DIFF
--- a/inc/includes.php
+++ b/inc/includes.php
@@ -94,6 +94,7 @@ if (isset($_FILES)) {
       $file['name'] = Toolbox::clean_cross_side_scripting_deep($file['name']);
    }
 }
+unset($file);
 
 // Mark if Header is loaded or not :
 $HEADER_LOADED = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

When some code executes after running includes.php and defines a variable ```$file``` it will unexpectedly alter and corrupts the variable $_FILES.