### PR TITLE
Fix handling of existing document in rich text saving

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -4826,10 +4826,11 @@ class CommonDBTM extends CommonGLPI {
                 && ($docID > 0)
                 && isset($input[$options['content_field']])) {
 
-               $input[$options['content_field']]
-                  = preg_replace('/'.Document::getImageTag($input['_tag'][$key]).'/',
-                                 Document::getImageTag($doc->fields["tag"]),
-                                 $input[$options['content_field']]);
+               $input[$options['content_field']] = str_replace(
+                  $input['_tag'][$key],
+                  $doc->fields["tag"],
+                  $input[$options['content_field']]
+               );
                $docadded[$docID]['tag'] = $doc->fields["tag"];
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4157

Replacement was based on prefixed+suffixed tag, but prefix and suffix are removed by JS process on line https://github.com/glpi-project/glpi/blob/9.2/bugfixes/js/fileupload.js#L231.