### PR TITLE
softwarelicences are recursive

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -4573,9 +4573,6 @@ class CommonDBTM extends CommonGLPI {
          return false;
       }
 
-      // force template
-      $item->fields['is_template'] = true;
-
       $query = "SELECT *
                 FROM `".$item->getTable()."`
                 WHERE `is_template` = '1' ";

--- a/inc/softwarelicense.class.php
+++ b/inc/softwarelicense.class.php
@@ -463,13 +463,7 @@ class SoftwareLicense extends CommonTreeDropdown {
          return $soft->isRecursive();
       }
 
-      // when CommonDBTM::listTemplates, return true
-      if (isset($this->fields["is_template"])
-          && $this->fields["is_template"]) {
-         return true;
-      }
-
-      return false;
+      return true;
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3451

Additionaly to #3451, we detected another bug in Management > Licences list.
For a `is_recursive = 1` entry, and after switching globally to a sub entity, the entry isn't listed.

> Internal ref 13999
