### PR TITLE
Fix entities in infocom creation addin purchase date from mass actions

### DIFF
--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -1113,8 +1113,10 @@ class MassiveAction {
                                 && in_array($link_entity_type,
                                             getAncestorsOf("glpi_entities",
                                                            $item->getEntityID())))) {
-                           $input2["items_id"] = $key;
-                           $input2["itemtype"] = $item->getType();
+                           $input2 = [
+                              'items_id'  => $key,
+                              'itemtype'  => $item->getType()
+                           ];
 
                            if ($ic->can(-1, CREATE, $input2)) {
                               // Add infocom if not exists


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

To reproduce: create two monitors in two different entities; and add a purchase date on both of them from massive actions (implies infocom are not activated yet). Doing this, entities_id in the infocom table is the one of the first selected monitor.

This is because `$input2` array is created on the first loop iteration, and not reset after.