### PR TITLE
Fix progress bar display on sync error

### DIFF
--- a/inc/console/abstractcommand.class.php
+++ b/inc/console/abstractcommand.class.php
@@ -40,6 +40,7 @@ use DB;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -50,7 +51,20 @@ abstract class AbstractCommand extends Command {
     */
    protected $db;
 
+   /**
+    * @var InputInterface
+    */
+   protected $input;
+
+   /**
+    * @var OutputInterface
+    */
+   protected $output;
+
    protected function initialize(InputInterface $input, OutputInterface $output) {
+
+      $this->input = $input;
+      $this->output = $output;
 
       $this->initDbConnection();
    }
@@ -71,5 +85,30 @@ abstract class AbstractCommand extends Command {
       }
 
       $this->db = $DB;
+   }
+
+   /**
+    * Correctly write output messages when a progress bar is displayed.
+    *
+    * @param string|array $messages
+    * @param ProgressBar  $progress_bar
+    * @param integer      $verbosity
+    *
+    * @return void
+    */
+   protected function writelnOutputWithProgressBar($messages,
+                                                   ProgressBar $progress_bar,
+                                                   $verbosity = OutputInterface::VERBOSITY_NORMAL) {
+
+      if ($verbosity > $this->output->getVerbosity()) {
+         return; // Do nothing if message will not be output due to its too high verbosity
+      }
+
+      $progress_bar->clear();
+      $this->output->writeln(
+         $messages,
+         $verbosity
+      );
+      $progress_bar->display();
    }
 }

--- a/inc/console/ldap/synchronizeuserscommand.class.php
+++ b/inc/console/ldap/synchronizeuserscommand.class.php
@@ -41,12 +41,12 @@ use User;
 use Glpi\Console\AbstractCommand;
 
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Exception\RuntimeException;
-use Symfony\Component\Console\Helper\ProgressBar;
 
 class SynchronizeUsersCommand extends AbstractCommand {
 
@@ -334,8 +334,9 @@ class SynchronizeUsersCommand extends AbstractCommand {
                if (false !== $result) {
                   $results[$result['action']] += 1;
                } else {
-                  $output->writeln(
+                  $this->writelnOutputWithProgressBar(
                      sprintf(__('Unable to synchronize user "%s".'), $user['user']),
+                     $users_progress_bar,
                      OutputInterface::VERBOSITY_VERBOSE
                   );
                }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Before fix:
```
   1/174 [>---------------------------]   0%Unable to synchronize user "someone".
   2/174 [>---------------------------]   1%Unable to synchronize user "johndoe".
   3/174 [>---------------------------]   1%
```

Will be:
```
   1/174 [>---------------------------]   0%
```
then
```
Unable to synchronize user "someone".
   2/174 [>---------------------------]   1%
```
then
```
Unable to synchronize user "someone".
Unable to synchronize user "johndoe".
   3/174 [>---------------------------]   1%
```