### PR TITLE
Add CommonDBTM::getTableField() method

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -232,6 +232,30 @@ class CommonDBTM extends CommonGLPI {
       return $_SESSION['glpi_foreign_key_field_of'][get_called_class()];
    }
 
+   /**
+    * Return SQL path to access a field.
+    *
+    * @param string      $field     Name of the field (or SQL keyword like '*')
+    * @param string|null $classname Forced classname (to avoid late_binding on inheritance)
+    *
+    * @return string
+    *
+    * @throws InvalidArgumentException
+    * @throws LogicException
+    **/
+   static function getTableField($field, $classname = null) {
+
+      if (empty($field)) {
+         throw new InvalidArgumentException('Argument $field cannot be empty.');
+      }
+
+      $tablename = self::getTable($classname);
+      if (empty($tablename)) {
+         throw new LogicException('Invalid table name.');
+      }
+
+      return sprintf('%s.%s', $tablename, $field);
+   }
 
    /**
     * Retrieve an item from the database

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -221,4 +221,38 @@ class CommonDBTM extends DbTestCase {
          ->isEqualTo(\CommonDBTM::getTable($classname))
          ->isEqualTo($tablename);
    }
+
+   /**
+    * Test CommonDBTM::getTableField() method.
+    *
+    * @return void
+    */
+   public function testGetTableField() {
+
+      // Exception if field argument is empty
+      $this->exception(
+         function() {
+            \Computer::getTableField('');
+         }
+      )->isInstanceOf(\InvalidArgumentException::class)
+         ->hasMessage('Argument $field cannot be empty.');
+
+      // Exception if class has no table
+      $this->exception(
+         function() {
+            \Item_Devices::getTableField('id');
+         }
+      )->isInstanceOf(\LogicException::class)
+         ->hasMessage('Invalid table name.');
+
+      // Base case
+      $this->string(\Computer::getTableField('serial'))
+         ->isEqualTo(\CommonDBTM::getTableField('serial', \Computer::class))
+         ->isEqualTo('glpi_computers.serial');
+
+      // Wildcard case
+      $this->string(\Config::getTableField('*'))
+         ->isEqualTo(\CommonDBTM::getTableField('*', \Config::class))
+         ->isEqualTo('glpi_configs.*');
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

New method proposal to facilitate writing of SQL querying.

Examples of usage: 
```diff
diff --git a/inc/commondbtm.class.php b/inc/commondbtm.class.php
index 807a96895d..bebdb0eed4 100644
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -275,7 +275,7 @@ class CommonDBTM extends CommonGLPI {
       $iterator = $DB->request([
          'FROM'   => $this->getTable(),
          'WHERE'  => [
-            $this->getTable() . '.' . $this->getIndexName() => Toolbox::cleanInteger($ID)
+            $this->getTableField($this->getIndexName()) => Toolbox::cleanInteger($ID)
          ],
          'LIMIT'  => 1
       ]);
diff --git a/inc/computer_softwareversion.class.php b/inc/computer_softwareversion.class.php
index ece4d872e5..2e21930701 100644
--- a/inc/computer_softwareversion.class.php
+++ b/inc/computer_softwareversion.class.php
@@ -741,8 +741,8 @@ class Computer_SoftwareVersion extends CommonDBRelation {
             ]
          ],
          'WHERE'     => [
-            self::getTable() . '.computers_id'  => $computers_id,
-            self::getTable() . '.is_deleted'     => 0,
+            self::getTableField('computers_id')  => $computers_id,
+            self::getTableField('is_deleted')    => 0,
          ] + $where,
          'ORDER'     => ['softname', 'version']
       ]);
@@ -1087,12 +1087,12 @@ class Computer_SoftwareVersion extends CommonDBRelation {
             ]
          ],
          'WHERE'        => [
-            'glpi_computers_softwarelicenses.computers_id'  => $computers_id,
+            Computer_SoftwareLicense::getTableField('computers_id') => $computers_id,
             'OR'                                            => [
-               'glpi_softwarelicenses.softwareversions_id_use' => $verid,
+               self::getTableField('softwareversions_id_use') => $verid,
                'AND'                                           => [
-                  'glpi_softwarelicenses.softwareversions_id_use' => 0,
-                  'glpi_softwarelicenses.softwareversions_id_buy' => $verid
+                  self::getTableField('softwareversions_id_use') => 0,
+                  self::getTableField('softwareversions_id_buy') => $verid
                ]
             ]
          ]

```