### PR TITLE
Use template hiding functions also when a SLA is set on current ticket

### DIFF
--- a/inc/levelagreement.class.php
+++ b/inc/levelagreement.class.php
@@ -257,9 +257,12 @@ abstract class LevelAgreement extends CommonDBChild {
       if ($ticket->fields['id']) {
          if ($this->getDataForTicket($ticket->fields['id'], $type)) {
             echo "<td style='width: 105px'>";
+            echo $tt->getBeginHiddenFieldValue($dateField);
             echo Html::convDateTime($ticket->fields[$dateField]);
+            echo $tt->getEndHiddenFieldValue($dateField, $ticket);
             echo "</td>";
             echo "<td>";
+            echo $tt->getBeginHiddenFieldText($laField);
             echo "<i class='fa fa-clock-o slt'></i>";
             echo Dropdown::getDropdownName(static::getTable(),
                                            $ticket->fields[$laField])."&nbsp;";
@@ -311,6 +314,7 @@ abstract class LevelAgreement extends CommonDBChild {
                echo "<span class='sr-only'>"._x('button', 'Delete permanently')."</span>";
                echo "</a>";
             }
+            echo $tt->getEndHiddenFieldText($laField);
             echo "</td>";
 
          } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4842 

SLA's (added by business rule by example) on ticket are displayed even if TTR or TTO field is hidden in ticket template. This PR fix this.