### PR TITLE
Fix warning when display IPv4 range in history; fixes #4018

### DIFF
--- a/inc/apiclient.class.php
+++ b/inc/apiclient.class.php
@@ -157,7 +157,10 @@ class APIClient extends CommonDBTM {
 
          case 'ipv4_range_start':
          case 'ipv4_range_end':
-            return long2ip($values[$field]);
+            if (empty($values[$field])) {
+               return '';
+            }
+            return long2ip((int)$values[$field]);
       }
 
       return parent::getSpecificValueToDisplay($field, $values, $options);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4018