### PR TITLE
Fixed session init for APIs

### DIFF
--- a/apirest.php
+++ b/apirest.php
@@ -36,14 +36,11 @@
 */
 
 
+define('GLPI_ROOT', __DIR__);
 define('DO_NOT_CHECK_HTTP_REFERER', 1);
 ini_set('session.use_cookies', 0);
 
-include ('./inc/includes.php');
+include ('./inc/autoload.function.php');
 
 $api = new APIRest;
-if ($CFG_GLPI['enable_api']) {
-   $api->call();
-} else {
-   Html::displayErrorAndDie(__("API disabled"), true);
-}
+$api->call();

--- a/apixmlrpc.php
+++ b/apixmlrpc.php
@@ -36,13 +36,10 @@
 */
 
 
+define('GLPI_ROOT', __DIR__);
 define('DO_NOT_CHECK_HTTP_REFERER', 1);
 
-include ('./inc/includes.php');
+include ('./inc/autoload.function.php');
 
 $api = new APIXmlrpc;
-if ($CFG_GLPI['enable_api']) {
-   $api->call();
-} else {
-   Html::displayErrorAndDie(__("API disabled"), true);
-}
+$api->call();

--- a/inc/apirest.class.php
+++ b/inc/apirest.class.php
@@ -55,6 +55,23 @@ class APIRest extends API {
       return __('Rest API');
    }
 
+   /**
+    * Upload and validate files from request and append to $this->parameters['input']
+    *
+    * @return void
+    */
+   public function manageUploadedFiles() {
+      foreach ($_FILES as $filename => $files) {
+         $upload_result
+            = GLPIUploadHandler::uploadFiles(['name'           => $filename,
+                                              'print_response' => false]);
+         foreach ($upload_result as $uresult) {
+            $this->parameters['input']->_filename[] = $uresult[0]->name;
+            $this->parameters['input']->_prefix_filename[] = $uresult[0]->prefix;
+         }
+         $this->parameters['upload_result'][] = $upload_result;
+      }
+   }
 
    /**
     * Parse url and http body to retrieve :
@@ -99,6 +116,8 @@ class APIRest extends API {
 
       // retrieve session (if exist)
       $this->retrieveSession();
+      $this->initApi();
+      $this->manageUploadedFiles();
 
       // retrieve param who permit session writing
       if (isset($this->parameters['session_write'])) {
@@ -419,16 +438,6 @@ class APIRest extends API {
          $parameters['upload_result'] = [];
          $parameters['input']->_filename = [];
          $parameters['input']->_prefix_filename = [];
-         foreach ($_FILES as $filename => $files) {
-            $upload_result
-               = GLPIUploadHandler::uploadFiles(['name'           => $filename,
-                                                 'print_response' => false]);
-            foreach ($upload_result as $uresult) {
-               $parameters['input']->_filename[] = $uresult[0]->name;
-               $parameters['input']->_prefix_filename[] = $uresult[0]->prefix;
-            }
-            $parameters['upload_result'][] = $upload_result;
-         }
 
       } else if (strpos($content_type, "application/x-www-form-urlencoded") !== false) {
          parse_str($body, $postvars);

--- a/inc/apixmlrpc.class.php
+++ b/inc/apixmlrpc.class.php
@@ -42,11 +42,19 @@ class APIXmlrpc extends API {
    protected $debug = 0;
    protected $format = "json";
 
+   static $content_type = "application/xml";
 
    public static function getTypeName($nb = 0) {
       return __('XMLRPC API');
    }
 
+   /**
+    * Upload and validate files from request and append to $this->parameters['input']
+    *
+    * @return void
+    */
+   public function manageUploadedFiles() {
+   }
 
    /**
     * parse POST var to retrieve
@@ -65,6 +73,7 @@ class APIXmlrpc extends API {
 
       // retrieve session (if exist)
       $this->retrieveSession();
+      $this->initApi();
 
       $code = 200;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3688

With this, the session is initialized only once
First check the session token, for later, initialize the session
For get the session, need parse the content, to run later.
