### PR TITLE
Fix lang selector if lang is same as default; fixes #4155

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -2413,9 +2413,19 @@ class User extends CommonDBTM {
 
          if (!GLPI_DEMO_MODE) {
             $langrand = mt_rand();
-            echo "<td><label for='dropdown_language$rand'>" . __('Language') . "</label></td><td>";
-            // Use session variable because field in table may be null if same of the global config
-            Dropdown::showLanguages("language", ['value' => $this->fields["language"], 'rand' => $langrand]);
+            echo "<td><label for='dropdown_language$langrand'>" . __('Language') . "</label></td><td>";
+            // Language is stored as null in DB if value is same as the global config.
+            $language = $this->fields["language"];
+            if (null === $this->fields["language"]) {
+               $language = $CFG_GLPI['language'];
+            }
+            Dropdown::showLanguages(
+               "language",
+               [
+                  'rand'  => $langrand,
+                  'value' => $language,
+               ]
+            );
             echo "</td>";
          } else {
             echo "<td colspan='2'>&nbsp;</td>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4155 

When user uses the same lang as default one, value is not stored in DB. This fix adds empty choice display to handle this case.