### PR TITLE
Synchronously search in kb tree from first char; fixes #5153

### DIFF
--- a/inc/knowbase.class.php
+++ b/inc/knowbase.class.php
@@ -212,12 +212,7 @@ class Knowbase extends CommonGLPI {
             };
 
             $(document).on('keyup', '#kb_tree_search$rand', function() {
-               var inputsearch = $(this);
-               typewatch(function () {
-                  if (inputsearch.val().length >= 3) {
-                     $('#tree_category$rand').jstree('search', inputsearch.val());
-                  }
-               }, 300);
+               $('#tree_category$rand').jstree('search', inputsearch.val());
             });
 
             $('#items_list$rand').on('click', 'a.kb-category', function(event) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5153 

Search in KB tree does not requires ajax loading anymore (see a85b7b58cee8b9c7bf9e8c83a6631fc14926c373), so search can now be done synchronously and can be performed from the first typed char.