### PR TITLE
warn user if no templates_id selected in notification_notificationtem…

### DIFF
--- a/inc/notification_notificationtemplate.class.php
+++ b/inc/notification_notificationtemplate.class.php
@@ -139,9 +139,17 @@ class Notification_NotificationTemplate extends CommonDBChild {
             $tpl = new NotificationTemplate();
             $tpl->getFromDB($data['notificationtemplates_id']);
 
+            $tpl_link = $tpl->getLink();
+            if (empty($tpl_link)) {
+               $tpl_link = "<i class='fa fa-exclamation-triangle red'></i>&nbsp;
+                            <a href='".$notiftpl->getLinkUrl()."'>".
+                              __("No template selected").
+                           "</a>";
+            }
+
             echo "<tr class='tab_bg_2'>";
             echo "<td>".$notiftpl->getLink()."</td>";
-            echo "<td>".$tpl->getLink()."</td>";
+            echo "<td>$tpl_link</td>";
             $mode = self::getMode($data['mode']);
             if ($mode === NOT_AVAILABLE) {
                $mode = "{$data['mode']} ($mode)";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2963 

For the [armin83 comment](https://github.com/glpi-project/glpi/issues/2963#issuecomment-347357041) only, add a warning when no templates selected:

![image](https://user-images.githubusercontent.com/418844/36484664-45954600-171a-11e8-8a56-ce2176476847.png)
