### PR TITLE
Fix logs history purge date criterion; fixes #4529

### DIFF
--- a/inc/purgelogs.class.php
+++ b/inc/purgelogs.class.php
@@ -364,7 +364,7 @@ class PurgeLogs extends CommonDBTM {
     */
    static function getDateModRestriction($month) {
       if ($month > 0) {
-         return ['date_mod' => new QueryExpression("DATE_ADD(NOW(), INTERVAL -$month MONTH)")];
+         return ['date_mod' => ['<=', new QueryExpression("DATE_ADD(NOW(), INTERVAL -$month MONTH)")]];
       } else if ($month == Config::DELETE_ALL) {
          return [1 => 1];
       } else if ($month == Config::KEEP_ALL) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4529 

Date criterion was using `=` operator instead of `<=`.