### PR TITLE
Fixed select2 matcher for options without optgroup

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -4310,6 +4310,11 @@ class Html {
 
             // Skip if there is no 'children' property
             if (typeof data.children === 'undefined') {
+               if (typeof data.text === 'string'
+                  && data.text.toUpperCase().indexOf(params.term.toUpperCase()) >= 0
+               ) {
+                  return data;
+               }
                return null;
             }
 


### PR DESCRIPTION
Ex.: `Dropdown::showLanguages`

For language switcher, if you type some word, empty results are shown

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 