### PR TITLE
Fix datacenter items deletion

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -192,6 +192,10 @@ a:hover {
    color: black;
 }
 
+a.target-deleted {
+   text-decoration:line-through;
+}
+
 hr {
    border: 1px solid #cccccc;
 }

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -907,10 +907,19 @@ class CommonDBTM extends CommonGLPI {
 
       if (in_array($this->getType(), $CFG_GLPI['rackable_types'])) {
          //delete relation beetween rackable type and its rack
-         $DB->delete(
-            Item_Rack::getTable(), [
-               'itemtype'  => $this->getType(),
-               'items_id'  => $this->fields['id']
+         $item_rack = new Item_Rack();
+         $item_rack->deleteByCriteria(
+            [
+               'itemtype' => $this->getType(),
+               'items_id' => $this->fields['id']
+            ]
+         );
+
+         $item_enclosure = new Item_Enclosure();
+         $item_enclosure->deleteByCriteria(
+            [
+               'itemtype' => $this->getType(),
+               'items_id' => $this->fields['id']
             ]
          );
       }

--- a/inc/dcbreadcrumb.class.php
+++ b/inc/dcbreadcrumb.class.php
@@ -58,7 +58,8 @@ trait DCBreadcrumb {
       if (in_array($item->getType(), $enclosure_types)) {
          //check if asset is part of an enclosure
          if ($enclosure = $this->isEnclosurePart($item->getType(), $item->getID(), true)) {
-            $breadcrumb[] = $enclosure->getLink();
+            $options = ['linkoption' => $enclosure->isDeleted() ? 'class="target-deleted"' : ''];
+            $breadcrumb[] = $enclosure->getLink($options);
             $item = $enclosure;
          }
       }
@@ -66,7 +67,8 @@ trait DCBreadcrumb {
       if (in_array($item->getType(), $types)) {
          //check if asset (or its enclosure) is part of a rack
          if ($rack = $this->isRackPart($item->getType(), $item->getID(), true)) {
-            $breadcrumb[] = $rack->getLink();
+            $options = ['linkoption' => $rack->isDeleted() ? 'class="target-deleted"' : ''];
+            $breadcrumb[] = $rack->getLink($options);
             $item = $rack;
          }
       }
@@ -75,7 +77,8 @@ trait DCBreadcrumb {
          if ($item->fields['dcrooms_id'] > 0) {
             $dcroom = new DCRoom();
             if ($dcroom->getFromDB($item->fields['dcrooms_id'])) {
-               $breadcrumb[] = $dcroom->getLink();
+               $options = ['linkoption' => $dcroom->isDeleted() ? 'class="target-deleted"' : ''];
+               $breadcrumb[] = $dcroom->getLink($options);
                $item = $dcroom;
             }
          }
@@ -85,7 +88,8 @@ trait DCBreadcrumb {
          if ($item->fields['datacenters_id'] > 0) {
             $datacenter = new Datacenter();
             if ($datacenter->getFromDB($item->fields['datacenters_id'])) {
-               $breadcrumb[] = $datacenter->getLink();
+               $options = ['linkoption' => $datacenter->isDeleted() ? 'class="target-deleted"' : ''];
+               $breadcrumb[] = $datacenter->getLink($options);
             }
          }
       }

--- a/inc/dcbreadcrumb.class.php
+++ b/inc/dcbreadcrumb.class.php
@@ -122,6 +122,9 @@ trait DCBreadcrumb {
          $enclosure = new Enclosure();
          if ($enclosure->getFromDB($ien->fields['enclosures_id'])) {
             return $enclosure;
+         } else {
+            // Association to unexisting enclosure is possible due to a bug in 9.3.0.
+            return false;
          }
       }
 
@@ -147,6 +150,9 @@ trait DCBreadcrumb {
          $rack = new \Rack();
          if ($rack->getFromDb($ira->fields['racks_id'])) {
             return $rack;
+         } else {
+            // Association to unexisting rack is possible due to a bug in 9.3.0.
+            return false;
          }
       }
 

--- a/inc/pdu.class.php
+++ b/inc/pdu.class.php
@@ -313,4 +313,13 @@ class PDU extends CommonDBTM {
 
       return $tab;
    }
+
+   function cleanDBonPurge() {
+
+      $pdu_plug = new Pdu_Plug();
+      $pdu_plug->deleteByCriteria(['pdus_id' => $this->fields['id']]);
+
+      $pdu_rack = new PDU_Rack();
+      $pdu_rack->deleteByCriteria(['pdus_id' => $this->fields['id']]);
+   }
 }

--- a/inc/plug.class.php
+++ b/inc/plug.class.php
@@ -41,4 +41,10 @@ class Plug extends CommonDropdown {
    static function getTypeName($nb = 0) {
       return _n('Plug', 'Plugs', $nb);
    }
+
+   function cleanDBonPurge() {
+
+      $pdu_plug = new Pdu_Plug();
+      $pdu_plug->deleteByCriteria(['plugs_id' => $this->fields['id']]);
+   }
 }

--- a/inc/rack.class.php
+++ b/inc/rack.class.php
@@ -1039,6 +1039,15 @@ JAVASCRIPT;
       return true;
    }
 
+   function cleanDBonPurge() {
+
+      $item_rack = new Item_Rack();
+      $item_rack->deleteByCriteria(['racks_id' => $this->fields['id']]);
+
+      $pdu_rack = new PDU_Rack();
+      $pdu_rack->deleteByCriteria(['racks_id' => $this->fields['id']]);
+   }
+
    /**
     * Get cell content
     *

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -110,6 +110,12 @@ $RELATION = ["glpi_authldaps"
                         "glpi_contracttypes"
                         => ['glpi_contracts' => 'contracttypes_id'],
 
+                        "glpi_datacenters"
+                        => ['glpi_dcrooms' => 'datacenters_id'],
+
+                        "glpi_dcrooms"
+                        => ['glpi_racks' => 'dcrooms_id'],
+
                         "glpi_devicecases"
                         => ['glpi_items_devicecases' => 'devicecases_id'],
 
@@ -180,6 +186,9 @@ $RELATION = ["glpi_authldaps"
                                  'glpi_printers'          => 'domains_id',
                                  'glpi_networkequipments' => 'domains_id'],
 
+                        "glpi_enclosuremodels"
+                        => ['glpi_enclosures' => 'enclosuremodels_id'],
+
                         "glpi_entities"
                         => ['glpi_savedsearches'                   => 'entities_id',
                                  'glpi_budgets'                         => 'entities_id',
@@ -194,8 +203,11 @@ $RELATION = ["glpi_authldaps"
                                  '_glpi_consumables'                    => 'entities_id',
                                  'glpi_contacts'                        => 'entities_id',
                                  'glpi_contracts'                       => 'entities_id',
+                                 'glpi_datacenters'                     => 'entities_id',
+                                 'glpi_dcrooms'                         => 'entities_id',
                                  'glpi_documents'                       => 'entities_id',
                                  '_glpi_documents_items'                => 'entities_id',
+                                 'glpi_enclosures'                      => 'entities_id',
                                  '_glpi_entities'                       => 'entities_id',
                                  'glpi_entities'                        => 'entities_id_software',
                                  'glpi_entities_knowbaseitems'          => 'entities_id',
@@ -222,6 +234,8 @@ $RELATION = ["glpi_authldaps"
                                  'glpi_networknames'                    => 'entities_id',
                                  '_glpi_networkports'                   => 'entities_id',
                                  'glpi_notifications'                   => 'entities_id',
+                                 'glpi_pdus'                            => 'entities_id',
+                                 'glpi_pdutypes'                        => 'entities_id',
                                  'glpi_peripherals'                     => 'entities_id',
                                  'glpi_phones'                          => 'entities_id',
                                  'glpi_printers'                        => 'entities_id',
@@ -230,6 +244,8 @@ $RELATION = ["glpi_authldaps"
                                  '_glpi_projecttasks'                   => 'entities_id',
                                  'glpi_profiles_reminders'              => 'entities_id',
                                  'glpi_profiles_users'                  => 'entities_id',
+                                 'glpi_racks'                           => 'entities_id',
+                                 'glpi_racktypes'                       => 'entities_id',
                                  '_glpi_reservationitems'               => 'entities_id',
                                  'glpi_rules'                           => 'entities_id',
                                  '_glpi_slalevels'                      => 'entities_id',
@@ -264,6 +280,7 @@ $RELATION = ["glpi_authldaps"
                            'glpi_computers'            => ['groups_id_tech', 'groups_id'],
                            'glpi_consumables'          => ['items_id', 'itemtype'],
                            'glpi_consumableitems'      => 'groups_id_tech',
+                           'glpi_enclosures'           => 'groups_id_tech',
                            'glpi_groups'               => 'groups_id',
                            'glpi_groups_knowbaseitems' => 'groups_id',
                            'glpi_groups_problems'      => 'groups_id',
@@ -273,10 +290,12 @@ $RELATION = ["glpi_authldaps"
                            'glpi_itilcategories'       => 'groups_id',
                            'glpi_monitors'             => ['groups_id_tech', 'groups_id'],
                            'glpi_networkequipments'    => ['groups_id_tech', 'groups_id'],
+                           'glpi_pdus'                 => 'groups_id_tech',
                            'glpi_peripherals'          => ['groups_id_tech', 'groups_id'],
                            'glpi_phones'               => ['groups_id_tech', 'groups_id'],
                            'glpi_printers'             => ['groups_id_tech', 'groups_id'],
                            'glpi_certificates'         => ['groups_id_tech', 'groups_id'],
+                           'glpi_racks'                => 'groups_id_tech',
                            'glpi_projects'             => 'groups_id',
                            'glpi_softwarelicenses'     => ['groups_id_tech', 'groups_id'],
                            'glpi_softwares'            => ['groups_id_tech', 'groups_id']
@@ -318,13 +337,18 @@ $RELATION = ["glpi_authldaps"
                                  'glpi_cartridgeitems'    => 'locations_id',
                                  'glpi_consumableitems'   => 'locations_id',
                                  'glpi_computers'         => 'locations_id',
+                                 'glpi_datacenters'       => 'locations_id',
+                                 'glpi_dcrooms'           => 'locations_id',
+                                 'glpi_enclosures'        => 'locations_id',
                                  'glpi_locations'         => 'locations_id',
                                  'glpi_monitors'          => 'locations_id',
                                  'glpi_netpoints'         => 'locations_id',
                                  'glpi_networkequipments' => 'locations_id',
+                                 'glpi_pdus'              => 'locations_id',
                                  'glpi_peripherals'       => 'locations_id',
                                  'glpi_phones'            => 'locations_id',
                                  'glpi_printers'          => 'locations_id',
+                                 'glpi_racks'             => 'locations_id',
                                  'glpi_softwarelicenses'  => 'locations_id',
                                  'glpi_softwares'         => 'locations_id',
                                  'glpi_tickets'           => 'locations_id',
@@ -352,12 +376,15 @@ $RELATION = ["glpi_authldaps"
                                  'glpi_devicegenerics'      => 'manufacturers_id',
                                  'glpi_devicesensors'       => 'manufacturers_id',
                                  'glpi_devicesimcards'      => 'manufacturers_id',
+                                 'glpi_enclosures'          => 'manufacturers_id',
                                  'glpi_monitors'            => 'manufacturers_id',
                                  'glpi_networkequipments'   => 'manufacturers_id',
+                                 'glpi_pdus'                => 'manufacturers_id',
                                  'glpi_peripherals'         => 'manufacturers_id',
                                  'glpi_phones'              => 'manufacturers_id',
                                  'glpi_printers'            => 'manufacturers_id',
                                  'glpi_certificates'        => 'manufacturers_id',
+                                 'glpi_racks'               => 'manufacturers_id',
                                  'glpi_softwarelicenses'    => 'manufacturers_id',
                                  'glpi_softwares'           => 'manufacturers_id'],
 
@@ -408,6 +435,12 @@ $RELATION = ["glpi_authldaps"
 
                         "glpi_operatingsystemversions"
                         => ['glpi_items_operatingsystems' => 'operatingsystemversions_id'],
+
+                        "glpi_pdumodels"
+                        => ['glpi_pdus' => 'pdumodels_id'],
+
+                        "glpi_pdutypes"
+                        => ['glpi_pdus' => 'pdutypes_id'],
 
                         "glpi_peripheralmodels"
                         => ['glpi_peripherals' =>' peripheralmodels_id'],
@@ -474,6 +507,12 @@ $RELATION = ["glpi_authldaps"
                                  'glpi_profiles_reminders'     => 'profiles_id',
                                  'glpi_profiles_users'         => 'profiles_id',
                                  'glpi_users'                  => 'profiles_id'],
+
+                        "glpi_rackmodels"
+                        => ['glpi_racks' => 'rackmodels_id'],
+
+                        "glpi_racktypes"
+                        => ['glpi_racks' => 'racktypes_id'],
 
                         "glpi_reminders"
                         => ['glpi_entities_reminders'  => 'reminders_id',
@@ -542,12 +581,15 @@ $RELATION = ["glpi_authldaps"
 
                         "glpi_states"
                         => ['glpi_computers'         => 'states_id',
+                                 'glpi_enclosures'        => 'states_id',
                                  'glpi_monitors'          => 'states_id',
                                  'glpi_networkequipments' => 'states_id',
+                                 'glpi_pdus'             => 'states_id',
                                  'glpi_peripherals'       => 'states_id',
                                  'glpi_phones'            => 'states_id',
                                  'glpi_printers'          => 'states_id',
                                  'glpi_certificates'      => 'states_id',
+                                 'glpi_racks'             => 'states_id',
                                  'glpi_softwarelicenses'  => 'states_id',
                                  'glpi_softwareversions'  => 'states_id',
                                  'glpi_states'            => 'states_id'],
@@ -630,6 +672,7 @@ $RELATION = ["glpi_authldaps"
                                  'glpi_consumableitems'           => 'users_id_tech',
                                  'glpi_displaypreferences'        => 'users_id',
                                  'glpi_documents'                 => 'users_id',
+                                 'glpi_enclosures'                => 'users_id_tech',
                                  'glpi_groups_users'              => 'users_id',
                                  'glpi_itilcategories'            => 'users_id',
                                  'glpi_knowbaseitems'             => 'users_id',
@@ -637,6 +680,7 @@ $RELATION = ["glpi_authldaps"
                                  'glpi_monitors'                  => ['users_id_tech', 'users_id'],
                                  'glpi_networkequipments'         => ['users_id_tech', 'users_id'],
                                  'glpi_notimportedemails'         => 'users_id',
+                                 'glpi_pdus'                      => 'users_id_tech',
                                  'glpi_peripherals'               => ['users_id_tech', 'users_id'],
                                  'glpi_phones'                    => ['users_id_tech', 'users_id'],
                                  'glpi_printers'                  => ['users_id_tech', 'users_id'],
@@ -648,6 +692,7 @@ $RELATION = ["glpi_authldaps"
                                  'glpi_profiles_users'            => 'users_id',
                                  'glpi_projects'                  => 'users_id',
                                  'glpi_projecttasks'              => 'users_id',
+                                 'glpi_racks'                     => 'users_id_tech',
                                  'glpi_reminders'                 => 'users_id',
                                  'glpi_reminders_users'           => 'users_id',
                                  'glpi_reservations'              => 'users_id',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4424 

1. Deleted items will now be line-through in DC breadcrumb.
2. Deleting DC items using massive actions will be prevented if there are liked items.
3. Forced deletion of DC items will update foreign keys pointing to them or purge elements that depends on them.