### PR TITLE
fix sql mode query

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -691,8 +691,8 @@ class DBmysql {
       global $DB;
 
       $msg = 'STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,NO_AUTO_CREATE_USER';
-      $req = $DB->request("SELECT @@sql_mode as mode");
-      if (($data = $req->next())) {
+      $result = $DB->query("SELECT @@sql_mode as mode");
+      if ($data = $DB->fetch_assoc($result)) {
          return (preg_match("/STRICT_TRANS/", $data['mode'])
                  && preg_match("/NO_ZERO_/", $data['mode'])
                  && preg_match("/ONLY_FULL_GROUP_BY/", $data['mode']));


### PR DESCRIPTION
FIx this error:

```
[2018-06-13 08:36:55] glpisqllog.ERROR: DBmysql::query() in /var/www/html/glpi/9.3-git/inc/dbmysql.class.php line 181
  *** MySQL query error:
  SQL: SELECT * FROM `SELECT @@sql_mode` AS `mode`
  Error: Table 'glpi-9.3-git.SELECT @@sql_mode' doesn't exist
  Backtrace :
  inc/dbmysqliterator.class.php:78                   
  inc/dbmysql.class.php:587                          DBmysqlIterator->execute()
  inc/dbmysql.class.php:694                          DBmysql->request()
  inc/central.class.php:177                          DBmysql::isMySQLStrictMode()
  inc/central.class.php:80                           Central::showMyView()
  inc/commonglpi.class.php:478                       Central::displayTabContentForItem()
  ajax/common.tabs.php:92                            CommonGLPI::displayStandardTab()
  {"user":"2@LU002"}
```

As this query is specific mysql, i removed the usage of iterator