### PR TITLE
WIP make getFromDBByCrit use one less SQL query

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -272,27 +272,8 @@ class CommonDBTM extends CommonGLPI {
     * @return boolean|array
     */
    public function getFromDBByCrit(array $crit) {
-      global $DB;
-
-      $crit = ['SELECT' => 'id',
-               'FROM'   => $this->getTable(),
-               'WHERE'  => $crit];
-
-      $iter = $DB->request($crit);
-      if (count($iter) == 1) {
-         $row = $iter->next();
-         return $this->getFromDB($row['id']);
-      } else if (count($iter) > 1) {
-         Toolbox::logWarning(
-            sprintf(
-               'getFromDBByCrit expects to get one result, %1$s found!',
-               count($iter)
-            )
-         );
-      }
-      return false;
+      return $this->getFromDBByRequest(['WHERE' => $crit]);
    }
-
 
    /**
     * Retrieve an item from the database by request. The request is an array

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -808,14 +808,14 @@ class Migration {
                                        AND `itemtype` = '$type'";
                      if ($result2 = $DB->query($query)) {
                         if ($DB->numrows($result2) == 0) {
-                              $DB->insert(
-                                 'glpi_displaypreferences', [
-                                    'itemtype'  => $type,
-                                    'num'       => $newval,
-                                    'rank'      => $rank++,
-                                    'users_id'  => $data['users_id']
-                                 ]
-                              );
+                           $DB->insert(
+                              'glpi_displaypreferences', [
+                                 'itemtype'  => $type,
+                                 'num'       => $newval,
+                                 'rank'      => $rank++,
+                                 'users_id'  => $data['users_id']
+                              ]
+                           );
                         }
                      }
                   }
@@ -824,14 +824,14 @@ class Migration {
             } else { // Add for default user
                $rank = 1;
                foreach ($tab as $newval) {
-                     $DB->insert(
-                        'glpi_displaypreferences', [
-                           'itemtype'  => $type,
-                           'num'       => $newval,
-                           'rank'      => $rank++,
-                           'users_id'  => 0
-                        ]
-                     );
+                  $DB->insert(
+                     'glpi_displaypreferences', [
+                        'itemtype'  => $type,
+                        'num'       => $newval,
+                        'rank'      => $rank++,
+                        'users_id'  => 0
+                     ]
+                  );
                }
             }
          }

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -115,6 +115,31 @@ class CommonDBTM extends DbTestCase {
 
    }
 
+   public function testGetFromDBByCrit() {
+      $instance = new \Computer();
+      $instance->getFromDBByCrit(['name' => '_test_pc01']);
+      // the instance must be populated
+      $this->boolean($instance->isNewItem())->isFalse();
+
+      $instance = new \Computer();
+      $this->exception(
+         function() use ($instance) {
+            $instance->getFromDBByCrit(['entities_id' => '1']);
+         }
+      )->isInstanceOf(\RuntimeException::class)
+      ->message
+      ->contains('getFromDBByRequest expects to get one result, 3 found!');;
+      // the instance must not be populated
+      $this->boolean($instance->isNewItem())->isTrue();
+
+      $instance = new \Computer();
+      $success = $instance->getFromDBByCrit(['name' => 'non existent computer']);
+      // Must return false because no row returned by the SQL query
+      $this->boolean($success)->isFalse();
+      // the instance must not be populated
+      $this->string($instance->getField('name'))->isEqualTo(NOT_AVAILABLE);
+   }
+
    public function testGetFromDBByRequest() {
       $instance = new \Computer();
       $instance->getFromDbByRequest([

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -124,9 +124,9 @@ class Migration extends \GLPITestCase {
 
       $this->array($this->queries)->isIdenticalTo([
          0 => 'SELECT * FROM `glpi_configs` WHERE `context` = \'core\' AND `name` IN (\'one\', \'two\')',
-         1 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'one\'',
+         1 => 'SELECT  `glpi_configs`.* FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'one\'',
          2 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'one\', \'key\')',
-         3 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'two\'',
+         3 => 'SELECT  `glpi_configs`.* FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'two\'',
          4 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'two\', \'value\')'
       ]);
 
@@ -142,9 +142,9 @@ class Migration extends \GLPITestCase {
 
       $this->array($this->queries)->isIdenticalTo([
          0 => 'SELECT * FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` IN (\'one\', \'two\')',
-         1 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'one\'',
+         1 => 'SELECT  `glpi_configs`.* FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'one\'',
          2 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'one\', \'key\')',
-         3 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'two\'',
+         3 => 'SELECT  `glpi_configs`.* FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'two\'',
          4 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'two\', \'value\')'
       ]);
 
@@ -159,7 +159,24 @@ class Migration extends \GLPITestCase {
          'value'     => 'setted value'
       ]];
       $it = new \ArrayIterator($dbresult);
-      $this->calling($this->db)->request = $it;
+      $this->db = new \mock\DB();
+      $queries = &$this->queries;
+      $this->calling($this->db)->query = function ($query) use (&$queries) {
+         $queries[] = $query;
+         return true;
+      };
+      $this->calling($this->db)->free_result = true;
+      $this->calling($this->db)->request[1] = $it;
+      $this->calling($this->db)->request[2] = [];
+      $this->calling($this->db)->numrows = 0;
+      $this->calling($this->db)->fetch_assoc = [];
+      $this->calling($this->db)->data_seek = true;
+      $this->calling($this->db)->list_fields = [
+         'id'        => '',
+         'context'   => '',
+         'name'      => '',
+         'value'     => ''
+      ];
 
       $DB = $this->db;
 

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -124,9 +124,9 @@ class Migration extends \GLPITestCase {
 
       $this->array($this->queries)->isIdenticalTo([
          0 => 'SELECT * FROM `glpi_configs` WHERE `context` = \'core\' AND `name` IN (\'one\', \'two\')',
-         1 => 'SELECT  `glpi_configs`.* FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'one\'',
+         1 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'one\'',
          2 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'one\', \'key\')',
-         3 => 'SELECT  `glpi_configs`.* FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'two\'',
+         3 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'two\'',
          4 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'two\', \'value\')'
       ]);
 
@@ -142,9 +142,9 @@ class Migration extends \GLPITestCase {
 
       $this->array($this->queries)->isIdenticalTo([
          0 => 'SELECT * FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` IN (\'one\', \'two\')',
-         1 => 'SELECT  `glpi_configs`.* FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'one\'',
+         1 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'one\'',
          2 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'one\', \'key\')',
-         3 => 'SELECT  `glpi_configs`.* FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'two\'',
+         3 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'two\'',
          4 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'two\', \'value\')'
       ]);
 
@@ -159,24 +159,7 @@ class Migration extends \GLPITestCase {
          'value'     => 'setted value'
       ]];
       $it = new \ArrayIterator($dbresult);
-      $this->db = new \mock\DB();
-      $queries = &$this->queries;
-      $this->calling($this->db)->query = function ($query) use (&$queries) {
-         $queries[] = $query;
-         return true;
-      };
-      $this->calling($this->db)->free_result = true;
-      $this->calling($this->db)->request[1] = $it;
-      $this->calling($this->db)->request[2] = [];
-      $this->calling($this->db)->numrows = 0;
-      $this->calling($this->db)->fetch_assoc = [];
-      $this->calling($this->db)->data_seek = true;
-      $this->calling($this->db)->list_fields = [
-         'id'        => '',
-         'context'   => '',
-         'name'      => '',
-         'value'     => ''
-      ];
+      $this->calling($this->db)->request = $it;
 
       $DB = $this->db;
 

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -124,9 +124,9 @@ class Migration extends \GLPITestCase {
 
       $this->array($this->queries)->isIdenticalTo([
          0 => 'SELECT * FROM `glpi_configs` WHERE `context` = \'core\' AND `name` IN (\'one\', \'two\')',
-         1 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'one\'',
+         1 => 'SELECT  `glpi_configs`.* FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'one\'',
          2 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'one\', \'key\')',
-         3 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'two\'',
+         3 => 'SELECT  `glpi_configs`.* FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'two\'',
          4 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'two\', \'value\')'
       ]);
 
@@ -142,9 +142,9 @@ class Migration extends \GLPITestCase {
 
       $this->array($this->queries)->isIdenticalTo([
          0 => 'SELECT * FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` IN (\'one\', \'two\')',
-         1 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'one\'',
+         1 => 'SELECT  `glpi_configs`.* FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'one\'',
          2 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'one\', \'key\')',
-         3 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'two\'',
+         3 => 'SELECT  `glpi_configs`.* FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'two\'',
          4 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'two\', \'value\')'
       ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3725 

CommonDBTM::getFromDbByQuery() deprecated without any alternative.