### PR TITLE
Fix missing return status in cartridge cron

### DIFF
--- a/inc/cartridgeitem.class.php
+++ b/inc/cartridgeitem.class.php
@@ -534,6 +534,8 @@ class CartridgeItem extends CommonDBTM {
             }
          }
       }
+
+      return $cron_status;
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Cartridge cron was not returning its status.
Even if this status will always be 1, it seems preferable than always show "Action aborted" in task log.