### PR TITLE
avoid overflow of pictures in timeline when followup collected

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -3577,9 +3577,12 @@ a.copyright {
    background-repeat: no-repeat;
 }
 
-
 .timeline_history .approbation_separator {
    margin-bottom: 55px;
+}
+
+.timeline_history .item_content img {
+   max-width: 100%;
 }
 
 .assign_la {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Follow #4803, as now collected followups can now have inline image (and not parsed separately), no miniature is generated in case of collector.
To avoid overflow, i set a max-width for img.

## Before: 
![image](https://user-images.githubusercontent.com/418844/47551260-031a0900-d902-11e8-9867-7d5abca9af37.png)


## After:
![image](https://user-images.githubusercontent.com/418844/47551239-f4335680-d901-11e8-9a0d-85251989065f.png)
