### PR TITLE
Feature/fix ticket self service

### DIFF
--- a/inc/levelagreement.class.php
+++ b/inc/levelagreement.class.php
@@ -244,8 +244,6 @@ abstract class LevelAgreement extends CommonDBChild {
     * @param  bool           $canupdate update right
     */
    function showForTicket(Ticket $ticket, $type, $tt, $canupdate) {
-      global $CFG_GLPI;
-
       list($dateField, $laField) = static::getFieldNames($type);
       $rand = mt_rand();
       $pre  = static::$prefix;

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -299,7 +299,8 @@ class Ticket extends CommonITILObject {
    static function canUpdate() {
 
       // To allow update of urgency and category for post-only
-      if ($_SESSION["glpiactiveprofile"]["interface"] == "helpdesk") {
+      if (isset($_SESSION["glpiactiveprofile"]["interface"])
+          && $_SESSION["glpiactiveprofile"]["interface"] == "helpdesk") {
          return Session::haveRight(self::$rightname, CREATE);
       }
 
@@ -4375,7 +4376,7 @@ class Ticket extends CommonITILObject {
 
 
    function showForm($ID, $options = []) {
-      global $DB, $CFG_GLPI;
+      global $CFG_GLPI;
 
       $default_values = self::getDefaultValues();
 
@@ -4542,8 +4543,8 @@ class Ticket extends CommonITILObject {
 
       // check right used for this ticket
       $canupdate   = !$ID
-                     || Session::haveRight(self::$rightname, UPDATE)
-                     || $this->canRequesterUpdateItem();
+                     || Session::haveRight(self::$rightname, UPDATE);
+      $can_requester = $this->canRequesterUpdateItem();
       $canpriority = Session::haveRight(self::$rightname, self::CHANGEPRIORITY);
 
       if ($ID && in_array($this->fields['status'], $this->getClosedStatusArray())) {
@@ -4785,7 +4786,7 @@ class Ticket extends CommonITILObject {
                                              $tt->getMandatoryMark('itilcategories_id'))."</th>";
       echo "<td width='$colsize4%'>";
       // Permit to set category when creating ticket without update right
-      if ($canupdate) {
+      if ($canupdate || $can_requester) {
 
          $opt = ['value'  => $this->fields["itilcategories_id"],
                       'entity' => $this->fields["entities_id"]];
@@ -4880,7 +4881,7 @@ class Ticket extends CommonITILObject {
       echo $tt->getEndHiddenFieldText('urgency')."</th>";
       echo "<td>";
 
-      if ($canupdate) {
+      if ($canupdate || $can_requester) {
          echo $tt->getBeginHiddenFieldValue('urgency');
          $idurgency = self::dropdownUrgency(['value' => $this->fields["urgency"]]);
          echo $tt->getEndHiddenFieldValue('urgency', $this);
@@ -5004,10 +5005,10 @@ class Ticket extends CommonITILObject {
          echo $tt->getEndHiddenFieldValue('priority', $this);
       }
 
-      if ($canupdate) {
+      if ($canupdate || $can_requester) {
          $params = ['urgency'  => '__VALUE0__',
-                         'impact'   => '__VALUE1__',
-                         'priority' => $idpriority];
+                    'impact'   => '__VALUE1__',
+                    'priority' => $idpriority];
          Ajax::updateItemOnSelectEvent(['dropdown_urgency'.$idurgency,
                                              'dropdown_impact'.$idimpact],
                                        $idajax,
@@ -5037,7 +5038,7 @@ class Ticket extends CommonITILObject {
       } else {
          echo "<td>";
          echo $tt->getBeginHiddenFieldValue('items_id');
-         $options['_canupdate'] = $canupdate;
+         $options['_canupdate'] = $canupdate || $can_requester;
          Item_Ticket::itemAddForm($this, $options);
          echo $tt->getEndHiddenFieldValue('items_id', $this);
          echo "</td>";
@@ -5072,7 +5073,7 @@ class Ticket extends CommonITILObject {
       printf(__('%1$s%2$s'), __('Title'), $tt->getMandatoryMark('name'));
       echo $tt->getEndHiddenFieldText('name')."</th>";
       echo "<td colspan='3'>";
-      if ($canupdate) {
+      if ($canupdate || $can_requester) {
          echo $tt->getBeginHiddenFieldValue('name');
          echo "<input type='text' style='width:98%' maxlength=250 name='name' ".
                 ($tt->isMandatoryField('name') ? " required='required'" : '') .
@@ -5091,7 +5092,7 @@ class Ticket extends CommonITILObject {
       echo "<tr class='tab_bg_1'>";
       echo "<th style='width:$colsize1%'>".$tt->getBeginHiddenFieldText('content');
       printf(__('%1$s%2$s'), __('Description'), $tt->getMandatoryMark('content'));
-      if ($canupdate) {
+      if ($canupdate || $can_requester) {
          $content = Toolbox::unclean_cross_side_scripting_deep(Html::entity_decode_deep($this->fields['content']));
          Html::showTooltip(nl2br(Html::Clean($content)));
       }
@@ -5120,7 +5121,7 @@ class Ticket extends CommonITILObject {
       }
 
       echo "<div id='content$rand_text'>";
-      if ($CFG_GLPI['use_rich_text'] || $canupdate) {
+      if ($CFG_GLPI['use_rich_text'] || $canupdate || $can_requester) {
          echo "<textarea id='$content_id' name='content' style='width:100%' rows='$rows'".
                ($tt->isMandatoryField('content') ? " required='required'" : '') . ">" .
                $content."</textarea></div>";
@@ -5220,6 +5221,7 @@ class Ticket extends CommonITILObject {
       echo "</table>";
 
       if (($canupdate
+           || $can_requester
            || $canpriority
            || $this->canAssign()
            || $this->canAssignTome())
@@ -5228,7 +5230,7 @@ class Ticket extends CommonITILObject {
          if ($ID) {
             if (self::canPurge()
                 || $this->canDeleteItem()
-                || $canupdate) {
+                  || $canupdate || $can_requester) {
                echo "<div class='center'>";
                if ($this->fields["is_deleted"] == 1) {
                   if (self::canPurge()) {
@@ -5236,7 +5238,7 @@ class Ticket extends CommonITILObject {
                             _sx('button', 'Restore')."'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
                   }
                } else {
-                  if ($canupdate || $canpriority) {
+                  if ($canupdate || $can_requester || $canpriority) {
                      echo "<input type='submit' class='submit' name='update' value='".
                             _sx('button', 'Save')."'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
                   }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -299,8 +299,7 @@ class Ticket extends CommonITILObject {
    static function canUpdate() {
 
       // To allow update of urgency and category for post-only
-      if (isset($_SESSION["glpiactiveprofile"]["interface"])
-          && $_SESSION["glpiactiveprofile"]["interface"] == "helpdesk") {
+      if ($_SESSION["glpiactiveprofile"]["interface"] == "helpdesk") {
          return Session::haveRight(self::$rightname, CREATE);
       }
 

--- a/tests/units/Ticket.php
+++ b/tests/units/Ticket.php
@@ -748,7 +748,16 @@ class Ticket extends DbTestCase {
       $textarea = true,
       $priority = true,
       $save = true,
-      $assign = true
+      $assign = true,
+      $openDate = true,
+      $timeOwnResolve = true,
+      $type = true,
+      $status = true,
+      $urgency = true,
+      $impact = true,
+      $category = true,
+      $requestSource = true,
+      $location = true
    ) {
       ob_start();
       $ticket->showForm($ticket->getID());
@@ -762,6 +771,102 @@ class Ticket extends DbTestCase {
          $matches
       );
       $this->array($matches)->hasSize(1);
+
+      // Opening date, editable
+      preg_match(
+         '/.*<input[^>]*name=\'_date\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($openDate === true ? 1 : 0));
+
+      // Time to own, editable
+      preg_match(
+         '/.*<input[^>]*name=\'_time_to_own\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0));
+
+      // Internal time to own, editable
+      preg_match(
+         '/.*<input[^>]*name=\'_internal_time_to_own\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0));
+
+      // Time to resolve, editable
+      preg_match(
+         '/.*<input[^>]*name=\'_time_to_resolve\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0));
+
+      // Internal time to resolve, editable
+      preg_match(
+         '/.*<input[^>]*name=\'_internal_time_to_resolve\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0));
+
+      //Type
+      preg_match(
+         '/.*<select[^>]*name=\'type\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($type === true ? 1 : 0));
+
+      //Status
+      preg_match(
+         '/.*<select[^>]*name=\'status\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($status === true ? 1 : 0));
+
+      //Urgency
+      preg_match(
+         '/.*<select[^>]*name=\'urgency\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($urgency === true ? 1 : 0));
+
+      //Impact
+      preg_match(
+         '/.*<select[^>]*name=\'impact\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($impact === true ? 1 : 0));
+
+      //Category
+      preg_match(
+         '/.*<input[^>]*name="itilcategories_id"[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($category === true ? 1 : 0));
+
+      //Request source file_put_contents('/tmp/out.html', $output)
+      preg_match(
+         '/.*<input[^>]*name="requesttypes_id"[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($requestSource === true ? 1 : 0));
+
+      //Location
+      preg_match(
+         '/.*<input[^>]*name="locations_id"[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($location === true ? 1 : 0));
 
       //Ticket name, editable
       preg_match(
@@ -833,7 +938,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = false,
          $save = true,
-         $assign = false
+         $assign = false,
+         $openDate = false,
+         $timeOwnResolve = false,
+         $type = false,
+         $status = false,
+         $urgency = true,
+         $impact = false,
+         $category = true,
+         $requestSource = true,
+         $location = false
       );
 
       $uid = getItemByTypeName('User', TU_USER, true);
@@ -853,7 +967,16 @@ class Ticket extends DbTestCase {
          $textarea = false,
          $priority = false,
          $save = false,
-         $assign = false
+         $assign = false,
+         $openDate = false,
+         $timeOwnResolve = false,
+         $type = false,
+         $status = false,
+         $urgency = false,
+         $impact = false,
+         $category = false,
+         $requestSource = true,
+         $location = false
       );
    }
 
@@ -879,7 +1002,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = false,
          $save = true,
-         $assign = false
+         $assign = false,
+         $openDate = true,
+         $timeOwnResolve = true,
+         $type = true,
+         $status = true,
+         $urgency = true,
+         $impact = true,
+         $category = true,
+         $requestSource = true,
+         $location = true
       );
 
       //drop update ticket right from tech profile
@@ -900,7 +1032,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = false,
          $save = true,
-         $assign = false
+         $assign = false,
+         $openDate = false,
+         $timeOwnResolve = false,
+         $type = false,
+         $status = false,
+         $urgency = true,
+         $impact = false,
+         $category = true,
+         $requestSource = true,
+         $location = false
       );
 
       $uid = getItemByTypeName('User', TU_USER, true);
@@ -921,7 +1062,16 @@ class Ticket extends DbTestCase {
          $textarea = false,
          $priority = false,
          $save = false,
-         $assign = false
+         $assign = false,
+         $openDate = false,
+         $timeOwnResolve = false,
+         $type = false,
+         $status = false,
+         $urgency = false,
+         $impact = false,
+         $category = false,
+         $requestSource = true,
+         $location = false
       );
    }
 
@@ -949,7 +1099,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = false,
          $save = true,
-         $assign = false
+         $assign = false,
+         $openDate = true,
+         $timeOwnResolve = true,
+         $type = true,
+         $status = true,
+         $urgency = true,
+         $impact = true,
+         $category = true,
+         $requestSource = true,
+         $location = true
       );
 
       //Add priority right from tech profile
@@ -971,7 +1130,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = true,
          $save = true,
-         $assign = false
+         $assign = false,
+         $openDate = true,
+         $timeOwnResolve = true,
+         $type = true,
+         $status = true,
+         $urgency = true,
+         $impact = true,
+         $category = true,
+         $requestSource = true,
+         $location = true
       );
    }
 
@@ -1000,7 +1168,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = false,
          $save = true,
-         $assign = false
+         $assign = false,
+         $openDate = true,
+         $timeOwnResolve = true,
+         $type = true,
+         $status = true,
+         $urgency = true,
+         $impact = true,
+         $category = true,
+         $requestSource = true,
+         $location = true
       );
 
       //Drop being in charge from tech profile
@@ -1023,7 +1200,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = false,
          $save = true,
-         $assign = false
+         $assign = false,
+         $openDate = true,
+         $timeOwnResolve = true,
+         $type = true,
+         $status = true,
+         $urgency = true,
+         $impact = true,
+         $category = true,
+         $requestSource = true,
+         $location = true
       );
 
       //Add assign in charge from tech profile
@@ -1045,7 +1231,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = false,
          $save = true,
-         $assign = true
+         $assign = true,
+         $openDate = true,
+         $timeOwnResolve = true,
+         $type = true,
+         $status = true,
+         $urgency = true,
+         $impact = true,
+         $category = true,
+         $requestSource = true,
+         $location = true
       );
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | wait and see
| Fixed tickets | #2504 #3187

Somewhere between GLPI 9.1.2 and 9.1.6 post only users can edit not modifiable fields. These fields are not actually saved in DB, but displayed as HTML inputs.

## Comaprison before the regression
GLPI 9.1.2 (self service profile)
![image](https://user-images.githubusercontent.com/14139801/34160294-9ce5f510-e4cc-11e7-8a95-66104448e43e.png)

GLPI 9.2.1 (self service profile)
![image](https://user-images.githubusercontent.com/14139801/34160301-a6f88ec8-e4cc-11e7-9a5a-c4d80f32d16f.png)

## with the fix

![image](https://user-images.githubusercontent.com/14139801/34160459-5969b6d6-e4cd-11e7-9fc1-215261e10e9c.png)
