### PR TITLE
Fix deprecated usages

### DIFF
--- a/front/backup.php
+++ b/front/backup.php
@@ -71,9 +71,9 @@ function xmlbackup() {
    //on parcoure la DB et on liste tous les noms des tables dans $table
    //on incremente $query[] de "select * from $table"  pour chaque occurence de $table
 
-   $result = $DB->list_tables();
+   $result = $DB->listTables();
    $i      = 0;
-   while ($line = $DB->fetch_row($result)) {
+   while ($line = $result->next()) {
       $table = $line[0];
 
       $query[$i] = "SELECT *
@@ -353,9 +353,9 @@ function backupMySql($DB, $dumpFile, $duree, $rowlimit) {
       gzwrite ($fileHandle, $todump);
    }
 
-   $result = $DB->list_tables();
+   $result = $DB->listTables();
    $numtab = 0;
-   while ($t = $DB->fetch_row($result)) {
+   while ($t = $result->next()) {
       $tables[$numtab] = $t[0];
       $numtab++;
    }
@@ -467,8 +467,7 @@ if (isset($_GET["dump"]) && $_GET["dump"] != "") {
          $fichier = $_GET["fichier"];
       }
 
-      $tab = $DB->list_tables();
-      $tot = $DB->numrows($tab);
+      $tot = $DB->listTables()->count();
       if (isset($offsettable)) {
          if ($offsettable >= 0) {
             $percent = min(100, round(100*$offsettable/$tot, 0));

--- a/inc/ruleright.class.php
+++ b/inc/ruleright.class.php
@@ -337,7 +337,7 @@ class RuleRight extends Rule {
    function addSpecificCriteriasToArray(&$criterias) {
 
       $criterias['ldap'] = __('LDAP criteria');
-      foreach (getAllDatasFromTable('glpi_rulerightparameters', '', true) as $datas) {
+      foreach (getAllDatasFromTable('glpi_rulerightparameters', [], true) as $datas) {
          $criterias[$datas["value"]]['name']      = $datas["name"];
          $criterias[$datas["value"]]['field']     = $datas["value"];
          $criterias[$datas["value"]]['linkfield'] = '';

--- a/install/update_06_065.php
+++ b/install/update_06_065.php
@@ -1183,8 +1183,8 @@ function update06to065() {
       }
    }
 
-   $result = $DB->list_tables();
-   while ($line = $DB->fetch_array($result)) {
+   $result = $DB->listTables();
+   while ($line = $result->next()) {
       if (strstr($line[0], "glpi_dropdown") || strstr($line[0], "glpi_type")) {
          if (!isIndex($line[0], "name")) {
             $query = "ALTER TABLE `".$line[0]."`
@@ -1294,8 +1294,8 @@ function update06to065() {
       $DB->queryOrDie($query, "0.65 add reminder");
    }
 
-   $result = $DB->list_tables();
-   while ($line = $DB->fetch_array($result)) {
+   $result = $DB->listTables();
+   while ($line = $result->next()) {
       if (strstr($line[0], "glpi_dropdown") || strstr($line[0], "glpi_type")) {
          if ($line[0] != "glpi_type_docs") {
             if (!$DB->fieldExists($line[0], "comments", false)) {

--- a/install/update_content.php
+++ b/install/update_content.php
@@ -143,9 +143,9 @@ function UpdateContent($DB, $duree, $rowlimit, $conv_utf8, $complete_utf8) {
    // $histMySql, nom de la machine serveur MySQl
    // $duree=timeout pour changement de page (-1 = aucun)
 
-   $result = $DB->list_tables();
+   $result = $DB->listTables();
    $numtab = 0;
-   while ($t=$DB->fetch_row($result)) {
+   while ($t = $result->next()) {
       $tables[$numtab] = $t[0];
       $numtab++;
    }
@@ -310,8 +310,7 @@ if (!isset($_GET["rowlimit"])) {
    $rowlimit = $_GET["rowlimit"];
 }
 
-$tab = $DB->list_tables();
-$tot = $DB->numrows($tab);
+$tot = $DB->listTables()->count();
 
 if (isset($offsettable)) {
    if ($offsettable>=0) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Fix usage of string condition in getAllDatasFromTable
2. Replace usage of '$DB->list_tables()' by '$DB->listTables()'