### PR TITLE
Fix potential undefined index on State dropdown update

### DIFF
--- a/inc/state.class.php
+++ b/inc/state.class.php
@@ -389,6 +389,14 @@ class State extends CommonTreeDropdown {
       return parent::prepareInputForUpdate($input);
    }
 
+   /**
+    * Checks that this state is unique given the new field values.
+    *    Unique fields checked:
+    *       - states_id
+    *       - name
+    * @param array $input Array of field names and values
+    * @return boolean True if the new/updated record will be unique
+    */
    public function isUnique($input) {
       global $DB;
 
@@ -397,10 +405,13 @@ class State extends CommonTreeDropdown {
       $has_changed = false;
       $where = [];
       foreach ($unicity_fields as $unicity_field) {
-         if (!isset($this->fields[$unicity_field]) || $input[$unicity_field] != $this->fields[$unicity_field]) {
+         if (isset($input[$unicity_field]) &&
+               (!isset($this->fields[$unicity_field]) || $input[$unicity_field] != $this->fields[$unicity_field])) {
             $has_changed = true;
          }
-         $where[$unicity_field] = $input[$unicity_field];
+         if (isset($input[$unicity_field])) {
+            $where[$unicity_field] = $input[$unicity_field];
+         }
       }
       if (!$has_changed) {
          //state has not changed; this is OK.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When updating a non-unique field, an undefined index would be shown for each unique field. Not all fields are passed into the input on update (at least on massive action like Child Entities).