### PR TITLE
Disallow usage of nameless search options

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -3522,9 +3522,26 @@ class CommonDBTM extends CommonGLPI {
       }
 
       foreach ($this->rawSearchOptions() as $opt) {
+         $missingFields = [];
          if (!isset($opt['id'])) {
-            throw new \Exception(get_called_class() . ': invalid search option! ' . print_r($opt, true));
+            $missingFields[] = 'id';
          }
+         if (!isset($opt['name'])) {
+            $missingFields[] = 'name';
+         }
+         if (count($missingFields) > 0) {
+            throw new \Exception(
+               vsprintf(
+                  'Invalid search option in "%1$s": missing "%2$s" field(s). %3$s',
+                  [
+                     get_called_class(),
+                     implode('", "', $missingFields),
+                     print_r($opt, true)
+                  ]
+               )
+            );
+         }
+
          $optid = $opt['id'];
          unset($opt['id']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It seems that there is somewhere search options that has no name (see https://github.com/pluginsGLPI/genericobject/issues/205). I do not know if it comes from core or plugins.
However, nameless search options should not be allowed.