### PR TITLE
fix adding itil object from items

### DIFF
--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -386,12 +386,12 @@ class Change extends CommonITILObject {
          NotificationEvent::raiseEvent($type, $this);
       }
 
-      if (isset($this->input['_items_id'])
-          && isset($this->input['_itemtype'])) {
+      if (isset($this->input['_from_items_id'])
+          && isset($this->input['_from_itemtype'])) {
          $change_item = new Change_Item();
          $change_item->add([
-            'items_id'      => (int)$this->input['_items_id'],
-            'itemtype'      => $this->input['_itemtype'],
+            'items_id'      => (int)$this->input['_from_items_id'],
+            'itemtype'      => $this->input['_from_itemtype'],
             'changes_id'    => $this->fields['id'],
             '_disablenotif' => true
          ]);
@@ -682,10 +682,10 @@ class Change extends CommonITILObject {
       }
 
       if (isset($options['_add_fromitem'])
-          && isset($options['_items_id'])
-          && isset($options['_itemtype'])) {
-         echo Html::hidden('_items_id', ['value' => $options['_items_id']]);
-         echo Html::hidden('_itemtype', ['value' => $options['_itemtype']]);
+          && isset($options['_from_items_id'])
+          && isset($options['_from_itemtype'])) {
+         echo Html::hidden('_from_items_id', ['value' => $options['_from_items_id']]);
+         echo Html::hidden('_from_itemtype', ['value' => $options['_from_itemtype']]);
       }
 
       $date = $this->fields["date"];
@@ -1084,8 +1084,9 @@ class Change extends CommonITILObject {
             '_add_fromitem',
             __('New change for this item...'),
             [
-               '_itemtype' => $item->getType(),
-               '_items_id' => $item->getID()
+               '_from_itemtype' => $item->getType(),
+               '_from_items_id' => $item->getID(),
+               'entities_id'    => $item->fields['entities_id']
             ]
          );
          echo "</div>";

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -382,12 +382,12 @@ class Problem extends CommonITILObject {
          NotificationEvent::raiseEvent($type, $this);
       }
 
-      if (isset($this->input['_items_id'])
-          && isset($this->input['_itemtype'])) {
+      if (isset($this->input['_from_items_id'])
+          && isset($this->input['_from_itemtype'])) {
          $item_problem = new Item_Problem();
          $item_problem->add([
-            'items_id'      => (int)$this->input['_items_id'],
-            'itemtype'      => $this->input['_itemtype'],
+            'items_id'      => (int)$this->input['_from_items_id'],
+            'itemtype'      => $this->input['_from_itemtype'],
             'problems_id'   => $this->fields['id'],
             '_disablenotif' => true
          ]);
@@ -1113,10 +1113,10 @@ class Problem extends CommonITILObject {
       }
 
       if (isset($options['_add_fromitem'])
-          && isset($options['_items_id'])
-          && isset($options['_itemtype'])) {
-         echo Html::hidden('_items_id', ['value' => $options['_items_id']]);
-         echo Html::hidden('_itemtype', ['value' => $options['_itemtype']]);
+          && isset($options['_from_items_id'])
+          && isset($options['_from_itemtype'])) {
+         echo Html::hidden('_from_items_id', ['value' => $options['_from_items_id']]);
+         echo Html::hidden('_from_itemtype', ['value' => $options['_from_itemtype']]);
       }
 
       $date = $this->fields["date"];
@@ -1455,8 +1455,9 @@ class Problem extends CommonITILObject {
             '_add_fromitem',
             __('New problem for this item...'),
             [
-               '_itemtype' => $item->getType(),
-               '_items_id' => $item->getID()
+               '_from_itemtype' => $item->getType(),
+               '_from_items_id' => $item->getID(),
+               'entities_id'    => $item->fields['entities_id']
             ]
          );
          echo "</div>";

--- a/tests/functionnal/Change.php
+++ b/tests/functionnal/Change.php
@@ -46,8 +46,8 @@ class Change extends DbTestCase {
          'name'           => "test add from computer \'_test_pc01\'",
          'content'        => "test add from computer \'_test_pc01\'",
          '_add_from_item' => true,
-         '_itemtype'      => 'Computer',
-         '_items_id'      => $computer->getID(),
+         '_from_itemtype' => 'Computer',
+         '_from_items_id' => $computer->getID(),
       ]);
       $this->integer($changes_id)->isGreaterThan(0);
       $this->boolean($change->getFromDB($changes_id))->isTrue();

--- a/tests/functionnal/Problem.php
+++ b/tests/functionnal/Problem.php
@@ -46,8 +46,8 @@ class Problem extends DbTestCase {
          'name'           => "test add from computer \'_test_pc01\'",
          'content'        => "test add from computer \'_test_pc01\'",
          '_add_from_item' => true,
-         '_itemtype'      => 'Computer',
-         '_items_id'      => $computer->getID(),
+         '_from_itemtype' => 'Computer',
+         '_from_items_id' => $computer->getID(),
       ]);
       $this->integer($problems_id)->isGreaterThan(0);
       $this->boolean($problem->getFromDB($problems_id))->isTrue();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Follow 5004

the key `_itemtype` conflicted with this part https://github.com/glpi-project/glpi/blob/9.4/bugfixes/ajax/common.tabs.php#L65

