### PR TITLE
tables in kb with highcontrast enabled should have borders; fix #5026

### DIFF
--- a/css/_highcontrast.scss
+++ b/css/_highcontrast.scss
@@ -111,6 +111,14 @@ table[class^="tab_cadre"] table:not([class^="tab_cadre"]) {
   }
 }
 
+
+// Tables in KB should still have border
+#kbanswer table {
+   th, td {
+      border: 1px solid #adadad;
+   }
+}
+
 #searchcriterias {
   .tab_cadre_fixe {
     border: 1px solid #ADADAD;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5026
