### PR TITLE
ldap connection: try to find user by its login+auth_id before trying …

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -658,16 +658,16 @@ class Auth extends CommonGLPI {
                         ],
                      ];
                      try {
-                        $user_dn
-                           = AuthLdap::searchUserDn($ds,
-                                                   ['basedn'      => $ldap_method["basedn"],
-                                                         'login_field' => $ldap_method['login_field'],
-                                                         'search_parameters'
-                                                                        => $params,
-                                                         'user_params'
-                                                            => ['method' => AuthLDAP::IDENTIFIER_LOGIN,
-                                                                     'value'  => $login_name],
-                                                            'condition'   => $ldap_method["condition"]]);
+                        $user_dn = AuthLdap::searchUserDn($ds, [
+                           'basedn'            => $ldap_method["basedn"],
+                           'login_field'       => $ldap_method['login_field'],
+                           'search_parameters' => $params,
+                           'condition'         => $ldap_method["condition"],
+                           'user_params'       => [
+                              'method' => AuthLDAP::IDENTIFIER_LOGIN,
+                              'value'  => $login_name
+                           ],
+                        ]);
                      } catch (\RuntimeException $e) {
                         Toolbox::logError($e->getMessage());
                         $user_dn = false;

--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -2684,7 +2684,9 @@ class AuthLDAP extends CommonDBTM {
 
       if ($user_dn) {
          $auth->auth_succeded            = true;
-         if ($auth->user->getFromDBbyDn(toolbox::addslashes_deep($user_dn))) {
+         // try by login+auth_id and next by dn
+         if ($auth->user->getFromDBbyNameAndAuth($login, Auth::LDAP, $ldap_method['id'])
+             || $auth->user->getFromDBbyDn(toolbox::addslashes_deep($user_dn))) {
             //There's already an existing user in DB with the same DN but its login field has changed
             $auth->user->fields['name'] = $login;
             $auth->user_present         = true;

--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -2718,7 +2718,7 @@ class AuthLDAP extends CommonDBTM {
     * @param integer $auths_id auths_id already used for the user (default 0)
     * @param boolean $user_dn  user LDAP DN if present (false by default)
     * @param boolean $break    if user is not found in the first directory,
-    *                          stop searching or try the following ones (true by default)
+    *                          continue searching on the following ones (true by default)
     *
     * @return object identification object
     */
@@ -2727,11 +2727,11 @@ class AuthLDAP extends CommonDBTM {
       //If no specific source is given, test all ldap directories
       if ($auths_id <= 0) {
          foreach ($auth->authtypes["ldap"] as $ldap_method) {
-            if (!$auth->auth_succeded
-                && $ldap_method['is_active']) {
+            if ($ldap_method['is_active']) {
                $auth = self::ldapAuth($auth, $login, $password, $ldap_method, $user_dn);
-            } else {
-               if ($break) {
+
+               if ($auth->auth_succeded
+                   && $break) {
                   break;
                }
             }


### PR DESCRIPTION
…to find it by its dn

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | maybe #4622 

internal ref 15135
If a user dn is duplicated in the glpi_users table (the unicity is on name+authtype+auth_id).
The iterator find more than one user and fail to login even if the good login is passed.
So we have a login error message like: 'You don't have right to connect"
We are in a case of the user is found in the ldap_directory and its credentials are ok.

I suggest to try to find by the unicity key first, and if not found by the dn.