### PR TITLE
Add missing getTypeName() methods; closes #4202

### DIFF
--- a/inc/olalevel_ticket.class.php
+++ b/inc/olalevel_ticket.class.php
@@ -41,6 +41,10 @@ if (!defined('GLPI_ROOT')) {
 /// Class OLALevel
 class OlaLevel_Ticket extends CommonDBTM {
 
+   static function getTypeName($nb = 0) {
+      return __('OLA level for Ticket');
+   }
+
 
    /**
     * Retrieve an item from the database

--- a/inc/purgelogs.class.php
+++ b/inc/purgelogs.class.php
@@ -36,6 +36,10 @@ if (!defined('GLPI_ROOT')) {
 
 class PurgeLogs extends CommonDBTM {
 
+   static function getTypeName($nb = 0) {
+      return __('Logs purge');
+   }
+
    static function cronPurgeLogs($task) {
       $logs_before = self::getLogsCount();
       if (self::canLaunchPurge() && $logs_before) {

--- a/inc/slalevel_ticket.class.php
+++ b/inc/slalevel_ticket.class.php
@@ -37,6 +37,10 @@ if (!defined('GLPI_ROOT')) {
 /// Class SLALevel
 class SlaLevel_Ticket extends CommonDBTM {
 
+   static function getTypeName($nb = 0) {
+      return __('SLA level for Ticket');
+   }
+
 
    /**
     * Retrieve an item from the database

--- a/inc/telemetry.class.php
+++ b/inc/telemetry.class.php
@@ -36,6 +36,10 @@ if (!defined('GLPI_ROOT')) {
 
 class Telemetry extends CommonGLPI {
 
+   static function getTypeName($nb = 0) {
+      return __('Telemetry');
+   }
+
    /**
     * Grab telemetry informations
     *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4202 

Won't be included in 9.3; since this includes new strings, and strings are freezed.