### PR TITLE
Enhancement : Add an automated cycle of life to a change

### DIFF
--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -251,8 +251,8 @@ class Change extends CommonITILObject {
    }
 
 
-   function cleanDBonPurge() {  
-   
+   function cleanDBonPurge() {
+
       // CommonITILTask does not extends CommonDBConnexity
       $ct = new ChangeTask();
       $ct->deleteByCriteria(['changes_id' => $this->fields['id']]);
@@ -269,8 +269,8 @@ class Change extends CommonITILObject {
             ChangeCost::class,
             ChangeValidation::class,
             // Done by parent: ITILSolution::class,
-		 ]
-	  );
+         ]
+      );
 
       parent::cleanDBonPurge();
    }

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -252,10 +252,11 @@ class Change extends CommonITILObject {
 
 
    function cleanDBonPurge() {  
+   
       // CommonITILTask does not extends CommonDBConnexity
       $ct = new ChangeTask();
       $ct->deleteByCriteria(['changes_id' => $this->fields['id']]);
-	  
+
       $this->deleteChildrenAndRelationsFromDb(
          [
             // Done by parent: Change_Group::class,
@@ -268,6 +269,8 @@ class Change extends CommonITILObject {
             ChangeCost::class,
             ChangeValidation::class,
             // Done by parent: ITILSolution::class,
+		 ]
+	  );
 
       parent::cleanDBonPurge();
    }

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -251,12 +251,12 @@ class Change extends CommonITILObject {
    }
 
 
-   function cleanDBonPurge() {
-	   
+   function cleanDBonPurge() {  
       // CommonITILTask does not extends CommonDBConnexity
       $ct = new ChangeTask();
       $ct->deleteByCriteria(['changes_id' => $this->fields['id']]);
-       $this->deleteChildrenAndRelationsFromDb(
+	  
+      $this->deleteChildrenAndRelationsFromDb(
          [
             // Done by parent: Change_Group::class,
             Change_Item::class,

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -252,31 +252,22 @@ class Change extends CommonITILObject {
 
 
    function cleanDBonPurge() {
-      global $DB;
-
-      $DB->delete(
-         'glpi_changetasks', [
-            'changes_id'   => $this->fields['id']
-         ]
-      );
-
-      $cp = new Change_Problem();
-      $cp->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ct = new Change_Ticket();
-      $ct->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $cp = new Change_Project();
-      $cp->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $ci = new Change_Item();
-      $ci->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $cv = new ChangeValidation();
-      $cv->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
-
-      $cc = new ChangeCost();
-      $cc->cleanDBonItemDelete(__CLASS__, $this->fields['id']);
+	   
+      // CommonITILTask does not extends CommonDBConnexity
+      $ct = new ChangeTask();
+      $ct->deleteByCriteria(['changes_id' => $this->fields['id']]);
+       $this->deleteChildrenAndRelationsFromDb(
+         [
+            // Done by parent: Change_Group::class,
+            Change_Item::class,
+            Change_Problem::class,
+            Change_Project::class,
+            // Done by parent: Change_Supplier::class,
+            Change_Ticket::class,
+            // Done by parent: Change_User::class,
+            ChangeCost::class,
+            ChangeValidation::class,
+            // Done by parent: ITILSolution::class,
 
       parent::cleanDBonPurge();
    }
@@ -311,7 +302,7 @@ class Change extends CommonITILObject {
       if (isset($this->input['_disablenotif'])) {
          $donotif = false;
       }
- 
+
       if ($donotif && $CFG_GLPI["use_notifications"]) {
          $mailtype = "update";
          if (isset($this->input["status"]) && $this->input["status"]
@@ -565,7 +556,7 @@ class Change extends CommonITILObject {
 
 
    function showForm($ID, $options = []) {
-      global $CFG_GLPI, $DB;
+      global $CFG_GLPI;
 
       if (!static::canView()) {
          return false;
@@ -980,7 +971,7 @@ class Change extends CommonITILObject {
     * @return boolean|void
    **/
    static function showListForItem(CommonDBTM $item) {
-      global $DB, $CFG_GLPI;
+      global $DB;
 
       if (!Session::haveRight(self::$rightname, self::READALL)) {
          return false;
@@ -1096,8 +1087,6 @@ class Change extends CommonITILObject {
 
          //TRANS : %d is the number of problems
          echo sprintf(_n('Last %d change', 'Last %d changes', $number), $number);
-         // echo "<span class='small_space'><a href='".$CFG_GLPI["root_doc"]."/front/ticket.php?".
-         //            Toolbox::append_params($options,'&amp;')."'>".__('Show all')."</a></span>";
 
          echo "</th></tr>";
 

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -285,9 +285,9 @@ class Change extends CommonITILObject {
 
    function pre_updateInDB() {
       /* Modified by Lolokai Conseil */
-      if ((array_key_exists('changeisnotupdate',$this->input) == 0) && (($this->fields['status'] == self::INCOMING) || ($this->fields['status'] == self::APPROVAL) || ($this->fields['status'] == self::ACCEPTED) || ($this->fields['status'] == self::WAITING))) { 
-       	    $this->updates[] = 'status';
-       	    $this->fields['status']= self::EVALUATION;
+      if ((array_key_exists('changeisnotupdate', $this->input) == 0) && (($this->fields['status'] == self::INCOMING) || ($this->fields['status'] == self::APPROVAL) || ($this->fields['status'] == self::ACCEPTED) || ($this->fields['status'] == self::WAITING))) {
+         $this->updates[] = 'status';
+         $this->fields['status']= self::EVALUATION;
       }
       parent::pre_updateInDB();
    }

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -284,10 +284,10 @@ class Change extends CommonITILObject {
 
 
    function pre_updateInDB() {
-	/* Modified by Lolokai Conseil */
-      if ((array_key_exists('changeisnotupdate',$this->input) == 0) && (($this->fields['status'] == self::INCOMING) || ($this->fields['status'] == self::APPROVAL) || ($this->fields['status'] == self::ACCEPTED) || ($this->fields['status'] == self::WAITING))) {
-       		$this->updates[] = 'status';
-       		$this->fields['status']= self::EVALUATION;
+      /* Modified by Lolokai Conseil */
+      if ((array_key_exists('changeisnotupdate',$this->input) == 0) && (($this->fields['status'] == self::INCOMING) || ($this->fields['status'] == self::APPROVAL) || ($this->fields['status'] == self::ACCEPTED) || ($this->fields['status'] == self::WAITING))) { 
+       	    $this->updates[] = 'status';
+       	    $this->fields['status']= self::EVALUATION;
       }
       parent::pre_updateInDB();
    }

--- a/inc/changetask.class.php
+++ b/inc/changetask.class.php
@@ -182,35 +182,35 @@ class ChangeTask extends CommonITILTask {
 
    /* Update By Lolokai Conseil */
    function post_addItem() {
-	global $CFG_GLPI;
+      global $CFG_GLPI;
 
-	parent::post_addItem();
-	// change change status (from splitted button)
-        $change = new Change();
-        $change->getFromDB($this->fields['changes_id']);
-        if ($change->isStatusExists(Change::EVALUATION) && (($change->fields["status"] == Change::INCOMING) || ($change->fields["status"] == Change::WAITING))) {
+      parent::post_addItem();
+      // change change status (from splitted button)
+      $change = new Change();
+      $change->getFromDB($this->fields['changes_id']);
+      if ($change->isStatusExists(Change::EVALUATION) && (($change->fields["status"] == Change::INCOMING) || ($change->fields["status"] == Change::WAITING))) {
                $input = [
                   'id'            => $change->getID(),
                   'status'        => Change::EVALUATION
                ];
                $change->update($input);
-        }
+      }
    }
 
    function post_updateItem($history = 1) {
-	global $CFG_GLPI;
+      global $CFG_GLPI;
 
-	parent::post_updateItem($history);
-	// change change status (from splitted button)
-	$change = new Change();
-	$change->getFromDB($this->fields['changes_id']);
-        if ($change->isStatusExists(Change::EVALUATION) && (($change->fields["status"] == Change::INCOMING) || ($change->fields["status"] == Change::WAITING))) {
+      parent::post_updateItem($history);
+      // change change status (from splitted button)
+      $change = new Change();
+      $change->getFromDB($this->fields['changes_id']);
+      if ($change->isStatusExists(Change::EVALUATION) && (($change->fields["status"] == Change::INCOMING) || ($change->fields["status"] == Change::WAITING))) {
                $input = [
                   'id'            => $change->getID(),
                   'status'        => Change::EVALUATION
                ];
                $change->update($input);
-            }
+      }
    }
 
 }

--- a/inc/changetask.class.php
+++ b/inc/changetask.class.php
@@ -159,7 +159,7 @@ class ChangeTask extends CommonITILTask {
     *
     * @param $val array of the item to display
     *
-    * @return string Already planned information
+    * @return Already planned information
    **/
    static function getAlreadyPlannedInformation($val) {
       return parent::genericGetAlreadyPlannedInformation(__CLASS__, $val);
@@ -169,16 +169,49 @@ class ChangeTask extends CommonITILTask {
    /**
     * Display a Planning Item
     *
-    * @param array           $val       array of the item to display
-    * @param integer         $who       ID of the user (0 if all)
-    * @param string          $type      position of the item in the time block (in, through, begin or end)
-    * @param integer|boolean $complete  complete display (more details)
+    * @param $val       array of the item to display
+    * @param $who             ID of the user (0 if all)
+    * @param $type            position of the item in the time block (in, through, begin or end)
+    *                         (default '')
+    * @param $complete        complete display (more details) (default 0)
     *
-    * @return string
-    */
+    * @return Nothing (display function)
+   **/
    static function displayPlanningItem(array $val, $who, $type = "", $complete = 0) {
       return parent::genericDisplayPlanningItem(__CLASS__, $val, $who, $type, $complete);
    }
 
+   /* Update By Lolokai Conseil */
+   function post_addItem() {
+	global $CFG_GLPI;
+
+	parent::post_addItem();
+	// change change status (from splitted button)
+        $change = new Change();
+        $change->getFromDB($this->fields['changes_id']);
+        if ($change->isStatusExists(Change::EVALUATION) && (($change->fields["status"] == Change::INCOMING) || ($change->fields["status"] == Change::WAITING))) {
+               $input = [
+                  'id'            => $change->getID(),
+                  'status'        => Change::EVALUATION
+               ];
+               $change->update($input);
+        }
+   }
+
+   function post_updateItem($history = 1) {
+	global $CFG_GLPI;
+
+	parent::post_updateItem($history);
+	// change change status (from splitted button)
+	$change = new Change();
+	$change->getFromDB($this->fields['changes_id']);
+        if ($change->isStatusExists(Change::EVALUATION) && (($change->fields["status"] == Change::INCOMING) || ($change->fields["status"] == Change::WAITING))) {
+               $input = [
+                  'id'            => $change->getID(),
+                  'status'        => Change::EVALUATION
+               ];
+               $change->update($input);
+            }
+   }
 
 }

--- a/inc/changetask.class.php
+++ b/inc/changetask.class.php
@@ -159,7 +159,7 @@ class ChangeTask extends CommonITILTask {
     *
     * @param $val array of the item to display
     *
-    * @return Already planned information
+    * @return string Already planned information
    **/
    static function getAlreadyPlannedInformation($val) {
       return parent::genericGetAlreadyPlannedInformation(__CLASS__, $val);
@@ -169,14 +169,13 @@ class ChangeTask extends CommonITILTask {
    /**
     * Display a Planning Item
     *
-    * @param $val       array of the item to display
-    * @param $who             ID of the user (0 if all)
-    * @param $type            position of the item in the time block (in, through, begin or end)
-    *                         (default '')
-    * @param $complete        complete display (more details) (default 0)
+    * @param array           $val       array of the item to display
+    * @param integer         $who       ID of the user (0 if all)
+    * @param string          $type      position of the item in the time block (in, through, begin or end)
+    * @param integer|boolean $complete  complete display (more details)
     *
-    * @return Nothing (display function)
-   **/
+    * @return string
+   */
    static function displayPlanningItem(array $val, $who, $type = "", $complete = 0) {
       return parent::genericDisplayPlanningItem(__CLASS__, $val, $who, $type, $complete);
    }

--- a/inc/changetask.class.php
+++ b/inc/changetask.class.php
@@ -175,7 +175,7 @@ class ChangeTask extends CommonITILTask {
     * @param integer|boolean $complete  complete display (more details)
     *
     * @return string
-   */
+    */
    static function displayPlanningItem(array $val, $who, $type = "", $complete = 0) {
       return parent::genericDisplayPlanningItem(__CLASS__, $val, $who, $type, $complete);
    }

--- a/inc/changevalidation.class.php
+++ b/inc/changevalidation.class.php
@@ -45,7 +45,7 @@ class ChangeValidation  extends CommonITILValidation {
 
    static $rightname                 = 'changevalidation';
 
-      static function rawSearchOptionsToAdd() {
+   static function rawSearchOptionsToAdd() {
       $tab = [];
       $tab[] = [
          'id'                 => 'validation',
@@ -296,51 +296,51 @@ class ChangeValidation  extends CommonITILValidation {
    }
 
    function post_addItem() {
-        global $CFG_GLPI;
+      global $CFG_GLPI;
 
-	$change = new static::$itemtype();
-        $change->getFromDB($this->fields['changes_id']);
-        if ($change->isStatusExists(Change::EVALUATION) && (($change->fields["status"] == Change::INCOMING) || ($change->fields["status"] == Change::EVALUATION))) {
+      $change = new static::$itemtype();
+      $change->getFromDB($this->fields['changes_id']);
+      if ($change->isStatusExists(Change::EVALUATION) && (($change->fields["status"] == Change::INCOMING) || ($change->fields["status"] == Change::EVALUATION))) {
                $input = [
-                  'id'            => $change->getID(),
-                  'status'        => Change::APPROVAL,
-		  'changeisnotupdate' => 1
-               ];
-               $change->update($input);
-        }
-	parent::post_addItem();
-   }
-
-   function post_updateItem($history = 1) {
-     global $CFG_GLPI;
-     parent::post_updateItem($history);
-
-     $change = new static::$itemtype();
-     $change->getFromDB($this->fields['changes_id']);
-
-     if ($this->fields["status"] == self::WAITING) {
-	$input = [
                   'id'            => $change->getID(),
                   'status'        => Change::APPROVAL,
                   'changeisnotupdate' => 1
                ];
-        $change->update($input);
-     }
-     if ($this->fields["status"] == self::ACCEPTED) {
-        $input = [
+               $change->update($input);
+      }
+      parent::post_addItem();
+   }
+
+   function post_updateItem($history = 1) {
+      global $CFG_GLPI;
+      parent::post_updateItem($history);
+
+      $change = new static::$itemtype();
+      $change->getFromDB($this->fields['changes_id']);
+
+      if ($this->fields["status"] == self::WAITING) {
+         $input = [
+                  'id'            => $change->getID(),
+                  'status'        => Change::APPROVAL,
+                  'changeisnotupdate' => 1
+               ];
+         $change->update($input);
+      }
+      if ($this->fields["status"] == self::ACCEPTED) {
+         $input = [
                   'id'            => $change->getID(),
                   'status'        => Change::ACCEPTED,
                   'changeisnotupdate' => 1
                ];
-        $change->update($input);
-     }
-     if ($this->fields["status"] == self::REFUSED) {
-        $input = [
+         $change->update($input);
+      }
+      if ($this->fields["status"] == self::REFUSED) {
+         $input = [
                   'id'            => $change->getID(),
                   'status'        => Change::CLOSED,
                   'changeisnotupdate' => 1
                ];
-        $change->update($input);
-     }
+         $change->update($input);
+      }
    }
 }

--- a/inc/changevalidation.class.php
+++ b/inc/changevalidation.class.php
@@ -45,4 +45,302 @@ class ChangeValidation  extends CommonITILValidation {
 
    static $rightname                 = 'changevalidation';
 
+      static function rawSearchOptionsToAdd() {
+      $tab = [];
+      $tab[] = [
+         'id'                 => 'validation',
+         'name'               => __('Approval')
+      ];
+      $tab[] = [
+         'id'                 => '52',
+         'table'              => getTableForItemtype(static::$itemtype),
+         'field'              => 'global_validation',
+         'name'               => __('Approval'),
+         'searchtype'         => 'equals',
+         'datatype'           => 'specific'
+      ];
+      $tab[] = [
+         'id'                 => '53',
+         'table'              => static::getTable(),
+         'field'              => 'comment_submission',
+         'name'               => __('Request comments'),
+         'datatype'           => 'text',
+         'forcegroupby'       => true,
+         'massiveaction'      => false,
+         'joinparams'         => [
+            'jointype'           => 'child'
+         ]
+      ];
+      $tab[] = [
+         'id'                 => '54',
+         'table'              => static::getTable(),
+         'field'              => 'comment_validation',
+         'name'               => __('Approval comments'),
+         'datatype'           => 'text',
+         'forcegroupby'       => true,
+         'massiveaction'      => false,
+         'joinparams'         => [
+            'jointype'           => 'child'
+         ]
+      ];
+      $tab[] = [
+         'id'                 => '55',
+         'table'              => static::getTable(),
+         'field'              => 'status',
+         'datatype'           => 'specific',
+         'name'               => __('Approval status'),
+         'searchtype'         => 'equals',
+         'forcegroupby'       => true,
+         'massiveaction'      => false,
+         'joinparams'         => [
+            'jointype'           => 'child'
+         ]
+      ];
+      $tab[] = [
+         'id'                 => '56',
+         'table'              => static::getTable(),
+         'field'              => 'submission_date',
+         'name'               => __('Request date'),
+         'datatype'           => 'datetime',
+         'forcegroupby'       => true,
+         'massiveaction'      => false,
+         'joinparams'         => [
+            'jointype'           => 'child'
+         ]
+      ];
+      $tab[] = [
+         'id'                 => '57',
+         'table'              => static::getTable(),
+         'field'              => 'validation_date',
+         'name'               => __('Approval date'),
+         'datatype'           => 'datetime',
+         'forcegroupby'       => true,
+         'massiveaction'      => false,
+         'joinparams'         => [
+            'jointype'           => 'child'
+         ]
+      ];
+      $tab[] = [
+         'id'                 => '58',
+         'table'              => 'glpi_users',
+         'field'              => 'name',
+         'name'               => __('Requester'),
+         'datatype'           => 'itemlink',
+         'right'              => (static::$itemtype == 'Ticket' ? 'create_ticket_validate' : 'create_validate'),
+         'forcegroupby'       => true,
+         'massiveaction'      => false,
+         'joinparams'         => [
+            'beforejoin'         => [
+               'table'              => static::getTable(),
+               'joinparams'         => [
+                  'jointype'           => 'child'
+               ]
+            ]
+         ]
+      ];
+      $tab[] = [
+         'id'                 => '59',
+         'table'              => 'glpi_users',
+         'field'              => 'name',
+         'linkfield'          => 'users_id_validate',
+         'name'               => __('Approver'),
+         'datatype'           => 'itemlink',
+         'right'              => (static::$itemtype == 'Ticket' ?
+            ['validate_request', 'validate_incident'] :
+            'validate'
+         ),
+         'forcegroupby'       => true,
+         'massiveaction'      => false,
+         'joinparams'         => [
+            'beforejoin'         => [
+               'table'              => static::getTable(),
+               'joinparams'         => [
+                  'jointype'           => 'child'
+               ]
+            ]
+         ]
+      ];
+      return $tab;
+   }
+
+   /**
+    * Print the validation list into item
+    *
+    * @param CommonDBTM $item
+   **/
+   function showSummary(CommonDBTM $item) {
+      global $DB, $CFG_GLPI;
+      if (!Session::haveRightsOr(static::$rightname,
+                                 array_merge(static::getCreateRights(),
+                                             static::getValidateRights(),
+                                             static::getPurgeRights()))) {
+         return false;
+      }
+      $tID    = $item->fields['id'];
+      $tmp    = [static::$items_id => $tID];
+      $canadd = $this->can(-1, CREATE, $tmp);
+      $rand   = mt_rand();
+      if ($canadd) {
+         $itemtype = static::$itemtype;
+         echo "<form method='post' name=form action='".$itemtype::getFormURL()."'>";
+      }
+      echo "<table class='tab_cadre_fixe'>";
+      echo "<tr>";
+      echo "<th colspan='3'>".self::getTypeName(Session::getPluralNumber())."</th>";
+      echo "</tr>";
+      echo "<tr class='tab_bg_1'>";
+      echo "<td>".__('Global approval status')."</td>";
+      echo "<td colspan='2'>";
+      if (Session::haveRightsOr(static::$rightname, TicketValidation::getValidateRights())) {
+         self::dropdownStatus("global_validation",
+                              ['value'    => $item->fields["global_validation"]]);
+      } else {
+         echo TicketValidation::getStatus($item->fields["global_validation"]);
+      }
+      echo "</td></tr>";
+      echo "<tr>";
+      echo "<th colspan='2'>"._x('item', 'State')."</th>";
+      echo "<th colspan='2'>";
+      echo self::getValidationStats($tID);
+      echo "</th>";
+      echo "</tr>";
+      echo "</table>";
+      if ($canadd) {
+         Html::closeForm();
+      }
+      echo "<div id='viewvalidation" . $tID . "$rand'></div>\n";
+      if ($canadd) {
+         echo "<script type='text/javascript' >\n";
+         echo "function viewAddValidation" . $tID . "$rand() {\n";
+         $params = ['type'             => $this->getType(),
+                         'parenttype'       => static::$itemtype,
+                         static::$items_id  => $tID,
+                         'id'               => -1];
+         Ajax::updateItemJsCode("viewvalidation" . $tID . "$rand",
+                                $CFG_GLPI["root_doc"]."/ajax/viewsubitem.php",
+                                $params);
+         echo "};";
+         echo "</script>\n";
+      }
+      $iterator = $DB->Request([
+         'FROM'   => $this->getTable(),
+         'WHERE'  => [static::$items_id => $item->getField('id')],
+         'ORDER'  => 'submission_date DESC'
+      ]);
+      $colonnes = [_x('item', 'State'), __('Request date'), __('Approval requester'),
+                     __('Request comments'), __('Approval status'),
+                     __('Approver'), __('Approval comments')];
+      $nb_colonnes = count($colonnes);
+      echo "<table class='tab_cadre_fixehov'>";
+      echo "<tr class='noHover'><th colspan='".$nb_colonnes."'>".__('Approvals for the ticket').
+           "</th></tr>";
+      if ($canadd) {
+         if (!in_array($item->fields['status'], array_merge($item->getSolvedStatusArray(),
+            $item->getClosedStatusArray()))) {
+               echo "<tr class='tab_bg_1 noHover'><td class='center' colspan='" . $nb_colonnes . "'>";
+               echo "<a class='vsubmit' href='javascript:viewAddValidation".$tID."$rand();'>";
+               echo __('Send an approval request')."</a></td></tr>\n";
+         }
+      }
+      if (count($iterator)) {
+         $header = "<tr>";
+         foreach ($colonnes as $colonne) {
+            $header .= "<th>".$colonne."</th>";
+         }
+         $header .= "</tr>";
+         echo $header;
+         Session::initNavigateListItems($this->getType(),
+               //TRANS : %1$s is the itemtype name, %2$s is the name of the item (used for headings of a list)
+                                        sprintf(__('%1$s = %2$s'), $item->getTypeName(1),
+                                                $item->fields["name"]));
+         while ($row = $iterator->next()) {
+            $canedit = $this->canEdit($row["id"]);
+            Session::addToNavigateListItems($this->getType(), $row["id"]);
+            $bgcolor = self::getStatusColor($row['status']);
+            $status  = self::getStatus($row['status']);
+            echo "<tr class='tab_bg_1' ".
+                   ($canedit ? "style='cursor:pointer' onClick=\"viewEditValidation".
+                               $item->fields['id'].$row["id"]."$rand();\""
+                             : '') .
+                  " id='viewvalidation" . $this->fields[static::$items_id] . $row["id"] . "$rand'>";
+            echo "<td>";
+            if ($canedit) {
+               echo "\n<script type='text/javascript' >\n";
+               echo "function viewEditValidation" .$item->fields['id']. $row["id"]. "$rand() {\n";
+               $params = ['type'             => $this->getType(),
+                               'parenttype'       => static::$itemtype,
+                               static::$items_id  => $this->fields[static::$items_id],
+                               'id'               => $row["id"]];
+               Ajax::updateItemJsCode("viewvalidation" . $item->fields['id'] . "$rand",
+                                      $CFG_GLPI["root_doc"]."/ajax/viewsubitem.php",
+                                      $params);
+               echo "};";
+               echo "</script>\n";
+            }
+            echo "<div style='background-color:".$bgcolor.";'>".$status."</div></td>";
+            echo "<td>".Html::convDateTime($row["submission_date"])."</td>";
+            echo "<td>".getUserName($row["users_id"])."</td>";
+            echo "<td>".$row["comment_submission"]."</td>";
+            echo "<td>".Html::convDateTime($row["validation_date"])."</td>";
+            echo "<td>".getUserName($row["users_id_validate"])."</td>";
+            echo "<td>".$row["comment_validation"]."</td>";
+            echo "</tr>";
+         }
+         echo $header;
+      } else {
+         //echo "<div class='center b'>".__('No item found')."</div>";
+         echo "<tr class='tab_bg_1 noHover'><th colspan='" . $nb_colonnes . "'>";
+         echo __('No item found')."</th></tr>\n";
+      }
+      echo "</table>";
+   }
+
+   function post_addItem() {
+        global $CFG_GLPI;
+
+	$change = new static::$itemtype();
+        $change->getFromDB($this->fields['changes_id']);
+        if ($change->isStatusExists(Change::EVALUATION) && (($change->fields["status"] == Change::INCOMING) || ($change->fields["status"] == Change::EVALUATION))) {
+               $input = [
+                  'id'            => $change->getID(),
+                  'status'        => Change::APPROVAL,
+		  'changeisnotupdate' => 1
+               ];
+               $change->update($input);
+        }
+	parent::post_addItem();
+   }
+
+   function post_updateItem($history = 1) {
+     global $CFG_GLPI;
+     parent::post_updateItem($history);
+
+     $change = new static::$itemtype();
+     $change->getFromDB($this->fields['changes_id']);
+
+     if ($this->fields["status"] == self::WAITING) {
+	$input = [
+                  'id'            => $change->getID(),
+                  'status'        => Change::APPROVAL,
+                  'changeisnotupdate' => 1
+               ];
+        $change->update($input);
+     }
+     if ($this->fields["status"] == self::ACCEPTED) {
+        $input = [
+                  'id'            => $change->getID(),
+                  'status'        => Change::ACCEPTED,
+                  'changeisnotupdate' => 1
+               ];
+        $change->update($input);
+     }
+     if ($this->fields["status"] == self::REFUSED) {
+        $input = [
+                  'id'            => $change->getID(),
+                  'status'        => Change::CLOSED,
+                  'changeisnotupdate' => 1
+               ];
+        $change->update($input);
+     }
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | XXX

## Enhancement : Add an automated cycle of life to a change

* If we create a task in a change which status is New ou Waiting ==> The status change to Evaluate
* If we modify the change : add or update something ==> The status change to Evaluate
* If we send a validation ==> The status change to Validation

When the change manager validate the change :

* If he disagrees with the description but agrees with the change : He select "Waiting for validation" ==> the status change to Validation
* If he agrees : He select Accepted ==> the status change to "Accepted"
* If he doesn't want to implement this change : he refused ==> the status change to "Closed"

The others status should be changed manually by the person which is in charge of the change.

We also deleted the criteria "Minimum validation required" for the change which is not usefull because there is just only one change manager which should validate the change.