### PR TITLE
Add error when adding no contract to license

### DIFF
--- a/front/contract_item.form.php
+++ b/front/contract_item.form.php
@@ -43,6 +43,13 @@ Session::checkCentralAccess();
 $contract_item   = new Contract_Item();
 
 if (isset($_POST["add"])) {
+   if (!isset($_POST['contracts_id']) || empty($_POST['contracts_id'])) {
+      $message = sprintf(__('Mandatory fields are not filled. Please correct: %s'),
+                         _n('Contract', 'Contract', 1));
+      Session::addMessageAfterRedirect($message, false, ERROR);
+      Html::back();
+   }
+   
    $contract_item->check(-1, CREATE, $_POST);
    if ($contract_item->add($_POST)) {
       Event::log($_POST["contracts_id"], "contracts", 4, "financial",


### PR DESCRIPTION
Software license form previously displayed a rights error instead of an error about not selecting a contract.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1506 