### PR TITLE
Fix slaticket cron

### DIFF
--- a/inc/slalevel_ticket.class.php
+++ b/inc/slalevel_ticket.class.php
@@ -160,7 +160,7 @@ class SlaLevel_Ticket extends CommonDBTM {
       $iterator = $DB->request([
          'SELECT'    => [
             'glpi_slalevels_tickets.*',
-            'glpi_slas.typa AS type',
+            'glpi_slas.type AS type',
          ],
          'FROM'      => 'glpi_slalevels_tickets',
          'LEFT JOIN' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

```
  *** MySQL query error:
  SQL: SELECT `glpi_slalevels_tickets`.*, `glpi_slas`.`typa` AS `type` FROM `glpi_slalevels_tickets` LEFT JOIN `glpi_slalevels` ON (`glpi_slalevels_tickets`.`slalevels_id` = `glpi_slalevels`.`id`) LEFT JOIN `glpi_slas` ON (`glpi_slalevels`.`slas_id` = `glpi_slas`.`id`) WHERE `glpi_slalevels_tickets`.`date` < NOW()
  Error: Unknown column 'glpi_slas.typa' in 'field list'
  Backtrace :
  inc/dbmysqliterator.class.php:95                   
  inc/dbmysql.class.php:561                          DBmysqlIterator->execute()
  inc/slalevel_ticket.class.php:181                  DBmysql->request()
  inc/crontask.class.php:825                         SlaLevel_Ticket::cronSlaTicket()
  front/cron.php:83                                  CronTask::launch()
```
