### PR TITLE
Fix presence of signature in ajax notifications

### DIFF
--- a/inc/notificationevent.class.php
+++ b/inc/notificationevent.class.php
@@ -119,20 +119,19 @@ class NotificationEvent extends CommonDBTM {
          //Process more infos (for example for tickets)
          $notificationtarget->addAdditionnalInfosForTarget();
 
-         //Get template's information
-         $template           = new NotificationTemplate();
-
-         $entity             = $notificationtarget->getEntity();
          //Foreach notification
          $notifications = Notification::getNotificationsByEventAndType(
             $event,
             $item->getType(),
-            $entity
+            $notificationtarget->getEntity()
          );
 
          foreach ($notifications as $data) {
             $notificationtarget->clearAddressesList();
             $notificationtarget->setMode($data['mode']);
+
+            //Get template's information
+            $template = new NotificationTemplate();
             $template->getFromDB($data['notificationtemplates_id']);
             $template->resetComputedTemplates();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If a notification uses both email and ajax templates, and if ajax notification is send after the email one, the `$CFG_GLPI['mailing_signature']` will be included in the ajax notification.
This behaviour is due to the fact that the template object is not recreated on each notification and in the fact that the signature is handled by the template itself. (see https://github.com/glpi-project/glpi/blob/9.3/bugfixes/inc/notificationeventmailing.class.php#L317 and https://github.com/glpi-project/glpi/blob/9.3/bugfixes/inc/notificationtemplate.class.php#L315)

Recreating the template object on each notification fixes the problem.

Note that signature can be invisible as browser can strip messages that are too long.