### PR TITLE
Fix #3358: the last global criterion can be deleted

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5122,7 +5122,8 @@ class Search {
       $default_values["criteria"]    = [0 => ['field' => $default_criteria,
                                                         'link'  => 'contains',
                                                         'value' => '']];
-      $default_values["metacriteria"]    = [];
+      // Do not set a default value for metacriteria else
+      // $default_values["metacriteria"]    = [];
 
       // Reorg search array
       // start


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3358

*Please update this template with something that matches your PR*