### PR TITLE
moveUploadedDocument use UPLOAD dir not TMP dir

### DIFF
--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -1034,7 +1034,7 @@ class Document extends CommonDBTM {
          $prefix = array_shift($input['_prefix_filename']);
       }
 
-      $fullpath = GLPI_TMP_DIR."/".$filename;
+      $fullpath = GLPI_UPLOAD_DIR."/".$filename;
       $filename = str_replace($prefix, '', $filename);
 
       if (!is_dir(GLPI_UPLOAD_DIR)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal ref 15401

## Explanation

When manually creating a document, we have two possible actions:

1. Upload from server directory (GLPI_UPLOAD_DIR)
2. Upload from directly user computer and place temporarly in tmp dir (GLPI_TMP_DIR)

case 1 use `moveUploadedDocument` function, case 2 use `moveDocument` function (names are confusing)

since 448f6998601


![image](https://user-images.githubusercontent.com/418844/49739105-587f5f00-fc91-11e8-9bb0-dad69ff5b431.png)

