### PR TITLE
More intuitive way of building 'SELECT DISTINCT' queries with DBmysqlIterator

### DIFF
--- a/inc/calendar_holiday.class.php
+++ b/inc/calendar_holiday.class.php
@@ -76,8 +76,7 @@ class Calendar_Holiday extends CommonDBRelation {
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_calendars_holidays.id AS linkID',
-         'FIELDS'          => 'glpi_holidays.*',
+         'SELECT DISTINCT' => ['glpi_calendars_holidays.id AS linkID', 'glpi_holidays.*'],
          'FROM'            => 'glpi_calendars_holidays',
          'LEFT JOIN'       => [
             'glpi_holidays'   => [

--- a/inc/change_problem.class.php
+++ b/inc/change_problem.class.php
@@ -124,8 +124,7 @@ class Change_Problem extends CommonDBRelation{
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_changes_problems.id AS linkID',
-         'FIELDS'          => 'glpi_changes.*',
+         'SELECT DISTINCT' => ['glpi_changes_problems.id AS linkID', 'glpi_changes.*'],
          'FROM'            => 'glpi_changes_problems',
          'LEFT JOIN'       => [
             'glpi_changes' => [
@@ -234,8 +233,7 @@ class Change_Problem extends CommonDBRelation{
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_changes_problems.id AS linkID',
-         'FIELDS'          => 'glpi_problems.*',
+         'SELECT DISTINCT' => ['glpi_changes_problems.id AS linkID', 'glpi_problems.*'],
          'FROM'            => 'glpi_changes_problems',
          'LEFT JOIN'       => [
             'glpi_problems' => [

--- a/inc/change_ticket.class.php
+++ b/inc/change_ticket.class.php
@@ -238,8 +238,7 @@ class Change_Ticket extends CommonDBRelation{
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_changes_tickets.id AS linkID',
-         'FIELDS'          => 'glpi_tickets.*',
+         'SELECT DISTINCT' => ['glpi_changes_tickets.id AS linkID', 'glpi_tickets.*'],
          'FROM'            => 'glpi_changes_tickets',
          'LEFT JOIN'       => [
             'glpi_tickets' => [
@@ -355,8 +354,7 @@ class Change_Ticket extends CommonDBRelation{
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_changes_tickets.id AS linkID',
-         'FIELDS'          => 'glpi_changes.*',
+         'SELECT DISTINCT' => ['glpi_changes_tickets.id AS linkID', 'glpi_changes.*'],
          'FROM'            => 'glpi_changes_tickets',
          'LEFT JOIN'       => [
             'glpi_changes' => [

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -4771,8 +4771,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_users.id AS users_id',
-         'FIELDS'          => [
+         'SELECT DISTINCT' => [
+            'glpi_users.id AS users_id',
             'glpi_users.name AS name',
             'glpi_users.realname AS realname',
             'glpi_users.firstname AS firstname'
@@ -4847,8 +4847,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_users.id AS user_id',
-         'FIELDS'          => [
+         'SELECT DISTINCT' => [
+            'glpi_users.id AS user_id',
             'glpi_users.name AS name',
             'glpi_users.realname AS realname',
             'glpi_users.firstname AS firstname'
@@ -4915,8 +4915,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_groups.id',
-         'FIELDS'          => [
+         'SELECT DISTINCT' => [
+            'glpi_groups.id',
             'glpi_groups.completename'
          ],
          'FROM'            => $ctable,
@@ -5284,8 +5284,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_users.id AS users_id',
-         'FIELDS'          => [
+         'SELECT DISTINCT' => [
+            'glpi_users.id AS users_id',
             'glpi_users.name AS name',
             'glpi_users.realname AS realname',
             'glpi_users.firstname AS firstname'
@@ -5356,8 +5356,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_users.id AS users_id',
-         'FIELDS'          => [
+         'SELECT DISTINCT' => [
+            'glpi_users.id AS users_id',
             'glpi_users.name AS name',
             'glpi_users.realname AS realname',
             'glpi_users.firstname AS firstname'
@@ -5446,8 +5446,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_suppliers.id AS suppliers_id_assign',
-         'FIELDS'          => [
+         'SELECT DISTINCT' => [
+            'glpi_suppliers.id AS suppliers_id_assign',
             'glpi_suppliers.name AS name'
          ],
          'FROM'            => $ctable,
@@ -5513,8 +5513,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_groups.id',
-         'FIELDS'          => [
+         'SELECT DISTINCT' => [
+            'glpi_groups.id',
             'glpi_groups.completename'
          ],
          'FROM'            => $ctable,
@@ -6943,8 +6943,10 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $union = new \QueryUnion([$subquery1, $subquery2], false, 'allactors');
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'users_id',
-         'FIELDS'          => ['type'],
+         'SELECT DISTINCT' => [
+            'users_id',
+            'type'
+         ],
          'FROM'            => $union
       ]);
 
@@ -7037,8 +7039,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $table = self::getTable();
       $criteria = [
-         'SELECT DISTINCT' => "$table.*",
-         'FIELDS'          => [
+         'SELECT DISTINCT' => [
+            "$table.*",
             'glpi_itilcategories.completename AS catname'
          ],
          'FROM'            => $table,

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -2785,8 +2785,10 @@ class Dropdown {
 
             case KnowbaseItem::getType():
                $criteria = [
-                  'SELECT DISTINCT' => "$table.*",
-                  'FIELDS'          => $addselect,
+                  'SELECT DISTINCT' => [
+                     "$table.*",
+                     $addselect,
+                  ],
                   'FROM'            => $table
                ];
                if (count($ljoin)) {
@@ -3050,8 +3052,8 @@ class Dropdown {
       }
 
       $criteria = [
-         'SELECT DISTINCT' => "$table.id",
-         'FIELDS'          => [
+         'SELECT DISTINCT' => [
+            "$table.id",
             "$table.name AS name",
             "$table.serial AS serial",
             "$table.otherserial AS otherserial",

--- a/inc/dropdowntranslation.class.php
+++ b/inc/dropdowntranslation.class.php
@@ -746,8 +746,10 @@ class DropdownTranslation extends CommonDBChild {
       $tab = [];
       if (self::isDropdownTranslationActive()) {
          $iterator = $DB->request([
-            'SELECT DISTINCT' => 'itemtype',
-            'FIELDS'          => 'field',
+            'SELECT DISTINCT' => [
+            	'itemtype',
+            	'field'
+            ],
             'FROM'            => self::getTable(),
             'WHERE'           => ['language' => $language]
          ]);

--- a/inc/group_user.class.php
+++ b/inc/group_user.class.php
@@ -392,8 +392,8 @@ class Group_User extends CommonDBRelation{
 
       // All group members
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_users.id',
-         'SELECT'       => [
+         'SELECT DISTINCT' => [
+         	'glpi_users.id',
             'glpi_groups_users.id AS linkID',
             'glpi_groups_users.groups_id',
             'glpi_groups_users.is_dynamic AS is_dynamic',

--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -895,8 +895,8 @@ class Item_Ticket extends CommonDBRelation{
             // Software
             if (in_array('Software', $_SESSION["glpiactiveprofile"]["helpdesk_item_type"])) {
                $iterator = $DB->request([
-                  'SELECT DISTINCT' => 'glpi_softwareversions.name AS version',
-                  'FIELDS'          => [
+                  'SELECT DISTINCT' => [
+                  	'glpi_softwareversions.name AS version',
                      'glpi_softwares.name AS name',
                      'glpi_softwares.id'
                   ],

--- a/inc/itil_project.class.php
+++ b/inc/itil_project.class.php
@@ -137,8 +137,10 @@ class Itil_Project extends CommonDBRelation {
          $itemTable = $itemtype::getTable();
 
          $iterator = $DB->request([
-            'SELECT DISTINCT' => "$selfTable.id AS linkID",
-            'FIELDS'          => "$itemTable.*",
+            'SELECT DISTINCT' => [
+            	"$selfTable.id AS linkID",
+            	"$itemTable.*"
+         	],
             'FROM'            => $selfTable,
             'LEFT JOIN'       => [
                $itemTable => [
@@ -279,8 +281,10 @@ class Itil_Project extends CommonDBRelation {
       $projectTable = Project::getTable();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => "$selfTable.id AS linkID",
-         'FIELDS'          => "$projectTable.*",
+         'SELECT DISTINCT' => [
+         	"$selfTable.id AS linkID",
+         	"$projectTable.*"
+         ],
          'FROM'            => $selfTable,
          'LEFT JOIN'       => [
             $projectTable => [

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -979,7 +979,7 @@ class NotificationTarget extends CommonDBChild {
       global $DB;
 
       $criteria = $this->getDistinctUserCriteria() + $this->getProfileJoinCriteria();
-      $criteria['FIELDS'][] = Profile_User::getTable() . '.entities_id AS entity';
+      $criteria['SELECT DISTINCT'][] = Profile_User::getTable() . '.entities_id AS entity';
       $criteria['FROM'] = User::getTable();
       $criteria['WHERE'][Profile_User::getTable() . '.profiles_id'] = $profiles_id;
 

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -744,8 +744,10 @@ class NotificationTarget extends CommonDBChild {
     */
    final public function getDistinctUserCriteria() {
       return [
-         'SELECT DISTINCT' => User::getTable() . '.id AS users_id',
-         'FIELDS'          => [User::getTable() . '.language AS language']
+         'SELECT DISTINCT' => [
+         	User::getTable() . '.id AS users_id',
+         	User::getTable() . '.language AS language'
+         ]
       ];
    }
 

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -393,8 +393,10 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
          $fkfield           = $this->obj->getForeignKeyField();
 
          $iterator = $DB->request([
-            'SELECT DISTINCT' => 'glpi_suppliers.email AS email',
-            'FIELDS'          => 'glpi_suppliers.name AS name',
+            'SELECT DISTINCT' => [
+            	'glpi_suppliers.email AS email',
+            	'glpi_suppliers.name AS name'
+         	],
             'FROM'            => $supplierlinktable,
             'LEFT JOIN'       => [
                'glpi_suppliers'  => [

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -157,8 +157,8 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
          ]
       ]] + $this->getDistinctUserCriteria() + $this->getProfileJoinCriteria();
       $criteria['FROM'] = $userlinktable;
-      $criteria['FIELDS'] = array_merge(
-         $criteria['FIELDS'], [
+      $criteria['SELECT DISTINCT'] = array_merge(
+         $criteria['SELECT DISTINCT'], [
             "$userlinktable.use_notification AS notif",
             "$userlinktable.alternative_email AS altemail"
          ]

--- a/inc/problem_ticket.class.php
+++ b/inc/problem_ticket.class.php
@@ -273,8 +273,10 @@ class Problem_Ticket extends CommonDBRelation{
       $rand = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_problems_tickets.id AS linkID',
-         'FIELDS'          => 'glpi_tickets.*',
+         'SELECT DISTINCT' => [
+         	'glpi_problems_tickets.id AS linkID',
+         	'glpi_tickets.*'
+         ],
          'FROM'            => 'glpi_problems_tickets',
          'LEFT JOIN'       => [
             'glpi_tickets' => [
@@ -402,8 +404,10 @@ class Problem_Ticket extends CommonDBRelation{
       $rand = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_problems_tickets.id AS linkID',
-         'FIELDS'          => 'glpi_problems.*',
+         'SELECT DISTINCT' => [
+         	'glpi_problems_tickets.id AS linkID',
+         	'glpi_problems.*'
+         ],
          'FROM'            => 'glpi_problems_tickets',
          'LEFT JOIN'       => [
             'glpi_problems'   => [

--- a/inc/profile_user.class.php
+++ b/inc/profile_user.class.php
@@ -450,8 +450,8 @@ class Profile_User extends CommonDBRelation {
       $putable = Profile_User::getTable();
       $etable = Entity::getTable();
       $iterator = $DB->request([
-         'SELECT DISTINCT' => "$utable.*",
-         'FIELDS'          => [
+         'SELECT DISTINCT' => [
+         	"$utable.*",
             "$putable.entities_id AS entity",
             "$putable.id AS linkID",
             "$putable.is_dynamic",
@@ -622,8 +622,10 @@ class Profile_User extends CommonDBRelation {
       global $DB;
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'entities_id',
-         'FIELDS'          => 'is_recursive',
+         'SELECT DISTINCT' => [
+         	'entities_id',
+         	'is_recursive'
+         ],
          'FROM'            => 'glpi_profiles_users',
          'WHERE'           => ['users_id' => $user_ID]
       ]);
@@ -674,8 +676,10 @@ class Profile_User extends CommonDBRelation {
       $ptable = Profile::getTable();
       $prtable = ProfileRight::getTable();
       $iterator = $DB->request([
-         'SELECT DISTINCT' => "$putable.entities_id",
-         'FIELDS'          => ["$putable.is_recursive"],
+         'SELECT DISTINCT' => [
+         	"$putable.entities_id",
+         	"$putable.is_recursive"
+         ],
          'FROM'            => $putable,
          'INNER JOIN'      => [
             $ptable  => [

--- a/inc/reservation.class.php
+++ b/inc/reservation.class.php
@@ -916,8 +916,10 @@ class Reservation extends CommonDBChild {
          $fin   = $date." 23:59:59";
 
          $iterator = $DB->request([
-            'SELECT DISTINCT' => 'glpi_reservationitems.id',
-            'FROM'            => 'glpi_reservationitems',
+            'SELECT DISTINCT' => [
+            	'glpi_reservationitems.id',
+            	'glpi_reservationitems'
+            ],
             'INNER JOIN'      => [
                'glpi_reservations'  => [
                   'ON' => [

--- a/inc/ruledictionnarydropdowncollection.class.php
+++ b/inc/ruledictionnarydropdowncollection.class.php
@@ -146,8 +146,8 @@ class RuleDictionnaryDropdownCollection extends RuleCollection {
 
       // Need to give manufacturer from item table
       $criteria =[
-         'SELECT DISTINCT' => 'glpi_manufacturers.id AS idmanu',
-         'FIELDS'          => [
+         'SELECT DISTINCT' => [
+         	'glpi_manufacturers.id AS idmanu',
             'glpi_manufacturers.name AS manufacturer',
             $this->item_table . '.id',
             $this->item_table . '.name AS name',

--- a/inc/ruledictionnarysoftwarecollection.class.php
+++ b/inc/ruledictionnarysoftwarecollection.class.php
@@ -119,8 +119,8 @@ class RuleDictionnarySoftwareCollection extends RuleCollection {
       if (count($items) == 0) {
          //Select all the differents software
          $criteria = [
-            'SELECT DISTINCT' => 'glpi_softwares.name',
-            'FIELDS'          => [
+            'SELECT DISTINCT' => [
+            	'glpi_softwares.name',
                'glpi_manufacturers.name AS manufacturer',
                'glpi_softwares.manufacturers_id AS manufacturers_id',
                'glpi_softwares.entities_id AS entities_id',

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -472,8 +472,10 @@ class Session {
       }
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_profiles.id',
-         'FIELDS'          => ['glpi_profiles.name'],
+         'SELECT DISTINCT' => [
+         	'glpi_profiles.id',
+         	'glpi_profiles.name'
+      	],
          'FROM'            => 'glpi_profiles_users',
          'INNER JOIN'      => [
             'glpi_profiles'   => [

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -726,8 +726,10 @@ class Software extends CommonDBTM {
       global $CFG_GLPI, $DB;
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_softwares.id',
-         'FIELDS'          => ['glpi_softwares.name'],
+         'SELECT DISTINCT' => [
+         	'glpi_softwares.id',
+         	'glpi_softwares.name'
+      	],
          'FROM'            => 'glpi_softwares',
          'INNER JOIN'      => [
             'glpi_softwarelicenses' => [

--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -536,8 +536,8 @@ class Transfer extends CommonDBTM {
                   $devicetable     = getTableForItemType($devicetype);
                   $fk              = getForeignKeyFieldForTable($devicetable);
                   $iterator = $DB->request([
-                     'SELECT DISTINCT' => "$itemdevicetable.$fk",
-                     'FIELDS'          => [
+                     'SELECT DISTINCT' => [
+                     	"$itemdevicetable.$fk",
                         "$devicetable.entities_id",
                         "$devicetable.is_recursive"
                      ],

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -162,7 +162,7 @@ class DBmysqlIterator extends DbTestCase {
       $it = $this->it->execute('foo', ['DISTINCT FIELDS' => 'bar']);
       $this->string($it->getSql())->isIdenticalTo('SELECT DISTINCT `bar` FROM `foo`');
 
-      $it = $this->it->execute('foo', ['DISTINCT FIELDS' => 'bar', 'FIELDS' => 'baz']);
+      $it = $this->it->execute('foo', ['DISTINCT FIELDS' => ['bar', 'baz']]);
       $this->string($it->getSql())->isIdenticalTo('SELECT DISTINCT `bar`, `baz` FROM `foo`');
 
       $it = $this->it->execute('foo', ['FIELDS' => 'bar']);
@@ -200,12 +200,12 @@ class DBmysqlIterator extends DbTestCase {
 
       $this->exception(
          function() {
-            $it = $this->it->execute('foo', ['DISTINCT FIELDS' => ['bar', 'baz']]);
+            $it = $this->it->execute('foo', ['DISTINCT FIELDS' => 'bar', 'FIELDS' => 'baz']);
             $this->string($it->getSql())->isIdenticalTo('SELECT `bar`, `baz` FROM `foo`');
          }
       )
          ->isInstanceOf('RuntimeException')
-         ->message->contains('DISTINCT selection can only take one field!');
+         ->message->contains('Can\'t use "SELECT DISTINCT | DISTINCT FIELDS" and "SELECT | FIELDS" in the same query');
    }
 
 
@@ -871,8 +871,10 @@ class DBmysqlIterator extends DbTestCase {
 
       $union = new \QueryUnion([$subquery1, $subquery2], false, 'allactors');
       $it = $this->it->execute([
-         'SELECT DISTINCT' => 'users_id',
-         'FIELDS'          => ['type'],
+         'SELECT DISTINCT' => [
+         	'users_id',
+         	'type'
+      	],
          'FROM'            => $union
       ]);
       $this->string($it->getSql())->isIdenticalTo($raw_query);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | ---

Current implementation of SELECT DISTINCT :
```
'SELECT DISTINCT' => 'field1',
'FIELDS'          => ['field2', 'field3']
```

Proposed new implementation :
```
'SELECT DISTINCT' => ['field1', 'field2', 'field3'],
```

The 'DISTINCT' keyword isn't specific to one of the selected field of a query. 
This make the current implementation feel counterintuitive in my opinion.

The current implementation will still work after this changes but will raise a warning.