### PR TITLE
Add SQL parameters support

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -806,9 +806,12 @@ class DBmysql {
     * @return mixed
     */
    public static function quoteValue($value) {
-      if ($value === null || $value === 'NULL' || $value === 'null') {
+      if ($value instanceof QueryParam) {
+         //no quote for query parameters
+         $value = $value->getValue();
+      } else if ($value === null || $value === 'NULL' || $value === 'null') {
          $value = 'NULL';
-      } else {
+      } else if (!preg_match("/^`.*?`$/", $value)) { //`field` is valid only for mysql :/
          //phone numbers may start with '+' and will be considered as numeric
          $value = "'$value'";
       }

--- a/inc/queryparam.class.php
+++ b/inc/queryparam.class.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2017 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ *  Database iterator class for Mysql
+**/
+class QueryParam  {
+   private $value;
+
+   /**
+    * Create a query param with a value
+    *
+    * @param string $value Query parameter value, defaults to '?'
+    */
+   public function __construct($value = '?') {
+      if ($value == null || trim($value) == '') {
+         $value = '?';
+      }
+      if ($value != '?' && !Toolbox::startsWith($value, ':')) {
+         $value = ':' . $value;
+      }
+      $this->value = $value;
+   }
+
+   /**
+    * Query parameter value
+    *
+    * @return string
+    */
+   public function getValue() {
+      return $this->value;
+   }
+}

--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -1250,10 +1250,16 @@ class SavedSearch extends CommonDBTM {
             //prepare variables we'll use
             $self = new self();
             $now = date('Y-m-d H:i:s');
-            $stmt = $DB->prepare("UPDATE `".self::getTable()."`
-                                  SET `last_execution_time` = ?,
-                                      `last_execution_date` = ?
-                                  WHERE `id` = ?");
+
+            $query = $DB->buildUpdate(
+               self::getTable(), [
+                  'last_execution_time'   => new QueryParam(),
+                  'last_execution_date'   => new QueryParam()
+               ], [
+                  'id'                    => new QueryParam()
+               ]
+            );
+            $stmt = $DB->prepare($query);
 
             $DB->dbh->begin_transaction();
             while ($row = $iterator->next()) {

--- a/tests/units/DB.php
+++ b/tests/units/DB.php
@@ -93,7 +93,9 @@ class DB extends atoum {
          ['+33', "'+33'"],
          [null, 'NULL'],
          ['null', 'NULL'],
-         ['NULL', 'NULL']
+         ['NULL', 'NULL'],
+         ['`field`', '`field`'],
+         ['`field', "'`field'"]
       ];
    }
 
@@ -119,6 +121,18 @@ class DB extends atoum {
                '`other`'  => 'doe'
             ],
             'INSERT INTO `table` (`field`, `other`) VALUES (\'value\', \'doe\')'
+         ], [
+            'table', [
+               'field'  => new \QueryParam(),
+               'other'  => new \QueryParam()
+            ],
+            'INSERT INTO `table` (`field`, `other`) VALUES (?, ?)'
+         ], [
+            'table', [
+               'field'  => new \QueryParam('field'),
+               'other'  => new \QueryParam('other')
+            ],
+            'INSERT INTO `table` (`field`, `other`) VALUES (:field, :other)'
          ]
       ];
    }
@@ -142,21 +156,35 @@ class DB extends atoum {
             ], [
                'id'  => 1
             ],
-            'UPDATE `table` SET `field` = \'value\', `other` = \'doe\' WHERE `id` = 1'
+            'UPDATE `table` SET `field` = \'value\', `other` = \'doe\' WHERE `id` = \'1\''
          ], [
             'table', [
                'field'  => 'value'
             ], [
                'id'  => [1, 2]
             ],
-            'UPDATE `table` SET `field` = \'value\' WHERE `id` IN (1, 2)'
+            'UPDATE `table` SET `field` = \'value\' WHERE `id` IN (\'1\', \'2\')'
          ], [
             'table', [
                'field'  => 'value'
             ], [
                'NOT'  => ['id' => [1, 2]]
             ],
-            'UPDATE `table` SET `field` = \'value\' WHERE  NOT (`id` IN (1, 2))'
+            'UPDATE `table` SET `field` = \'value\' WHERE  NOT (`id` IN (\'1\', \'2\'))'
+         ], [
+            'table', [
+               'field'  => new \QueryParam()
+            ], [
+               'NOT' => ['id' => [new \QueryParam(), new \QueryParam()]]
+            ],
+            'UPDATE `table` SET `field` = ? WHERE  NOT (`id` IN (?, ?))'
+         ], [
+            'table', [
+               'field'  => new \QueryParam('field')
+            ], [
+               'NOT' => ['id' => [new \QueryParam('idone'), new \QueryParam('idtwo')]]
+            ],
+            'UPDATE `table` SET `field` = :field WHERE  NOT (`id` IN (:idone, :idtwo))'
          ]
       ];
    }
