### PR TITLE
Fix personalization rights on update

### DIFF
--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -1017,15 +1017,7 @@ class Migration {
 
          while ($profile = $prof_iterator->next()) {
             if (empty($requiredrights)) {
-               $DB->insertOrDie(
-                  'glpi_profilerights', [
-                     'id'           => null,
-                     'profiles_id'  => $profile['id'],
-                     'name'         => $name,
-                     'rights'       => $rights
-                  ],
-                  sprintf('%1$s add right for %2$s', $this->version, $name)
-               );
+               $reqmet = true;
             } else {
                $iterator = $DB->request([
                   'SELECT' => [
@@ -1037,17 +1029,17 @@ class Migration {
                ]);
 
                $reqmet = (count($iterator) == count($requiredrights));
-
-               $DB->insertOrDie(
-                  'glpi_profilerights', [
-                     'id'           => null,
-                     'profiles_id'  => $profile['id'],
-                     'name'         => $name,
-                     'rights'       => $reqmet ? $rights : 0
-                  ],
-                  sprintf('%1$s add right for %2$s', $this->version, $name)
-               );
             }
+
+            $DB->insertOrDie(
+               'glpi_profilerights', [
+                  'id'           => null,
+                  'profiles_id'  => $profile['id'],
+                  'name'         => $name,
+                  'rights'       => $reqmet ? $rights : 0
+               ],
+               sprintf('%1$s add right for %2$s', $this->version, $name)
+            );
          }
 
          $this->displayWarning(

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -979,43 +979,75 @@ class Migration {
    }
 
    /**
-    * Add new right
-    * Give full rights to profiles having config right
+    * Add new right to profiles that match rights requirements
+    *    Default is to give rights to profiles with READ and UPDATE rights on config
     *
     * @param string  $name   Right name
     * @param integer $rights Right to set (defaults to ALLSTANDARDRIGHT)
+    * @param array   $requiredrights Array of right name => value
+    *                   A profile must have these rights in order to get the new right.
+    *                   This array can be empty to add the right to every profile.
+    *                   Default is ['config' => READ | UPDATE].
     *
     * @return void
     */
-   public function addRight($name, $rights = ALLSTANDARDRIGHT) {
+   public function addRight($name, $rights = ALLSTANDARDRIGHT, $requiredrights = ['config' => READ | UPDATE]) {
       global $DB;
 
       $count = countElementsInTable(
          'glpi_profilerights',
          ['name' => $name]
       );
+
       if ($count == 0) {
-         //new right for certificate
-         //give full rights to profiles having config right
-         foreach ($DB->request("glpi_profilerights", ['name' => 'config']) as $profrights) {
-            if ($profrights['rights'] && (READ + UPDATE)) {
-               $rightValue = $rights;
+         $where = [];
+         foreach ($requiredrights as $reqright => $reqvalue) {
+            $where['OR'][] = [
+               'AND' => [
+                  'name'   => $reqright,
+                  new QueryExpression("rights & $reqvalue = $reqvalue")
+               ]
+            ];
+         }
+
+         $prof_iterator = $DB->request([
+            'SELECT' => 'id',
+            'FROM'   => 'glpi_profiles'
+         ]);
+
+         while ($profile = $prof_iterator->next()) {
+            if (empty($requiredrights)) {
+               $DB->insertOrDie(
+                  'glpi_profilerights', [
+                     'id'           => null,
+                     'profiles_id'  => $profile['id'],
+                     'name'         => $name,
+                     'rights'       => $rights
+                  ],
+                  sprintf('%1$s add right for %2$s', $this->version, $name)
+               );
             } else {
-               $rightValue = 0;
+               $iterator = $DB->request([
+                  'SELECT' => [
+                     'name',
+                     'rights'
+                  ],
+                  'FROM'   => 'glpi_profilerights',
+                  'WHERE'  => $where + ['profiles_id' => $profile['id']]
+               ]);
+
+               $reqmet = (count($iterator) == count($requiredrights));
+
+               $DB->insertOrDie(
+                  'glpi_profilerights', [
+                     'id'           => null,
+                     'profiles_id'  => $profile['id'],
+                     'name'         => $name,
+                     'rights'       => $reqmet ? $rights : 0
+                  ],
+                  sprintf('%1$s add right for %2$s', $this->version, $name)
+               );
             }
-            $DB->insertOrDie(
-               'glpi_profilerights', [
-                  'id'           => null,
-                  'profiles_id'  => $profrights['profiles_id'],
-                  'name'         => $name,
-                  'rights'       => $rightValue
-               ],
-               sprintf(
-                  '%1$s add right for %2$s',
-                  $this->version,
-                  $name
-               )
-            );
          }
 
          $this->displayWarning(

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -1005,7 +1005,7 @@ class Migration {
             $where['OR'][] = [
                'AND' => [
                   'name'   => $reqright,
-                  new QueryExpression("rights & $reqvalue = $reqvalue")
+                  new QueryExpression("{$DB->quoteName('rights')} & $reqvalue = $reqvalue")
                ]
             ];
          }

--- a/install/update_93_94.php
+++ b/install/update_93_94.php
@@ -300,18 +300,7 @@ function update93to94() {
    $migration->addField("glpi_problemtasks", "timeline_position", "tinyint(1) NOT NULL DEFAULT '0'");
 
    /** Give all existing profiles access to personalizations for legacy functionality */
-   $iterator = $DB->request([
-      'SELECT' => 'id',
-      'FROM'   => 'glpi_profiles'
-   ]);
-   while ($profile = $iterator->next()) {
-      $DB->insertOrDie('glpi_profilerights', [
-         'id'           => null,
-         'profiles_id'  => $profile['id'],
-         'name'         => 'personalization',
-         'rights'       => READ | UPDATE
-      ]);
-   }
+   $migration->addRight('personalization', READ | UPDATE, []);
 
    /** Search engine on plugins */
    $ADDTODISPLAYPREF['Plugin'] = [2, 3, 4, 5, 6, 7, 8];

--- a/install/update_93_94.php
+++ b/install/update_93_94.php
@@ -300,7 +300,18 @@ function update93to94() {
    $migration->addField("glpi_problemtasks", "timeline_position", "tinyint(1) NOT NULL DEFAULT '0'");
 
    /** Give all existing profiles access to personalizations for legacy functionality */
-   $migration->addRight('personalization', READ | UPDATE);
+   $iterator = $DB->request([
+      'SELECT' => 'id',
+      'FROM'   => 'glpi_profiles'
+   ]);
+   while ($profile = $iterator->next()) {
+      $DB->insertOrDie('glpi_profilerights', [
+         'id'           => null,
+         'profiles_id'  => $profile['id'],
+         'name'         => 'personalization',
+         'rights'       => READ | UPDATE
+      ]);
+   }
 
    /** Search engine on plugins */
    $ADDTODISPLAYPREF['Plugin'] = [2, 3, 4, 5, 6, 7, 8];

--- a/tests/files/_log/event.log
+++ b/tests/files/_log/event.log
@@ -1,0 +1,2 @@
+2018-10-04 20:34:16 [@CCDev-PC]
+[login] 3: _test_user log in from IP 

--- a/tests/files/_log/event.log
+++ b/tests/files/_log/event.log
@@ -1,2 +1,0 @@
-2018-10-04 20:34:16 [@CCDev-PC]
-[login] 3: _test_user log in from IP 

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -436,7 +436,7 @@ class Migration extends \GLPITestCase {
          ->exists();
    }
 
-      public function testAddRight() {
+   public function testAddRight() {
       global $DB;
 
       $DB->delete('glpi_profilerights', [

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -436,4 +436,60 @@ class Migration extends \GLPITestCase {
          ->exists();
    }
 
+      public function testAddRight() {
+      global $DB;
+
+      $DB->delete('glpi_profilerights', [
+         'name' => [
+            'testright1', 'testright2', 'testright3', 'testright4'
+         ]
+      ]);
+      //Test adding a READ right when profile has READ and UPDATE config right (Default)
+      $this->migration->addRight('testright1', READ);
+      //Test adding a READ right when profile has UPDATE group right
+      $this->migration->addRight('testright2', READ, ['group' => UPDATE]);
+      //Test adding an UPDATE right when profile has READ and UPDATE group right and CREATE entity right
+      $this->migration->addRight('testright3', UPDATE, [
+         'group'  => READ | UPDATE,
+         'entity' => CREATE
+      ]);
+      //Test adding a READ right when profile with no requirements
+      $this->migration->addRight('testright4', READ, []);
+
+      $right1 = $DB->request([
+         'FROM' => 'glpi_profilerights',
+         'WHERE'  => [
+            'name'   => 'testright1',
+            'rights' => READ
+         ]
+      ]);
+      $this->integer(count($right1))->isEqualTo(1);
+
+      $right1 = $DB->request([
+         'FROM' => 'glpi_profilerights',
+         'WHERE'  => [
+            'name'   => 'testright2',
+            'rights' => READ
+         ]
+      ]);
+      $this->integer(count($right1))->isEqualTo(2);
+
+      $right1 = $DB->request([
+         'FROM' => 'glpi_profilerights',
+         'WHERE'  => [
+            'name'   => 'testright3',
+            'rights' => UPDATE
+         ]
+      ]);
+      $this->integer(count($right1))->isEqualTo(1);
+
+      $right1 = $DB->request([
+         'FROM' => 'glpi_profilerights',
+         'WHERE'  => [
+            'name'   => 'testright4',
+            'rights' => READ
+         ]
+      ]);
+      $this->integer(count($right1))->isEqualTo(8);
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When updating to 9.4.0, only profiles with access to read and update the config can personalize their own personal settings (only super-admin by default). It was intended that all profiles get personalization rights by default to keep existing functionality.