### PR TITLE
Fix ticket last editor in mailcollector context; fixes #4924

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -391,12 +391,6 @@ class Ticket extends CommonITILObject {
     */
    public function canTakeIntoAccount() {
 
-      // Ticket already taken into account
-      if (array_key_exists('takeintoaccount_delay_stat', $this->fields)
-          && $this->fields['takeintoaccount_delay_stat'] != 0) {
-         return false;
-      }
-
       // Can take into account if user is assigned user
       if ($this->isUser(CommonITILActor::ASSIGN, Session::getLoginUserID())
           || (isset($_SESSION["glpigroups"])
@@ -424,6 +418,17 @@ class Ticket extends CommonITILObject {
       // Can take into account if user has rights to add tasks or followups,
       // assuming that users that does not have those rights cannot treat the ticket.
       return $canAddTask || $canAddFollowup;
+   }
+
+   /**
+    * Check if ticket has already been taken into account.
+    *
+    * @return boolean
+    */
+   public function isAlreadyTakenIntoAccount() {
+
+      return array_key_exists('takeintoaccount_delay_stat', $this->fields)
+          && $this->fields['takeintoaccount_delay_stat'] != 0;
    }
 
    /**
@@ -1585,7 +1590,7 @@ class Ticket extends CommonITILObject {
 
    function pre_updateInDB() {
 
-      if ($this->canTakeIntoAccount()) {
+      if (!$this->isAlreadyTakenIntoAccount() && $this->canTakeIntoAccount()) {
          $this->updates[]                            = "takeintoaccount_delay_stat";
          $this->fields['takeintoaccount_delay_stat'] = $this->computeTakeIntoAccountDelayStat();
       }
@@ -2550,7 +2555,9 @@ class Ticket extends CommonITILObject {
    function updateDateMod($ID, $no_stat_computation = false, $users_id_lastupdater = 0) {
 
       if ($this->getFromDB($ID)) {
-         if (!$no_stat_computation && ($this->canTakeIntoAccount() || isCommandLine())) {
+         if (!$no_stat_computation
+             && !$this->isAlreadyTakenIntoAccount()
+             && ($this->canTakeIntoAccount() || isCommandLine())) {
             return $this->update(
                [
                   'id'                         => $ID,

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -2029,17 +2029,6 @@ class Ticket extends DbTestCase {
             ],
             'expected' => true, // has not enough rights so cannot take into account
          ],
-         [
-            'input'    => [
-               '_users_id_requester'        => ['3'], // "post-only"
-               'takeintoaccount_delay_stat' => '10',
-            ],
-            'user'     => [
-               'login'    => 'tech',
-               'password' => 'tech',
-            ],
-            'expected' => false, // ticket is already taken into account
-         ],
          /* Cannot test that requester user can take ticket into account if also assigned
           * because assigning a user makes the ticket automatically taken into account.
           * We decided with @orthagh to keep this rule even if it cannot be tested yet.
@@ -2102,5 +2091,46 @@ class Ticket extends DbTestCase {
 
       // Verify result
       $this->boolean($ticket->canTakeIntoAccount())->isEqualTo($expected);
+   }
+
+   /**
+    * Tests taken into account state.
+    */
+   public function testIsAlreadyTakenIntoAccount() {
+
+      // Create a ticket
+      $this->login();
+      $_SESSION['glpiset_default_tech'] = false;
+      $ticket = new \Ticket();
+      $ticket_id = $ticket->add(
+         [
+            'name'    => '',
+            'content' => 'A ticket to check isAlreadyTakenIntoAccount() results',
+         ]
+      );
+      $this->integer((int)$ticket_id)->isGreaterThan(0);
+
+      // Reload ticket to get all default fields values
+      $this->boolean($ticket->getFromDB($ticket_id))->isTrue();
+
+      // Empty ticket is not taken into account
+      $this->boolean($ticket->isAlreadyTakenIntoAccount())->isFalse();
+
+      // Take into account
+      $this->login('tech', 'tech');
+      $ticket_user = new \Ticket_User();
+      $ticket_user_id = $ticket_user->add(
+         [
+            'tickets_id'       => $ticket_id,
+            'users_id'         => \Session::getLoginUserID(),
+            'use_notification' => 1,
+            'type'             => \CommonITILActor::ASSIGN
+         ]
+      );
+      $this->integer((int)$ticket_user_id)->isGreaterThan(0);
+
+      // Assign to tech made ticket taken into account
+      $this->boolean($ticket->getFromDB($ticket_id))->isTrue();
+      $this->boolean($ticket->isAlreadyTakenIntoAccount())->isTrue();
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4924 

Commit 894c1db98cd996897151be2732118a0cff83a2f5 introduced a bug in command line context (mail collector). Even when 'takeintoaccount_delay_stat' was already set, it was recomputed, preventing the call of the method responsible of defining the last updater (in https://github.com/glpi-project/glpi/pull/4969/files#diff-007edb12589cf3c8df3121cd7b19028aR2570).