### PR TITLE
Handle deprecation state for Dropdown::addNewCondition()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,9 @@ The present file will list all changes made to the project; according to the
 - Remove `$CFG_GLPI['ticket_timeline']` parameter. Will now be `true` per default.
 - Remove `$CFG_GLPI['ticket_timeline_keep_replaced_tabs']` parameter. Will now be `false` per default.
 - Usage of `TicketFollowup` class has been deprecated.
-- Usage of string `$condition` parameter in `CommonDBTM::find()` has been deprecated
-- Usage of string in `$option['condition']` parameter in `Dropdown::show()` has been deprecated
+- Usage of string `$condition` parameter in `CommonDBTM::find()` has been deprecated.
+- Usage of string `$condition` parameter in `Dropdown::addNewCondition()` has been deprecated.
+- Usage of string in `$option['condition']` parameter in `Dropdown::show()` has been deprecated.
 
 The following methods have been deprecated:
 

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -279,10 +279,17 @@ class Dropdown {
     *
     * @return string
     */
-   static function addNewCondition(array $condition) {
-       $sha1 = sha1(serialize($condition));
-       $_SESSION['glpicondition'][$sha1] = $condition;
-       return $sha1;
+   static function addNewCondition($condition) {
+      if (!is_array($condition)) {
+         Toolbox::deprecated('Using a string in dropdown condition is deprecated.');
+         $condition = Toolbox::cleanNewLines($condition);
+         $sha1 = sha1($condition);
+      } else {
+         $sha1 = sha1(serialize($condition));
+      }
+
+      $_SESSION['glpicondition'][$sha1] = $condition;
+      return $sha1;
    }
 
    /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #5059 

Usage of search options defining a condition as a string leads to a fatal error.
This PR add a deprecated state to ease the transition to array conditions (especially for plugins).

This will avoid:
```
Fatal error: Uncaught TypeError: Argument 1 passed to Dropdown::addNewCondition() must be of the type array, string given, called in /var/www/glpi/inc/dropdown.class.php on line 161 and defined in /var/www/glpi/inc/dropdown.class.php:282
Stack trace:
#0 /var/www/glpi/inc/dropdown.class.php(161): Dropdown::addNewCondition('is_assign')
#1 /var/www/glpi/inc/commondbtm.class.php(3836): Dropdown::show('Group', Array)
#2 /var/www/glpi/inc/commondbtm.class.php(4748): CommonDBTM::dropdown(Array)
#3 /var/www/glpi/inc/ticket.class.php(6792): CommonDBTM->getValueToSelect(Array, 'criteria[0][val...', Array, Array)
#4 /var/www/glpi/inc/search.class.php(2915): Ticket->getValueToSelect(Array, 'criteria[0][val...', 'mygroups', Array)
#5 /var/www/glpi/inc/search.class.php(2809): Search::displaySearchoptionValue(Array)
#6 /var/www/glpi/inc/search.class.php(2494): Search::displaySearchoption(Array)
#7 /var/www/glpi/inc/search.class.php(2197): Search::displayCriteria(Array)
#8 /var/www/glpi/inc/search.class.php(76): Search::showGenericSearch in /var/www/glpi/inc/dropdown.class.php on line 282
```