### PR TITLE
Add missing try / catch block

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -657,16 +657,21 @@ class Auth extends CommonGLPI {
                            AuthLdap::IDENTIFIER_LOGIN => $ldap_method["login_field"],
                         ],
                      ];
-                     $user_dn
-                        = AuthLdap::searchUserDn($ds,
-                                                 ['basedn'      => $ldap_method["basedn"],
-                                                       'login_field' => $ldap_method['login_field'],
-                                                       'search_parameters'
-                                                                     => $params,
-                                                       'user_params'
-                                                         => ['method' => AuthLDAP::IDENTIFIER_LOGIN,
-                                                                  'value'  => $login_name],
-                                                         'condition'   => $ldap_method["condition"]]);
+                     try {
+                        $user_dn
+                           = AuthLdap::searchUserDn($ds,
+                                                   ['basedn'      => $ldap_method["basedn"],
+                                                         'login_field' => $ldap_method['login_field'],
+                                                         'search_parameters'
+                                                                        => $params,
+                                                         'user_params'
+                                                            => ['method' => AuthLDAP::IDENTIFIER_LOGIN,
+                                                                     'value'  => $login_name],
+                                                            'condition'   => $ldap_method["condition"]]);
+                     } catch (\RuntimeException $e) {
+                        Toolbox::logError($e->getMessage());
+                        $user_dn = false;
+                     }
                      if ($user_dn) {
                         $this->user->fields['auths_id'] = $ldap_method['id'];
                         $this->user->getFromLDAP($ds, $ldap_method, $user_dn['dn'], $login_name,

--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -2757,6 +2757,7 @@ class AuthLDAP extends CommonDBTM {
     *          - condition : ldap condition used
     *
     * @return array|boolean dn of the user, else false
+    * @throws \RuntimeException
     */
    static function searchUserDn($ds, $options = []) {
 


### PR DESCRIPTION
When trying to login from the A1PI with a user token, when GLPI has LDAP authentication sources,
AuthLdap::searchUserDn() fails to find the user by login or by DN and raises an exception

Signed-off-by: Thierry Bugier <tbugier@teclib.com>

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4717 
*Please update this template with something that matches your PR*