### PR TITLE
Fix software category filter in Software tab of computers

### DIFF
--- a/inc/computer_softwareversion.class.php
+++ b/inc/computer_softwareversion.class.php
@@ -698,7 +698,7 @@ class Computer_SoftwareVersion extends CommonDBRelation {
       $where_str    = '';
       if ($crit > -1) {
          $where['glpi_softwares.softwarecategories_id'] = (int) $crit;
-         $where_str = "`glpi_softwares`.`softwarecategories_id` = " . (int)$crit;
+         $where_str = "AND `glpi_softwares`.`softwarecategories_id` = " . (int)$crit;
       }
 
       $select = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When choosing "Uncategorized software" or other filters in Software tab of computer form, it would always show no software because of a malformed where string.