### PR TITLE
manage external authtype in login

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -607,6 +607,9 @@ class Auth extends CommonGLPI {
          } else if ($auths[0] == 'mail') {
             $authtype = self::MAIL;
             $this->user->fields["authtype"] = self::MAIL;
+         } else if ($auths[0] == 'external') {
+            $authtype = self::EXTERNAL;
+            $this->user->fields["authtype"] = self::EXTERNAL;
          }
       }
       if (!$noauto && ($authtype = self::checkAlternateAuthSystems())) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

I need this pr in order to retrieve emails.
In case of SSO login (Auth::EXTERNAL), emails are set only if the user have a field authtype set
Cf: https://github.com/glpi-project/glpi/blob/9.3/bugfixes/inc/user.class.php#L1265-L1269