### PR TITLE
Avoid double compiling SCSS files

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -6663,10 +6663,11 @@ class Html {
             }
             $import .= '@import "' . $file . '";';
             $fckey = md5($file);
+            $md5file = md5(file_get_contents($path));
+
             //check if files has changed
             if ($GLPI_CACHE->has($fckey)) {
                $md5 = $GLPI_CACHE->get($fckey);
-               $md5file = md5(file_get_contents($path));
 
                if ($md5file != $md5) {
                   //file has changed
@@ -6676,7 +6677,7 @@ class Html {
                }
             } else {
                Toolbox::logDebug("$file is new, loading");
-               $GLPI_CACHE->set($fckey, md5(file_get_contents($path)));
+               $GLPI_CACHE->set($fckey, $md5file);
             }
          } else {
             Toolbox::logWarning('Requested file ' . $path . ' does not exists.');

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -6676,7 +6676,7 @@ class Html {
                }
             } else {
                Toolbox::logDebug("$file is new, loading");
-               $GLPI_CACHE->set(md5($file), md5($path));
+               $GLPI_CACHE->set($fckey, md5(file_get_contents($path)));
             }
          } else {
             Toolbox::logWarning('Requested file ' . $path . ' does not exists.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Initial loading of scss files would cache hash of path but updating scss files would then check and cache the hash of the contents. This caused each file to compile once on the first page load, and again on the second load.