### PR TITLE
Fix images in changes, problems and tickets notifications; fixes #4345

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -5633,17 +5633,18 @@ class Html {
                   }
                   // Replace tags by image in textarea
                   if ($addLink) {
-                     $out .= '<a href="'.$glpi_root.
-                             '/front/document.send.php?docid='.$id.$more_link.
-                             '" target="_blank"><img alt="'.$image['tag'].
-                             '" width="'.$width.
-                             '" src="'.$glpi_root.
-                        '/front/document.send.php?docid='.$id.$more_link.'" /></a>';
-                  } else {
-                     $out .= '<img alt="'.$image['tag'].
-                             '" width="'.$width.
-                             '" src="'.$glpi_root.
-                             '/front/document.send.php?docid='.$id.$more_link.'" />';
+                     $out .= '<a '
+                             . 'href="' . $glpi_root . '/front/document.send.php?docid=' . $id . $more_link . '" '
+                             . 'target="_blank" '
+                             . '>';
+                  }
+                  $out .= '<img '
+                          . 'alt="' . $image['tag'] . '" '
+                          . 'width="' . $width . '" '
+                          . 'src="' . $glpi_root . '/front/document.send.php?docid=' . $id.$more_link . '" '
+                          . '/>';
+                  if ($addLink) {
+                     $out .= '</a>';
                   }
                }
             }

--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -234,6 +234,14 @@ class ITILSolution extends CommonDBTM {
          echo "<textarea id='content$rand' name='content' rows='12' cols='80'>".
                 $this->getField('content')."</textarea></div>";
 
+         // Hide file input to handle only images pasted in text editor
+         echo '<div style="display:none;">';
+         Html::file(['editor_id' => "content$rand",
+                     'filecontainer' => "filecontainer$rand",
+                     'onlyimages' => true,
+                     'showtitle' => false,
+                     'multiple' => true]);
+         echo '</div>';
       } else {
          echo Toolbox::unclean_cross_side_scripting_deep($this->getField('content'));
       }
@@ -302,6 +310,10 @@ class ITILSolution extends CommonDBTM {
    }
 
    function post_addItem() {
+
+      // Replace inline pictures
+      $this->input = $this->addFiles($this->input, ['force_update' => true]);
+
       //adding a solution mean the ITIL object is now solved
       //and maybe closed (according to entitiy configuration)
       if ($this->item == null) {
@@ -331,6 +343,18 @@ class ITILSolution extends CommonDBTM {
       if ($this->item->getType() == 'Ticket' && !isset($this->input['_linked_ticket'])) {
          Ticket_Ticket::manageLinkedTicketsOnSolved($this->item->getID(), $this);
       }
+   }
+
+
+   /**
+    * @see CommonDBTM::prepareInputForUpdate()
+   **/
+   function prepareInputForUpdate($input) {
+
+      // Replace inline pictures
+      $input = $this->addFiles($input);
+
+      return $input;
    }
 
    /**

--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -139,7 +139,7 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
 
          if (empty($current->fields['body_html'])) {
             $mmail->isHTML(false);
-            $mmail->Body = $current->fields['body_text'];
+            $mmail->Body = GLPIMailer::normalizeBreaks($current->fields['body_text']);
          } else {
             $mmail->isHTML(true);
             $mmail->Body = '';
@@ -236,14 +236,14 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                      '/src=["\'][^"\']*document\.send\.php\?docid='.$docID.'[^"\']*["\']/',
                      '/href=["\'][^"\']*document\.send\.php\?docid='.$docID.'[^"\']*["\']/',
                   ], [
-                     "src=\"cid:$tag\"",
-                     "href='".$CFG_GLPI['url_base']."/front/document.send.php?docid=$docID'",
+                     'src="cid:' . $tag . '"',
+                     'href="' . $CFG_GLPI['url_base'] . '/front/document.send.php?docid=' . $docID . '"',
                   ],
                   $current->fields['body_html']);
             }
 
-            $mmail->Body   .= $current->fields['body_html'];
-            $mmail->AltBody = $current->fields['body_text'];
+            $mmail->Body    = GLPIMailer::normalizeBreaks($current->fields['body_html']);
+            $mmail->AltBody = GLPIMailer::normalizeBreaks($current->fields['body_text']);
          }
 
          $recipient = $current->getField('recipient');

--- a/inc/notificationtargetchange.class.php
+++ b/inc/notificationtargetchange.class.php
@@ -44,9 +44,6 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject {
 
    public $private_profiles = [];
 
-   public $html_tags        = ['##change.solution.description##'];
-
-
    /**
     * Get events related to tickets
    **/

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1010,9 +1010,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
             );
          }
 
