### PR TITLE
Don't use getFromIter for one result

### DIFF
--- a/inc/olalevel_ticket.class.php
+++ b/inc/olalevel_ticket.class.php
@@ -82,8 +82,9 @@ class OlaLevel_Ticket extends CommonDBTM {
          ],
          'LIMIT'        => 1
       ]);
-      if (count($iterator)) {
-         return $this->getFromIter($iterator);
+      if (count($iterator) == 1) {
+         $row = $iterator->next();
+         return $this->getFromDB($row['id']);
       }
       return false;
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4530 

Fix matches a previous patch to slalevel_ticket class