### PR TITLE
Fix relation constraints and cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The present file will list all changes made to the project; according to the
 
 The following methods have been deprecated:
 
+- `ITILSolution::removeForItem()`
 - `Session::isViewAllEntities()`
 
 ## [9.3.1] 2018-09-12

--- a/inc/calendar.class.php
+++ b/inc/calendar.class.php
@@ -227,17 +227,11 @@ class Calendar extends CommonDropdown {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $DB->delete(
-         'glpi_calendars_holidays', [
-            'calendars_id' => $this->fields['id']
-         ]
-      );
-
-      $DB->delete(
-         'glpi_calendarsegments', [
-            'calendars_id' => $this->fields['id']
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Calendar_Holiday::class,
+            CalendarSegment::class,
          ]
       );
    }

--- a/inc/cartridgeitem.class.php
+++ b/inc/cartridgeitem.class.php
@@ -80,11 +80,12 @@ class CartridgeItem extends CommonDBTM {
 
    function cleanDBonPurge() {
 
-      $class = new Cartridge();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $class = new CartridgeItem_PrinterModel();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Cartridge::class,
+            CartridgeItem_PrinterModel::class,
+         ]
+      );
 
       $class = new Alert();
       $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);

--- a/inc/certificate.class.php
+++ b/inc/certificate.class.php
@@ -55,8 +55,13 @@ class Certificate extends CommonDBTM {
     * Clean certificate items
     */
    function cleanDBonPurge() {
-      $cert_item = new Certificate_Item();
-      $cert_item->deleteByCriteria(['certificates_id' => $this->fields['id']]);
+
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Certificate_Item::class,
+            Change_Item::class,
+         ]
+      );
    }
 
    function rawSearchOptions() {

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -252,31 +252,25 @@ class Change extends CommonITILObject {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $DB->delete(
-         'glpi_changetasks', [
-            'changes_id'   => $this->fields['id']
+      // CommonITILTask does not extends CommonDBConnexity
+      $ct = new ChangeTask();
+      $ct->deleteByCriteria(['changes_id' => $this->fields['id']]);
+
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            // Done by parent: Change_Group::class,
+            Change_Item::class,
+            Change_Problem::class,
+            Change_Project::class,
+            // Done by parent: Change_Supplier::class,
+            Change_Ticket::class,
+            // Done by parent: Change_User::class,
+            ChangeCost::class,
+            ChangeValidation::class,
+            // Done by parent: ITILSolution::class,
          ]
       );
-
-      $cp = new Change_Problem();
-      $cp->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ct = new Change_Ticket();
-      $ct->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $cp = new Change_Project();
-      $cp->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ci = new Change_Item();
-      $ci->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $cv = new ChangeValidation();
-      $cv->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $cc = new ChangeCost();
-      $cc->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
 
       parent::cleanDBonPurge();
    }

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -863,6 +863,34 @@ class CommonDBTM extends CommonGLPI {
 
 
    /**
+    * Delete children items and relation with other items from database.
+    *
+    * @param array $relations_classes List of classname on which deletion will be done
+    *                                 Classes needs to extends CommonDBConnexity.
+    *
+    * @return void
+    **/
+   protected function deleteChildrenAndRelationsFromDb(array $relations_classes) {
+
+      foreach ($relations_classes as $classname) {
+         if (!is_a($classname, CommonDBConnexity::class, true)) {
+            Toolbox::logWarning(
+               sprintf(
+                  'Unable to clean elements of class %s as it does not extends "CommonDBConnexity"',
+                  $classname
+               )
+            );
+            continue;
+         }
+
+         /** @var CommonDBConnexity $relation_item */
+         $relation_item = new $classname();
+         $relation_item->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      }
+   }
+
+
+   /**
     * Clean translations associated to a dropdown
     *
     * @since 0.85

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -584,23 +584,23 @@ abstract class CommonITILObject extends CommonDBTM {
 
    function cleanDBonPurge() {
 
-      if (!empty($this->grouplinkclass)) {
-         $class = new $this->grouplinkclass();
-         $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      $link_classes = [
+         ITILSolution::class
+      ];
+
+      if (is_a($this->grouplinkclass, CommonDBConnexity::class, true)) {
+         $link_classes[] = $this->grouplinkclass;
       }
 
-      if (!empty($this->userlinkclass)) {
-         $class = new $this->userlinkclass();
-         $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      if (is_a($this->userlinkclass, CommonDBConnexity::class, true)) {
+         $link_classes[] = $this->userlinkclass;
       }
 
-      if (!empty($this->supplierlinkclass)) {
-         $class = new $this->supplierlinkclass();
-         $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      if (is_a($this->supplierlinkclass, CommonDBConnexity::class, true)) {
+         $link_classes[] = $this->supplierlinkclass;
       }
 
-      $solution = new ITILSolution();
-      $solution->removeForItem($this->getType(), $this->getID());
+      $this->deleteChildrenAndRelationsFromDb($link_classes);
    }
 
 

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -543,8 +543,11 @@ abstract class CommonITILTask  extends CommonDBTM {
    **/
    function cleanDBonPurge() {
 
-      $class = new PlanningRecall();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            PlanningRecall::class,
+         ]
+      );
    }
 
 

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -315,38 +315,24 @@ class Computer extends CommonDBTM {
 
    function cleanDBonPurge() {
 
-      $csv = new Computer_SoftwareVersion();
-      $csv->cleanDBonItemDelete('Computer', $this->fields['id']);
-
-      $csl = new Computer_SoftwareLicense();
-      $csl->cleanDBonItemDelete('Computer', $this->fields['id']);
-
-      $ip = new Item_Problem();
-      $ip->cleanDBonItemDelete('Computer', $this->fields['id']);
-
-      $ci = new Change_Item();
-      $ci->cleanDBonItemDelete('Computer', $this->fields['id']);
-
-      $ip = new Item_Project();
-      $ip->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ci = new Computer_Item();
-      $ci->cleanDBonItemDelete('Computer', $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Certificate_Item::class,
+            Change_Item::class,
+            Computer_Item::class,
+            Computer_SoftwareLicense::class,
+            Computer_SoftwareVersion::class,
+            ComputerAntivirus::class,
+            ComputerVirtualMachine::class,
+            Item_Disk::class,
+            Item_OperatingSystem::class,
+            Item_Problem::class,
+            Item_Project::class,
+         ]
+      );
 
       Item_Devices::cleanItemDeviceDBOnItemDelete($this->getType(), $this->fields['id'],
                                                   (!empty($this->input['keep_devices'])));
-
-      $disk = new Item_Disk();
-      $disk->cleanDBonItemDelete('Computer', $this->fields['id']);
-
-      $vm = new ComputerVirtualMachine();
-      $vm->cleanDBonItemDelete('Computer', $this->fields['id']);
-
-      $antivirus = new ComputerAntivirus();
-      $antivirus->cleanDBonItemDelete('Computer', $this->fields['id']);
-
-      $ios = new Item_OperatingSystem();
-      $ios->cleanDBonItemDelete('Computer', $this->fields['id']);
    }
 
 

--- a/inc/consumable.class.php
+++ b/inc/consumable.class.php
@@ -80,12 +80,10 @@ class Consumable extends CommonDBChild {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $DB->delete(
-         'glpi_infocoms', [
-            'items_id'  => $this->fields['id'],
-            'itemtype'  => $this->getType()
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Infocom::class,
          ]
       );
    }

--- a/inc/consumableitem.class.php
+++ b/inc/consumableitem.class.php
@@ -94,11 +94,15 @@ class ConsumableItem extends CommonDBTM {
 
    function cleanDBonPurge() {
 
-      $class = new Consumable();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Consumable::class,
+         ]
+      );
 
-      $class = new Alert();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      // Alert does not extends CommonDBConnexity
+      $alert = new Alert();
+      $alert->cleanDBonItemDelete($this->getType(), $this->fields['id']);
    }
 
 

--- a/inc/contact.class.php
+++ b/inc/contact.class.php
@@ -55,22 +55,12 @@ class Contact extends CommonDBTM{
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $cs = new Contact_Supplier();
-      $cs->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $DB->delete(
-         'glpi_projecttaskteams', [
-            'items_id'  => $this->fields['id'],
-            'itemtype'  => __CLASS__
-         ]
-      );
-
-      $DB->delete(
-         'glpi_projectteams', [
-            'items_id'  => $this->fields['id'],
-            'itemtype'  => __CLASS__
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Contact_Supplier::class,
+            ProjectTaskTeam::class,
+            ProjectTeam::class,
          ]
       );
    }

--- a/inc/contract.class.php
+++ b/inc/contract.class.php
@@ -64,17 +64,17 @@ class Contract extends CommonDBTM {
 
    function cleanDBonPurge() {
 
-      $class = new Contract_Supplier();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Contract_Item::class,
+            Contract_Supplier::class,
+            ContractCost::class,
+         ]
+      );
 
-      $class = new ContractCost();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $class = new Contract_Item();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $class = new Alert();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      // Alert does not extends CommonDBConnexity
+      $alert = new Alert();
+      $alert->cleanDBonItemDelete($this->getType(), $this->fields['id']);
    }
 
 

--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -106,13 +106,10 @@ class CronTask extends CommonDBTM{
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $DB->delete(
-         'glpi_crontasklogs', [
-            'crontasks_id' => $this->fields['id']
-         ]
-      );
+      // CronTaskLog does not extends CommonDBConnexity
+      $ctl = new CronTaskLog();
+      $ctl->deleteByCriteria(['crontasks_id' => $this->fields['id']]);
    }
 
 

--- a/inc/dcroom.class.php
+++ b/inc/dcroom.class.php
@@ -472,4 +472,14 @@ class DCRoom extends CommonDBTM {
       }
       return $positions;
    }
+
+
+   function cleanDBonPurge() {
+
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Change_Item::class,
+         ]
+      );
+   }
 }

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -150,8 +150,11 @@ class Document extends CommonDBTM {
 
    function cleanDBonPurge() {
 
-      $di = new Document_Item();
-      $di->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Document_Item::class,
+         ]
+      );
 
       // UNLINK DU FICHIER
       if (!empty($this->fields["filepath"])) {

--- a/inc/enclosure.class.php
+++ b/inc/enclosure.class.php
@@ -359,8 +359,13 @@ class Enclosure extends CommonDBTM {
    }
 
    function cleanDBonPurge() {
-      $class = new Item_Enclosure();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Change_Item::class,
+            Item_Enclosure::class,
+         ]
+      );
    }
 
 

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -445,17 +445,18 @@ class Entity extends CommonTreeDropdown {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
       // most use entities_id, RuleDictionnarySoftwareCollection use new_entities_id
       Rule::cleanForItemAction($this, '%entities_id');
       Rule::cleanForItemCriteria($this);
 
-      $gki = new Entity_KnowbaseItem();
-      $gki->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $gr = new Entity_Reminder();
-      $gr->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Entity_KnowbaseItem::class,
+            Entity_Reminder::class,
+            Entity_RSSFeed::class,
+         ]
+      );
    }
 
    function rawSearchOptions() {

--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -89,39 +89,20 @@ class Group extends CommonTreeDropdown {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $gu = new Group_User();
-      $gu->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $gt = new Group_Ticket();
-      $gt->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $gp = new Group_Problem();
-      $gp->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $cg = new Change_Group();
-      $cg->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $DB->delete(
-         'glpi_projecttaskteams', [
-            'items_id'  => $this->fields['id'],
-            'itemtype'  => __CLASS__
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Change_Group::class,
+            Group_KnowbaseItem::class,
+            Group_Problem::class,
+            Group_Reminder::class,
+            Group_RSSFeed::class,
+            Group_Ticket::class,
+            Group_User::class,
+            ProjectTaskTeam::class,
+            ProjectTeam::class,
          ]
       );
-
-      $DB->delete(
-         'glpi_projectteams', [
-            'items_id'  => $this->fields['id'],
-            'itemtype'  => __CLASS__
-         ]
-      );
-
-      $gki = new Group_KnowbaseItem();
-      $gki->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $gr = new Group_Reminder();
-      $gr->cleanDBonItemDelete($this->getType(), $this->fields['id']);
 
       // Ticket rules use various _groups_id_*
       Rule::cleanForItemAction($this, '_groups_id%');

--- a/inc/ipaddress.class.php
+++ b/inc/ipaddress.class.php
@@ -202,10 +202,11 @@ class IPAddress extends CommonDBChild {
 
    function cleanDBonPurge() {
 
-      $link = new IPAddress_IPNetwork();
-      $link->cleanDBonItemDelete($this->getType(), $this->getID());
-
-      return true;
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            IPAddress_IPNetwork::class,
+         ]
+      );
    }
 
 

--- a/inc/ipnetwork.class.php
+++ b/inc/ipnetwork.class.php
@@ -406,13 +406,12 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
    function cleanDBonPurge() {
 
-      $link = new IPNetwork_Vlan();
-      $link->cleanDBonItemDelete($this->getType(), $this->getID());
-
-      $link = new IPAddress_IPNetwork();
-      $link->cleanDBonItemDelete($this->getType(), $this->getID());
-
-      return true;
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            IPAddress_IPNetwork::class,
+            IPNetwork_Vlan::class,
+         ]
+      );
    }
 
 

--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -375,15 +375,13 @@ class ITILSolution extends CommonDBChild {
     * @param integer $items_id Item ID
     *
     * @return void
+    *
+    * @deprecated 9.3.2
     */
    public function removeForItem($itemtype, $items_id) {
-      $this->deleteByCriteria(
-         [
-            'itemtype'  => $itemtype,
-            'items_id'  => $items_id
-         ],
-         true
-      );
+      Toolbox::deprecated();
+
+      $this->cleanDBonItemDelete($itemtype, $items_id);
    }
 
    /**

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -334,20 +334,24 @@ class KnowbaseItem extends CommonDBVisible {
    **/
    function cleanDBonPurge() {
 
-      $class = new KnowbaseItem_User();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-      $class = new Entity_KnowbaseItem();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-      $class = new Group_KnowbaseItem();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-      $class = new KnowbaseItem_Profile();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-      $class = new KnowbaseItem_Item();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-      $class = new KnowbaseItem_Revision();
-      $class->deleteByCriteria(['knowbaseitems_id' => $this->getID()]);
-      $class = new KnowbaseItem_Comment();
-      $class->deleteByCriteria(['knowbaseitems_id' => $this->fields['id']]);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Entity_KnowbaseItem::class,
+            Group_KnowbaseItem::class,
+            KnowbaseItem_Item::class,
+            KnowbaseItem_Profile::class,
+            KnowbaseItem_User::class,
+            KnowbaseItemTranslation::class,
+         ]
+      );
+
+      /// KnowbaseItem_Comment does not extends CommonDBConnexity
+      $kbic = new KnowbaseItem_Comment();
+      $kbic->deleteByCriteria(['knowbaseitems_id' => $this->fields['id']]);
+
+      /// KnowbaseItem_Revision does not extends CommonDBConnexity
+      $kbir = new KnowbaseItem_Revision();
+      $kbir->deleteByCriteria(['knowbaseitems_id' => $this->fields['id']]);
    }
 
    /**

--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -102,11 +102,10 @@ class Link extends CommonDBTM {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $DB->delete(
-         'glpi_links_itemtypes', [
-            'links_id'  => $this->fields['id']
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Link_Itemtype::class,
          ]
       );
    }

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -139,19 +139,15 @@ class Monitor extends CommonDBTM {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $ci = new Computer_Item();
-      $ci->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ip = new Item_Problem();
-      $ip->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ci = new Change_Item();
-      $ci->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ip = new Item_Project();
-      $ip->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Change_Item::class,
+            Computer_Item::class,
+            Item_Problem::class,
+            Item_Project::class,
+         ]
+      );
 
       Item_Devices::cleanItemDeviceDBOnItemDelete($this->getType(), $this->fields['id'],
                                                   (!empty($this->input['keep_devices'])));

--- a/inc/networkequipment.class.php
+++ b/inc/networkequipment.class.php
@@ -96,17 +96,15 @@ class NetworkEquipment extends CommonDBTM {
    **/
    function cleanDBonPurge() {
 
-      $ip = new Item_Problem();
-      $ip->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ci = new Change_Item();
-      $ci->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ip = new Item_Project();
-      $ip->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ios = new Item_OperatingSystem();
-      $ios->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Certificate_Item::class,
+            Change_Item::class,
+            Item_OperatingSystem::class,
+            Item_Project::class,
+            Item_Problem::class,
+         ]
+      );
 
       Item_Devices::cleanItemDeviceDBOnItemDelete($this->getType(), $this->fields['id'],
                                                   (!empty($this->input['keep_devices'])));

