### PR TITLE
Fix path calculation for windows (slash and reverse slash mixed)

### DIFF
--- a/front/backup.php
+++ b/front/backup.php
@@ -45,7 +45,7 @@ if (isset($_POST['check_version'])) {
 Session::checkRight("backup", READ);
 
 // full path
-$path = GLPI_DUMP_DIR;
+$path = realpath(GLPI_DUMP_DIR);
 
 Html::header(__('Maintenance'), $_SERVER['PHP_SELF'], "admin", "backup");
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3939 

Fix path calculation - on Windows the path can be written with \ and / ... => problems on path validation (on line 581)
Fix #3939 

Replace PR #3941 