### PR TITLE
Fix responsiveness of Search Field

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -5397,3 +5397,16 @@ input[name=as_map]:checked + label {
       margin-left: 200px;
    }
 }
+
+/** Responsive for search field */
+@media screen and (max-width: 454px) {
+   #c_recherche form #champRecherche input{
+      width:140px;
+   }
+
+   #c_recherche {
+      position:relative;
+      top:14px;
+      left:-47px;
+   }
+}


### PR DESCRIPTION

![screenshot_20180806_114846](https://user-images.githubusercontent.com/1380639/43712146-818fd64c-9975-11e8-8592-6fbb53115672.jpg)
Fix for responsiveness of the search field under 454px screen width, on some mobile (P20 pro for example).
The field was on top of the hamburger menu icon.
More width to the field added too, as it was possible.

| Bug fix?      | yes
| Tests pass?   | yes

Thanks