--- a/inc/networkname.class.php
+++ b/inc/networkname.class.php
@@ -316,11 +316,12 @@ class NetworkName extends FQDNLabel {
 
    function cleanDBonPurge() {
 
-      $alias = new NetworkAlias();
-      $alias->cleanDBonItemDelete($this->getType(), $this->GetID());
-
-      $ipAddress = new IPAddress();
-      $ipAddress->cleanDBonItemDelete($this->getType(), $this->GetID());
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            IPAddress::class,
+            NetworkAlias::class,
+         ]
+      );
    }
 
 

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -405,14 +405,13 @@ class NetworkPort extends CommonDBChild {
          unset($instantiation);
       }
 
-      $nn = new NetworkPort_NetworkPort();
-      $nn->cleanDBonItemDelete ($this->getType(), $this->getID());
-
-      $nv = new NetworkPort_Vlan();
-      $nv->cleanDBonItemDelete ($this->getType(), $this->getID());
-
-      $names = new NetworkName();
-      $names->cleanDBonItemDelete ($this->getType(), $this->getID());
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            NetworkName::class,
+            NetworkPort_NetworkPort::class,
+            NetworkPort_Vlan::class,
+         ]
+      );
    }
 
 

--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -437,17 +437,11 @@ class Notification extends CommonDBTM {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $DB->delete(
-         'glpi_notifications_notificationtemplates', [
-            'notifications_id'   => $this->fields['id']
-         ]
-      );
-
-      $DB->delete(
-         'glpi_notificationtargets', [
-            'notifications_id'   => $this->fields['id']
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Notification_NotificationTemplate::class,
+            NotificationTarget::class,
          ]
       );
    }

--- a/inc/notificationtemplate.class.php
+++ b/inc/notificationtemplate.class.php
@@ -549,4 +549,18 @@ class NotificationTemplate extends CommonDBTM {
       return $mailing_options;
    }
 
+
+   function cleanDBonPurge() {
+
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            NotificationTemplateTranslation::class,
+         ]
+      );
+
+      // QueuedNotification does not extends CommonDBConnexity
+      $queued = new QueuedNotification();
+      $queued->deleteByCriteria(['notificationtemplates_id' => $this->fields['id']]);
+   }
+
 }

--- a/inc/olalevel.class.php
+++ b/inc/olalevel.class.php
@@ -57,15 +57,12 @@ class OlaLevel extends LevelAgreementLevel {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      parent::cleanDBOnPurge();
+      parent::cleanDBonPurge();
 
-      $DB->delete(
-         'glpi_olalevels_tickets', [
-            $this->rules_id_field   => $this->fields['id']
-         ]
-      );
+      // OlaLevel_Ticket does not extends CommonDBConnexity
+      $olt = new OlaLevel_Ticket();
+      $olt->deleteByCriteria([$this->rules_id_field => $this->fields['id']]);
    }
 
 

--- a/inc/pdu.class.php
+++ b/inc/pdu.class.php
@@ -324,10 +324,12 @@ class PDU extends CommonDBTM {
 
    function cleanDBonPurge() {
 
-      $pdu_plug = new Pdu_Plug();
-      $pdu_plug->deleteByCriteria(['pdus_id' => $this->fields['id']]);
-
-      $pdu_rack = new PDU_Rack();
-      $pdu_rack->deleteByCriteria(['pdus_id' => $this->fields['id']]);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Change_Item::class,
+            Pdu_Plug::class,
+            PDU_Rack::class,
+         ]
+      );
    }
 }

--- a/inc/peripheral.class.php
+++ b/inc/peripheral.class.php
@@ -136,19 +136,16 @@ class Peripheral extends CommonDBTM {
    }
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $ci = new Computer_Item();
-      $ci->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ip = new Item_Problem();
-      $ip->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ci = new Change_Item();
-      $ci->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ip = new Item_Project();
-      $ip->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Certificate_Item::class,
+            Computer_Item::class,
+            Item_Problem::class,
+            Change_Item::class,
+            Item_Project::class,
+         ]
+      );
 
       Item_Devices::cleanItemDeviceDBOnItemDelete($this->getType(), $this->fields['id'],
                                                   (!empty($this->input['keep_devices'])));

--- a/inc/phone.class.php
+++ b/inc/phone.class.php
@@ -133,19 +133,15 @@ class Phone extends CommonDBTM {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $ci = new Computer_Item();
-      $ci->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ip = new Item_Problem();
-      $ip->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ci = new Change_Item();
-      $ci->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ip = new Item_Project();
-      $ip->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Computer_Item::class,
+            Item_Problem::class,
+            Change_Item::class,
+            Item_Project::class,
+         ]
+      );
 
       Item_Devices::cleanItemDeviceDBOnItemDelete($this->getType(), $this->fields['id'],
                                                   (!empty($this->input['keep_devices'])));

--- a/inc/plug.class.php
+++ b/inc/plug.class.php
@@ -44,7 +44,10 @@ class Plug extends CommonDropdown {
 
    function cleanDBonPurge() {
 
-      $pdu_plug = new Pdu_Plug();
-      $pdu_plug->deleteByCriteria(['plugs_id' => $this->fields['id']]);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Pdu_Plug::class,
+         ]
+      );
    }
 }

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -228,10 +228,8 @@ class Printer  extends CommonDBTM {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $ci = new Computer_Item();
-      $ci->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
+      global $DB;
 
       $DB->update(
          'glpi_cartridges', [
@@ -241,14 +239,15 @@ class Printer  extends CommonDBTM {
          ]
       );
 
-      $ip = new Item_Problem();
-      $ip->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ci = new Change_Item();
-      $ci->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ip = new Item_Project();
-      $ip->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Certificate_Item::class,
+            Change_Item::class,
+            Computer_Item::class,
+            Item_Problem::class,
+            Item_Project::class,
+         ]
+      );
 
       Item_Devices::cleanItemDeviceDBOnItemDelete($this->getType(), $this->fields['id'],
                                                   (!empty($this->input['keep_devices'])));

--- a/inc/printermodel.class.php
+++ b/inc/printermodel.class.php
@@ -46,10 +46,13 @@ class PrinterModel extends CommonDropdown {
 
 
    function cleanDBonPurge() {
-      // Temporary solution to clean wrong updated items
-      $cpm = new CartridgeItem_PrinterModel();
-      $cpm->deleteByCriteria(['printermodels_id' => $this->fields['id']]);
 
+      // Temporary solution to clean wrong updated items
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            CartridgeItem_PrinterModel::class,
+         ]
+      );
    }
 
 }

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -238,20 +238,22 @@ class Problem extends CommonITILObject {
    function cleanDBonPurge() {
       global $DB;
 
-      $DB->delete(
-         'glpi_problemtasks', [
-            'problems_id'  => $this->fields['id']
+      // CommonITILTask does not extends CommonDBConnexity
+      $pt = new ProblemTask();
+      $pt->deleteByCriteria(['problems_id' => $this->fields['id']]);
+
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Change_Problem::class,
+            // Done by parent: Group_Problem::class,
+            Item_Problem::class,
+            // Done by parent: ITILSolution::class,
+            // Done by parent: Problem_Supplier::class,
+            Problem_Ticket::class,
+            // Done by parent: Problem_User::class,
+            ProblemCost::class,
          ]
       );
-
-      $pt = new Problem_Ticket();
-      $pt->cleanDBonItemDelete('Problem', $this->fields['id']);
-
-      $cp = new Change_Problem();
-      $cp->cleanDBonItemDelete('Problem', $this->fields['id']);
-
-      $ip = new Item_Problem();
-      $ip->cleanDBonItemDelete('Problem', $this->fields['id']);
 
       parent::cleanDBonPurge();
    }

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -210,25 +210,21 @@ class Profile extends CommonDBTM {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $gpr = new ProfileRight();
-      $gpr->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $gpu = new Profile_User();
-      $gpu->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            KnowbaseItem_Profile::class,
+            Profile_Reminder::class,
+            Profile_RSSFeed::class,
+            Profile_User::class,
+            ProfileRight::class,
+         ]
+      );
 
       Rule::cleanForItemAction($this);
       // PROFILES and UNIQUE_PROFILE in RuleMailcollector
       Rule::cleanForItemCriteria($this, 'PROFILES');
       Rule::cleanForItemCriteria($this, 'UNIQUE_PROFILE');
-
-      $gki = new KnowbaseItem_Profile();
-      $gki->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $gr = new Profile_Reminder();
-      $gr->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
    }
 
 

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -43,7 +43,7 @@ class Project extends CommonDBTM {
 
    // From CommonDBTM
    public $dohistory                   = true;
-   static protected $forward_entity_to = ['ProjectTask'];
+   static protected $forward_entity_to = ['ProjectCost', 'ProjectTask'];
    static $rightname                   = 'project';
    protected $usenotepad               = true;
 
@@ -315,19 +315,16 @@ class Project extends CommonDBTM {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $pt = new ProjectTask();
-      $pt->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $cp = new Change_Project();
-      $cp->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ip = new Item_Project();
-      $ip->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $pt = new ProjectTeam();
-      $pt->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Change_Project::class,
+            Item_Project::class,
+            ProjectCost::class,
+            ProjectTask::class,
+            ProjectTeam::class,
+         ]
+      );
 
       parent::cleanDBonPurge();
    }

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -137,13 +137,13 @@ class ProjectTask extends CommonDBChild {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $pt = new ProjectTaskTeam();
-      $pt->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $pt = new ProjectTask_Ticket();
-      $pt->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            ProjectTask_Ticket::class,
+            ProjectTaskTeam::class,
+         ]
+      );
 
       parent::cleanDBonPurge();
    }

