### PR TITLE
Remove deprecated log on KB item

### DIFF
--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -409,8 +409,6 @@ class KnowbaseItem extends CommonDBVisible {
 
       global $DB;
 
-      Toolbox::deprecated('Use getVisibilityCriteria');
-
       //get and clean criteria
       $criteria = self::getVisibilityCriteria($forceall);
       unset($criteria['WHERE']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`KnowbaseItem::addVisibilityJoins()` triggers a deprecated log, but should not as it is still used in GLPI core (see line 408 comment).