### PR TITLE
Fix can connexity item on invalid items

### DIFF
--- a/inc/commondbconnexity.class.php
+++ b/inc/commondbconnexity.class.php
@@ -315,22 +315,28 @@ abstract class CommonDBConnexity extends CommonDBTM {
                              CommonDBTM &$item = null) {
 
       // Do not get it twice
-      if ($item == null) {
-         $item = $this->getConnexityItem($itemtype, $items_id);
+      $connexityItem = $item;
+      if ($connexityItem == null) {
+         $connexityItem = $this->getConnexityItem($itemtype, $items_id);
+
+         // Set value in $item to reuse it on future calls
+         if ($connexityItem instanceof CommonDBTM) {
+            $item = $this->getConnexityItem($itemtype, $items_id);
+         }
       }
       if ($item_right != self::DONT_CHECK_ITEM_RIGHTS) {
-         if ($item !== false) {
+         if ($connexityItem !== false) {
             if ($item_right == self::HAVE_VIEW_RIGHT_ON_ITEM) {
                $methodNotItem = 'canView';
                $methodItem    = 'canViewItem';
             }
             // here, we can check item's global rights
             if (preg_match('/^itemtype/', $itemtype)) {
-               if (!$item->$methodNotItem()) {
+               if (!$connexityItem->$methodNotItem()) {
                   return false;
                }
             }
-            return $item->$methodItem();
+            return $connexityItem->$methodItem();
          } else {
             // if we cannot get the parent, then we throw an exception
             throw new CommonDBConnexityItemNotFound();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Sometimes, `$item` argument passed to `CommonDBConnexity::canConnexityItem()` is `false`. It happens here https://github.com/glpi-project/glpi/blob/9.3/bugfixes/inc/commondbrelation.class.php#L409, when first call defines $item to false.

This PR prevent setting $item to false as it should juste be updated with a valid CommonDBTM item.