### PR TITLE
escape single quote in HTML option of a dropdown

### DIFF
--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -1922,7 +1922,7 @@ class Dropdown {
                $output .= "</optgroup>";
             } else {
                if (!isset($param['used'][$key])) {
-                  $output .= "<option value='".$key."'";
+                  $output .= "<option value='".Html::entities_deep($key)."'";
                   // Do not use in_array : trouble with 0 and empty value
                   foreach ($param['values'] as $value) {
                      if (strcmp($key, $value)===0) {


### PR DESCRIPTION
fix #3308

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3308 

Fix escaping of a single quote when defining HTML option tag for dropdowns, see #3308 