### PR TITLE
Load plugins on ajax files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The present file will list all changes made to the project; according to the
 
 ### API changes
 
+#### Changes
+- Plugins are now loaded in ajax files.
+
 #### Deprecated
 
 - Remove `$CFG_GLPI['use_rich_text']` parameter. Will now be `true` per default.

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -100,7 +100,7 @@ if (isset($AJAX_INCLUDE)) {
 }
 
 /* On startup, register all plugins configured for use. */
-if (!isset($AJAX_INCLUDE) && !isset($PLUGINS_INCLUDED)) {
+if (!isset($PLUGINS_INCLUDED)) {
    // PLugin already included
    $PLUGINS_INCLUDED = 1;
    $LOADED_PLUGINS   = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Plugins are not loaded from ajax files (due to presence of `$AJAX_INCLUDE = 1;`). This behaviour has been introduced a long time ago in commit b06a35d03460ae2a367898b1fa9ad73a408e3ede .

It may have technical reasons, but it does not seems logical at all. Plugins should be able to override core behaviour even if request is made on ajax. https://github.com/glpi-project/glpi/issues/4635 is an example of the limitation introduced by not loading plugins on ajax requests.

I think we should load  Plugins on ajax request. If it leads to some unintended behaviour, we should fix this behaviour, not neutralyze all plugins.