### PR TITLE
fix user creation or update with email address

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -1234,7 +1234,9 @@ class User extends CommonDBTM {
       }
 
       if ($userUpdated) {
-         $this->update(['id' => $this->fields['id'], 'date_mod' => $_SESSION['glpi_currenttime']]);
+         // calling $this->update() here leads to loss in $this->input
+         $user = new User();
+         $user->update(['id' => $this->fields['id'], 'date_mod' => $_SESSION['glpi_currenttime']]);
       }
    }
 
@@ -1303,7 +1305,9 @@ class User extends CommonDBTM {
       }
 
       if ($userUpdated) {
-         $this->update(['id' => $this->fields['id'], 'date_mod' => $_SESSION['glpi_currenttime']]);
+         // calling $this->update() here leads to loss in $this->input
+         $user = new User();
+         $user->update(['id' => $this->fields['id'], 'date_mod' => $_SESSION['glpi_currenttime']]);
       }
    }
 


### PR DESCRIPTION
bug introduced in commit a4bca634e4d055cdd6576000d8d0f2b89b0dcd9

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

Fixes a regression in https://github.com/glpi-project/glpi/commit/a4bca634e4d055cdd6576000d8d0f2b89b0dcd91

I observed that when a user is created with an email address and a default profile and defautl entity the habilitations are not propermy set.
The issue is in  User::post_addItem(). At its very beginning this method calls updateUserEmails()  which may call $this->update().

If an update occurs in in updateUserEmails() then $this->input is altered by CommonDBTM::update() and leads to a loss of information. The remaining of User::post_addItem() cannot process properly the default profile and default entity, leading in some cases in bad configuration of habilitation.

Solution in this PR: change updateUserEmails() in order to call User::update() from an other instance of User().

Other possible solution : backup and restore $this->input 