### PR TITLE
Update session.class.php

### DIFF
--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -1048,7 +1048,8 @@ class Session {
             if (!$check_once
                 || !isset($_SESSION["MESSAGE_AFTER_REDIRECT"][$message_type])
                 || in_array($msg, $_SESSION["MESSAGE_AFTER_REDIRECT"][$message_type]) === false) {
-               array_push($_SESSION["MESSAGE_AFTER_REDIRECT"][$message_type], $msg);
+               $session_mar = $_SESSION["MESSAGE_AFTER_REDIRECT"][$message_type];
+               array_push($session_mar, $msg);
             }
          }
       }


### PR DESCRIPTION
putting $_SESSION["MESSAGE_AFTER_REDIRECT"][$message_type] in a var before array_push

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

Getting this error : 
[Thu Jan 04 15:21:37.680071 2018] [php7:error] [pid 2524:tid 1724] [client 10.6.1.14:59333] PHP Fatal error:  Uncaught Error: Only variables can be passed by reference in \glpi\\inc\\session.class.php:1051\nStack trace:\n#0 \glpi\\inc\\ticket.class.php(2202): Session::addMessageAfterRedirect('Votre ticket a ...')\n#1 \glpi\\inc\\commondbtm.class.php(929): Ticket->post_addItem()\n#2 \glpi\\plugins\\webservices\\inc\\methodhelpdesk.class.php(674): CommonDBTM->add(Array)\n#3 \glpi\\plugins\\webservices\\inc\\methodsession.class.php(500): PluginWebservicesMethodHelpdesk::methodCreateTicket(Array, 'xml-rpc')\n#4 \glpi\\plugins\\webservices\\xmlrpc.php(102): PluginWebservicesMethodSession->execute('glpi.createTick...', Array, 'xml-rpc')\n#5 {main}\n  thrown in \glpi\\inc\\session.class.php on line 1051

First argument of array_push must be an array passed by reference. 
by creating a var before array_push, it remove the PHP Fatal Error.
