### PR TITLE
Both 'Web Link' and 'Web link' does exists, use same everywhere

### DIFF
--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -404,7 +404,7 @@ class Document extends CommonDBTM {
       echo "</tr>";
 
       echo "<tr class='tab_bg_1'>";
-      echo "<td>".__('Web Link')."</td>";
+      echo "<td>".__('Web link')."</td>";
       echo "<td>";
       Html::autocompletionTextField($this, "link");
       echo "</td>";
@@ -834,7 +834,7 @@ class Document extends CommonDBTM {
          'id'                 => '4',
          'table'              => $this->getTable(),
          'field'              => 'link',
-         'name'               => __('Web Link'),
+         'name'               => __('Web link'),
          'datatype'           => 'weblink'
       ];
 

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1343,7 +1343,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
                     'document.filename'          => sprintf(__('%1$s: %2$s'), __('Document'),
                                                             __('File')),
                     'document.weblink'           => sprintf(__('%1$s: %2$s'), __('Document'),
-                                                            __('Web Link')),
+                                                            __('Web link')),
                     'document.name'              => sprintf(__('%1$s: %2$s'), __('Document'),
                                                             __('Name')),
                      $objettype.'.urldocument'   => sprintf(__('%1$s: %2$s'),

--- a/inc/notificationtargetproject.class.php
+++ b/inc/notificationtargetproject.class.php
@@ -646,7 +646,7 @@ class NotificationTargetProject extends NotificationTarget {
                     'document.filename'       => sprintf(__('%1$s: %2$s'), __('Document'),
                                                          __('File')),
                     'document.weblink'        => sprintf(__('%1$s: %2$s'), __('Document'),
-                                                         __('Web Link')),
+                                                         __('Web link')),
                     'document.name'           => sprintf(__('%1$s: %2$s'), __('Document'),
                                                          __('Name')),
                     'project.urldocument'     => sprintf(__('%1$s: %2$s'),

--- a/inc/notificationtargetprojecttask.class.php
+++ b/inc/notificationtargetprojecttask.class.php
@@ -526,7 +526,7 @@ class NotificationTargetProjectTask extends NotificationTarget {
                     'document.filename'       => sprintf(__('%1$s: %2$s'), __('Document'),
                                                          __('File')),
                     'document.weblink'        => sprintf(__('%1$s: %2$s'), __('Document'),
-                                                         __('Web Link')),
+                                                         __('Web link')),
                     'document.name'           => sprintf(__('%1$s: %2$s'), __('Document'),
                                                          __('Name')),
                     'projecttask.urldocument' => sprintf(__('%1$s: %2$s'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

This is not a string change, since "Web link" already exists.