### PR TITLE
Iterator can use distinct on one field and select some others

### DIFF
--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -232,6 +232,18 @@ class DBmysqlIterator implements Iterator, Countable {
 
          $this->sql = 'SELECT ';
          $first = true;
+
+         //check DISTINCT is not an array
+         if (is_array($dfield)) {
+            Toolbox::logWarning('DISTINCT selection can only take one field!');
+            if (!is_array($field)) {
+               $field = $dfield;
+            } else {
+               $field = array_merge($field, $dfield);
+            }
+            $dfield = '';
+         }
+
          // SELECT field list
          if ($count) {
             $this->sql .= 'COUNT(';

--- a/inc/itil_project.class.php
+++ b/inc/itil_project.class.php
@@ -137,7 +137,8 @@ class Itil_Project extends CommonDBRelation {
          $itemTable = $itemtype::getTable();
 
          $iterator = $DB->request([
-            'SELECT DISTINCT' => ["{$selfTable}.id AS linkID", "{$itemTable}.*"],
+            'SELECT DISTINCT' => "$selfTable.id AS linkID",
+            'FIELDS'          => "$itemTable.*",
             'FROM'            => $selfTable,
             'LEFT JOIN'       => [
                $itemTable => [
@@ -278,7 +279,8 @@ class Itil_Project extends CommonDBRelation {
       $projectTable = Project::getTable();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => ["{$selfTable}.id AS linkID", "{$projectTable}.*"],
+         'SELECT DISTINCT' => "$selfTable.id AS linkID",
+         'FIELDS'          => "$projectTable.*",
          'FROM'            => $selfTable,
          'LEFT JOIN'       => [
             $projectTable => [

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -785,7 +785,7 @@ class Migration {
       if (count($toadd)) {
          foreach ($toadd as $type => $tab) {
             $iterator = $DB->request([
-               'SELECT DISTINCT' => ['users_id'],
+               'SELECT DISTINCT' => 'users_id',
                'FROM'            => 'glpi_displaypreferences',
                'WHERE'           => ['itemtype' => $type]
             ]);

--- a/inc/notificationtargetsavedsearch_alert.class.php
+++ b/inc/notificationtargetsavedsearch_alert.class.php
@@ -43,7 +43,7 @@ class NotificationTargetSavedsearch_Alert extends NotificationTarget {
       $events = [];
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => ['event'],
+         'SELECT DISTINCT' => 'event',
          'FROM'            => Notification::getTable(),
          'WHERE'           => ['itemtype' => SavedSearch_Alert::getType()]
       ]);

--- a/inc/profile_user.class.php
+++ b/inc/profile_user.class.php
@@ -594,7 +594,8 @@ class Profile_User extends CommonDBRelation {
       global $DB;
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => ['entities_id', 'is_recursive'],
+         'SELECT DISTINCT' => 'entities_id',
+         'FIELDS'          => 'is_recursive',
          'FROM'            => 'glpi_profiles_users',
          'WHERE'           => ['users_id' => $user_ID]
       ]);
@@ -693,7 +694,7 @@ class Profile_User extends CommonDBRelation {
       }
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => ['profiles_id'],
+         'SELECT DISTINCT' => 'profiles_id',
          'FROM'            => 'glpi_profiles_users',
          'WHERE'           => $where
       ]);

--- a/inc/profileright.class.php
+++ b/inc/profileright.class.php
@@ -61,7 +61,7 @@ class ProfileRight extends CommonDBChild {
           || count($GLPI_CACHE->get('all_possible_rights')) == 0) {
 
          $iterator = $DB->request([
-            'SELECT DISTINCT' => ['name'],
+            'SELECT DISTINCT' => 'name',
             'FROM'            => self::getTable()
          ]);
          while ($right = $iterator->next()) {

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -199,6 +199,15 @@ class DBmysqlIterator extends DbTestCase {
 
       $it = $this->it->execute('foo', ['FIELDS' => ['MAX' => 'bar AS cpt']]);
       $this->string($it->getSql())->isIdenticalTo('SELECT MAX(`bar`) AS cpt FROM `foo`');
+
+      $this->exception(
+         function() {
+            $it = $this->it->execute('foo', ['DISTINCT FIELDS' => ['bar', 'baz']]);
+            $this->string($it->getSql())->isIdenticalTo('SELECT `bar`, `baz` FROM `foo`');
+         }
+      )
+         ->isInstanceOf('RuntimeException')
+         ->message->contains('DISTINCT selection can only take one field!');
    }
 
 

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -164,6 +164,9 @@ class DBmysqlIterator extends DbTestCase {
       $it = $this->it->execute('foo', ['DISTINCT FIELDS' => 'bar']);
       $this->string($it->getSql())->isIdenticalTo('SELECT DISTINCT `bar` FROM `foo`');
 
+      $it = $this->it->execute('foo', ['DISTINCT FIELDS' => 'bar', 'FIELDS' => 'baz']);
+      $this->string($it->getSql())->isIdenticalTo('SELECT DISTINCT `bar`, `baz` FROM `foo`');
+
       $it = $this->it->execute('foo', ['FIELDS' => 'bar']);
       $this->string($it->getSql())->isIdenticalTo('SELECT `bar` FROM `foo`');
 

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -124,9 +124,9 @@ class Migration extends \GLPITestCase {
 
       $this->array($this->queries)->isIdenticalTo([
          0 => 'SELECT * FROM `glpi_configs` WHERE `context` = \'core\' AND `name` IN (\'one\', \'two\')',
-         1 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'one\'',
+         1 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'one\'',
          2 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'one\', \'key\')',
-         3 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'two\'',
+         3 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'two\'',
          4 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'two\', \'value\')'
       ]);
 
@@ -142,9 +142,9 @@ class Migration extends \GLPITestCase {
 
       $this->array($this->queries)->isIdenticalTo([
          0 => 'SELECT * FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` IN (\'one\', \'two\')',
-         1 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'one\'',
+         1 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'one\'',
          2 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'one\', \'key\')',
-         3 => 'SELECT  `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'two\'',
+         3 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'two\'',
          4 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'two\', \'value\')'
       ]);
 
@@ -188,10 +188,10 @@ class Migration extends \GLPITestCase {
       )->isIdenticalTo("Task completed.");
 
       $this->array($this->queries)->isIdenticalTo([
-         0 => 'SELECT  `TABLE_NAME` FROM `information_schema`.`TABLES`' .
+         0 => 'SELECT `TABLE_NAME` FROM `information_schema`.`TABLES`' .
                ' WHERE `TABLE_SCHEMA` = \'' . $DB->dbdefault .
                '\' AND `TABLE_TYPE` = \'BASE TABLE\' AND `TABLE_NAME` LIKE \'%table1%\'',
-         1 => 'SELECT  `TABLE_NAME` FROM `information_schema`.`TABLES`' .
+         1 => 'SELECT `TABLE_NAME` FROM `information_schema`.`TABLES`' .
                ' WHERE `TABLE_SCHEMA` = \'' . $DB->dbdefault  .
                '\' AND `TABLE_TYPE` = \'BASE TABLE\' AND `TABLE_NAME` LIKE \'%table2%\''
              ]);


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Still working on iterator replacements, I have the following:
```
       return  "SELECT DISTINCT `glpi_users`.`id` AS users_id,
                                `glpi_users`.`language` AS language";
```

This was not possible to achieve that with the iterator; distinct and regular fields were exclusive (see unit test that have been added).