### PR TITLE
fix missing 'add ticket' in user form

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1498,7 +1498,7 @@ td.rotate {
 }
 
 .firstbloc {
-   margin-bottom: 20px;
+   margin: 10px 0 20px 0;
 }
 
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -6069,6 +6069,18 @@ class Ticket extends CommonITILObject {
                                     'items_id' => $item->getID()]);
          echo "</div>";
       }
+
+      if ($item->getID()
+          && ($item->getType() == 'User')
+          && self::canCreate()
+          && !(!empty($withtemplate) && ($withtemplate == 2))) {
+         echo "<div class='firstbloc'>";
+         Html::showSimpleForm($CFG_GLPI["root_doc"]."/front/ticket.form.php",
+                              '_add_fromitem', __('New ticket for this item...'),
+                              ['_users_id_requester' => $item->getID()]);
+         echo "</div>";
+      }
+
       echo "<div>";
 
       if ($number > 0) {
@@ -6092,18 +6104,6 @@ class Ticket extends CommonITILObject {
       } else {
          echo "<table class='tab_cadre_fixe'>";
          echo "<tr><th>".__('No ticket found.')."</th></tr>";
-      }
-
-      if ($item->getID()
-          && ($item->getType() == 'User')
-          && self::canCreate()
-          && !(!empty($withtemplate) && ($withtemplate == 2))
-          && isset($item->fields['is_template']) && ($item->fields['is_template'] == 0)) {
-         echo "<tr><td class='tab_bg_2 center b' colspan='$colspan'>";
-         Html::showSimpleForm($CFG_GLPI["root_doc"]."/front/ticket.form.php",
-                              '_add_fromitem', __('New ticket for this item...'),
-                              ['_users_id_requester' => $item->getID()]);
-         echo "</td></tr>";
       }
 
       // Ticket list


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3157 

I moved the code to match other parts but for information the bug was in 
```&& isset($item->fields['is_template']) && ($item->fields['is_template'] == 0)```
User don't have any templates
