### PR TITLE
fix gristack loading following #3408

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -445,7 +445,9 @@ $CFG_GLPI['javascript'] = [
       'reminder'     => ['tinymce']
    ],
    'management' => [
-      'dcroom'       => ['colorpicker', 'gridstack']
+      'datacenter'       => [
+         'dcroom' => ['colorpicker', 'gridstack']
+      ]
    ],
    'config'    => [
       'config'    => ['colorpicker'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

With the menu change, gristack and colorpicker didn't load anymore in dcroom viz
See #3408 