### PR TITLE
Massive action key is now 'update_notif' and not 'enable_notif'

### DIFF
--- a/inc/commonitilactor.class.php
+++ b/inc/commonitilactor.class.php
@@ -341,6 +341,33 @@ abstract class CommonITILActor extends CommonDBRelation {
       return $input;
    }
 
+   function prepareInputForUpdate($input) {
+      if ($input['alternative_email'] == '') {
+        if (isset($input['users_id'])) {
+          $actor = new User();
+          if ($actor->getFromDB($input["users_id"])) {
+             $input['alternative_email'] = $actor->getDefaultEmail();
+          }
+        }
+        if (isset($input['suppliers_id'])) {
+          $actor = new Supplier;
+          if ($actor->getFromDB($input["suppliers_id"])) {
+             $input['alternative_email'] = $actor->fields['email'];
+          }
+        }
+      }
+      if (isset($input['alternative_email']) && !NotificationMailing::isUserAddressValid($input['alternative_email'])) {
+         Session::addMessageAfterRedirect(
+            __('Invalid email address'),
+            false,
+            ERROR
+         );
+         return false;
+      }
+
+      $input = parent::prepareInputForUpdate($input);
+      return $input;
+   }
 
    function post_addItem() {
 

--- a/inc/commonitilactor.class.php
+++ b/inc/commonitilactor.class.php
@@ -343,18 +343,18 @@ abstract class CommonITILActor extends CommonDBRelation {
 
    function prepareInputForUpdate($input) {
       if ($input['alternative_email'] == '') {
-        if (isset($input['users_id'])) {
-          $actor = new User();
-          if ($actor->getFromDB($input["users_id"])) {
-             $input['alternative_email'] = $actor->getDefaultEmail();
-          }
-        }
-        if (isset($input['suppliers_id'])) {
-          $actor = new Supplier;
-          if ($actor->getFromDB($input["suppliers_id"])) {
-             $input['alternative_email'] = $actor->fields['email'];
-          }
-        }
+         if (isset($input['users_id'])) {
+            $actor = new User();
+            if ($actor->getFromDB($input["users_id"])) {
+               $input['alternative_email'] = $actor->getDefaultEmail();
+            }
+         }
+         if (isset($input['suppliers_id'])) {
+            $actor = new Supplier;
+            if ($actor->getFromDB($input["suppliers_id"])) {
+               $input['alternative_email'] = $actor->fields['email'];
+            }
+         }
       }
       if (isset($input['alternative_email']) && !NotificationMailing::isUserAddressValid($input['alternative_email'])) {
          Session::addMessageAfterRedirect(

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2706,7 +2706,7 @@ class Ticket extends CommonITILObject {
          if (Session::haveRight(self::$rightname, UPDATE)) {
             $actions[__CLASS__.MassiveAction::CLASS_ACTION_SEPARATOR.'add_actor']
                = __('Add an actor');
-            $actions[__CLASS__.MassiveAction::CLASS_ACTION_SEPARATOR.'enable_notif']
+            $actions[__CLASS__.MassiveAction::CLASS_ACTION_SEPARATOR.'update_notif']
                = __('Set notifications for all actors');
             $actions['Ticket_Ticket'.MassiveAction::CLASS_ACTION_SEPARATOR.'add']
                = _x('button', 'Link tickets');

--- a/inc/ticket_user.class.php
+++ b/inc/ticket_user.class.php
@@ -43,20 +43,6 @@ class Ticket_User extends CommonITILActor {
    static public $itemtype_2 = 'User';
    static public $items_id_2 = 'users_id';
 
-   function prepareInputForUpdate($input) {
-      if (isset($input['alternative_email']) && !NotificationMailing::isUserAddressValid($input['alternative_email'])) {
-         Session::addMessageAfterRedirect(
-            __('Invalid email address'),
-            false,
-            ERROR
-         );
-         return false;
-      }
-
-      $input = parent::prepareInputForUpdate($input);
-      return $input;
-   }
-
    function post_addItem() {
 
       switch ($this->input['type']) { // Values from CommonITILObject::getSearchOptionsActors()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4835

Massive action "enable_notif" on itil objects has been modified to handle yes/no answer, but in Ticket class the old "enable_notif" key wasnt modified in new "update_notif" key. This pr fix this.