### PR TITLE
Savedsearch ajax notification doesn't work

### DIFF
--- a/inc/notificationtargetsavedsearch_alert.class.php
+++ b/inc/notificationtargetsavedsearch_alert.class.php
@@ -142,6 +142,7 @@ class NotificationTargetSavedsearch_Alert extends NotificationTarget {
                   $data = ['name'     => $user->getName(),
                                 'email'    => $user->getDefaultEmail(),
                                 'language' => $user->getField('language'),
+                                'users_id' => $user->getID(),
                                 'usertype' => $usertype];
                   $this->addToRecipientsList($data);
             }


### PR DESCRIPTION
Hello,

The crontask in charge of sending ajax notification to users if their saved searches trigger the goal is not working, a "users_id" index is missing so nobody is added as a target of the notification.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3549 