### PR TITLE
paste image at current cursor position in tinymce

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -730,24 +730,6 @@ var getSize = function (size) {
 };
 
 /**
- * Replace content in tinyMCE
- *
- * @param {Object} editor   TinyMCE editor instance
- * @param {String} search   The search
- * @param {String} replace  The replace
- */
-var replaceContent = function(editor, search, replace) {
-   if (!replace) {
-      replace = '';
-   }
-
-   var re =/\[\*\*(.*?)\*\*\]/;
-   var body = editor.getContent();
-   body = body.replace(re,replace);
-   editor.setContent(body);
-};
-
-/**
  * Convert a integer index into an excel like alpha index (A, B, ..., AA, AB, ...)
  * @since  9.3
  * @param  integer index    the numeric index
@@ -761,20 +743,6 @@ var getBijectiveIndex = function(index) {
       index /= 26;
    }
    return bij_str;
-};
-
-/**
- * Sets the cursor at the end in a tinymce editor.
- *
- * @param  {Object}  editor TinyMCE editor instance
- */
-var setCursorAtTheEnd = function(editor) {
-   var body = editor.getContent();
-   body +='<p> </p>';
-   editor.setContent(body);
-   editor.dom.add(editor.getBody(),'p');
-   editor.selection.select(editor.getBody(), true); // ed is the editor instance
-   editor.selection.collapse(false);
 };
 
 /**

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -309,22 +309,11 @@ var extractSrcFromImgTag = function(content) {
  * @param  {Blob}   image  The image to insert
  */
 var insertImageInTinyMCE = function(editor, image) {
-   // set a tempory tag in mce editor
-   var state_upload = '[** UPLOADING FILE == '+image.name+' **]';
-   editor.execCommand('mceInsertContent', false, state_upload);
-
    //make ajax call for upload doc
    var tag = uploadFile(image, editor);
-
-   //replace upload state by html render of image
-   replaceContent(editor, state_upload, '');
-
    if (tag !== false) {
       insertImgFromFile(editor, image, tag);
    }
-
-   //Set cursor at the end
-   setCursorAtTheEnd(editor);
 
    return tag;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Before this fix image was always pasted at the end of the editor due to a racing condition when storing pictures with placing cursor at end.
I also cleaned some superflu code

internal ref 15413
