### PR TITLE
Fix task template selection from select2; fixes #3895

### DIFF
--- a/ajax/task.php
+++ b/ajax/task.php
@@ -46,6 +46,25 @@ if (isset($_POST['tasktemplates_id']) && ($_POST['tasktemplates_id'] > 0)) {
    $template = new TaskTemplate();
    $template->getFromDB($_POST['tasktemplates_id']);
 
-   $template->fields = array_map('html_entity_decode', $template->fields);
-   echo json_encode($template->fields);
+   $fields = $template->fields;
+   if ($fields['taskcategories_id']) {
+      $cat = new TaskCategory();
+      $cat->getFromDB($fields['taskcategories_id']);
+      $fields['taskcategories_name'] = $cat->fields['name'];
+   }
+
+   if ($fields['users_id_tech']) {
+      $user = new User();
+      $user->getFromDB($fields['users_id_tech']);
+      $fields['users_id_tech_name'] = $user->getRawName();
+   }
+
+   if ($fields['groups_id_tech']) {
+      $group = new Group();
+      $group->getFromDB($fields['groups_id_tech']);
+      $fields['groups_id_tech_name'] = $group->fields['name'];
+   }
+
+   $fields = array_map('html_entity_decode', $fields);
+   echo json_encode($fields);
 }

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1432,17 +1432,19 @@ abstract class CommonITILTask  extends CommonDBTM {
                   tasktinymce.setContent(data.content.replace(/\r?\n/g, "<br />"));
                }
                // set category
-               $("#dropdown_taskcategories_id'.$rand_type.'").select2("val", taskcategories_id);
+               console.log(taskcategories_id);
+               console.log($("#dropdown_taskcategories_id'.$rand_type.'"));
+               $("#dropdown_taskcategories_id'.$rand_type.'").val(taskcategories_id).trigger("change");
                // set action time
-               $("#dropdown_actiontime'.$rand_time.'").select2("val", actiontime);
+               $("#dropdown_actiontime'.$rand_time.'").val(actiontime).trigger("change");
                // set is_private
-               $("#dropdown_is_private'.$rand_is_private.'").select2("val", data.is_private);
+               $("#dropdown_is_private'.$rand_is_private.'").val(data.is_private).trigger("change");
                // set users_tech
-               $("#dropdown_users_id_tech'.$rand_user.'").select2("val", user_tech);
+               $("#dropdown_users_id_tech'.$rand_user.'").val(user_tech).trigger("change");
                // set group_tech
-               $("#dropdown_groups_id_tech'.$rand_group.'").select2("val", group_tech);
+               $("#dropdown_groups_id_tech'.$rand_group.'").val(group_tech).trigger("change");
                // set state
-               $("#dropdown_state'.$rand_state.'").select2("val", data.state);
+               $("#dropdown_state'.$rand_state.'").val(data.state).trigger("change");
             });
          }
       ');

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1432,17 +1432,36 @@ abstract class CommonITILTask  extends CommonDBTM {
                   tasktinymce.setContent(data.content.replace(/\r?\n/g, "<br />"));
                }
                // set category
-               console.log(taskcategories_id);
-               console.log($("#dropdown_taskcategories_id'.$rand_type.'"));
-               $("#dropdown_taskcategories_id'.$rand_type.'").val(taskcategories_id).trigger("change");
+               if ($("#dropdown_taskcategories_id'.$rand_type.'").find("option[value=\'" + taskcategories_id + "\']").length) {
+                  $("#dropdown_taskcategories_id'.$rand_type.'").val(taskcategories_id).trigger("change");
+               } else {
+                  // Create a DOM Option and pre-select by default
+                  var newOption = new Option(data.taskcategories_name, taskcategories_id, true, true);
+                  // Append it to the select
+                  $("#dropdown_taskcategories_id'.$rand_type.'").append(newOption).trigger("change");
+               }
                // set action time
                $("#dropdown_actiontime'.$rand_time.'").val(actiontime).trigger("change");
                // set is_private
                $("#dropdown_is_private'.$rand_is_private.'").val(data.is_private).trigger("change");
                // set users_tech
-               $("#dropdown_users_id_tech'.$rand_user.'").val(user_tech).trigger("change");
+               if ($("#dropdown_users_id_tech'.$rand_user.'").find("option[value=\'" + user_tech + "\']").length) {
+                  $("#dropdown_users_id_tech'.$rand_user.'").val(user_tech).trigger("change");
+               } else {
+                  // Create a DOM Option and pre-select by default
+                  var newOption = new Option(data.users_id_tech_name, user_tech, true, true);
+                  // Append it to the select
+                  $("#dropdown_users_id_tech'.$rand_user.'").append(newOption).trigger("change");
+               }
                // set group_tech
-               $("#dropdown_groups_id_tech'.$rand_group.'").val(group_tech).trigger("change");
+               if ($("#dropdown_groups_id_tech'.$rand_group.'").find("option[value=\'" + group_tech + "\']").length) {
+                  $("#dropdown_groups_id_tech'.$rand_group.'").val(group_tech).trigger("change");
+               } else {
+                  // Create a DOM Option and pre-select by default
+                  var newOption = new Option(data.groups_id_tech_name, group_tech, true, true);
+                  // Append it to the select
+                  $("#dropdown_groups_id_tech'.$rand_group.'").append(newOption).trigger("change");
+               }
                // set state
                $("#dropdown_state'.$rand_state.'").val(data.state).trigger("change");
             });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3895 

This PR fixes the select2 issue (`.select2('val', value)` is deprecated).
This works for dropdowns that already have the value loaded, but not ajax loaded ones (category, user, group, ...) :/