### PR TITLE
api: fix Entity getItems

### DIFF
--- a/inc/apirest.class.php
+++ b/inc/apirest.class.php
@@ -205,8 +205,8 @@ class APIRest extends API {
          switch ($this->verb) {
             default:
             case "GET" : // retrieve item(s)
-               if (($id > 0)
-                   || (($id == 0) && ($itemtype == "Entity"))) {
+               if ($id > 0
+                   || ($id !== false && $id == 0 && $itemtype == "Entity")) {
                   $response = $this->getItem($itemtype, $id, $this->parameters);
                   if (isset($response['date_mod'])) {
                      $datemod = strtotime($response['date_mod']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

When querying `apirest.php/Entity/` url we pass in `getItem` endpoint where we should pass in `getItems`.
This is due to `$id = false` returned by `$this->getId()`