### PR TITLE
Fix lock rights checking

### DIFF
--- a/front/lock.form.php
+++ b/front/lock.form.php
@@ -40,18 +40,28 @@ if (isset($_POST['itemtype'])) {
 
    $itemtype    = $_POST['itemtype'];
    $source_item = new $itemtype();
-   if ($source_item->canCreate()) {
+   if ($source_item->can($_POST['id'], UPDATE)) {
 
       $devices = Item_Devices::getDeviceTypes();
       $actions = array_merge($CFG_GLPI['inventory_lockable_objects'], array_values($devices));
 
       if (isset($_POST["unlock"])) {
-         $source_item->check($_POST['id'], UPDATE);
-
          foreach ($actions as $type) {
             if (isset($_POST[$type]) && count($_POST[$type])) {
                $item = new $type();
                foreach (array_keys($_POST[$type]) as $key) {
+                  if (!$item->can($key, UPDATE)) {
+                     Session::addMessageAfterRedirect(
+                        sprintf(
+                           __('You do not have rights to restore %s item.'),
+                           $type
+                        ),
+                        true,
+                        ERROR
+                     );
+                     continue;
+                  }
+
                   //Force unlock
                   $item->restore(['id' => $key]);
                }
@@ -62,12 +72,22 @@ if (isset($_POST['itemtype'])) {
          Plugin::doHookFunction('unlock_fields', $_POST);
 
       } else if (isset($_POST["purge"])) {
-         $source_item->check($_POST['id'], PURGE);
-
          foreach ($actions as $type) {
             if (isset($_POST[$type]) && count($_POST[$type])) {
                $item = new $type();
                foreach (array_keys($_POST[$type]) as $key) {
+                  if (!$item->can($key, PURGE)) {
+                     Session::addMessageAfterRedirect(
+                        sprintf(
+                           __('You do not have rights to delete %s item.'),
+                           $type
+                        ),
+                        true,
+                        ERROR
+                     );
+                     continue;
+                  }
+
                   //Force unlock
                   $item->delete(['id' => $key], 1);
                }
@@ -76,4 +96,5 @@ if (isset($_POST['itemtype'])) {
       }
    }
 }
+
 Html::back();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #785

~~There is an `UNLOCK` right that can be set on many items in profile management, but it seems to not be really used.~~

~~I add some rights check on unlock form inside an asset.~~

~~To really fix this, new logic should be added on `CommonDBTM` (`canUnlock()` method and `UNLOCK` case in `can()` method) and in `CommonDBConnexity`.~~