### PR TITLE
Make Html::getPrefixedUrl public and final; closes #4149

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -5870,7 +5870,7 @@ class Html {
     *
     * @return string
     */
-   static private function getPrefixedUrl($url) {
+   static public final function getPrefixedUrl($url) {
       global $CFG_GLPI;
       $prefix = $CFG_GLPI['root_doc'];
       if (substr($url, 0, 1) != '/') {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4149 