@@ -188,17 +216,27 @@ class DB extends atoum {
             'table', [
                'id'  => 1
             ],
-            'DELETE FROM `table` WHERE `id` = 1'
+            'DELETE FROM `table` WHERE `id` = \'1\''
          ], [
             'table', [
                'id'  => [1, 2]
             ],
-            'DELETE FROM `table` WHERE `id` IN (1, 2)'
+            'DELETE FROM `table` WHERE `id` IN (\'1\', \'2\')'
          ], [
             'table', [
                'NOT'  => ['id' => [1, 2]]
             ],
-            'DELETE FROM `table` WHERE  NOT (`id` IN (1, 2))'
+            'DELETE FROM `table` WHERE  NOT (`id` IN (\'1\', \'2\'))'
+         ], [
+            'table', [
+               'NOT'  => ['id' => [new \QueryParam(), new \QueryParam()]]
+            ],
+            'DELETE FROM `table` WHERE  NOT (`id` IN (?, ?))'
+         ], [
+            'table', [
+               'NOT'  => ['id' => [new \QueryParam('idone'), new \QueryParam('idtwo')]]
+            ],
+            'DELETE FROM `table` WHERE  NOT (`id` IN (:idone, :idtwo))'
          ]
       ];
    }

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -85,7 +85,7 @@ class DBmysqlIterator extends DbTestCase {
       $this->when(
          function () {
             $it = $this->it->execute('', ['foo' => 1]);
-            $this->string($it->getSql())->isIdenticalTo('SELECT * WHERE `foo` = 1');
+            $this->string($it->getSql())->isIdenticalTo('SELECT * WHERE `foo` = \'1\'');
          }
       )->error()
          ->withType(E_USER_ERROR)
@@ -219,7 +219,7 @@ class DBmysqlIterator extends DbTestCase {
       $this->exception(
          function () {
             $it = $this->it->execute('foo', ['JOIN' => ['bar' => ['FKEY' => ['id', 'fk'], 'val' => 1]]]);
-            $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` LEFT JOIN `bar` ON (`id` = `fk` AND `val` = 1)');
+            $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` LEFT JOIN `bar` ON (`id` = `fk` AND `val` = \'1\')');
          }
       )->message->contains('"JOIN" is deprecated, please use "LEFT JOIN" instead');
 
@@ -251,13 +251,13 @@ class DBmysqlIterator extends DbTestCase {
 
    public function testOperators() {
       $it = $this->it->execute('foo', ['a' => 1]);
-      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `a` = 1');
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `a` = \'1\'');
 
       $it = $this->it->execute('foo', ['a' => ['=', 1]]);
-      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `a` = 1');
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `a` = \'1\'');
 
       $it = $this->it->execute('foo', ['a' => ['>', 1]]);
-      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `a` > 1');
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `a` > \'1\'');
 
       $it = $this->it->execute('foo', ['a' => ['LIKE', '%bar%']]);
       $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `a` LIKE \'%bar%\'');
@@ -269,10 +269,10 @@ class DBmysqlIterator extends DbTestCase {
       $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `a` NOT LIKE \'%bar%\'');
 
       $it = $this->it->execute('foo', ['a' => ['<>', 1]]);
-      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `a` <> 1');
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `a` <> \'1\'');
 
       $it = $this->it->execute('foo', ['a' => ['&', 1]]);
-      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `a` & 1');
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `a` & \'1\'');
    }
 
 
