### PR TITLE
fix bottom positioning in split layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -787,7 +787,7 @@ input.submit[type=reset] {
    }
 
    .layout_vsplit #page .glpi_tabs {
-      height: 96%;
+      height: calc(100% - 50px);
       position: relative;
       z-index:1;
    }
@@ -831,7 +831,7 @@ input.submit[type=reset] {
       overflow-y: auto;
       position: absolute;
       top: 0;
-      bottom: 50px;
+      bottom: 33px;
    }
 
    .layout_classic #tabspanel + div.ui-tabs:not(.horizontal),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

in split layout:
- 33px for left form corresponds to the footer height on bare glpi (50px is with fusioninventory additional footer, not our problem)
- 50px for right (with a calculated value instead of a raw percent) is the height of previous element (.navigationheader), in fact 49px but i kept 1px for having a soft border.

## Results

### before
![image](https://user-images.githubusercontent.com/418844/46288461-0d0c4e80-c586-11e8-8861-3b56cf41c9d6.png)

### after
![image](https://user-images.githubusercontent.com/418844/46288448-f9f97e80-c585-11e8-82bb-3674e28b163b.png)
