### PR TITLE
Prevent plugins loading for install and update commands

### DIFF
--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -387,6 +387,7 @@ class Application extends BaseApplication {
          }
       } catch (CommandNotFoundException $e) {
          // Command will not be found at this point if it is a plugin command
+         $command = null; // Say hello to CS checker
       }
 
       return !$input->hasParameterOption('--no-plugins', true);

--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -39,6 +39,7 @@ if (!defined('GLPI_ROOT')) {
 use Config;
 use DB;
 use GLPI;
+use Glpi\Console\Command\ForceNoPluginsOptionCommandInterface;
 use Plugin;
 use Session;
 use Toolbox;
@@ -49,6 +50,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -77,12 +79,16 @@ class Application extends BaseApplication {
 
       $this->computeAndLoadOutputLang();
 
+      // Load core commands only to check if called command prevent or not usage of plugins
+      // Plugin commands will be loaded later
+      $loader = new CommandLoader(false);
+      $this->setCommandLoader($loader);
+
       $use_plugins = $this->usePlugins();
       if ($use_plugins) {
          $this->loadActivePlugins();
+         $loader->registerPluginsCommands();
       }
-
-      $this->setCommandLoader(new CommandLoader($use_plugins));
    }
 
    protected function getDefaultInputDefinition() {
@@ -147,7 +153,7 @@ class Application extends BaseApplication {
                '--no-plugins',
                null,
                InputOption::VALUE_NONE,
-               __('Disable GLPI plugins')
+               __('Disable GLPI plugins (unless commands forces plugins loading)')
             ),
             new InputOption(
                '--lang',
@@ -373,6 +379,16 @@ class Application extends BaseApplication {
    private function usePlugins() {
 
       $input = new ArgvInput();
+
+      try {
+         $command = $this->get($this->getCommandName($input));
+         if ($command instanceof ForceNoPluginsOptionCommandInterface) {
+            return !$command->getNoPluginsOptionValue();
+         }
+      } catch (CommandNotFoundException $e) {
+         // Command will not be found at this point if it is a plugin command
+      }
+
       return !$input->hasParameterOption('--no-plugins', true);
    }
 }

--- a/inc/console/command/forcenopluginsoptioncommandinterface.class.php
+++ b/inc/console/command/forcenopluginsoptioncommandinterface.class.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Command;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+interface ForceNoPluginsOptionCommandInterface {
+
+   /**
+    * Defines whether or not command prevents plugins to be loaded.
+    *
+    * @return boolean
+    */
+   public function getNoPluginsOptionValue();
+}

--- a/inc/console/commandloader.class.php
+++ b/inc/console/commandloader.class.php
@@ -98,6 +98,16 @@ class CommandLoader implements CommandLoaderInterface {
    }
 
    /**
+    * Register plugin commands in command list.
+    *
+    * @return void
+    */
+   public function registerPluginsCommands() {
+
+      $this->findPluginCommands();
+   }
+
+   /**
     * Find all core commands.
     *
     * return void

--- a/inc/console/database/installcommand.class.php
+++ b/inc/console/database/installcommand.class.php
@@ -38,6 +38,7 @@ if (!defined('GLPI_ROOT')) {
 
 use Config;
 use DBConnection;
+use Glpi\Console\Command\ForceNoPluginsOptionCommandInterface;
 use Toolbox;
 
 use Symfony\Component\Console\Command\Command;
@@ -50,7 +51,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 
-class InstallCommand extends Command {
+class InstallCommand extends Command implements ForceNoPluginsOptionCommandInterface {
 
    /**
     * Error code returned if DB connection initialization fails.
@@ -305,5 +306,10 @@ class InstallCommand extends Command {
       $output->writeln('<info>' . __('Installation done.') . '</info>');
 
       return 0; // Success
+   }
+
+   public function getNoPluginsOptionValue() {
+
+      return true;
    }
 }

--- a/inc/console/database/updatecommand.class.php
+++ b/inc/console/database/updatecommand.class.php
@@ -38,6 +38,7 @@ if (!defined('GLPI_ROOT')) {
 
 use CliMigration;
 use Glpi\Console\AbstractCommand;
+use Glpi\Console\Command\ForceNoPluginsOptionCommandInterface;
 use Session;
 use Update;
 
@@ -48,7 +49,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
-class UpdateCommand extends AbstractCommand {
+class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionCommandInterface {
 
    /**
     * Error code returned when trying to update from an unstable version.
@@ -176,5 +177,10 @@ class UpdateCommand extends AbstractCommand {
       }
 
       return 0; // Success
+   }
+
+   public function getNoPluginsOptionValue() {
+
+      return true;
    }
 }

--- a/tests/units/Glpi/Console/CommandLoader.php
+++ b/tests/units/Glpi/Console/CommandLoader.php
@@ -157,5 +157,13 @@ PHP
          $this->boolean($command_loader->has($name))->isTrue();
          $this->object($command_loader->get($name))->isInstanceOf($classname);
       }
+
+      // Check async plugin registration
+      $command_loader->registerPluginsCommands();
+      $this->array($command_loader->getNames())->isIdenticalTo(array_keys($all_names_to_class));
+      foreach ($all_names_to_class as $name => $classname) {
+         $this->boolean($command_loader->has($name))->isTrue();
+         $this->object($command_loader->get($name))->isInstanceOf($classname);
+      }
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I added an interface that can be implemented by core commands to defines if plugins should be loaded or disabled without taking into account the `--no-plugins` option.