### PR TITLE
Update transfer.class.php for quote usage

### DIFF
--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -1428,7 +1428,7 @@ class Transfer extends CommonDBTM {
             }
             $query = "SELECT *
                       FROM `glpi_softwares`
-                      WHERE `entities_id` = ".$this->to."
+                      WHERE `entities_id` = '".$this->to."'
                             AND `name` = '".addslashes($soft->fields['name'])."'
                             $manufacturer";
 


### PR DESCRIPTION
Fix the usage of entities_id if they contain non standard caracters
This is a fix for #3245

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3245 
