### PR TITLE
Fix TinyMCE languages file existence check; fixes #4640

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3515,9 +3515,9 @@ class Html {
       Html::requireJs('tinymce');
 
       $language = $_SESSION['glpilanguage'];
-      if (!file_exists(GLPI_ROOT."/lib/tiny_mce/langs/$language.js")) {
+      if (!file_exists(GLPI_ROOT."/lib/tiny_mce/lib/langs/$language.js")) {
          $language = $CFG_GLPI["languages"][$_SESSION['glpilanguage']][2];
-         if (!file_exists(GLPI_ROOT."/lib/tiny_mce/langs/$language.js")) {
+         if (!file_exists(GLPI_ROOT."/lib/tiny_mce/lib/langs/$language.js")) {
             $language = "en_GB";
          }
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4640 

TinyMCE files were moved from `lib/tiny_mce/` to `lib/tiny_mce/lib/` in commit 7a2d0dbd1fdd4492511122282de3f9aae5b41725.

When using a fresh install of GLPI, TinyMCE is always in english.
When copying new files onto an existing instance of GLPI, checks are made on old path, and loading is made on new path, which can lead to try to load an unexisting file.