### PR TITLE
Display list of related notifications in notification templates

### DIFF
--- a/inc/notificationtemplate.class.php
+++ b/inc/notificationtemplate.class.php
@@ -75,6 +75,7 @@ class NotificationTemplate extends CommonDBTM {
       $ong = [];
       $this->addDefaultFormTab($ong);
       $this->addStandardTab('NotificationTemplateTranslation', $ong, $options);
+      $this->addStandardTab('Notification_NotificationTemplate', $ong, $options);
       $this->addStandardTab('Log', $ong, $options);
 
       return $ong;
@@ -554,6 +555,7 @@ class NotificationTemplate extends CommonDBTM {
 
       $this->deleteChildrenAndRelationsFromDb(
          [
+            Notification_NotificationTemplate::class,
             NotificationTemplateTranslation::class,
          ]
       );

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -807,8 +807,9 @@ $RELATION = [
    ],
 
    'glpi_notificationtemplates' => [
-      '_glpi_notificationtemplatetranslations' => 'notificationtemplates_id',
-      '_glpi_queuednotifications'              => 'notificationtemplates_id',
+      '_glpi_notifications_notificationtemplates' => 'notificationtemplates_id',
+      '_glpi_notificationtemplatetranslations'    => 'notificationtemplates_id',
+      '_glpi_queuednotifications'                 => 'notificationtemplates_id',
    ],
 
    'glpi_olalevels' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4694

1) Fix deletion of a notification template in order to clean all related elements.
2) New tab on notification template items to show related notifications. It does not prevent deletion of used templates, but now the fact that there is related notification is more visible.


