### PR TITLE
Fix cases where rack position is not set

### DIFF
--- a/inc/rack.class.php
+++ b/inc/rack.class.php
@@ -920,6 +920,22 @@ JAVASCRIPT;
     * @return array
     */
    private function prepareInput($input) {
+
+      if (!array_key_exists('dcrooms_id', $input) || $input['dcrooms_id'] == 0) {
+         // Position is not set if room not selected
+         return $input;
+      }
+
+      if ($input['position'] == 0) {
+         return $input;
+         Session::addMessageAfterRedirect(
+            __('Position must be set'),
+            true,
+            ERROR
+         );
+         return false;
+      }
+
       $where = [
          'dcrooms_id'   => $input['dcrooms_id'],
          'position'     => $input['position'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. When adding a rack without selecting a room, PHP was trigerring a `Undefined index: position` notice.
2. When adding a rack in a room without selecting a position, rack position was set to 0 for the first one added. Other additions were refused due to conflict at position 0.