### PR TITLE
Fix QueuedNotification clean cron

### DIFF
--- a/inc/queuednotification.class.php
+++ b/inc/queuednotification.class.php
@@ -589,7 +589,7 @@ class QueuedNotification extends CommonDBTM {
          $vol = $DB->delete(
             self::getTable(), [
                'is_deleted'   => 1,
-               new \QueryExpression('UNIX_TIMESTAMP('.$DB->quoteName('send_time').') < '.$DB->quoteValue($send_time).')')
+               new \QueryExpression('UNIX_TIMESTAMP('.$DB->quoteName('send_time').') < '.$DB->quoteValue($send_time))
             ]
          );
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes:
SQL: DELETE FROM `glpi_queuednotifications` WHERE `is_deleted` = '1' AND UNIX_TIMESTAMP(`send_time`) < '1542826920')
  Error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')' at line 1
