### PR TITLE
Add hooks on notification recipient add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The present file will list all changes made to the project; according to the
    - `addHaving()`,
    - `giveItem()`
 - `NotificationTarget::getMode()` visibility is now `public`.
+- Added `add_recipient_to_target` hook, triggered when a recipient is added to a notification.
 
 #### Deprecated
 

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -511,6 +511,15 @@ class NotificationTarget extends CommonDBChild {
          $param[$target_field] = $data[$target_field];
          $this->target[$data[$target_field]] = $param;
       }
+
+      if (isset($data['users_id']) && $data['users_id']) {
+         $this->recipient_data = [
+            'itemtype' => User::class,
+            'items_id' => $data['users_id'],
+         ];
+         Plugin::doHook('add_recipient_to_target', $this);
+         unset($this->recipient_data);
+      }
    }
 
 
@@ -712,6 +721,16 @@ class NotificationTarget extends CommonDBChild {
       $iterator = $DB->request($criteria);
       while ($data = $iterator->next()) {
          $this->addToRecipientsList($data);
+      }
+
+      if ($manager != 1) {
+         // Do not consider it as a group notification if it only targets supervisor
+         $this->recipient_data = [
+            'itemtype' => Group::class,
+            'items_id' => $group_id,
+         ];
+         Plugin::doHook('add_recipient_to_target', $this);
+         unset($this->recipient_data);
       }
    }
 
@@ -975,6 +994,13 @@ class NotificationTarget extends CommonDBChild {
       while ($data = $iterator->next()) {
          $this->addToRecipientsList($data);
       }
+
+      $this->recipient_data = [
+         'itemtype' => Profile::class,
+         'items_id' => $profiles_id,
+      ];
+      Plugin::doHook('add_recipient_to_target', $this);
+      unset($this->recipient_data);
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I am developping a plugin where I want to map notification recipients to a specific information channel, but, for now, there is no way to get notified users, groups, or profiles in the notification process.