### PR TITLE
rule for ticket's supplier now set use_notification = 1, fix #4467

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -1725,13 +1725,17 @@ abstract class CommonITILObject extends CommonDBTM {
              && is_array($input['_additional_suppliers_assigns'])
              && count($input['_additional_suppliers_assigns'])) {
 
-            $input2 = [$supplieractors->getItilObjectForeignKey() => $this->fields['id'],
-                            'type'                                     => CommonITILActor::ASSIGN];
+            $input2 = [
+               $supplieractors->getItilObjectForeignKey() => $this->fields['id'],
+               'type'                                     => CommonITILActor::ASSIGN,
+               '_from_object'                             => true
+            ];
 
-            foreach ($input['_additional_suppliers_assigns'] as $tmp) {
-               if ($tmp > 0) {
-                  $input2['suppliers_id'] = $tmp;
-                  $input2['_from_object'] = true;
+            foreach ($input["_additional_suppliers_assigns"] as $tmp) {
+               if (isset($tmp['suppliers_id'])) {
+                  foreach ($tmp as $key => $val) {
+                     $input2[$key] = $val;
+                  }
                   $supplieractors->add($input2);
                }
             }

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -546,6 +546,8 @@ class RuleTicket extends Rule {
       $actions['_suppliers_id_assign']['force_actions']     = ['assign', 'append'];
       $actions['_suppliers_id_assign']['permitseveral']     = ['append'];
       $actions['_suppliers_id_assign']['appendto']          = '_additional_suppliers_assigns';
+      $actions['_suppliers_id_assign']['appendtoarray']     = ['use_notification' => 1];
+      $actions['_suppliers_id_assign']['appendtoarrayfield']  = 'suppliers_id';
 
       $actions['_users_id_observer']['name']                = __('Watcher');
       $actions['_users_id_observer']['type']                = 'dropdown_users';

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8305,7 +8305,7 @@ CREATE TABLE `glpi_suppliers_tickets` (
   `tickets_id` int(11) NOT NULL DEFAULT '0',
   `suppliers_id` int(11) NOT NULL DEFAULT '0',
   `type` int(11) NOT NULL DEFAULT '1',
-  `use_notification` tinyint(1) NOT NULL DEFAULT '0',
+  `use_notification` tinyint(1) NOT NULL DEFAULT '1',
   `alternative_email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`tickets_id`,`type`,`suppliers_id`),

--- a/install/update_930_931.php
+++ b/install/update_930_931.php
@@ -59,6 +59,16 @@ function update930to931() {
    );
    /** /Change field type */
 
+   // supplier now have use_notification = 1 by default
+   $migration->changeField(
+      'glpi_suppliers_tickets',
+      'use_notification',
+      'use_notification',
+      'bool', [
+         'value' => 1
+      ]
+   );
+
    // ************ Keep it at the end **************
    $migration->executeMigration();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4467 

2 points, we have two rule types:
![image](https://user-images.githubusercontent.com/418844/44030832-518291d2-9f02-11e8-905f-54e80d10c18e.png)

- assign: `use_notification` use default from table definition (`appendtoarray` not used, don't know why)
- append (add): `use_notification` set from `appendtoarray` key.

In fact, second one is not necessary but to kept it coherent with assign/requester part, i still did the modification.

Finally, changes in `commonitilobject` is to fix some warnings (i just adapted lines from assignee part):
```
  *** PHP Warning(2): preg_match() expects parameter 2 to be string, array given
  Backtrace :
  :                                                  
  inc/dbmysql.class.php:875                          preg_match()
  inc/dbmysql.class.php:898                          DBmysql::quoteValue()
  inc/dbmysql.class.php:921                          DBmysql->buildInsert()
  inc/commondbtm.class.php:620                       DBmysql->insert()
  inc/commondbtm.class.php:1057                      CommonDBTM->addToDB()
  inc/commonitilobject.class.php:1737                CommonDBTM->add()
  inc/commonitilobject.class.php:1642                CommonITILObject->addAdditionalActors()
  inc/ticket.class.php:2183                          CommonITILObject->post_addItem()
  inc/commondbtm.class.php:1058                      Ticket->post_addItem()
  inc/mailcollector.class.php:678                    CommonDBTM->add()
  front/mailcollector.form.php:77                    MailCollector->collect()
``` 
