### PR TITLE
fix(export): display object name rather path

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -6114,7 +6114,7 @@ class Search {
 
          case self::SYLK_OUTPUT : //sylk
             global $SYLK_ARRAY,$SYLK_HEADER,$SYLK_SIZE;
-            $value                  = Html::weblink_extract($value);
+            $value                  = Html::weblink_extract(Html::clean($value));
             $value = preg_replace('/'.self::LBBR.'/', '<br>', $value);
             $value = preg_replace('/'.self::LBHR.'/', '<hr>', $value);
             $SYLK_ARRAY[$row][$num] = self::sylk_clean($value);
@@ -6125,7 +6125,7 @@ class Search {
          case self::CSV_OUTPUT : //csv
             $value = preg_replace('/'.self::LBBR.'/', '<br>', $value);
             $value = preg_replace('/'.self::LBHR.'/', '<hr>', $value);
-            $value = Html::weblink_extract($value);
+            $value = Html::weblink_extract(Html::clean($value));
             $out   = "\"".self::csv_clean($value)."\"".$_SESSION["glpicsv_delimiter"];
             break;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

When exporting CSV or SLK, if a cell contains a href, the export displays the path of the object.
![image](https://user-images.githubusercontent.com/7335054/47074518-d6c40580-d1fa-11e8-823b-ab7d5d3bc274.png)

this PR fix that, displaying the name of the object (as for the PDF export)
![image](https://user-images.githubusercontent.com/7335054/47074592-fce9a580-d1fa-11e8-8f3d-e00eac3eaf6b.png)


