### PR TITLE
Fixes #3896

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -105,12 +105,12 @@ class Auth extends CommonGLPI {
             $menu['options']['ldap']['title']           = AuthLDAP::getTypeName(Session::getPluralNumber());
             $menu['options']['ldap']['page']            = '/front/authldap.php';
             $menu['options']['ldap']['links']['search'] = '/front/authldap.php';
-            $menu['options']['ldap']['links']['add']    = AuthLDAP::getFormURL();
+            $menu['options']['ldap']['links']['add']    = AuthLDAP::getFormURL(false);
 
             $menu['options']['imap']['title']           = AuthMail::getTypeName(Session::getPluralNumber());
             $menu['options']['imap']['page']            = '/front/authmail.php';
             $menu['options']['imap']['links']['search'] = '/front/authmail.php';
-            $menu['options']['imap']['links']['add']    = AuthMail::getFormURL();
+            $menu['options']['imap']['links']['add']    = AuthMail::getFormURL(false);
 
             $menu['options']['others']['title']         = __('Others');
             $menu['options']['others']['page']          = '/front/auth.others.php';

--- a/inc/control.class.php
+++ b/inc/control.class.php
@@ -60,7 +60,7 @@ class Control extends CommonGLPI {
       if (static::canView()) {
          $options['FieldUnicity']['title']           = __('Fields unicity');
          $options['FieldUnicity']['page']            = FieldUnicity::getSearchURL();
-         $options['FieldUnicity']['links']['add']    = FieldUnicity::getFormURL();
+         $options['FieldUnicity']['links']['add']    = FieldUnicity::getFormURL(false);
          $options['FieldUnicity']['links']['search'] = FieldUnicity::getSearchURL();
 
          return $options;

--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -158,7 +158,7 @@ class Notification extends CommonDBTM {
          $menu['page']                                       = '/front/setup.notification.php';
          $menu['options']['notification']['title']           = _n('Notification', 'Notifications', Session::getPluralNumber());
          $menu['options']['notification']['page']            = '/front/notification.php';
-         $menu['options']['notification']['links']['add']    = Notification::getFormURL();
+         $menu['options']['notification']['links']['add']    = Notification::getFormURL(false);
          $menu['options']['notification']['links']['search'] = '/front/notification.php';
 
          $menu['options']['notificationtemplate']['title']

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -225,7 +225,7 @@ class Project extends CommonDBTM {
 
          $links[$pic_validate] = '/front/projecttask.php';
 
-         $links['summary'] = Project::getFormURL().'?showglobalgantt=1';
+         $links['summary'] = Project::getFormURL(false).'?showglobalgantt=1';
       }
       if (count($links)) {
          return $links;

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -236,7 +236,7 @@ class Rule extends CommonDBTM {
          if (Session::haveRightsOr("transfer", [CREATE, UPDATE])) {
             $menu['rule']['options']['transfer']['links']['summary']
                                                                  = "/front/transfer.action.php";
-            $menu['rule']['options']['transfer']['links']['add'] = Transfer::getFormURL();
+            $menu['rule']['options']['transfer']['links']['add'] = Transfer::getFormURL(false);
          }
       }
 

--- a/inc/slm.class.php
+++ b/inc/slm.class.php
@@ -183,7 +183,7 @@ class SLM extends CommonDBTM {
          $menu['page']            = '/front/slm.php';
          $menu['links']['search'] = '/front/slm.php';
          if (static::canCreate()) {
-            $menu['links']['add'] = Slm::getFormURL();
+            $menu['links']['add'] = Slm::getFormURL(false);
          }
 
          $menu['options']['sla']['title']           = SLA::getTypeName(1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3896

Fixes the issue with the double root in URL when trying to add a new SLM item.