### PR TITLE
Fix missing EOL after 'composer install' requirement warning

### DIFF
--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -393,7 +393,7 @@ if ($needrun) {
    $getComposerUrl = 'https://getcomposer.org/';
    if (isCommandLine()) {
       echo 'Run "composer install --no-dev" in the glpi tree.' . PHP_EOL
-          . 'To install composer please refer to ' . $getComposerUrl;
+          . 'To install composer please refer to ' . $getComposerUrl . PHP_EOL;
    } else {
       echo 'Run "composer install --no-dev" in the glpi tree.<br>'
           . 'To install composer please refer to <a href="'.$getComposerUrl.'">'.$getComposerUrl.'</a>';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Before:
![image](https://user-images.githubusercontent.com/33253653/47221511-d66f6a00-d3b4-11e8-833e-6aafe93069ba.png)

After:
![image](https://user-images.githubusercontent.com/33253653/47221543-f0a94800-d3b4-11e8-98a4-b26b789d67c9.png)
