### PR TITLE
Multiple Search Folding Fixes

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2312,7 +2312,6 @@ JAVASCRIPT;
 
          $(document).on("click", ".remove-search-criteria", function() {
             var rowID = $(this).data('rowid');
-            console.log('remove-search-criteria', rowID);
             $('#' + rowID).remove();
             $('#searchcriteria ul li:first-child').addClass('headerRow').show();
          });

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2309,10 +2309,13 @@ JAVASCRIPT;
                .toggleClass('fa-angle-double-down');
             $('#searchcriteria ul li:not(:first-child)').toggle();
          });
-         function removeSearchCriteria(rowID) {
+
+         $(document).on("click", ".remove-search-criteria", function() {
+            var rowID = $(this).data('rowid');
+            console.log('remove-search-criteria', rowID);
             $('#' + rowID).remove();
             $('#searchcriteria ul li:first-child').addClass('headerRow').show();
-         }
+         });
 JAVASCRIPT;
       }
       echo Html::scriptBlock($JS);
@@ -2412,8 +2415,8 @@ JAVASCRIPT;
                'id'    => 'as_map'
             ]);
          }
-         echo "<i class='far fa-minus-square' alt='-' title=\"".
-                  __s('Delete a rule')."\" onclick=\"removeSearchCriteria('$rowid');\"></i>&nbsp;";
+         echo "<i class='far fa-minus-square remove-search-criteria' alt='-' title=\"".
+                  __s('Delete a rule')."\" data-rowid='$rowid'></i>&nbsp;";
 
       }
 
@@ -2552,8 +2555,8 @@ JAVASCRIPT;
       $rowid  = 'metasearchrow'.$request['itemtype'].$rand;
 
       echo "<li class='metacriteria' id='$rowid'>";
-      echo "<i class='far fa-minus-square' alt='-' title=\"".
-               __s('Delete a global rule')."\" onclick=\"removeSearchCriteria('$rowid');\"></i>&nbsp;";
+      echo "<i class='far fa-minus-square remove-search-criteria' alt='-' title=\"".
+               __s('Delete a global rule')."\" data-rowid='$rowid'></i>&nbsp;";
 
       // Display link item (not for the first item)
       Dropdown::showFromArray(
@@ -2635,8 +2638,8 @@ JAVASCRIPT;
       }
 
       echo "<li class='normalcriteria$addclass' id='$rowid'>";
-      echo "<i class='far fa-minus-square' alt='-' title=\"".
-               __s('Delete a rule')."\" onclick=\"removeSearchCriteria('$rowid');\"></i>&nbsp;";
+      echo "<i class='far fa-minus-square remove-search-criteria' alt='-' title=\"".
+               __s('Delete a rule')."\" data-rowid='$rowid'></i>&nbsp;";
       Dropdown::showFromArray("criteria{$prefix}[$num][link]", Search::getLogicalOperators(), [
          'value' => isset($criteria["link"]) ? $criteria["link"] : '',
          'width' => '80px'

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2309,6 +2309,10 @@ JAVASCRIPT;
                .toggleClass('fa-angle-double-down');
             $('#searchcriteria ul li:not(:first-child)').toggle();
          });
+         function removeSearchCriteria(rowID) {
+            $('#' + rowID).remove();
+            $('#searchcriteria ul li:first-child').addClass('headerRow').show();
+         }
 JAVASCRIPT;
       }
       echo Html::scriptBlock($JS);
@@ -2409,8 +2413,7 @@ JAVASCRIPT;
             ]);
          }
          echo "<i class='far fa-minus-square' alt='-' title=\"".
-                  __s('Delete a rule')."\" onclick=\"$('#$rowid').remove();
-                  $('#searchcriteria ul li:first-child').addClass('headerRow').show();\"></i>&nbsp;";
+                  __s('Delete a rule')."\" onclick=\"removeSearchCriteria('$rowid');\"></i>&nbsp;";
 
       }
 
@@ -2550,8 +2553,7 @@ JAVASCRIPT;
 
       echo "<li class='metacriteria' id='$rowid'>";
       echo "<i class='far fa-minus-square' alt='-' title=\"".
