### PR TITLE
dropdown fuzzy matches (non-ajax ones)

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -4337,9 +4337,12 @@ class Html {
                // Skip if there is no 'children' property
                if (typeof data.children === 'undefined') {
                   var match  = fuzzy.match(searched_term, data_text, select2_fuzzy_opts);
-                  return match !== null
-                     ? {text: data, rendered_text: match.rendered_text, score: match[1]}
-                     : false;
+                  if (match == null) {
+                     return false;
+                  }
+                  data.rendered_text = match.rendered_text;
+                  data.score = match.score;
+                  return data;
                }
 
                // `data.children` contains the actual options that we are matching against
@@ -4353,17 +4356,13 @@ class Html {
 
                   var match_child = fuzzy.match(searched_term, child_text, select2_fuzzy_opts);
                   var match_text  = fuzzy.match(searched_term, data_text, select2_fuzzy_opts);
-                  if (match_child !== null
-                     || match_text !== null
-                  ) {
-                     if (match_text !== null
-                         && typeof match_text.score != 'undefined') {
+                  if (match_child !== null || match_text !== null) {
+                     if (match_text !== null) {
                         data.score         = match_text.score;
                         data.rendered_text = match_text.rendered;
                      }
 
-                     if (match_child !== null
-                         && typeof match_child.score != 'undefined') {
+                     if (match_child !== null) {
                         child.score         = match_child.score;
                         child.rendered_text = match_child.rendered;
                      }

--- a/js/common.js
+++ b/js/common.js
@@ -917,28 +917,33 @@ function markMatch (text, term) {
  * Function that renders select2 results.
  */
 var templateResult = function(result) {
-   if (!result.id) {
-      return result.text;
-   }
-
    var _elt = $('<span></span>');
    _elt.attr('title', result.title);
 
-   var markup=[result.text];
-
-   var _term = query.term || '';
-   var markup = markMatch(result.text, _term);
-
-   if (result.level) {
-      var a='';
-      var i=result.level;
-      while (i>1) {
-         a = a+'&nbsp;&nbsp;&nbsp;';
-         i=i-1;
-      }
-      _elt.html(a+'&raquo;'+markup);
+   if (typeof query.term !== 'undefined' &&
+       typeof result.rendered_text !== 'undefined') {
+      _elt.html(result.rendered_text);
    } else {
-      _elt.html(markup);
+      if (!result.id) {
+         return result.text;
+      }
+
+      var markup=[result.text];
+
+      var _term = query.term || '';
+      var markup = markMatch(result.text, _term);
+
+      if (result.level) {
+         var a='';
+         var i=result.level;
+         while (i>1) {
+            a = a+'&nbsp;&nbsp;&nbsp;';
+            i=i-1;
+         }
+         _elt.html(a+'&raquo;'+markup);
+      } else {
+         _elt.html(markup);
+      }
    }
 
    return _elt;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Not really urgent (can be merged after release), a speedy dev before vacations.
Add a fuzzy search on select2 matcher:

![image](https://user-images.githubusercontent.com/418844/50294954-511d3a00-0477-11e9-91ca-dbebe989b918.png)

![image](https://user-images.githubusercontent.com/418844/50295127-ace7c300-0477-11e9-87a0-54d7682fb15e.png)


Fix a little bug also, the markMatch seems broken since some months ([here](https://github.com/glpi-project/glpi/pull/5149/files#diff-298092ebe134c5b9ccbc7042328fb02cR4319))
