### PR TITLE
Fix missing right parameter on user dropdown

### DIFF
--- a/inc/commondropdown.class.php
+++ b/inc/commondropdown.class.php
@@ -289,14 +289,14 @@ abstract class CommonDropdown extends CommonDBTM {
 
          switch ($field['type']) {
             case 'UserDropdown' :
-               $param = ['name'   => $field['name'],
-                         'value'  => $this->fields[$field['name']],
-                         'right'  => 'interface',
-                         'entity' => $this->fields["entities_id"]];
+               $params = ['name'   => $field['name'],
+                          'value'  => $this->fields[$field['name']],
+                          'right'  => 'interface',
+                          'entity' => $this->fields["entities_id"]];
                if (isset($field['right'])) {
                   $params['right'] = $field['right'];
                }
-               User::dropdown($param);
+               User::dropdown($params);
 
                break;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I did not take time to check the usecase, but I think the typo on variable name can lead to have a dropdown that show users that does not match requested restrictions.