### PR TITLE
Fix undefined rank in migration

### DIFF
--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -800,7 +800,7 @@ class Migration {
             if (count($iterator) > 0) {
                while ($data = $iterator->next()) {
                   $result = $DB->request([
-                     'SELECT' => ['MAX' => 'rank'],
+                     'SELECT' => ['MAX' => 'rank as maxrank'],
                      'FROM'   => 'glpi_displaypreferences',
                      'WHERE'  => [
                         'users_id'  => $data['users_id'],
@@ -808,7 +808,7 @@ class Migration {
                      ]
                   ])->next();
 
-                  $rank = $result['rank'];
+                  $rank = $result['maxrank'];
                   ++$rank;
 
                   foreach ($tab as $newval) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

```
  *** PHP Notice(8): Undefined index: rank
  Backtrace :
  inc/migration.class.php:811                        
  install/update_93_94.php:377                       Migration->updateDisplayPrefs()
  inc/update.class.php:323                           update93to94()
  install/update.php:92                              Update->doUpdates()
  install/update.php:163                             doUpdateDb()
  {"user":"@88a417eb0414"} 
```
