### PR TITLE
Deprecate NotificationTargetCommonITILObject::getProfileJoinSql()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The following methods have been deprecated:
 - `Ticket::showMassiveActionsSubForm()`
 - `NotificationTarget::getProfileJoinSql()`
 - `NotificationTarget::getDistinctUserSql()`
+- `NotificationTargetCommonITILObject::getProfileJoinSql()`
 - `RuleCollection::getRuleListQuery()`
 - `getNextItem()`
 - `getPreviousItem()`

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -648,6 +648,8 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
 
    public function getProfileJoinSql() {
 
+      Toolbox::deprecated('Use getProfileJoinCriteria');
+
       $query = parent::getProfileJoinSql();
 
       if ($this->isPrivate()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Parent class method `NotificationTarget::getProfileJoinSql()` is deprecated and this one is not even used.