-               __s('Delete a global rule')."\" onclick=\"$('#$rowid').remove();
-               $('#searchcriteria ul li:first-child').addClass('headerRow').show();\"></i>&nbsp;";
+               __s('Delete a global rule')."\" onclick=\"removeSearchCriteria('$rowid');\"></i>&nbsp;";
 
       // Display link item (not for the first item)
       Dropdown::showFromArray(
@@ -2634,8 +2636,7 @@ JAVASCRIPT;
 
       echo "<li class='normalcriteria$addclass' id='$rowid'>";
       echo "<i class='far fa-minus-square' alt='-' title=\"".
-               __s('Delete a rule')."\" onclick=\"$('#$rowid').remove();
-               $('#searchcriteria ul li:first-child').addClass('headerRow').show();\"></i>&nbsp;";
+               __s('Delete a rule')."\" onclick=\"removeSearchCriteria('$rowid');\"></i>&nbsp;";
       Dropdown::showFromArray("criteria{$prefix}[$num][link]", Search::getLogicalOperators(), [
          'value' => isset($criteria["link"]) ? $criteria["link"] : '',
          'width' => '80px'

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2202,14 +2202,13 @@ class Search {
          ]);
       }
 
-      echo "<li id='more-criteria'
-                class='normalcriteria headerRow'
-                style='display: none;'>...</li>";
+      $rand_criteria = mt_rand();
+      echo "<li id='more-criteria$rand_criteria'
+            class='normalcriteria headerRow'
+            style='display: none;'>...</li>";
 
       echo "</ul>";
-
       echo "<div class='search_actions'>";
-      $rand_criteria = mt_rand();
       $linked = self::getMetaItemtypeAvailable($itemtype);
       echo "<span id='addsearchcriteria$rand_criteria' class='secondary'>
                <i class='fas fa-plus-square'></i>
@@ -2265,7 +2264,7 @@ class Search {
                'p': $json_p
             })
             .done(function(data) {
-               $('#$searchcriteriatableid').append(data);
+               $(data).insertBefore('#more-criteria$rand_criteria');
                $nbsearchcountvar++;
             });
          });
@@ -2280,7 +2279,7 @@ class Search {
                'p': $json_p
             })
             .done(function(data) {
-               $('#$searchcriteriatableid').append(data);
+               $(data).insertBefore('#more-criteria$rand_criteria');
                $nbsearchcountvar++;
             });
          });
@@ -2295,11 +2294,14 @@ class Search {
                'p': $json_p
             })
             .done(function(data) {
-               $('#$searchcriteriatableid').append(data);
+               $(data).insertBefore('#more-criteria$rand_criteria');
                $nbsearchcountvar++;
             });
          });
+JAVASCRIPT;
 
+      if ($p['mainform']) {
+         $JS .= <<<JAVASCRIPT
          $('.fold-search').on('click', function(event) {
             event.preventDefault();
             $(this)
@@ -2308,6 +2310,7 @@ class Search {
             $('#searchcriteria ul li:not(:first-child)').toggle();
          });
 JAVASCRIPT;
+      }
       echo Html::scriptBlock($JS);
 
       if (count($p['addhidden'])) {
@@ -2406,7 +2409,8 @@ JAVASCRIPT;
             ]);
          }
          echo "<i class='far fa-minus-square' alt='-' title=\"".
-                  __s('Delete a rule')."\" onclick=\"$('#$rowid').remove();\"></i>&nbsp;";
+                  __s('Delete a rule')."\" onclick=\"$('#$rowid').remove();
+                  $('#searchcriteria ul li:first-child').addClass('headerRow').show();\"></i>&nbsp;";
 
       }
 
@@ -2546,7 +2550,8 @@ JAVASCRIPT;
 
       echo "<li class='metacriteria' id='$rowid'>";
       echo "<i class='far fa-minus-square' alt='-' title=\"".
-               __s('Delete a global rule')."\" onclick=\"$('#$rowid').remove();\"></i>&nbsp;";
+               __s('Delete a global rule')."\" onclick=\"$('#$rowid').remove();
+               $('#searchcriteria ul li:first-child').addClass('headerRow').show();\"></i>&nbsp;";
 
       // Display link item (not for the first item)
       Dropdown::showFromArray(
@@ -2629,7 +2634,8 @@ JAVASCRIPT;
 
       echo "<li class='normalcriteria$addclass' id='$rowid'>";
       echo "<i class='far fa-minus-square' alt='-' title=\"".
-               __s('Delete a rule')."\" onclick=\"$('#$rowid').remove();\"></i>&nbsp;";
+               __s('Delete a rule')."\" onclick=\"$('#$rowid').remove();
+               $('#searchcriteria ul li:first-child').addClass('headerRow').show();\"></i>&nbsp;";
       Dropdown::showFromArray("criteria{$prefix}[$num][link]", Search::getLogicalOperators(), [
          'value' => isset($criteria["link"]) ? $criteria["link"] : '',
          'width' => '80px'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Use unique ids for more-criteria list items (Required for other fixes listed)
Add new criteria before the more-criteria list item (Fixes issues with deleting any criteria that wasn't last)
When removing criteria, make sure the first list item is still the headerRow and visible (Fix issue with deleting first criteria while folded)
Removed duplicate folding JavaScript (Fix issue trying to fold after adding a new group but before committing the search)