--- a/inc/rack.class.php
+++ b/inc/rack.class.php
@@ -1057,11 +1057,13 @@ JAVASCRIPT;
 
    function cleanDBonPurge() {
 
-      $item_rack = new Item_Rack();
-      $item_rack->deleteByCriteria(['racks_id' => $this->fields['id']]);
-
-      $pdu_rack = new PDU_Rack();
-      $pdu_rack->deleteByCriteria(['racks_id' => $this->fields['id']]);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Change_Item::class,
+            Item_Rack::class,
+            PDU_Rack::class,
+         ]
+      );
    }
 
    /**

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -34,693 +34,1296 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
-// _ before the link table name => no clean cache on this relation
-// Table's names are in alphabetic order - Please respect it
+/**
+ * Relation constants between tables.
+ *
+ * This mapping is used for to detect links between objects.
+ * For example, it is used to detect if items are associated to another item that
+ * is going to be deleted, in order to prevent deletion or ask for user what to do with
+ * linked items.
+ *
+ * Format is:
+ * [
+ *    'referenced_table_name' => [
+ *       'linked_table_name_1' => 'foreign_key_1',
+ *       'linked_table_name_2' => ['foreign_key_2', 'foreign_key_3'],
+ *       'linked_table_name_2' => [['items_id', 'itemtype']],
+ *    ]
+ * ]
+ * where:
+ *  - 'referenced_table_name' is the name of a table having its id referenced in other tables,
+ *  - 'linked_table_name_*' is the name of a table that have foreign keys referencing the table 'referenced_table_name',
+ *  - 'foreign_key_*' is the name of the field that is a foreign key (can be ['items_id', 'itemtype']).
+ *
+ * /!\ "_" prefix is used to disable usage check on relations while deleting an item when they are
+ *     handled by application.
+ *     Applications handle specific usage check and links updates :
+ *      - on `$item::cleanDBonPurge()` function,
+ *      - using `$forward_entity_to` values,
+ *      - by `CommonTreeDropdown` logic for recursive keys.
+ *     Relations will still be used to check ability to disable recursivity on an element.
+ *
+ * /!\ Table's names are in alphabetic order - Please respect it
+ *
+ * /!\ "_virtual_device" mapping is a special mapping used on CommonDBTM::CanUnrecurs().
+ *
+ * @var array $RELATION
+ */
+$RELATION = [
+   'glpi_authldaps' => [
+      'glpi_authldapreplicates' => 'authldaps_id',
+      'glpi_entities'           => 'authldaps_id',
+      'glpi_users'              => 'auths_id',
+   ],
+
+   'glpi_authmails' => [
+      'glpi_users' => 'auths_id',
+   ],
+
+   'glpi_autoupdatesystems' => [
+      'glpi_computers' => 'autoupdatesystems_id',
+   ],
+
+   'glpi_budgets' => [
+      'glpi_changecosts'   => 'budgets_id',
+      'glpi_contractcosts' => 'budgets_id',
+      'glpi_infocoms'      => 'budgets_id',
+      'glpi_problemcosts'  => 'budgets_id',
+      'glpi_projectcosts'  => 'budgets_id',
+      'glpi_ticketcosts'   => 'budgets_id',
+   ],
+
+   'glpi_budgettypes' => [
+      'glpi_budgets' => 'budgettypes_id',
+   ],
+
+   'glpi_businesscriticities' => [
+      '_glpi_businesscriticities' => 'businesscriticities_id',
+      'glpi_infocoms'             => 'businesscriticities_id',
+   ],
+
+   'glpi_calendars' => [
+      '_glpi_calendars_holidays' => 'calendars_id',
+      '_glpi_calendarsegments'   => 'calendars_id',
+      'glpi_entities'            => 'calendars_id',
+      'glpi_olas'                => 'calendars_id',
+      'glpi_slas'                => 'calendars_id',
+      'glpi_slms'                => 'calendars_id',
+      'glpi_ticketrecurrents'    => 'calendars_id',
+   ],
+
+   'glpi_cartridgeitems' => [
+      '_glpi_cartridgeitems_printermodels' => 'cartridgeitems_id',
+      '_glpi_cartridges'                   => 'cartridgeitems_id',
+   ],
+
+   'glpi_cartridgeitemtypes' => [
+      'glpi_cartridgeitems' => 'cartridgeitemtypes_id',
+   ],
+
+   'glpi_certificates' => [
+      '_glpi_certificates_items' => 'certificates_id',
+   ],
+
+   'glpi_certificatetypes' => [
+      'glpi_certificates' => 'certificatetypes_id',
+   ],
+
+   'glpi_changes' => [
+      '_glpi_changecosts'       => 'changes_id',
+      '_glpi_changes_groups'    => 'changes_id',
+      '_glpi_changes_items'     => 'changes_id',
+      '_glpi_changes_problems'  => 'changes_id',
+      '_glpi_changes_projects'  => 'changes_id',
+      '_glpi_changes_suppliers' => 'changes_id',
+      '_glpi_changes_tickets'   => 'changes_id',
+      '_glpi_changes_users'     => 'changes_id',
+      '_glpi_changetasks'       => 'changes_id',
+      '_glpi_changevalidations' => 'changes_id',
+   ],
+
+   'glpi_computermodels' => [
+      'glpi_computers' => 'computermodels_id',
+   ],
+
+   'glpi_computers' => [
+      '_glpi_computerantiviruses'       => 'computers_id',
+      '_glpi_computers_items'           => 'computers_id',
+      'glpi_computers_softwarelicenses' => 'computers_id',
+      'glpi_computers_softwareversions' => 'computers_id',
+      'glpi_computervirtualmachines'    => 'computers_id',
+   ],
+
+   'glpi_computertypes' => [
+      'glpi_computers' => 'computertypes_id',
+   ],
+
+   'glpi_consumableitems' => [
+      '_glpi_consumables' => 'consumableitems_id',
+   ],
+
+   'glpi_consumableitemtypes' => [
+      'glpi_consumableitems' => 'consumableitemtypes_id',
+   ],
+
+   'glpi_contacts' => [
+      '_glpi_contacts_suppliers' => 'contacts_id',
+   ],
+
+   'glpi_contacttypes' => [
+      'glpi_contacts' => 'contacttypes_id',
+   ],
+
+   'glpi_contracts' => [
+      '_glpi_contractcosts'       => 'contracts_id',
+      '_glpi_contracts_items'     => 'contracts_id',
+      '_glpi_contracts_suppliers' => 'contracts_id',
+   ],
+
+   'glpi_contracttypes' => [
+      'glpi_contracts' => 'contracttypes_id',
+   ],
+
+   'glpi_crontasklogs' => [
+      '_glpi_crontasklogs' => 'crontasklogs_id',
+   ],
+
+   'glpi_crontasks' => [
+      '_glpi_crontasklogs' => 'crontasks_id',
+   ],
+
+   'glpi_datacenters' => [
+      'glpi_dcrooms' => 'datacenters_id',
+   ],
+
+   'glpi_dcrooms' => [
+      'glpi_racks' => 'dcrooms_id',
+   ],
+
+   'glpi_devicebatteries' => [
+      'glpi_items_devicebatteries' => 'devicebatteries_id',
+   ],
+
+   'glpi_devicebatterymodels' => [
+      'glpi_devicebatteries' => 'devicebatterymodels_id',
+   ],
+
+   'glpi_devicebatterytypes' => [
+      'glpi_devicebatteries' => 'devicebatterytypes_id',
+   ],
+
+   'glpi_devicecasemodels' => [
+      'glpi_devicecases' => 'devicecasemodels_id',
+   ],
+
+   'glpi_devicecases' => [
+      'glpi_items_devicecases' => 'devicecases_id',
+   ],
+
+   'glpi_devicecasetypes' => [
+      'glpi_devicecases' => 'devicecasetypes_id',
+   ],
+
+   'glpi_devicecontrolmodels' => [
+      'glpi_devicecontrols' => 'devicecontrolmodels_id',
+   ],
+
+   'glpi_devicecontrols' => [
+      'glpi_items_devicecontrols' => 'devicecontrols_id',
+   ],
+
+   'glpi_devicedrivemodels' => [
+      'glpi_devicedrives' => 'devicedrivemodels_id',
+   ],
+
+   'glpi_devicedrives' => [
+      'glpi_items_devicedrives' => 'devicedrives_id',
+   ],
+
+   'glpi_devicefirmwaremodels' => [
+      'glpi_devicefirmwares' => 'devicefirmwaremodels_id',
+   ],
+
+   'glpi_devicefirmwares' => [
+      'glpi_items_devicefirmwares' => 'devicefirmwares_id',
+   ],
+
+   'glpi_devicefirmwaretypes' => [
+      'glpi_devicefirmwares' => 'devicefirmwaretypes_id',
+   ],
+
+   'glpi_devicegenericmodels' => [
+      'glpi_devicegenerics' => 'devicegenericmodels_id',
+   ],
+
+   'glpi_devicegenerics' => [
+      'glpi_items_devicegenerics' => 'devicegenerics_id',
+   ],
+
+   'glpi_devicegenerictypes' => [
+      'glpi_devicegenerics' => 'devicegenerictypes_id',
+   ],
+
+   'glpi_devicegraphiccardmodels' => [
+      'glpi_devicegraphiccards' => 'devicegraphiccardmodels_id',
+   ],
+
+   'glpi_devicegraphiccards' => [
+      'glpi_items_devicegraphiccards' => 'devicegraphiccards_id',
+   ],
+
+   'glpi_deviceharddrivemodels' => [
+      'glpi_deviceharddrives' => 'deviceharddrivemodels_id',
+   ],
+
+   'glpi_deviceharddrives' => [
+      'glpi_items_deviceharddrives' => 'deviceharddrives_id',
+   ],
+
+   'glpi_devicememories' => [
+      'glpi_items_devicememories' => 'devicememories_id',
+   ],
+
+   'glpi_devicememorymodels' => [
+      'glpi_devicememories' => 'devicememorymodels_id',
+   ],
+
+   'glpi_devicememorytypes' => [
+      'glpi_devicememories' => 'devicememorytypes_id',
+   ],
+
+   'glpi_devicemotherboardmodels' => [
+      'glpi_devicemotherboards' => 'devicemotherboardmodels_id',
+   ],
+
+   'glpi_devicemotherboards' => [
+      'glpi_items_devicemotherboards' => 'devicemotherboards_id',
+   ],
+
+   'glpi_devicenetworkcardmodels' => [
+      'glpi_devicenetworkcards' => 'devicenetworkcardmodels_id',
+   ],
+
+   'glpi_devicenetworkcards' => [
+      'glpi_items_devicenetworkcards' => 'devicenetworkcards_id',
+   ],
+
+   'glpi_devicepcimodels' => [
+      'glpi_devicepcis' => 'devicepcimodels_id',
+   ],
+
+   'glpi_devicepcis' => [
+      'glpi_items_devicepcis' => 'devicepcis_id',
+   ],
+
+   'glpi_devicepowersupplies' => [
+      'glpi_items_devicepowersupplies' => 'devicepowersupplies_id',
+   ],
+
+   'glpi_devicepowersupplymodels' => [
+      'glpi_devicepowersupplies' => 'devicepowersupplymodels_id',
+   ],
+
+   'glpi_deviceprocessormodels' => [
+      'glpi_deviceprocessors' => 'deviceprocessormodels_id',
+   ],
+
+   'glpi_deviceprocessors' => [
+      'glpi_items_deviceprocessors' => 'deviceprocessors_id',
+   ],
+
+   'glpi_devicesensormodels' => [
+      'glpi_devicesensors' => 'devicesensormodels_id',
+   ],
+
+   'glpi_devicesensors' => [
+      'glpi_items_devicesensors' => 'devicesensors_id',
+   ],
+
+   'glpi_devicesensortypes' => [
+      'glpi_devicesensors' => 'devicesensortypes_id',
+   ],
+
+   'glpi_devicesimcards' => [
+      'glpi_items_devicesimcards' => 'devicesimcards_id',
+   ],
+
+   'glpi_devicesimcardtypes' => [
+      'glpi_devicesimcards' => 'devicesimcardtypes_id',
+   ],
+
+   'glpi_devicesoundcardmodels' => [
+      'glpi_devicesoundcards' => 'devicesoundcardmodels_id',
+   ],
+
+   'glpi_devicesoundcards' => [
+      'glpi_items_devicesoundcards' => 'devicesoundcards_id',
+   ],
+
+   'glpi_documentcategories' => [
+      'glpi_documentcategories' => 'documentcategories_id',
+      'glpi_documents'          => 'documentcategories_id',
+   ],
+
+   'glpi_documents' => [
+      'glpi_documents_items' => 'documents_id',
+   ],
+
+   'glpi_domains' => [
+      'glpi_computers'         => 'domains_id',
+      'glpi_networkequipments' => 'domains_id',
+      'glpi_printers'          => 'domains_id',
+   ],
+
+   'glpi_enclosuremodels' => [
+      'glpi_enclosures' => 'enclosuremodels_id',
+   ],
+
+   'glpi_enclosures' => [
+      '_glpi_items_enclosures' => 'enclosures_id',
+   ],
+
+   'glpi_entities' => [
+      'glpi_apiclients'                  => 'entities_id',
+      'glpi_budgets'                     => 'entities_id',
+      'glpi_businesscriticities'         => 'entities_id',
+      'glpi_calendars'                   => 'entities_id',
+      '_glpi_calendarsegments'           => 'entities_id',
+      'glpi_cartridgeitems'              => 'entities_id',
+      '_glpi_cartridges'                 => 'entities_id',
+      'glpi_certificates'                => 'entities_id',
+      'glpi_certificatetypes'            => 'entities_id',
+      '_glpi_changecosts'                => 'entities_id',
+      'glpi_changes'                     => 'entities_id',
+      '_glpi_changevalidations'          => 'entities_id',
+      'glpi_computers'                   => 'entities_id',
+      '_glpi_computers_softwareversions' => 'entities_id',
+      '_glpi_computervirtualmachines'    => 'entities_id',
+      'glpi_consumableitems'             => 'entities_id',
+      '_glpi_consumables'                => 'entities_id',
+      'glpi_contacts'                    => 'entities_id',
+      '_glpi_contractcosts'              => 'entities_id',
+      'glpi_contracts'                   => 'entities_id',
+      'glpi_datacenters'                 => 'entities_id',
+      'glpi_dcrooms'                     => 'entities_id',
+      'glpi_devicebatteries'             => 'entities_id',
+      'glpi_devicecases'                 => 'entities_id',
+      'glpi_devicecontrols'              => 'entities_id',
+      'glpi_devicedrives'                => 'entities_id',
+      'glpi_devicefirmwares'             => 'entities_id',
+      'glpi_devicegenerics'              => 'entities_id',
+      'glpi_devicegraphiccards'          => 'entities_id',
+      'glpi_deviceharddrives'            => 'entities_id',
+      'glpi_devicememories'              => 'entities_id',
+      'glpi_devicemotherboards'          => 'entities_id',
+      'glpi_devicenetworkcards'          => 'entities_id',
+      'glpi_devicepcis'                  => 'entities_id',
+      'glpi_devicepowersupplies'         => 'entities_id',
+      'glpi_deviceprocessors'            => 'entities_id',
+      'glpi_devicesensors'               => 'entities_id',
+      'glpi_devicesimcards'              => 'entities_id',
+      'glpi_devicesoundcards'            => 'entities_id',
+      'glpi_documents'                   => 'entities_id',
+      '_glpi_documents_items'            => 'entities_id',
+      'glpi_domains'                     => 'entities_id',
+      'glpi_enclosures'                  => 'entities_id',
+      '_glpi_entities'                   => 'entities_id',
+      'glpi_entities'                    => 'entities_id_software',
+      '_glpi_entities_knowbaseitems'     => 'entities_id',
+      '_glpi_entities_reminders'         => 'entities_id',
+      '_glpi_entities_rssfeeds'          => 'entities_id',
+      'glpi_fieldblacklists'             => 'entities_id',
+      'glpi_fieldunicities'              => 'entities_id',
+      'glpi_fqdns'                       => 'entities_id',
+      'glpi_groups'                      => 'entities_id',
+      'glpi_groups_knowbaseitems'        => 'entities_id',
+      'glpi_groups_reminders'            => 'entities_id',
+      'glpi_groups_rssfeeds'             => 'entities_id',
+      'glpi_holidays'                    => 'entities_id',
+      '_glpi_infocoms'                   => 'entities_id',
+      'glpi_ipaddresses'                 => 'entities_id',
+      'glpi_ipnetworks'                  => 'entities_id',
+      '_glpi_items_devicebatteries'      => 'entities_id',
+      '_glpi_items_devicecases'          => 'entities_id',
+      '_glpi_items_devicecontrols'       => 'entities_id',
+      '_glpi_items_devicedrives'         => 'entities_id',
+      '_glpi_items_devicefirmwares'      => 'entities_id',
+      '_glpi_items_devicegenerics'       => 'entities_id',
+      '_glpi_items_devicegraphiccards'   => 'entities_id',
+      '_glpi_items_deviceharddrives'     => 'entities_id',
+      '_glpi_items_devicememories'       => 'entities_id',
+      '_glpi_items_devicemotherboards'   => 'entities_id',
+      '_glpi_items_devicenetworkcards'   => 'entities_id',
+      '_glpi_items_devicepcis'           => 'entities_id',
+      '_glpi_items_devicepowersupplies'  => 'entities_id',
+      '_glpi_items_deviceprocessors'     => 'entities_id',
+      '_glpi_items_devicesensors'        => 'entities_id',
+      '_glpi_items_devicesimcards'       => 'entities_id',
+      '_glpi_items_devicesoundcards'     => 'entities_id',
+      '_glpi_items_disks'                => 'entities_id',
+      '_glpi_items_operatingsystems'     => 'entities_id',
+      'glpi_itilcategories'              => 'entities_id',
+      'glpi_knowbaseitemcategories'      => 'entities_id',
+      'glpi_knowbaseitems_profiles'      => 'entities_id',
+      'glpi_lineoperators'               => 'entities_id',
+      'glpi_lines'                       => 'entities_id',
+      'glpi_links'                       => 'entities_id',
+      'glpi_locations'                   => 'entities_id',
+      'glpi_monitors'                    => 'entities_id',
+      'glpi_netpoints'                   => 'entities_id',
+      '_glpi_networkaliases'             => 'entities_id',
+      'glpi_networkequipments'           => 'entities_id',
+      'glpi_networknames'                => 'entities_id',
+      '_glpi_networkports'               => 'entities_id',
+      'glpi_notifications'               => 'entities_id',
+      '_glpi_olalevels'                  => 'entities_id',
+      '_glpi_olas'                       => 'entities_id',
+      'glpi_pdus'                        => 'entities_id',
+      'glpi_pdutypes'                    => 'entities_id',
+      'glpi_peripherals'                 => 'entities_id',
+      'glpi_phones'                      => 'entities_id',
+      'glpi_printers'                    => 'entities_id',
+      '_glpi_problemcosts'               => 'entities_id',
+      'glpi_problems'                    => 'entities_id',
+      'glpi_profiles_reminders'          => 'entities_id',
+      'glpi_profiles_rssfeeds'           => 'entities_id',
+      'glpi_profiles_users'              => 'entities_id',
+      '_glpi_projectcosts'               => 'entities_id',
+      'glpi_projects'                    => 'entities_id',
+      '_glpi_projecttasks'               => 'entities_id',
+      'glpi_projecttasktemplates'        => 'entities_id',
+      'glpi_queuednotifications'         => 'entities_id',
+      'glpi_racks'                       => 'entities_id',
+      'glpi_racktypes'                   => 'entities_id',
+      '_glpi_reservationitems'           => 'entities_id',
+      'glpi_rules'                       => 'entities_id',
+      'glpi_savedsearches'               => 'entities_id',
+      '_glpi_slalevels'                  => 'entities_id',
+      '_glpi_slas'                       => 'entities_id',
+      'glpi_slms'                        => 'entities_id',
+      'glpi_softwarelicenses'            => 'entities_id',
+      'glpi_softwarelicensetypes'        => 'entities_id',
+      'glpi_softwares'                   => 'entities_id',
+      '_glpi_softwareversions'           => 'entities_id',
+      'glpi_solutiontemplates'           => 'entities_id',
+      'glpi_solutiontypes'               => 'entities_id',
+      'glpi_states'                      => 'entities_id',
+      'glpi_suppliers'                   => 'entities_id',
+      'glpi_taskcategories'              => 'entities_id',
+      'glpi_tasktemplates'               => 'entities_id',
+      '_glpi_ticketcosts'                => 'entities_id',
+      'glpi_ticketrecurrents'            => 'entities_id',
+      'glpi_tickets'                     => 'entities_id',
+      'glpi_tickettemplates'             => 'entities_id',
+      '_glpi_ticketvalidations'          => 'entities_id',
+      'glpi_users'                       => 'entities_id',
+      'glpi_vlans'                       => 'entities_id',
+      'glpi_wifinetworks'                => 'entities_id',
+   ],
+
+   'glpi_filesystems' => [
+      'glpi_items_disks' => 'filesystems_id',
+   ],
+
+   'glpi_fqdns' => [
+      'glpi_networkaliases' => 'fqdns_id',
+      'glpi_networknames'   => 'fqdns_id',
+   ],
+
+   'glpi_groups' => [
+      'glpi_cartridgeitems'        => 'groups_id_tech',
+      'glpi_certificates'          => [
+         'groups_id_tech',
+         'groups_id',
+      ],
+      '_glpi_changes_groups'       => 'groups_id',
+      'glpi_changetasks'           => 'groups_id_tech',
+      'glpi_computers'             => [
+         'groups_id_tech',
+         'groups_id',
+      ],
+      'glpi_consumableitems'       => 'groups_id_tech',
+      'glpi_enclosures'            => 'groups_id_tech',
+      'glpi_groups'                => 'groups_id',
+      '_glpi_groups_knowbaseitems' => 'groups_id',
+      '_glpi_groups_problems'      => 'groups_id',
+      '_glpi_groups_reminders'     => 'groups_id',
+      '_glpi_groups_rssfeeds'      => 'groups_id',
+      '_glpi_groups_tickets'       => 'groups_id',
+      '_glpi_groups_users'         => 'groups_id',
+      'glpi_itilcategories'        => 'groups_id',
+      'glpi_lines'                 => 'groups_id',
+      'glpi_monitors'              => [
+         'groups_id_tech',
+         'groups_id',
+      ],
+      'glpi_networkequipments'     => [
+         'groups_id_tech',
+         'groups_id',
+      ],
+      'glpi_pdus'                  => 'groups_id_tech',
+      'glpi_peripherals'           => [
+         'groups_id_tech',
+         'groups_id',
+      ],
+      'glpi_phones'                => [
+         'groups_id_tech',
+         'groups_id',
+      ],
+      'glpi_printers'              => [
+         'groups_id_tech',
+         'groups_id',
+      ],
+      'glpi_problemtasks'          => 'groups_id_tech',
+      'glpi_projects'              => 'groups_id',
+      'glpi_racks'                 => 'groups_id_tech',
+      'glpi_softwarelicenses'      => [
+         'groups_id_tech',
+         'groups_id',
+      ],
+      'glpi_softwares'             => [
+         'groups_id_tech',
+         'groups_id',
+      ],
+      'glpi_tasktemplates'         => 'groups_id_tech',
+      'glpi_tickettasks'           => 'groups_id_tech',
+   ],
+
+   'glpi_holidays' => [
+      'glpi_calendars_holidays' => 'holidays_id',
+   ],
+
+   'glpi_interfacetypes' => [
+      'glpi_devicecontrols'     => 'interfacetypes_id',
+      'glpi_devicedrives'       => 'interfacetypes_id',
+      'glpi_devicegraphiccards' => 'interfacetypes_id',
+      'glpi_deviceharddrives'   => 'interfacetypes_id',
+   ],
+
+   'glpi_ipaddresses' => [
+      '_glpi_ipaddresses_ipnetworks' => 'ipaddresses_id',
+   ],
+
+   'glpi_ipnetworks' => [
+      '_glpi_ipaddresses_ipnetworks' => 'ipnetworks_id',
+      'glpi_ipnetworks'              => 'ipnetworks_id',
+      '_glpi_ipnetworks_vlans'       => 'ipnetworks_id',
+   ],
+
+   'glpi_items_devicenetworkcards' => [
+      'glpi_networkportethernets'     => 'items_devicenetworkcards_id',
+      'glpi_networkportfiberchannels' => 'items_devicenetworkcards_id',
+      'glpi_networkportwifis'         => 'items_devicenetworkcards_id',
+   ],
+
+   'glpi_itilcategories' => [
+      'glpi_changes'        => 'itilcategories_id',
+      'glpi_itilcategories' => 'itilcategories_id',
+      'glpi_problems'       => 'itilcategories_id',
+      'glpi_tickets'        => 'itilcategories_id',
+   ],
+
+   'glpi_knowbaseitemcategories' => [
+      'glpi_itilcategories'         => 'knowbaseitemcategories_id',
+      'glpi_knowbaseitemcategories' => 'knowbaseitemcategories_id',
+      'glpi_knowbaseitems'          => 'knowbaseitemcategories_id',
+      'glpi_taskcategories'         => 'knowbaseitemcategories_id',
+   ],
+
+   'glpi_knowbaseitems' => [
+      '_glpi_entities_knowbaseitems'   => 'knowbaseitems_id',
+      '_glpi_groups_knowbaseitems'     => 'knowbaseitems_id',
+      '_glpi_knowbaseitems_comments'   => 'knowbaseitems_id',
+      '_glpi_knowbaseitems_items'      => 'knowbaseitems_id',
+      '_glpi_knowbaseitems_profiles'   => 'knowbaseitems_id',
+      '_glpi_knowbaseitems_revisions'  => 'knowbaseitems_id',
+      '_glpi_knowbaseitems_users'      => 'knowbaseitems_id',
+      '_glpi_knowbaseitemtranslations' => 'knowbaseitems_id',
+   ],
+
+   'glpi_knowbaseitems_comments' => [
+      'glpi_knowbaseitems_comments' => 'parent_comment_id',
+   ],
+
+   'glpi_lineoperators' => [
+      'glpi_lines' => 'lineoperators_id',
+   ],
+
+   'glpi_lines' => [
+      'glpi_items_devicesimcards' => 'lines_id',
+   ],
+
+   'glpi_linetypes' => [
+      'glpi_lines' => 'linetypes_id',
+   ],
+
+   'glpi_links' => [
+      '_glpi_links_itemtypes' => 'links_id',
+   ],
+
+   'glpi_locations' => [
+      'glpi_budgets'                   => 'locations_id',
+      'glpi_cartridgeitems'            => 'locations_id',
+      'glpi_certificates'              => 'locations_id',
+      'glpi_computers'                 => 'locations_id',
+      'glpi_consumableitems'           => 'locations_id',
+      'glpi_datacenters'               => 'locations_id',
+      'glpi_dcrooms'                   => 'locations_id',
+      'glpi_devicegenerics'            => 'locations_id',
+      'glpi_devicesensors'             => 'locations_id',
+      'glpi_enclosures'                => 'locations_id',
+      'glpi_items_devicebatteries'     => 'locations_id',
+      'glpi_items_devicecases'         => 'locations_id',
+      'glpi_items_devicecontrols'      => 'locations_id',
+      'glpi_items_devicedrives'        => 'locations_id',
+      'glpi_items_devicefirmwares'     => 'locations_id',
+      'glpi_items_devicegenerics'      => 'locations_id',
+      'glpi_items_devicegraphiccards'  => 'locations_id',
+      'glpi_items_deviceharddrives'    => 'locations_id',
+      'glpi_items_devicememories'      => 'locations_id',
+      'glpi_items_devicemotherboards'  => 'locations_id',
+      'glpi_items_devicenetworkcards'  => 'locations_id',
+      'glpi_items_devicepcis'          => 'locations_id',
+      'glpi_items_devicepowersupplies' => 'locations_id',
+      'glpi_items_deviceprocessors'    => 'locations_id',
+      'glpi_items_devicesensors'       => 'locations_id',
+      'glpi_items_devicesimcards'      => 'locations_id',
+      'glpi_items_devicesoundcards'    => 'locations_id',
+      'glpi_lines'                     => 'locations_id',
+      'glpi_locations'                 => 'locations_id',
+      'glpi_monitors'                  => 'locations_id',
+      'glpi_netpoints'                 => 'locations_id',
+      'glpi_networkequipments'         => 'locations_id',
+      'glpi_pdus'                      => 'locations_id',
+      'glpi_peripherals'               => 'locations_id',
+      'glpi_phones'                    => 'locations_id',
+      'glpi_printers'                  => 'locations_id',
+      'glpi_racks'                     => 'locations_id',
+      'glpi_softwarelicenses'          => 'locations_id',
+      'glpi_softwares'                 => 'locations_id',
+      'glpi_tickets'                   => 'locations_id',
+      'glpi_users'                     => 'locations_id',
+   ],
+
+   'glpi_mailcollectors' => [
+      'glpi_notimportedemails' => 'mailcollectors_id',
+   ],
+
+   'glpi_manufacturers' => [
+      'glpi_cartridgeitems'      => 'manufacturers_id',
+      'glpi_certificates'        => 'manufacturers_id',
+      'glpi_computerantiviruses' => 'manufacturers_id',
+      'glpi_computers'           => 'manufacturers_id',
+      'glpi_consumableitems'     => 'manufacturers_id',
+      'glpi_devicebatteries'     => 'manufacturers_id',
+      'glpi_devicecases'         => 'manufacturers_id',
+      'glpi_devicecontrols'      => 'manufacturers_id',
+      'glpi_devicedrives'        => 'manufacturers_id',
+      'glpi_devicefirmwares'     => 'manufacturers_id',
+      'glpi_devicegenerics'      => 'manufacturers_id',
+      'glpi_devicegraphiccards'  => 'manufacturers_id',
+      'glpi_deviceharddrives'    => 'manufacturers_id',
+      'glpi_devicememories'      => 'manufacturers_id',
+      'glpi_devicemotherboards'  => 'manufacturers_id',
+      'glpi_devicenetworkcards'  => 'manufacturers_id',
+      'glpi_devicepcis'          => 'manufacturers_id',
+      'glpi_devicepowersupplies' => 'manufacturers_id',
+      'glpi_deviceprocessors'    => 'manufacturers_id',
+      'glpi_devicesensors'       => 'manufacturers_id',
+      'glpi_devicesimcards'      => 'manufacturers_id',
+      'glpi_devicesoundcards'    => 'manufacturers_id',
+      'glpi_enclosures'          => 'manufacturers_id',
+      'glpi_monitors'            => 'manufacturers_id',
+      'glpi_networkequipments'   => 'manufacturers_id',
+      'glpi_pdus'                => 'manufacturers_id',
+      'glpi_peripherals'         => 'manufacturers_id',
+      'glpi_phones'              => 'manufacturers_id',
+      'glpi_printers'            => 'manufacturers_id',
+      'glpi_racks'               => 'manufacturers_id',
+      'glpi_softwarelicenses'    => 'manufacturers_id',
+      'glpi_softwares'           => 'manufacturers_id',
+   ],
+
+   'glpi_monitormodels' => [
+      'glpi_monitors' => 'monitormodels_id',
+   ],
+
+   'glpi_monitortypes' => [
+      'glpi_monitors' => 'monitortypes_id',
+   ],
+
+   'glpi_netpoints' => [
+      'glpi_networkportethernets'     => 'netpoints_id',
+      'glpi_networkportfiberchannels' => 'netpoints_id',
+   ],
+
+   'glpi_networkequipmentmodels' => [
+      'glpi_networkequipments' => 'networkequipmentmodels_id',
+   ],
+
+   'glpi_networkequipmenttypes' => [
+      'glpi_networkequipments' => 'networkequipmenttypes_id',
+   ],
+
+   'glpi_networknames' => [
+      '_glpi_networkaliases' => 'networknames_id',
+   ],
+
+   'glpi_networkports' => [
+      'glpi_networkportaggregates'      => 'networkports_id',
+      'glpi_networkportaliases'         => [
+         'networkports_id',
+         'networkports_id_alias',
+      ],
+      'glpi_networkportdialups'         => 'networkports_id',
+      'glpi_networkportethernets'       => 'networkports_id',
+      'glpi_networkportfiberchannels'   => 'networkports_id',
+      'glpi_networkportlocals'          => 'networkports_id',
+      '_glpi_networkports_networkports' => [
+         'networkports_id_1',
+         'networkports_id_2',
+      ],
+      '_glpi_networkports_vlans'        => 'networkports_id',
+      'glpi_networkportwifis'           => 'networkports_id',
+   ],
+
+   'glpi_networkportwifis' => [
+      'glpi_networkportwifis' => 'networkportwifis_id',
+   ],
+
+   'glpi_networks' => [
+      'glpi_computers'         => 'networks_id',
+      'glpi_networkequipments' => 'networks_id',
+      'glpi_printers'          => 'networks_id',
+   ],
+
+   'glpi_notifications' => [
+      '_glpi_notifications_notificationtemplates' => 'notifications_id',
+      '_glpi_notificationtargets'                 => 'notifications_id',
+   ],
+
+   'glpi_notificationtemplates' => [
+      '_glpi_notificationtemplatetranslations' => 'notificationtemplates_id',
+      '_glpi_queuednotifications'              => 'notificationtemplates_id',
+   ],
+
+   'glpi_olalevels' => [
+      '_glpi_olalevelactions'   => 'olalevels_id',
+      '_glpi_olalevelcriterias' => 'olalevels_id',
+      '_glpi_olalevels_tickets' => 'olalevels_id',
+      'glpi_tickets'            => 'ttr_olalevels_id',
+   ],
+
+   'glpi_olas' => [
+      'glpi_olalevels' => 'olas_id',
+      'glpi_tickets'   => [
+         'olas_ttr_id',
+         'olas_tto_id',
+      ],
+   ],
+
+   'glpi_operatingsystemarchitectures' => [
+      'glpi_items_operatingsystems' => 'operatingsystemarchitectures_id',
+   ],
+
+   'glpi_operatingsystemeditions' => [
+      'glpi_items_operatingsystems' => 'operatingsystemeditions_id',
+   ],
+
+   'glpi_operatingsystemkernels' => [
+      'glpi_operatingsystemkernelversions' => 'operatingsystemkernels_id',
+   ],
+
+   'glpi_operatingsystemkernelversions' => [
+      'glpi_items_operatingsystems' => 'operatingsystemkernelversions_id',
+   ],
+
+   'glpi_operatingsystems' => [
+      'glpi_items_operatingsystems' => 'operatingsystems_id',
+      'glpi_softwareversions'       => 'operatingsystems_id',
+   ],
+
+   'glpi_operatingsystemservicepacks' => [
+      'glpi_items_operatingsystems' => 'operatingsystemservicepacks_id',
+   ],
+
+   'glpi_operatingsystemversions' => [
+      'glpi_items_operatingsystems' => 'operatingsystemversions_id',
+   ],
+
+   'glpi_pdumodels' => [
+      'glpi_pdus' => 'pdumodels_id',
+   ],
+
+   'glpi_pdus' => [
+      '_glpi_pdus_plugs' => 'pdus_id',
+      '_glpi_pdus_racks' => 'pdus_id',
+   ],
+
+   'glpi_pdutypes' => [
+      'glpi_pdus' => 'pdutypes_id',
+   ],
+
+   'glpi_peripheralmodels' => [
+      'glpi_peripherals' => 'peripheralmodels_id',
+   ],
+
+   'glpi_peripheraltypes' => [
+      'glpi_peripherals' => 'peripheraltypes_id',
+   ],
+
+   'glpi_phonemodels' => [
+      'glpi_phones' => 'phonemodels_id',
+   ],
+
+   'glpi_phonepowersupplies' => [
+      'glpi_phones' => 'phonepowersupplies_id',
+   ],
+
+   'glpi_phonetypes' => [
+      'glpi_phones' => 'phonetypes_id',
+   ],
+
+   'glpi_plugs' => [
+      '_glpi_pdus_plugs' => 'pdus_id',
+   ],
+
+   'glpi_printermodels' => [
+      '_glpi_cartridgeitems_printermodels' => 'printermodels_id',
+      'glpi_printers'                      => 'printermodels_id',
+   ],
+
+   'glpi_printers' => [
+      '_glpi_cartridges' => 'printers_id',
+   ],
+
+   'glpi_printertypes' => [
+      'glpi_printers' => 'printertypes_id',
+   ],
+
+   'glpi_problems' => [
+      '_glpi_changes_problems'   => 'problems_id',
+      '_glpi_groups_problems'    => 'problems_id',
+      '_glpi_items_problems'     => 'problems_id',
+      '_glpi_problemcosts'       => 'problems_id',
+      '_glpi_problems_suppliers' => 'problems_id',
+      '_glpi_problems_tickets'   => 'problems_id',
+      '_glpi_problems_users'     => 'problems_id',
+      '_glpi_problemtasks'       => 'problems_id',
+   ],
+
+   'glpi_profiles' => [
+      '_glpi_knowbaseitems_profiles' => 'profiles_id',
+      '_glpi_profilerights'          => 'profiles_id',
+      '_glpi_profiles_reminders'     => 'profiles_id',
+      '_glpi_profiles_rssfeeds'      => 'profiles_id',
+      '_glpi_profiles_users'         => 'profiles_id',
+      'glpi_users'                   => 'profiles_id',
+   ],
+
+   'glpi_projects' => [
+      '_glpi_changes_projects' => 'projects_id',
+      '_glpi_items_projects'   => 'projects_id',
+      '_glpi_projectcosts'     => 'projects_id',
+      'glpi_projects'          => 'projects_id',
+      '_glpi_projecttasks'     => 'projects_id',
+      '_glpi_projectteams'     => 'projects_id',
+   ],
+
+   'glpi_projectstates' => [
+      'glpi_projects'             => 'projectstates_id',
+      'glpi_projecttasks'         => 'projectstates_id',
+      'glpi_projecttasktemplates' => 'projectstates_id',
+   ],
+
+   'glpi_projecttasks' => [
+      'glpi_projecttasks'          => 'projecttasks_id',
+      '_glpi_projecttasks_tickets' => 'projecttasks_id',
+      '_glpi_projecttaskteams'     => 'projecttasks_id',
+      'glpi_projecttasktemplates'  => 'projecttasks_id',
+   ],
+
+   'glpi_projecttasktemplates' => [
+      'glpi_projecttasks' => 'projecttasktemplates_id',
+   ],
+
+   'glpi_projecttasktypes' => [
+      'glpi_projecttasks'         => 'projecttasktypes_id',
+      'glpi_projecttasktemplates' => 'projecttasktypes_id',
+   ],
+
+   'glpi_projecttypes' => [
+      'glpi_projects' => 'projecttypes_id',
+   ],
+
+   'glpi_rackmodels' => [
+      'glpi_racks' => 'rackmodels_id',
+   ],
+
+   'glpi_racks' => [
+      '_glpi_items_racks' => 'racks_id',
+      '_glpi_pdus_racks'  => 'racks_id',
+   ],
+
+   'glpi_racktypes' => [
+      'glpi_racks' => 'racktypes_id',
+   ],
+
+   'glpi_reminders' => [
+      '_glpi_entities_reminders' => 'reminders_id',
+      '_glpi_groups_reminders'   => 'reminders_id',
+      '_glpi_profiles_reminders' => 'reminders_id',
+      '_glpi_reminders_users'    => 'reminders_id',
+   ],
+
+   'glpi_requesttypes' => [
+      'glpi_ticketfollowups' => 'requesttypes_id',
+      'glpi_tickets'         => 'requesttypes_id',
+      'glpi_users'           => 'default_requesttypes_id',
+   ],
+
+   'glpi_reservationitems' => [
+      '_glpi_reservations' => 'reservationitems_id',
+   ],
+
+   'glpi_rssfeeds' => [
+      '_glpi_entities_rssfeeds' => 'rssfeeds_id',
+      '_glpi_groups_rssfeeds'   => 'rssfeeds_id',
+      '_glpi_profiles_rssfeeds' => 'rssfeeds_id',
+      '_glpi_rssfeeds_users'    => 'rssfeeds_id',
+   ],
+
+   'glpi_rules' => [
+      '_glpi_ruleactions'   => 'rules_id',
+      '_glpi_rulecriterias' => 'rules_id',
+   ],
+
+   'glpi_savedsearches' => [
+      '_glpi_savedsearches_alerts' => 'savedsearches_id',
+      '_glpi_savedsearches_users'  => 'savedsearches_id',
+   ],
+
+   'glpi_slalevels' => [
+      '_glpi_slalevelactions'   => 'slalevels_id',
+      '_glpi_slalevelcriterias' => 'slalevels_id',
+      '_glpi_slalevels_tickets' => 'slalevels_id',
+      'glpi_tickets'            => 'ttr_slalevels_id',
+   ],
+
+   'glpi_slas' => [
+      'glpi_slalevels' => 'slas_id',
+      'glpi_tickets'   => [
+         'slas_ttr_id',
+         'slas_tto_id',
+      ],
+   ],
+
+   'glpi_slms' => [
+      '_glpi_olas' => 'slms_id',
+      '_glpi_slas' => 'slms_id',
+   ],
+
+   'glpi_softwarecategories' => [
+      '_glpi_softwarecategories' => 'softwarecategories_id',
+      'glpi_softwares'           => 'softwarecategories_id',
+   ],
+
+   'glpi_softwarelicenses' => [
+      '_glpi_computers_softwarelicenses' => 'softwarelicenses_id',
+      '_glpi_softwarelicenses'           => 'softwarelicenses_id',
+   ],
+
+   'glpi_softwarelicensetypes' => [
+      'glpi_softwarelicenses'      => 'softwarelicensetypes_id',
+      '_glpi_softwarelicensetypes' => 'softwarelicensetypes_id',
+   ],
+
+   'glpi_softwares' => [
+      '_glpi_softwarelicenses' => 'softwares_id',
+      'glpi_softwares'         => 'softwares_id',
+      '_glpi_softwareversions' => 'softwares_id',
+   ],
+
+   'glpi_softwareversions' => [
+      '_glpi_computers_softwareversions' => 'softwareversions_id',
+      'glpi_softwarelicenses'            => [
+         'softwareversions_id_buy',
+         'softwareversions_id_use',
+      ],
+   ],
+
+   'glpi_solutiontypes' => [
+      'glpi_itilsolutions'     => 'solutiontypes_id',
+      'glpi_solutiontemplates' => 'solutiontypes_id',
+   ],
+
+   'glpi_states' => [
+      'glpi_certificates'              => 'states_id',
+      'glpi_computers'                 => 'states_id',
+      'glpi_devicegenerics'            => 'states_id',
+      'glpi_devicesensors'             => 'states_id',
+      'glpi_enclosures'                => 'states_id',
+      'glpi_items_devicebatteries'     => 'states_id',
+      'glpi_items_devicecases'         => 'states_id',
+      'glpi_items_devicecontrols'      => 'states_id',
+      'glpi_items_devicedrives'        => 'states_id',
+      'glpi_items_devicefirmwares'     => 'states_id',
+      'glpi_items_devicegenerics'      => 'states_id',
+      'glpi_items_devicegraphiccards'  => 'states_id',
+      'glpi_items_deviceharddrives'    => 'states_id',
+      'glpi_items_devicememories'      => 'states_id',
+      'glpi_items_devicemotherboards'  => 'states_id',
+      'glpi_items_devicenetworkcards'  => 'states_id',
+      'glpi_items_devicepcis'          => 'states_id',
+      'glpi_items_devicepowersupplies' => 'states_id',
+      'glpi_items_deviceprocessors'    => 'states_id',
+      'glpi_items_devicesensors'       => 'states_id',
+      'glpi_items_devicesimcards'      => 'states_id',
+      'glpi_items_devicesoundcards'    => 'states_id',
+      'glpi_lines'                     => 'states_id',
+      'glpi_monitors'                  => 'states_id',
+      'glpi_networkequipments'         => 'states_id',
+      'glpi_pdus'                      => 'states_id',
+      'glpi_peripherals'               => 'states_id',
+      'glpi_phones'                    => 'states_id',
+      'glpi_printers'                  => 'states_id',
+      'glpi_racks'                     => 'states_id',
+      'glpi_softwarelicenses'          => 'states_id',
+      'glpi_softwareversions'          => 'states_id',
+      'glpi_states'                    => 'states_id',
+   ],
+
+   'glpi_suppliers' => [
+      '_glpi_changes_suppliers'   => 'suppliers_id',
+      '_glpi_contacts_suppliers'  => 'suppliers_id',
+      '_glpi_contracts_suppliers' => 'suppliers_id',
+      'glpi_infocoms'             => 'suppliers_id',
+      '_glpi_problems_suppliers'  => 'suppliers_id',
+      '_glpi_suppliers_tickets'   => 'suppliers_id',
+   ],
+
+   'glpi_suppliertypes' => [
+      'glpi_suppliers' => 'suppliertypes_id',
+   ],
+
+   'glpi_taskcategories' => [
+      'glpi_changetasks'    => 'taskcategories_id',
+      'glpi_problemtasks'   => 'taskcategories_id',
+      'glpi_taskcategories' => 'taskcategories_id',
+      'glpi_tasktemplates'  => 'taskcategories_id',
+      'glpi_tickettasks'    => 'taskcategories_id',
+   ],
+
+   'glpi_tasktemplates' => [
+      'glpi_changetasks'  => 'tasktemplates_id',
+      'glpi_problemtasks' => 'tasktemplates_id',
+      'glpi_tickettasks'  => 'tasktemplates_id',
+   ],
+
+   'glpi_ticketfollowups' => [
+      'glpi_itilsolutions' => 'ticketfollowups_id',
+   ],
+
+   'glpi_tickets' => [
+      '_glpi_changes_tickets'      => 'tickets_id',
+      'glpi_documents'             => 'tickets_id',
+      '_glpi_groups_tickets'       => 'tickets_id',
+      '_glpi_items_tickets'        => 'tickets_id',
+      '_glpi_olalevels_tickets'    => 'tickets_id',
+      '_glpi_problems_tickets'     => 'tickets_id',
+      '_glpi_projecttasks_tickets' => 'tickets_id',
+      '_glpi_slalevels_tickets'    => 'tickets_id',
+      '_glpi_suppliers_tickets'    => 'tickets_id',
+      '_glpi_ticketcosts'          => 'tickets_id',
+      '_glpi_ticketfollowups'      => 'tickets_id',
+      '_glpi_tickets_tickets'      => [
+         'tickets_id_1',
+         'tickets_id_2',
+      ],
+      '_glpi_tickets_users'        => 'tickets_id',
+      '_glpi_ticketsatisfactions'  => 'tickets_id',
+      '_glpi_tickettasks'          => 'tickets_id',
+      '_glpi_ticketvalidations'    => 'tickets_id',
+   ],
+
+   'glpi_tickettemplates' => [
+      'glpi_entities'                        => 'tickettemplates_id',
+      'glpi_itilcategories'                  => [
+         'tickettemplates_id_incident',
+         'tickettemplates_id_demand',
+      ],
+      'glpi_profiles'                        => 'tickettemplates_id',
+      'glpi_ticketrecurrents'                => 'tickettemplates_id',
+      '_glpi_tickettemplatehiddenfields'     => 'tickettemplates_id',
+      '_glpi_tickettemplatemandatoryfields'  => 'tickettemplates_id',
+      '_glpi_tickettemplatepredefinedfields' => 'tickettemplates_id',
+   ],
+
+   'glpi_usercategories' => [
+      'glpi_users' => 'usercategories_id',
+   ],
+
+   'glpi_users' => [
+      'glpi_cartridgeitems'           => 'users_id_tech',
+      'glpi_certificates'             => [
+         'users_id_tech',
+         'users_id',
+      ],
+      'glpi_changes'                  => [
+         'users_id_recipient',
+         'users_id_lastupdater',
+      ],
+      '_glpi_changes_users'           => 'users_id',
+      'glpi_changetasks'              => [
+         'users_id',
+         'users_id_editor',
+         'users_id_tech',
+      ],
+      'glpi_changevalidations'        => [
+         'users_id',
+         'users_id_validate',
+      ],
+      'glpi_computers'                => [
+         'users_id_tech',
+         'users_id',
+      ],
+      'glpi_consumableitems'          => 'users_id_tech',
+      '_glpi_displaypreferences'      => 'users_id',
+      'glpi_documents'                => 'users_id',
+      'glpi_documents_items'          => 'users_id',
+      'glpi_enclosures'               => 'users_id_tech',
+      '_glpi_groups_users'            => 'users_id',
+      'glpi_itilcategories'           => 'users_id',
+      'glpi_itilsolutions'            => [
+         'users_id_approval',
+         'users_id_editor',
+         'users_id',
+      ],
+      'glpi_knowbaseitems'            => 'users_id',
+      'glpi_knowbaseitems_comments'   => 'users_id',
+      'glpi_knowbaseitems_revisions'  => 'users_id',
+      '_glpi_knowbaseitems_users'     => 'users_id',
+      'glpi_knowbaseitemtranslations' => 'users_id',
+      'glpi_lines'                    => 'users_id',
+      'glpi_monitors'                 => [
+         'users_id_tech',
+         'users_id',
+      ],
+      'glpi_networkequipments'        => [
+         'users_id_tech',
+         'users_id',
+      ],
+      'glpi_notepads'                 => [
+         'users_id',
+         'users_id_lastupdater',
+      ],
+      'glpi_notimportedemails'        => 'users_id',
+      '_glpi_objectlocks'             => 'users_id',
+      'glpi_pdus'                     => 'users_id_tech',
+      'glpi_peripherals'              => [
+         'users_id_tech',
+         'users_id',
+      ],
+      'glpi_phones'                   => [
+         'users_id_tech',
+         'users_id',
+      ],
+      'glpi_planningrecalls'          => 'users_id',
+      'glpi_printers'                 => [
+         'users_id_tech',
+         'users_id',
+      ],
+      'glpi_problems'                 => [
+         'users_id_recipient',
+         'users_id_lastupdater',
+      ],
+      '_glpi_problems_users'          => 'users_id',
+      'glpi_problemtasks'             => [
+         'users_id',
+         'users_id_editor',
+         'users_id_tech',
+      ],
+      '_glpi_profiles_users'          => 'users_id',
+      'glpi_projects'                 => 'users_id',
+      'glpi_projecttasks'             => 'users_id',
+      'glpi_racks'                    => 'users_id_tech',
+      'glpi_reminders'                => 'users_id',
+      '_glpi_reminders_users'         => 'users_id',
+      'glpi_reservations'             => 'users_id',
+      'glpi_rssfeeds'                 => 'users_id',
+      '_glpi_rssfeeds_users'          => 'users_id',
+      '_glpi_savedsearches'           => 'users_id',
+      '_glpi_savedsearches_users'     => 'users_id',
+      'glpi_softwarelicenses'         => [
+         'users_id_tech',
+         'users_id',
+      ],
+      'glpi_softwares'                => [
+         'users_id_tech',
+         'users_id',
+      ],
+      'glpi_tasktemplates'            => 'users_id_tech',
+      'glpi_ticketfollowups'          => [
+         'users_id',
+         'users_id_editor',
+      ],
+      'glpi_tickets'                  => [
+         'users_id_recipient',
+         'users_id_lastupdater',
+      ],
+      '_glpi_tickets_users'           => 'users_id',
+      'glpi_tickettasks'              => [
+         'users_id',
+         'users_id_editor',
+         'users_id_tech',
+      ],
+      'glpi_ticketvalidations'        => [
+         'users_id',
+         'users_id_validate',
+      ],
+      '_glpi_useremails'              => 'users_id',
+   ],
+
+   'glpi_usertitles' => [
+      'glpi_contacts' => 'usertitles_id',
+      'glpi_users'    => 'usertitles_id',
+   ],
+
+   'glpi_virtualmachinestates' => [
+      'glpi_computervirtualmachines' => 'virtualmachinestates_id',
+   ],
+
+   'glpi_virtualmachinesystems' => [
+      'glpi_computervirtualmachines' => 'virtualmachinesystems_id',
+   ],
+
+   'glpi_virtualmachinetypes' => [
+      'glpi_computervirtualmachines' => 'virtualmachinetypes_id',
+   ],
+
+   'glpi_vlans' => [
+      '_glpi_ipnetworks_vlans'   => 'vlans_id',
+      '_glpi_networkports_vlans' => 'vlans_id',
+   ],
+
+   'glpi_wifinetworks' => [
+      'glpi_networkportwifis' => 'wifinetworks_id',
+   ],
+
+   '_virtual_device' => [
+      'glpi_contracts_items' => [
+         'items_id',
+         'itemtype',
+      ],
+      'glpi_documents_items' => [
+         'items_id',
+         'itemtype',
+      ],
+      'glpi_infocoms'        => [
+         'items_id',
+         'itemtype',
+      ],
+   ],
+
+];
 
-$RELATION = ["glpi_authldaps"
-                        => ['glpi_authldapreplicates' => 'authldaps_id',
-                                 'glpi_entities'           => 'authldaps_id',],
-
-                        "glpi_autoupdatesystems"
-                        => ['glpi_computers' => 'autoupdatesystems_id'],
-
-                        "glpi_savedsearches"
-                        => ['glpi_savedsearches_users' => 'savedsearches_id'],
-
-                        "glpi_budgets"
-                        => ['glpi_infocoms' => 'budgets_id'],
-
-                        "glpi_calendars"
-                        => ['_glpi_calendarsegments'   => 'calendars_id',
-                                 '_glpi_calendars_holidays' => 'calendars_id',
-                                 'glpi_slms'                => 'calendars_id',
-                                 'glpi_entities'            => 'calendars_id',],
-
-                        "glpi_cartridgeitems"
-                        => ['glpi_cartridges'                   => 'cartridgeitems_id',
-                                 'glpi_cartridgeitems_printermodels' => 'cartridgeitems_id'],
-
-                        "glpi_cartridgeitemtypes"
-                        => ['glpi_cartridgeitems' => 'cartridgeitemtypes_id'],
-
-                        "glpi_changes"
-                        => ['glpi_changes_groups'    => 'changes_id',
-                                 'glpi_changes_items'     => 'changes_id',
-                                 'glpi_changes_problems'  => 'changes_id',
-                                 'glpi_changes_projects'  => 'changes_id',
-                                 'glpi_changes_suppliers' => 'changes_id',
-                                 'glpi_changes_tickets'   => 'changes_id',
-                                 'glpi_changes_users'     => 'changes_id',
-                                 'glpi_changetasks'       => 'changes_id'],
-
-                        "glpi_changetasks"
-                        => ['glpi_changetasks'   => 'changetasks_id'],
-
-                        "glpi_computermodels"
-                        => ['glpi_computers' => 'computermodels_id'],
-
-                        "glpi_computers"
-                        => ['glpi_computers_items'                => 'computers_id',
-                                 'glpi_computers_softwarelicenses'     => 'computers_id',
-                                 'glpi_computers_softwareversions'     => 'computers_id',
-                                 'glpi_computervirtualmachines'        => 'computers_id'],
-
-                        "glpi_computertypes"
-                        => ['glpi_computers' => 'computertypes_id'],
-
-                        "glpi_certificatetypes"
-                        => ['glpi_certificatetypes' => 'certificatetypes_id'],
-
-                        "glpi_consumableitems"
-                        => ['glpi_consumables' => 'consumableitems_id'],
-
-                        "glpi_consumableitemtypes"
-                        => ['glpi_consumableitems' => 'consumableitemtypes_id'],
-
-                        "glpi_contacts"
-                        => ['glpi_contacts_suppliers' => 'contacts_id'],
-
-                        "glpi_contacttypes"
-                        => ['glpi_contacts' => 'contacttypes_id'],
-
-                        "glpi_contracts"
-                        => ['glpi_contracts_items'     => 'contracts_id',
-                                 'glpi_contracts_suppliers' => 'contracts_id'],
-
-                        "glpi_contracttypes"
-                        => ['glpi_contracts' => 'contracttypes_id'],
-
-                        "glpi_datacenters"
-                        => ['glpi_dcrooms' => 'datacenters_id'],
-
-                        "glpi_dcrooms"
-                        => ['glpi_racks' => 'dcrooms_id'],
-
-                        "glpi_devicecases"
-                        => ['glpi_items_devicecases' => 'devicecases_id'],
-
-                        "glpi_devicecasetypes"
-                        => ['glpi_devicecases' => 'devicecasetypes_id'],
-
-                        "glpi_devicecontrols"
-                        => ['glpi_items_devicecontrols' => 'devicecontrols_id'],
-
-                        "glpi_devicedrives"
-                        => ['glpi_items_devicedrives' => 'devicedrives_id'],
-
-                        "glpi_devicegraphiccards"
-                        => ['glpi_items_devicegraphiccards' => 'devicegraphiccards_id'],
-
-                        "glpi_deviceharddrives"
-                        => ['glpi_items_deviceharddrives' => 'deviceharddrives_id'],
-
-                        "glpi_devicememories"
-                        => ['glpi_items_devicememories' => 'devicememories_id'],
-
-                        "glpi_devicememorytypes"
-                        => ['glpi_devicememories' => 'devicememorytypes_id'],
-
-                        "glpi_devicemotherboards"
-                        => ['glpi_items_devicemotherboards' => 'devicemotherboards_id'],
-
-                        "glpi_devicenetworkcards"
-                        => ['glpi_items_devicenetworkcards' => 'devicenetworkcards_id'],
-
-                        "glpi_devicepcis"
-                        => ['glpi_items_devicepcis' => 'devicepcis_id'],
-
-                        "glpi_devicepowersupplies"
-                        => ['glpi_items_devicepowersupplies' => 'devicepowersupplies_id'],
-
-                        "glpi_deviceprocessors"
-                        => ['glpi_items_deviceprocessors' => 'deviceprocessors_id'],
-
-                        "glpi_devicesoundcards"
-                        => ['glpi_items_devicesoundcards' => 'devicesoundcards_id'],
-
-                        "glpi_devicebatteries"
-                        => ['glpi_items_devicebatteries' => 'devicebatteries_id'],
-
-                        "glpi_devicefirmwares"
-                        => ['glpi_items_devicefirmwares' => 'devicefirmwares_id'],
-
-                        "glpi_devicesensors"
-                        => ['glpi_items_devicesensors' => 'devicesensors_id'],
-
-                        "glpi_devicesimcards"
-                        => ['glpi_items_devicesimcards' => 'devicesimcards_id'],
-
-                        "glpi_devicemotherboards"
-                        => ['glpi_items_devicegenerics' => 'devicegenerics_id'],
-
-                        "glpi_documentcategories"
-                        => ['glpi_documents'           => 'documentcategories_id',
-                                 'glpi_documentcategories'  => 'documentcategories_id'],
-
-                        "glpi_documents"
-                        => ['glpi_documents_items' => 'documents_id'],
-
-                        "glpi_domains"
-                        => ['glpi_computers'         => 'domains_id',
-                                 'glpi_printers'          => 'domains_id',
-                                 'glpi_networkequipments' => 'domains_id'],
-
-                        "glpi_enclosuremodels"
-                        => ['glpi_enclosures' => 'enclosuremodels_id'],
-
-                        "glpi_entities"
-                        => ['glpi_savedsearches'                   => 'entities_id',
-                                 'glpi_budgets'                         => 'entities_id',
-                                 'glpi_calendars'                       => 'entities_id',
-                                 '_glpi_calendarsegments'               => 'entities_id',
-                                 'glpi_cartridgeitems'                  => 'entities_id',
-                                 '_glpi_cartridges'                     => 'entities_id',
-                                 'glpi_changes'                         => 'entities_id',
-                                 'glpi_computers'                       => 'entities_id',
-                                 '_glpi_computervirtualmachines'        => 'entities_id',
-                                 'glpi_consumableitems'                 => 'entities_id',
-                                 '_glpi_consumables'                    => 'entities_id',
-                                 'glpi_contacts'                        => 'entities_id',
-                                 'glpi_contracts'                       => 'entities_id',
-                                 'glpi_datacenters'                     => 'entities_id',
-                                 'glpi_dcrooms'                         => 'entities_id',
-                                 'glpi_documents'                       => 'entities_id',
-                                 '_glpi_documents_items'                => 'entities_id',
-                                 'glpi_enclosures'                      => 'entities_id',
-                                 '_glpi_entities'                       => 'entities_id',
-                                 'glpi_entities'                        => 'entities_id_software',
-                                 'glpi_entities_knowbaseitems'          => 'entities_id',
-                                 'glpi_entities_reminders'              => 'entities_id',
-                                 'glpi_fieldblacklists'                 => 'entities_id',
-                                 'glpi_fieldunicities'                  => 'entities_id',
-                                 'glpi_fqdns'                           => 'entities_id',
-                                 'glpi_groups'                          => 'entities_id',
-                                 'glpi_groups_knowbaseitems'            => 'entities_id',
-                                 'glpi_groups_reminders'                => 'entities_id',
-                                 'glpi_holidays'                        => 'entities_id',
-                                 '_glpi_infocoms'                       => 'entities_id',
-                                 'glpi_ipaddresses'                     => 'entities_id',
-                                 'glpi_ipnetworks'                      => 'entities_id',
-                                 'glpi_itilcategories'                  => 'entities_id',
-                                 'glpi_knowbaseitemcategories'          => 'entities_id',
-                                 'glpi_knowbaseitems_profiles'          => 'entities_id',
-                                 'glpi_links'                           => 'entities_id',
-                                 'glpi_locations'                       => 'entities_id',
-                                 'glpi_monitors'                        => 'entities_id',
-                                 'glpi_netpoints'                       => 'entities_id',
-                                 'glpi_networkaliases'                  => 'entities_id',
-                                 'glpi_networkequipments'               => 'entities_id',
-                                 'glpi_networknames'                    => 'entities_id',
-                                 '_glpi_networkports'                   => 'entities_id',
-                                 'glpi_notifications'                   => 'entities_id',
-                                 'glpi_pdus'                            => 'entities_id',
-                                 'glpi_pdutypes'                        => 'entities_id',
-                                 'glpi_peripherals'                     => 'entities_id',
-                                 'glpi_phones'                          => 'entities_id',
-                                 'glpi_printers'                        => 'entities_id',
-                                 'glpi_problems'                        => 'entities_id',
-                                 'glpi_projects'                        => 'entities_id',
-                                 '_glpi_projecttasks'                   => 'entities_id',
-                                 'glpi_profiles_reminders'              => 'entities_id',
-                                 'glpi_profiles_users'                  => 'entities_id',
-                                 'glpi_racks'                           => 'entities_id',
-                                 'glpi_racktypes'                       => 'entities_id',
-                                 '_glpi_reservationitems'               => 'entities_id',
-                                 'glpi_rules'                           => 'entities_id',
-                                 '_glpi_slalevels'                      => 'entities_id',
-                                 'glpi_slms'                            => 'entities_id',
-                                 'glpi_softwarelicenses'                => 'entities_id',
-                                 'glpi_softwareversions'                => 'entities_id',
-                                 'glpi_softwares'                       => 'entities_id',
-                                 'glpi_solutiontemplates'               => 'entities_id',
-                                 'glpi_solutiontypes'                   => 'entities_id',
-                                 'glpi_taskcategories'                  => 'entities_id',
-                                 'glpi_tasktemplates'                   => 'entities_id',
-                                 'glpi_projecttasktemplates'            => 'entities_id',
-                                 'glpi_suppliers'                       => 'entities_id',
-                                 'glpi_taskcategories'                  => 'entities_id',
-                                 'glpi_ticketrecurrents'                => 'entities_id',
-                                 'glpi_tickettemplates'                 => 'entities_id',
-                                 'glpi_tickets'                         => 'entities_id',
-                                 '_glpi_ticketvalidations'              => 'entities_id',
-                                 'glpi_users'                           => 'entities_id',
-                                 'glpi_certificates'                    => 'entities_id'],
-
-                        "glpi_filesystems"
-                        => ['glpi_items_disks' => 'filesystems_id'],
-
-                        "glpi_fqdns"
-                        => ['glpi_networkaliases'   => 'fqdns_id',
-                                 'glpi_networknames'     => 'fqdns_id'],
-
-                        "glpi_groups" => [
-                           'glpi_cartridgeitems'       => 'groups_id_tech',
-                           'glpi_changes_groups'       => 'groups_id',
-                           'glpi_computers'            => ['groups_id_tech', 'groups_id'],
-                           'glpi_consumableitems'      => 'groups_id_tech',
-                           'glpi_enclosures'           => 'groups_id_tech',
-                           'glpi_groups'               => 'groups_id',
-                           'glpi_groups_knowbaseitems' => 'groups_id',
-                           'glpi_groups_problems'      => 'groups_id',
-                           'glpi_groups_reminders'     => 'groups_id',
-                           'glpi_groups_tickets'       => 'groups_id',
-                           'glpi_groups_users'         => 'groups_id',
-                           'glpi_itilcategories'       => 'groups_id',
-                           'glpi_monitors'             => ['groups_id_tech', 'groups_id'],
-                           'glpi_networkequipments'    => ['groups_id_tech', 'groups_id'],
-                           'glpi_pdus'                 => 'groups_id_tech',
-                           'glpi_peripherals'          => ['groups_id_tech', 'groups_id'],
-                           'glpi_phones'               => ['groups_id_tech', 'groups_id'],
-                           'glpi_printers'             => ['groups_id_tech', 'groups_id'],
-                           'glpi_certificates'         => ['groups_id_tech', 'groups_id'],
-                           'glpi_racks'                => 'groups_id_tech',
-                           'glpi_projects'             => 'groups_id',
-                           'glpi_softwarelicenses'     => ['groups_id_tech', 'groups_id'],
-                           'glpi_softwares'            => ['groups_id_tech', 'groups_id']
-                        ],
-
-                        "glpi_holidays"
-                        => ['glpi_calendars_holidays' => 'holidays_id',],
-
-                        "glpi_interfacetypes"
-                        => ['glpi_deviceharddrives'   => 'interfacetypes_id',
-                                 'glpi_devicedrives'       => 'interfacetypes_id',
-                                 'glpi_devicegraphiccards' => 'interfacetypes_id',
-                                 'glpi_devicecontrols'     => 'interfacetypes_id'],
-
-                        "glpi_ipaddresses"
-                        => ['glpi_ipaddresses_ipnetworks'   => 'ipaddresses_id'],
-
-                        "glpi_ipnetworks"
-                        => ['glpi_ipaddresses_ipnetworks'   => 'ipnetworks_id',
-                                 'glpi_ipnetworks'               => 'ipnetworks_id',
-                                 'glpi_ipnetworks_vlans'         => 'ipnetworks_id'],
-
-                        "glpi_knowbaseitemcategories"
-                        => ['glpi_itilcategories'         => 'knowbaseitemcategories_id',
-                                 'glpi_knowbaseitemcategories' => 'knowbaseitemcategories_id',
-                                 'glpi_knowbaseitems'          => 'knowbaseitemcategories_id'],
-
-                        "glpi_knowbaseitems"
-                        => ['glpi_entities_knowbaseitems' => 'knowbaseitems_id',
-                                 'glpi_groups_knowbaseitems'   => 'knowbaseitems_id',
-                                 'glpi_knowbaseitems_profiles' => 'knowbaseitems_id',
-                                 'glpi_knowbaseitems_users'    => 'knowbaseitems_id'],
-
-                        "glpi_links"
-                        => ['_glpi_links_itemtypes' => 'links_id'],
-
-                        "glpi_locations"
-                        => ['glpi_budgets'           => 'locations_id',
-                                 'glpi_cartridgeitems'    => 'locations_id',
-                                 'glpi_consumableitems'   => 'locations_id',
-                                 'glpi_computers'         => 'locations_id',
-                                 'glpi_datacenters'       => 'locations_id',
-                                 'glpi_dcrooms'           => 'locations_id',
-                                 'glpi_enclosures'        => 'locations_id',
-                                 'glpi_locations'         => 'locations_id',
-                                 'glpi_monitors'          => 'locations_id',
-                                 'glpi_netpoints'         => 'locations_id',
-                                 'glpi_networkequipments' => 'locations_id',
-                                 'glpi_pdus'              => 'locations_id',
-                                 'glpi_peripherals'       => 'locations_id',
-                                 'glpi_phones'            => 'locations_id',
-                                 'glpi_printers'          => 'locations_id',
-                                 'glpi_racks'             => 'locations_id',
-                                 'glpi_softwarelicenses'  => 'locations_id',
-                                 'glpi_softwares'         => 'locations_id',
-                                 'glpi_tickets'           => 'locations_id',
-                                 'glpi_certificates'      => 'locations_id',
-                                 'glpi_users'             => 'locations_id'],
-
-                        "glpi_manufacturers"
-                        => ['glpi_cartridgeitems'      => 'manufacturers_id',
-                                 'glpi_computers'           => 'manufacturers_id',
-                                 'glpi_consumableitems'     => 'manufacturers_id',
-                                 'glpi_devicecases'         => 'manufacturers_id',
-                                 'glpi_devicecontrols'      => 'manufacturers_id',
-                                 'glpi_devicedrives'        => 'manufacturers_id',
-                                 'glpi_devicegraphiccards'  => 'manufacturers_id',
-                                 'glpi_deviceharddrives'    => 'manufacturers_id',
-                                 'glpi_devicenetworkcards'  => 'manufacturers_id',
-                                 'glpi_devicemotherboards'  => 'manufacturers_id',
-                                 'glpi_devicepcis'          => 'manufacturers_id',
-                                 'glpi_devicepowersupplies' => 'manufacturers_id',
-                                 'glpi_deviceprocessors'    => 'manufacturers_id',
-                                 'glpi_devicememories'      => 'manufacturers_id',
-                                 'glpi_devicesoundcards'    => 'manufacturers_id',
-                                 'glpi_devicefirmwares'     => 'manufacturers_id',
-                                 'glpi_devicebatteries'     => 'manufacturers_id',
-                                 'glpi_devicegenerics'      => 'manufacturers_id',
-                                 'glpi_devicesensors'       => 'manufacturers_id',
-                                 'glpi_devicesimcards'      => 'manufacturers_id',
-                                 'glpi_enclosures'          => 'manufacturers_id',
-                                 'glpi_monitors'            => 'manufacturers_id',
-                                 'glpi_networkequipments'   => 'manufacturers_id',
-                                 'glpi_pdus'                => 'manufacturers_id',
-                                 'glpi_peripherals'         => 'manufacturers_id',
-                                 'glpi_phones'              => 'manufacturers_id',
-                                 'glpi_printers'            => 'manufacturers_id',
-                                 'glpi_certificates'        => 'manufacturers_id',
-                                 'glpi_racks'               => 'manufacturers_id',
-                                 'glpi_softwarelicenses'    => 'manufacturers_id',
-                                 'glpi_softwares'           => 'manufacturers_id'],
-
-                        "glpi_monitormodels"
-                        => ['glpi_monitors' => 'monitormodels_id'],
-
-                        "glpi_monitortypes"
-                        => ['glpi_monitors' => 'monitortypes_id'],
-
-                        "glpi_netpoints"
-                        => ['glpi_networkportethernets'   => 'netpoints_id'],
-
-                        "glpi_networkequipmentmodels"
-                        => ['glpi_networkequipments' =>'networkequipmentmodels_id'],
-
-                        "glpi_networkequipmenttypes"
-                        => ['glpi_networkequipments' => 'networkequipmenttypes_id'],
-
-                        "glpi_networknames"
-                        => ['glpi_networkaliases'          => 'networknames_id'],
-
-                        "glpi_networkports"
-                        => ['glpi_networkportaggregates'     => 'networkports_id',
-                                 'glpi_networkportaliases'        => ['networkports_id',
-                                                                           'networkports_id_alias'],
-                                 'glpi_networkportdialups'        => 'networkports_id',
-                                 'glpi_networkportethernets'      => 'networkports_id',
-                                 'glpi_networkportlocals'         => 'networkports_id',
-                                 'glpi_networkports_vlans'        => 'networkports_id',
-                                 'glpi_networkports_networkports' => ['networkports_id_1',
-                                                                           'networkports_id_2'],
-                                 'glpi_networkportwifis'          => 'networkports_id'],
-
-                        "glpi_networkportwifis"
-                        => ['glpi_networkportwifis' => 'networkportwifis_id'],
-
-                        "glpi_networks"
-                        => ['glpi_computers'         => 'networks_id',
-                                 'glpi_printers'          => 'networks_id',
-                                 'glpi_networkequipments' => 'networks_id'],
-
-                        "glpi_operatingsystems"
-                        => ['glpi_items_operatingsystems'  => 'operatingsystems_id',
-                                 'glpi_softwareversions'       => 'operatingsystems_id'],
-
-                        "glpi_operatingsystemservicepacks"
-                        => ['glpi_items_operatingsystems' => 'operatingsystemservicepacks_id'],
-
-                        "glpi_operatingsystemversions"
-                        => ['glpi_items_operatingsystems' => 'operatingsystemversions_id'],
-
-                        "glpi_pdumodels"
-                        => ['glpi_pdus' => 'pdumodels_id'],
-
-                        "glpi_pdutypes"
-                        => ['glpi_pdus' => 'pdutypes_id'],
-
-                        "glpi_peripheralmodels"
-                        => ['glpi_peripherals' => 'peripheralmodels_id'],
-
-                        "glpi_peripheraltypes"
-                        => ['glpi_peripherals' => 'peripheraltypes_id'],
-
-                        "glpi_phonemodels"
-                        => ['glpi_phones' => 'phonemodels_id'],
-
-                        "glpi_phoneoperators"
-                        => ['glpi_devicesimcards' => 'phoneoperators_id'],
-
-                        "glpi_phonepowersupplies"
-                        => ['glpi_phones' => 'phonepowersupplies_id'],
-
-                        "glpi_phonetypes"
-                        => ['glpi_phones' => 'phonetypes_id'],
-
-                        "glpi_printermodels"
-                        => ['glpi_printers'                     => 'printermodels_id',
-                                 'glpi_cartridgeitems_printermodels' => 'printermodels_id'],
-
-                        "glpi_printers"
-                        => ['glpi_cartridges' => 'printers_id'],
-
-                        "glpi_printertypes"
-                        => ['glpi_printers' => 'printertypes_id'],
-
-                        "glpi_projects"
-                        => ['glpi_projects'         => 'projects_id',
-                                 'glpi_projecttasks'     => 'projects_id',
-                                 'glpi_projectteams'     => 'projects_id',
-                                 'glpi_changes_projects' => 'projects_id',
-                                 'glpi_items_projects'   => 'projects_id'],
-
-                        "glpi_projectstates"
-                        => ['glpi_projects'        => 'projectstates_id',
-                                 'glpi_projecttasks'    => 'projectstates_id'],
-
-                        "glpi_projecttasks"
-                        => ['glpi_projecttasks'         => 'projecttasks_id',
-                                 'glpi_projecttasks_tickets' => 'projecttasks_id',
-                                 'glpi_projecttaskteams'     => 'projecttasks_id'],
-
-                        "glpi_projecttasktypes"
-                        => ['glpi_projecttasks'   => 'projecttasktypes_id'],
-
-                        "glpi_projecttypes"
-                        => ['glpi_projects'   => 'projecttypes_id'],
-
-                        "glpi_problems"
-                        => ['glpi_changes_problems'   => 'problems_id',
-                                 'glpi_groups_problems'    => 'problems_id',
-                                 'glpi_items_problems'     => 'problems_id',
-                                 'glpi_problems_suppliers' => 'problems_id',
-                                 'glpi_problems_tickets'   => 'problems_id',
-                                 'glpi_problems_users'     => 'problems_id',
-                                 'glpi_problemtasks'       => 'problems_id'],
-
-                        "glpi_profiles"
-                        => ['glpi_knowbaseitems_profiles' => 'profiles_id',
-                                 'glpi_profilerights'          => 'profiles_id',
-                                 'glpi_profiles_reminders'     => 'profiles_id',
-                                 'glpi_profiles_users'         => 'profiles_id',
-                                 'glpi_users'                  => 'profiles_id'],
-
-                        "glpi_rackmodels"
-                        => ['glpi_racks' => 'rackmodels_id'],
-
-                        "glpi_racktypes"
-                        => ['glpi_racks' => 'racktypes_id'],
-
-                        "glpi_reminders"
-                        => ['glpi_entities_reminders'  => 'reminders_id',
-                                 'glpi_groups_reminders'    => 'reminders_id',
-                                 'glpi_profiles_reminders'  => 'reminders_id',
-                                 'glpi_reminders_users'     => 'reminders_id',],
-
-                        "glpi_requesttypes"
-                        => ['glpi_ticketfollowups'  => 'requesttypes_id',
-                                 'glpi_tickets'          => 'requesttypes_id',
-                                 'glpi_users'            => 'default_requesttypes_id'],
-
-                        "glpi_reservationitems"
-                        => ['glpi_reservations' => 'reservationitems_id'],
-
-                        "glpi_rules"
-                        => ['glpi_ruleactions'                          => 'rules_id',
-                                 'glpi_rulecriterias'                        => 'rules_id'],
-
-                        "glpi_slalevels"
-                        => ['glpi_slalevelactions'   => 'slalevels_id',
-                                 'glpi_slalevelcriterias' => 'slalevels_id',
-                                 'glpi_tickets'           => 'ttr_slalevels_id',
-                                 'glpi_slalevels_tickets' => 'slalevels_id'],
-
-                        "glpi_slas"
-                        => ['glpi_slalevels' => 'slas_id',
-                            'glpi_tickets'   => ['slas_ttr_id', 'slas_tto_id']],
-
-                        "glpi_olalevels"
-                        => ['glpi_olalevelactions'   => 'olalevels_id',
-                            'glpi_olalevelcriterias' => 'olalevels_id',
-                            'glpi_tickets'           => 'ttr_olalevels_id',
-                            'glpi_olalevels_tickets' => 'olalevels_id'],
-
-                        "glpi_olas"
-                        => ['glpi_slalevels' => 'slas_id',
-                            'glpi_tickets'   => ['olas_ttr_id', 'olas_tto_id']],
-
-                        "glpi_softwarecategories"
-                        => ['glpi_softwares' => 'softwarecategories_id'],
-
-                        "glpi_softwarelicensetypes"
-                        => ['glpi_softwarelicenses' =>'softwarelicensetypes_id'],
-
-                        "glpi_softwareversions"
-                        => ['glpi_computers_softwareversions' => 'softwareversions_id',
-                            'glpi_softwarelicenses'           => ['softwareversions_id_buy',
-                                                                  'softwareversions_id_use']],
-
-                        "glpi_softwarelicenses"
-                        => ['glpi_computers_softwarelicenses' =>'softwarelicenses_id'],
-
-                        "glpi_softwares"
-                        => ['glpi_softwarelicenses' => 'softwares_id',
-                            'glpi_softwareversions' => 'softwares_id',
-                            'glpi_softwares'        => 'softwares_id'],
-
-                        "glpi_solutiontypes"
-                        => ['glpi_changes'           => 'solutiontypes_id',
-                            'glpi_problems'          => 'solutiontypes_id',
-                            'glpi_tickets'           => 'solutiontypes_id',
-                            'glpi_solutiontemplates' => 'solutiontypes_id'],
-
-                        "glpi_states"
-                        => ['glpi_computers'         => 'states_id',
-                                 'glpi_enclosures'        => 'states_id',
-                                 'glpi_monitors'          => 'states_id',
-                                 'glpi_networkequipments' => 'states_id',
-                                 'glpi_pdus'             => 'states_id',
-                                 'glpi_peripherals'       => 'states_id',
-                                 'glpi_phones'            => 'states_id',
-                                 'glpi_printers'          => 'states_id',
-                                 'glpi_certificates'      => 'states_id',
-                                 'glpi_racks'             => 'states_id',
-                                 'glpi_softwarelicenses'  => 'states_id',
-                                 'glpi_softwareversions'  => 'states_id',
-                                 'glpi_states'            => 'states_id'],
-
-                        "glpi_suppliers"
-                        => ['glpi_changes_suppliers'   => 'suppliers_id',
-                            'glpi_contacts_suppliers'  => 'suppliers_id',
-                            'glpi_contracts_suppliers' => 'suppliers_id',
-                            'glpi_infocoms'            => 'suppliers_id',
-                            'glpi_problems_suppliers'  => 'suppliers_id',
-                            'glpi_suppliers_tickets'   => 'suppliers_id',],
-
-                        "glpi_suppliertypes"
-                        => ['glpi_suppliers' => 'suppliertypes_id'],
-
-                        "glpi_taskcategories"
-                        => ['glpi_changetasks'    => 'taskcategories_id',
-                            'glpi_problemtasks'   => 'taskcategories_id',
-                            'glpi_taskcategories' => 'taskcategories_id',
-                            'glpi_tickettasks'    => 'taskcategories_id',
-                            'glpi_tasktemplates'  => 'taskcategories_id'],
-
-                        "glpi_itilcategories"
-                        => ['glpi_changes'         => 'itilcategories_id',
-                            'glpi_itilcategories'  => 'itilcategories_id',
-                            'glpi_tickets'         => 'itilcategories_id',
-                            'glpi_problems'        => 'itilcategories_id'],
-
-                        "glpi_tickettemplates"
-                        => ['glpi_entities'            => 'tickettemplates_id',
-                            'glpi_itilcategories'      => ['tickettemplates_id_incident',
-                                                           'tickettemplates_id_demand'],
-                            'glpi_ticketrecurrents'    => 'tickettemplates_id',
-                            '_glpi_tickettemplatehiddenfields'
-                                                       => 'tickettemplates_id',
-                            '_glpi_tickettemplatepredefinedfields'
-                                                       => 'tickettemplates_id',
-                            '_glpi_tickettemplatemandatoryfields'
-                                                       => 'tickettemplates_id'],
-
-                        "glpi_tickets"
-                        => ['_glpi_documents'          => 'tickets_id',
-                            'glpi_changes_tickets'     => 'tickets_id',
-                            'glpi_groups_tickets'      => 'tickets_id',
-                            'glpi_problems_tickets'    => 'tickets_id',
-                            'glpi_projecttasks_tickets'=> 'tickets_id',
-                            'glpi_slalevels_tickets'   => 'tickets_id',
-                            'glpi_suppliers_tickets'   => 'tickets_id',
-                            'glpi_ticketfollowups'     => 'tickets_id',
-                            'glpi_ticketsatisfactions' => 'tickets_id',
-                            'glpi_tickettasks'         => 'tickets_id',
-                            'glpi_ticketvalidations'   => 'tickets_id',
-                            'glpi_tickets_tickets'     => ['tickets_id_1', 'tickets_id_2'],
-                            'glpi_tickets_users'       => 'tickets_id'],
-
-                        "glpi_solutiontypes"
-                        => ['glpi_changes'             => 'solutiontypes_id',
-                            'glpi_tickets'             => 'solutiontypes_id',
-                            'glpi_solutiontemplates'   => 'solutiontypes_id',
-                            'glpi_problems'            => 'solutiontypes_id'],
-
-                        "glpi_usercategories"
-                        => ['glpi_users' => 'usercategories_id'],
-
-                        "glpi_users"
-                        => ['glpi_savedsearches'             => 'users_id',
-                                 'glpi_savedsearches_users'       => 'users_id',
-                                 'glpi_cartridgeitems'            => 'users_id_tech',
-                                 'glpi_changes'                   => ['users_id_recipient',
-                                                                           'users_id_lastupdater'],
-                                 'glpi_changes_users'             => 'users_id',
-                                 'glpi_changetasks'               => ['users_id', 'users_id_tech'],
-                                 'glpi_computers'                 => ['users_id_tech', 'users_id'],
-                                 'glpi_consumableitems'           => 'users_id_tech',
-                                 'glpi_displaypreferences'        => 'users_id',
-                                 'glpi_documents'                 => 'users_id',
-                                 'glpi_enclosures'                => 'users_id_tech',
-                                 'glpi_groups_users'              => 'users_id',
-                                 'glpi_itilcategories'            => 'users_id',
-                                 'glpi_knowbaseitems'             => 'users_id',
-                                 'glpi_knowbaseitems_users'       => 'users_id',
-                                 'glpi_monitors'                  => ['users_id_tech', 'users_id'],
-                                 'glpi_networkequipments'         => ['users_id_tech', 'users_id'],
-                                 'glpi_notimportedemails'         => 'users_id',
-                                 'glpi_pdus'                      => 'users_id_tech',
-                                 'glpi_peripherals'               => ['users_id_tech', 'users_id'],
-                                 'glpi_phones'                    => ['users_id_tech', 'users_id'],
-                                 'glpi_printers'                  => ['users_id_tech', 'users_id'],
-                                 'glpi_certificates'              => ['users_id_tech', 'users_id'],
-                                 'glpi_problems'                  => ['users_id_recipient',
-                                                                           'users_id_lastupdater'],
-                                 'glpi_problems_users'            => 'users_id',
-                                 'glpi_problemtasks'              => ['users_id', 'users_id_tech'],
-                                 'glpi_profiles_users'            => 'users_id',
-                                 'glpi_projects'                  => 'users_id',
-                                 'glpi_projecttasks'              => 'users_id',
-                                 'glpi_racks'                     => 'users_id_tech',
-                                 'glpi_reminders'                 => 'users_id',
-                                 'glpi_reminders_users'           => 'users_id',
-                                 'glpi_reservations'              => 'users_id',
-                                 'glpi_softwarelicenses'          => ['users_id_tech', 'users_id'],
-                                 'glpi_softwares'                 => ['users_id_tech', 'users_id'],
-                                 'glpi_ticketfollowups'           => 'users_id',
-                                 'glpi_tickets'                   => ['users_id_recipient',
-                                                                           'users_id_lastupdater'],
-                                 'glpi_tickets_users'             => 'users_id',
-                                 'glpi_tickettasks'               => ['users_id', 'users_id_tech'],
-                                 'glpi_ticketvalidations'         => 'users_id',
-                                 'glpi_ticketvalidations'         => 'users_id_validate',
-                                 'glpi_useremails'                => 'users_id'],
-
-                        "glpi_usertitles"
-                        => ['glpi_contacts'   => 'usertitles_id',
-                            'glpi_users'      => 'usertitles_id'],
-
-                        "glpi_vlans"
-                        => ['glpi_networkports_vlans' => 'vlans_id'],
-
-                        "glpi_virtualmachinestates"
-                        => ['glpi_computervirtualmachines' => 'virtualmachinestates_id'],
-
-                        "glpi_virtualmachinesystems"
-                        => ['glpi_computervirtualmachines' => 'virtualmachinesystems_id'],
-
-                        "glpi_virtualmachinetypes"
-                        => ['glpi_computervirtualmachines' => 'virtualmachinetypes_id'],
-
-                        "glpi_wifinetworks"
-                        => ['glpi_networkportwifis' => 'wifinetworks_id'],
-
-                         // link from devices tables (computers, software, ...) : only used for unrecurs check
-                         "_virtual_device" => ['glpi_contracts_items' => ['items_id', 'itemtype'],
-                                               'glpi_documents_items' => ['items_id', 'itemtype'],
-                                               'glpi_infocoms'        => ['items_id', 'itemtype']
-                        //                     'glpi_ipaddresses'     => array('items_id', 'itemtype'),
-                        //                     'glpi_networknames'    => array('items_id', 'itemtype'),
-                                                    ]
-                ];

