### PR TITLE
Fix php error on sql query :

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -101,7 +101,7 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
       // First try old config table : for update process management from < 0.80 to >= 0.80
       $config_object->forceTable('glpi_config');
 
-      if ($config_object->getFromDB(1)) {
+      if ($DB->tableExists('glpi_config') && $config_object->getFromDB(1)) {
          $current_config = $config_object->fields;
       } else {
          $config_object->forceTable('glpi_configs');


### PR DESCRIPTION
Fix error 
```
  *** MySQL query error:
  SQL: SELECT `glpi_config`.*
                FROM `glpi_config`
                WHERE `glpi_config`.`id` = '1' LIMIT 1
  Error: Table 'glpi_93.glpi_config' doesn't exist
  Backtrace :
  inc/commondbtm.class.php:196                       
  inc/commondbtm.class.php:169                       CommonDBTM->getFromDBByQuery()
  inc/config.php:104                                 CommonDBTM->getFromDB()
  inc/includes.php:53                                include_once()
  index.php:57                                       include()

```