### PR TITLE
fix attribute for additional icons

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -6489,7 +6489,7 @@ class Html {
                         break;
 
                      default :
-                        echo "<span>".Html::link($key, $CFG_GLPI["root_doc"].$val)."</span>";
+                        echo "<span>".Html::link($key, $CFG_GLPI["root_doc"].$val, ['class' => 'pointer'])."</span>";
                         break;
                   }
                }


### PR DESCRIPTION
Small color issue with non standard icons provided by an object

#### before
![image](https://user-images.githubusercontent.com/14139801/47916657-2d8e3800-dea7-11e8-9511-66fbfe04e7d0.png)

#### after
![image](https://user-images.githubusercontent.com/14139801/47916648-2404d000-dea7-11e8-9eec-122c8c561d23.png)

Notiec the color of the lock. The fix makes it behave like others when mouse overs.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

*Please update this template with something that matches your PR*