### PR TITLE
Fixed user icon in planning page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1863,6 +1863,7 @@ a.icon_nav_move:hover img {
 #planning_filter ul.filters > li .actor_icon {
    padding-bottom: 2px;
    vertical-align: middle;
+   font-size: 14px;
 }
 
 #planning_filter ul.filters > li label {

--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -1267,7 +1267,7 @@ JAVASCRIPT;
 
       if ($filter_data['type'] != 'event_filter') {
          $icon_type = explode('_', $filter_data['type']);
-         echo "<img class='actor_icon' src='".$CFG_GLPI['root_doc']."/pics/".$icon_type[0].".png'>";
+         echo "<i class='actor_icon fa fa-fw fa-".$icon_type[0]."'></i>";
       }
 
       echo "<label for='$filter_key'>$title</label>";


### PR DESCRIPTION
In planning page, the browser show 404 for `pics/user.png`, because #4745 has removed

Switched to FA to solve it

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4745