### PR TITLE
Fix satisfaction survey creation fixes #5115

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1651,17 +1651,26 @@ class Ticket extends CommonITILObject {
           && ($delay == 0)
           && ($rate > 0)
           && (mt_rand(1, 100) <= $rate)) {
-         $inquest_id = $inquest->add(
-            [
-               'tickets_id'    => $this->fields['id'],
-               'date_begin'    => $_SESSION["glpi_currenttime"],
-               'entities_id'   => $this->fields['entities_id'],
-               'type'          => $type,
-               'max_closedate' => $max_closedate,
-            ]
-         );
+
+         $ticket_inquests = $inquest->find(['tickets_id' => $this->getID()]);
+
+         //Do not create a new satisfaction survey if one exists
+         if (!count($ticket_inquests)) {
+            $inquest_id = $inquest->add(
+               [
+                  'tickets_id'    => $this->fields['id'],
+                  'date_begin'    => $_SESSION["glpi_currenttime"],
+                  'entities_id'   => $this->fields['entities_id'],
+                  'type'          => $type,
+                  'max_closedate' => $max_closedate,
+               ]
+            );
+         } else {
+            $inquest_id = reset($ticket_inquests)['tickets_id'];
+         }
+
          // Redirect to created survey
-         HTML::redirect(TicketSatisfaction::getFormURLWithID($inquest_id));
+         Html::redirect(TicketSatisfaction::getFormURLWithID($inquest_id));
       }
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5115 

Do not create a new satisfaction survey if re-opening and then closing a ticket. You are already able to modify a survey after it is submitted.