--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -152,18 +152,16 @@ class Reminder extends CommonDBVisible {
     * @since 0.83.1
    **/
    function cleanDBonPurge() {
-      global $DB;
 
-      $class = new Reminder_User();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-      $class = new Entity_Reminder();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-      $class = new Group_Reminder();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-      $class = new Profile_Reminder();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-      $class = new PlanningRecall();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Entity_Reminder::class,
+            Group_Reminder::class,
+            PlanningRecall::class,
+            Profile_Reminder::class,
+            Reminder_User::class,
+         ]
+      );
    }
 
    public function haveVisibilityAccess() {

--- a/inc/reservationitem.class.php
+++ b/inc/reservationitem.class.php
@@ -122,11 +122,15 @@ class ReservationItem extends CommonDBChild {
 
    function cleanDBonPurge() {
 
-      $class = new Reservation();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Reservation::class,
+         ]
+      );
 
-      $class = new Alert();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      // Alert does not extends CommonDBConnexity
+      $alert = new Alert();
+      $alert->cleanDBonItemDelete($this->getType(), $this->fields['id']);
 
    }
 

--- a/inc/rssfeed.class.php
+++ b/inc/rssfeed.class.php
@@ -172,14 +172,14 @@ class RSSFeed extends CommonDBVisible {
    **/
    function cleanDBonPurge() {
 
-      $class = new RSSFeed_User();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-      $class = new Entity_RSSFeed();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-      $class = new Group_RSSFeed();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-      $class = new Profile_RSSFeed();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Entity_RSSFeed::class,
+            Group_RSSFeed::class,
+            Profile_RSSFeed::class,
+            RSSFeed_User::class,
+         ]
+      );
    }
 
    public function haveVisibilityAccess() {

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -1823,23 +1823,18 @@ class Rule extends CommonDBTM {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
       // Delete a rule and all associated criterias and actions
       if (!empty($this->ruleactionclass)) {
-         $DB->delete(
-            getTableForItemType($this->ruleactionclass), [
-               $this->rules_id_field   => $this->fields['id']
-            ]
-         );
+         $ruleactionclass = $this->ruleactionclass;
+         $ra = new $ruleactionclass();
+         $ra->deleteByCriteria([$this->rules_id_field => $this->fields['id']]);
       }
 
       if (!empty($this->rulecriteriaclass)) {
-         $DB->delete(
-            getTableForItemType($this->rulecriteriaclass), [
-               $this->rules_id_field   => $this->fields['id']
-            ]
-         );
+         $rulecriteriaclass = $this->rulecriteriaclass;
+         $rc = new $rulecriteriaclass();
+         $rc->deleteByCriteria([$this->rules_id_field => $this->fields['id']]);
       }
    }
 

--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -320,11 +320,11 @@ class SavedSearch extends CommonDBTM {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $DB->delete(
-         'glpi_savedsearches_users', [
-            'savedsearches_id'   => $this->fields['id']
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            SavedSearch_Alert::class,
+            SavedSearch_User::class,
          ]
       );
    }
@@ -861,16 +861,16 @@ class SavedSearch extends CommonDBTM {
                _rows.each(function() {
                   var _row = $(this);
                   var rowtext = _row.text().toLowerCase();
- 
+
                   var show = true;
- 
+
                   for (var i=0; i < searchparts.length; i++) {
                      if (rowtext.indexOf(searchparts[i]) == -1) {
                         show = false;
                         break;
                      }
                   }
- 
+
                   if (show) {
                      _row.show();
                   } else {

--- a/inc/slalevel.class.php
+++ b/inc/slalevel.class.php
@@ -55,13 +55,11 @@ class SlaLevel extends LevelAgreementLevel {
    function cleanDBonPurge() {
       global $DB;
 
-      parent::cleanDBOnPurge();
+      parent::cleanDBonPurge();
 
-      $DB->delete(
-         'glpi_slalevels_tickets', [
-            $this->rules_id_field   => $this->fields['id']
-         ]
-      );
+      // SlaLevel_Ticket does not extends CommonDBConnexity
+      $slt = new SlaLevel_Ticket();
+      $slt->deleteByCriteria([$this->rules_id_field => $this->fields['id']]);
    }
 
 

--- a/inc/slm.class.php
+++ b/inc/slm.class.php
@@ -81,13 +81,13 @@ class SLM extends CommonDBTM {
    }
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $sla = new Sla();
-      $sla->deleteByCriteria(['slms_id' => $this->getID()]);
-
-      $ola = new Ola();
-      $ola->deleteByCriteria(['slms_id' => $this->getID()]);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Sla::class,
+            Ola::class,
+         ]
+      );
    }
 
    /**

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -178,34 +178,19 @@ class Software extends CommonDBTM {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      // Delete all licenses
-      $query2 = "SELECT `id`
-                 FROM `glpi_softwarelicenses`
-                 WHERE `softwares_id` = '".$this->fields['id']."'";
+      // SoftwareLicense does not extends CommonDBConnexity
+      $sl = new SoftwareLicense();
+      $sl->deleteByCriteria(['softwares_id' => $this->fields['id']]);
 
-      if ($result2 = $DB->query($query2)) {
-         if ($DB->numrows($result2)) {
-            $lic = new SoftwareLicense();
-            while ($data = $DB->fetch_assoc($result2)) {
-               $lic->delete(["id" => $data["id"]]);
-            }
-         }
-      }
-
-      $version = new SoftwareVersion();
-      $version->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ip = new Item_Problem();
-      $ip->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ci = new Change_Item();
-      $ci->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ip = new Item_Project();
-      $ip->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Change_Item::class,
+            Item_Problem::class,
+            Item_Project::class,
+            SoftwareVersion::class,
+         ]
+      );
    }
 
 

--- a/inc/softwarelicense.class.php
+++ b/inc/softwarelicense.class.php
@@ -158,11 +158,17 @@ class SoftwareLicense extends CommonTreeDropdown {
    **/
    function cleanDBonPurge() {
 
-      $csl = new Computer_SoftwareLicense();
-      $csl->cleanDBonItemDelete('SoftwareLicense', $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Certificate_Item::class,
+            Change_Item::class,
+            Computer_SoftwareLicense::class,
+         ]
+      );
 
-      $class = new Alert();
-      $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+      // Alert does not extends CommonDBConnexity
+      $alert = new Alert();
+      $alert->cleanDBonItemDelete($this->getType(), $this->fields['id']);
    }
 
 

--- a/inc/softwareversion.class.php
+++ b/inc/softwareversion.class.php
@@ -53,10 +53,12 @@ class SoftwareVersion extends CommonDBChild {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $csv = new Computer_SoftwareVersion();
-      $csv->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Computer_SoftwareVersion::class,
+         ]
+      );
    }
 
 

