### PR TITLE
Fix embedded image cid format; fixes #4421

### DIFF
--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -162,13 +162,12 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                         GLPI_DOC_DIR."/".$doc->fields['filepath'],
                         'mail'
                      );
-                     $cid = hash('sha256', $image_path) . '@glpimailer.0'; // RFC2392 S 2
                      if ($mmail->AddEmbeddedImage($image_path,
-                                                  $cid,
+                                                  $doc->fields['tag'],
                                                   $doc->fields['filename'],
                                                   'base64',
                                                   $doc->fields['mime'])) {
-                        $inline_docs[$doc_i_data['documents_id']] = $cid;
+                        $inline_docs[$doc_i_data['documents_id']] = $doc->fields['tag'];
                      }
                   } else if ($CFG_GLPI['attach_ticket_documents_to_mail']) {
                      // Add all other attachments, according to configuration
@@ -217,27 +216,26 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                            $width,
                            $height
                         );
-                        $cid = hash('sha256', $image_path) . '@glpimailer.0'; // RFC2392 S 2
                         if ($mmail->AddEmbeddedImage($image_path,
-                                                     $cid,
+                                                     $doc->fields['tag'],
                                                      $doc->fields['filename'],
                                                      'base64',
                                                      $doc->fields['mime'])) {
-                           $inline_docs[$docID] = $cid;
+                           $inline_docs[$docID] = $doc->fields['tag'];
                         }
                      }
                   }
                }
             }
 
-            // replace img[src] by cid:$cid in html content
+            // replace img[src] by cid:tag in html content
             // replace a[href] by absolute URL
-            foreach ($inline_docs as $docID => $cid) {
+            foreach ($inline_docs as $docID => $tag) {
                $current->fields['body_html'] = preg_replace([
                      '/src=["\'][^"\']*document\.send\.php\?docid='.$docID.'[^"\']*["\']/',
                      '/href=["\'][^"\']*document\.send\.php\?docid='.$docID.'[^"\']*["\']/',
                   ], [
-                     'src="cid:' . $cid . '"',
+                     'src="cid:' . $tag . '"',
                      'href="' . $CFG_GLPI['url_base'] . '/front/document.send.php?docid=' . $docID . '"',
                   ],
                   $current->fields['body_html']);

--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -158,17 +158,17 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                   // Add embeded image if tag present in ticket content
                   if (preg_match_all('/'.Document::getImageTag($doc->fields['tag']).'/',
                                      $current->fields['body_html'], $matches, PREG_PATTERN_ORDER)) {
-                     $tag = Document::getImageTag($doc->fields['tag']);
                      $image_path = Document::getImage(
                         GLPI_DOC_DIR."/".$doc->fields['filepath'],
                         'mail'
                      );
+                     $cid = hash('sha256', $image_path) . '@glpimailer.0'; // RFC2392 S 2
                      if ($mmail->AddEmbeddedImage($image_path,
-                                                  $tag,
+                                                  $cid,
                                                   $doc->fields['filename'],
                                                   'base64',
                                                   $doc->fields['mime'])) {
-                        $inline_docs[$doc_i_data['documents_id']] = $tag;
+                        $inline_docs[$doc_i_data['documents_id']] = $cid;
                      }
                   } else if ($CFG_GLPI['attach_ticket_documents_to_mail']) {
                      // Add all other attachments, according to configuration
@@ -196,7 +196,6 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                   foreach ($matches[2] as $pos=>$docID) {
                      if (!in_array($docID, $inline_docs)) {
                         $doc->getFromDB($docID);
-                        $tag = Document::getImageTag($doc->fields['tag']);
 
                         //find width
                         $width = null;
@@ -218,25 +217,27 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                            $width,
                            $height
                         );
+                        $cid = hash('sha256', $image_path) . '@glpimailer.0'; // RFC2392 S 2
                         if ($mmail->AddEmbeddedImage($image_path,
-                                                     $tag,
+                                                     $cid,
                                                      $doc->fields['filename'],
                                                      'base64',
                                                      $doc->fields['mime'])) {
-                           $inline_docs[$docID] = $tag;
+                           $inline_docs[$docID] = $cid;
                         }
                      }
                   }
                }
             }
 
-            // replace img[src] and a[href] by cid:tag in html content
-            foreach ($inline_docs as $docID => $tag) {
+            // replace img[src] by cid:$cid in html content
+            // replace a[href] by absolute URL
+            foreach ($inline_docs as $docID => $cid) {
                $current->fields['body_html'] = preg_replace([
                      '/src=["\'][^"\']*document\.send\.php\?docid='.$docID.'[^"\']*["\']/',
                      '/href=["\'][^"\']*document\.send\.php\?docid='.$docID.'[^"\']*["\']/',
                   ], [
-                     'src="cid:' . $tag . '"',
+                     'src="cid:' . $cid . '"',
                      'href="' . $CFG_GLPI['url_base'] . '/front/document.send.php?docid=' . $docID . '"',
                   ],
                   $current->fields['body_html']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4421

I take a cid format similar to the one used by PHPMailer in its internal replacement of images URL by cid + embedded (https://github.com/PHPMailer/PHPMailer/blob/master/src/PHPMailer.php#L3772). I am now able to view images in OWA (tester on a outlook.com account).