### PR TITLE
Deprecate isAllPluginsCSRFCompliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The following methods have been deprecated:
 - `Html::scriptStart()`
 - `Toolbox::is_a()`
 - `ComputerVirtualMachine::getUUIDRestrictRequest()`
+- `Plugin::isAllPluginsCSRFCompliant()`
+- `Profile::getUnderActiveProfileRestrictRequest()`
 
 The following constants have been deprecated:
 - `CommonDBTM::ERROR_FIELDSIZE_EXCEEDED`

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -160,9 +160,7 @@ if (!defined('DO_NOT_CHECK_HTTP_REFERER')
 // Security : check CSRF token
 if (GLPI_USE_CSRF_CHECK
     && !isAPI()
-    && isset($_POST) && is_array($_POST) && count($_POST)
-    // ALL plugins need to be CSRF compliant
-    /*&& Plugin::isAllPluginsCSRFCompliant()*/) {
+    && isset($_POST) && is_array($_POST) && count($_POST)) {
    // No ajax pages
    if (!preg_match(':'.$CFG_GLPI['root_doc'].'(/plugins/[^/]*|)/ajax/:', $_SERVER['REQUEST_URI'])) {
       Session::checkCSRF($_POST);

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -343,9 +343,13 @@ class Plugin extends CommonDBTM {
     * Check if all plugins are CSRF compliant
     *
     * @since 0.83.3
+    *
+    * @deprecated 9.3.1
    **/
    static function isAllPluginsCSRFCompliant() {
       global $PLUGIN_HOOKS;
+
+      Toolbox::deprecated();
 
       if (isset($_SESSION['glpi_plugins'])
           && is_array($_SESSION['glpi_plugins'])


### PR DESCRIPTION
Missing deprecated method in changelog

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes