### PR TITLE
Deprecated Config::getSQLMode() method (and fix it)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The present file will list all changes made to the project; according to the
 
 The following methods have been deprecated:
 
+- `Config::getSQLMode()`
 - `Html::checkAllAsCheckbox()`
 - `Html::scriptEnd()`
 - `Html::scriptStart()`

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1918,17 +1918,18 @@ class Config extends CommonDBTM {
 
 
    /**
-    * @since 0.90
-    *
     * @return string
-   **/
+    *
+    * @since 0.90
+    * @deprecated 9.3.1 No longer used.
+    **/
    static function getSQLMode() {
       global $DB;
 
       $query   = "SELECT @@GLOBAL.sql_mode;";
       $results = $DB->query($query);
       if ($DB->numrows($results) > 0) {
-         return $DB->results($result, 0);
+         return $DB->result($results, 0);
       }
       return '';
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes (but nobody uses this method)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This method is not used anymore, and it has a bug on it.