### PR TITLE
Addslashes on request build if unprotected quotes found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,11 +44,11 @@ shared: &shared
         name: Database tests
         command: php vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --configurations tests/telemetry.php --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/database
     - run:
-        name: Functionnal tests
-        command: php vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --configurations tests/telemetry.php --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/functionnal
-    - run:
         name: Unit tests
         command: php vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --configurations tests/telemetry.php --bootstrap-file tests/bootstrap.php --no-code-coverage -d tests/units
+    - run:
+        name: Functionnal tests
+        command: php vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --configurations tests/telemetry.php --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/functionnal
     - run:
         name: WEB tests
         command: |

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -770,10 +770,12 @@ class DBmysql {
 
          // backslash in regex is twice backslashed (first for PHP string and then for regex)
          $backslash = '\\\\';
-         // search for quotes or backslash preceded no backslashes or even count of backslashes
-         $regex = "/(?<!{$backslash})((?:{$backslash}{$backslash})*)['\"{$backslash}]{1}/";
+         // search for quotes preceded by no backslashes or even count of backslashes
+         $quotes_regex = "/(?<!{$backslash})((?:{$backslash}{$backslash})*)['\"]{1}/";
+         // search for backslash preceded no backslashes or even count of backslashes and not followed by backslashes
+         $backslashes_regex = "/(?<!{$backslash})((?:{$backslash}{$backslash})*)['\"{$backslash}]{1}(?!{$backslash})/";
          // escape if unprotected special chars are found
-         if (preg_match($regex, $value)) {
+         if (preg_match($quotes_regex, $value) || preg_match($backslashes_regex, $value)) {
             $value = $DB->escape($value);
          }
 

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -771,7 +771,7 @@ class DBmysql {
          // backslash in regex is twice backslashed (first for PHP string and then for regex)
          $backslash = '\\\\';
          // search for quotes or backslash preceded no backslashes or even count of backslashes
-         $regex = "/(?<!{$backslash})((?:{$backslash}{$backslash})*)['\"\\]{1}/";
+         $regex = "/(?<!{$backslash})((?:{$backslash}{$backslash})*)['\"{$backslash}]{1}/";
          // escape if unprotected special chars are found
          if (preg_match($regex, $value)) {
             $value = $DB->escape($value);

--- a/tests/units/DB.php
+++ b/tests/units/DB.php
@@ -97,7 +97,14 @@ class DB extends \GLPITestCase {
          ['null', 'NULL'],
          ['NULL', 'NULL'],
          ['`field`', '`field`'],
-         ['`field', "'`field'"]
+         ['`field', "'`field'"],
+         ['value with \ backslash', "'value with \\ backslash'"],
+         ["value with single ' quote", "'value with double \' quote '"],
+         ["value with escaped single \' quote", "'value with escaped single \' quote'"],
+         ["value with double escaped single \\\' quote", "'value with double escaped single \\\' quote'"],
+         ["value with not really escaped single \\' quote", "'value with not really escaped single \\\' quote'"],
+         ['value with double " quote', '\'value with double \" quote \''],
+         ['value with escaped double \" quote', '\'value with double \" quote \''],
       ];
    }
 

--- a/tests/units/DB.php
+++ b/tests/units/DB.php
@@ -98,13 +98,13 @@ class DB extends \GLPITestCase {
          ['NULL', 'NULL'],
          ['`field`', '`field`'],
          ['`field', "'`field'"],
-         ['value with \ backslash', "'value with \\ backslash'"],
-         ["value with single ' quote", "'value with double \' quote '"],
-         ["value with escaped single \' quote", "'value with escaped single \' quote'"],
-         ["value with double escaped single \\\' quote", "'value with double escaped single \\\' quote'"],
-         ["value with not really escaped single \\' quote", "'value with not really escaped single \\\' quote'"],
-         ['value with double " quote', '\'value with double \" quote \''],
-         ['value with escaped double \" quote', '\'value with double \" quote \''],
+         ["value with \\ backslash", "'value with \\\\ backslash'"],
+         ["value with single ' quote", "value with single \\' quote"],
+         ["value with escaped single \\' quote", "'value with escaped single \\' quote'"],
+         ["value with double escaped single \\\\\\' quote", "'value with double escaped single \\\\\\' quote'"],
+         ["value with not really escaped single \' quote", "'value with not really escaped single \' quote'"],
+         ["value with double \" quote", "'value with double \\\" quote'"],
+         ["value with escaped double \\\" quote", "'value with escaped double \\\" quote'"],
       ];
    }
 

--- a/tests/units/DB.php
+++ b/tests/units/DB.php
@@ -99,7 +99,7 @@ class DB extends \GLPITestCase {
          ['`field`', '`field`'],
          ['`field', "'`field'"],
          ["value with \\ backslash", "'value with \\\\ backslash'"],
-         ["value with single ' quote", "value with single \\' quote"],
+         ["value with single ' quote", "'value with single \\' quote'"],
          ["value with escaped single \\' quote", "'value with escaped single \\' quote'"],
          ["value with double escaped single \\\\\\' quote", "'value with double escaped single \\\\\\' quote'"],
          ["value with not really escaped single \' quote", "'value with not really escaped single \' quote'"],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Logic is simple: if an unprotected special char is found during request build, we protect the string using the escape function.

Not sure it is the best way to do.