### PR TITLE
Fix undefined offset when logging from front

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -399,7 +399,7 @@ class Toolbox {
       $msg = "";
       if (function_exists('debug_backtrace')) {
          $bt  = debug_backtrace();
-         if (count($bt) > 1) {
+         if (count($bt) > 2) {
             if (isset($bt[2]['class'])) {
                $msg .= $bt[2]['class'].'::';
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When logging from a method called directly from front, backtrace containes only 2 elements (0 is the log function, 1 is the caller function).
-> `(count($bt) > 1)` is true but offset 2 does not exists