### PR TITLE
Fix update of configuration when referenced item is deleted

### DIFF
--- a/inc/documentcategory.class.php
+++ b/inc/documentcategory.class.php
@@ -43,4 +43,45 @@ class DocumentCategory extends CommonTreeDropdown {
    static function getTypeName($nb = 0) {
       return _n('Document heading', 'Document headings', $nb);
    }
+
+
+   function cleanRelationData() {
+
+      parent::cleanRelationData();
+
+      if ($this->isUsedAsDefaultCategoryForTickets()) {
+         $newval = (isset($this->input['_replace_by']) ? $this->input['_replace_by'] : 0);
+
+         Config::setConfigurationValues(
+            'core',
+            [
+               'documentcategories_id_forticket' => $newval,
+            ]
+         );
+      }
+   }
+
+
+   function isUsed() {
+
+      if (parent::isUsed()) {
+         return true;
+      }
+
+      return $this->isUsedAsDefaultCategoryForTickets();
+   }
+
+
+   /**
+    * Check if category is used as default for tickets documents.
+    *
+    * @return boolean
+    */
+   private function isUsedAsDefaultCategoryForTickets() {
+
+      $config_values = Config::getConfigurationValues('core', ['documentcategories_id_forticket']);
+
+      return array_key_exists('documentcategories_id_forticket', $config_values)
+         && $config_values['documentcategories_id_forticket'] == $this->fields['id'];
+   }
 }

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -174,8 +174,7 @@ $RELATION = ["glpi_authldaps"
                         => ['glpi_items_devicegenerics' => 'devicegenerics_id'],
 
                         "glpi_documentcategories"
-                        => ['glpi_configs'             => 'documentcategories_id_forticket',
-                                 'glpi_documents'           => 'documentcategories_id',
+                        => ['glpi_documents'           => 'documentcategories_id',
                                  'glpi_documentcategories'  => 'documentcategories_id'],
 
                         "glpi_documents"
@@ -523,8 +522,7 @@ $RELATION = ["glpi_authldaps"
                         "glpi_requesttypes"
                         => ['glpi_ticketfollowups'  => 'requesttypes_id',
                                  'glpi_tickets'          => 'requesttypes_id',
-                                 'glpi_users'            => 'default_requesttypes_id',
-                                 'glpi_configs'          => 'default_requesttypes_id'],
+                                 'glpi_users'            => 'default_requesttypes_id'],
 
                         "glpi_reservationitems"
                         => ['glpi_reservations' => 'reservationitems_id'],
@@ -554,8 +552,7 @@ $RELATION = ["glpi_authldaps"
                             'glpi_tickets'   => ['olas_ttr_id', 'olas_tto_id']],
 
                         "glpi_softwarecategories"
-                        => ['glpi_softwares' => 'softwarecategories_id',
-                            'glpi_configs'   => 'softwarecategories_id_ondelete'],
+                        => ['glpi_softwares' => 'softwarecategories_id'],
 
                         "glpi_softwarelicensetypes"
                         => ['glpi_softwarelicenses' =>'softwarelicensetypes_id'],
@@ -650,12 +647,6 @@ $RELATION = ["glpi_authldaps"
                             'glpi_tickets'             => 'solutiontypes_id',
                             'glpi_solutiontemplates'   => 'solutiontypes_id',
                             'glpi_problems'            => 'solutiontypes_id'],
-
-                        "glpi_ssovariables"
-                        => ['glpi_configs' => 'ssovariables_id'],
-
-                        "glpi_transfers"
-                        => ['glpi_configs' => 'transfers_id_auto'],
 
                         "glpi_usercategories"
                         => ['glpi_users' => 'usercategories_id'],

--- a/inc/requesttype.class.php
+++ b/inc/requesttype.class.php
@@ -244,4 +244,44 @@ class RequestType extends CommonDropdown {
       Rule::cleanForItemCriteria($this);
    }
 
+
+   function cleanRelationData() {
+
+      parent::cleanRelationData();
+
+      if ($this->isUsedAsDefaultRequestType()) {
+         $newval = (isset($this->input['_replace_by']) ? $this->input['_replace_by'] : 0);
+
+         Config::setConfigurationValues(
+            'core',
+            [
+               'default_requesttypes_id' => $newval,
+            ]
+         );
+      }
+   }
+
+
+   function isUsed() {
+
+      if (parent::isUsed()) {
+         return true;
+      }
+
+      return $this->isUsedAsDefaultRequestType();
+   }
+
+
+   /**
+    * Check if type is used as default for new tickets.
+    *
+    * @return boolean
+    */
+   private function isUsedAsDefaultRequestType() {
+
+      $config_values = Config::getConfigurationValues('core', ['default_requesttypes_id']);
+
+      return array_key_exists('default_requesttypes_id', $config_values)
+         && $config_values['default_requesttypes_id'] == $this->fields['id'];
+   }
 }

--- a/inc/softwarecategory.class.php
+++ b/inc/softwarecategory.class.php
@@ -49,4 +49,44 @@ class SoftwareCategory extends CommonTreeDropdown {
       Rule::cleanForItemAction($this);
    }
 
+
+   function cleanRelationData() {
+
+      parent::cleanRelationData();
+
+      if ($this->isUsedAsCategoryOnSoftwareDeletion()) {
+         $newval = (isset($this->input['_replace_by']) ? $this->input['_replace_by'] : 0);
+
+         Config::setConfigurationValues(
+            'core',
+            [
+               'softwarecategories_id_ondelete' => $newval,
+            ]
+         );
+      }
+   }
+
+
+   function isUsed() {
+
+      if (parent::isUsed()) {
+         return true;
+      }
+
+      return $this->isUsedAsCategoryOnSoftwareDeletion();
+   }
+
+
+   /**
+    * Check if type is used as category for softwares deleted by rules.
+    *
+    * @return boolean
+    */
+   private function isUsedAsCategoryOnSoftwareDeletion() {
+
+      $config_values = Config::getConfigurationValues('core', ['softwarecategories_id_ondelete']);
+
+      return array_key_exists('softwarecategories_id_ondelete', $config_values)
+         && $config_values['softwarecategories_id_ondelete'] == $this->fields['id'];
+   }
 }

