### PR TITLE
Change max DC equipment weight

### DIFF
--- a/inc/commondcmodeldropdown.class.php
+++ b/inc/commondcmodeldropdown.class.php
@@ -60,7 +60,8 @@ abstract class CommonDCModelDropdown extends CommonDropdown {
          $fields[] = [
             'name'   => 'weight',
             'type'   => 'integer',
-            'label'  => __('Weight')
+            'label'  => __('Weight'),
+            'max'    => 1000
          ];
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

For my own companies requirements, some servers and equipment can reach over the default maximum weight of 100 (Especially 4U servers or blades when recording weight in pounds). I recommend increasing to 1000 to allow heavier devices and different weight measurements.

[Request on UserEcho with same concern](https://glpi.userecho.com/communities/1/topics/931-network-equipment-weight).