### PR TITLE
Fix error on infocom items list of supplier page

### DIFF
--- a/inc/supplier.class.php
+++ b/inc/supplier.class.php
@@ -483,7 +483,7 @@ class Supplier extends CommonDBTM {
       echo "</tr>";
 
       $num = 0;
-      while ($row = $iterator->next()) {
+      while ($row = $types_iterator->next()) {
          $itemtype = $row['itemtype'];
 
          if (!($item = getItemForItemtype($itemtype))) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix a fatal error on "items" tab in supplier page.
```
Fatal error: Uncaught Error: Call to a member function next() on null in /var/www/glpi/inc/supplier.class.php:486
Stack trace:
#0 /var/www/glpi/inc/infocom.class.php(161): Supplier->showInfocoms()
#1 /var/www/glpi/inc/commonglpi.class.php(488): Infocom::displayTabContentForItem(Object(Supplier), '1', '')
#2 /var/www/glpi/ajax/common.tabs.php(92): CommonGLPI::displayStandardTab(Object(Supplier), 'Infocom$1', '', Array)
#3 {main} thrown in /var/www/glpi/inc/supplier.class.php on line 486
```