### PR TITLE
Replace /front/dropdown.common.php by CommonDropdown::displaySearchPage()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The present file will list all changes made to the project; according to the
 [Keep a Changelog](http://keepachangelog.com/) project.
 
+## [9.3.2] unreleased
+
+### API changes
+
+#### Deprecated
+
+- Inclusion of `/front/dropdown.common.php` file has been deprecated
+
 ## [9.3.1] unreleased
 
 ### Added

--- a/front/autoupdatesystem.php
+++ b/front/autoupdatesystem.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new AutoUpdateSystem();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/blacklist.php
+++ b/front/blacklist.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new Blacklist();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/blacklistedmailcontent.php
+++ b/front/blacklistedmailcontent.php
@@ -38,4 +38,4 @@ include ('../inc/includes.php');
 
 $dropdown = new BlacklistedMailContent();
 
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/businesscriticity.php
+++ b/front/businesscriticity.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new BusinessCriticity();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/calendar.php
+++ b/front/calendar.php
@@ -34,4 +34,4 @@ include ('../inc/includes.php');
 
 $dropdown = new Calendar();
 
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/cartridgeitemtype.php
+++ b/front/cartridgeitemtype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new CartridgeItemType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/certificatetype.php
+++ b/front/certificatetype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new CertificateType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/computermodel.php
+++ b/front/computermodel.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new ComputerModel();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/computertype.php
+++ b/front/computertype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new ComputerType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/consumableitemtype.php
+++ b/front/consumableitemtype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new ConsumableItemType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/contacttype.php
+++ b/front/contacttype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new ContactType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/contracttype.php
+++ b/front/contracttype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new ContractType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/device.php
+++ b/front/device.php
@@ -39,4 +39,4 @@ if (!isset($_GET['itemtype']) || !class_exists($_GET['itemtype'])) {
 }
 
 $dropdown = new $_GET['itemtype'];
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/devicemodel.php
+++ b/front/devicemodel.php
@@ -39,4 +39,4 @@ if (!isset($_GET['itemtype']) || !class_exists($_GET['itemtype'])) {
 }
 
 $dropdown = new $_GET['itemtype'];
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/devicetype.php
+++ b/front/devicetype.php
@@ -39,4 +39,4 @@ if (!isset($_GET['itemtype']) || !class_exists($_GET['itemtype'])) {
 }
 
 $dropdown = new $_GET['itemtype'];
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/documentcategory.php
+++ b/front/documentcategory.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new DocumentCategory();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/documenttype.php
+++ b/front/documenttype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new DocumentType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/domain.php
+++ b/front/domain.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new Domain();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/dropdown.common.php
+++ b/front/dropdown.common.php
@@ -30,19 +30,10 @@
  * ---------------------------------------------------------------------
  */
 
+Toolbox::deprecated('Inclusion of dropdown.common.php file has been deprecated. Please use CommonDropdown::displaySearchPage().');
+
 if (!($dropdown instanceof CommonDropdown)) {
    Html::displayErrorAndDie('');
 }
-if (!$dropdown->canView()) {
-   // Gestion timeout session
-   Session::redirectIfNotLoggedIn();
-   Html::displayRightError();
-}
 
-$dropdown->displayHeader();
-
-$dropdown->title();
-
-Search::show(get_class($dropdown));
-
-Html::footer();
+$dropdown->displaySearchPage();

--- a/front/enclosuremodel.php
+++ b/front/enclosuremodel.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new EnclosureModel();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/entity.php
+++ b/front/entity.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new Entity();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/fieldblacklist.php
+++ b/front/fieldblacklist.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new Fieldblacklist();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/filesystem.php
+++ b/front/filesystem.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new Filesystem();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/fqdn.php
+++ b/front/fqdn.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new FQDN();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/holiday.php
+++ b/front/holiday.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new Holiday();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/interfacetype.php
+++ b/front/interfacetype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new InterfaceType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/ipnetwork.php
+++ b/front/ipnetwork.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new IPNetwork();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/itilcategory.php
+++ b/front/itilcategory.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new ITILCategory();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/knowbaseitemcategory.php
+++ b/front/knowbaseitemcategory.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new KnowbaseItemCategory();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/lineoperator.php
+++ b/front/lineoperator.php
@@ -37,4 +37,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new LineOperator();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/linetype.php
+++ b/front/linetype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new LineType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/location.php
+++ b/front/location.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new Location();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/manufacturer.php
+++ b/front/manufacturer.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new Manufacturer();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/monitormodel.php
+++ b/front/monitormodel.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new MonitorModel();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/monitortype.php
+++ b/front/monitortype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new MonitorType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/netpoint.php
+++ b/front/netpoint.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new Netpoint();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/network.php
+++ b/front/network.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new Network();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/networkequipmentmodel.php
+++ b/front/networkequipmentmodel.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new NetworkEquipmentModel();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/networkequipmenttype.php
+++ b/front/networkequipmenttype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new NetworkEquipmentType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/networkinterface.php
+++ b/front/networkinterface.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new NetworkInterface();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/operatingsystem.php
+++ b/front/operatingsystem.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new OperatingSystem();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/operatingsystemarchitecture.php
+++ b/front/operatingsystemarchitecture.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new OperatingSystemArchitecture();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/operatingsystemedition.php
+++ b/front/operatingsystemedition.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new OperatingSystemEdition();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/operatingsystemkernel.php
+++ b/front/operatingsystemkernel.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new OperatingSystemKernel();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/operatingsystemkernelversion.php
+++ b/front/operatingsystemkernelversion.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new OperatingSystemKernelVersion();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/operatingsystemservicepack.php
+++ b/front/operatingsystemservicepack.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new OperatingSystemServicePack();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/operatingsystemversion.php
+++ b/front/operatingsystemversion.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new OperatingSystemVersion();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/pdumodel.php
+++ b/front/pdumodel.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new PDUModel();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/pdutype.php
+++ b/front/pdutype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new PDUType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/peripheralmodel.php
+++ b/front/peripheralmodel.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new PeripheralModel();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/peripheraltype.php
+++ b/front/peripheraltype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new PeripheralType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/phonemodel.php
+++ b/front/phonemodel.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new PhoneModel();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/phonepowersupply.php
+++ b/front/phonepowersupply.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new PhonePowerSupply();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/phonetype.php
+++ b/front/phonetype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new PhoneType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/plug.php
+++ b/front/plug.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new Plug();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/printermodel.php
+++ b/front/printermodel.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new PrinterModel();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/printertype.php
+++ b/front/printertype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new PrinterType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/projectstate.php
+++ b/front/projectstate.php
@@ -37,4 +37,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new ProjectState();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/projecttasktemplate.php
+++ b/front/projecttasktemplate.php
@@ -37,4 +37,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new ProjecttaskTemplate();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/projecttasktype.php
+++ b/front/projecttasktype.php
@@ -37,4 +37,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new ProjectTaskType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/projecttype.php
+++ b/front/projecttype.php
@@ -37,4 +37,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new ProjectType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/rackmodel.php
+++ b/front/rackmodel.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new RackModel();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/racktype.php
+++ b/front/racktype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new RackType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/requesttype.php
+++ b/front/requesttype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new RequestType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/rulerightparameter.php
+++ b/front/rulerightparameter.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new RuleRightParameter();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/softwarecategory.php
+++ b/front/softwarecategory.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new SoftwareCategory();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/softwarelicensetype.php
+++ b/front/softwarelicensetype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new SoftwareLicenseType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/solutiontemplate.php
+++ b/front/solutiontemplate.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new SolutionTemplate();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/solutiontype.php
+++ b/front/solutiontype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new SolutionType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/ssovariable.php
+++ b/front/ssovariable.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new SsoVariable();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/state.php
+++ b/front/state.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new State();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/suppliertype.php
+++ b/front/suppliertype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new SupplierType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/taskcategory.php
+++ b/front/taskcategory.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new TaskCategory();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/tasktemplate.php
+++ b/front/tasktemplate.php
@@ -37,4 +37,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new TaskTemplate();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/ticketrecurrent.php
+++ b/front/ticketrecurrent.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new TicketRecurrent();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/tickettemplate.php
+++ b/front/tickettemplate.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new TicketTemplate();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/usercategory.php
+++ b/front/usercategory.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new UserCategory();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/usertitle.php
+++ b/front/usertitle.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new UserTitle();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/virtualmachinestate.php
+++ b/front/virtualmachinestate.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new VirtualMachineState();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/virtualmachinesystem.php
+++ b/front/virtualmachinesystem.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new VirtualMachineSystem();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/virtualmachinetype.php
+++ b/front/virtualmachinetype.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new VirtualMachineType();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/vlan.php
+++ b/front/vlan.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new Vlan();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/front/wifinetwork.php
+++ b/front/wifinetwork.php
@@ -33,4 +33,4 @@
 include ('../inc/includes.php');
 
 $dropdown = new WifiNetwork();
-include (GLPI_ROOT . "/front/dropdown.common.php");
+$dropdown->displaySearchPage();

--- a/inc/commondropdown.class.php
+++ b/inc/commondropdown.class.php
@@ -985,4 +985,24 @@ abstract class CommonDropdown extends CommonDBTM {
       }
       return $ret;
    }
+
+   /**
+    * Display list page for current item type.
+    *
+    * @since 9.3.2
+    *
+    * @return void
+    */
+   public function displaySearchPage() {
+
+      if (!$this->canView()) {
+         Session::redirectIfNotLoggedIn();
+         Html::displayRightError();
+      }
+
+      $this->displayHeader();
+      $this->title();
+      Search::show(get_class($this));
+      Html::footer();
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The idea is to get rid of includes that are done from outside the `/inc/includes.php` file.

May be done as well for:
 - /front/dropdown.common.form.php,
 - /front/commonitilcost.form.php,
 - /front/commonitiltask.form.php,
 - /front/commonitilvalidation.form.php,
 - /front/item_device.common.form.php,
 - /front/rule.common.form.php,
 - /front/rule.common.php.

Questions are (for mentioned elements only) :
 - Should we move front code to classes ?
 - Should we refactor it or just moved it as it is ?
 - Should we move it to related classes or new classes, like `Front_Dropdown` (or even a new namespace like `Glpi\Front`) ?