### PR TITLE
Do not show map option for itemtypes with no items and cannot be located

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1802,16 +1802,18 @@ class Search {
             }
          }
       } else {
-         echo "<div class='center pager_controls'>".
-         $map_link = "<input type='checkbox' name='as_map' id='as_map' value='1'";
-         if ($data['search']['as_map'] == 1) {
-            $map_link .= " checked='checked'";
+         echo "<div class='center pager_controls'>";
+         if (null == $item || $item->maybeLocated()) {
+            $map_link = "<input type='checkbox' name='as_map' id='as_map' value='1'";
+            if ($data['search']['as_map'] == 1) {
+               $map_link .= " checked='checked'";
+            }
+            $map_link .= "/>";
+            $map_link .= "<label for='as_map'><span title='".__s('Show as map')."' class='pointer fa fa-globe'
+               onClick=\"toogle('as_map','','','');
+                           document.forms['searchform".$data["itemtype"]."'].submit();\"></span></label>";
+            echo $map_link;
          }
-         $map_link .= "/>";
-         $map_link .= "<label for='as_map'><span title='".__s('Show as map')."' class='pointer fa fa-globe'
-            onClick=\"toogle('as_map','','','');
-                        document.forms['searchform".$data["itemtype"]."'].submit();\"></span></label>";
-         echo $map_link;
 
          if ($item !== null && $item->maybeDeleted()) {
             echo self::isDeletedSwitch($data['search']['is_deleted']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4524

Items like QueuedNotifications don't have a location but the map option was still showing when there were no items listed.

Supplements #4246 