### PR TITLE
Fix "notable" check on CommonBDTM::getTable() using specific $classname

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -193,12 +193,13 @@ class CommonDBTM extends CommonGLPI {
     * @return string
    **/
    static function getTable($classname = null) {
-      if (static::$notable) {
-         return '';
-      }
 
       if ($classname === null) {
          $classname = get_called_class();
+      }
+
+      if (!class_exists($classname) || $classname::$notable) {
+         return '';
       }
 
       if (empty($_SESSION['glpi_table_of'][$classname])) {

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -192,4 +192,33 @@ class CommonDBTM extends DbTestCase {
       $this->boolean($comp->getEmpty())->isFalse();
       unset($_SESSION['glpi_table_of']);*/
    }
+
+   /**
+    * Provider for self::testGetTable().
+    *
+    * @return array
+    */
+   protected function getTableProvider() {
+
+      return [
+         [\DBConnection::class, ''], // "static protected $notable = true;" case
+         [\Item_Devices::class, ''], // "static protected $notable = true;" case
+         [\Config::class, 'glpi_configs'],
+         [\Computer::class, 'glpi_computers'],
+         [\User::class, 'glpi_users'],
+      ];
+   }
+
+   /**
+    * Test CommonDBTM::getTable() method.
+    *
+    * @dataProvider getTableProvider
+    * @return void
+    */
+   public function testGetTable($classname, $tablename) {
+
+      $this->string($classname::getTable())
+         ->isEqualTo(\CommonDBTM::getTable($classname))
+         ->isEqualTo($tablename);
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If CommonDBTM::getTable() is used with $classname param from a class having $notable variable set to true, il will always return an empty string, even if requested classname has $notable flag set to false.