### PR TITLE
Display deleted itil with red background in lists

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -5409,7 +5409,7 @@ abstract class CommonITILObject extends CommonDBTM {
          $item_num = 1;
          $bgcolor  = $_SESSION["glpipriority_".$item->fields["priority"]];
 
-         echo Search::showNewLine($p['output_type'], $p['row_num']%2);
+         echo Search::showNewLine($p['output_type'], $p['row_num']%2, $item->isDeleted());
 
          $check_col = '';
          if (($candelete || $canupdate)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Deleted ITIL items were not displayed with red background.

To reproduce:
- create a change,
- create a problem,
- link each other,
- put the problem into dustbin,
- look at the list of problems in the change view.