### PR TITLE
decode entities in completion field

### DIFF
--- a/ajax/autocompletion.php
+++ b/ajax/autocompletion.php
@@ -87,7 +87,7 @@ $values = [];
 
 if (count($iterator)) {
    while ($data = $iterator->next()) {
-      $values[] = $data[$_GET['field']];
+      $values[] = Html::entity_decode_deep($data[$_GET['field']]);
    }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Very minor issue.
In all Html::autocompletionTextField if we have a previous object with special char, the autocompletion give the item with html entities.

The bug seems very old as i succeed to replicate it (i did it on Setup > Field unicity) on a 0.85 like the below screenshot:
![image](https://user-images.githubusercontent.com/418844/46012761-87daf280-c0ca-11e8-9041-1e31ba668693.png)

 
