### PR TITLE
Profile KnowbaseItem naming special case

### DIFF
--- a/inc/commondbvisible.class.php
+++ b/inc/commondbvisible.class.php
@@ -276,7 +276,12 @@ abstract class CommonDBVisible extends CommonDBTM {
                echo "<tr class='tab_bg_1'>";
                if ($canedit) {
                   echo "<td>";
-                  Html::showMassiveActionCheckBox('Profile_' . $this::getType(), $data["id"]);
+                  //Knowledgebase-specific case
+                  if ($this::getType() === "KnowbaseItem") {
+                     Html::showMassiveActionCheckBox($this::getType() . '_Profile', $data["id"]);
+                  } else {
+                     Html::showMassiveActionCheckBox('Profile_' . $this::getType(), $data["id"]);
+                  }
                   echo "</td>";
                }
                echo "<td>"._n('Profile', 'Profiles', 1)."</td>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #4337 

Add special case for knowledgebaseitem due to class naming scheme oddity.
Actual: KnowbaseItem_Profile
Expected and the scheme for other itemtypes: Profile_KnowbaseItem