### PR TITLE
Fix cache usage and clear cache in update process; fixes #5050

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2924,7 +2924,7 @@ class Config extends CommonDBTM {
     * @param string  $context name of the configuration context (default 'core')
     * @param boolean $psr16   Whether to return a PSR16 compliant obkect or not (since ZendTranslator is NOT PSR16 compliant).
     *
-    * @return Zend\Cache\Storage\StorageInterface object
+    * @return Zend\Cache\Psr\SimpleCache\SimpleCacheDecorator|Zend\Cache\Storage\StorageInterface object
     */
    public static function getCache($optname, $context = 'core', $psr16 = true) {
       global $DB, $CFG_GLPI;

--- a/install/update.php
+++ b/install/update.php
@@ -37,6 +37,13 @@ if (!defined('GLPI_ROOT')) {
 include_once (GLPI_ROOT . "/inc/based_config.php");
 include_once (GLPI_ROOT . "/inc/db.function.php");
 include_once (GLPI_CONFIG_DIR . "/config_db.php");
+
+$GLPI_CACHE = Config::getCache('cache_db');
+$GLPI_CACHE->clear(); // Force cache cleaning to prevent usage of outdated cache data
+
+$translation_cache = Config::getCache('cache_trans');
+$translation_cache->clear(); // Force cache cleaning to prevent usage of outdated cache data
+
 Config::detectRootDoc();
 
 $GLPI = new GLPI();
@@ -445,7 +452,7 @@ function changeVarcharToID($table1, $table2, $chps) {
 
 //update database
 function doUpdateDb() {
-   global $DB, $migration, $update;
+   global $DB, $GLPI_CACHE, $migration, $update;
 
    $currents            = $update->getCurrents();
    $current_version     = $currents['version'];
@@ -462,6 +469,7 @@ function doUpdateDb() {
    }
 
    $update->doUpdates($current_version);
+   $GLPI_CACHE->clear();
 }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5050 

Update process requires $GLPI_CACHE to be defined.
I thought using a dedicated cache in memory is more relevant as this cache declaration is just a workaround and will not be used anymore after update is done.