### PR TITLE
Extract en_GB verbatim from pot file

### DIFF
--- a/tools/locale/extract_template.sh
+++ b/tools/locale/extract_template.sh
@@ -39,6 +39,8 @@ copyright='INDEPNET Development Team'
 xgettext *.php */*.php -o locales/glpi.pot -L PHP --add-comments=TRANS --from-code=UTF-8 --force-po \
     --keyword=_n:1,2 --keyword=__s --keyword=__ --keyword=_e --keyword=_x:1c,2 --keyword=_ex:1c,2 --keyword=_sx:1c,2 --keyword=_nx:1c,2,3 --keyword=_sn:1,2
 
+#Update main language
+LANG=C msginit --no-translator -i locales/glpi.pot -l en_GB -o locales/en_GB.po
 
 ### for using tx :
 ##tx set --execute --auto-local -r GLPI.glpipot 'locales/<lang>.po' --source-lang en_GB --source-file locales/glpi.pot


### PR DESCRIPTION
en_GB PO file is not updated from transifex... And is therefore never up to date.
I propose to regenerate the empty PO file on extracting templates (file is needed for Zend Translator as far as I can say). It will be empty, so defaults will be used.