### PR TITLE
Fix ticket self service for GLPI 9.3

### DIFF
--- a/inc/levelagreement.class.php
+++ b/inc/levelagreement.class.php
@@ -244,8 +244,6 @@ abstract class LevelAgreement extends CommonDBChild {
     * @param  bool           $canupdate update right
     */
    function showForTicket(Ticket $ticket, $type, $tt, $canupdate) {
-      global $CFG_GLPI;
-
       list($dateField, $laField) = static::getFieldNames($type);
       $rand = mt_rand();
       $pre  = static::$prefix;

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -295,8 +295,7 @@ class Ticket extends CommonITILObject {
    static function canUpdate() {
 
       // To allow update of urgency and category for post-only
-      if (isset($_SESSION["glpiactiveprofile"]["interface"])
-          && $_SESSION["glpiactiveprofile"]["interface"] == "helpdesk") {
+      if ($_SESSION["glpiactiveprofile"]["interface"] == "helpdesk") {
          return Session::haveRight(self::$rightname, CREATE);
       }
 

--- a/tests/units/Ticket.php
+++ b/tests/units/Ticket.php
@@ -710,7 +710,16 @@ class Ticket extends DbTestCase {
       $textarea = true,
       $priority = true,
       $save = true,
-      $assign = true
+      $assign = true,
+      $openDate = true,
+      $timeOwnResolve = true,
+      $type = true,
+      $status = true,
+      $urgency = true,
+      $impact = true,
+      $category = true,
+      $requestSource = true,
+      $location = true
    ) {
       ob_start();
       $ticket->showForm($ticket->getID());
@@ -724,6 +733,111 @@ class Ticket extends DbTestCase {
          $matches
       );
       $this->array($matches)->hasSize(1);
+
+      // Opening date, editable
+      preg_match(
+         '/.*<input[^>]*name=\'_date\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($openDate === true ? 1 : 0));
+
+      // Time to own, editable
+      preg_match(
+         '/.*<input[^>]*name=\'_time_to_own\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0));
+
+      // Internal time to own, editable
+      preg_match(
+         '/.*<input[^>]*name=\'_internal_time_to_own\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0));
+
+      // Time to resolve, editable
+      preg_match(
+         '/.*<input[^>]*name=\'_time_to_resolve\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0));
+
+      // Internal time to resolve, editable
+      preg_match(
+         '/.*<input[^>]*name=\'_internal_time_to_resolve\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0));
+
+      //Type
+      preg_match(
+         '/.*<select[^>]*name=\'type\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($type === true ? 1 : 0));
+
+      //Status
+      preg_match(
+         '/.*<select[^>]*name=\'status\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($status === true ? 1 : 0));
+
+      //Urgency
+      preg_match(
+         '/.*<select[^>]*name=\'urgency\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($urgency === true ? 1 : 0));
+
+      //Impact
+      preg_match(
+         '/.*<select[^>]*name=\'impact\'[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($impact === true ? 1 : 0));
+
+      //Category
+      preg_match(
+         '/.*<select[^>]*name="itilcategories_id"[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($category === true ? 1 : 0));
+
+      //Request source file_put_contents('/tmp/out.html', $output)
+      if ($requestSource === true) {
+         preg_match(
+            '/.*<select[^>]*name="requesttypes_id"[^>]*>.*/',
+            $output,
+            $matches
+            );
+         $this->array($matches)->hasSize(1);
+      } else {
+         preg_match(
+            '/.*<input[^>]*name="requesttypes_id"[^>]*>.*/',
+            $output,
+            $matches
+            );
+         $this->array($matches)->hasSize(1);
+      }
+
+      //Location
+      preg_match(
+         '/.*<select[^>]*name="locations_id"[^>]*>.*/',
+         $output,
+         $matches
+      );
+      $this->array($matches)->hasSize(($location === true ? 1 : 0));
 
       //Ticket name, editable
       preg_match(
@@ -795,7 +909,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = false,
          $save = true,
-         $assign = false
+         $assign = false,
+         $openDate = false,
+         $timeOwnResolve = false,
+         $type = false,
+         $status = false,
+         $urgency = true,
+         $impact = false,
+         $category = true,
+         $requestSource = false,
+         $location = false
       );
 
       $uid = getItemByTypeName('User', TU_USER, true);
@@ -815,7 +938,16 @@ class Ticket extends DbTestCase {
          $textarea = false,
          $priority = false,
          $save = false,
-         $assign = false
+         $assign = false,
+         $openDate = false,
+         $timeOwnResolve = false,
+         $type = false,
+         $status = false,
+         $urgency = false,
+         $impact = false,
+         $category = false,
+         $requestSource = false,
+         $location = false
       );
    }
 
@@ -841,7 +973,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = false,
          $save = true,
-         $assign = false
+         $assign = false,
+         $openDate = true,
+         $timeOwnResolve = true,
+         $type = true,
+         $status = true,
+         $urgency = true,
+         $impact = true,
+         $category = true,
+         $requestSource = true,
+         $location = true
       );
 
       //drop update ticket right from tech profile
@@ -862,7 +1003,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = false,
          $save = true,
-         $assign = false
+         $assign = false,
+         $openDate = false,
+         $timeOwnResolve = false,
+         $type = false,
+         $status = false,
+         $urgency = true,
+         $impact = false,
+         $category = true,
+         $requestSource = false,
+         $location = false
       );
 
       $uid = getItemByTypeName('User', TU_USER, true);
@@ -883,7 +1033,16 @@ class Ticket extends DbTestCase {
          $textarea = false,
          $priority = false,
          $save = false,
-         $assign = false
+         $assign = false,
+         $openDate = false,
+         $timeOwnResolve = false,
+         $type = false,
+         $status = false,
+         $urgency = false,
+         $impact = false,
+         $category = false,
+         $requestSource = false,
+         $location = false
       );
    }
 
@@ -911,7 +1070,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = false,
          $save = true,
-         $assign = false
+         $assign = false,
+         $openDate = true,
+         $timeOwnResolve = true,
+         $type = true,
+         $status = true,
+         $urgency = true,
+         $impact = true,
+         $category = true,
+         $requestSource = true,
+         $location = true
       );
 
       //Add priority right from tech profile
@@ -933,7 +1101,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = true,
          $save = true,
-         $assign = false
+         $assign = false,
+         $openDate = true,
+         $timeOwnResolve = true,
+         $type = true,
+         $status = true,
+         $urgency = true,
+         $impact = true,
+         $category = true,
+         $requestSource = true,
+         $location = true
       );
    }
 
@@ -962,7 +1139,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = false,
          $save = true,
-         $assign = false
+         $assign = false,
+         $openDate = true,
+         $timeOwnResolve = true,
+         $type = true,
+         $status = true,
+         $urgency = true,
+         $impact = true,
+         $category = true,
+         $requestSource = true,
+         $location = true
       );
 
       //Drop being in charge from tech profile
@@ -985,7 +1171,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = false,
          $save = true,
-         $assign = false
+         $assign = false,
+         $openDate = true,
+         $timeOwnResolve = true,
+         $type = true,
+         $status = true,
+         $urgency = true,
+         $impact = true,
+         $category = true,
+         $requestSource = true,
+         $location = true
       );
 
       //Add assign in charge from tech profile
@@ -1007,7 +1202,16 @@ class Ticket extends DbTestCase {
          $textarea = true,
          $priority = false,
          $save = true,
-         $assign = true
+         $assign = true,
+         $openDate = true,
+         $timeOwnResolve = true,
+         $type = true,
+         $status = true,
+         $urgency = true,
+         $impact = true,
+         $category = true,
+         $requestSource = true,
+         $location = true
       );
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | wait and see
| Fixed tickets | #2504 #3187

This PR is a copy of #3317 and its purpose is to ehnance it to solve unit tests issues not encounteered with GLPI 9.2.

The difference between 9.2 and 9.3 is due to update of the select 2 component.

With GLPI 9.2, dropdowns are created from HTML input tags

with GLPI 9.3, dropdowns are created with HTML select tags.

Somewhere between GLPI 9.1.2 and 9.1.6 post only users can edit not modifiable fields. These fields are not actually saved in DB, but displayed as HTML inputs.


## Comparison before the regression
GLPI 9.1.2 (self service profile)
![image](https://user-images.githubusercontent.com/14139801/34160294-9ce5f510-e4cc-11e7-8a95-66104448e43e.png)

GLPI 9.2.1 (self service profile)
![image](https://user-images.githubusercontent.com/14139801/34160301-a6f88ec8-e4cc-11e7-9a5a-c4d80f32d16f.png)

## with the fix

![image](https://user-images.githubusercontent.com/14139801/34160459-5969b6d6-e4cd-11e7-9fc1-215261e10e9c.png)

  
  