### PR TITLE
Fix list of unaffected devices in computer components form

### DIFF
--- a/ajax/selectUnaffectedOrNewItem_Device.php
+++ b/ajax/selectUnaffectedOrNewItem_Device.php
@@ -48,14 +48,16 @@ if ($_POST['items_id']
    $linktype   = $devicetype::getItem_DeviceType();
 
    if (count($linktype::getSpecificities())) {
-      $name_field = "CONCAT_WS(' - ', `".implode('`, `',
-                                                 array_keys($linktype::getSpecificities()))."`)";
+      $name_field = new QueryExpression(
+         "CONCAT_WS(' - ', `" . implode('`, `', array_keys($linktype::getSpecificities())) . "`)"
+         . "AS `name`"
+      );
    } else {
-      $name_field = "`id`";
+      $name_field = "id AS name";
    }
    $result = $DB->request(
       [
-         'SELECT' => ['id', $name_field . ' AS name'],
+         'SELECT' => ['id', $name_field],
          'FROM'   => $linktype::getTable(),
          'WHERE'  => [
             $devicetype::getForeignKeyField() => $_POST['items_id'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`CONCAT_WS` SQL function call was escaped, making SQL query invalid.
Bug was introduced in #4697, so is not present in GLPI releases.