### PR TITLE
Try to exclude 9.1/bf branch from circleci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,19 @@ workflows:
   version: 2
   tests_all:
     jobs:
-      - php5.6
-      - php7.0
-      - php7.1
-      - php7.2
+      - php5.6:
+          branches:
+            ignore:
+              - 9.1/bugfixes
+      - php7.0:
+          branches:
+            ignore:
+              - 9.1/bugfixes
+      - php7.1:
+          branches:
+            ignore:
+              - 9.1/bugfixes
+      - php7.2:
+          branches:
+            ignore:
+              - 9.1/bugfixes


### PR DESCRIPTION
circleci is not setup on 9.1/branch; and there are still commits on this branch...