### PR TITLE
Remove definition of unexisting and unused property

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -1022,7 +1022,7 @@ class CommonDBTM extends CommonGLPI {
          }
 
       }
-      $this->last_status = self::NOTHING_TO_DO;
+
       return false;
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

$last_status property does not exists and is not used anywhere. I do not try to check if defining it raises an error, but it is definitely a dead code.