### PR TITLE
Fix new version check; fixes #4221

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1577,11 +1577,16 @@ class Html {
          echo "</span></td>";
       }
 
-      if (!empty($CFG_GLPI["founded_new_version"])) {
+      $currentVersion = preg_replace('/^((\d+\.?)+).*$/', '$1', GLPI_VERSION);
+      $foundedNewVersion = array_key_exists('founded_new_version', $CFG_GLPI)
+         ? $CFG_GLPI['founded_new_version']
+         : '';
+      if (!empty($foundedNewVersion) && version_compare($currentVersion, $foundedNewVersion, '<')) {
          echo "<td class='copyright'>";
-         $latest_version = "<a href='http://www.glpi-project.org' target='_blank' title=\"".
-                              __s('You will find it on the GLPI-PROJECT.org site.')."\"> ".
-                           preg_replace('/0$/', '', $CFG_GLPI["founded_new_version"])."</a>";
+         $latest_version = "<a href='http://www.glpi-project.org' target='_blank' title=\""
+             . __s('You will find it on the GLPI-PROJECT.org site.')."\"> "
+             . $foundedNewVersion
+             . "</a>";
          printf(__('A new version is available: %s.'), $latest_version);
 
          echo "</td>";

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -1415,10 +1415,7 @@ class Toolbox {
 
       } else {
          if (version_compare($CFG_GLPI["version"], $latest_version, '<')) {
-            $config_object                = new Config();
-            $input["id"]                  = 1;
-            $input["founded_new_version"] = $latest_version;
-            $config_object->update($input);
+            Config::setConfigurationValues('core', ['founded_new_version' => $latest_version]);
 
             if (!$auto) {
                if ($messageafterredirect) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4221 

1. Fixes `founded_new_version` value update.
2. Remove display of "New version available" if `founded_new_version` is not greater than current version. This is an edge case that can only happens if update process and check process are runned at the same time and check process overwrite `founded_new_version` value saved by update process.