### PR TITLE
missing breadcrumb in fieldunicity

### DIFF
--- a/inc/fieldunicity.class.php
+++ b/inc/fieldunicity.class.php
@@ -66,6 +66,10 @@ class FieldUnicity extends CommonDropdown {
    }
 
 
+   function displayHeader() {
+      Html::header(FieldUnicity::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "config", "fieldunicity");
+   }
+
    function getAdditionalFields() {
 
       return [['name'  => 'is_active',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

I use `displayHeader` because front/fieldunicity.form.php uses commondropdown.form.php for display