### PR TITLE
Fix update of consumable when deleting group or user

### DIFF
--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -910,4 +910,60 @@ class Group extends CommonTreeDropdown {
       echo "</div>";
    }
 
+
+   function cleanRelationData() {
+
+      global $DB;
+
+      parent::cleanRelationData();
+
+      if ($this->isUsedInConsumables()) {
+         // Replace relation with Consumable
+         $newval = (isset($this->input['_replace_by']) ? $this->input['_replace_by'] : 0);
+
+         $fields_updates = [
+            'items_id' => $newval,
+         ];
+         if (empty($newval)) {
+            $fields_updates['itemtype'] = 'NULL';
+            $fields_updates['date_out'] = 'NULL';
+         }
+
+         $DB->update(
+            'glpi_consumables',
+            $fields_updates,
+            [
+               'items_id' => $this->fields['id'],
+               'itemtype' => self::class,
+            ]
+         );
+      }
+   }
+
+
+   function isUsed() {
+
+      if (parent::isUsed()) {
+         return true;
+      }
+
+      return $this->isUsedInConsumables();
+   }
+
+
+   /**
+    * Check if group is used in consumables.
+    *
+    * @return boolean
+    */
+   private function isUsedInConsumables() {
+
+      return countElementsInTable(
+         Consumable::getTable(),
+         [
+            'items_id' => $this->fields['id'],
+            'itemtype' => self::class,
+         ]
+      ) > 0;
+   }
 }

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -278,7 +278,6 @@ $RELATION = ["glpi_authldaps"
                            'glpi_cartridgeitems'       => 'groups_id_tech',
                            'glpi_changes_groups'       => 'groups_id',
                            'glpi_computers'            => ['groups_id_tech', 'groups_id'],
-                           'glpi_consumables'          => ['items_id', 'itemtype'],
                            'glpi_consumableitems'      => 'groups_id_tech',
                            'glpi_enclosures'           => 'groups_id_tech',
                            'glpi_groups'               => 'groups_id',

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -360,10 +360,12 @@ class User extends CommonDBTM {
       // Set no user to consumables
       $DB->update(
          'glpi_consumables', [
-            'items_id' => 0
+            'items_id' => 0,
+            'itemtype' => 'NULL',
+            'date_out' => 'NULL'
          ], [
-            'items_id'  => $this->fields['id'],
-            'itemtype'  => 'User'
+            'items_id' => $this->fields['id'],
+            'itemtype' => 'User'
          ]
       );
 

--- a/tests/functionnal/Consumable.php
+++ b/tests/functionnal/Consumable.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+*/
+
+namespace tests\units;
+
+/* Test for inc/consumable.class.php */
+
+class Consumable extends \DbTestCase {
+
+   /**
+    * Test "out" and "back to stock" functions.
+    * Test "back" to stock whend linked user or group is deleted.
+    */
+   public function testOutAndBackToStock() {
+
+      $consumable = new \Consumable();
+
+      $consumable_item = new \ConsumableItem();
+      $cu_id = (int)$consumable_item->add([
+         'name' => 'Test consumable item'
+      ]);
+      $this->integer($cu_id)->isGreaterThan(0);
+
+      $group = new \Group();
+      $gid1 = (int)$group->add([
+         'name' => 'Test group 1'
+      ]);
+      $this->integer($gid1)->isGreaterThan(0);
+      $gid2 = (int)$group->add([
+         'name' => 'Test group 2'
+      ]);
+      $this->integer($gid2)->isGreaterThan(0);
+
+      $user = new \User();
+      $uid = (int)$user->add([
+         'name' => 'User group'
+      ]);
+      $this->integer($uid)->isGreaterThan(0);
+
+      $c_ids = [];
+      for ($i = 0; $i < 20; $i++) {
+         $c_id = (int)$consumable->add([
+            'name'               => 'Test consumable',
+            'consumableitems_id' => $cu_id,
+         ]);
+         $this->integer($c_id)->isGreaterThan(0);
+
+         $c_ids[] = $c_id;
+
+         // Give 1/4 of consumable pool to test group 1
+         if ($i % 4 === 0) {
+            $consumable->out($c_id, 'Group', $gid1);
+         }
+         // Give 1/4 of consumable pool to test group 2
+         if ($i % 4 === 1) {
+            $consumable->out($c_id, 'Group', $gid2);
+         }
+         // Give 1/4 of consumable pool to test user
+         if ($i % 4 === 2) {
+            $consumable->out($c_id, 'User', $uid);
+         }
+      }
+
+      // Test counters
+      $this->integer($consumable->getTotalNumber($cu_id))->isEqualTo(20);
+      $this->integer($consumable->getUnusedNumber($cu_id))->isEqualTo(5);
+      $this->integer($consumable->getOldNumber($cu_id))->isEqualTo(15);
+
+      // Test back to stock
+      $this->boolean($consumable->backToStock(['id' => $c_ids[0]]))->isTrue();
+      $this->integer($consumable->getUnusedNumber($cu_id))->isEqualTo(6);
+      $this->integer($consumable->getOldNumber($cu_id))->isEqualTo(14);
+
+      // Test forced back to stock by removal of group (not replaced)
+      $this->boolean($group->delete(['id' => $gid1, true]))->isTrue();
+      $this->integer($consumable->getUnusedNumber($cu_id))->isEqualTo(10);
+      $this->integer($consumable->getOldNumber($cu_id))->isEqualTo(10);
+      $this->integer(
+            countElementsInTable(
+               $consumable->getTable(),
+               [
+                  'consumableitems_id' => $cu_id,
+                  'itemtype'           => 'Group',
+                  'items_id'           => $gid1,
+               ]
+            )
+         )->isEqualTo(0);
+
+      // Test replacement of a group (no back to stock)
+      $this->boolean($group->delete(['id' => $gid2, '_replace_by' => $gid1], true))->isTrue();
+      $this->integer($consumable->getUnusedNumber($cu_id))->isEqualTo(10);
+      $this->integer($consumable->getOldNumber($cu_id))->isEqualTo(10);
+      $this->integer(
+            countElementsInTable(
+               $consumable->getTable(),
+               [
+                  'consumableitems_id' => $cu_id,
+                  'itemtype'           => 'Group',
+                  'items_id'           => $gid2,
+               ]
+            )
+         )->isEqualTo(0);
+      $this->integer(
+            countElementsInTable(
+               $consumable->getTable(),
+               [
+                  'consumableitems_id' => $cu_id,
+                  'itemtype'           => 'Group',
+                  'items_id'           => $gid1,
+               ]
+            )
+         )->isEqualTo(5);
+
+      // Test forced back to stock by removal of user (not replaced)
+      $this->boolean($user->delete(['id' => $uid], true))->isTrue();
+      $this->integer($consumable->getUnusedNumber($cu_id))->isEqualTo(15);
+      $this->integer($consumable->getOldNumber($cu_id))->isEqualTo(5);
+      $this->integer(
+            countElementsInTable(
+               $consumable->getTable(),
+               [
+                  'consumableitems_id' => $cu_id,
+                  'itemtype'           => 'User',
+                  'items_id'           => $uid,
+               ]
+            )
+         )->isEqualTo(0);
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Multiple problems.

1) Deletion of a group removes relation between consumable and user if user have same id as deleted group.
Problem was that the relation is based on composite key (`itemtype` + `items_id`) but `CommonDBTM::cleanRelationData()` handles it as 2 differents foreign keys (so it updates everything matching the given item_id, regardless of the itemtype).

2) Deletion of a user or group does not put back consumable in stock.
Problem was that only itemsid was updated to `0`, but consumables are considered in stock if `date_out` is NULL.
