### PR TITLE
Add autoresize_max_height to fix mce toolbar on top

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3533,6 +3533,7 @@ class Html {
                   ? 'glpi_upload_doc'
                   : '',
             ],
+            autoresize_max_height: 500,
             toolbar: 'styleselect | bold italic | forecolor backcolor | bullist numlist outdent indent | table link image | code fullscreen',
             $readonlyjs
          });


### PR DESCRIPTION
If you have a long kb, mce toolbar is not fixed on top. Add autoresize_max_height  to 500 to limit height of textarea and use scroll bar.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number