### PR TITLE
add getFromDbByRequest

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -294,6 +294,47 @@ class CommonDBTM extends CommonGLPI {
 
 
    /**
+    * Retrieve an item from the database by request. The request is an array
+    * similar to the one expected in DB::request().
+    *
+    * @since 9.3
+    *
+    * @see DB::request()
+    *
+    * @param array $request expression
+    *
+    * @return boolean true if succeed else false
+    **/
+   public function getFromDBByRequest(array $request) {
+      global $DB;
+
+      // Limit the request to the useful expressions
+      $request = array_diff_key($request, [
+         'FROM' => '',
+         'SELECT' => '',
+         'COUNT' => '',
+         'GROUPBY' => '',
+      ]);
+      $request['FROM'] = $this->getTable();
+      $request['SELECT'] = $this->getTable() . '.*';
+
+      $iterator = $DB->request($request);
+      if (count($iterator) == 1) {
+         $this->fields = $iterator->next();
+         $this->post_getFromDB();
+         return true;
+      } else if (count($iterator) > 1) {
+         Toolbox::logWarning(
+               sprintf(
+                     'getFromDBByRequest expects to get one result, %1$s found!',
+                     count($iterator)
+                     )
+               );
+      }
+      return false;
+   }
+
+   /**
     * Get the identifier of the current item
     *
     * @return integer ID

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -72,7 +72,7 @@ function loadDataset() {
    // Unit test data definition
    $data = [
       // bump this version to force reload of the full dataset, when content change
-      '_version' => '4.2',
+      '_version' => '4.3',
 
       // Type => array of entries
       'Entity' => [
@@ -90,17 +90,27 @@ function loadDataset() {
          [
             'name'        => '_test_pc01',
             'entities_id' => '_test_root_entity',
-            'comment'     => 'Comment for computer _test_pc01'
+            'comment'     => 'Comment for computer _test_pc01',
          ], [
             'name'        => '_test_pc02',
             'entities_id' => '_test_root_entity',
-            'comment'     => 'Comment for computer _test_pc02'
+            'comment'     => 'Comment for computer _test_pc02',
+         ], [
+            'name'        => '_test_pc03',
+            'entities_id' => '_test_root_entity',
+            'comment'     => 'Comment for computer _test_pc03',
+            'contact'     => 'johndoe',
          ], [
             'name'        => '_test_pc11',
             'entities_id' => '_test_child_1',
          ], [
             'name'        => '_test_pc12',
             'entities_id' => '_test_child_1',
+         ], [
+            'name'        => '_test_pc13',
+            'entities_id' => '_test_child_1',
+            'comment'     => 'Comment for computer _test_pc13',
+            'contact'     => 'johndoe',
          ], [
             'name'        => '_test_pc21',
             'entities_id' => '_test_child_2',

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -114,4 +114,38 @@ class CommonDBTM extends DbTestCase {
       ]))->isFalse();
 
    }
+
+   public function testGetFromDBByRequest() {
+      $instance = new \Computer();
+      $instance->getFromDbByRequest([
+         'LEFT JOIN' => [
+            \Entity::getTable() => [
+               'FKEY' => [
+                  \Entity::getTable() => 'id',
+                  \Computer::getTable() => \Entity::getForeignKeyField()
+               ]
+            ]
+         ],
+         'WHERE' => ['AND' => [
+            'contact' => 'johndoe'],
+            \Entity::getTable() . '.name' => '_test_root_entity',
+         ]
+      ]);
+      // the instance must be populated
+      $this->boolean($instance->isNewItem())->isFalse();
+
+      $instance = new \Computer();
+      $this->exception(
+         function() use ($instance) {
+            $instance->getFromDbByRequest([
+               'WHERE' => ['contact' => 'johndoe'],
+            ]);
+         }
+      )->isInstanceOf(\RuntimeException::class)
+      ->message
+      ->contains('getFromDBByRequest expects to get one result, 2 found!');
+
+      // the instance must not be populated
+      $this->boolean($instance->isNewItem())->isTrue();
+   }
 }

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -342,17 +342,17 @@ class DbUtils extends DbTestCase {
 
    protected function dataCountMyEntities() {
       return [
-         ['_test_root_entity', true, 'glpi_computers', '', 6],
+         ['_test_root_entity', true, 'glpi_computers', '', 8],
          ['_test_root_entity', true, 'glpi_computers', ['name' => '_test_pc11'], 1],
          ['_test_root_entity', true, 'glpi_computers', ['name' => '_test_pc01'], 1],
          //test old syntax, once only
          ['_test_root_entity', true, 'glpi_computers', 'name="_test_pc11"', 1],
 
-         ['_test_root_entity', false, 'glpi_computers', '', 2],
+         ['_test_root_entity', false, 'glpi_computers', '', 3],
          ['_test_root_entity', false, 'glpi_computers', ['name' => '_test_pc11'], 0],
          ['_test_root_entity', false, 'glpi_computers', ['name' => '_test_pc01'], 1],
 
-         ['_test_child_1', false, 'glpi_computers', '', 2],
+         ['_test_child_1', false, 'glpi_computers', '', 3],
          ['_test_child_1', false, 'glpi_computers', ['name' => '_test_pc11'], 1],
          ['_test_child_1', false, 'glpi_computers', ['name' => '_test_pc01'], 0],
       ];
@@ -382,13 +382,13 @@ class DbUtils extends DbTestCase {
 
    protected function dataCountEntities() {
       return [
-         ['_test_root_entity', 'glpi_computers', '', 2],
+         ['_test_root_entity', 'glpi_computers', '', 3],
          ['_test_root_entity', 'glpi_computers', ['name' => '_test_pc11'], 0],
          ['_test_root_entity', 'glpi_computers', ['name' => '_test_pc01'], 1],
          //test old syntax, once only
          ['_test_root_entity', 'glpi_computers', 'name="_test_pc11"', 0],
 
-         ['_test_child_1', 'glpi_computers', '', 2],
+         ['_test_child_1', 'glpi_computers', '', 3],
          ['_test_child_1', 'glpi_computers', ['name' => '_test_pc11'], 1],
          ['_test_child_1', 'glpi_computers', ['name' => '_test_pc01'], 0],
       ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3725 

Replaces #3724 : keep getFromDbByCrit() intact to workaround optimization impacting Migration unit tests.