### PR TITLE
Cache infos were missing, cache_trans was always false

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1584,7 +1584,7 @@ class Config extends CommonDBTM {
     * @since 9.1
    **/
    function showPerformanceInformations() {
-      global $GLPI_CACHE;
+      $GLPI_CACHE = self::getCache('cache_db', 'core', false);
 
       if (!Config::canUpdate()) {
          return false;
@@ -2976,6 +2976,8 @@ class Config extends CommonDBTM {
          $storage = Zend\Cache\StorageFactory::factory($opt);
          if ($psr16) {
             $cache = new SimpleCacheDecorator($storage);
+         } else {
+            $cache = $storage;
          }
          $cache_class = get_class($storage);
       } catch (Exception $e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes