### PR TITLE
Remove GLPI version on source code

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -4736,7 +4736,10 @@ class Html {
       $url = self::getPrefixedUrl($url);
 
       if ($version) {
-         $url .= '?v=' . $version;
+         // Calculate a token specific to the instance & the version
+         $instance = md5(Telemetry::getInstanceUuid() . GLPI_VERSION);
+         // Add the token on the URL to invalidate local cache after a GLPI update
+         $url .= '?v=' . $instance;
       }
 
       return sprintf('<link rel="stylesheet" type="text/css" href="%s" %s>', $url,

--- a/tests/units/Html.php
+++ b/tests/units/Html.php
@@ -421,7 +421,7 @@ class Html extends atoum {
       ];
       $dir = str_replace(GLPI_ROOT, '', GLPI_TMP_DIR);
       $base_expected = '<link rel="stylesheet" type="text/css" href="'.
-         $CFG_GLPI['root_doc'] . $dir .'/%url?v='. md5(Telemetry::getInstanceUuid() . GLPI_VERSION) .'" %attrs>';
+         $CFG_GLPI['root_doc'] . $dir .'/%url?v='. md5(\Telemetry::getInstanceUuid() . GLPI_VERSION) .'" %attrs>';
       $base_attrs = 'media="screen"';
 
       //create test files

--- a/tests/units/Html.php
+++ b/tests/units/Html.php
@@ -421,7 +421,7 @@ class Html extends atoum {
       ];
       $dir = str_replace(GLPI_ROOT, '', GLPI_TMP_DIR);
       $base_expected = '<link rel="stylesheet" type="text/css" href="'.
-         $CFG_GLPI['root_doc'] . $dir .'/%url?v='. GLPI_VERSION .'" %attrs>';
+         $CFG_GLPI['root_doc'] . $dir .'/%url?v='. md5(Telemetry::getInstanceUuid() . GLPI_VERSION) .'" %attrs>';
       $base_attrs = 'media="screen"';
 
       //create test files


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no (completion of an exising)
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2976 

Generate a token linked to instance & GLPI version to (securely) manage cache invalidation after glpi update
Complete the PR #3396 