### PR TITLE
Fix drag and drop upload

### DIFF
--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -116,7 +116,7 @@ var getFileTag = function(data) {
 var fileindex = 0;
 var displayUploadedFile = function(file, tag, editor, input_name) {
    // default argument(s)
-   input_name = (typeof input_name === 'undefined') ? 'filename' : input_name;
+   input_name = (typeof input_name === 'undefined' || input_name == null) ? 'filename' : input_name;
 
    // find the nearest fileupload_info where to append file list
    var current_dom_point = $(editor.targetElm);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4523 

When doing drag and drop, input_name would be a null object, not undefined.