### PR TITLE
Fix variable override in rights matrix display

### DIFF
--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -2828,11 +2828,11 @@ class Profile extends CommonDBTM {
             }
 
             if (isset($info['rights'])) {
-               $rights = $info['rights'];
+               $itemRights = $info['rights'];
             } else {
-               $rights = self::getRightsFor($info['itemtype']);
+               $itemRights = self::getRightsFor($info['itemtype']);
             }
-            foreach ($rights as $right => $label) {
+            foreach ($itemRights as $right => $label) {
                if (!isset($column_labels[$right])) {
                   $column_labels[$right] = [];
                }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | not sure
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The `$rights` variable is used for another purpose in the same function, and the new value affectation is made inside a loop on this variable. I didi not check if it leads to a bug, but it does not log good.