### PR TITLE
Use Event from Glpi namespace; see #1175

### DIFF
--- a/front/knowbaseitem_comment.form.php
+++ b/front/knowbaseitem_comment.form.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Event;
+
 include ('../inc/includes.php');
 
 Session::checkLoginUser();

--- a/front/knowbaseitem_item.form.php
+++ b/front/knowbaseitem_item.form.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Event;
+
 include ('../inc/includes.php');
 
 Session ::checkLoginUser();

--- a/front/savedsearch_alert.form.php
+++ b/front/savedsearch_alert.form.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Event;
+
 include ('../inc/includes.php');
 
 Session::checkCentralAccess();

--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -329,6 +329,15 @@ function glpi_autoload($classname) {
 
    $dir = GLPI_ROOT . "/inc/";
 
+   //hack for \Event
+   //@since 9.3.1 -- WILL BE REMOVED IN FUTURE RELEASE
+   if ($classname === 'Event') {
+      Toolbox::deprecated('Event has been replaced by Glpi\\Event.');
+      include_once($dir . 'event.class.php');
+      class_alias('Glpi\\Event', 'Event');
+      return true;
+   }
+
    if ($plug = isPluginItemType($classname)) {
       $plugname = strtolower($plug['plugin']);
       $dir      = GLPI_ROOT . "/plugins/$plugname/inc/";

--- a/inc/event.class.php
+++ b/inc/event.class.php
@@ -409,8 +409,3 @@ class Event extends CommonDBTM {
       echo "</table></div><br>";
    }
 }
-
-// For compatibility
-if (!class_exists('Event', false)) {
-   class_alias('Glpi\\Event', 'Event');
-}

--- a/inc/knowbaseitemtranslation.class.php
+++ b/inc/knowbaseitemtranslation.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Event;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1175

I think we could drop the class alias (here https://github.com/glpi-project/glpi/blob/9.3/bugfixes/inc/event.class.php#L413), to prevent someone entering the case where using the Event class does not uses the Glpi one.