### PR TITLE
Fix fetching of user's groups from LDAP

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -1401,7 +1401,7 @@ class User extends CommonDBTM {
                      'WHERE'  => ['ldap_group_dn' => Toolbox::addslashes_deep($v[$i]['ou'])]
                   ]);
 
-                  while ($group = $iterator->next()) {
+                  while ($group = $group_iterator->next()) {
                      $this->fields["_groups"][] = $group['id'];
                   }
                }
@@ -1417,6 +1417,7 @@ class User extends CommonDBTM {
                    && ($v[$i][$field]['count'] > 0)) {
 
                   unset($v[$i][$field]['count']);
+                  $lgroups = [];
                   foreach (Toolbox::addslashes_deep($v[$i][$field]) as $lgroup) {
                      $lgroups[] = [
                         new \QueryExpression($DB::quoteValue($lgroup).
@@ -1433,7 +1434,7 @@ class User extends CommonDBTM {
                      ]
                   ]);
 
-                  while ($group = $iterator->next()) {
+                  while ($group = $group_iterator->next()) {
                      $this->fields["_groups"][] = $group['id'];
                   }
                }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I do not know this part so I am not sure how to test it. It seems that fetching groups was based on wrong iterator variable.