### PR TITLE
Remove ability to use password recovery when using ext auth

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -1048,6 +1048,8 @@ class Auth extends CommonGLPI {
     */
    static function useAuthExt() {
 
+      global $CFG_GLPI;
+
       //Get all the ldap directories
       if (AuthLdap::useAuthLdap()) {
          return true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It seems that it is possible to use the password recovery process when using external auth like CAS.