### PR TITLE
Fix personnal display preferences list

### DIFF
--- a/inc/displaypreference.class.php
+++ b/inc/displaypreference.class.php
@@ -598,12 +598,13 @@ class DisplayPreference extends CommonDBTM {
       $url = Toolbox::getItemTypeFormURL(__CLASS__);
 
       $iterator = $DB->request([
-         'SELECT' => ['itemtype', ['COUNT' => '* AS nb']],
-         'FROM'   => self::getTable(),
-         'WHERE'  => [
+         'SELECT'  => ['itemtype'],
+         'COUNT'   => 'nb',
+         'FROM'    => self::getTable(),
+         'WHERE'   => [
             'users_id'  => $users_id
          ],
-         'GROUP'  => 'itemtype'
+         'GROUPBY' => 'itemtype'
       ]);
 
       if (count($iterator) > 0) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Personnal display preferenceslist was not displayed due to MySQL error and was trigerring PHP warnings.