### PR TITLE
Fix undefined $toadd on solution update

### DIFF
--- a/front/itilsolution.form.php
+++ b/front/itilsolution.form.php
@@ -65,7 +65,7 @@ if (isset($_POST["add"])) {
    $solution->check($_POST['id'], UPDATE);
    $solution->update($_POST);
    $handled = true;
-   $redirect = $track->getLinkURL() . $toadd;
+   $redirect = $track->getLinkURL();
 
    Event::log($_POST["id"], "solution", 4, "tracking",
               //TRANS: %s is the user login


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When updating a solution, following notice is triggered:
```
[2018-07-27 09:12:11] glpiphplog.ERROR: Toolbox::userErrorHandlerNormal() in /var/www/glpi/inc/toolbox.class.php line 657
  *** PHP Notice(8): Undefined variable: toadd
  Backtrace :
  front/itilsolution.form.php:68                     
  {"user":"2@87e8d9f523bd"}
```