### PR TITLE
fix(calendar): fix timezone from begin and end date

### DIFF
--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -2188,8 +2188,15 @@ class Planning extends CommonGLPI {
             }
 
             $vevent['UID']     = $uid;
-            $vevent['DTSTART'] = new \DateTime($val["begin"]);
-            $vevent['DTEND']   = new \DateTime($val["end"]);
+
+            $dateBegin = new DateTime($val["begin"]);
+            $dateBegin->setTimeZone(new DateTimeZone('UTC'));
+
+            $dateEnd = new DateTime($val["end"]);
+            $dateEnd->setTimeZone(new DateTimeZone('UTC'));
+
+            $vevent['DTSTART'] = $dateBegin;
+            $vevent['DTEND']   = $dateEnd;
 
             if (isset($val["tickets_id"])) {
                $summary = sprintf(__('Ticket #%1$s %2$s'), $val["tickets_id"], $val["name"]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

When exporting ical, Outlook misconstrues the TZID directive, resulting a time shift.
The idea is to include in the start and end timestamp the UTC time zone