### PR TITLE
Fix 'nodisplay' specificities in item devices list; closes #3247

### DIFF
--- a/inc/item_devices.class.php
+++ b/inc/item_devices.class.php
@@ -691,6 +691,8 @@ class Item_Devices extends CommonDBRelation {
                                             "<a href='" . $this->getLinkURL() . "'>$mode</a>");
 
          foreach ($this->getSpecificities() as $field => $attributs) {
+            $content = '';
+
             if (!empty($link[$field])) {
                // Check the user can view the field
                if (!isset($attributs['right'])) {
@@ -718,9 +720,8 @@ class Item_Devices extends CommonDBRelation {
                         $content = $link[$field];
                   }
                }
-            } else {
-               $content = '';
             }
+
             $spec_cell = $current_row->addCell($specificity_columns[$field], $content, $spec_cell);
          }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3247 

When preceded by a non empty field, "nodiplay" fields where filled with value of previous field.