@@ -290,10 +290,10 @@ class DBmysqlIterator extends DbTestCase {
       $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `bar` IS NULL');
 
       $it = $this->it->execute('foo', ['bar' => 1]);
-      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `bar` = 1');
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `bar` = \'1\'');
 
       $it = $this->it->execute('foo', ['bar' => [1, 2, 4]]);
-      $this->string($it->getSql())->isIdenticalTo("SELECT * FROM `foo` WHERE `bar` IN (1, 2, 4)");
+      $this->string($it->getSql())->isIdenticalTo("SELECT * FROM `foo` WHERE `bar` IN ('1', '2', '4')");
 
       $it = $this->it->execute('foo', ['bar' => ['a', 'b', 'c']]);
       $this->string($it->getSql())->isIdenticalTo("SELECT * FROM `foo` WHERE `bar` IN ('a', 'b', 'c')");
@@ -303,6 +303,15 @@ class DBmysqlIterator extends DbTestCase {
 
       $it = $this->it->execute('foo', ['bar' => '`field`']);
       $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `bar` = `field`');
+
+      $it = $this->it->execute('foo', ['bar' => '?']);
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `bar` = \'?\'');
+
+      $it = $this->it->execute('foo', ['bar' => new \QueryParam()]);
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `bar` = ?');
+
+      $it = $this->it->execute('foo', ['bar' => new \QueryParam('myparam')]);
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `bar` = :myparam');
    }
 
 
@@ -351,16 +360,16 @@ class DBmysqlIterator extends DbTestCase {
 
    public function testLogical() {
       $it = $this->it->execute(['foo'], [['a' => 1, 'b' => 2]]);
-      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE (`a` = 1 AND `b` = 2)');
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE (`a` = \'1\' AND `b` = \'2\')');
 
       $it = $this->it->execute(['foo'], ['AND' => ['a' => 1, 'b' => 2]]);
-      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE (`a` = 1 AND `b` = 2)');
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE (`a` = \'1\' AND `b` = \'2\')');
 
       $it = $this->it->execute(['foo'], ['OR' => ['a' => 1, 'b' => 2]]);
-      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE (`a` = 1 OR `b` = 2)');
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE (`a` = \'1\' OR `b` = \'2\')');
 
       $it = $this->it->execute(['foo'], ['NOT' => ['a' => 1, 'b' => 2]]);
-      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE NOT (`a` = 1 AND `b` = 2)');
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE NOT (`a` = \'1\' AND `b` = \'2\')');
 
       $crit = [
          'WHERE' => [
@@ -377,7 +386,7 @@ class DBmysqlIterator extends DbTestCase {
             ],
          ],
       ];
-      $sql = "SELECT * FROM `foo` WHERE `a` = 1 AND (`b` = 2 OR NOT (`c` IN (2, 3) AND (`d` = 4 AND `e` = 5)))";
+      $sql = "SELECT * FROM `foo` WHERE `a` = '1' AND (`b` = '2' OR NOT (`c` IN ('2', '3') AND (`d` = '4' AND `e` = '5')))";
       $it = $this->it->execute(['foo'], $crit);
       $this->string($it->getSql())->isIdenticalTo($sql);
 
@@ -393,7 +402,7 @@ class DBmysqlIterator extends DbTestCase {
          'FROM'   => 'foo',
          'WHERE'  => ['c' => 1],
       ];
-      $sql = "SELECT `a`, `b` FROM `foo` WHERE `c` = 1";
+      $sql = "SELECT `a`, `b` FROM `foo` WHERE `c` = '1'";
       $it = $this->it->execute($req);
       $this->string($it->getSql())->isIdenticalTo($sql);
    }

--- a/tests/units/DbUtils.php
+++ b/tests/units/DbUtils.php
@@ -553,14 +553,14 @@ class DbUtils extends DbTestCase {
          ->isIdenticalTo("WHERE ( `glpi_computers`.`entities_id` IN ('1', '2', '3')  ) ");
       $it->execute('glpi_computers', $this->testedInstance->getEntitiesRestrictCriteria('glpi_computers'));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (1, 2, 3)');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (\'1\', \'2\', \'3\')');
 
       //keep testing old method from db.function
       $this->string(getEntitiesRestrictRequest('WHERE', 'glpi_computers'))
          ->isIdenticalTo("WHERE ( `glpi_computers`.`entities_id` IN ('1', '2', '3')  ) ");
       $it->execute('glpi_computers', getEntitiesRestrictCriteria('glpi_computers'));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (1, 2, 3)');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (\'1\', \'2\', \'3\')');
 
       // Root entity
       $this->setEntity('_test_root_entity', false);
