### PR TITLE
Enable copy/paste image from MS Office Word

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3542,6 +3542,7 @@ class Html {
             remove_script_host: false,
             entity_encoding: 'raw',
             paste_data_images: $('.fileupload').length,
+            paste_word_valid_elements: 'b,strong,i,em,h1,h2',
             paste_block_drop: true,
             menubar: false,
             statusbar: false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | #4413 
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Enable copy/paste image from MS Office Word. I'm not sure about right tag allowed, with this patch it's not possible to copy text and image at the same time