### PR TITLE
Fix migration issue while renaming queuedmail to queuednotification

### DIFF
--- a/install/update_92_921.php
+++ b/install/update_92_921.php
@@ -299,6 +299,11 @@ function update92to921() {
    $migration->addPreQuery("UPDATE `glpi_crontasks`
                              SET `name` = 'queuednotificationclean'
                              WHERE `name` = 'queuedmailclean'");
+   $migration->addPreQuery("DELETE `duplicated` FROM `glpi_profilerights` AS `duplicated`
+                            INNER JOIN `glpi_profilerights` AS `original`
+                            WHERE `duplicated`.`profiles_id` = `original`.`profiles_id`
+                            AND `original`.`name` = 'queuednotification'
+                            AND `duplicated`.`name` = 'queuedmail'");
    $migration->addPreQuery("UPDATE `glpi_profilerights`
                              SET `name` = 'queuednotification'
                              WHERE `name` = 'queuedmail'");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I do not know why, but I had the case where a right exists at the same time for `queuednotification` (new naming) and `queuedmail` (old naming) for a same profile. Migration from 9.2 to 9.2.1 fails with this error `Erreur durant l'éxecution de la requête : UPDATE glpi_profilerights SET name = 'queuednotification' WHERE name = 'queuedmail' - L'erreur est Duplicate entry '6-queuednotification' for key 'unicity'`.

This patch removes rights with old naming if one with new naming already exists for same profile.