### PR TITLE
Fix old format search options retrieval

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -3388,7 +3388,7 @@ class CommonDBTM extends CommonGLPI {
    public final function searchOptions() {
       $options = [];
 
-      if (method_exists(get_class(), 'getSearchOptions')) {
+      if (method_exists(get_class($this), 'getSearchOptions')) {
          if (defined('TU_USER')) {
             throw new \RuntimeException('getSearchOptions must not be used!');
          }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

Not passing `$this` results in checking method existence on `CommonDBTM` class instead of checking it on top level object instance.