--- a/inc/supplier.class.php
+++ b/inc/supplier.class.php
@@ -58,36 +58,18 @@ class Supplier extends CommonDBTM {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $supplierjob = new Supplier_Ticket();
-      $supplierjob->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $ps = new Problem_Supplier();
-      $ps->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $cs = new Change_Supplier();
-      $cs->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $DB->delete(
-         'glpi_projecttaskteams', [
-            'items_id'  => $this->fields['id'],
-            'itemtype'  => __CLASS__
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Change_Supplier::class,
+            Contact_Supplier::class,
+            Contract_Supplier::class,
+            Problem_Supplier::class,
+            ProjectTaskTeam::class,
+            ProjectTeam::class,
+            Supplier_Ticket::class,
          ]
       );
-
-      $DB->delete(
-         'glpi_projectteams', [
-            'items_id'  => $this->fields['id'],
-            'itemtype'  => __CLASS__
-         ]
-      );
-
-      $cs  = new Contract_Supplier();
-      $cs->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $cs  = new Contact_Supplier();
-      $cs->cleanDBonItemDelete($this->getType(), $this->fields['id']);
 
       // Ticket rules use suppliers_id_assign
       Rule::cleanForItemAction($this, 'suppliers_id%');

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -984,57 +984,40 @@ class Ticket extends CommonITILObject {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $DB->delete(
-         'glpi_tickettasks', [
-            'tickets_id'   => $this->fields['id']
-         ]
-      );
-
-      $DB->delete(
-         'glpi_ticketfollowups', [
-            'tickets_id'   => $this->fields['id']
-         ]
-      );
-
-      $ts = new TicketValidation();
-      $ts->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $DB->delete(
-         'glpi_ticketsatisfactions', [
-            'tickets_id'   => $this->fields['id']
-         ]
-      );
-
-      $pt = new Problem_Ticket();
-      $pt->cleanDBonItemDelete('Ticket', $this->fields['id']);
-
-      $ts = new TicketCost();
-      $ts->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $slaLevel_ticket = new SlaLevel_Ticket();
-      $slaLevel_ticket->deleteForTicket($this->getID(), SLM::TTO);
-      $slaLevel_ticket->deleteForTicket($this->getID(), SLM::TTR);
-
+      // OlaLevel_Ticket does not extends CommonDBConnexity
       $olaLevel_ticket = new OlaLevel_Ticket();
-      $olaLevel_ticket->deleteForTicket($this->getID(), SLM::TTO);
-      $olaLevel_ticket->deleteForTicket($this->getID(), SLM::TTR);
+      $olaLevel_ticket->deleteForTicket($this->fields['id'], SLM::TTO);
+      $olaLevel_ticket->deleteForTicket($this->fields['id'], SLM::TTR);
 
-      $DB->delete(
-         'glpi_tickets_tickets', [
-            'OR'  => [
-               'tickets_id_1' => $this->fields['id'],
-               'tickets_id_2' => $this->fields['id']
-            ]
+      // SlaLevel_Ticket does not extends CommonDBConnexity
+      $slaLevel_ticket = new SlaLevel_Ticket();
+      $slaLevel_ticket->deleteForTicket($this->fields['id'], SLM::TTO);
+      $slaLevel_ticket->deleteForTicket($this->fields['id'], SLM::TTR);
+
+      // TicketFollowup does not extends CommonDBConnexity
+      $tf = new TicketFollowup();
+      $tf->deleteByCriteria(['tickets_id' => $this->fields['id']]);
+
+      // TicketSatisfaction does not extends CommonDBConnexity
+      $tf = new TicketSatisfaction();
+      $tf->deleteByCriteria(['tickets_id' => $this->fields['id']]);
+
+      // CommonITILTask does not extends CommonDBConnexity
+      $tt = new TicketTask();
+      $tt->deleteByCriteria(['tickets_id' => $this->fields['id']]);
+
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Change_Ticket::class,
+            Item_Ticket::class,
+            Problem_Ticket::class,
+            ProjectTask_Ticket::class,
+            TicketCost::class,
+            Ticket_Ticket::class,
+            TicketValidation::class,
          ]
       );
-
-      $ct = new Change_Ticket();
-      $ct->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ip = new Item_Ticket();
-      $ip->cleanDBonItemDelete('Ticket', $this->fields['id']);
 
       parent::cleanDBonPurge();
 

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -311,46 +311,29 @@ class User extends CommonDBTM {
 
 
    function cleanDBonPurge() {
+
       global $DB;
 
-      $DB->delete(
-         'glpi_profiles_users', [
-            'users_id' => $this->fields['id']
-         ]
-      );
+      // ObjectLock does not extends CommonDBConnexity
+      $ol = new ObjectLock();
+      $ol->deleteByCriteria(['users_id' => $this->fields['id']]);
 
-      if ($this->fields['id'] > 0) { // Security
-         $DB->delete(
-            'glpi_displaypreferences', [
-               'users_id' => $this->fields['id']
-            ]
-         );
-
-         $DB->delete(
-            'glpi_savedsearches_users', [
-               'users_id' => $this->fields['id']
-            ]
-         );
-      }
-
-      // Delete own reminders
-      $DB->delete(
-         'glpi_reminders', [
-            'users_id' => $this->fields['id']
-         ]
-      );
+      // Reminder does not extends CommonDBConnexity
+      $r = new Reminder();
+      $r->deleteByCriteria(['users_id' => $this->fields['id']]);
 
       // Delete private bookmark
-      $DB->delete(
-         'glpi_savedsearches', [
-            'users_id'     => $this->fields['id'],
-            'is_private'   => 1
+      $ss = new SavedSearch();
+      $ss->deleteByCriteria(
+         [
+            'users_id'   => $this->fields['id'],
+            'is_private' => 1,
          ]
       );
 
       // Set no user to public bookmark
       $DB->update(
-         'glpi_savedsearches', [
+         SavedSearch::getTable(), [
             'users_id' => 0
          ], [
             'users_id' => $this->fields['id']
@@ -369,40 +352,29 @@ class User extends CommonDBTM {
          ]
       );
 
-      $gu = new Group_User();
-      $gu->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $tu = new Ticket_User();
-      $tu->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $pu = new Problem_User();
-      $pu->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $cu = new Change_User();
-      $cu->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $DB->delete(
-         'glpi_projecttaskteams', [
-            'items_id'  => $this->fields['id'],
-            'itemtype'  => __CLASS__
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Certificate_Item::class,
+            Change_User::class,
+            Group_User::class,
+            KnowbaseItem_User::class,
+            Problem_User::class,
+            Profile_User::class,
+            ProjectTaskTeam::class,
+            ProjectTeam::class,
+            Reminder_User::class,
+            RSSFeed_User::class,
+            SavedSearch_User::class,
+            Ticket_User::class,
+            UserEmail::class,
          ]
       );
 
-      $DB->delete(
-         'glpi_projectteams', [
-            'items_id'  => $this->fields['id'],
-            'itemtype'  => __CLASS__
-         ]
-      );
-
-      $kiu = new KnowbaseItem_User();
-      $kiu->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $ru = new Reminder_User();
-      $ru->cleanDBonItemDelete($this->getType(), $this->fields['id']);
-
-      $ue = new UserEmail();
-      $ue->deleteByCriteria(['users_id' => $this->fields['id']]);
+      if ($this->fields['id'] > 0) { // Security
+         // DisplayPreference does not extends CommonDBConnexity
+         $dp = new DisplayPreference();
+         $dp->deleteByCriteria(['users_id' => $this->fields['id']]);
+      }
 
       $this->dropPictureFiles($this->fields['picture']);
 

--- a/inc/vlan.class.php
+++ b/inc/vlan.class.php
@@ -87,15 +87,13 @@ class Vlan extends CommonDropdown {
 
 
    function cleanDBonPurge() {
-      global $DB;
 
-      $link = new NetworkPort_Vlan();
-      $link->cleanDBonItemDelete($this->getType(), $this->getID());
-
-      $link = new IPNetwork_Vlan();
-      $link->cleanDBonItemDelete($this->getType(), $this->getID());
-
-      return true;
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            IPNetwork_Vlan::class,
+            NetworkPort_Vlan::class,
+         ]
+      );
    }
 
 

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -962,4 +962,53 @@ class DbUtils extends DbTestCase {
       $this->runGetSonsOf(true, true);
    }
 
+   /**
+    * Validates that relation mapping is based on existing tables and fields.
+    */
+   public function testRelationsValidity() {
+
+      global $DB;
+
+      $this
+         ->if($this->newTestedInstance)
+         ->then
+         ->array($mapping = $this->testedInstance->getDbRelations())
+         ->hasKey('_virtual_device');
+
+      $virtual_mapping = $mapping['_virtual_device'];
+      unset($mapping['_virtual_device']);
+
+      foreach ($mapping as $tablename => $relations) {
+         $this->boolean($DB->tableExists($tablename))
+            ->isTrue(sprintf('Invalid table "%s" in relation mapping.', $tablename));
+
+         foreach ($relations as $relation_tablename => $fields) {
+            if (strpos($relation_tablename, '_') === 0) {
+               $relation_tablename = substr($relation_tablename, 1);
+            }
+
+            $this->boolean($DB->tableExists($relation_tablename))
+               ->isTrue(sprintf('Invalid table "%s" in relation mapping.', $relation_tablename));
+
+            if (!is_array($fields)) {
+               $fields = [$fields];
+            }
+
+            foreach ($fields as $field) {
+               $this->boolean($DB->fieldExists($relation_tablename, $field))
+                  ->isTrue(sprintf('Invalid table field "%s.%s" in relation mapping.', $relation_tablename, $field));
+            }
+         }
+      }
+
+      foreach ($virtual_mapping as $tablename => $fields) {
+         $this->boolean($DB->tableExists($tablename))
+            ->isTrue(sprintf('Invalid table "%s" in _virtual_device mapping.', $tablename));
+
+         foreach ($fields as $field) {
+            $this->boolean($DB->fieldExists($tablename, $field))
+               ->isTrue(sprintf('Invalid table field "%s.%s" in _virtual_device mapping.', $tablename, $field));
+         }
+      }
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I made 3 commits.
1. Reindent and alphabetically reorder existing mapping.
2. Fixes
3. Reindent fixed mapping.

Review should be made on 2nd commit.

Changes: 
- Add "_" prefix and add missing recursive relation for `CommonTreeDropdown` tables
- Add "_" prefix and add missing relations handled in-code (by `$item::cleanDBonPurge()` method or using `$forward_entity_to` property value)
- Factorize deletion of childs and relations on item deletion
- Fix missing cleanup when deleting items:
  - costs related to deleted change,
  - changes related to deleted certificate, dc room, enclosure pdu, rack or software license,
  - certificate items related to deleted computer, network equipement, peripheral, printer, software license or user,
  - rss feed relation with deleted entity, group, profile or user,
  - knowbase item translation related to deleted knowbase item,
  - notification template translation related to deleted notification template,
  - change items related to deleted pdu, rack, software license,
  - locks on objects related to deleted user,
  - costs related to deleted problem,
  - costs related to deleted project,
  - queued notifications related to deleted notification template,
  - saved search alerts related to deleted save search,
- Fix missing entity forward to information:
  - from project to project cost,
- Fix relations mapping to enable detection/transfer when deleting item and enable check on ability to disable recursivity of an item:
  - between API client and entity,
  - between business criticities and entity,
  - between change cost and budget,
  - between budget and budget type,
  - between certificate and certificate type,
  - between certificate type and entity,
  - between change task and editor user, group and task template,
  - between change validation and user,
  - between computer antivirus and manufacturer,
  - between contract cost and budget,
  - between device and model, type, entity, location and state,
  - between document item and user,
  - between domain and entity,
  - between infocom and business criticity,
  - between generic device and generic device item,
  - between motherboard device and motherboard device item,
  - between simcard device and line,
  - between device item and location and state,
  - between operation system and achitecture, edition and kernel version,
  - between itil solution and solution type, users and ticket followup,
  - between knowbase sub items and users,
  - between line operator and entity,
  - between line and entity, user, group, line operator, location, state and line type,
  - between ethernet network port and network card device,
  - between fiber channel network and network car device, network port and net point,
  - between network migrations and entity, net point and network interface,
  - between network port and network interface,
  - between wifi network port and network card device,
  - between notepad and users,
  - between notification template and notification template translation,
  - between refused emails and mail collector,
  - between ola level and ola,
  - between ola and calendar,
  - between operation system kernel version and operating system kernel,
  - between planning recall and user,
  - between problem stask adn editor user, group and task template,
  - between profile and ticket template,
  - between rss feed profile and entity,
  - between project cost and project, budget and entity,
  - between project task and project task template,
  - between project task template and project task, project state and project task type,
  - between queued notification and entity,
  - between rss feed and user,
  - between sla and calendar,
  - between software license type and entity,
  - between state and entity,
  - between task category and knowbase item category,
  - between task template and user and group,
  - between ticket cost and budget,
  - between ticket followup and editor user,
  - between recurrent ticket and calendar,
  - between user and auth methods,
  - between ticket task and task template, group and editor user,
  - between ticket validation and users,
- Remove obsolete relations