### PR TITLE
fix call to undefined method DB::quoteField, fix #4364

### DIFF
--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -403,8 +403,13 @@ class DBmysqlIterator implements Iterator, Countable {
             $ret .= " $bool ";
          }
          if (is_numeric($name)) {
-            // No Key case => recurse.
-            $ret .= "(" . $this->analyseCrit($value, $bool) . ")";
+            // no key and direct expression
+            if ($value instanceof QueryExpression) {
+               $ret .= $value->getValue();
+            } else {
+               // No Key case => recurse.
+               $ret .= "(" . $this->analyseCrit($value, $bool) . ")";
+            }
 
          } else if (($name === "OR") || ($name === "AND")) {
             // Binary logical operator

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -1418,7 +1418,11 @@ class User extends CommonDBTM {
 
                   unset($v[$i][$field]['count']);
                   foreach (Toolbox::addslashes_deep($v[$i][$field]) as $lgroup) {
-                     $lgroups[] = ['ldap_value' => $lgroup];
+                     $lgroups[] = [
+                        new \QueryExpression($DB::quoteValue($lgroup).
+                                             " LIKE ".
+                                             $DB::quoteName('ldap_value'))
+                     ];
                   }
                   $group_iterator = $DB->request([
                      'SELECT' => 'id',

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -1418,14 +1418,14 @@ class User extends CommonDBTM {
 
                   unset($v[$i][$field]['count']);
                   foreach (Toolbox::addslashes_deep($v[$i][$field]) as $lgroup) {
-                     $lgroups[] = ['LIKE', new QueryExpression($DB::quoteField('ldap_value'))];
+                     $lgroups[] = ['ldap_value' => $lgroup];
                   }
                   $group_iterator = $DB->request([
                      'SELECT' => 'id',
                      'FROM'   => 'glpi_groups',
                      'WHERE'  => [
-                        'ldap_field'   => $field,
-                        'OR'           => $lgroups
+                        'ldap_field' => $field,
+                        'OR'         => $lgroups
                      ]
                   ]);
 

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -176,9 +176,6 @@ class DBmysqlIterator extends DbTestCase {
       $it = $this->it->execute('foo', ['FIELDS' => ['b' => 'bar', '`c`' => '`baz`']]);
       $this->string($it->getSql())->isIdenticalTo('SELECT `b`.`bar`, `c`.`baz` FROM `foo`');
 
-      $it = $this->it->execute('foo', ['FIELDS' => ['b' => 'bar', '`c`' => '`baz`', new \QueryExpression('1 AS `myfield`')]]);
-      $this->string($it->getSql())->isIdenticalTo('SELECT `b`.`bar`, `c`.`baz`, 1 AS `myfield` FROM `foo`');
-
       $it = $this->it->execute('foo', ['FIELDS' => ['a' => ['`bar`', 'baz']]]);
       $this->string($it->getSql())->isIdenticalTo('SELECT `a`.`bar`, `a`.`baz` FROM `foo`');
 
@@ -550,5 +547,13 @@ class DBmysqlIterator extends DbTestCase {
          ]
       ]);
       $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `bar` AS `b` INNER JOIN `foo` AS `f` ON (`b`.`fid` = `f`.`id`)');
+   }
+
+   public function testExpression() {
+      $it = $this->it->execute('foo', [new \QueryExpression('a LIKE b')]);
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE a LIKE b');
+
+      $it = $this->it->execute('foo', ['FIELDS' => ['b' => 'bar', '`c`' => '`baz`', new \QueryExpression('1 AS `myfield`')]]);
+      $this->string($it->getSql())->isIdenticalTo('SELECT `b`.`bar`, `c`.`baz`, 1 AS `myfield` FROM `foo`');
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4364

Reading the previous code before https://github.com/glpi-project/glpi/commit/155cc60fd56ea747854cd100cf726129f269704d#diff-a9c4448deb6265f035355e2a9ca92bc0L1408, i think the LIKE part is completly useless.


By the way the new line in above commit was not equivalent to previous, it miss to include $lgroup in expression.
