### PR TITLE
remove bad default criteria

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2714,10 +2714,6 @@ JAVASCRIPT;
             'field' => $field,
             'link'  => 'contains',
             'value' => ''
-         ],  [
-            'field' => $field,
-            'link'  => 'notcontains',
-            'value' => ''
          ]
       ];
    }

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -743,12 +743,7 @@ class Search extends DbTestCase {
                            'field' => 'view',
                            'link'  => 'contains',
                            'value' => '',
-                        ],
-                        1 => [
-                           'field' => 'view',
-                           'link'  => 'notcontains',
-                           'value' => '',
-                        ],
+                        ]
                      ],
                     'metacriteria' => [],
                     'as_map'       => 0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

When adding `notcontains` link, I must have been tired

**Before**

![image](https://user-images.githubusercontent.com/418844/48559921-fb3ffa00-e8ec-11e8-95a7-5f6f4c004eb1.png)

**After**

![image](https://user-images.githubusercontent.com/418844/48559908-ec594780-e8ec-11e8-9cdb-73a9d51b724e.png)

