### PR TITLE
CAS logout fix

### DIFF
--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -588,8 +588,8 @@ class Session {
       }
       $TRANSLATE = new Zend\I18n\Translator\Translator;
       $cache = Config::getCache('cache_trans');
-      if ($GLPI_CACHE !== false) {
-         $TRANSLATE->setCache($GLPI_CACHE);
+      if ($cache !== false) {
+         $TRANSLATE->setCache($cache);
       }
       $TRANSLATE->addTranslationFile('gettext', GLPI_ROOT.$newfile, 'glpi', $trytoload);
 

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -587,6 +587,7 @@ class Session {
          $_SESSION['glpipluralnumber'] = $CFG_GLPI["languages"][$trytoload][5];
       }
       $TRANSLATE = new Zend\I18n\Translator\Translator;
+      $cache = Config::getCache('cache_trans');
       if ($GLPI_CACHE !== false) {
          $TRANSLATE->setCache($GLPI_CACHE);
       }

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -113,7 +113,13 @@ class Session {
                $_SESSION["glpidefault_entity"]  = $auth->user->fields['entities_id'];
                $_SESSION["glpiusers_idisation"] = true;
                $_SESSION["glpiextauth"]         = $auth->extauth;
-               $_SESSION["glpiauthtype"]        = $auth->user->fields['authtype'];
+	       if (isset($_SESSION['phpCAS']['user']) )
+	       {
+		       $_SESSION["glpiauthtype"]        = Auth::CAS;
+		       $_SESSION["glpiextauth"] = 0;
+	       }
+	       else
+ 	           $_SESSION["glpiauthtype"]        = $auth->user->fields['authtype'];
                $_SESSION["glpiroot"]            = $CFG_GLPI["root_doc"];
                $_SESSION["glpi_use_mode"]       = $auth->user->fields['use_mode'];
                $_SESSION["glpi_plannings"]      = importArrayFromDB($auth->user->fields['plannings']);
@@ -581,9 +587,8 @@ class Session {
          $_SESSION['glpipluralnumber'] = $CFG_GLPI["languages"][$trytoload][5];
       }
       $TRANSLATE = new Zend\I18n\Translator\Translator;
-      $cache = Config::getCache('cache_trans');
-      if ($cache !== false) {
-         $TRANSLATE->setCache($cache);
+      if ($GLPI_CACHE !== false) {
+         $TRANSLATE->setCache($GLPI_CACHE);
       }
       $TRANSLATE->addTranslationFile('gettext', GLPI_ROOT.$newfile, 'glpi', $trytoload);
 

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -113,13 +113,12 @@ class Session {
                $_SESSION["glpidefault_entity"]  = $auth->user->fields['entities_id'];
                $_SESSION["glpiusers_idisation"] = true;
                $_SESSION["glpiextauth"]         = $auth->extauth;
-	       if (isset($_SESSION['phpCAS']['user']) )
-	       {
-		       $_SESSION["glpiauthtype"]        = Auth::CAS;
-		       $_SESSION["glpiextauth"] = 0;
-	       }
-	       else
- 	           $_SESSION["glpiauthtype"]        = $auth->user->fields['authtype'];
+               if (isset($_SESSION['phpCAS']['user']) ) {
+                  $_SESSION["glpiauthtype"]     = Auth::CAS;
+                  $_SESSION["glpiextauth"]      = 0;
+               }
+               else
+                  $_SESSION["glpiauthtype"]     = $auth->user->fields['authtype'];
                $_SESSION["glpiroot"]            = $CFG_GLPI["root_doc"];
                $_SESSION["glpi_use_mode"]       = $auth->user->fields['use_mode'];
                $_SESSION["glpi_plannings"]      = importArrayFromDB($auth->user->fields['plannings']);

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -113,12 +113,12 @@ class Session {
                $_SESSION["glpidefault_entity"]  = $auth->user->fields['entities_id'];
                $_SESSION["glpiusers_idisation"] = true;
                $_SESSION["glpiextauth"]         = $auth->extauth;
-               if (isset($_SESSION['phpCAS']['user']) ) {
+               if (isset($_SESSION['phpCAS']['user'])) {
                   $_SESSION["glpiauthtype"]     = Auth::CAS;
                   $_SESSION["glpiextauth"]      = 0;
-               }
-               else
+               } else {
                   $_SESSION["glpiauthtype"]     = $auth->user->fields['authtype'];
+               }
                $_SESSION["glpiroot"]            = $CFG_GLPI["root_doc"];
                $_SESSION["glpi_use_mode"]       = $auth->user->fields['use_mode'];
                $_SESSION["glpi_plannings"]      = importArrayFromDB($auth->user->fields['plannings']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3424 

This is a fix which force logged CAS user authtype to 5 in session so that logout works as expected.
Something more clean should be use I suppose. I think the root cause is when it sync attributes from LDAP then authtype move to 3.