### PR TITLE
Fix access to undefined tag for documents; fixes #4256

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -5103,8 +5103,12 @@ class CommonDBTM extends CommonGLPI {
                $input2["name"] = addslashes(sprintf(__('Document Ticket %d'), $this->getID()));
                $input2["tickets_id"] = $this->getID();
             }
-            // Insert image tag
-            $input2["tag"] = $input['_tag'][$key];
+
+            if (isset($input['_tag'][$key])) {
+               // Insert image tag
+               $input2["tag"] = $input['_tag'][$key];
+            }
+
             $input2["entities_id"]             = $entities_id;
             $input2["is_recursive"]            = 1;
             $input2["documentcategories_id"]   = $CFG_GLPI["documentcategories_id_forticket"];
@@ -5114,7 +5118,11 @@ class CommonDBTM extends CommonGLPI {
                $input2["_prefix_filename"]  = [$this->input['_prefix_filename'][$key]];
             }
             $docID = $doc->add($input2);
-            $docadded[$docID]['tag'] = $input['_tag'][$key];
+
+            if (isset($input['_tag'][$key])) {
+               // Store image tag
+               $docadded[$docID]['tag'] = $doc->fields["tag"];
+            }
          }
 
          if ($docID > 0) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4256

`_tag` may not contains an entry for a document, as it this entry is mainly used to store tags that are used in rich text content to replace images src.

When using mail collector, for exemple, tags are only set for images (see https://github.com/glpi-project/glpi/blob/9.3/bugfixes/inc/mailcollector.class.php#L1630 ).

I do not understand why, but I was not able to reproduce with a mail that only contains a document. To reproduce, I had to test on an email containing a document AND an embedded image. My mail was sent from Zimbra web client.