### PR TITLE
Fix minimum number when used

### DIFF
--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -1463,7 +1463,12 @@ class Dropdown {
          }
       }
       if (($p['value'] < $p['min']) && !isset($p['toadd'][$p['value']])) {
-         $p['value'] = $p['min'];
+         $min = $p['min'];
+
+         while (isset($p['used'][$min])) {
+            ++$min;
+         }
+         $p['value'] = $min;
       }
 
       $field_id = Html::cleanId("dropdown_".$myname.$p['rand']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

When using `Dropdown::showNumber()` without value, with a mini of 1 and with 1 as used value; default selection fro dropdown was 1; this is wrong.