### PR TITLE
Fix handling of ticket/followup content handling in collector

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -76,6 +76,12 @@ class MailCollector  extends CommonDBTM {
    /// Body converted
    public $body_converted  = false;
 
+   /**
+    * Flag that tells wheter the body is in HTML format or not.
+    * @var string
+    */
+   private $body_is_html   = false;
+
    public $dohistory       = true;
 
    static $rightname       = 'config';
@@ -877,32 +883,6 @@ class MailCollector  extends CommonDBTM {
          $tkt['tickets_id'] = intval($match[1]);
       }
 
-      // Double encoding for > and < char to avoid misinterpretations
-      $tkt['content'] = str_replace(['&lt;', '&gt;'], ['&amp;lt;', '&amp;gt;'], $tkt['content']);
-
-      $is_html = false;
-      //If files are present and content is html
-      if (isset($this->files)
-          && count($this->files)
-          && ($tkt['content'] != strip_tags($tkt['content']))
-          && !isset($tkt['tickets_id'])) {
-         $is_html = true;
-         $tkt['content'] = Ticket::convertContentForTicket($tkt['content'],
-                                                           $this->files + $this->altfiles,
-                                                           $this->tags);
-      }
-
-      // Clean mail content
-      $striptags = true;
-      if ($CFG_GLPI["use_rich_text"] && !isset($tkt['tickets_id'])) {
-         $striptags = false;
-      }
-      $tkt['content'] = $this->cleanMailContent(Html::entities_deep($tkt['content']), $striptags);
-
-      if ($is_html && !isset($tkt['tickets_id']) && $CFG_GLPI["use_rich_text"]) {
-         $tkt['content'] = nl2br($tkt['content']);
-      }
-
       $tkt['_supplier_email'] = false;
       // Found ticket link
       if (isset($tkt['tickets_id'])) {
@@ -931,33 +911,51 @@ class MailCollector  extends CommonDBTM {
 
             $begin_strip     = -1;
             $end_strip       = -1;
-            $begin_match     = "/".NotificationTargetTicket::HEADERTAG.".*".
-                                 NotificationTargetTicket::HEADERTAG."/";
-            $end_match       = "/".NotificationTargetTicket::FOOTERTAG.".*".
-                                 NotificationTargetTicket::FOOTERTAG."/";
+            $header_tag      = NotificationTargetTicket::HEADERTAG;
+            $header_pattern  = $header_tag . '.*' . $header_tag;
+            $footer_tag      = NotificationTargetTicket::FOOTERTAG;
+            $footer_pattern  = $footer_tag . '.*' . $footer_tag;
             foreach ($content as $ID => $val) {
                // Get first tag for begin
                if ($begin_strip < 0) {
-                  if (preg_match($begin_match, $val)) {
+                  if (preg_match('/' . $header_pattern . '/', $val)) {
                      $begin_strip = $ID;
                   }
                }
                // Get last tag for end
                if ($begin_strip >= 0) {
-                  if (preg_match($end_match, $val)) {
+                  if (preg_match('/' . $footer_pattern . '/', $val)) {
                      $end_strip = $ID;
                      continue;
                   }
                }
             }
 
-            if ($begin_strip >= 0) {
-               // Clean first and last lines
-               $content[$begin_strip] = preg_replace($begin_match, '', $content[$begin_strip]);
-            }
-            if ($end_strip >= 0) {
-               // Clean first and last lines
-               $content[$end_strip] = preg_replace($end_match, '', $content[$end_strip]);
+            if ($begin_strip >= 0 && $end_strip >= 0 && $begin_strip === $end_strip) {
+               // If header and footer tag are on same line,
+               // remove contents between header and footer tag
+               $content[$begin_strip] = preg_replace(
+                  '/' . $header_pattern . '.*' . $footer_pattern . '/',
+                  '',
+                  $content[$begin_strip]
+               );
+            } else {
+               if ($begin_strip >= 0) {
+                  // Remove contents between header and end of line
+                  $content[$begin_strip] = preg_replace(
+                     '/' . $header_pattern . '.*$/',
+                     '',
+                     $content[$begin_strip]
+                  );
+               }
+               if ($end_strip >= 0) {
+                  // Remove contents between beginning of line and footer
+                  $content[$end_strip] = preg_replace(
+                     '/^.*' . $footer_pattern . '$/',
+                     '',
+                     $content[$end_strip]
+                  );
+               }
             }
 
             if ($begin_strip >= 0) {
@@ -999,6 +997,16 @@ class MailCollector  extends CommonDBTM {
       if ($this->addtobody) {
          $tkt['content'] .= $this->addtobody;
       }
+
+      //If files are present and content is html
+      if (isset($this->files) && count($this->files) && $this->body_is_html) {
+         $tkt['content'] = Ticket::convertContentForTicket($tkt['content'],
+                                                           $this->files + $this->altfiles,
+                                                           $this->tags);
+      }
+
+      // Clean mail content
+      $tkt['content'] = $this->cleanMailContent($tkt['content'], !$CFG_GLPI["use_rich_text"]);
 
       $tkt['name'] = $this->textCleaner($head['subject']);
       if (!Toolbox::seems_utf8($tkt['name'])) {
@@ -1065,33 +1073,49 @@ class MailCollector  extends CommonDBTM {
     * @return cleaned text
    **/
    function cleanMailContent($string, $striptags = true) {
-      global $DB;
+      global $CFG_GLPI, $DB;
 
-      // Delete html tags
-      $string = Html::clean($string, $striptags, 2);
+      // Clean HTML
+      $string = Html::clean(Html::entities_deep($string), $striptags, 2);
 
-      // First clean HTML and XSS
-      $string = Toolbox::clean_cross_side_scripting_deep($string);
+      $br_marker = '==' . mt_rand() . '==';
 
-      $rand   = mt_rand();
-      // Move line breaks to special CHARS
-      $string = str_replace(["<br>"], "==$rand==", $string);
+      // Replace HTML line breaks to marker
+      $string = preg_replace('/<br\s*\/?>/', $br_marker, $string);
 
-      $string = str_replace(["\r\n", "\n", "\r"], "==$rand==", $string);
+      // Replace plain text line breaks to marker if content is not html
+      // and rich text mode is enabled (otherwise remove them)
+      $string = str_replace(
+         ["\r\n", "\n", "\r"],
+         $CFG_GLPI["use_rich_text"] && $this->body_is_html ? '' : $br_marker,
+         $string
+      );
 
       // Wrap content for blacklisted items
       $itemstoclean = [];
       foreach ($DB->request('glpi_blacklistedmailcontents') as $data) {
          $toclean = trim($data['content']);
          if (!empty($toclean)) {
-            $toclean        = str_replace(["\r\n", "\n", "\r"], "==$rand==", $toclean);
-            $itemstoclean[] = $toclean;
+            $itemstoclean[] = str_replace(["\r\n", "\n", "\r"], $br_marker, $toclean);
          }
       }
       if (count($itemstoclean)) {
          $string = str_replace($itemstoclean, '', $string);
       }
-      $string = str_replace("==$rand==", "\n", $string);
+
+      $string = str_replace($br_marker, "\n", $string);
+
+      if ($CFG_GLPI["use_rich_text"]) {
+         // Convert new lines to <br> as it will not be done on display is using rich text mode
+         $string = str_replace("\n", "<br />", $string);
+      }
+
+      // Double encoding for > and < char to avoid misinterpretations
+      $string = str_replace(['&lt;', '&gt;'], ['&amp;lt;', '&amp;gt;'], $string);
+
+      // Prevent XSS
+      $string = Toolbox::clean_cross_side_scripting_deep($string);
+
       return $string;
    }
 
@@ -1394,11 +1418,7 @@ class MailCollector  extends CommonDBTM {
                $text =  imap_qprint($text);
             }
 
-            //else { return $text; }
-            if ($structure->subtype && ($structure->subtype == "HTML")) {
-               $text = str_replace("\r", " ", $text);
-               $text = str_replace("\n", " ", $text);
-            }
+            $text = str_replace(["\r\n", "\r"], "\n", $text); // Normalize line breaks
 
             if (count($structure->parameters) > 0) {
                foreach ($structure->parameters as $param) {
@@ -1654,8 +1674,11 @@ class MailCollector  extends CommonDBTM {
       $this->getStructure($uid);
       $body = $this->get_part($this->marubox, $uid, "TEXT/HTML", $this->structure);
 
-      if ($body == "") {
+      if (!empty($body)) {
+         $this->body_is_html = true;
+      } else {
          $body = $this->get_part($this->marubox, $uid, "TEXT/PLAIN", $this->structure);
+         $this->body_is_html = false;
       }
 
       if ($body == "") {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -6635,16 +6635,14 @@ class Ticket extends CommonITILObject {
     *
     * @since 0.85
     *
-    * @param $content_html         html content of input
-    * @param $files         array  of filename
-    * @param $tags          array  of image tag
+    * @param string $html  html content of input
+    * @param array  $files filenames
+    * @param array  $tags  image tags
     *
-    * @return htlm content
+    * @return string html content
    **/
-   static function convertContentForTicket($content_html, $files, $tags) {
+   static function convertContentForTicket($html, $files, $tags) {
 
-      // We inject another meta tag
-      $html = Html::entity_decode_deep($content_html);
       preg_match_all("/src\s*=\s*['|\"](.+?)['|\"]/", $html, $matches, PREG_PATTERN_ORDER);
       if (isset($matches[1]) && count($matches[1])) {
          // Get all image src


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4623

Multiple fixes in this PR:
 - enable html in followups
 - enable images in followups
 - fix stripping of initial mail content in HTML mails
 - fix double decoding in display of followup content
 - remove usage of nl2br when displaying content already containing `<br>` or `<p>` tags
 - fix line breaks in followups when not using rich text mode
 - fix detection of `<br>` and `<p>` tags when checking for usage of nl2br

Nota: This cannot be cherry-picked directly in master as it uses `$CFG_GLPI["use_rich_text"]`.