### PR TITLE
Feature/deprecate non array conds

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -543,10 +543,14 @@ abstract class API extends CommonGLPI {
           && in_array($itemtype, Item_Devices::getConcernedItems())) {
          $all_devices = [];
          foreach (Item_Devices::getItemAffinities($item->getType()) as $device_type) {
-            $found_devices = getAllDatasFromTable($device_type::getTable(),
-                                                  "`items_id` = '".$item->getID()."'
-                                                   AND `itemtype` = '".$item->getType()."'
-                                                   AND `is_deleted` = 0", true);
+            $found_devices = getAllDatasFromTable(
+               $device_type::getTable(), [
+                  'items_id'     => $item->getID(),
+                  'itemtype'     => $item->getType(),
+                  'is_deleted'   => 0
+               ],
+               true
+            );
 
             foreach ($found_devices as $devices_id => &$device) {
                unset($device['items_id']);
@@ -910,9 +914,12 @@ abstract class API extends CommonGLPI {
          if (!Session::haveRight($itemtype::$rightname, READNOTE)) {
             $fields['_logs'] = self::arrayRightError();
          } else {
-            $fields['_logs'] = getAllDatasFromTable("glpi_logs",
-                                                    "`items_id` = '".$item->getID()."'
-                                                    AND `itemtype` = '".$item->getType()."'");
+            $fields['_logs'] = getAllDatasFromTable(
+               "glpi_logs", [
+                  'items_id'  => $item->getID(),
+                  'itemtype'  => $item->getType()
+               ]
+            );
          }
       }
 

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -543,8 +543,10 @@ class Auth extends CommonGLPI {
    function getAuthMethods() {
 
       //Return all the authentication methods in an array
-      $this->authtypes = ['ldap' => getAllDatasFromTable('glpi_authldaps'),
-                               'mail' => getAllDatasFromTable('glpi_authmails')];
+      $this->authtypes = [
+         'ldap' => getAllDatasFromTable('glpi_authldaps'),
+         'mail' => getAllDatasFromTable('glpi_authmails')
+      ];
    }
 
    /**
@@ -623,7 +625,7 @@ class Auth extends CommonGLPI {
                      $ldapservers[] = $authldap->fields;
                   }
                } else { // User has never beeen authenticated : try all active ldap server to find the right one
-                  foreach (getAllDatasFromTable('glpi_authldaps', "`is_active`='1'") as $ldap_config) {
+                  foreach (getAllDatasFromTable('glpi_authldaps', ['is_active' => 1]) as $ldap_config) {
                      $ldapservers[] = $ldap_config;
                   }
                }

--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -2593,7 +2593,7 @@ class AuthLDAP extends CommonDBTM {
     * @return array
     */
    static function getLdapServers() {
-      return getAllDatasFromTable('glpi_authldaps', '', false, '`is_default` DESC');
+      return getAllDatasFromTable('glpi_authldaps', [], false, '`is_default` DESC');
    }
 
 

--- a/inc/blacklist.class.php
+++ b/inc/blacklist.class.php
@@ -243,7 +243,7 @@ class Blacklist extends CommonDropdown {
    **/
    static function getBlacklistedItems($type) {
 
-      $datas = getAllDatasFromTable('glpi_blacklists', "type = '$type'");
+      $datas = getAllDatasFromTable('glpi_blacklists', ['type' => $type]);
       $items = [];
       if (count($datas)) {
          foreach ($datas as $val) {

--- a/inc/budget.class.php
+++ b/inc/budget.class.php
@@ -677,7 +677,7 @@ class Budget extends CommonDropdown{
       echo "</tr>";
 
       // get all entities ordered by names
-      $allentities = getAllDatasFromTable('glpi_entities', '', true, 'completename');
+      $allentities = getAllDatasFromTable('glpi_entities', [], true, 'completename');
 
       foreach ($allentities as $entity => $data) {
          if (isset($entities_values[$entity])) {

--- a/inc/calendarsegment.class.php
+++ b/inc/calendarsegment.class.php
@@ -131,12 +131,21 @@ class CalendarSegment extends CommonDBChild {
       global $DB;
 
       // Do not check hour if day before the end day of after the begin day
-      return getAllDatasFromTable('glpi_calendarsegments',
-                                  "`calendars_id` = '$calendars_id'
-                                    AND `day` >= '$begin_day'
-                                    AND `day` <= '$end_day'
-                                    AND (`begin` < '$end_time' OR `day` < '$end_day')
-                                    AND ('$begin_time' < `end` OR `day` > '$begin_day')");
+      return getAllDatasFromTable(
+         'glpi_calendarsegments', [
+            'calendars_id' => $calendars_id,
+            ['day'          => ['>=', $begin_day]],
+            ['day'          => ['<=', $end_day]],
+            ['OR'          => [
+               'begin'  => ['<', $end_time],
+               'day'    => ['<', $end_day]
+            ]],
+            ['OR'          => [
+               'end'    => ['>=', $begin_time],
+               'day'    => ['>', $begin_day]
+            ]]
+         ]
+      );
    }
 
 

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -4033,7 +4033,7 @@ class CommonDBTM extends CommonGLPI {
 
             //If there's fields to check
             if (!empty($fields) && !empty($fields['fields'])) {
-               $where    = "";
+               $where    = [];
                $continue = true;
                foreach (explode(',', $fields['fields']) as $field) {
                   if (isset($this->input[$field]) //Field is set
@@ -4045,32 +4045,31 @@ class CommonDBTM extends CommonGLPI {
                               && ($this->input[$field] > 0)))
                       && !Fieldblacklist::isFieldBlacklisted(get_class($this), $entities_id, $field,
                                                              $this->input[$field])) {
-                     $where .= " AND `".$this->getTable()."`.`$field` = '".$this->input[$field]."'";
+                     $where[$this->getTable() . '.' . $field] = $this->input[$field];
                   } else {
                      $continue = false;
                   }
                }
 
                if ($continue
-                   && ($where != '')) {
+                   && count($where)) {
                   $entities = $fields['entities_id'];
                   if ($fields['is_recursive']) {
                      $entities = getSonsOf('glpi_entities', $fields['entities_id']);
                   }
-                  $where_global = getEntitiesRestrictRequest(" AND", $this->getTable(), '',
-                                                             $entities);
+                  $where[] = getEntitiesRestrictCriteria($this->getTable(), '', $entities);
 
                   $tmp = clone $this;
                   if ($tmp->maybeTemplate()) {
-                     $where_global .= " AND `is_template` = 0";
+                     $where['is_template'] = 0;
                   }
 
                   //If update, exclude ID of the current object
                   if (!$add) {
-                     $where .= " AND `".$this->getTable()."`.`id` NOT IN (".$this->input['id'].") ";
+                     $where['NOT'] = [$this->getTable() . '.id' => $this->input['id']];
                   }
 
-                  if (countElementsInTable($this->getTable(), "1 $where $where_global") > 0) {
+                  if (countElementsInTable($this->getTable(), $where) > 0) {
                      if ($p['unicity_error_message']
                          || $p['add_event_on_duplicate']) {
                         $message = [];
@@ -4078,8 +4077,7 @@ class CommonDBTM extends CommonGLPI {
                            $message[$field] = $this->input[$field];
                         }
 
-                        $doubles      = getAllDatasFromTable($this->gettable(),
-                                                             "1 $where $where_global");
+                        $doubles      = getAllDatasFromTable($this->getTable(), $where);
                         $message_text = $this->getUnicityErrorMessage($message, $fields, $doubles);
                         if ($p['unicity_error_message']) {
                            if (!$fields['action_refuse']) {
@@ -4103,15 +4101,16 @@ class CommonDBTM extends CommonGLPI {
                         $result = false;
                      }
                      if ($fields['action_notify']) {
-                        $params = ['action_type' => $add,
-                                        'action_user' => getUserName(Session::getLoginUserID()),
-                                        'entities_id' => $entities_id,
-                                        'itemtype'    => get_class($this),
-                                        'date'        => $_SESSION['glpi_currenttime'],
-                                        'refuse'      => $fields['action_refuse'],
-                                        'label'       => $message,
-                                        'field'       => $fields,
-                                        'double'      => $doubles];
+                        $params = [
+                           'action_type' => $add,
+                           'action_user' => getUserName(Session::getLoginUserID()),
+                           'entities_id' => $entities_id,
+                           'itemtype'    => get_class($this),
+                           'date'        => $_SESSION['glpi_currenttime'],
+                           'refuse'      => $fields['action_refuse'],
+                           'label'       => $message,
+                           'field'       => $fields,
+                           'double'      => $doubles];
                         NotificationEvent::raiseEvent('refuse', new FieldUnicity(), $params);
                      }
                   }

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -486,17 +486,20 @@ abstract class CommonITILObject extends CommonDBTM {
       $itemfk    = $this->getForeignKeyField();
       $linktable = $linkclass->getTable();
 
-      return countElementsInTable([$itemtable,$linktable],
-                                  getEntitiesRestrictRequest("", $itemtable)."
-                                    AND `$linktable`.`$itemfk` = `$itemtable`.`id`
-                                    AND `$linktable`.`users_id` = '$users_id'
-                                    AND `$linktable`.`type` = '".CommonITILActor::REQUESTER."'
-                                    AND `$itemtable`.`is_deleted` = 0
-                                    AND `$itemtable`.`status`
-                                       NOT IN ('".implode("', '",
-                                                          array_merge($this->getSolvedStatusArray(),
-                                                                      $this->getClosedStatusArray())
-                                                          )."')");
+      return countElementsInTable(
+         [$itemtable, $linktable], [
+            "$linktable.$itemfk"    => new \QueryExpression("`$itemtable`.`id`"),
+            "$linktable.users_id"   => $users_id,
+            "$linktable.type"       => CommonITILActor::REQUESTER,
+            "$itemtable.is_deleted" => 0,
+            "NOT"                   => [
+               "$itemtable.status" => array_merge(
+                  $this->getSolvedStatusArray(),
+                  $this->getClosedStatusArray()
+               )
+            ]
+         ] + getEntitiesRestrictCriteria($itemtable)
+      );
    }
 
 
@@ -517,17 +520,20 @@ abstract class CommonITILObject extends CommonDBTM {
       $itemfk    = $this->getForeignKeyField();
       $linktable = $linkclass->getTable();
 
-      return countElementsInTable([$itemtable,$linktable],
-                                  getEntitiesRestrictRequest("", $itemtable)."
-                                    AND `$linktable`.`$itemfk` = `$itemtable`.`id`
-                                    AND `$linktable`.`users_id` = '$users_id'
-                                    AND `$linktable`.`type` = '".CommonITILActor::ASSIGN."'
-                                    AND `$itemtable`.`is_deleted` = 0
-                                    AND `$itemtable`.`status`
-                                       NOT IN ('".implode("', '",
-                                                          array_merge($this->getSolvedStatusArray(),
-                                                                      $this->getClosedStatusArray())
-                                                          )."')");
+      return countElementsInTable(
+         [$itemtable, $linktable], [
+            "$linktable.$itemfk"    => new \QueryExpression("`$itemtable`.`id`"),
+            "$linktable.users_id"   => $users_id,
+            "$linktable.type"       => CommonITILActor::ASSIGN,
+            "$itemtable.is_deleted" => 0,
+            "NOT"                   => [
+               "$itemtable.status" => array_merge(
+                  $this->getSolvedStatusArray(),
+                  $this->getClosedStatusArray()
+               )
+            ]
+         ] + getEntitiesRestrictCriteria($itemtable)
+      );
    }
 
 
@@ -548,17 +554,20 @@ abstract class CommonITILObject extends CommonDBTM {
       $itemfk    = $this->getForeignKeyField();
       $linktable = $linkclass->getTable();
 
-      return countElementsInTable([$itemtable,$linktable],
-                                  getEntitiesRestrictRequest("", $itemtable)."
-                                    AND `$linktable`.`$itemfk` = `$itemtable`.`id`
-                                    AND `$linktable`.`groups_id` = '$groups_id'
-                                    AND `$linktable`.`type` = '".CommonITILActor::ASSIGN."'
-                                    AND `$itemtable`.`is_deleted` = 0
-                                    AND `$itemtable`.`status`
-                                       NOT IN ('".implode("', '",
-                                                          array_merge($this->getSolvedStatusArray(),
-                                                                      $this->getClosedStatusArray())
-                                                          )."')");
+      return countElementsInTable(
+         [$itemtable, $linktable], [
+            "$linktable.$itemfk"    => new \QueryExpression("`$itemtable`.`id`"),
+            "$linktable.groups_id"  => $groups_id,
+            "$linktable.type"       => CommonITILActor::ASSIGN,
+            "$itemtable.is_deleted" => 0,
+            "NOT"                   => [
+               "$itemtable.status" => array_merge(
+                  $this->getSolvedStatusArray(),
+                  $this->getClosedStatusArray()
+               )
+            ]
+         ] + getEntitiesRestrictCriteria($itemtable)
+      );
    }
 
 
@@ -579,17 +588,20 @@ abstract class CommonITILObject extends CommonDBTM {
       $itemfk    = $this->getForeignKeyField();
       $linktable = $linkclass->getTable();
 
-      return countElementsInTable([$itemtable,$linktable],
-                                  getEntitiesRestrictRequest("", $itemtable)."
-                                    AND `$linktable`.`$itemfk` = `$itemtable`.`id`
-                                    AND `$linktable`.`suppliers_id` = '$suppliers_id'
-                                    AND `$linktable`.`type` = '".CommonITILActor::ASSIGN."'
-                                    AND `$itemtable`.`is_deleted` = 0
-                                    AND `$itemtable`.`status`
-                                    NOT IN ('".implode("', '",
-                                                       array_merge($this->getSolvedStatusArray(),
-                                                                   $this->getClosedStatusArray())
-                                                      )."')");
+      return countElementsInTable(
+         [$itemtable, $linktable], [
+            "$linktable.$itemfk"       => new \QueryExpression("`$itemtable`.`id`"),
+            "$linktable.suppliers_id"  => $suppliers_id,
+            "$linktable.type"          => CommonITILActor::ASSIGN,
+            "$itemtable.is_deleted"    => 0,
+            "NOT"                      => [
+               "$itemtable.status" => array_merge(
+                  $this->getSolvedStatusArray(),
+                  $this->getClosedStatusArray()
+               )
+            ]
+         ] + getEntitiesRestrictCriteria($itemtable)
+      );
    }
 
 
@@ -3791,7 +3803,7 @@ abstract class CommonITILObject extends CommonDBTM {
                                         ? $options['entities_id']: $options['entity_restrict'])];
 
       //only for active ldap and corresponding right
-      $ldap_methods = getAllDatasFromTable('glpi_authldaps', '`is_active`=1');
+      $ldap_methods = getAllDatasFromTable('glpi_authldaps', ['is_active' => 1]);
       if (count($ldap_methods)
             && Session::haveRight('user', User::IMPORTEXTAUTHUSERS)) {
          $params['ldap_import'] = true;

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -179,12 +179,14 @@ abstract class CommonITILTask  extends CommonDBTM {
           && $this->canView()) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $restrict = "`".$item->getForeignKeyField()."` = '".$item->getID()."'";
+            $restrict = [$item->getForeignKeyField() => $item->getID()];
 
             if ($this->maybePrivate()
                 && !$this->canViewPrivates()) {
-               $restrict .= " AND (`is_private` = 0
-                                   OR `users_id` = '" . Session::getLoginUserID() . "') ";
+               $restrict['OR'] = [
+                  'is_private'   => 0,
+                  'users_id'     => Session::getLoginUserID()
+               ];
             }
             $nb = countElementsInTable($this->getTable(), $restrict);
          }

--- a/inc/commonitilvalidation.class.php
+++ b/inc/commonitilvalidation.class.php
@@ -200,10 +200,10 @@ abstract class CommonITILValidation  extends CommonDBChild {
       if (!$hidetab) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $restrict = "`".static::$items_id."` = '".$item->getID()."'";
+            $restrict = [static::$items_id => $item->getID()];
             // No rights for create only count asign ones
             if (!Session::haveRightsOr(static::$rightname, static::getCreateRights())) {
-               $restrict .= " AND `users_id_validate` = '".Session::getLoginUserID()."'";
+               $restrict['users_id_validate'] = Session::getLoginUserID();
             }
             $nb = countElementsInTable(static::getTable(), $restrict);
          }
@@ -1382,8 +1382,11 @@ abstract class CommonITILValidation  extends CommonDBChild {
       $statuses           = [self::ACCEPTED => 0,
                                   self::WAITING  => 0,
                                   self::REFUSED  => 0];
-      $restrict           = "`".static::$items_id."` = '".$item->getID()."'";
-      $validations        = getAllDatasFromTable(static::getTable(), $restrict);
+      $validations        = getAllDatasFromTable(
+         static::getTable(), [
+            static::$items_id => $item->getID()
+         ]
+      );
 
       if ($total = count($validations)) {
          foreach ($validations as $validation) {

--- a/inc/db.function.php
+++ b/inc/db.function.php
@@ -201,15 +201,15 @@ function countElementsInTable($table, $condition = "") {
 /**
  * Count the number of elements in a table.
  *
- * @param $table        string/array   table names
- * @param $field        string         field name
- * @param $condition    string         condition to use (default '')
+ * @param string|array $table     table names
+ * @param string       $field     field name
+ * @param array        $condition condition to use (default [])
  *
  * @return int nb of elements in table
  *
  * @deprecated 9.2 see DbUtils::countDistinctElementsInTable()
 **/
-function countDistinctElementsInTable($table, $field, $condition = "") {
+function countDistinctElementsInTable($table, $field, $condition = []) {
    $dbu = new DbUtils();
    return $dbu->countDistinctElementsInTable($table, $field, $condition);
 }
@@ -217,14 +217,14 @@ function countDistinctElementsInTable($table, $field, $condition = "") {
 /**
  * Count the number of elements in a table for a specific entity
  *
- * @param $table        string         table name
- * @param $condition    string/array   additional condition (default '') or criteria
+ * @param string $table     table name
+ * @param array  $condition additional criteria, defaults to []
  *
  * @return int nb of elements in table
  *
  * @deprecated 9.2 see DbUtils::countElementsInTableForMyEntities()
 **/
-function countElementsInTableForMyEntities($table, $condition = '') {
+function countElementsInTableForMyEntities($table, $condition = []) {
    $dbu = new DbUtils();
    return $dbu->countElementsInTableForMyEntities($table, $condition);
 }
@@ -235,14 +235,14 @@ function countElementsInTableForMyEntities($table, $condition = '') {
  *
  * @param string  $table     table name
  * @param integer $entity    the entity ID
- * @param string  $condition additional condition (default '')
+ * @param string  $condition additional condition (default [])
  * @param boolean $recursive Whether to recurse or not. If true, will be conditionned on item recursivity
  *
  * @return int nb of elements in table
  *
  * @deprecated 9.2 see DbUtils::countElementsInTableForEntity()
 **/
-function countElementsInTableForEntity($table, $entity, $condition = '', $recursive = true) {
+function countElementsInTableForEntity($table, $entity, $condition = [], $recursive = true) {
    $dbu = new DbUtils();
    return $dbu->countElementsInTableForEntity($table, $entity, $condition, $recursive);
 }
@@ -252,16 +252,16 @@ function countElementsInTableForEntity($table, $entity, $condition = '', $recurs
  * Get datas from a table in an array :
  * CAUTION TO USE ONLY FOR SMALL TABLES OR USING A STRICT CONDITION
  *
- * @param $table        string   table name
- * @param $condition    string   condition to use (default '')
- * @param $usecache     boolean  (false by default)
- * @param $order        string   result order (default '')
+ * @param string  $table     table name
+ * @param array   $condition condition to use (default [])
+ * @param boolean $usecache  Use cache (false by default)
+ * @param string  $order     result order (default '')
  *
  * @return array containing all the datas
  *
  * @deprecated 9.2 see DbUtils::getAllDataFromTable()
 **/
-function getAllDatasFromTable($table, $condition = '', $usecache = false, $order = '') {
+function getAllDatasFromTable($table, $condition = [], $usecache = false, $order = '') {
    $dbu = new DbUtils();
    return $dbu->getAllDataFromTable($table, $condition, $usecache, $order);
 }

--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -439,7 +439,7 @@ class DBmysqlIterator implements Iterator, Countable {
     * @return string
     */
    public function analyseCrit ($crit, $bool = "AND") {
-      static $operators = ['=', '<', '<=', '>', '>=', '<>', 'LIKE', 'REGEXP', 'NOT LIKE', 'NOT REGEX', '&'];
+      static $operators = ['=', '<', '<=', '>', '>=', '<>', 'LIKE', 'REGEXP', 'NOT LIKE', 'NOT REGEX', '&', '|'];
 
       if (!is_array($crit)) {
          //if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
@@ -490,7 +490,6 @@ class DBmysqlIterator implements Iterator, Countable {
          } else if (is_array($value)) {
             if (count($value) == 2
                   && isset($value[0]) && in_array($value[0], $operators, true)) {
-
                $ret .= DBmysql::quoteName($name) . " {$value[0]} " . DBmysql::quoteValue($value[1]);
             } else {
                // Array of Values

--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -483,6 +483,10 @@ class DBmysqlIterator implements Iterator, Countable {
                trigger_error("BAD FOREIGN KEY, should be [ key1, key2 ]", E_USER_ERROR);
             }
 
+         } else if ($name === 'RAW') {
+            $key = key($value);
+            $value = current($value);
+            $ret .= '((' . $key . ') = ' . $this->analyseCrit($value) . ')';
          } else if (is_array($value)) {
             if (count($value) == 2
                   && isset($value[0]) && in_array($value[0], $operators, true)) {

--- a/inc/dbutils.class.php
+++ b/inc/dbutils.class.php
@@ -320,7 +320,7 @@ final class DbUtils {
          if (empty($condition)) {
             $condition = [];
          } else {
-            //TODO throw a warning?
+            Toolbox::Deprecated('Condition should be an array!');
             $condition = ['WHERE' => $condition]; // Deprecated use case
          }
       }
@@ -346,6 +346,7 @@ final class DbUtils {
          if (empty($condition)) {
             $condition = [];
          } else {
+            Toolbox::Deprecated('Condition should be an array!');
             $condition = ['WHERE' => $condition]; // Deprecated use case
          }
       }
@@ -419,7 +420,7 @@ final class DbUtils {
     *
     * @return array containing all the datas
     */
-   public function getAllDataFromTable($table, $condition = '', $usecache = false, $order = '') {
+   public function getAllDataFromTable($table, $condition = [], $usecache = false, $order = '') {
       global $DB;
 
       static $cache = [];
@@ -434,11 +435,13 @@ final class DbUtils {
          if (empty($condition)) {
             $condition = [];
          } else {
+            Toolbox::Deprecated('Condition should be an array!');
             $condition = ['WHERE' => $condition]; // Deprecated use case
          }
       }
 
       if (!empty($order)) {
+         //Toolbox::Deprecated('Order should be defined in condition!');
          $condition['ORDER'] = $order; // Deprecated use case
       }
 

--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -1020,7 +1020,7 @@ class Item_Ticket extends CommonDBRelation{
     */
    static function getUsedItems($tickets_id) {
 
-      $data = getAllDatasFromTable('glpi_items_tickets', " `tickets_id` = ".$tickets_id);
+      $data = getAllDatasFromTable('glpi_items_tickets', ['tickets_id' => $tickets_id]);
       $used = [];
       if (!empty($data)) {
          foreach ($data as $val) {

--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -70,10 +70,12 @@ class Link extends CommonDBTM {
       if (self::canView()) {
          $nb = 0;
          if ($_SESSION['glpishow_count_on_tabs']) {
-            $restrict = "`glpi_links_itemtypes`.`links_id` = `glpi_links`.`id`
-                         AND `glpi_links_itemtypes`.`itemtype` = '".$item->getType()."'".
-                          getEntitiesRestrictRequest(" AND ", "glpi_links", '', '', false);
-            $nb = countElementsInTable(['glpi_links_itemtypes','glpi_links'], $restrict);
+            $nb = countElementsInTable(
+               ['glpi_links_itemtypes','glpi_links'], [
+                  'glpi_links_itemtypes.links_id'  => new \QueryExpression(DB::quoteName('glpi_links.id')),
+                  'glpi_links_itemtypes.itemtype'  => $item->getType()
+               ] + getEntitiesRestrictCriteria('glpi_links', '', '', false)
+            );
          }
          return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
       }

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -1879,7 +1879,7 @@ class MailCollector  extends CommonDBTM {
          $buttons["notimportedemail.php"] = __('List of not imported emails');
       }
 
-      $errors  = getAllDatasFromTable($this->getTable(), '`errors` > 0');
+      $errors  = getAllDatasFromTable($this->getTable(), ['errors' => ['>', 0]]);
       $message = '';
       if (count($errors)) {
          $servers = [];

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -1158,9 +1158,10 @@ class NetworkPort extends CommonDBChild {
          } else {
             $aliases = '';
          }
-         $nbAggregates = countElementsInTable('glpi_networkportaggregates',
-                                              "`networkports_id_list`
-                                                   LIKE '%\"".$item->getField('id')."\"%'");
+         $nbAggregates = countElementsInTable(
+            'glpi_networkportaggregates',
+            ['networkports_id_list'   => ['LIKE', '%"'.$item->getField('id').'"%']]
+         );
          if ($nbAggregates > 0) {
             $aggregates = self::createTabEntry(NetworkPortAggregate::getTypeName(Session::getPluralNumber()),
                                                $nbAggregates);

--- a/inc/notificationeventabstract.class.php
+++ b/inc/notificationeventabstract.class.php
@@ -67,7 +67,7 @@ abstract class NotificationEventAbstract {
 
          $targets = getAllDatasFromTable(
             'glpi_notificationtargets',
-            "notifications_id = {$data['id']}"
+            ['notifications_id' => $data['id']]
          );
 
          static::extraRaise([

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -341,8 +341,11 @@ class NotificationTarget extends CommonDBChild {
             list($type,$id) = explode('_', $key);
             $values[$key]   = $this->notification_targets_labels[$type][$id];
          }
-         $targets = getAllDatasFromTable('glpi_notificationtargets',
-                                         'notifications_id = '.$notifications_id);
+         $targets = getAllDatasFromTable(
+            self::getTable(), [
+               'notifications_id' => $notifications_id
+            ]
+         );
          $actives = [];
          if (count($targets)) {
             foreach ($targets as $data) {
@@ -384,8 +387,11 @@ class NotificationTarget extends CommonDBChild {
       if (!isset($input['notifications_id'])) {
          return;
       }
-      $targets = getAllDatasFromTable('glpi_notificationtargets',
-                                      'notifications_id = '.$input['notifications_id']);
+      $targets = getAllDatasFromTable(
+         self::getTable(), [
+            'notifications_id' => $input['notifications_id']
+         ]
+      );
       $actives = [];
       if (count($targets)) {
          foreach ($targets as $data) {

--- a/inc/notificationtargetchange.class.php
+++ b/inc/notificationtargetchange.class.php
@@ -91,7 +91,7 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject {
 
       // Complex mode
       if (!$simple) {
-         $restrict = "`changes_id`='".$item->getField('id')."'";
+         $restrict = ['changes_id' => $item->getField('id')];
          $tickets  = getAllDatasFromTable('glpi_changes_tickets', $restrict);
 
          $data['tickets'] = [];
@@ -114,7 +114,6 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject {
 
          $data['##change.numberoftickets##'] = count($data['tickets']);
 
-         $restrict = "`changes_id`='".$item->getField('id')."'";
          $problems = getAllDatasFromTable('glpi_changes_problems', $restrict);
 
          $data['problems'] = [];
@@ -142,7 +141,6 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject {
 
          $data['##change.numberofproblems##'] = count($data['problems']);
 
-         $restrict = "`changes_id` = '".$item->getField('id')."'";
          $items    = getAllDatasFromTable('glpi_changes_items', $restrict);
 
          $data['items'] = [];
@@ -200,15 +198,16 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject {
          $data['##change.numberofitems##'] = count($data['items']);
 
          //Validation infos
-         $restrict = "`changes_id`='".$item->getField('id')."'";
-
          if (isset($options['validation_id']) && $options['validation_id']) {
-            $restrict .= " AND `glpi_changevalidations`.`id` = '".$options['validation_id']."'";
+            $restrict['glpi_changevalidations.id'] = $options['validation_id'];
          }
 
-         $restrict .= " ORDER BY `submission_date` DESC, `id` ASC";
-
-         $validations = getAllDatasFromTable('glpi_changevalidations', $restrict);
+         $validations = getAllDatasFromTable(
+            'glpi_changevalidations',
+            $restrict,
+            false,
+            ['submission_date DESC', 'id ASC']
+         );
          $data['validations'] = [];
          foreach ($validations as $validation) {
             $tmp = [];

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1107,11 +1107,13 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
          $data["##$objettype.costtime##"]     = $costs['costtime'];
          $data["##$objettype.totalcost##"]    = $costs['totalcost'];
 
-         $restrict  = "`".$item->getForeignKeyField()."`='".$item->getField('id')."'";
+         $costs          = getAllDatasFromTable(
+            getTableForItemType($costtype),
+            [$item->getForeignKeyField() => $item->getField('id')],
+            false,
+            ['begin_date DESC', 'id ASC']
 
-         $restrict .= " ORDER BY `begin_date` DESC, `id` ASC";
-
-         $costs          = getAllDatasFromTable(getTableForItemType($costtype), $restrict);
+         );
          $data['costs'] = [];
          foreach ($costs as $cost) {
             $tmp = [];
@@ -1136,15 +1138,19 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
          //Task infos
          $tasktype = $item->getType().'Task';
          $taskobj  = new $tasktype();
-         $restrict = "`".$item->getForeignKeyField()."`='".$item->getField('id')."'";
+         $restrict = [$item->getForeignKeyField() => $item->getField('id')];
          if ($taskobj->maybePrivate()
              && (!isset($options['additionnaloption']['show_private'])
-                 || !$options['additionnaloption']['show_private'])) {
-            $restrict .= " AND `is_private` = 0";
+             || !$options['additionnaloption']['show_private'])) {
+            $restrict['is_private'] = 0;
          }
-         $restrict .= " ORDER BY `date_mod` DESC, `id` ASC";
 
-         $tasks          = getAllDatasFromTable($taskobj->getTable(), $restrict);
+         $tasks          = getAllDatasFromTable(
+            $taskobj->getTable(),
+            $restrict,
+            false,
+            ['date_mod DESC', 'id ASC']
+         );
          $data['tasks'] = [];
          foreach ($tasks as $task) {
             $tmp                          = [];

--- a/inc/notificationtargetproblem.class.php
+++ b/inc/notificationtargetproblem.class.php
@@ -74,7 +74,7 @@ class NotificationTargetProblem extends NotificationTargetCommonITILObject {
 
       // Complex mode
       if (!$simple) {
-         $restrict = "`problems_id`='".$item->getField('id')."'";
+         $restrict = ['problems_id' => $item->getField('id')];
          $tickets  = getAllDatasFromTable('glpi_problems_tickets', $restrict);
 
          $data['tickets'] = [];
@@ -103,7 +103,6 @@ class NotificationTargetProblem extends NotificationTargetCommonITILObject {
 
          $data['##problem.numberoftickets##'] = count($data['tickets']);
 
-         $restrict = "`problems_id`='".$item->getField('id')."'";
          $changes  = getAllDatasFromTable('glpi_changes_problems', $restrict);
 
          $data['changes'] = [];
@@ -131,7 +130,6 @@ class NotificationTargetProblem extends NotificationTargetCommonITILObject {
 
          $data['##problem.numberofchanges##'] = count($data['changes']);
 
-         $restrict = "`problems_id` = '".$item->getField('id')."'";
          $items    = getAllDatasFromTable('glpi_items_problems', $restrict);
 
          $data['items'] = [];

--- a/inc/notificationtargetproject.class.php
+++ b/inc/notificationtargetproject.class.php
@@ -313,7 +313,7 @@ class NotificationTargetProject extends NotificationTarget {
                                                           $item->getField('groups_id'));
       }
       // Team infos
-      $restrict = "`projects_id` = '".$item->getField('id')."'";
+      $restrict = ['projects_id' => $item->getField('id')];
       $items    = getAllDatasFromTable('glpi_projectteams', $restrict);
 
       $this->data['teammembers'] = [];
@@ -333,10 +333,7 @@ class NotificationTargetProject extends NotificationTarget {
       $this->data['##project.numberofteammembers##'] = count($this->data['teammembers']);
 
       // Task infos
-      $restrict             = "`projects_id`='".$item->getField('id')."'";
-      $restrict            .= " ORDER BY `date` DESC, `id` ASC";
-
-      $tasks                = getAllDatasFromTable('glpi_projecttasks', $restrict);
+      $tasks                = getAllDatasFromTable('glpi_projecttasks', $restrict, false, ['date DESC', 'id ASC']);
       $this->data['tasks'] = [];
       foreach ($tasks as $task) {
          $tmp                            = [];
@@ -375,10 +372,7 @@ class NotificationTargetProject extends NotificationTarget {
       $this->data["##project.numberoftasks##"] = count($this->data['tasks']);
 
       //costs infos
-      $restrict             = "`projects_id`='".$item->getField('id')."'";
-      $restrict            .= " ORDER BY `begin_date` DESC, `id` ASC";
-
-      $costs                = getAllDatasFromTable('glpi_projectcosts', $restrict);
+      $costs                = getAllDatasFromTable('glpi_projectcosts', $restrict, false, ['begin_date DESC', 'id ASC']);
       $this->data['costs'] = [];
       $this->data["##project.totalcost##"] = 0;
       foreach ($costs as $cost) {
@@ -412,7 +406,6 @@ class NotificationTargetProject extends NotificationTarget {
       $this->data["##project.numberoflogs##"] = count($this->data['log']);
 
       // Changes infos
-      $restrict               = "`projects_id`='".$item->getField('id')."'";
       $changes                = getAllDatasFromTable('glpi_changes_projects', $restrict);
       $this->data['changes'] = [];
       if (count($changes)) {
@@ -483,7 +476,6 @@ class NotificationTargetProject extends NotificationTarget {
                      = count($this->data['documents']);
 
       // Items infos
-      $restrict             = "`projects_id` = '".$item->getField('id')."'";
       $items                = getAllDatasFromTable('glpi_items_projects', $restrict);
 
       $this->data['items'] = [];

--- a/inc/notificationtargetprojecttask.class.php
+++ b/inc/notificationtargetprojecttask.class.php
@@ -288,7 +288,8 @@ class NotificationTargetProjectTask extends NotificationTarget {
       }
 
       // Team infos
-      $restrict = "`projecttasks_id` = '".$item->getField('id')."'";
+      $restrict = ['projecttasks_id' => $item->getField('id')];
+      $order    = ['date DESC', 'id ASC'];
       $items    = getAllDatasFromTable('glpi_projecttaskteams', $restrict);
 
       $this->data['teammembers'] = [];
@@ -308,10 +309,7 @@ class NotificationTargetProjectTask extends NotificationTarget {
       $this->data['##projecttask.numberofteammembers##'] = count($this->data['teammembers']);
 
       // Task infos
-      $restrict             = "`projecttasks_id`='".$item->getField('id')."'";
-      $restrict            .= " ORDER BY `date` DESC, `id` ASC";
-
-      $tasks                = getAllDatasFromTable('glpi_projecttasks', $restrict);
+      $tasks                = getAllDatasFromTable('glpi_projecttasks', $restrict, false, $order);
       $this->data['tasks'] = [];
       foreach ($tasks as $task) {
          $tmp                            = [];
@@ -365,7 +363,6 @@ class NotificationTargetProjectTask extends NotificationTarget {
       $this->data["##projecttask.numberoflogs##"] = count($this->data['log']);
 
       // Tickets infos
-      $restrict = "`projecttasks_id`='".$item->getField('id')."'";
       $tickets  = getAllDatasFromTable('glpi_projecttasks_tickets', $restrict);
 
       $this->data['tickets'] = [];
@@ -434,7 +431,6 @@ class NotificationTargetProjectTask extends NotificationTarget {
                      = count($this->data['documents']);
 
       // Items infos
-      $restrict = "`projects_id` = '".$item->getField('id')."'";
       $items    = getAllDatasFromTable('glpi_items_projects', $restrict);
 
       $this->getTags();

--- a/inc/notificationtemplatetranslation.class.php
+++ b/inc/notificationtemplatetranslation.class.php
@@ -324,8 +324,11 @@ class NotificationTemplateTranslation extends CommonDBChild {
    **/
    static function getAllUsedLanguages($language_id) {
 
-      $used_languages = getAllDatasFromTable('glpi_notificationtemplatetranslations',
-                                             'notificationtemplates_id='.$language_id);
+      $used_languages = getAllDatasFromTable(
+         'glpi_notificationtemplatetranslations', [
+            'notificationtemplates_id' => $language_id
+         ]
+      );
       $used           = [];
 
       foreach ($used_languages as $used_language) {

--- a/inc/objectlock.class.php
+++ b/inc/objectlock.class.php
@@ -625,9 +625,11 @@ class ObjectLock extends CommonDBTM {
       $actionCode = 0; // by default
       $task->setVolume(0); // start with zero
 
-      $lockedItems = getAllDatasFromTable(getTableForItemType(__CLASS__),
-                                          "`date_mod` < '" . date("Y-m-d H:i:s",
-                                          time() - ($task->fields['param'] * HOUR_TIMESTAMP)) . "'");
+      $lockedItems = getAllDatasFromTable(
+         getTableForItemType(__CLASS__), [
+            'date_mod' => ['<', date("Y-m-d H:i:s", time() - ($task->fields['param'] * HOUR_TIMESTAMP))]
+         ]
+      );
 
       foreach ($lockedItems as $row) {
          $ol = new self;

--- a/inc/profile_user.class.php
+++ b/inc/profile_user.class.php
@@ -800,10 +800,10 @@ class Profile_User extends CommonDBRelation {
    static function getForUser($user_ID, $only_dynamic = false) {
       global $DB;
 
-      $condition = "`users_id` = '$user_ID'";
+      $condition = ['users_id' => $user_ID];
 
       if ($only_dynamic) {
-         $condition .= " AND `is_dynamic` = 1";
+         $condition['is_dynamic'] = 1;
       }
 
       return getAllDatasFromTable('glpi_profiles_users', $condition);

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -3003,13 +3003,13 @@ class Rule extends CommonDBTM {
                      $types[] = 'RuleMailCollector';
                   }
                   if (count($types)) {
-                     $nb = countElementsInTable(['glpi_rules', 'glpi_ruleactions'],
-                                                "`glpi_ruleactions`.`rules_id` = `glpi_rules`.`id`
-                                                  AND `glpi_rules`.`sub_type`
-                                                         IN ('".implode("','", $types)."')
-                                                  AND `glpi_ruleactions`.`field` = 'entities_id'
-                                                  AND `glpi_ruleactions`.`value`
-                                                            = '".$item->getID()."'");
+                     $nb = countElementsInTable(
+                        ['glpi_rules', 'glpi_ruleactions'], [
+                           'glpi_ruleactions.rules_id'   => new \QueryExpression(Db::quoteName('glpi_rules.id')),
+                           'glpi_rules.sub_type'         => $types,
+                           'glpi_ruleactions.field'      => 'entities_id',
+                           'glpi_ruleactions.value'      => $item->getID()
+                        ]);
                   }
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);

--- a/inc/ruleaction.class.php
+++ b/inc/ruleaction.class.php
@@ -572,11 +572,13 @@ class RuleAction extends CommonDBChild {
                   case "dropdown_users_validate" :
                      $used = [];
                      if ($item = getItemForItemtype($options["sub_type"])) {
-                        $rule_data = getAllDatasFromTable('glpi_ruleactions',
-                                                          "`action_type` = 'add_validation'
-                                                           AND `field` = 'users_id_validate'
-                                                           AND `".$item->getRuleIdField()."`
-                                                            = '".$options[$item->getRuleIdField()]."'");
+                        $rule_data = getAllDatasFromTable(
+                           self::getTable(), [
+                              'action_type'           => 'add_validation',
+                              'field'                 => 'users_id_validate',
+                              $item->getRuleIdField() => $options[$item->getRuleIdField()]
+                           ]
+                        );
 
                         foreach ($rule_data as $data) {
                            $used[] = $data['value'];
@@ -592,12 +594,13 @@ class RuleAction extends CommonDBChild {
                   case "dropdown_groups_validate" :
                      $used = [];
                      if ($item = getItemForItemtype($options["sub_type"])) {
-                        $rule_data = getAllDatasFromTable('glpi_ruleactions',
-                                                          "`action_type` = 'add_validation'
-                                                           AND `field` = 'groups_id_validate'
-                                                           AND `".$item->getRuleIdField()."`
-                                                            = '".$options[$item->getRuleIdField()]."'");
-
+                        $rule_data = getAllDatasFromTable(
+                           self::getTable, [
+                              'action_type'           => 'add_validation',
+                              'field'                 => 'groups_id_validate',
+                              $item->getRuleIdField() => $options[$item->getRuleIdField()]
+                           ]
+                        );
                         foreach ($rule_data as $data) {
                            $used[] = $data['value'];
                         }

--- a/inc/rulecollection.class.php
+++ b/inc/rulecollection.class.php
@@ -96,12 +96,12 @@ class RuleCollection extends CommonDBTM {
    **/
    function getCollectionSize($recursive = true, $condition = 0) {
 
-      $restrict = "`sub_type` = '".$this->getRuleClassName()."'".
-                  getEntitiesRestrictRequest(" AND", "glpi_rules", "entities_id",
-                                             $this->entity, $recursive);
+      $restrict = [
+         'sub_type'  => $this->getRuleClassName()
+      ] + getEntitiesRestrictCriteria('glpi_rules', 'entities_id', $this->entity, $recursive);
 
       if ($condition > 0) {
-         $restrict .= ' AND `condition` & '. (int) $condition;
+         $restrict['condition'] = ['&', (int)$condition];
       }
       return countElementsInTable("glpi_rules", $restrict);
    }

--- a/inc/ruledictionnaryprintercollection.class.php
+++ b/inc/ruledictionnaryprintercollection.class.php
@@ -319,9 +319,11 @@ class RuleDictionnaryPrinterCollection extends RuleCollection {
 
       $computeritem = new Computer_Item();
       //For each direct connection of this printer
-      foreach (getAllDatasFromTable("glpi_computers_items",
-                                    "`itemtype` = 'Printer'
-                                        AND `items_id` = '$ID'") as $connection) {
+      foreach (getAllDatasFromTable(
+         'glpi_computers_items', [
+            'itemtype'  => 'Printer',
+            'items_id'  => $ID]
+         ) as $connection) {
 
          //Direct connection exists in the target printer ?
          if (!countElementsInTable("glpi_computers_items",

--- a/inc/softwarelicense.class.php
+++ b/inc/softwarelicense.class.php
@@ -1005,10 +1005,11 @@ class SoftwareLicense extends CommonTreeDropdown {
       $showmassiveactions  = $canedit;
 
       // Total Number of events
-      $number = countElementsInTable("glpi_softwarelicenses",
-                                     "glpi_softwarelicenses.softwares_id = $softwares_id " .
-                                          getEntitiesRestrictRequest('AND', 'glpi_softwarelicenses',
-                                                                     '', '', true));
+      $number = countElementsInTable(
+         "glpi_softwarelicenses", [
+            'glpi_softwarelicenses.softwares_id'   => $softwares_id
+         ] + getEntitiesRestrictCriteria('glpi_softwarelicenses', '', '', true)
+      );
       echo "<div class='spaced'>";
 
       Session::initNavigateListItems('SoftwareLicense',
@@ -1214,8 +1215,10 @@ class SoftwareLicense extends CommonTreeDropdown {
                   return '';
                }
                if ($_SESSION['glpishow_count_on_tabs']) {
-                   $nb = countElementsInTable($this->getTable(),
-                                             "`softwarelicenses_id` = '".$item->getID()."'");
+                  $nb = countElementsInTable(
+                     $this->getTable(),
+                     ['softwarelicenses_id' => $item->getID()]
+                  );
                }
                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()),
                                            (($nb >= 0) ? $nb : '&infin;'));

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -692,38 +692,54 @@ class Ticket extends CommonITILObject {
          if ($_SESSION['glpishow_count_on_tabs']) {
             switch ($item->getType()) {
                case 'User' :
-                  $nb = countElementsInTable(['glpi_tickets', 'glpi_tickets_users'],
-                                             getEntitiesRestrictRequest("", 'glpi_tickets').
-                                               "AND `glpi_tickets_users`.`tickets_id` = `glpi_tickets`.`id`
-                                                AND `glpi_tickets_users`.`users_id` = '".$item->getID()."'
-                                                AND `glpi_tickets_users`.`type` = ".CommonITILActor::REQUESTER);
+                  $nb = countElementsInTable(
+                     ['glpi_tickets', 'glpi_tickets_users'], [
+                        'glpi_tickets_users.tickets_id'  => new \QueryExpression(DB::quoteName('glpi_tickets.id')),
+                        'glpi_tickets_users.users_id'    => $item->getID(),
+                        'glpi_tickets_users.type'        => CommonITILActor::REQUESTER
+                     ] + getEntitiesRestrictCriteria(self::getTable())
+                  );
                   $title = __('Created tickets');
                   break;
 
                case 'Supplier' :
-                  $nb = countElementsInTable(['glpi_tickets', 'glpi_suppliers_tickets'],
-                                             getEntitiesRestrictRequest("", 'glpi_tickets').
-                                               "AND `glpi_suppliers_tickets`.`tickets_id` = `glpi_tickets`.`id`
-                                                AND `glpi_suppliers_tickets`.`suppliers_id` = '".$item->getID()."'");
+                  $nb = countElementsInTable(
+                     ['glpi_tickets', 'glpi_suppliers_tickets'], [
+                        'glpi_suppliers_tickets.tickets_id'    => new \QueryExpression(DB::quoteName('glpi_tickets.id')),
+                        'glpi_suppliers_tickets.suppliers_id'  => $item->getID()
+                     ] + getEntitiesRestrictCriteria(self::getTable())
+                  );
                   break;
 
                case 'SLA' :
-                  $nb = countElementsInTable('glpi_tickets',
-                                             "`slas_tto_id` = ".$item->getID()."
-                                             OR `slas_ttr_id` = ".$item->getID());
+                  $nb = countElementsInTable(
+                     'glpi_tickets', [
+                        'OR'  => [
+                           'slas_tto_id'  => $item->getID(),
+                           'slas_ttr_id'  => $item->getID()
+                        ]
+                     ]
+                  );
                   break;
                case 'OLA' :
-                  $nb = countElementsInTable('glpi_tickets',
-                                             "`olas_tto_id` = ".$item->getID()."
-                                             OR `olas_ttr_id` = ".$item->getID());
+                  $nb = countElementsInTable(
+                     'glpi_tickets', [
+                        'OR'  => [
+                           'olas_tto_id'  => $item->getID(),
+                           'olas_ttr_id'  => $item->getID()
+                        ]
+                     ]
+                  );
                   break;
 
                case 'Group' :
-                  $nb = countElementsInTable(['glpi_tickets', 'glpi_groups_tickets'],
-                                             getEntitiesRestrictRequest("", 'glpi_tickets').
-                                               "AND `glpi_groups_tickets`.`tickets_id` = `glpi_tickets`.`id`
-                                                AND `glpi_groups_tickets`.`groups_id` = '".$item->getID()."'
-                                                AND `glpi_groups_tickets`.`type` = ".CommonITILActor::REQUESTER);
+                  $nb = countElementsInTable(
+                     ['glpi_tickets', 'glpi_groups_tickets'], [
+                        'glpi_groups_tickets.tickets_id' => new \QueryExpression(DB::quoteName('glpi_tickets.id')),
+                        'glpi_groups_tickets.groups_id'  => $item->getID(),
+                        'glpi_groups_tickets.type'       => CommonITILActor::REQUESTER
+                     ] + getEntitiesRestrictCriteria(self::getTable())
+                  );
                   $title = __('Created tickets');
                   break;
 

--- a/inc/tickettemplate.class.php
+++ b/inc/tickettemplate.class.php
@@ -660,17 +660,23 @@ class TicketTemplate extends CommonDropdown {
       // Source fields
       $source = [];
       foreach ($to_merge as $merge) {
-         $source[$merge]
-            = $this->formatFieldsToMerge(getAllDatasFromTable('glpi_tickettemplate'.$merge,
-                                                              "tickettemplates_id='".$source_id."'"));
+         $source[$merge] = $this->formatFieldsToMerge(
+            getAllDatasFromTable(
+               'glpi_tickettemplate'.$merge,
+               ['tickettemplates_id' => $source_id]
+            )
+         );
       }
 
       // Target fields
       $target = [];
       foreach ($to_merge as $merge) {
-         $target[$merge]
-            = $this->formatFieldsToMerge(getAllDatasFromTable('glpi_tickettemplate'.$merge,
-                                                              "tickettemplates_id='".$target_id."'"));
+         $target[$merge] = $this->formatFieldsToMerge(
+            getAllDatasFromTable(
+               'glpi_tickettemplate'.$merge,
+               ['tickettemplates_id' => $target_id]
+            )
+         );
       }
 
       // Merge
@@ -706,13 +712,13 @@ class TicketTemplate extends CommonDropdown {
       // Source categories
       $source = [];
       foreach ($to_merge as $merge) {
-         $source[$merge] = getAllDatasFromTable('glpi_itilcategories', "$merge='".$source_id."'");
+         $source[$merge] = getAllDatasFromTable('glpi_itilcategories', [$merge => $source_id]);
       }
 
       // Target categories
       $target = [];
       foreach ($to_merge as $merge) {
-         $target[$merge] = getAllDatasFromTable('glpi_itilcategories', "$merge='".$target_id."'");
+         $target[$merge] = getAllDatasFromTable('glpi_itilcategories', [$merge => $target_id]);
       }
 
       // Merge

--- a/index.php
+++ b/index.php
@@ -158,10 +158,13 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
          </p>';
 
    if ($CFG_GLPI["notifications_mailing"]
-       && countElementsInTable('glpi_notifications',
-                               "`itemtype`='User'
-                                AND `event`='passwordforget'
-                                AND `is_active`=1")) {
+      && countElementsInTable(
+         'glpi_notifications', [
+            'itemtype'  => 'User',
+            'event'     => 'passwordforget',
+            'is_active' => 1
+         ])
+      ) {
       echo '<a id="forget" href="front/lostpassword.php?lostpassword=1">'.
              __('Forgotten password?').'</a>';
    }

--- a/status.php
+++ b/status.php
@@ -96,7 +96,7 @@ if (($ok_master || $ok_slave )
     && DBConnection::establishDBConnection(false, false, false)) {
 
    // Check LDAP Auth connections
-   $ldap_methods = getAllDatasFromTable('glpi_authldaps', '`is_active`=1');
+   $ldap_methods = getAllDatasFromTable('glpi_authldaps', ['is_active' => 1]);
 
    if (count($ldap_methods)) {
       echo "Check LDAP servers:";
@@ -119,7 +119,7 @@ if (($ok_master || $ok_slave )
    }
 
    // Check IMAP Auth connections
-   $imap_methods = getAllDatasFromTable('glpi_authmails', '`is_active`=1');
+   $imap_methods = getAllDatasFromTable('glpi_authmails', ['is_active' => 1]);
 
    if (count($imap_methods)) {
       echo "Check IMAP servers:";
@@ -171,7 +171,7 @@ if (($ok_master || $ok_slave )
    }
 
    /// Check mailcollectors
-   $mailcollectors = getAllDatasFromTable('glpi_mailcollectors', '`is_active`=1');
+   $mailcollectors = getAllDatasFromTable('glpi_mailcollectors', ['is_active' => 1]);
    if (count($mailcollectors)) {
       echo "Check mail collectors:";
       $mailcol = new MailCollector();
@@ -195,10 +195,21 @@ if (($ok_master || $ok_slave )
    }
 
    // Check crontask
-   $crontasks = getAllDatasFromTable('glpi_crontasks',
-                                     "`state`=".CronTask::STATE_RUNNING."
-                                      AND ((unix_timestamp(`lastrun`) + 2 * `frequency` < unix_timestamp(now()))
-                                           OR (unix_timestamp(`lastrun`) + 2*".HOUR_TIMESTAMP." < unix_timestamp(now())))");
+   $crontasks = getAllDatasFromTable(
+      'glpi_crontasks', [
+         'state'  => CronTask::STATE_RUNNING,
+         'OR'     => [
+            new \QueryExpression(
+               '(unix_timestamp(' . DBmysql::quoteName('lastrun') . ') + 2 * '.
+               DBmysql::quoteName('frequency') .' < unix_timestamp(now()))'
+            ),
+            new \QueryExpression(
+               '(unix_timestamp(' . DBmysql::quoteName('lastrun') . ') + 2 * '.
+               HOUR_TIMESTAMP . ' < unix_timestamp(now()))'
+            )
+         ]
+      ]
+   );
    if (count($crontasks)) {
       echo "Check crontasks:";
       foreach ($crontasks as $ct) {

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -269,26 +269,14 @@ class DbUtils extends DbTestCase {
          ->then
             ->integer($this->testedInstance->countElementsInTable('glpi_configs'))->isGreaterThan(100)
             ->integer($this->testedInstance->countElementsInTable(['glpi_configs', 'glpi_users']))->isGreaterThan(100)
-            ->integer($this->testedInstance->countElementsInTable('glpi_configs', "context = 'core'"))->isGreaterThan(100)
             ->integer($this->testedInstance->countElementsInTable('glpi_configs', ['context' => 'core']))->isGreaterThan(100)
-            ->integer($this->testedInstance->countElementsInTable('glpi_configs', "context = 'core' AND name = 'version'"))->isIdenticalTo(1)
             ->integer($this->testedInstance->countElementsInTable('glpi_configs', ['context' => 'core', 'name' => 'version']))->isIdenticalTo(1)
-            ->integer($this->testedInstance->countElementsInTable('glpi_configs', "context = 'fakecontext'"))->isIdenticalTo(0)
             ->integer($this->testedInstance->countElementsInTable('glpi_configs', ['context' => 'fakecontext']))->isIdenticalTo(0);
 
       //keep testing old method from db.function
       //the case of using an element that is not a table is not handle in the function :
-      //testCountElementsInTable($table, $condition="")
       $this->integer(countElementsInTable('glpi_configs'))->isGreaterThan(100);
       $this->integer(countElementsInTable(['glpi_configs', 'glpi_users']))->isGreaterThan(100);
-      $this->integer(countElementsInTable('glpi_configs', "context = 'core'"))->isGreaterThan(100);
-      $this->integer(
-         countElementsInTable(
-            'glpi_configs', "context = 'core' AND `name` = 'version'"
-         )
-      )->isIdenticalTo(1);
-      $this->integer(countElementsInTable('glpi_configs', "context = 'fakecontext'"))->isIdenticalTo(0);
-      // Using iterator
       $this->integer(countElementsInTable('glpi_configs', ['context' => 'core', 'name' => 'version']))->isIdenticalTo(1);
       $this->integer(countElementsInTable('glpi_configs', ['context' => 'core']))->isGreaterThan(100);
       $this->integer(countElementsInTable('glpi_configs', ['context' => 'fakecontext']))->isIdenticalTo(0);
@@ -304,20 +292,8 @@ class DbUtils extends DbTestCase {
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_tickets', 'entities_id'))->isIdenticalTo(2)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'itemtype', ['frequency' => '86400']))->isIdenticalTo(12)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'id', ['frequency' => '86400']))->isIdenticalTo(15)
-            ->integer(
-               countDistinctElementsInTable(
-                  'glpi_configs',
-                  'context',
-                  "name = 'version'"
-               )
-            )->isIdenticalTo(1)
-            ->integer(
-               countDistinctElementsInTable(
-                  'glpi_configs',
-                  'id',
-                  "context ='fakecontext'"
-               )
-            )->isIdenticalTo(0);
+            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'context', ['name' => 'version']))->isIdenticalTo(1)
+            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'id', ['context' => 'fakecontext']))->isIdenticalTo(0);
 
       //keep testing old method from db.function
       //the case of using an element that is not a table is not handle in the function :
@@ -328,14 +304,14 @@ class DbUtils extends DbTestCase {
          countDistinctElementsInTable(
             'glpi_configs',
             'context',
-            "name = 'version'"
+            ['name' => 'version']
          )
       )->isIdenticalTo(1);
       $this->integer(
          countDistinctElementsInTable(
             'glpi_configs',
             'id',
-            "context ='fakecontext'"
+            ['context' => 'fakecontext']
          )
       )->isIdenticalTo(0);
    }
@@ -430,9 +406,8 @@ class DbUtils extends DbTestCase {
       $this
          ->if($this->newTestedInstance)
          ->then
-            ->array($this->testedInstance->getAllDataFromTable('glpi_configs', "context = 'core' AND `name` = 'version'"))->hasSize(1)
             ->array($this->testedInstance->getAllDataFromTable('glpi_configs', ['context' => 'core', 'name' => 'version']))->hasSize(1)
-            ->array($data = $this->testedInstance->getAllDataFromTable('glpi_configs', "", false, 'name'))->isNotEmpty();
+            ->array($data = $this->testedInstance->getAllDataFromTable('glpi_configs', [], false, 'name'))->isNotEmpty();
       $previousArrayName = "";
       foreach ($data as $key => $array) {
          $this->boolean($previousArrayName <= $previousArrayName = $array['name'])->isTrue();
@@ -449,10 +424,10 @@ class DbUtils extends DbTestCase {
             ->variable['id']->isEqualTo($key);
       }
 
-      $data = getAllDatasFromTable('glpi_configs', "context = 'core' AND `name` = 'version'");
+      $data = getAllDatasFromTable('glpi_configs', ['context' => 'core', 'name' => 'version']);
       $this->array($data)->hasSize(1);
 
-      $data = getAllDatasFromTable('glpi_configs', "", false, 'name');
+      $data = getAllDatasFromTable('glpi_configs', [], false, 'name');
       $this->array($data)->isNotEmpty();
       $previousArrayName = "";
       foreach ($data as $key => $array) {

--- a/tests/functionnal/Networkport.php
+++ b/tests/functionnal/Networkport.php
@@ -60,7 +60,7 @@ class Networkport extends DbTestCase {
       $this->integer((int)countElementsInTable('glpi_logs'))->isGreaterThan($nb_log);
 
       // check data in db
-      $all_netports = getAllDatasFromTable('glpi_networkports', '', false, 'id');
+      $all_netports = getAllDatasFromTable('glpi_networkports', [], false, 'id');
       $current_networkport = end($all_netports);
       unset($current_networkport['id']);
       unset($current_networkport['date_mod']);
@@ -80,7 +80,7 @@ class Networkport extends DbTestCase {
       ];
       $this->array($current_networkport)->isIdenticalTo($expected);
 
-      $all_netportethernets = getAllDatasFromTable('glpi_networkportethernets', '', false, 'id');
+      $all_netportethernets = getAllDatasFromTable('glpi_networkportethernets', [], false, 'id');
       $networkportethernet = end($all_netportethernets);
       $this->boolean($networkportethernet)->isFalse();
 
@@ -134,7 +134,7 @@ class Networkport extends DbTestCase {
 
       // check data in db
       // 1 -> NetworkPortEthernet
-      $all_netportethernets = getAllDatasFromTable('glpi_networkportethernets', '', false, 'id');
+      $all_netportethernets = getAllDatasFromTable('glpi_networkportethernets', [], false, 'id');
       $networkportethernet = end($all_netportethernets);
       unset($networkportethernet['id']);
       unset($networkportethernet['date_mod']);
@@ -149,7 +149,7 @@ class Networkport extends DbTestCase {
       $this->array($networkportethernet)->isIdenticalTo($expected);
 
       // 2 -> NetworkName
-      $all_networknames = getAllDatasFromTable('glpi_networknames', '', false, 'id');
+      $all_networknames = getAllDatasFromTable('glpi_networknames', [], false, 'id');
       $networkname = end($all_networknames);
       $networknames_id = $networkname['id'];
       unset($networkname['id']);
@@ -168,7 +168,7 @@ class Networkport extends DbTestCase {
       $this->array($networkname)->isIdenticalTo($expected);
 
       // 3 -> IPAddress
-      $all_ipadresses = getAllDatasFromTable('glpi_ipaddresses', '', false, 'id');
+      $all_ipadresses = getAllDatasFromTable('glpi_ipaddresses', [], false, 'id');
       $ipadress = end($all_ipadresses);
       unset($ipadress['id']);
       unset($ipadress['date_mod']);

--- a/tests/functionnal/Printer.php
+++ b/tests/functionnal/Printer.php
@@ -142,8 +142,7 @@ class Printer extends DbTestCase {
       $this->boolean($obj->getFromDB($id))->isTrue();
       $this->variable($obj->getField('is_deleted'))->isEqualTo(0);;
       $this->variable($obj->isDeleted())->isEqualTo(0);
-      $nb_before = (int)countElementsInTable('glpi_logs', "itemtype = 'Printer'
-                                          AND items_id = '$id'");
+      $nb_before = (int)countElementsInTable('glpi_logs', ['itemtype' => 'Printer', 'items_id' => $id]);
 
       // DeleteByCriteria without history
       $this->boolean($obj->deleteByCriteria(['name' => $this->method], 0, 0))->isTrue();
@@ -151,8 +150,7 @@ class Printer extends DbTestCase {
       $this->variable($obj->getField('is_deleted'))->isEqualTo(1);
       $this->variable($obj->isDeleted())->isEqualTo(1);
 
-      $nb_after = (int)countElementsInTable('glpi_logs', "itemtype = 'Printer'
-                                          AND items_id = '$id'");
+      $nb_after = (int)countElementsInTable('glpi_logs', ['itemtype' => 'Printer', 'items_id' => $id]);
       $this->integer($nb_after)->isidenticalTo($nb_after);
 
       // Restore
@@ -161,8 +159,7 @@ class Printer extends DbTestCase {
       $this->variable($obj->getField('is_deleted'))->isEqualTo(0);
       $this->variable($obj->isDeleted())->isEqualTo(0);
 
-      $nb_before = (int)countElementsInTable('glpi_logs', "itemtype = 'Printer'
-                                          AND items_id = '$id'");
+      $nb_before = (int)countElementsInTable('glpi_logs', ['itemtype' => 'Printer', 'items_id' => $id]);
 
       // DeleteByCriteria with history
       $this->boolean($obj->deleteByCriteria(['name' => $this->method], 0, 1))->isTrue;
@@ -170,8 +167,7 @@ class Printer extends DbTestCase {
       $this->variable($obj->getField('is_deleted'))->isEqualTo(1);
       $this->variable($obj->isDeleted())->isEqualTo(1);
 
-      $nb_after = (int)countElementsInTable('glpi_logs', "itemtype = 'Printer'
-                                          AND items_id = '$id'");
+      $nb_after = (int)countElementsInTable('glpi_logs', ['itemtype' => 'Printer', 'items_id' => $id]);
       $this->integer($nb_after)->isidenticalTo($nb_before + 1);
    }
 }

--- a/tests/functionnal/RuleSoftwareCategoryCollection.php
+++ b/tests/functionnal/RuleSoftwareCategoryCollection.php
@@ -85,8 +85,10 @@ class RuleSoftwareCategoryCollection extends DbTestCase {
                 'manufacturer'     => 'My Manufacturer',
                 '_system_category' => 'dev'];
 
-      $rules = getAllDatasFromTable('glpi_rules',
-                                    "`uuid`='500717c8-2bd6e957-53a12b5fd38869.86003425'");
+      $rules = getAllDatasFromTable(
+         'glpi_rules',
+         ['uuid' => '500717c8-2bd6e957-53a12b5fd38869.86003425']
+      );
       $this->array($rules)->hasSize(1);
 
       $myrule = current($rules);
@@ -159,7 +161,7 @@ class RuleSoftwareCategoryCollection extends DbTestCase {
       )->isGreaterThan(0);
 
       $this->integer(
-         (int)countElementsInTable('glpi_rules', "`sub_type`='RuleSoftwareCategory'")
+         (int)countElementsInTable('glpi_rules', ['sub_type' => 'RuleSoftwareCategory'])
       )->isIdenticalTo(2);
 
       //Test that a software category can be assigned
@@ -215,14 +217,14 @@ class RuleSoftwareCategoryCollection extends DbTestCase {
       $this->integer(
          (int)countElementsInTable(
             'glpi_rules',
-            "`sub_type`='RuleSoftwareCategory'"
+            ['sub_type' => 'RuleSoftwareCategory']
          )
       )->isIdenticalTo(2);
 
       $this->integer(
          (int)countElementsInTable(
             'glpi_rules',
-            "`sub_type`='RuleSoftwareCategory' AND `is_active`='1'"
+            ['sub_type' => 'RuleSoftwareCategory', 'is_active' => 1]
          )
       )->isIdenticalTo(1);
 

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -276,8 +276,12 @@ class Search extends DbTestCase {
                $number++;
             }
          }
-         $this->integer((int)countElementsInTable($displaypref->getTable(),
-                 "`itemtype`='".$itemtype."' AND `users_id`=0"))->isIdenticalTo($number);
+         $this->integer(
+            (int)countElementsInTable(
+               $displaypref->getTable(),
+               ['itemtype' => $itemtype, 'users_id' => 0]
+            )
+         )->isIdenticalTo($number);
 
          // do a search query
          $search_params = ['is_deleted'   => 0,

--- a/tests/functionnal/Software.php
+++ b/tests/functionnal/Software.php
@@ -193,7 +193,7 @@ class Software extends DbTestCase {
       $this->variable($software->fields['is_template'])->isEqualTo(0);
       $this->string($software->fields['name'])->isIdenticalTo('MySoft');
 
-      $query = "`itemtype`='Software' AND `items_id`='$softwares_id'";
+      $query = ['itemtype' => 'Software', 'items_id' => $softwares_id];
       $this->integer((int)countElementsInTable('glpi_infocoms', $query))->isIdenticalTo(0);
       $this->integer((int)countElementsInTable('glpi_contracts_items', $query))->isIdenticalTo(0);
 
@@ -207,7 +207,7 @@ class Software extends DbTestCase {
       ]);
       $this->integer((int)$softwares_id)->isGreaterThan(0);
 
-      $query = "`itemtype`='Software' AND `items_id`='$softwares_id'";
+      $query = ['itemtype' => 'Software', 'items_id' => $softwares_id];
       $this->integer((int)countElementsInTable('glpi_infocoms', $query))->isIdenticalTo(1);
    }
 
@@ -258,7 +258,7 @@ class Software extends DbTestCase {
       $this->variable($software->fields['is_template'])->isEqualTo(0);
       $this->string($software->fields['name'])->isIdenticalTo('MySoft');
 
-      $query = "`itemtype`='Software' AND `items_id`='$softwares_id_2'";
+      $query = ['itemtype' => 'Software', 'items_id' => $softwares_id_2];
       $this->integer((int)countElementsInTable('glpi_infocoms', $query))->isIdenticalTo(1);
       $this->integer((int)countElementsInTable('glpi_contracts_items', $query))->isIdenticalTo(1);
    }
@@ -295,7 +295,7 @@ class Software extends DbTestCase {
       )->isGreaterThan(0);
 
       $this->boolean($software->delete(['id' => $softwares_id], true))->isTrue();
-      $query = "`itemtype`='Software' AND `items_id`='$softwares_id'";
+      $query = ['itemtype' => 'Software', 'items_id' => $softwares_id];
       $this->integer((int)countElementsInTable('glpi_infocoms', $query))->isIdenticalTo(0);
       $this->integer((int)countElementsInTable('glpi_contracts_items', $query))->isIdenticalTo(0);
 

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -368,6 +368,9 @@ class DBmysqlIterator extends DbTestCase {
 
       $it = $this->it->execute('foo', ['a' => ['&', 1]]);
       $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `a` & \'1\'');
+
+      $it = $this->it->execute('foo', ['a' => ['|', 1]]);
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` WHERE `a` | \'1\'');
    }
 
 

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -488,6 +488,16 @@ class DBmysqlIterator extends DbTestCase {
       $crit['FROM'] = 'foo';
       $it = $this->it->execute($crit);
       $this->string($it->getSql())->isIdenticalTo($sql);
+
+      $crit = [
+         'FROM'   => 'foo',
+         'WHERE'  => [
+            'bar' => 'baz',
+            'RAW' => ['SELECT COUNT(*) FROM xyz' => 5]
+         ]
+      ];
+      $it = $this->it->execute($crit);
+      $this->string($it->getSql())->isIdenticalTo("SELECT * FROM `foo` WHERE `bar` = 'baz' AND ((SELECT COUNT(*) FROM xyz) = 5)");
    }
 
 

--- a/tests/web/APIXmlrpc.php
+++ b/tests/web/APIXmlrpc.php
@@ -45,7 +45,7 @@ class APIXmlrpc extends APIBaseClass {
 
    public function setUp() {
       parent::setUp();
-      $this->boolean(extension_loaded('xmlrpc'))->isTrue();
+      $this->boolean(extension_loaded('xmlrpc'))->isTrue('xmlrpc extension is missing');
    }
 
    public function beforeTestMethod($method) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes

countElementsInTable* conditions parameter as string is deprecated from a while, but not marked as such.
Some improvements has been made to the iterator because of a call to countElementsInTable from Profiles :/