### PR TITLE
fix location of local_define.php

### DIFF
--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -53,7 +53,7 @@ if (!defined("GLPI_CONFIG_DIR")) {
 }
 
 // If this file exists, it is load
-if (file_exists(GLPI_CONFIG_DIR. '/local_define.php')) {
+if (file_exists(GLPI_CONFIG_DIR. '/local_define.php') && !defined('TU_USER')) {
    require_once GLPI_CONFIG_DIR. '/local_define.php';
 }
 

--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -42,11 +42,6 @@ if (!empty($tz)) {
    date_default_timezone_set(@date_default_timezone_get());
 }
 
-// If this file exists, it is load
-if (file_exists(GLPI_ROOT. '/config/local_define.php') && !defined('TU_USER')) {
-   require_once GLPI_ROOT. '/config/local_define.php';
-}
-
 // If this file exists, it is load, allow to set configdir/dumpdir elsewhere
 if (file_exists(GLPI_ROOT . '/inc/downstream.php')) {
    include_once (GLPI_ROOT . '/inc/downstream.php');
@@ -55,6 +50,11 @@ if (file_exists(GLPI_ROOT . '/inc/downstream.php')) {
 // Default location for database configuration : config_db.php
 if (!defined("GLPI_CONFIG_DIR")) {
    define("GLPI_CONFIG_DIR", GLPI_ROOT . "/config");
+}
+
+// If this file exists, it is load
+if (file_exists(GLPI_CONFIG_DIR. '/local_define.php')) {
+   require_once GLPI_CONFIG_DIR. '/local_define.php';
 }
 
 // Default location for all files


### PR DESCRIPTION
According to the documentation on https://glpi-install.readthedocs.io/fr/latest/install/ a local_define.php file can be placed in the GLPI_CONFIG_DIR. This fixes the issue.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

*Please update this template with something that matches your PR*