### PR TITLE
Fix image paste on tickets on IE

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -5343,7 +5343,7 @@ class Html {
       window.old_alert = window.alert;
       window.alert = function(message, caption) {
          // Don't apply methods on undefined objects... ;-) #3866
-         if(message !== undefined) {
+         if(typeof message == 'string') {
             message = message.replace('\\n', '<br>');
          }
          caption = caption || '".addslashes(__("Information"))."';

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -5342,7 +5342,10 @@ class Html {
       echo self::scriptBlock("
       window.old_alert = window.alert;
       window.alert = function(message, caption) {
-         message = message.replace('\\n', '<br>');
+         // Don't apply methods on undefined objects... ;-) #3866
+         if(message !== undefined) {
+            message = message.replace('\\n', '<br>');
+         }
          caption = caption || '".addslashes(__("Information"))."';
          $('<div/>').html(message).dialog({
             title: caption,

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -65,7 +65,7 @@ function uploadFile(file, editor, input_name) {
 
       error: function (request) {
          // If this is an error on the return
-         if (request.responseText !== undefined) {
+         if ("responseText" in request && request.responseText.length > 0) {
             alert(request.responseText);
          } else {
             // Error before sending request #3866

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -68,7 +68,7 @@ function uploadFile(file, editor, input_name) {
          if(request.responseText !== undefined) {
             alert(request.responseText);
          } else {
-            // Error before sending request
+            // Error before sending request #3866
             alert(request.statusText);
          }
       }

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -368,6 +368,11 @@ if (typeof tinymce != 'undefined') {
             //transform to blob and insert into editor
             if (base64.length) {
                var file = dataURItoBlob(base64);
+               // Fix #3866 - undefined file name
+               if(file.name === undefined) {
+                  // fill missing file properties
+                  file.name = 'image_paste'+ Math.floor((Math.random() * 10000000) + 1)+".png";
+               }
                uploaded = insertImageInTinyMCE(editor, file);
             }
 
@@ -385,7 +390,7 @@ if (typeof tinymce != 'undefined') {
                   var file  = new Blob([this.response], {type: 'image/png'});
                   file.name = 'image_paste'+ Math.floor((Math.random() * 10000000) + 1)+".png";
 
-                  uploaded = insertImageInTinyMCE(editor, file);
+                    uploaded = insertImageInTinyMCE(editor, file);
                } else {
                   console.log("paste error");
                }

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -65,7 +65,7 @@ function uploadFile(file, editor, input_name) {
 
       error: function (request) {
          // If this is an error on the return
-         if(request.responseText !== undefined) {
+         if (request.responseText !== undefined) {
             alert(request.responseText);
          } else {
             // Error before sending request #3866

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -64,7 +64,13 @@ function uploadFile(file, editor, input_name) {
       },
 
       error: function (request) {
-         alert(request.responseText);
+         // If this is an error on the return
+         if(request.responseText !== undefined) {
+            alert(request.responseText);
+         } else {
+            // Error before sending request
+            alert(request.statusText);
+         }
       }
    });
 
@@ -373,7 +379,7 @@ if (typeof tinymce != 'undefined') {
                   // fill missing file properties
                   file.name = 'image_paste'+ Math.floor((Math.random() * 10000000) + 1)+".png";
                }
-               uploaded = insertImageInTinyMCE(editor, file);
+                  uploaded = insertImageInTinyMCE(editor, file);
             }
 
          } else if (uploaded === false

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -379,7 +379,7 @@ if (typeof tinymce != 'undefined') {
                   // fill missing file properties
                   file.name = 'image_paste'+ Math.floor((Math.random() * 10000000) + 1)+".png";
                }
-                  uploaded = insertImageInTinyMCE(editor, file);
+               uploaded = insertImageInTinyMCE(editor, file);
             }
 
          } else if (uploaded === false

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -375,7 +375,7 @@ if (typeof tinymce != 'undefined') {
             if (base64.length) {
                var file = dataURItoBlob(base64);
                // Fix #3866 - undefined file name
-               if (file.name === undefined) {
+               if (typeof file.name != "string") {
                   // fill missing file properties
                   file.name = 'image_paste'+ Math.floor((Math.random() * 10000000) + 1)+".png";
                }

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -396,7 +396,7 @@ if (typeof tinymce != 'undefined') {
                   var file  = new Blob([this.response], {type: 'image/png'});
                   file.name = 'image_paste'+ Math.floor((Math.random() * 10000000) + 1)+".png";
 
-                    uploaded = insertImageInTinyMCE(editor, file);
+                  uploaded = insertImageInTinyMCE(editor, file);
                } else {
                   console.log("paste error");
                }

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -369,7 +369,7 @@ if (typeof tinymce != 'undefined') {
             if (base64.length) {
                var file = dataURItoBlob(base64);
                // Fix #3866 - undefined file name
-               if(file.name === undefined) {
+               if (file.name === undefined) {
                   // fill missing file properties
                   file.name = 'image_paste'+ Math.floor((Math.random() * 10000000) + 1)+".png";
                }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3866

  - Fix error "Filetype not allowed" on pasting image (ctrl + v) on tinymce on a ticket with IE11
  - Fix undefined or null reference when right click-> paste on IE11 => display error message
Fix #3866