### PR TITLE
Show tokens to other users with right to read Users;fixes #5013

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -2257,6 +2257,47 @@ class User extends CommonDBTM {
 
          }
 
+         echo "<tr class='tab_bg_1'><th colspan='4'>". __('Remote access keys') ."</th></tr>";
+
+         echo "<tr class='tab_bg_1'><td>";
+         echo __("Personal token");
+         echo "</td><td colspan='2'>";
+
+         if (!empty($this->fields["personal_token"])) {
+            echo "<div class='copy_to_clipboard_wrapper'>";
+            echo Html::input('_personal_token', [
+                                 'value'    => $this->fields["personal_token"],
+                                 'style'    => 'width:90%'
+                             ]);
+            echo "</div>";
+            echo "(".sprintf(__('generated on %s'),
+                                Html::convDateTime($this->fields["personal_token_date"])).")";
+         }
+         echo "</td><td>";
+         Html::showCheckbox(['name'  => '_reset_personal_token',
+                             'title' => __('Regenerate')]);
+         echo "&nbsp;&nbsp;".__('Regenerate');
+         echo "</td></tr>";
+
+         echo "<tr class='tab_bg_1'><td>";
+         echo __("API token");
+         echo "</td><td colspan='2'>";
+         if (!empty($this->fields["api_token"])) {
+            echo "<div class='copy_to_clipboard_wrapper'>";
+            echo Html::input('_api_token', [
+                                 'value'    => $this->fields["api_token"],
+                                 'style'    => 'width:90%'
+                             ]);
+            echo "</div>";
+            echo "(".sprintf(__('generated on %s'),
+                                Html::convDateTime($this->fields["api_token_date"])).")";
+         }
+         echo "</td><td>";
+         Html::showCheckbox(['name'  => '_reset_api_token',
+                             'title' => __('Regenerate')]);
+         echo "&nbsp;&nbsp;".__('Regenerate');
+         echo "</td></tr>";
+
          echo "<tr class='tab_bg_1'>";
          echo "<td colspan='2' class='center'>";
          if ($this->fields["last_login"]) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5013 

Tokens were moved to main user page in #4784 to allow token usage even if personalizations were locked. However, I only moved to showMyForm() and not showForm(). This prevented administrators from regenerating other user's tokens.