### PR TITLE
No SSL certificate validation for telemetry (self-signed, wildcard, ...)

### DIFF
--- a/inc/telemetry.class.php
+++ b/inc/telemetry.class.php
@@ -146,7 +146,7 @@ class Telemetry extends CommonGLPI {
           FILTER_VALIDATE_IP)) {
           
           // Issue #3180 - disable SSL certificate validation (wildcard, self-signed)
-          stream_context_set_default( [
+          stream_context_set_default([
             'ssl' => [
                 'verify_peer' => false,
                 'verify_peer_name' => false,

--- a/inc/telemetry.class.php
+++ b/inc/telemetry.class.php
@@ -144,6 +144,15 @@ class Telemetry extends CommonGLPI {
       // check if host is present (do no throw php warning in contrary of get_headers)
       if (filter_var(gethostbyname(parse_url($CFG_GLPI['url_base'], PHP_URL_HOST)),
           FILTER_VALIDATE_IP)) {
+          
+          // Issue #3180 - disable SSL certificate validation (wildcard, self-signed)
+          stream_context_set_default( [
+            'ssl' => [
+                'verify_peer' => false,
+                'verify_peer_name' => false,
+                ]
+            ]);
+          
          $headers = get_headers($CFG_GLPI['url_base']);
       }
 

--- a/inc/telemetry.class.php
+++ b/inc/telemetry.class.php
@@ -144,7 +144,7 @@ class Telemetry extends CommonGLPI {
       // check if host is present (do no throw php warning in contrary of get_headers)
       if (filter_var(gethostbyname(parse_url($CFG_GLPI['url_base'], PHP_URL_HOST)),
           FILTER_VALIDATE_IP)) {
-          
+
           // Issue #3180 - disable SSL certificate validation (wildcard, self-signed)
           stream_context_set_default([
             'ssl' => [
@@ -152,7 +152,7 @@ class Telemetry extends CommonGLPI {
                 'verify_peer_name' => false,
                 ]
             ]);
-          
+
          $headers = get_headers($CFG_GLPI['url_base']);
       }
 


### PR DESCRIPTION
Fix #3180 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3180

Remove SSL certificate validation which fail for telemetry if we have a self-signed or wildcard certificate