### PR TITLE
Prevent filtering while choosing mailbox folders

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -326,10 +326,10 @@ class MailCollector  extends CommonDBTM {
 
             var data = 'action=getFoldersList';
             data += '&input_id=' + input.attr('id');
-            // Get form values without current input value to prevent filtering
-            data += '&' + $(this).closest('form').find(':not([name=\"' + input.attr('name') + '\"])').serialize();
-            // Force empty value for current input
-            data += '&' + input.attr('name') + '=';
+            // Get form values without server_mailbox value to prevent filtering
+            data += '&' + $(this).closest('form').find(':not([name=\"server_mailbox\"])').serialize();
+            // Force empty value for server_mailbox
+            data += '&server_mailbox=';
 
             $('#imap-folder')
                .html('')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

On "Accepted mail archive folder" and "Refused mail archive folder" folder selection, only childs of "Incoming mail folder" where proposed.

Not really a bug, but could be considered as a bug.