### PR TITLE
Attach documents to plain-text emails

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -491,7 +491,7 @@ class CommonDBTM extends CommonGLPI {
                if (($this->getType() == 'ProfileRight') && ($values[$i] == '')) {
                   $values[$i] = 0;
                }
-               $query .= "'".$DB->escape($values[$i])."'";
+               $query .= "'".htmlspecialchars($values[$i])."'";
             }
 
             if ($i != ($nb_fields-1)) {

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -491,7 +491,7 @@ class CommonDBTM extends CommonGLPI {
                if (($this->getType() == 'ProfileRight') && ($values[$i] == '')) {
                   $values[$i] = 0;
                }
-               $query .= "'".htmlspecialchars($values[$i])."'";
+               $query .= "'".$values[$i]."'";
             }
 
             if ($i != ($nb_fields-1)) {

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -491,7 +491,7 @@ class CommonDBTM extends CommonGLPI {
                if (($this->getType() == 'ProfileRight') && ($values[$i] == '')) {
                   $values[$i] = 0;
                }
-               $query .= "'".$values[$i]."'";
+               $query .= "'".$DB->escape($values[$i])."'";
             }
 
             if ($i != ($nb_fields-1)) {

--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -140,6 +140,27 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
          if (empty($current->fields['body_html'])) {
             $mmail->isHTML(false);
             $mmail->Body = $current->fields['body_text'];
+
+             if ($CFG_GLPI['attach_ticket_documents_to_mail']) {
+                 // manage item attached documents
+                 $document_items = $DB->request('glpi_documents_items', [
+                     'items_id' => $current->fields['items_id'],
+                     'itemtype' => $current->fields['itemtype'],
+                 ]);
+
+                 $doc = new Document();
+
+                 foreach ($document_items as $doc_i_data) {
+                     $doc->getFromDB($doc_i_data['documents_id']);
+
+                     // Add all other attachments, according to configuration
+                     $path = GLPI_DOC_DIR . "/" . $doc->fields['filepath'];
+                     $mmail->addAttachment(
+                         $path,
+                         $doc->fields['filename']
+                     );
+                 }
+             }
          } else {
             $mmail->isHTML(true);
             $mmail->Body = '';

--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -141,26 +141,26 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
             $mmail->isHTML(false);
             $mmail->Body = $current->fields['body_text'];
 
-             if ($CFG_GLPI['attach_ticket_documents_to_mail']) {
-                 // manage item attached documents
-                 $document_items = $DB->request('glpi_documents_items', [
-                     'items_id' => $current->fields['items_id'],
-                     'itemtype' => $current->fields['itemtype'],
-                 ]);
+            if ($CFG_GLPI['attach_ticket_documents_to_mail']) {
+               // manage item attached documents
+               $document_items = $DB->request('glpi_documents_items', [
+                  'items_id' => $current->fields['items_id'],
+                  'itemtype' => $current->fields['itemtype'],
+               ]);
 
-                 $doc = new Document();
+               $doc = new Document();
 
-                 foreach ($document_items as $doc_i_data) {
-                     $doc->getFromDB($doc_i_data['documents_id']);
+               foreach ($document_items as $doc_i_data) {
+                  $doc->getFromDB($doc_i_data['documents_id']);
 
-                     // Add all other attachments, according to configuration
-                     $path = GLPI_DOC_DIR . "/" . $doc->fields['filepath'];
-                     $mmail->addAttachment(
-                         $path,
-                         $doc->fields['filename']
-                     );
-                 }
-             }
+                  // Add all other attachments, according to configuration
+                  $path = GLPI_DOC_DIR . "/" . $doc->fields['filepath'];
+                  $mmail->addAttachment(
+                     $path,
+                     $doc->fields['filename']
+                  );
+               }
+            }
          } else {
             $mmail->isHTML(true);
             $mmail->Body = '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Very useful feature for Plain Text emails - send documents as attachments with follow-up emails.

*Please update this template with something that matches your PR*