### PR TITLE
cleanup RPM stuff (moved to downstream.php)

### DIFF
--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -43,9 +43,7 @@ if (!empty($tz)) {
 }
 
 // If this file exists, it is load
-if (!is_dir(GLPI_ROOT. '/config') && file_exists('/etc/glpi/local_define.php')) { // Relocated (Linux only)
-   require_once '/etc/glpi/local_define.php';
-} else if (file_exists(GLPI_ROOT. '/config/local_define.php')) {
+if (file_exists(GLPI_ROOT. '/config/local_define.php')) {
    require_once GLPI_ROOT. '/config/local_define.php';
 }
 


### PR DESCRIPTION
I think this RPM specific code can be cleaned, as it make more sense to have this in the downstream.php file.

Example: see change appllied with this patch to the RPM spec file.
https://git.remirepo.net/cgit/rpms/glpi/glpi.git/commit/?id=e42ffe560f69c604c96e8b9bd254019cbd957240