@@ -569,14 +569,14 @@ class DbUtils extends DbTestCase {
          ->isIdenticalTo("WHERE ( `glpi_computers`.`entities_id` IN ('1')  ) ");
       $it->execute('glpi_computers', $this->testedInstance->getEntitiesRestrictCriteria('glpi_computers'));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (1)');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (\'1\')');
 
       //keep testing old method from db.function
       $this->string(getEntitiesRestrictRequest('WHERE', 'glpi_computers'))
          ->isIdenticalTo("WHERE ( `glpi_computers`.`entities_id` IN ('1')  ) ");
       $it->execute('glpi_computers', getEntitiesRestrictCriteria('glpi_computers'));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (1)');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (\'1\')');
 
       // Child
       $this->setEntity('_test_child_1', false);
@@ -585,28 +585,28 @@ class DbUtils extends DbTestCase {
          ->isIdenticalTo("WHERE ( `glpi_computers`.`entities_id` IN ('2')  ) ");
       $it->execute('glpi_computers', $this->testedInstance->getEntitiesRestrictCriteria('glpi_computers'));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (2)');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (\'2\')');
 
       //keep testing old method from db.function
       $this->string(getEntitiesRestrictRequest('WHERE', 'glpi_computers'))
          ->isIdenticalTo("WHERE ( `glpi_computers`.`entities_id` IN ('2')  ) ");
       $it->execute('glpi_computers', getEntitiesRestrictCriteria('glpi_computers'));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (2)');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (\'2\')');
 
       // Child without table
       $this->string($this->testedInstance->getEntitiesRestrictRequest('WHERE'))
          ->isIdenticalTo("WHERE ( `entities_id` IN ('2')  ) ");
       $it->execute('glpi_computers', $this->testedInstance->getEntitiesRestrictCriteria());
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `entities_id` IN (2)');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `entities_id` IN (\'2\')');
 
       //keep testing old method from db.function
       $this->string(getEntitiesRestrictRequest('WHERE'))
          ->isIdenticalTo("WHERE ( `entities_id` IN ('2')  ) ");
       $it->execute('glpi_computers', getEntitiesRestrictCriteria());
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `entities_id` IN (2)');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `entities_id` IN (\'2\')');
 
       // Child + parent
       $this->setEntity('_test_child_2', false);
