### PR TITLE
Collector : can now specify where the requester's email is found

### DIFF
--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -4292,6 +4292,7 @@ CREATE TABLE `glpi_mailcollectors` (
   `errors` int(11) NOT NULL DEFAULT '0',
   `use_mail_date` tinyint(1) NOT NULL DEFAULT '0',
   `date_creation` datetime DEFAULT NULL,
+  `caller_location` enum('from', 'reply-to') NOT NULL DEFAULT 'from',
   PRIMARY KEY (`id`),
   KEY `is_active` (`is_active`),
   KEY `date_mod` (`date_mod`),

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -4292,7 +4292,7 @@ CREATE TABLE `glpi_mailcollectors` (
   `errors` int(11) NOT NULL DEFAULT '0',
   `use_mail_date` tinyint(1) NOT NULL DEFAULT '0',
   `date_creation` datetime DEFAULT NULL,
-  `caller_location` enum('from', 'reply-to') NOT NULL DEFAULT 'from',
+  `requester_field` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `is_active` (`is_active`),
   KEY `date_mod` (`date_mod`),

--- a/install/update_93_94.php
+++ b/install/update_93_94.php
@@ -61,11 +61,11 @@ function update93to94() {
    }
    /** /Add default group for a user */
 
-   /** Add caller location on glpi_mailcollectors */
-   if (!$DB->fieldExists('glpi_mailcollectors', 'requester_field')) {
-      $migration->addField("glpi_mailcollectors", "requester_field", "int(11) NOT NULL DEFAULT '0'");
-   }
-   /** /Add caller location on glpi_mailcollectors */
+   /** Add requester field on glpi_mailcollectors */
+   $migration->addField("glpi_mailcollectors", "requester_field", "integer", [
+      'value' => '0'
+   ]);
+   /** /Add requester field on glpi_mailcollectors */
 
    /** Add business rules on assets */
    $rule = ['name'         => 'Domain user assignation',

--- a/install/update_93_94.php
+++ b/install/update_93_94.php
@@ -62,8 +62,8 @@ function update93to94() {
    /** /Add default group for a user */
 
    /** Add caller location on glpi_mailcollectors */
-   if (!$DB->fieldExists('glpi_mailcollectors', 'caller_location')) {
-      $migration->addField("glpi_mailcollectors", "caller_location", "enum('from', 'reply-to') NOT NULL DEFAULT 'from'");
+   if (!$DB->fieldExists('glpi_mailcollectors', 'requester_field')) {
+      $migration->addField("glpi_mailcollectors", "requester_field", "int(11) NOT NULL DEFAULT '0'");
    }
    /** /Add caller location on glpi_mailcollectors */
 

--- a/install/update_93_94.php
+++ b/install/update_93_94.php
@@ -61,6 +61,12 @@ function update93to94() {
    }
    /** /Add default group for a user */
 
+   /** Add caller location on glpi_mailcollectors */
+   if (!$DB->fieldExists('glpi_mailcollectors', 'caller_location')) {
+      $migration->addField("glpi_mailcollectors", "caller_location", "enum('from', 'reply-to') NOT NULL DEFAULT 'from'");
+   }
+   /** /Add caller location on glpi_mailcollectors */
+
    /** Add business rules on assets */
    $rule = ['name'         => 'Domain user assignation',
             'is_active'    => 1,


### PR DESCRIPTION
'from' : current behavior
'reply-to' : use the email found in the 'reply-to' header

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
