### PR TITLE
Fix undefined index for PDU consumption

### DIFF
--- a/inc/item_rack.class.php
+++ b/inc/item_rack.class.php
@@ -482,7 +482,10 @@ JAVASCRIPT;
                }
             }
 
-            $power += $model->fields['power_consumption'];
+            if (array_key_exists('power_consumption', $model->fields)) { // PDU does not consume energy
+               $power += $model->fields['power_consumption'];
+            }
+
             $weight += $model->fields['weight'];
          } else {
             $units[Rack::FRONT][$row['position']] = 1;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When adding a PDU as `Item_Rack`, following trace is generated.
```
glpiphplog.ERROR: Toolbox::userErrorHandlerNormal() in /var/www/glpi/inc/toolbox.class.php line 657
  *** PHP Notice(8): Undefined index: power_consumption
  Backtrace :
  inc/item_rack.class.php:486                        
  inc/item_rack.class.php:360                        Item_Rack::showStats()
  inc/item_rack.class.php:72                         Item_Rack::showItems()
  inc/commonglpi.class.php:488                       Item_Rack::displayTabContentForItem()
  ajax/common.tabs.php:92                            CommonGLPI::displayStandardTab()
  {"user":"2@87e8d9f523bd"} 
```