@@ -615,64 +615,64 @@ class DbUtils extends DbTestCase {
          ->isIdenticalTo("WHERE ( `glpi_computers`.`entities_id` IN ('3')  OR (`glpi_computers`.`is_recursive`='1' AND `glpi_computers`.`entities_id` IN ('0','1')) ) ");
       $it->execute('glpi_computers', $this->testedInstance->getEntitiesRestrictCriteria('glpi_computers', '', '', true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`glpi_computers`.`entities_id` IN (3) OR (`glpi_computers`.`is_recursive` = 1 AND `glpi_computers`.`entities_id` IN (0, 1)))');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`glpi_computers`.`entities_id` IN (\'3\') OR (`glpi_computers`.`is_recursive` = \'1\' AND `glpi_computers`.`entities_id` IN (\'0\', \'1\')))');
 
       //keep testing old method from db.function
       $this->string(getEntitiesRestrictRequest('WHERE', 'glpi_computers', '', '', true))
          ->isIdenticalTo("WHERE ( `glpi_computers`.`entities_id` IN ('3')  OR (`glpi_computers`.`is_recursive`='1' AND `glpi_computers`.`entities_id` IN ('0','1')) ) ");
       $it->execute('glpi_computers', getEntitiesRestrictCriteria('glpi_computers', '', '', true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`glpi_computers`.`entities_id` IN (3) OR (`glpi_computers`.`is_recursive` = 1 AND `glpi_computers`.`entities_id` IN (0, 1)))');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`glpi_computers`.`entities_id` IN (\'3\') OR (`glpi_computers`.`is_recursive` = \'1\' AND `glpi_computers`.`entities_id` IN (\'0\', \'1\')))');
 
       //Child + parent on glpi_entities
       $it->execute('glpi_entities', $this->testedInstance->getEntitiesRestrictCriteria('glpi_entities', '', '', true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE (`glpi_entities`.`id` IN (3, 0, 1))');
+         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE (`glpi_entities`.`id` IN (\'3\', \'0\', \'1\'))');
 
       //keep testing old method from db.function
       $it->execute('glpi_entities', getEntitiesRestrictCriteria('glpi_entities', '', '', true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE (`glpi_entities`.`id` IN (3, 0, 1))');
+         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE (`glpi_entities`.`id` IN (\'3\', \'0\', \'1\'))');
 
       //Child + parent -- automatic recusrivity detection
       $it->execute('glpi_computers', $this->testedInstance->getEntitiesRestrictCriteria('glpi_computers', '', '', 'auto'));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`glpi_computers`.`entities_id` IN (3) OR (`glpi_computers`.`is_recursive` = 1 AND `glpi_computers`.`entities_id` IN (0, 1)))');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`glpi_computers`.`entities_id` IN (\'3\') OR (`glpi_computers`.`is_recursive` = \'1\' AND `glpi_computers`.`entities_id` IN (\'0\', \'1\')))');
 
       //keep testing old method from db.function
       $it->execute('glpi_computers', getEntitiesRestrictCriteria('glpi_computers', '', '', 'auto'));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`glpi_computers`.`entities_id` IN (3) OR (`glpi_computers`.`is_recursive` = 1 AND `glpi_computers`.`entities_id` IN (0, 1)))');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`glpi_computers`.`entities_id` IN (\'3\') OR (`glpi_computers`.`is_recursive` = \'1\' AND `glpi_computers`.`entities_id` IN (\'0\', \'1\')))');
 
       // Child + parent without table
       $this->string($this->testedInstance->getEntitiesRestrictRequest('WHERE', '', '', '', true))
          ->isIdenticalTo("WHERE ( `entities_id` IN ('3')  OR (`is_recursive`='1' AND `entities_id` IN ('0','1')) ) ");
       $it->execute('glpi_computers', $this->testedInstance->getEntitiesRestrictCriteria('', '', '', true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`entities_id` IN (3) OR (`is_recursive` = 1 AND `entities_id` IN (0, 1)))');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`entities_id` IN (\'3\') OR (`is_recursive` = \'1\' AND `entities_id` IN (\'0\', \'1\')))');
 
       $it->execute('glpi_entities', $this->testedInstance->getEntitiesRestrictCriteria('glpi_entities', '', 3, true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE (`glpi_entities`.`id` IN (3, 0, 1))');
+         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE (`glpi_entities`.`id` IN (\'3\', \'0\', \'1\'))');
 
       $it->execute('glpi_entities', $this->testedInstance->getEntitiesRestrictCriteria('glpi_entities', '', 7, true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE `glpi_entities`.`id` = 7');
+         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE `glpi_entities`.`id` = \'7\'');
 
       //keep testing old method from db.function
       $this->string(getEntitiesRestrictRequest('WHERE', '', '', '', true))
          ->isIdenticalTo("WHERE ( `entities_id` IN ('3')  OR (`is_recursive`='1' AND `entities_id` IN ('0','1')) ) ");
       $it->execute('glpi_computers', getEntitiesRestrictCriteria('', '', '', true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`entities_id` IN (3) OR (`is_recursive` = 1 AND `entities_id` IN (0, 1)))');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`entities_id` IN (\'3\') OR (`is_recursive` = \'1\' AND `entities_id` IN (\'0\', \'1\')))');
 
       $it->execute('glpi_entities', getEntitiesRestrictCriteria('glpi_entities', '', 3, true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE (`glpi_entities`.`id` IN (3, 0, 1))');
+         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE (`glpi_entities`.`id` IN (\'3\', \'0\', \'1\'))');
 
       $it->execute('glpi_entities', getEntitiesRestrictCriteria('glpi_entities', '', 7, true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE `glpi_entities`.`id` = 7');
+         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE `glpi_entities`.`id` = \'7\'');
    }
 
    /**

--- a/tests/units/QueryParam.php
+++ b/tests/units/QueryParam.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2017 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use \DbTestCase;
+
+/* Test for inc/dbutils.class.php */
+
+class QueryParam extends DbTestCase {
+
+   protected function dataParams() {
+
+      return [
+         [null, '?'],
+         ['', '?'],
+         ['?', '?'],
+         ['myparam', ':myparam'],
+         [':myparam', ':myparam']
+      ];
+   }
+
+   /**
+    * @dataProvider dataParams
+    */
+   public function testQueryParam($value, $expected) {
+      $qpa = new \QueryParam($value);
+      $this->string($qpa->getValue())->isIdenticalTo($expected);
+   }
+
+   public function testEmptyQueryParam() {
+      $qpa = new \QueryParam();
+      $this->string($qpa->getValue())->isIdenticalTo('?');
+   }
+
+}

--- a/tests/units/TicketTask.php
+++ b/tests/units/TicketTask.php
@@ -81,7 +81,7 @@ class TicketTask extends DbTestCase {
 
       $iterator = $task::getTaskList('todo', false);
       $this->string($iterator->getSql())->isIdenticalTo(
-         'SELECT `glpi_tickettasks`.`id` FROM `glpi_tickettasks` INNER JOIN `glpi_tickets` ON (`glpi_tickettasks`.`tickets_id` = `glpi_tickets`.`id`) WHERE `glpi_tickets`.`status` IN (1, 2, 3, 4) AND `glpi_tickettasks`.`state` = 1 AND `glpi_tickettasks`.`users_id_tech` = ' . $uid . ' ORDER BY `glpi_tickettasks`.`date_mod` DESC'
+         'SELECT `glpi_tickettasks`.`id` FROM `glpi_tickettasks` INNER JOIN `glpi_tickets` ON (`glpi_tickettasks`.`tickets_id` = `glpi_tickets`.`id`) WHERE `glpi_tickets`.`status` IN (\'1\', \'2\', \'3\', \'4\') AND `glpi_tickettasks`.`state` = \'1\' AND `glpi_tickettasks`.`users_id_tech` = \'' . $uid . '\' ORDER BY `glpi_tickettasks`.`date_mod` DESC'
       );
       //we create two ones plus the one in bootstrap data
       $this->integer(count($iterator))->isIdenticalTo(3);
@@ -92,7 +92,7 @@ class TicketTask extends DbTestCase {
       $_SESSION['glpigroups'] = [42, 157];
       $iterator = $task::getTaskList('todo', true);
       $this->string($iterator->getSql())->isIdenticalTo(
-         'SELECT `glpi_tickettasks`.`id` FROM `glpi_tickettasks` INNER JOIN `glpi_tickets` ON (`glpi_tickettasks`.`tickets_id` = `glpi_tickets`.`id`) WHERE `glpi_tickets`.`status` IN (1, 2, 3, 4) AND `glpi_tickettasks`.`state` = 1 AND `glpi_tickettasks`.`groups_id_tech` IN (42, 157) ORDER BY `glpi_tickettasks`.`date_mod` DESC'
+         'SELECT `glpi_tickettasks`.`id` FROM `glpi_tickettasks` INNER JOIN `glpi_tickets` ON (`glpi_tickettasks`.`tickets_id` = `glpi_tickets`.`id`) WHERE `glpi_tickets`.`status` IN (\'1\', \'2\', \'3\', \'4\') AND `glpi_tickettasks`.`state` = \'1\' AND `glpi_tickettasks`.`groups_id_tech` IN (\'42\', \'157\') ORDER BY `glpi_tickettasks`.`date_mod` DESC'
       );
       //no task for those groups
       $this->integer(count($iterator))->isIdenticalTo(0);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Current pull request add a `QueryParam` object to manage named and positional parameters building prepared queries.
I've aslo switched local value quoting in the iterator to use `DB::quoteValue()`