### PR TITLE
Make NotificationTarget::getMode() public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The present file will list all changes made to the project; according to the
    - `addOrderBy()`,
    - `addHaving()`,
    - `giveItem()`
+- `NotificationTarget::getMode()` visibility is now `public`.
 
 #### Deprecated
 

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -1358,7 +1358,7 @@ class NotificationTarget extends CommonDBChild {
     *
     * @return string
     */
-   protected function getMode() {
+   public function getMode() {
       return $this->mode;
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Due to `protected` visibility of `NotificationTarget::getMode()`, it is not possible to know which mode the target uses in pugin hook `item_action_targets`. As this hook is made to populate informations related to recipients, it can be problematic to not be able to adapt the behaviour to the notification mode.
