### PR TITLE
fix(menu) remove old control part for fieldunicity breadcrumb

### DIFF
--- a/front/fieldunicity.php
+++ b/front/fieldunicity.php
@@ -33,8 +33,9 @@
 include ('../inc/includes.php');
 
 Session::checkRight('config', READ);
-Html::header(FieldUnicity::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "config", "control",
-             "FieldUnicity");
+
+Html::header(FieldUnicity::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "config", "fieldunicity");
 
 Search::show('FieldUnicity');
+
 Html::footer();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

GLPI 9.3, go to **Setup > Fields Uniqueness** :

Before fix :cry: 
![image](https://user-images.githubusercontent.com/470612/40547961-a2b0ed50-6033-11e8-8558-819d2f9ca91f.png)

After fix :champagne: 
![image](https://user-images.githubusercontent.com/470612/40547970-a86062bc-6033-11e8-9788-346a56b9cae7.png)
