### PR TITLE
Fix availability of expert mode of LDAP import

### DIFF
--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -2920,6 +2920,7 @@ class AuthLDAP extends CommonDBTM {
             $_SESSION['ldap_import']['mode']           = self::ACTION_IMPORT;
          } else {
             $_SESSION['ldap_import']['_in_modal']      = 0;
+            $_SESSION['ldap_import']['no_expert_mode'] = 0;
          }
       }
 
@@ -3053,7 +3054,8 @@ class AuthLDAP extends CommonDBTM {
       // If not coming from the ticket form, then give expert/simple link
       if ((Config::canUpdate()
            || Entity::canUpdate())
-          && !isset($_SESSION['ldap_import']['no_expert_mode'])) {
+          && (!isset($_SESSION['ldap_import']['no_expert_mode'])
+              || $_SESSION['ldap_import']['no_expert_mode'] != 1)) {
 
          echo "</span>&nbsp;<span class='floatright'><a href='".$_SERVER['PHP_SELF']."?action=".
               $_SESSION['ldap_import']['action']."&amp;mode=".$_SESSION['ldap_import']['mode'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix edge case where "expert mode" of LDAP user import is not available in user list context.

1) Use user import function from Ticket form (it opens a modal that defines `$_SESSION['ldap_import']['no_expert_mode']` to `1`).
2) Use user import function from user list.
-> Expert mode is not available as `$_SESSION['ldap_import']['no_expert_mode']` value is still `1`.
