### PR TITLE
Ensure return higher error code

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2583,7 +2583,9 @@ class Config extends CommonDBTM {
                  "<p class='red'>".__('The file could not be created.')."</p>".
                  sprintf(__('Check permissions to the directory: %s'), GLPI_LOG_DIR)."</td></tr>";
          }
-         $error = 1;
+         if ($error == 0) {
+            $error = 1;
+         }
       }
 
       $check_access = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

On install, if directories were not writable, error code returned was always 1.

Not sure if we should not return 2 in that case.