### PR TITLE
WIP : experiment - give input to canUpdateItem

### DIFF
--- a/front/apiclient.form.php
+++ b/front/apiclient.form.php
@@ -43,7 +43,7 @@ if (isset($_POST["add"])) {
    Html::back();
 
 } else if (isset($_POST["update"])) {
-   $client->check($_POST["id"], UPDATE);
+   $client->check($_POST["id"], UPDATE, $_POST);
    $client->update($_POST);
    Html::back();
 

--- a/front/budget.form.php
+++ b/front/budget.form.php
@@ -88,7 +88,7 @@ if (isset($_POST["add"])) {
    $budget->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $budget->check($_POST["id"], UPDATE);
+   $budget->check($_POST["id"], UPDATE, $_POST);
 
    if ($budget->update($_POST)) {
       Event::log($_POST["id"], "budget", 4, "financial",

--- a/front/cartridge.form.php
+++ b/front/cartridge.form.php
@@ -63,7 +63,7 @@ if (isset($_POST["add"])) {
 
 } else if (isset($_POST["install"])) {
    if ($_POST["cartridgeitems_id"]) {
-      $cartype->check($_POST["cartridgeitems_id"], UPDATE);
+      $cartype->check($_POST["cartridgeitems_id"], UPDATE, $_POST);
       for ($i=0; $i<$_POST["nbcart"]; $i++) {
          if ($cart->install($_POST["printers_id"], $_POST["cartridgeitems_id"])) {
             Event::log($_POST["printers_id"], "printers", 5, "inventory",
@@ -75,7 +75,7 @@ if (isset($_POST["add"])) {
    Html::redirect(Printer::getFormURLWithID($_POST["printers_id"]));
 
 } else if (isset($_POST["update"])) {
-   $cart->check($_POST["id"], UPDATE);
+   $cart->check($_POST["id"], UPDATE, $_POST);
 
    if ($cart->update($_POST)) {
       Event::log($_POST["printers_id"], "printers", 4, "inventory",

--- a/front/cartridgeitem.form.php
+++ b/front/cartridgeitem.form.php
@@ -85,7 +85,7 @@ if (isset($_POST["add"])) {
    $cartype->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $cartype->check($_POST["id"], UPDATE);
+   $cartype->check($_POST["id"], UPDATE, $_POST);
 
    if ($cartype->update($_POST)) {
       Event::log($_POST["id"], "cartridgeitems", 4, "inventory",

--- a/front/certificate.form.php
+++ b/front/certificate.form.php
@@ -86,7 +86,7 @@ if (isset($_POST["add"])) {
    $certificate->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $certificate->check($_POST["id"], UPDATE);
+   $certificate->check($_POST["id"], UPDATE, $_POST);
 
    $certificate->update($_POST);
    Event::log($_POST["id"], "certificates", 4, "inventory",

--- a/front/change.form.php
+++ b/front/change.form.php
@@ -82,7 +82,7 @@ if (isset($_POST["add"])) {
    $change->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $change->check($_POST["id"], UPDATE);
+   $change->check($_POST["id"], UPDATE, $_POST);
 
    $change->update($_POST);
    Event::log($_POST["id"], "change", 4, "maintain",

--- a/front/change_supplier.form.php
+++ b/front/change_supplier.form.php
@@ -46,7 +46,7 @@ Session ::checkLoginUser();
 Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
 
 if (isset($_POST["update"])) {
-   $link->check($_POST["id"], UPDATE);
+   $link->check($_POST["id"], UPDATE, $_POST);
 
    $link->update($_POST);
    echo "<script type='text/javascript' >\n";
@@ -68,5 +68,3 @@ if (isset($_POST["update"])) {
 }
 
 Html::popFooter();
-
-

--- a/front/change_user.form.php
+++ b/front/change_user.form.php
@@ -47,7 +47,7 @@ Session ::checkLoginUser();
 Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
 
 if (isset($_POST["update"])) {
-   $link->check($_POST["id"], UPDATE);
+   $link->check($_POST["id"], UPDATE, $_POST);
 
    $link->update($_POST);
    echo "<script type='text/javascript' >\n";

--- a/front/commonitilcost.form.php
+++ b/front/commonitilcost.form.php
@@ -77,7 +77,7 @@ if (isset($_POST["add"])) {
    Html::redirect($itemtype::getFormURLWithID($cost->fields[$fk]));
 
 } else if (isset($_POST["update"])) {
-   $cost->check($_POST["id"], UPDATE);
+   $cost->check($_POST["id"], UPDATE, $_POST);
 
    if ($cost->update($_POST)) {
       Event::log($cost->fields[$fk], strtolower($itemtype), 4, "tracking",

--- a/front/commonitiltask.form.php
+++ b/front/commonitiltask.form.php
@@ -72,7 +72,7 @@ if (isset($_POST["add"])) {
    Html::redirect($itemtype::getFormURLWithID($task->getField($fk)));
 
 } else if (isset($_POST["update"])) {
-   $task->check($_POST["id"], UPDATE);
+   $task->check($_POST["id"], UPDATE, $_POST);
    $task->update($_POST);
 
    Event::log($task->getField($fk), strtolower($itemtype), 4, "tracking",

--- a/front/commonitilvalidation.form.php
+++ b/front/commonitilvalidation.form.php
@@ -75,7 +75,7 @@ if (isset($_POST["add"])) {
    Html::back();
 
 } else if (isset($_POST["update"])) {
-   $validation->check($_POST['id'], UPDATE);
+   $validation->check($_POST['id'], UPDATE, $_POST);
    $validation->update($_POST);
    Event::log($validation->getField($fk), strtolower($itemtype), 4, "tracking",
         //TRANS: %s is the user login

--- a/front/computer.form.php
+++ b/front/computer.form.php
@@ -89,7 +89,7 @@ if (isset($_POST["add"])) {
 
    //update a computer
 } else if (isset($_POST["update"])) {
-   $computer->check($_POST['id'], UPDATE);
+   $computer->check($_POST['id'], UPDATE, $_POST);
    $computer->update($_POST);
    Event::log($_POST["id"], "computers", 4, "inventory",
               //TRANS: %s is the user login

--- a/front/computerantivirus.form.php
+++ b/front/computerantivirus.form.php
@@ -71,7 +71,7 @@ if (isset($_POST["add"])) {
                   ($computer->fields['is_template']?"&withtemplate=1":""));
 
 } else if (isset($_POST["update"])) {
-   $antivirus->check($_POST["id"], UPDATE);
+   $antivirus->check($_POST["id"], UPDATE, $_POST);
 
    if ($antivirus->update($_POST)) {
       Event::log($antivirus->fields['computers_id'], "computers", 4, "inventory",

--- a/front/computervirtualmachine.form.php
+++ b/front/computervirtualmachine.form.php
@@ -72,7 +72,7 @@ if (isset($_POST["add"])) {
                   ($computer->fields['is_template']?"&withtemplate=1":""));
 
 } else if (isset($_POST["update"])) {
-   $disk->check($_POST["id"], UPDATE);
+   $disk->check($_POST["id"], UPDATE, $_POST);
 
    if ($disk->update($_POST)) {
       Event::log($disk->fields['computers_id'], "computers", 4, "inventory",
@@ -87,4 +87,3 @@ if (isset($_POST["add"])) {
                         'computers_id' => $_GET["computers_id"]]);
    Html::footer();
 }
-

--- a/front/consumableitem.form.php
+++ b/front/consumableitem.form.php
@@ -85,7 +85,7 @@ if (isset($_POST["add"])) {
    $constype->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $constype->check($_POST["id"], UPDATE);
+   $constype->check($_POST["id"], UPDATE, $_POST);
 
    if ($constype->update($_POST)) {
       Event::log($_POST["id"], "consumableitems", 4, "inventory",

--- a/front/contact.form.php
+++ b/front/contact.form.php
@@ -92,7 +92,7 @@ if (isset($_GET['getvcard'])) {
    $contact->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $contact->check($_POST["id"], UPDATE);
+   $contact->check($_POST["id"], UPDATE, $_POST);
 
    if ($contact->update($_POST)) {
       Event::log($_POST["id"], "contacts", 4, "financial",

--- a/front/contract.form.php
+++ b/front/contract.form.php
@@ -90,7 +90,7 @@ if (isset($_POST["add"])) {
    $contract->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $contract->check($_POST['id'], UPDATE);
+   $contract->check($_POST['id'], UPDATE, $_POST);
 
    if ($contract->update($_POST)) {
       Event::log($_POST["id"], "contracts", 4, "financial",

--- a/front/contractcost.form.php
+++ b/front/contractcost.form.php
@@ -72,7 +72,7 @@ if (isset($_POST["add"])) {
                   ($contract->fields['is_template']?"&withtemplate=1":""));
 
 } else if (isset($_POST["update"])) {
-   $cost->check($_POST["id"], UPDATE);
+   $cost->check($_POST["id"], UPDATE, $_POST);
 
    if ($cost->update($_POST)) {
       Event::log($cost->fields['contracts_id'], "contracts", 4, "financial",

--- a/front/datacenter.form.php
+++ b/front/datacenter.form.php
@@ -85,7 +85,7 @@ if (isset($_POST["add"])) {
    $datacenter->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $datacenter->check($_POST["id"], UPDATE);
+   $datacenter->check($_POST["id"], UPDATE, $_POST);
 
    $datacenter->update($_POST);
    Event::log($_POST["id"], "datacenters", 4, "inventory",

--- a/front/dcroom.form.php
+++ b/front/dcroom.form.php
@@ -85,7 +85,7 @@ if (isset($_POST["add"])) {
    $room->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $room->check($_POST["id"], UPDATE);
+   $room->check($_POST["id"], UPDATE, $_POST);
 
    $room->update($_POST);
    Event::log($_POST["id"], "serverroms", 4, "inventory",

--- a/front/document.form.php
+++ b/front/document.form.php
@@ -103,7 +103,7 @@ if (isset($_POST["add"])) {
    $doc->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $doc->check($_POST["id"], UPDATE);
+   $doc->check($_POST["id"], UPDATE, $_POST);
 
    if ($doc->update($_POST)) {
       Event::log($_POST["id"], "documents", 4, "document",

--- a/front/dropdown.common.form.php
+++ b/front/dropdown.common.form.php
@@ -102,7 +102,7 @@ if (isset($_POST["add"])) {
    $dropdown->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $dropdown->check($_POST["id"], UPDATE);
+   $dropdown->check($_POST["id"], UPDATE, $_POST);
    $dropdown->update($_POST);
 
    Event::log($_POST["id"], get_class($dropdown), 4, "setup",

--- a/front/enclosure.form.php
+++ b/front/enclosure.form.php
@@ -85,7 +85,7 @@ if (isset($_POST["add"])) {
    $enclosure->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $enclosure->check($_POST["id"], UPDATE);
+   $enclosure->check($_POST["id"], UPDATE, $_POST);
 
    $enclosure->update($_POST);
    Event::log($_POST["id"], "enclosure", 4, "inventory",

--- a/front/group.form.php
+++ b/front/group.form.php
@@ -71,7 +71,7 @@ if (isset($_POST["add"])) {
    }
 
 } else if (isset($_POST["update"])) {
-   $group->check($_POST["id"], UPDATE);
+   $group->check($_POST["id"], UPDATE, $_POST);
    $group->update($_POST);
    Event::log($_POST["id"], "groups", 4, "setup",
               //TRANS: %s is the user login
@@ -97,4 +97,3 @@ if (isset($_POST["add"])) {
    $group->display(['id' =>$_GET["id"]]);
    Html::footer();
 }
-

--- a/front/infocom.form.php
+++ b/front/infocom.form.php
@@ -53,7 +53,7 @@ if (isset($_POST['add'])) {
    Html::back();
 
 } else if (isset($_POST["update"])) {
-   $ic->check($_POST["id"], UPDATE);
+   $ic->check($_POST["id"], UPDATE, $_POST);
 
    $ic->update($_POST);
    Event::log($_POST["id"], "infocom", 4, "financial",

--- a/front/item_device.common.form.php
+++ b/front/item_device.common.form.php
@@ -69,7 +69,7 @@ if (isset($_POST["purge"])) {
    Html::redirect($device->getLinkURL());
 
 } else if (isset($_POST["update"])) {
-   $item_device->check($_POST["id"], UPDATE);
+   $item_device->check($_POST["id"], UPDATE, $_POST);
    $item_device->update($_POST);
 
    Event::log($_POST["id"], get_class($item_device), 4, "setup",

--- a/front/item_disk.form.php
+++ b/front/item_disk.form.php
@@ -75,7 +75,7 @@ if (isset($_POST["add"])) {
                   ($item->fields['is_template']?"&withtemplate=1":""));
 
 } else if (isset($_POST["update"])) {
-   $disk->check($_POST["id"], UPDATE);
+   $disk->check($_POST["id"], UPDATE, $_POST);
 
    if ($disk->update($_POST)) {
       Event::log($disk->fields['items_id'], $disk->fields['itemtype'], 4, "inventory",
@@ -102,4 +102,3 @@ if (isset($_POST["add"])) {
    ]);
    Html::footer();
 }
-

--- a/front/item_enclosure.form.php
+++ b/front/item_enclosure.form.php
@@ -38,7 +38,7 @@ $ien = new \Item_Enclosure();
 $enclosure = new Enclosure();
 
 if (isset($_POST['update'])) {
-   $ien->check($_POST['id'], UPDATE);
+   $ien->check($_POST['id'], UPDATE, $_POST);
    //update existing relation
    if ($ien->update($_POST)) {
       $url = $enclosure->getFormURLWithID($_POST['enclosures_id']);

--- a/front/item_operatingsystem.form.php
+++ b/front/item_operatingsystem.form.php
@@ -37,7 +37,7 @@ Session::checkCentralAccess();
 $ios = new \Item_OperatingSystem();
 
 if (isset($_POST['update'])) {
-   $ios->check($_POST['id'], UPDATE);
+   $ios->check($_POST['id'], UPDATE, $_POST);
    //update existing OS
    $ios->update($_POST);
 

--- a/front/item_rack.form.php
+++ b/front/item_rack.form.php
@@ -38,7 +38,7 @@ $ira = new \Item_Rack();
 $rack = new Rack();
 
 if (isset($_POST['update'])) {
-   $ira->check($_POST['id'], UPDATE);
+   $ira->check($_POST['id'], UPDATE, $_POST);
    //update existing relation
    if ($ira->update($_POST)) {
       $url = $rack->getFormURLWithID($_POST['racks_id']);

--- a/front/itilfollowup.form.php
+++ b/front/itilfollowup.form.php
@@ -65,7 +65,7 @@ if (isset($_POST["add"])) {
    }
 
 } else if (isset($_POST["update"])) {
-   $fup->check($_POST['id'], UPDATE);
+   $fup->check($_POST['id'], UPDATE, $_POST);
    $fup->update($_POST);
 
    Event::log($fup->getField('items_id'), strtolower($_POST['itemtype']), 4, "tracking",

--- a/front/itilsolution.form.php
+++ b/front/itilsolution.form.php
@@ -62,7 +62,7 @@ if (isset($_POST["add"])) {
    }
 } else if (isset($_POST['update'])) {
    $solution->getFromDB($_POST['id']);
-   $solution->check($_POST['id'], UPDATE);
+   $solution->check($_POST['id'], UPDATE, $_POST);
    $solution->update($_POST);
    $handled = true;
    $redirect = $track->getLinkURL();

--- a/front/knowbaseitem.form.php
+++ b/front/knowbaseitem.form.php
@@ -64,7 +64,7 @@ if (isset($_POST["add"])) {
 
 } else if (isset($_POST["update"])) {
    // actualiser  un item dans la base de connaissances
-   $kb->check($_POST["id"], UPDATE);
+   $kb->check($_POST["id"], UPDATE, $_POST);
 
    $kb->update($_POST);
    Event::log($_POST["id"], "knowbaseitem", 5, "tools",
@@ -118,7 +118,7 @@ if (isset($_POST["add"])) {
    Html::back();
 
 } else if (isset($_GET["id"]) and isset($_GET['to_rev'])) {
-   $kb->check($_GET["id"], UPDATE);
+   $kb->check($_GET["id"], UPDATE, $_POST);
    if ($kb->revertTo($_GET['to_rev'])) {
       Session::addMessageAfterRedirect(
          sprintf(

--- a/front/knowbaseitemtranslation.form.php
+++ b/front/knowbaseitemtranslation.form.php
@@ -45,7 +45,7 @@ if (isset($_POST['add'])) {
    $translation->update($_POST);
    Html::back();
 } else if (isset($_GET["id"]) and isset($_GET['to_rev'])) {
-   $translation->check($_GET["id"], UPDATE);
+   $translation->check($_GET["id"], UPDATE, $_POST);
    if ($translation->revertTo($_GET['to_rev'])) {
       Session::addMessageAfterRedirect(
          sprintf(

--- a/front/line.form.php
+++ b/front/line.form.php
@@ -85,7 +85,7 @@ if (isset($_POST["add"])) {
    $line->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $line->check($_POST["id"], UPDATE);
+   $line->check($_POST["id"], UPDATE, $_POST);
 
    $line->update($_POST);
    Event::log($_POST["id"], "lines", 4, "financial",

--- a/front/link.form.php
+++ b/front/link.form.php
@@ -59,7 +59,7 @@ if (isset($_POST["add"])) {
    $link->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $link->check($_POST["id"], UPDATE);
+   $link->check($_POST["id"], UPDATE, $_POST);
    $link->update($_POST);
    Event::log($_POST["id"], "links", 4, "setup",
               //TRANS: %s is the user login

--- a/front/mailcollector.form.php
+++ b/front/mailcollector.form.php
@@ -64,7 +64,7 @@ if (isset($_POST["add"])) {
    $mailgate->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $mailgate->check($_POST['id'], UPDATE);
+   $mailgate->check($_POST['id'], UPDATE, $_POST);
    $mailgate->update($_POST);
 
    Event::log($_POST["id"], "mailcollector", 4, "setup",
@@ -83,4 +83,3 @@ if (isset($_POST["add"])) {
    $mailgate->display(['id' =>$_GET["id"]]);
    Html::footer();
 }
-

--- a/front/monitor.form.php
+++ b/front/monitor.form.php
@@ -85,7 +85,7 @@ if (isset($_POST["add"])) {
    $monitor->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $monitor->check($_POST["id"], UPDATE);
+   $monitor->check($_POST["id"], UPDATE, $_POST);
 
    $monitor->update($_POST);
    Event::log($_POST["id"], "monitors", 4, "inventory",
@@ -94,7 +94,7 @@ if (isset($_POST["add"])) {
    Html::back();
 
 } else if (isset($_POST["unglobalize"])) {
-   $monitor->check($_POST["id"], UPDATE);
+   $monitor->check($_POST["id"], UPDATE, $_POST);
 
    Computer_Item::unglobalizeItem($monitor);
    Event::log($_POST["id"], "monitors", 4, "inventory",

--- a/front/networkalias.form.php
+++ b/front/networkalias.form.php
@@ -69,7 +69,7 @@ if (isset($_POST["add"])) {
    }
 
 } else if (isset($_POST["update"])) {
-   $alias->check($_POST["id"], UPDATE);
+   $alias->check($_POST["id"], UPDATE, $_POST);
    $alias->update($_POST);
 
    Event::log($_POST["id"], $alias->getType(), 4, "setup",
@@ -94,4 +94,3 @@ if (isset($_GET['_in_modal'])) {
    $alias->display($_GET);
    Html::footer();
 }
-

--- a/front/networkequipment.form.php
+++ b/front/networkequipment.form.php
@@ -85,7 +85,7 @@ if (isset($_POST["add"])) {
    $netdevice->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $netdevice->check($_POST["id"], UPDATE);
+   $netdevice->check($_POST["id"], UPDATE, $_POST);
 
    $netdevice->update($_POST);
    Event::log($_POST["id"], "networkequipment", 4, "inventory",

--- a/front/networkname.form.php
+++ b/front/networkname.form.php
@@ -63,7 +63,7 @@ if (isset($_POST["add"])) {
    $nn->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $nn->check($_POST['id'], UPDATE);
+   $nn->check($_POST['id'], UPDATE, $_POST);
    $nn->update($_POST);
    Event::log($_POST["id"], "networkname", 4, "inventory",
               //TRANS: %s is the user login

--- a/front/networkport.form.php
+++ b/front/networkport.form.php
@@ -104,7 +104,7 @@ if (isset($_POST["add"])) {
    Html::redirect($CFG_GLPI["root_doc"]."/front/central.php");
 
 } else if (isset($_POST["update"])) {
-   $np->check($_POST['id'], UPDATE);
+   $np->check($_POST['id'], UPDATE, $_POST);
 
    $np->update($_POST);
    Event::log($_POST["id"], "networkport", 4, "inventory",

--- a/front/notepad.form.php
+++ b/front/notepad.form.php
@@ -57,7 +57,7 @@ if (isset($_POST['add'])) {
    Html::back();
 
 } else if (isset($_POST["update"])) {
-   $note->check($_POST["id"], UPDATE);
+   $note->check($_POST["id"], UPDATE, $_POST);
 
    $note->update($_POST);
    Event::log($_POST["id"], "notepad", 4, "tools",

--- a/front/notification.form.php
+++ b/front/notification.form.php
@@ -59,7 +59,7 @@ if (isset($_POST["add"])) {
    $notification->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $notification->check($_POST["id"], UPDATE);
+   $notification->check($_POST["id"], UPDATE, $_POST);
 
    $notification->update($_POST);
    Event::log($_POST["id"], "notifications", 4, "notification",

--- a/front/notification_notificationtemplate.form.php
+++ b/front/notification_notificationtemplate.form.php
@@ -55,7 +55,7 @@ if (isset($_POST["add"])) {
    $notiftpl->delete($_POST, 1);
    $notiftpl->redirectToList();
 } else if (isset($_POST["update"])) {
-   $notiftpl->check($_POST["id"], UPDATE);
+   $notiftpl->check($_POST["id"], UPDATE, $_POST);
 
    $notiftpl->update($_POST);
    Html::back();

--- a/front/notificationtemplate.form.php
+++ b/front/notificationtemplate.form.php
@@ -62,7 +62,7 @@ if (isset($_POST["add"])) {
    $notificationtemplate->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $notificationtemplate->check($_POST["id"], UPDATE);
+   $notificationtemplate->check($_POST["id"], UPDATE, $_POST);
 
    $notificationtemplate->update($_POST);
    Event::log($_POST["id"], "notificationtemplates", 4, "notification",

--- a/front/notificationtemplatetranslation.form.php
+++ b/front/notificationtemplatetranslation.form.php
@@ -59,7 +59,7 @@ if (isset($_POST["add"])) {
    $language->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $language->check($_POST["id"], UPDATE);
+   $language->check($_POST["id"], UPDATE, $_POST);
    $language->update($_POST);
 
    Event::log($_POST["id"], "notificationtemplatetranslations", 4, "notification",

--- a/front/ola.form.php
+++ b/front/ola.form.php
@@ -68,7 +68,7 @@ if (isset($_POST["add"])) {
    $ola->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $ola->check($_POST["id"], UPDATE);
+   $ola->check($_POST["id"], UPDATE, $_POST);
    $ola->update($_POST);
 
    Event::log($_POST["id"], "olas", 4, "setup",

--- a/front/olalevel.form.php
+++ b/front/olalevel.form.php
@@ -42,7 +42,7 @@ include ('../inc/includes.php');
 $item = new OlaLevel();
 
 if (isset($_POST["update"])) {
-   $item->check($_POST["id"], UPDATE);
+   $item->check($_POST["id"], UPDATE, $_POST);
 
    $item->update($_POST);
 

--- a/front/olalevelaction.form.php
+++ b/front/olalevelaction.form.php
@@ -44,7 +44,7 @@ if (isset($_POST["add"])) {
 
    Html::back();
 } else if (isset($_POST["update"])) {
-   $criteria->check($_POST['id'], UPDATE);
+   $criteria->check($_POST['id'], UPDATE, $_POST);
    $criteria->update($_POST);
 
    Html::back();

--- a/front/olalevelcriteria.form.php
+++ b/front/olalevelcriteria.form.php
@@ -45,7 +45,7 @@ if (isset($_POST["add"])) {
    Html::back();
 
 } else if (isset($_POST["update"])) {
-   $criteria->check($_POST['id'], UPDATE);
+   $criteria->check($_POST['id'], UPDATE, $_POST);
    $criteria->update($_POST);
 
    Html::back();

--- a/front/pdu.form.php
+++ b/front/pdu.form.php
@@ -85,7 +85,7 @@ if (isset($_POST["add"])) {
    $pdu->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $pdu->check($_POST["id"], UPDATE);
+   $pdu->check($_POST["id"], UPDATE, $_POST);
 
    $pdu->update($_POST);
    Event::log($_POST["id"], "pdus", 4, "inventory",

--- a/front/pdu_plug.form.php
+++ b/front/pdu_plug.form.php
@@ -38,7 +38,7 @@ $pdup = new \Pdu_Plug();
 $pdu = new PDU();
 
 if (isset($_POST['update'])) {
-   $pdup->check($_POST['id'], UPDATE);
+   $pdup->check($_POST['id'], UPDATE, $_POST);
    //update existing relation
    if ($pdup->update($_POST)) {
       $url = $pdu->getFormURLWithID($_POST['pdus_id']);

--- a/front/pdu_rack.form.php
+++ b/front/pdu_rack.form.php
@@ -38,7 +38,7 @@ $pra  = new \PDU_Rack();
 $rack = new Rack();
 
 if (isset($_POST['update'])) {
-   $pra->check($_POST['id'], UPDATE);
+   $pra->check($_POST['id'], UPDATE, $_POST);
    //update existing relation
    if ($pra->update($_POST)) {
       $url = $rack->getFormURLWithID($_POST['racks_id']);

--- a/front/peripheral.form.php
+++ b/front/peripheral.form.php
@@ -85,7 +85,7 @@ if (isset($_POST["add"])) {
    $peripheral->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $peripheral->check($_POST["id"], UPDATE);
+   $peripheral->check($_POST["id"], UPDATE, $_POST);
 
    $peripheral->update($_POST);
    Event::log($_POST["id"], "peripherals", 4, "inventory",
@@ -94,7 +94,7 @@ if (isset($_POST["add"])) {
    Html::back();
 
 } else if (isset($_POST["unglobalize"])) {
-   $peripheral->check($_POST["id"], UPDATE);
+   $peripheral->check($_POST["id"], UPDATE, $_POST);
 
    Computer_Item::unglobalizeItem($peripheral);
    Event::log($_POST["id"], "peripherals", 4, "inventory",

--- a/front/phone.form.php
+++ b/front/phone.form.php
@@ -85,7 +85,7 @@ if (isset($_POST["add"])) {
    $phone->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $phone->check($_POST["id"], UPDATE);
+   $phone->check($_POST["id"], UPDATE, $_POST);
 
    $phone->update($_POST);
    Event::log($_POST["id"], "phones", 4, "inventory",
@@ -94,7 +94,7 @@ if (isset($_POST["add"])) {
    Html::back();
 
 } else if (isset($_POST["unglobalize"])) {
-   $phone->check($_POST["id"], UPDATE);
+   $phone->check($_POST["id"], UPDATE, $_POST);
 
    Computer_Item::unglobalizeItem($phone);
    Event::log($_POST["id"], "phones", 4, "inventory",

--- a/front/printer.form.php
+++ b/front/printer.form.php
@@ -84,7 +84,7 @@ if (isset($_POST["add"])) {
    $print->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $print->check($_POST["id"], UPDATE);
+   $print->check($_POST["id"], UPDATE, $_POST);
 
    $print->update($_POST);
    Event::log($_POST["id"], "printers", 4, "inventory",
@@ -93,7 +93,7 @@ if (isset($_POST["add"])) {
    Html::back();
 
 } else if (isset($_POST["unglobalize"])) {
-   $print->check($_POST["id"], UPDATE);
+   $print->check($_POST["id"], UPDATE, $_POST);
 
    Computer_Item::unglobalizeItem($print);
    Event::log($_POST["id"], "printers", 4, "inventory",

--- a/front/problem.form.php
+++ b/front/problem.form.php
@@ -81,7 +81,7 @@ if (isset($_POST["add"])) {
    $problem->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $problem->check($_POST["id"], UPDATE);
+   $problem->check($_POST["id"], UPDATE, $_POST);
 
    $problem->update($_POST);
    Event::log($_POST["id"], "problem", 4, "maintain",

--- a/front/problem_supplier.form.php
+++ b/front/problem_supplier.form.php
@@ -46,7 +46,7 @@ Session ::checkLoginUser();
 Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
 
 if (isset($_POST["update"])) {
-   $link->check($_POST["id"], UPDATE);
+   $link->check($_POST["id"], UPDATE, $_POST);
 
    $link->update($_POST);
    echo "<script type='text/javascript' >\n";

--- a/front/problem_user.form.php
+++ b/front/problem_user.form.php
@@ -47,7 +47,7 @@ Session ::checkLoginUser();
 Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
 
 if (isset($_POST["update"])) {
-   $link->check($_POST["id"], UPDATE);
+   $link->check($_POST["id"], UPDATE, $_POST);
    $link->update($_POST);
 
 } else if (isset($_POST['delete'])) {

--- a/front/profile.form.php
+++ b/front/profile.form.php
@@ -57,7 +57,7 @@ if (isset($_POST["add"])) {
 
 } else if (isset($_POST["update"])
            || isset($_POST["interface"])) {
-   $prof->check($_POST['id'], UPDATE);
+   $prof->check($_POST['id'], UPDATE, $_POST);
 
    $prof->update($_POST);
    Html::back();

--- a/front/project.form.php
+++ b/front/project.form.php
@@ -89,7 +89,7 @@ if (isset($_POST["add"])) {
    $project->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $project->check($_POST["id"], UPDATE);
+   $project->check($_POST["id"], UPDATE, $_POST);
 
    $project->update($_POST);
    Event::log($_POST["id"], "project", 4, "maintain",

--- a/front/projectcost.form.php
+++ b/front/projectcost.form.php
@@ -70,7 +70,7 @@ if (isset($_POST["add"])) {
    Html::redirect(Toolbox::getItemTypeFormURL('Project').'?id='.$cost->fields['projects_id']);
 
 } else if (isset($_POST["update"])) {
-   $cost->check($_POST["id"], UPDATE);
+   $cost->check($_POST["id"], UPDATE, $_POST);
 
    if ($cost->update($_POST)) {
       Event::log($cost->fields['projects_id'], "project", 4, "maintain",

--- a/front/projecttask.form.php
+++ b/front/projecttask.form.php
@@ -74,7 +74,7 @@ if (isset($_POST["add"])) {
    Html::redirect(Project::getFormURLWithID($task->fields['projects_id']));
 
 } else if (isset($_POST["update"])) {
-   $task->check($_POST["id"], UPDATE);
+   $task->check($_POST["id"], UPDATE, $_POST);
    $task->update($_POST);
 
    Event::log($task->fields['projects_id'], 'project', 4, "maintain",
@@ -92,4 +92,3 @@ if (isset($_POST["add"])) {
    $task->display($_GET);
    Html::footer();
 }
-

--- a/front/rack.form.php
+++ b/front/rack.form.php
@@ -85,7 +85,7 @@ if (isset($_POST["add"])) {
    $rack->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $rack->check($_POST["id"], UPDATE);
+   $rack->check($_POST["id"], UPDATE, $_POST);
 
    $rack->update($_POST);
    Event::log($_POST["id"], "racks", 4, "inventory",

--- a/front/reminder.form.php
+++ b/front/reminder.form.php
@@ -65,7 +65,7 @@ if (isset($_POST["add"])) {
    }
 
 } else if (isset($_POST["update"])) {
-   $remind->check($_POST["id"], UPDATE);   // Right to update the reminder
+   $remind->check($_POST["id"], UPDATE, $_POST);   // Right to update the reminder
 
    $remind->update($_POST);
    Event::log($_POST["id"], "reminder", 4, "tools",
@@ -124,4 +124,3 @@ if (isset($_POST["add"])) {
       Html::footer();
    }
 }
-

--- a/front/reservationitem.form.php
+++ b/front/reservationitem.form.php
@@ -79,7 +79,7 @@ if (isset($_POST["add"])) {
    Html::back();
 
 } else if (isset($_POST["update"])) {
-   $ri->check($_POST["id"], UPDATE);
+   $ri->check($_POST["id"], UPDATE, $_POST);
    $ri->update($_POST);
    Event::log($_POST['id'], "reservationitem", 4, "inventory",
               //TRANS: %s is the user login

--- a/front/rssfeed.form.php
+++ b/front/rssfeed.form.php
@@ -62,7 +62,7 @@ if (isset($_POST["add"])) {
    $rssfeed->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $rssfeed->check($_POST["id"], UPDATE);   // Right to update the rssfeed
+   $rssfeed->check($_POST["id"], UPDATE, $_POST);   // Right to update the rssfeed
 
    $rssfeed->update($_POST);
    Event::log($_POST["id"], "rssfeed", 4, "tools",

--- a/front/ruleaction.form.php
+++ b/front/ruleaction.form.php
@@ -46,7 +46,7 @@ if (isset($_POST["add"])) {
 
    Html::back();
 } else if (isset($_POST["update"])) {
-   $action->check($_POST['id'], UPDATE);
+   $action->check($_POST['id'], UPDATE, $_POST);
    $action->update($_POST);
 
    Html::back();
@@ -56,4 +56,3 @@ if (isset($_POST["add"])) {
 
    Html::back();
 }
-

--- a/front/rulecriteria.form.php
+++ b/front/rulecriteria.form.php
@@ -47,7 +47,7 @@ if (isset($_POST["add"])) {
    Html::back();
 
 } else if (isset($_POST["update"])) {
-   $criteria->check($_POST['id'], UPDATE);
+   $criteria->check($_POST['id'], UPDATE, $_POST);
    $criteria->update($_POST);
 
    Html::back();

--- a/front/savedsearch.form.php
+++ b/front/savedsearch.form.php
@@ -57,7 +57,7 @@ if (isset($_POST["add"])) {
    $savedsearch->redirectToList();
 } else if (isset($_POST["update"])) {
    //update a saved search
-   $savedsearch->check($_POST['id'], UPDATE);
+   $savedsearch->check($_POST['id'], UPDATE, $_POST);
    $savedsearch->update($_POST);
    Html::back();
 } else if (isset($_GET['create_notif'])) {

--- a/front/savedsearch_alert.form.php
+++ b/front/savedsearch_alert.form.php
@@ -70,7 +70,7 @@ if (isset($_POST["add"])) {
    Html::redirect(Toolbox::getItemTypeFormURL('SavedSearch').'?id='.$alert->fields['savedsearches_id']);
 
 } else if (isset($_POST["update"])) {
-   $alert->check($_POST["id"], UPDATE);
+   $alert->check($_POST["id"], UPDATE, $_POST);
 
    if ($alert->update($_POST)) {
       Event::log($alert->fields['savedsearches_id'], "savedsearches", 4, "inventory",

--- a/front/sla.form.php
+++ b/front/sla.form.php
@@ -64,7 +64,7 @@ if (isset($_POST["add"])) {
    $sla->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $sla->check($_POST["id"], UPDATE);
+   $sla->check($_POST["id"], UPDATE, $_POST);
    $sla->update($_POST);
 
    Event::log($_POST["id"], "slas", 4, "setup",
@@ -78,4 +78,3 @@ if (isset($_POST["add"])) {
    $sla->display(['id' => $_GET["id"]]);
    Html::footer();
 }
-

--- a/front/slalevel.form.php
+++ b/front/slalevel.form.php
@@ -38,7 +38,7 @@ include ('../inc/includes.php');
 $item = new SlaLevel();
 
 if (isset($_POST["update"])) {
-   $item->check($_POST["id"], UPDATE);
+   $item->check($_POST["id"], UPDATE, $_POST);
 
    $item->update($_POST);
 
@@ -97,4 +97,3 @@ if (isset($_POST["update"])) {
    $item->display(['id' => $_GET["id"]]);
    Html::footer();
 }
-

--- a/front/slalevelaction.form.php
+++ b/front/slalevelaction.form.php
@@ -44,7 +44,7 @@ if (isset($_POST["add"])) {
 
    Html::back();
 } else if (isset($_POST["update"])) {
-   $criteria->check($_POST['id'], UPDATE);
+   $criteria->check($_POST['id'], UPDATE, $_POST);
    $criteria->update($_POST);
 
    Html::back();

--- a/front/slalevelcriteria.form.php
+++ b/front/slalevelcriteria.form.php
@@ -45,7 +45,7 @@ if (isset($_POST["add"])) {
    Html::back();
 
 } else if (isset($_POST["update"])) {
-   $criteria->check($_POST['id'], UPDATE);
+   $criteria->check($_POST['id'], UPDATE, $_POST);
    $criteria->update($_POST);
 
    Html::back();

--- a/front/slm.form.php
+++ b/front/slm.form.php
@@ -68,7 +68,7 @@ if (isset($_POST["add"])) {
    $slm->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $slm->check($_POST["id"], UPDATE);
+   $slm->check($_POST["id"], UPDATE, $_POST);
    $slm->update($_POST);
 
    Event::log($_POST["id"], "slms", 4, "setup",

--- a/front/software.form.php
+++ b/front/software.form.php
@@ -85,7 +85,7 @@ if (isset($_POST["add"])) {
    $soft->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $soft->check($_POST["id"], UPDATE);
+   $soft->check($_POST["id"], UPDATE, $_POST);
 
    $soft->update($_POST);
    Event::log($_POST["id"], "software", 4, "inventory",

--- a/front/softwarelicense.form.php
+++ b/front/softwarelicense.form.php
@@ -85,7 +85,7 @@ if (isset($_POST["add"])) {
    $license->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $license->check($_POST['id'], UPDATE);
+   $license->check($_POST['id'], UPDATE, $_POST);
 
    $license->update($_POST);
    Event::log($license->fields['softwares_id'], "software", 4, "inventory",

--- a/front/softwareversion.form.php
+++ b/front/softwareversion.form.php
@@ -65,7 +65,7 @@ if (isset($_POST["add"])) {
    $version->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $version->check($_POST['id'], UPDATE);
+   $version->check($_POST['id'], UPDATE, $_POST);
 
    $version->update($_POST);
    Event::log($version->fields['softwares_id'], "software", 4, "inventory",

--- a/front/supplier.form.php
+++ b/front/supplier.form.php
@@ -82,7 +82,7 @@ if (isset($_POST["add"])) {
    $ent->redirectToList();
 
 } else if (isset($_POST["update"])) {
-   $ent->check($_POST["id"], UPDATE);
+   $ent->check($_POST["id"], UPDATE, $_POST);
    $ent->update($_POST);
    Event::log($_POST["id"], "suppliers", 4, "financial",
                //TRANS: %s is the user login

--- a/front/supplier_ticket.form.php
+++ b/front/supplier_ticket.form.php
@@ -46,7 +46,7 @@ Session ::checkLoginUser();
 Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
 
 if (isset($_POST["update"])) {
-   $link->check($_POST["id"], UPDATE);
+   $link->check($_POST["id"], UPDATE, $_POST);
 
    $link->update($_POST);
    echo "<script type='text/javascript' >\n";

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -68,7 +68,7 @@ if (isset($_POST["add"])) {
    Html::back();
 
 } else if (isset($_POST['update'])) {
-   $track->check($_POST['id'], UPDATE);
+   $track->check($_POST['id'], UPDATE, $_POST);
 
    $track->update($_POST);
 
@@ -135,7 +135,7 @@ if (isset($_POST["add"])) {
    $track->redirectToList();
 
 } else if (isset($_POST['sla_delete'])) {
-   $track->check($_POST["id"], UPDATE);
+   $track->check($_POST["id"], UPDATE, $_POST);
 
    $track->deleteLevelAgreement("SLA", $_POST["id"], $_POST['type'], $_POST['delete_date']);
    Event::log($_POST["id"], "ticket", 4, "tracking",
@@ -145,7 +145,7 @@ if (isset($_POST["add"])) {
    Html::redirect(Ticket::getFormURLWithID($_POST["id"]));
 
 } else if (isset($_POST['ola_delete'])) {
-   $track->check($_POST["id"], UPDATE);
+   $track->check($_POST["id"], UPDATE, $_POST);
 
    $track->deleteLevelAgreement("OLA", $_POST["id"], $_POST['type'], $_POST['delete_date']);
    Event::log($_POST["id"], "ticket", 4, "tracking",

--- a/front/ticket_user.form.php
+++ b/front/ticket_user.form.php
@@ -43,7 +43,7 @@ Session ::checkLoginUser();
 Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
 
 if (isset($_POST["update"])) {
-   $link->check($_POST["id"], UPDATE);
+   $link->check($_POST["id"], UPDATE, $_POST);
 
    if ($link->update($_POST)) {
       echo "<script type='text/javascript' >\n";
@@ -75,4 +75,3 @@ if (isset($_POST["update"])) {
 }
 
 Html::popFooter();
-

--- a/front/ticketcost.form.php
+++ b/front/ticketcost.form.php
@@ -61,7 +61,7 @@ if (isset($_POST["add"])) {
    Html::redirect(Toolbox::getItemTypeFormURL('Ticket').'?id='.$cost->fields['tickets_id']);
 
 } else if (isset($_POST["update"])) {
-   $cost->check($_POST["id"], UPDATE);
+   $cost->check($_POST["id"], UPDATE, $_POST);
 
    if ($cost->update($_POST)) {
       Event::log($cost->fields['tickets_id'], "tickets", 4, "tracking",

--- a/front/ticketsatisfaction.form.php
+++ b/front/ticketsatisfaction.form.php
@@ -39,7 +39,7 @@ Session::checkLoginUser();
 $inquest = new TicketSatisfaction();
 
 if (isset($_POST["update"])) {
-   $inquest->check($_POST["tickets_id"], UPDATE);
+   $inquest->check($_POST["tickets_id"], UPDATE, $_POST);
    $inquest->update($_POST);
 
    Event::log($inquest->getField('tickets_id'), "ticket", 4, "tracking",

--- a/front/transfer.form.php
+++ b/front/transfer.form.php
@@ -60,7 +60,7 @@ if (isset($_POST["add"])) {
    Html::redirect($CFG_GLPI["root_doc"]."/front/transfer.php");
 
 } else if (isset($_POST["update"])) {
-   $transfer->check($_POST["id"], UPDATE);
+   $transfer->check($_POST["id"], UPDATE, $_POST);
 
    $transfer->update($_POST);
    Event::log($_POST["id"], "transfers", 4, "setup",

--- a/front/user.form.php
+++ b/front/user.form.php
@@ -103,7 +103,7 @@ if (isset($_GET['getvcard'])) {
    Html::back();
 
 } else if (isset($_POST["update"])) {
-   $user->check($_POST['id'], UPDATE);
+   $user->check($_POST['id'], UPDATE, $_POST);
    $user->update($_POST);
    Event::log($_POST['id'], "users", 5, "setup",
               //TRANS: %s is the user login

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1840,19 +1840,20 @@ abstract class API extends CommonGLPI {
          $failed       = 0;
          $index        = 0;
          foreach ($input as $object) {
+            $object      = self::inputObjectToArray($object);
             $current_res = [];
-            if (isset($object->id)) {
-               if (!$item->getFromDB($object->id)) {
+            if (isset($object['id'])) {
+               if (!$item->getFromDB($object['id'])) {
                   $failed++;
-                  $current_res = [$object->id => false,
+                  $current_res = [$object['id'] => false,
                                   'message'   => __("Item not found")];
                   continue;
                }
 
                //check rights
-               if (!$item->can($object->id, UPDATE)) {
+               if (!$item->can($object['id'], UPDATE)) {
                   $failed++;
-                  $current_res = [$object->id => false,
+                  $current_res = [$object['id'] => false,
                                  'message'    => __("You don't have permission to perform this action.")];
                } else {
                   // if parent key not provided in input and present in parameter
@@ -1867,7 +1868,7 @@ abstract class API extends CommonGLPI {
                   }
 
                   //update item
-                  $object = Toolbox::sanitize((array)$object);
+                  $object = Toolbox::sanitize($object);
                   $update_return = $item->update($object);
                   if ($update_return === false) {
                      $failed++;

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1857,8 +1857,8 @@ abstract class API extends CommonGLPI {
                                  'message'    => __("You don't have permission to perform this action.")];
                } else {
                   // if parent key not provided in input and present in parameter
-                  // (detected from url for example), try to appent it do input
-                  // This is usefull to have logs in parent (and avoid some warnings in commonDBTM)
+                  // (detected from url for example), try to append it do input
+                  // This is useful to have logs in parent (and avoid some warnings in commonDBTM)
                   if (isset($params['parent_itemtype'])
                       && isset($params['parent_id'])) {
                      $fk_parent = getForeignKeyFieldForItemType($params['parent_itemtype']);

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1851,7 +1851,7 @@ abstract class API extends CommonGLPI {
                }
 
                //check rights
-               if (!$item->can($object['id'], UPDATE)) {
+               if (!$item->can($object['id'], UPDATE, $object)) {
                   $failed++;
                   $current_res = [$object['id'] => false,
                                  'message'    => __("You don't have permission to perform this action.")];

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -2807,6 +2807,11 @@ class CommonDBTM extends CommonGLPI {
          }
       }
 
+      if (is_array($input)) {
+         // Store to be available for others functions
+         $this->input = $input;
+      }
+
       /* Hook to restrict user right on current item @since 9.2 */
       $this->right = $right;
       Plugin::doHook("item_can", $this);


### PR DESCRIPTION
Hi

In Flyve MDM there is a growing need to allow or forbid update of an itemtype depending on the data to update, the user ID compared against users_id foreign key and the current profile of the user.

the method canCreateItem() can access the payload, see CommonDBTM::can()
https://github.com/glpi-project/glpi/blob/9.3/bugfixes/inc/commondbtm.class.php#L2755

If item does not exists yet, the payload is added in $item->input, then canCreatep() and canCreateItem() are called. They may access $item->input and do some specific checks.

However this is not possible when we update an item. The idea is to ad  the same mechanism to allow itemtypes to do checks in the data from the DB (already accessible via $item->fields) and also check if some fields may be updated depending on current user context.

This allows to keep rights checks in can*() and can*Item() methods in one hand, and payload preparation in prepareInputForUpdate() in the other hand. 

First commits of the PR implement the need, and one of them changes many fields in front/ folder to pass the payload. This commit is useful to ensure that calls from the UI and from the API are done the same way. Please not that some checks on the UPDATE right are not updated because they are specific cases and need deeper analysis.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |