### PR TITLE
Fix massive action child entity move

### DIFF
--- a/inc/commontreedropdown.class.php
+++ b/inc/commontreedropdown.class.php
@@ -620,7 +620,8 @@ abstract class CommonTreeDropdown extends CommonDropdown {
             echo __('As child of');
             Dropdown::show($itemtype, ['name'     => 'parent',
                                             'comments' => 0,
-                                            'entity'   => $_SESSION['glpiactive_entity']]);
+                                            'entity'   => $_SESSION['glpiactive_entity'],
+                                            'entity_sons' => $_SESSION['glpiactive_entity_recursive']]);
             echo "<br><br><input type='submit' name='massiveaction' class='submit' value='".
                            _sx('button', 'Move')."'>\n";
             return true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4437 

Fix commontreedropdown move massive action to allow moving to child entities.