### PR TITLE
Subqueries in JOIN

### DIFF
--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -211,7 +211,14 @@ class DBmysqlIterator implements Iterator, Countable {
                               break;
                         }
                         foreach ($val as $jointable => $joincrit) {
-                           $join .= " $jointype JOIN " .  DBmysql::quoteName($jointable) . " ON (" . $this->analyseCrit($joincrit) . ")";
+                           if (isset($joincrit['SUBQUERY'])) {
+                              $subquery = new QuerySubquery($joincrit['SUBQUERY']);
+                              unset($joincrit['SUBQUERY']);
+                              $alias = DBMysql::quoteName($jointable);
+                              $join .= " $jointype JOIN (" . $subquery->getSubQuery() . ") AS $alias ON (" . $this->analyseCrit($joincrit) . ")";
+                           } else {
+                              $join .= " $jointype JOIN " .  DBmysql::quoteName($jointable) . " ON (" . $this->analyseCrit($joincrit) . ")";
+                           }
                         }
                      } else {
                         trigger_error("BAD JOIN, value must be [ table => criteria ]", E_USER_ERROR);

--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -211,10 +211,12 @@ class DBmysqlIterator implements Iterator, Countable {
                               break;
                         }
                         foreach ($val as $jointable => $joincrit) {
-                           if (isset($joincrit['SUBQUERY'])) {
-                              $subquery = new QuerySubquery($joincrit['SUBQUERY']);
-                              unset($joincrit['SUBQUERY']);
+                           $joinExpressionKeys = ['FKEY' => null, 'ON' => null];
+                           $subquery = array_diff_key($joincrit, $joinExpressionKeys);
+                           if (count($subquery)) {
+                              $subquery = new QuerySubquery($subquery);
                               $alias = DBMysql::quoteName($jointable);
+                              $joincrit = array_intersect_key($joincrit, $joinExpressionKeys);
                               $join .= " $jointype JOIN (" . $subquery->getSubQuery() . ") AS $alias ON (" . $this->analyseCrit($joincrit) . ")";
                            } else {
                               $join .= " $jointype JOIN " .  DBmysql::quoteName($jointable) . " ON (" . $this->analyseCrit($joincrit) . ")";

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -366,9 +366,7 @@ class DBmysqlIterator extends DbTestCase {
          'foo', [
             'LEFT JOIN' => [
                't2' => [
-                  'SUBQUERY' => [
-                     'FROM' => 'bar'
-                  ],
+                  'FROM' => 'bar',
                   'FKEY' => [
                      't2'  => 'id',
                      'foo' => 'fk'

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -360,6 +360,26 @@ class DBmysqlIterator extends DbTestCase {
       $this->string($it->getSql())->isIdenticalTo(
          'SELECT * FROM `foo` LEFT JOIN `bar` ON (`bar`.`id` = `foo`.`fk` OR `field` > \'20\')'
       );
+
+      //test derived table in JOIN statement
+      $it = $this->it->execute(
+         'foo', [
+            'LEFT JOIN' => [
+               't2' => [
+                  'SUBQUERY' => [
+                     'FROM' => 'bar'
+                  ],
+                  'FKEY' => [
+                     't2'  => 'id',
+                     'foo' => 'fk'
+                  ]
+               ],
+            ]
+         ]
+      );
+      $this->string($it->getSql())->isIdenticalTo(
+         'SELECT * FROM `foo` LEFT JOIN (SELECT * FROM `bar`) AS `t2` ON (`t2`.`id` = `foo`.`fk`)'
+      );
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

This PR is a proposal to allows to create subqueries in JOIN. Example in the unit tests.

Example of the need in Flyve MDM: https://github.com/flyve-mdm/glpi-plugin/pull/785

```php
      $result = $DB->request("SELECT `l1`.*
         FROM `$table`  AS `l1` INNER JOIN
         (SELECT  MAX(`date`) AS `maxdate`, `topic`
            FROM `$table`
            WHERE `itemtype` = '$itemtype' AND `items_id` = '$itemId'
            GROUP BY `topic`
         ) AS `l2`
         ON `l1`.`topic` = `l2`.`topic` AND `l1`.`date` = `l2`.`maxdate`
         WHERE `itemtype`='$itemtype' AND `items_id` = '$itemId'
         GROUP BY `topic`");
```

In this example I need to get a single row for the column topic, with the latest associated value. Without a subquery, mysql messes the rows and may give a value of the column message for an date which is not the highest. Using a subquery like this one is requires to have accurate results.


