### PR TITLE
Uneeded concat (on licence name) for licence inventory number and lic…

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2495,7 +2495,7 @@ class Search {
                         $ADDITONALFIELDS";
             }
             break;
-            
+
          default:
             break;
       }

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2455,7 +2455,6 @@ class Search {
                               AS `".$NAME."_".$num."_mailname`,
                      $ADDITONALFIELDS";
 
-         case "glpi_softwarelicenses.name" :
          case "glpi_softwareversions.name" :
             if ($meta) {
                return " GROUP_CONCAT(DISTINCT CONCAT(`glpi_softwares`.`name`, ' - ',
@@ -2466,9 +2465,6 @@ class Search {
             }
             break;
 
-         case "glpi_softwarelicenses.serial" :
-         case "glpi_softwarelicenses.otherserial" :
-         case "glpi_softwarelicenses.comment" :
          case "glpi_softwareversions.comment" :
             if ($meta) {
                return " GROUP_CONCAT(DISTINCT CONCAT(`glpi_softwares`.`name`, ' - ',
@@ -2498,6 +2494,9 @@ class Search {
                                     AS `".$NAME."_".$num."`,
                         $ADDITONALFIELDS";
             }
+            break;
+            
+         default:
             break;
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #426 #2643 

Remove uneeded concat for Licence inventory number and licence serial number and comments.
It's usefull for column name, but not for column value.

Previous design
![image](https://cloud.githubusercontent.com/assets/13583138/12817796/f7eb4876-cb64-11e5-8e73-dca23c57f7b5.png)
New design :
![image](https://user-images.githubusercontent.com/6187125/33245439-2cb661ce-d308-11e7-9d68-a4eb91f9ef6d.png)
