### PR TITLE
avoid scrolling to top when reloading tab panel

### DIFF
--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -457,10 +457,16 @@ class Ajax {
             function reloadTab(add) {
                forceReload$rand = true;
                var current_index = $('#tabs$rand').tabs('option','active');
+
+               // remove scroll event bind, select2 bind it on parent with scrollbars (the tab currently)
+               // as the select2 disapear with this tab reload, remove the event to prevent issues (infinite scroll to top)
+               $('#tabs$rand .ui-tabs-panel[aria-expanded=true]').unbind('scroll');
+
                // Save tab
                var currenthref = $('#tabs$rand ul>li a').eq(current_index).attr('href');
                $('#tabs$rand ul>li a').eq(current_index).attr('href',currenthref+'&'+add);
                $('#tabs$rand').tabs( 'load' , current_index);
+
                // Restore tab
                $('#tabs$rand ul>li a').eq(current_index).attr('href',currenthref);
             };";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

intenal ref: 15118


## Replication of the issue

- enable vertical split layout
- into dictionary admin page (like softwares), change the list limit dropdown
- try to scroll -> fail

Also with testable in software list tab in computer form (with vertical split layout).

## Explanation

I don't understand when precisely the select2 lib fails and why only split layout is affected.
It bind a scroll event on ui-tabs-panel which scroll to the current select2.
The event is normally limited to the scope of the select2 results panel (scrollevent in source) but when we reload the tab, that scope doesn't exist anymore, and it triggers on all scroll of the tab (and launch a scroll to top) not only when scrolling into the select2 results panel.

See:
https://github.com/glpi-project/glpi/blob/9.3/bugfixes/lib/jqueryplugins/select2/js/select2.full.js#L4235-L4238

and 
![image](https://user-images.githubusercontent.com/418844/46735216-de812880-cc95-11e8-828f-e32807d9482f.png)


