### PR TITLE
ipv6 field needs to be NULL instead of empty string

### DIFF
--- a/inc/apiclient.class.php
+++ b/inc/apiclient.class.php
@@ -270,6 +270,10 @@ class APIClient extends CommonDBTM {
          }
       }
 
+      if (isset($input['ipv6']) && empty($input['ipv6'])) {
+         $input['ipv6'] = "NULL";
+      }
+
       if (isset($input['_reset_app_token'])) {
          $input['app_token']      = self::getUniqueAppToken();
          $input['app_token_date'] = $_SESSION['glpi_currenttime'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

If I create or edit an API client entry and set the IP v6 field empty, the field in the database is an epoty string, but the API expects a NULL value.

If there is one API client declared, and ipv6 field is empty (not NULL) then a consumer with any address is rejected.

The PR converts empty string into NULL the same way as IP v4 range fields