-         $data["##$objettype.solution.description##"] = Toolbox::unclean_cross_side_scripting_deep(
-            $itilsolution->getField('content')
-         );
+         $data["##$objettype.solution.description##"] = $itilsolution->getField('content');
       }
 
       // Complex mode

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -36,6 +36,16 @@ if (!defined('GLPI_ROOT')) {
 
 abstract class NotificationTargetCommonITILObject extends NotificationTarget {
 
+   public $html_tags        = [
+      '##change.solution.description##',
+      '##followup.description##',
+      '##linkedticket.content##',
+      '##problem.solution.description##',
+      '##ticket.content##',
+      '##ticket.description##',
+      '##ticket.solution.description##'
+   ];
+
    /**
     * @param $entity          (default '')
     * @param $event           (default '')

--- a/inc/notificationtargetproblem.class.php
+++ b/inc/notificationtargetproblem.class.php
@@ -42,9 +42,6 @@ class NotificationTargetProblem extends NotificationTargetCommonITILObject {
 
    public $private_profiles = [];
 
-   public $html_tags        = ['##problem.solution.description##'];
-
-
    /**
     * Get events related to tickets
    **/

--- a/inc/notificationtargetticket.class.php
+++ b/inc/notificationtargetticket.class.php
@@ -41,12 +41,8 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject {
 
    public $private_profiles = [];
 
-   public $html_tags        = ['##ticket.content##', '##ticket.description##', '##ticket.solution.description##'];
-
    const HEADERTAG = '=-=-=-=';
    const FOOTERTAG = '=_=_=_=';
-
-
 
    /**
     * @param $entity          (default '')
@@ -522,7 +518,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject {
          if (count($problems)) {
             $problem = new Problem();
             foreach ($problems as $row) {
-               if ($problem->getFromDB($data['problems_id'])) {
+               if ($problem->getFromDB($row['problems_id'])) {
                   $tmp = [];
 
                   $tmp['##problem.id##']

--- a/inc/notificationtargetticket.class.php
+++ b/inc/notificationtargetticket.class.php
@@ -41,7 +41,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject {
 
    public $private_profiles = [];
 
-   public $html_tags        = ['##ticket.solution.description##'];
+   public $html_tags        = ['##ticket.content##', '##ticket.description##', '##ticket.solution.description##'];
 
    const HEADERTAG = '=-=-=-=';
    const FOOTERTAG = '=_=_=_=';

--- a/inc/notificationtemplate.class.php
+++ b/inc/notificationtemplate.class.php
@@ -272,8 +272,8 @@ class NotificationTemplate extends CommonDBTM {
             // Decode html chars to have clean text
             $template_datas['content_text']
                                        = Html::entity_decode_deep($template_datas['content_text']);
-            $save_data                 = $data;
             $data                      = Html::entity_decode_deep($data);
+            $save_data                 = $data;
 
             $template_datas['subject'] = Html::entity_decode_deep($template_datas['subject']);
             $this->signature           = Html::entity_decode_deep($this->signature);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4345 

Inline images were not correctly handled in solution, and pasting was not working in most cases.
I added the file field to enable JS handling of image pasting and added the call to `addFiles` method which replaces inline images by the stored image.