### PR TITLE
Merge and Split Tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The present file will list all changes made to the project; according to the
 - Add timeline to Changes and Problems.
 - CLI console to centralize CLI commands.
 - Search on devices from Printers and Network equipments.
+- Ability to merge and split tickets.
+- Search on devices from Printers and Network equipments.
 - Ability to specify creation and modification dates during CommonDBTM object add method.
 
 ### Changed

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -3531,14 +3531,18 @@ a.copyright {
       float: right;
       height: 20px;
     }
-    .edit_item {
+    .h_controls {
       display: block;
       float: right;
-      opacity: .5;
-      font-size: 1.5em;
-      &:hover {
-        opacity: 1;
-        cursor: pointer;
+
+      .control_item {
+        margin-left: 5px;
+        opacity: .5;
+        font-size: 1.3em;
+        &:hover {
+          opacity: 1;
+          cursor: pointer;
+        }
       }
     }
     .long_text {

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -69,7 +69,6 @@ if (isset($_POST["add"])) {
 
 } else if (isset($_POST['update'])) {
    $track->check($_POST['id'], UPDATE);
-
    $track->update($_POST);
 
    if (isset($_POST['kb_linked_id'])) {

--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -438,6 +438,19 @@ class Ajax {
                $.get('".$CFG_GLPI['root_doc']."/ajax/updatecurrenttab.php',
                   { itemtype: '$type', id: '$ID', tab: newIndex });
             },
+            load: function(event) {
+               var _url = window.location.href;
+               //get the anchor
+               var _parts = _url.split('#');
+               var _anchor = _parts[1];
+
+               //get the top offset of the target anchor
+               var target_offset = $('#' + _anchor).offset();
+               var target_top = target_offset.top;
+
+               //goto that anchor by setting the body scroll top to anchor top
+               $('html, body').animate({scrollTop:target_top}, 2000, 'easeOutQuad');
+            },
             ajaxOptions: {type: 'POST'}
          });";
 

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6124,16 +6124,19 @@ abstract class CommonITILObject extends CommonDBTM {
                var target = e.target || window.event.srcElement;
                if (target.nodeName == 'a') return;
                if (target.className == 'read_more_button') return;
-               $('#'+domid).addClass('edited');
-               $('#'+domid+' .displayed_content').hide();
-               $('#'+domid+' .cancel_edit_item_content').show()
+
+               var _eltsel = '[data-uid='+domid+']';
+               var _elt = $(_eltsel);
+               _elt.addClass('edited');
+               $(_eltsel + ' .displayed_content').hide();
+               $(_eltsel + ' .cancel_edit_item_content').show()
                                                         .click(function() {
                                                             $(this).hide();
-                                                            $('#'+domid).removeClass('edited');
-                                                            $('#'+domid+' .edit_item_content').empty().hide();
-                                                            $('#'+domid+' .displayed_content').show();
+                                                            _elt.removeClass('edited');
+                                                            $(_eltsel + ' .edit_item_content').empty().hide();
+                                                            $(_eltsel + ' .displayed_content').show();
                                                         });
-               $('#'+domid+' .edit_item_content').show()
+               $(_eltsel + ' .edit_item_content').show()
                                                  .load('".$CFG_GLPI["root_doc"]."/ajax/timeline.php',
                                                        {'action'    : 'viewsubitem',
                                                         'type'      : itemtype,
@@ -6504,7 +6507,8 @@ abstract class CommonITILObject extends CommonDBTM {
          if ($item['type'] == $objType.'Validation' && isset($item_i['status'])) {
             $domid .= $item_i['status'];
          }
-         $domid .= $rand;
+         $randdomid = $domid . $rand;
+         $domid = Toolbox::slugify($domid);
 
          $fa = null;
          $class = "h_content";
@@ -6532,7 +6536,7 @@ abstract class CommonITILObject extends CommonDBTM {
             $class .= " {$item_i['status']}";
          }
 
-         echo "<div class='$class' id='$domid'>";
+         echo "<div class='$class' id='$domid' data-uid='$randdomid'>";
          if ($fa !== null) {
             echo "<i class='solimg fa fa-$fa fa-5x'></i>";
          }
@@ -6558,7 +6562,7 @@ abstract class CommonITILObject extends CommonDBTM {
                }
             }
             echo "<span class='far fa-edit control_item' title='".__('Edit')."'";
-            echo "onclick='javascript:viewEditSubitem".$this->fields['id']."$rand(event, \"".$item['type']."\", ".$item_i['id'].", this, \"$domid\")'";
+            echo "onclick='javascript:viewEditSubitem".$this->fields['id']."$rand(event, \"".$item['type']."\", ".$item_i['id'].", this, \"$randdomid\")'";
             echo "></span>";
             echo "</div>";
          }

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6393,8 +6393,7 @@ abstract class CommonITILObject extends CommonDBTM {
     * @return void
     */
    function showTimeline($rand) {
-
-      global $CFG_GLPI, $autolink_options;
+      global $DB, $CFG_GLPI, $autolink_options;
 
       $user              = new User();
       $group             = new Group();
@@ -6550,7 +6549,7 @@ abstract class CommonITILObject extends CommonDBTM {
             echo "<div class='h_controls'>";
             if ($objType == 'Ticket' && $item['type'] == ITILFollowup::getType()) {
                if (isset($item_i['sourceof_items_id']) && $item_i['sourceof_items_id'] > 0) {
-                  echo Html::link('', '#', [
+                  echo Html::link('', Ticket::getFormURLWithID($item_i['sourceof_items_id']), [
                      'class' => 'fa fa-code-branch control_item disabled',
                      'title' => __('Followup was already promoted')
                   ]);
@@ -6799,7 +6798,29 @@ abstract class CommonITILObject extends CommonDBTM {
 
          echo "<div class='h_content ITILContent'>";
 
-         echo "<div class='b_right'>".sprintf(__($objType."# %s description"), $this->getID())."</div>";
+         echo "<div class='b_right'>";
+
+         if ($objType == 'Ticket') {
+            $result = $DB->request([
+               'SELECT' => ['id', 'itemtype', 'items_id'],
+               'FROM'   => ITILFollowup::getTable(),
+               'WHERE'  => [
+                  'sourceof_items_id'  => $this->fields['id'],
+                  'itemtype'           => static::getType()
+               ]
+            ])->next();
+            if ($result) {
+               echo Html::link(
+                  '',
+                  static::getFormURLWithID($result['items_id']) . '&forcetab=Ticket$1#viewitemitilfollowup' . $result['id'], [
+                     'class' => 'fa fa-code-branch control_item disabled',
+                     'title' => __('Followup promotion source')
+                  ]
+               );
+            }
+         }
+         echo sprintf(__($objType."# %s description"), $this->getID());
+         echo "</div>";
 
          echo "<div class='title'>";
          echo Html::setSimpleTextContent($this->fields['name']);

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9607,6 +9607,8 @@ CREATE TABLE `glpi_itilfollowups` (
   `date_mod` datetime DEFAULT NULL,
   `date_creation` datetime DEFAULT NULL,
   `timeline_position` tinyint(1) NOT NULL DEFAULT '0',
+  `sourceitems_id` int(11) NOT NULL DEFAULT '0',
+  `sourceof_items_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `itemtype` (`itemtype`),
   KEY `item_id` (`items_id`),
@@ -9617,5 +9619,7 @@ CREATE TABLE `glpi_itilfollowups` (
   KEY `users_id` (`users_id`),
   KEY `users_id_editor` (`users_id_editor`),
   KEY `is_private` (`is_private`),
-  KEY `requesttypes_id` (`requesttypes_id`)
+  KEY `requesttypes_id` (`requesttypes_id`),
+  KEY `sourceitems_id` (`sourceitems_id`),
+  KEY `sourceof_items_id` (`sourceof_items_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/install/update_93_94.php
+++ b/install/update_93_94.php
@@ -366,6 +366,20 @@ function update93to94() {
       );
    }
 
+   /** Add source item id to ITILFollowups. Used by followups created by merging tickets */
+   if (!$DB->fieldExists('glpi_itilfollowups', 'sourceitems_id')) {
+      if ($migration->addField('glpi_itilfollowups', 'sourceitems_id', "int(11) NOT NULL DEFAULT '0'")) {
+         $migration->addKey('glpi_itilfollowups', 'sourceitems_id');
+      }
+   }
+
+   /** Add sourceof item id to ITILFollowups. Used to link to tickets created by promotion */
+   if (!$DB->fieldExists('glpi_itilfollowups', 'sourceof_items_id')) {
+      if ($migration->addField('glpi_itilfollowups', 'sourceof_items_id', "int(11) NOT NULL DEFAULT '0'")) {
+         $migration->addKey('glpi_itilfollowups', 'sourceof_items_id');
+      }
+   }
+
    // ************ Keep it at the end **************
    $migration->executeMigration();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #914 

Work in progress. Open to any feedback about the implementation.

Done:

- [x]  Merge a ticket and its followups as followups of another ticket. Merged ticket is deleted.
- [x]  "Promote" a followup to a new ticket. A "son" relation is created. New ticket is son of original ticket.


To-do:

- [x]  Test rights
- [x]  Add new event logging for merge and promote actions
- [x]  Fix timeline ordering for merged followups (Don't just reassign items_id?)
- [x]  Fix style issues with new buttons in ticket and followup
- [x]  Add confirmation/warning for merge as ticket currently gets deleted


Should a ticket that gets merged as a followup be deleted or closed?
Should we use "split" or "promote" as the action name for turning a followup into a new ticket?