### PR TITLE
Fix associated elements label on helpdesk ticket form; see #4660

### DIFF
--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -323,7 +323,7 @@ class Item_Ticket extends CommonDBRelation{
                             'itemtype'   : (itemtype === undefined) ? $('#dropdown_itemtype$rand').val() : itemtype,
                             'items_id'   : (items_id === undefined) ? $('#dropdown_add_items_id$rand').val() : items_id},
                      success: function(response) {";
-      $js .= "          $(\"#itemAddForm$rand\").html(response);";
+      $js .= "          $(\"#itemAddForm$rand\").replaceWith(response);";
       $js .= "       }";
       $js .= "    });";
       $js .= " }";
@@ -686,10 +686,7 @@ class Item_Ticket extends CommonDBRelation{
       $already_add = $params['used'];
 
       if ($_SESSION["glpiactiveprofile"]["helpdesk_hardware"]&pow(2, Ticket::HELPDESK_MY_HARDWARE)) {
-         $my_devices = ['' => __('General')];
-         if ($params['tickets_id'] > 0) {
-            $my_devices = ['' => Dropdown::EMPTY_VALUE];
-         }
+         $my_devices = ['' => Dropdown::EMPTY_VALUE];
          $devices    = [];
 
          // My items

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -4015,7 +4015,7 @@ class Ticket extends CommonITILObject {
           && (count($_SESSION["glpiactiveprofile"]["helpdesk_item_type"]))) {
          if (!$tt->isHiddenField('items_id')) {
             echo "<tr class='tab_bg_1'>";
-            echo "<td>".sprintf(__('%1$s%2$s'), __('Hardware type'),
+            echo "<td>".sprintf(__('%1$s%2$s'), _n('Associated element', 'Associated elements', Session::getPluralNumber()),
                                 $tt->getMandatoryMark('items_id'))."</td>";
             echo "<td>";
             $options['_canupdate'] = Session::haveRight('ticket', CREATE);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | part of #4660 

1. Fix field label.
2. Fix replacement of HTML (previously, `itemAddForm` was added inside `itemAddForm` instead of replacing it).
3. Display default empty value instead of 'General' as 'General' label was made to be displayed as optgroup label, not as value label.