### PR TITLE
Fix issue #3348 - Unable to generate PDF export (9.2 + dev)

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1543,7 +1543,10 @@ class Search {
             }
             // End Line
             echo self::showEndLine($data['display_type']);
-            Html::glpi_flush();
+            // Flush ONLY for an HTML display (issue #3348)
+            if ($data['display_type'] == self::HTML_OUTPUT) {
+                Html::glpi_flush();
+            }
          }
 
          // Create title


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3348

Fix a regression introduced by commit 960640575496b32a29e28b96dc9da2586b910f4c :  each PDF export will failed with "headers already output" due to an unneeded flush (on the case of PDF generation) .

Bad code is present on [master](https://github.com/glpi-project/glpi/blame/master/inc/search.class.php#L1546) and [9.2/bugfixes](https://github.com/glpi-project/glpi/blame/9.2/bugfixes/inc/search.class.php#L1513).

Affected releases are 9.1.7.1 and 9.2.1 .
=> I suggest a trace on the changelog for this transversal (? in french transversale) issue.

Regards,
Anael