### PR TITLE
 Loading Plugins in Automatic Tasks (Bug)

### DIFF
--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -815,7 +815,7 @@ class CronTask extends CommonDBTM{
                $_SESSION["glpicronuserrunning"] = "cron_".$crontask->fields['name'];
 
                if ($plug = isPluginItemType($crontask->fields['itemtype'])) {
-                  Plugin::load($plug['plugin'], true);
+                  Plugin::load(strtolower($plug['plugin']), true);
                }
                $fonction = [$crontask->fields['itemtype'],
                                  'cron' . $crontask->fields['name']];


### PR DESCRIPTION
When loading Plugins into tasks, the name of the class is considered in the default "capitalize". So if I have a plugin in the "test" folder, when trying to execute the Cron task it tries to access the "Test" folder and the following error is displayed:
"Can not redeclare plugin_teste_check_config () ...."

To solve, I added the method "strtolower" in loading Plugins.
Att. Maykon Douglas

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