--- a/inc/ssovariable.class.php
+++ b/inc/ssovariable.class.php
@@ -63,4 +63,44 @@ class SsoVariable extends CommonDropdown {
       return static::canUpdate();
    }
 
+
+   function cleanRelationData() {
+
+      parent::cleanRelationData();
+
+      if ($this->isUsedInAuth()) {
+         $newval = (isset($this->input['_replace_by']) ? $this->input['_replace_by'] : 0);
+
+         Config::setConfigurationValues(
+            'core',
+            [
+               'ssovariables_id' => $newval,
+            ]
+         );
+      }
+   }
+
+
+   function isUsed() {
+
+      if (parent::isUsed()) {
+         return true;
+      }
+
+      return $this->isUsedInAuth();
+   }
+
+
+   /**
+    * Check if variable is used in auth process.
+    *
+    * @return boolean
+    */
+   private function isUsedInAuth() {
+
+      $config_values = Config::getConfigurationValues('core', ['ssovariables_id']);
+
+      return array_key_exists('ssovariables_id', $config_values)
+         && $config_values['ssovariables_id'] == $this->fields['id'];
+   }
 }

--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -3601,4 +3601,31 @@ class Transfer extends CommonDBTM {
    }
 
 
+   function cleanRelationData() {
+
+      parent::cleanRelationData();
+
+      if ($this->isUsedAsAutomaticTransferModel()) {
+         Config::setConfigurationValues(
+            'core',
+            [
+               'transfers_id_auto' => 0,
+            ]
+         );
+      }
+   }
+
+
+   /**
+    * Check if used as automatic transfer model.
+    *
+    * @return boolean
+    */
+   private function isUsedAsAutomaticTransferModel() {
+
+      $config_values = Config::getConfigurationValues('core', ['transfers_id_auto']);
+
+      return array_key_exists('transfers_id_auto', $config_values)
+         && $config_values['transfers_id_auto'] == $this->fields['id'];
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When deleting in item referenced in configuration, an SQL error is trigerred and configuration is not updated.

This fix gives ability to choose replacement item on deletion process.

To reproduce the bug/test the fix:
 - create a new `Fields storage of the login in the HTTP request` (/front/ssovariable.php),
 - use it in configuration (/front/auth.others.php),
 - delete it.

SQL error:
```
glpisqllog.ERROR: DBmysql::query() in /var/www/glpi/inc/dbmysql.class.php line 177
  *** MySQL query error:
  SQL: SELECT COUNT(*) AS cpt FROM `glpi_configs` WHERE `ssovariables_id` = '10'
  Error: Unknown column 'ssovariables_id' in 'where clause'
  Backtrace :
  inc/dbmysqliterator.class.php:95                   
  inc/dbmysql.class.php:580                          DBmysqlIterator->execute()
  inc/commondropdown.class.php:580                   DBmysql->request()
  front/dropdown.common.form.php:80                  CommonDropdown->isUsed()
  front/ssovariable.form.php:36                      include()
  {"user":"2@87e8d9f523bd"} 
```