### PR TITLE
Prevent proxy timeout on installation; fixes #5114

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -521,6 +521,13 @@ class DBmysql {
             if ($this->query($formattedQuerytorun)) { //if no success continue to concatenate
                $formattedQuery = "";
                $lastresult     = true;
+               if (!isCommandLine()) {
+                  // Flush will prevent proxy to timeout as it will receive data.
+                  // Flush requires a content to be sent, so we sent sp&aces as multiple spaces
+                  // will be shown as a single one on browser.
+                  echo ' ';
+                  flush();
+               }
             } else {
                $lastresult = false;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5114 

When the installation is made on a configuration where a proxy is located between client and server (webserver + php-fpm for instance), a proxy timeout can occurs during database schema and default data creation.

The timeout is calculated between two successive read operations, so if the server sends something to the client, the timeout delay is reset to 0. Adding a flush() operation to send a "space" char between each SQL operation would prevent having a timeout (unless a unique SQL operation takes more than the webserver timeout).