### PR TITLE
Fix reloadTab function scope

### DIFF
--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -451,19 +451,20 @@ class Ajax {
          } else {
             $js .=  "$('#tabs$rand').removeClass( 'ui-corner-top' ).addClass( 'ui-corner-left' );";
          }
+         $js .= '});';
 
-         $js .=  "// force reload
+         $js .=  "// force reload global function
             function reloadTab(add) {
                forceReload$rand = true;
                var current_index = $('#tabs$rand').tabs('option','active');
                // Save tab
-               currenthref = $('#tabs$rand ul>li a').eq(current_index).attr('href');
+               var currenthref = $('#tabs$rand ul>li a').eq(current_index).attr('href');
                $('#tabs$rand ul>li a').eq(current_index).attr('href',currenthref+'&'+add);
                $('#tabs$rand').tabs( 'load' , current_index);
                // Restore tab
                $('#tabs$rand ul>li a').eq(current_index).attr('href',currenthref);
             };";
-         $js .= '});';
+
          echo Html::scriptBlock($js);
       }
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Commit 37af82b96b350fd50b10dccc897d067bc2a60da6 removed global scope of `reloadTab` function. It makes some elements not working anymore, like pagination inside a tab or log history filtering.