### PR TITLE
More intuitive 'SELECT DISTINCT' queries with DBmysqlIterator 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The present file will list all changes made to the project; according to the
 - Deprecate `getCommonSelect()` and `getCommonLeftJoin()` in `Change`, `Problem` and `Ticket` classes
 - Deprecate `DB::query()` and `DB::queryOrDie()` to disallow executing raw queries (iterator querying must be used)
 - Deprecate raw SQL condition in `Migration::addField()`
+- Deprecate 'SELECT DISTINCT' and 'DISTINCT FIELDS' criteria in `DBmysqlIterator::buildQuery()`
 
 #### Removed
 

--- a/ajax/autocompletion.php
+++ b/ajax/autocompletion.php
@@ -72,7 +72,8 @@ if (isset($_GET['user_restrict']) && $_GET['user_restrict']>0) {
 }
 
 $iterator = $DB->request([
-   'SELECT DISTINCT' => $_GET['field'],
+   'SELECT'          => $_GET['field'],
+   'DISTINCT'        => true,
    'FROM'            => $table,
    'WHERE'           => [
       $_GET['field'] => ['LIKE', $_GET['term'] . '%'],

--- a/inc/budget.class.php
+++ b/inc/budget.class.php
@@ -311,7 +311,8 @@ class Budget extends CommonDropdown{
       }
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'itemtype',
+         'SELECT'          => 'itemtype',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_infocoms',
          'WHERE'           => [
             'budgets_id'   => $budgets_id,

--- a/inc/calendar_holiday.class.php
+++ b/inc/calendar_holiday.class.php
@@ -76,8 +76,11 @@ class Calendar_Holiday extends CommonDBRelation {
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_calendars_holidays.id AS linkID',
-         'FIELDS'          => 'glpi_holidays.*',
+         'SELECT ' => [
+            'glpi_calendars_holidays.id AS linkID',
+            'glpi_holidays.*'
+         ],
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_calendars_holidays',
          'LEFT JOIN'       => [
             'glpi_holidays'   => [

--- a/inc/change_problem.class.php
+++ b/inc/change_problem.class.php
@@ -124,8 +124,11 @@ class Change_Problem extends CommonDBRelation{
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_changes_problems.id AS linkID',
-         'FIELDS'          => 'glpi_changes.*',
+         'SELECT' => [
+            'glpi_changes_problems.id AS linkID',
+            'glpi_changes.*'
+         ],
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_changes_problems',
          'LEFT JOIN'       => [
             'glpi_changes' => [
@@ -234,8 +237,11 @@ class Change_Problem extends CommonDBRelation{
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_changes_problems.id AS linkID',
-         'FIELDS'          => 'glpi_problems.*',
+         'SELECT' => [
+            'glpi_changes_problems.id AS linkID',
+            'glpi_problems.*'
+         ],
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_changes_problems',
          'LEFT JOIN'       => [
             'glpi_problems' => [

--- a/inc/change_ticket.class.php
+++ b/inc/change_ticket.class.php
@@ -238,8 +238,11 @@ class Change_Ticket extends CommonDBRelation{
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_changes_tickets.id AS linkID',
-         'FIELDS'          => 'glpi_tickets.*',
+         'SELECT' => [
+            'glpi_changes_tickets.id AS linkID',
+            'glpi_tickets.*'
+         ],
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_changes_tickets',
          'LEFT JOIN'       => [
             'glpi_tickets' => [
@@ -355,8 +358,11 @@ class Change_Ticket extends CommonDBRelation{
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_changes_tickets.id AS linkID',
-         'FIELDS'          => 'glpi_changes.*',
+         'SELECT'          => [
+            'glpi_changes_tickets.id AS linkID',
+            'glpi_changes.*'
+         ],
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_changes_tickets',
          'LEFT JOIN'       => [
             'glpi_changes' => [

--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -1643,7 +1643,8 @@ abstract class CommonDBRelation extends CommonDBConnexity {
     */
    protected static function getDistinctTypesParams($items_id, $extra_where = []) {
       $params = [
-         'SELECT DISTINCT' => 'itemtype',
+         'SELECT'          => 'itemtype',
+         'DISTINCT'        => true,
          'FROM'            => static::getTable(),
          'WHERE'           => [
             static::$items_id_1  => $items_id,

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -2203,7 +2203,8 @@ class CommonDBTM extends CommonGLPI {
                         $typefield = $rel[$tablename][1]; // itemtype...
 
                         $iterator = $DB->request([
-                           'SELECT DISTINCT' => $typefield,
+                           'SELECT'          => $typefield,
+                           'DISTINCT'        => true,
                            'FROM'            => $tablename,
                            'WHERE'           => [$field => $ID]
                         ]);

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -4771,12 +4771,13 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_users.id AS users_id',
-         'FIELDS'          => [
+         'SELECT'          => [
+            'glpi_users.id AS users_id',
             'glpi_users.name AS name',
             'glpi_users.realname AS realname',
             'glpi_users.firstname AS firstname'
          ],
+         'DISTINCT' => true,
          'FROM'            => $ctable,
          'LEFT JOIN'       => [
             $linktable  => [
@@ -4847,12 +4848,13 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_users.id AS user_id',
-         'FIELDS'          => [
+         'SELECT'          => [
+            'glpi_users.id AS user_id',
             'glpi_users.name AS name',
             'glpi_users.realname AS realname',
             'glpi_users.firstname AS firstname'
          ],
+         'DISTINCT'        => true,
          'FROM'            => $ctable,
          'LEFT JOIN'       => [
             'glpi_users'   => [
@@ -4915,10 +4917,11 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_groups.id',
-         'FIELDS'          => [
+         'SELECT' => [
+            'glpi_groups.id',
             'glpi_groups.completename'
          ],
+         'DISTINCT'        => true,
          'FROM'            => $ctable,
          'LEFT JOIN'       => [
             $linktable  => [
@@ -4994,9 +4997,10 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => "glpi_users.$field",
+         'SELECT'          => "glpi_users.$field",
+         'DISTINCT'        => true,
          'FROM'            => $ctable,
-         'INNER JOIN'       => [
+         'INNER JOIN'      => [
             $linktable  => [
                'ON' => [
                   $linktable  => $this->getForeignKeyField(),
@@ -5060,7 +5064,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'priority',
+         'SELECT'          => 'priority',
+         'DISTINCT'        => true,
          'FROM'            => $ctable,
          'WHERE'           => [
             "$ctable.is_deleted" => 0
@@ -5102,7 +5107,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'urgency',
+         'SELECT'          => 'urgency',
+         'DISTINCT'        => true,
          'FROM'            => $ctable,
          'WHERE'           => [
             "$ctable.is_deleted" => 0
@@ -5145,7 +5151,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'impact',
+         'SELECT'          => 'impact',
+         'DISTINCT'        => true,
          'FROM'            => $ctable,
          'WHERE'           => [
             "$ctable.is_deleted" => 0
@@ -5188,7 +5195,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'requesttypes_id',
+         'SELECT'          => 'requesttypes_id',
+         'DISTINCT'        => true,
          'FROM'            => $ctable,
          'WHERE'           => [
             "$ctable.is_deleted" => 0
@@ -5230,7 +5238,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'solutiontypes_id',
+         'SELECT'          => 'solutiontypes_id',
+         'DISTINCT'        => true,
          'FROM'            => ITILSolution::getTable(),
          'INNER JOIN'      => [
             $ctable   => [
@@ -5284,12 +5293,13 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_users.id AS users_id',
-         'FIELDS'          => [
+         'SELECT'          => [
+            'glpi_users.id AS users_id',
             'glpi_users.name AS name',
             'glpi_users.realname AS realname',
             'glpi_users.firstname AS firstname'
          ],
+         'DISTINCT'        => true,
          'FROM'            => $ctable,
          'LEFT JOIN'       => [
             $linktable  => [
@@ -5356,12 +5366,13 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_users.id AS users_id',
-         'FIELDS'          => [
+         'SELECT'          => [
+            'glpi_users.id AS users_id',
             'glpi_users.name AS name',
             'glpi_users.realname AS realname',
             'glpi_users.firstname AS firstname'
          ],
+         'DISTINCT' => true,
          'FROM'            => $ctable,
          'LEFT JOIN'       => [
             $linktable  => [
@@ -5446,10 +5457,11 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_suppliers.id AS suppliers_id_assign',
-         'FIELDS'          => [
+         'SELECT'          => [
+            'glpi_suppliers.id AS suppliers_id_assign',
             'glpi_suppliers.name AS name'
          ],
+         'DISTINCT'        => true,
          'FROM'            => $ctable,
          'LEFT JOIN'       => [
             $linktable        => [
@@ -5513,10 +5525,11 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $ctable = $this->getTable();
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_groups.id',
-         'FIELDS'          => [
+         'SELECT' => [
+            'glpi_groups.id',
             'glpi_groups.completename'
          ],
+         'DISTINCT'        => true,
          'FROM'            => $ctable,
          'LEFT JOIN'       => [
             $linktable  => [
@@ -6943,8 +6956,11 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $union = new \QueryUnion([$subquery1, $subquery2], false, 'allactors');
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'users_id',
-         'FIELDS'          => ['type'],
+         'SELECT'          => [
+            'users_id',
+            'type'
+         ],
+         'DISTINCT'        => true,
          'FROM'            => $union
       ]);
 
@@ -7037,10 +7053,11 @@ abstract class CommonITILObject extends CommonDBTM {
 
       $table = self::getTable();
       $criteria = [
-         'SELECT DISTINCT' => "$table.*",
-         'FIELDS'          => [
+         'SELECT'          => [
+            "$table.*",
             'glpi_itilcategories.completename AS catname'
          ],
+         'DISTINCT'        => true,
          'FROM'            => $table,
          'LEFT JOIN'       => [
             $gtable  => [

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -941,7 +941,8 @@ abstract class CommonITILTask  extends CommonDBTM {
          if (!$options['genical']
              && count($_SESSION["glpigroups"])) {
             $ADDWHERE[$item->getTable() . '.users_id_tech'] = new QuerySubQuery([
-               'SELECT DISTINCT' => 'users_id',
+               'SELECT'          => 'users_id',
+               'DISTINCT'        => true,
                'FROM'            => 'glpi_groups_users',
                'INNER JOIN'      => [
                   'glpi_groups'  => [
@@ -966,7 +967,8 @@ abstract class CommonITILTask  extends CommonDBTM {
          }
          if ($who_group > 0) {
             $ADDWHERE[$item->getTable() . '.users_id_tech'] = new QuerySubQuery([
-               'SELECT DISTINCT' => 'users_id',
+               'SELECT'          => 'users_id',
+               'DISTINCT'        => true,
                'FROM'            => 'glpi_groups_users',
                'WHERE'           => [
                   'groups_id' => $who_group,
@@ -983,7 +985,8 @@ abstract class CommonITILTask  extends CommonDBTM {
       if (!count($ADDWHERE)) {
          $ADDWHERE = [
             $item->getTable() . '.users_id_tech' => new \QuerySubQuery([
-               'SELECT DISTINCT' => 'glpi_profiles_users.users_id',
+               'SELECT'          => 'glpi_profiles_users.users_id',
+               'DISTINCT'        => true,
                'FROM'            => 'glpi_profiles',
                'LEFT JOIN'       => [
                   'glpi_profiles_users'   => [

--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -166,7 +166,8 @@ class CronTask extends CommonDBTM{
 
       $types= [];
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'itemtype',
+         'SELECT'          => 'itemtype',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_crontasks'
       ]);
       while ($data = $iterator->next()) {

--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -150,7 +150,8 @@ class DBmysqlIterator implements Iterator, Countable {
 
          // Check field, orderby, limit, start in criterias
          $field    = "";
-         $dfield    = "";
+         $dfield   = "";
+         $distinct = false;
          $orderby  = null;
          $limit    = 0;
          $start    = 0;
@@ -171,6 +172,13 @@ class DBmysqlIterator implements Iterator, Countable {
                   case 'SELECT DISTINCT' :
                   case 'DISTINCT FIELDS' :
                      $dfield = $val;
+                     unset($crit[$key]);
+                     break;
+
+                  case 'DISTINCT' :
+                     if ($val) {
+                        $distinct = true;
+                     }
                      unset($crit[$key]);
                      break;
 
@@ -257,23 +265,37 @@ class DBmysqlIterator implements Iterator, Countable {
          $this->sql = 'SELECT ';
          $first = true;
 
-         //check DISTINCT is not an array
-         if (is_array($dfield)) {
-            Toolbox::logWarning('DISTINCT selection can only take one field!');
-            if (!is_array($field)) {
+         // Backward compatibility for "SELECT DISTINCT" and "DISTINCT FIELDS"
+         if (!empty($dfield)) {
+            Toolbox::logWarning('"SELECT DISTINCT" and "DISTINCT FIELDS" are depreciated.');
+
+            // Merge $field and $dfield
+            if (empty($field)) {
                $field = $dfield;
             } else {
-               $field = array_merge($field, $dfield);
+               if (is_array($field) && is_array($dfield)) {
+                  $field = array_merge($dfield, $field);
+               } else if (is_array($field) && !is_array($dfield)) {
+                  array_unshift($field, $dfield);
+               } else if (!is_array($field) && is_array($dfield)) {
+                  $dfield[] = $field;
+                  $field = $dfield;
+               } else { // both are strings
+                  $field = [$dfield, $field];
+               }
             }
-            $dfield = '';
+
+            $distinct = true;
+            unset($dfield);
          }
 
          // SELECT field list
          if ($count) {
             $this->sql .= 'COUNT(';
-            if (!empty($dfield)) {
-               $this->sql .= "DISTINCT " . DBmysql::quoteName($dfield);
-            } else if (!empty($field) && !is_array($field)) {
+            if ($distinct) {
+               $this->sql .= 'DISTINCT ';
+            }
+            if (!empty($field) && !is_array($field)) {
                $this->sql .= "" . DBmysql::quoteName($field);
             } else {
                $this->sql .= "*";
@@ -282,12 +304,11 @@ class DBmysqlIterator implements Iterator, Countable {
             $first = false;
          }
          if (!$count || $count && is_array($field)) {
-            if (empty($field) && empty($dfield)) {
-               $this->sql .= '*';
+            if ($distinct && !$count) {
+               $this->sql .= 'DISTINCT ';
             }
-            if (!empty($dfield)) {
-               $this->sql .= 'DISTINCT ' . DBmysql::quoteName($dfield);
-               $first = false;
+            if (empty($field)) {
+               $this->sql .= '*';
             }
             if (!empty($field)) {
                if (!is_array($field)) {

--- a/inc/dbutils.class.php
+++ b/inc/dbutils.class.php
@@ -347,7 +347,8 @@ final class DbUtils {
          }
       }
       $condition['COUNT'] = 'cpt';
-      $condition['SELECT DISTINCT'] = $field;
+      $condition['FIELDS'] = $field;
+      $condition['DISTINCT'] = true;
 
       return $this->countElementsInTable($table, $condition);
    }

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -1434,7 +1434,8 @@ class Document extends CommonDBTM {
          'FROM'   => 'glpi_documentcategories',
          'WHERE'  => [
             'id' => new QuerySubQuery([
-               'SELECT DISTINCT' => 'documentcategories_id',
+               'SELECT'          => 'documentcategories_id',
+               'DISTINCT'        => true,
                'FROM'            => 'glpi_documents',
                'WHERE'           => $subwhere
             ])

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -603,7 +603,8 @@ class Dropdown {
       }
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => $p['field'],
+         'SELECT'          => $p['field'],
+         'DISTINCT'        => true,
          'FROM'            => getTableForItemType($itemtype_ref)
       ]);
 
@@ -2770,7 +2771,8 @@ class Dropdown {
 
             case "Profile" :
                $criteria = [
-                  'SELECT DISTINCT' => "$table.*",
+                  'SELECT'          => "$table.*",
+                  'DISTINCT'        => true,
                   'FROM'            => $table,
                   'LEFT JOIN'       => [
                      'glpi_profilerights' => [
@@ -2785,8 +2787,11 @@ class Dropdown {
 
             case KnowbaseItem::getType():
                $criteria = [
-                  'SELECT DISTINCT' => "$table.*",
-                  'FIELDS'          => $addselect,
+                  'SELECT'          => [
+                     "$table.*",
+                     $addselect
+                  ],
+                  'DISTINCT'        => true,
                   'FROM'            => $table
                ];
                if (count($ljoin)) {
@@ -3050,13 +3055,14 @@ class Dropdown {
       }
 
       $criteria = [
-         'SELECT DISTINCT' => "$table.id",
-         'FIELDS'          => [
+         'SELECT'          => [
+            "$table.id",
             "$table.name AS name",
             "$table.serial AS serial",
             "$table.otherserial AS otherserial",
             "$table.entities_id AS entities_id"
          ],
+         'DISTINCT'        => true,
          'FROM'            => $table,
          'WHERE'           => $where,
          'ORDERBY'         => ['entities_id', 'name ASC'],

--- a/inc/dropdowntranslation.class.php
+++ b/inc/dropdowntranslation.class.php
@@ -746,8 +746,11 @@ class DropdownTranslation extends CommonDBChild {
       $tab = [];
       if (self::isDropdownTranslationActive()) {
          $iterator = $DB->request([
-            'SELECT DISTINCT' => 'itemtype',
-            'FIELDS'          => 'field',
+            'SELECT'          => [
+               'itemtype',
+               'field'
+            ],
+            'DISTINCT'        => true,
             'FROM'            => self::getTable(),
             'WHERE'           => ['language' => $language]
          ]);

--- a/inc/group_user.class.php
+++ b/inc/group_user.class.php
@@ -392,14 +392,15 @@ class Group_User extends CommonDBRelation{
 
       // All group members
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_users.id',
          'SELECT'       => [
+            'glpi_users.id',
             'glpi_groups_users.id AS linkID',
             'glpi_groups_users.groups_id',
             'glpi_groups_users.is_dynamic AS is_dynamic',
             'glpi_groups_users.is_manager AS is_manager',
             'glpi_groups_users.is_userdelegate AS is_userdelegate'
          ],
+         'DISTINCT'     => true,
          'FROM'         => self::getTable(),
          'INNER JOIN'   => [
             User::getTable()           => [

--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -2062,7 +2062,8 @@ class Infocom extends CommonDBChild {
       global $DB;
 
       $types_iterator = $DB->request([
-         'SELECT DISTINCT' => 'itemtype',
+         'SELECT'          => 'itemtype',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_infocoms',
          'WHERE'           => [
             'NOT'          => ['itemtype' => self::getExcludedTypes()]

--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -843,7 +843,8 @@ class Item_Ticket extends CommonDBRelation{
                      $already_add[$itemtype] = [];
                   }
                   $criteria = [
-                     'SELECT DISTINCT' => "$itemtable.*",
+                     'SELECT'          => "$itemtable.*",
+                     'DISTINCT'        => true,
                      'FROM'            => 'glpi_computers_items',
                      'LEFT JOIN'       => [
                         $itemtable  => [
@@ -895,11 +896,12 @@ class Item_Ticket extends CommonDBRelation{
             // Software
             if (in_array('Software', $_SESSION["glpiactiveprofile"]["helpdesk_item_type"])) {
                $iterator = $DB->request([
-                  'SELECT DISTINCT' => 'glpi_softwareversions.name AS version',
-                  'FIELDS'          => [
+                  'SELECT'          => [
+                     'glpi_softwareversions.name AS version',
                      'glpi_softwares.name AS name',
                      'glpi_softwares.id'
                   ],
+                  'DISTINCT'        => true,
                   'FROM'            => 'glpi_computers_softwareversions',
                   'LEFT JOIN'       => [
                      'glpi_softwareversions'  => [

--- a/inc/itil_project.class.php
+++ b/inc/itil_project.class.php
@@ -137,8 +137,11 @@ class Itil_Project extends CommonDBRelation {
          $itemTable = $itemtype::getTable();
 
          $iterator = $DB->request([
-            'SELECT DISTINCT' => "$selfTable.id AS linkID",
-            'FIELDS'          => "$itemTable.*",
+            'SELECT'          => [
+               "$selfTable.id AS linkID",
+               "$itemTable.*"
+            ],
+            'DISTINCT'        => true,
             'FROM'            => $selfTable,
             'LEFT JOIN'       => [
                $itemTable => [
@@ -279,8 +282,11 @@ class Itil_Project extends CommonDBRelation {
       $projectTable = Project::getTable();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => "$selfTable.id AS linkID",
-         'FIELDS'          => "$projectTable.*",
+         'SELECT'          => [
+            "$selfTable.id AS linkID",
+            "$projectTable.*"
+         ],
+         'DISTINCT'        => true,
          'FROM'            => $selfTable,
          'LEFT JOIN'       => [
             $projectTable => [

--- a/inc/levelagreement.class.php
+++ b/inc/levelagreement.class.php
@@ -529,7 +529,8 @@ abstract class LevelAgreement extends CommonDBChild {
       $canedit = self::canUpdate();
 
       $rules_id_list = iterator_to_array($DB->request([
-         'SELECT DISTINCT' => 'rules_id',
+         'SELECT'          => 'rules_id',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_ruleactions',
          'WHERE'           => [
             'field' => $fk,

--- a/inc/levelagreementlevel.class.php
+++ b/inc/levelagreementlevel.class.php
@@ -334,7 +334,8 @@ abstract class LevelAgreementLevel extends RuleTicket {
       $result = [];
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'execution_time',
+         'SELECT'          => 'execution_time',
+         'DISTINCT'        => true,
          'FROM'            => static::getTable(),
          'WHERE'           => [
             static::$fkparent => $las_id

--- a/inc/log.class.php
+++ b/inc/log.class.php
@@ -772,7 +772,8 @@ class Log extends CommonDBTM {
       $items_id = $item->getField('id');
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'user_name',
+         'SELECT'          => 'user_name',
+         'DISTINCT'        => true,
          'FROM'            => self::getTable(),
          'WHERE'  => [
                'items_id'  => $items_id,
@@ -980,7 +981,8 @@ class Log extends CommonDBTM {
       $items_id = $item->getField('id');
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'linked_action',
+         'SELECT'          => 'linked_action',
+         'DISTINCT'        => true,
          'FROM'            => self::getTable(),
          'WHERE'  => [
                'items_id'  => $items_id,

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -792,7 +792,8 @@ class Migration {
       if (count($toadd)) {
          foreach ($toadd as $type => $tab) {
             $iterator = $DB->request([
-               'SELECT DISTINCT' => 'users_id',
+               'SELECT'          => 'users_id',
+               'DISTINCT'        => true,
                'FROM'            => 'glpi_displaypreferences',
                'WHERE'           => ['itemtype' => $type]
             ]);

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -744,8 +744,11 @@ class NotificationTarget extends CommonDBChild {
     */
    final public function getDistinctUserCriteria() {
       return [
-         'SELECT DISTINCT' => User::getTable() . '.id AS users_id',
-         'FIELDS'          => [User::getTable() . '.language AS language']
+         'FIELDS'          => [
+            User::getTable() . '.id AS users_id',
+            User::getTable() . '.language AS language'
+         ],
+         'DISTINCT'        => true,
       ];
    }
 

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -393,8 +393,11 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
          $fkfield           = $this->obj->getForeignKeyField();
 
          $iterator = $DB->request([
-            'SELECT DISTINCT' => 'glpi_suppliers.email AS email',
-            'FIELDS'          => 'glpi_suppliers.name AS name',
+            'SELECT'          => [
+               'glpi_suppliers.email AS email',
+               'glpi_suppliers.name AS name'
+            ],
+            'DISTINCT'        => true,
             'FROM'            => $supplierlinktable,
             'LEFT JOIN'       => [
                'glpi_suppliers'  => [

--- a/inc/notificationtargetsavedsearch_alert.class.php
+++ b/inc/notificationtargetsavedsearch_alert.class.php
@@ -43,7 +43,8 @@ class NotificationTargetSavedsearch_Alert extends NotificationTarget {
       $events = [];
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'event',
+         'SELECT'          => 'event',
+         'DISTINCT'        => true,
          'FROM'            => Notification::getTable(),
          'WHERE'           => ['itemtype' => SavedSearch_Alert::getType()]
       ]);

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -710,7 +710,8 @@ class Problem extends CommonITILObject {
       }
 
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_problems.id',
+         'SELECT'          => 'glpi_problems.id',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_problems',
          'LEFT JOIN'       => [
             'glpi_problems_users'   => [

--- a/inc/problem_ticket.class.php
+++ b/inc/problem_ticket.class.php
@@ -273,8 +273,11 @@ class Problem_Ticket extends CommonDBRelation{
       $rand = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_problems_tickets.id AS linkID',
-         'FIELDS'          => 'glpi_tickets.*',
+         'SELECT'          => [
+            'glpi_problems_tickets.id AS linkID',
+            'glpi_tickets.*'
+         ],
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_problems_tickets',
          'LEFT JOIN'       => [
             'glpi_tickets' => [
@@ -402,8 +405,11 @@ class Problem_Ticket extends CommonDBRelation{
       $rand = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_problems_tickets.id AS linkID',
-         'FIELDS'          => 'glpi_problems.*',
+         'SELECT'          => [
+            'glpi_problems_tickets.id AS linkID',
+            'glpi_problems.*'
+         ],
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_problems_tickets',
          'LEFT JOIN'       => [
             'glpi_problems'   => [

--- a/inc/profile_user.class.php
+++ b/inc/profile_user.class.php
@@ -450,13 +450,14 @@ class Profile_User extends CommonDBRelation {
       $putable = Profile_User::getTable();
       $etable = Entity::getTable();
       $iterator = $DB->request([
-         'SELECT DISTINCT' => "$utable.*",
-         'FIELDS'          => [
+         'SELECT'          => [
+            "$utable.*",
             "$putable.entities_id AS entity",
             "$putable.id AS linkID",
             "$putable.is_dynamic",
             "$putable.is_recursive"
          ],
+         'DISTINCT'        => true,
          'FROM'            => $putable,
          'LEFT JOIN'       => [
             $etable  => [
@@ -622,8 +623,11 @@ class Profile_User extends CommonDBRelation {
       global $DB;
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'entities_id',
-         'FIELDS'          => 'is_recursive',
+         'SELECT'          => [
+            'entities_id',
+            'is_recursive'
+         ],
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_profiles_users',
          'WHERE'           => ['users_id' => $user_ID]
       ]);
@@ -674,8 +678,11 @@ class Profile_User extends CommonDBRelation {
       $ptable = Profile::getTable();
       $prtable = ProfileRight::getTable();
       $iterator = $DB->request([
-         'SELECT DISTINCT' => "$putable.entities_id",
-         'FIELDS'          => ["$putable.is_recursive"],
+         'SELECT'          => [
+            "$putable.entities_id",
+            "$putable.is_recursive"
+         ],
+         'DISTINCT'        => true,
          'FROM'            => $putable,
          'INNER JOIN'      => [
             $ptable  => [
@@ -738,7 +745,8 @@ class Profile_User extends CommonDBRelation {
       }
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'profiles_id',
+         'SELECT'          => 'profiles_id',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_profiles_users',
          'WHERE'           => $where
       ]);

--- a/inc/profileright.class.php
+++ b/inc/profileright.class.php
@@ -61,7 +61,8 @@ class ProfileRight extends CommonDBChild {
           || count($GLPI_CACHE->get('all_possible_rights')) == 0) {
 
          $iterator = $DB->request([
-            'SELECT DISTINCT' => 'name',
+            'SELECT'          => 'name',
+            'DISTINCT'        => true,
             'FROM'            => self::getTable()
          ]);
          while ($right = $iterator->next()) {
@@ -249,7 +250,8 @@ class ProfileRight extends CommonDBChild {
       ]);
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'POSSIBLE.name AS NAME',
+         'SELECT'          => 'POSSIBLE.name AS NAME',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_profilerights AS POSSIBLE',
          'WHERE'           => [
             new \QueryExpression('NOT EXISTS ' . $subq->getQuery())

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -1438,7 +1438,8 @@ class ProjectTask extends CommonDBChild {
              && count($_SESSION["glpigroups"])) {
             $ADDWHERE['glpi_projecttaskteams.itemtype'] = ['Group'];
             $ADDWHERE['glpi_projecttaskteams.items_id'] = new \QuerySubQuery([
-               'SELECT DISTINCT' => 'groups_id',
+               'SELECT'          => 'groups_id',
+               'DISTINCT'        => true,
                'FROM'            => 'glpi_groups',
                'WHERE'           => [
                   'groups_id' => $_SESSION['glpigroups'],
@@ -1466,7 +1467,8 @@ class ProjectTask extends CommonDBChild {
          $ADDWHERE = [
             'glpi_projecttaskteams.itemtype' => 'User',
             'glpi_projecttaskteams.items_id' => new \QuerySubQuery([
-               'SELECT DISTINCT' => 'glpi_profiles_users.users_id',
+               'SELECT'          => 'glpi_profiles_users.users_id',
+               'DISTINCT'        => true,
                'FROM'            => 'glpi_profiles',
                'LEFT JOIN'       => [
                   'glpi_profiles_users'   => [

--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -971,7 +971,8 @@ class Reminder extends CommonDBVisible {
 
       $table = self::getTable();
       $criteria = [
-         'SELECT DISTINCT' => "$table.*",
+         'SELECT'          => "$table.*",
+         'DISTINCT'        => true,
          'FROM'            => $table,
          'WHERE'           => $WHERE,
          'ORDER'           => 'begin'
@@ -1163,7 +1164,8 @@ class Reminder extends CommonDBVisible {
 
          $criteria = array_merge_recursive(
             [
-               'SELECT DISTINCT' => 'glpi_reminders.*',
+               'SELECT'          => 'glpi_reminders.*',
+               'DISTINCT'        => true,
                'FROM'            => 'glpi_reminders',
                'WHERE'           => $visibility_criteria,
                'ORDERBY'         => 'name'

--- a/inc/reservation.class.php
+++ b/inc/reservation.class.php
@@ -916,7 +916,8 @@ class Reservation extends CommonDBChild {
          $fin   = $date." 23:59:59";
 
          $iterator = $DB->request([
-            'SELECT DISTINCT' => 'glpi_reservationitems.id',
+            'SELECT'          => 'glpi_reservationitems.id',
+            'DISTINCT'        => true,
             'FROM'            => 'glpi_reservationitems',
             'INNER JOIN'      => [
                'glpi_reservations'  => [

--- a/inc/reservationitem.class.php
+++ b/inc/reservationitem.class.php
@@ -449,7 +449,8 @@ class ReservationItem extends CommonDBChild {
       echo "<tr class='tab_bg_2'><td>".__('Item type')."</td><td>";
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'itemtype',
+         'SELECT'          => 'itemtype',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_reservationitems',
          'WHERE'           => [
             'is_active' => 1

--- a/inc/rulecollection.class.php
+++ b/inc/rulecollection.class.php
@@ -1692,7 +1692,8 @@ class RuleCollection extends CommonDBTM {
       $input = [];
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_rulecriterias.criteria',
+         'SELECT'          => 'glpi_rulecriterias.criteria',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_rulecriterias',
          'INNER JOIN'      => [
             'glpi_rules'   => [
@@ -1915,7 +1916,8 @@ class RuleCollection extends CommonDBTM {
       $params = [];
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_rulecriterias.criteria',
+         'SELECT'          => 'glpi_rulecriterias.criteria',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_rulecriterias',
          'INNER JOIN'      => [
             'glpi_rules'   => [

--- a/inc/ruledictionnarydropdowncollection.class.php
+++ b/inc/ruledictionnarydropdowncollection.class.php
@@ -146,13 +146,14 @@ class RuleDictionnaryDropdownCollection extends RuleCollection {
 
       // Need to give manufacturer from item table
       $criteria =[
-         'SELECT DISTINCT' => 'glpi_manufacturers.id AS idmanu',
-         'FIELDS'          => [
+         'SELECT'          => [
+            'glpi_manufacturers.id AS idmanu',
             'glpi_manufacturers.name AS manufacturer',
             $this->item_table . '.id',
             $this->item_table . '.name AS name',
             $this->item_table . '.comment'
          ],
+         'DISTINCT'        => true,
          'FROM'            => $this->item_table,
          'INNER JOIN'      => [
             $model_table         => [

--- a/inc/ruledictionnarysoftwarecollection.class.php
+++ b/inc/ruledictionnarysoftwarecollection.class.php
@@ -119,13 +119,14 @@ class RuleDictionnarySoftwareCollection extends RuleCollection {
       if (count($items) == 0) {
          //Select all the differents software
          $criteria = [
-            'SELECT DISTINCT' => 'glpi_softwares.name',
-            'FIELDS'          => [
+            'SELECT'          => [
+               'glpi_softwares.name',
                'glpi_manufacturers.name AS manufacturer',
                'glpi_softwares.manufacturers_id AS manufacturers_id',
                'glpi_softwares.entities_id AS entities_id',
                'glpi_softwares.is_helpdesk_visible AS helpdesk'
             ],
+            'DISTINCT'        => true,
             'FROM'            => 'glpi_softwares',
             'LEFT JOIN'       => [
                'glpi_manufacturers' => [

--- a/inc/rulerightcollection.class.php
+++ b/inc/rulerightcollection.class.php
@@ -181,7 +181,8 @@ class RuleRightCollection extends RuleCollection {
 
       $params = [];
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'value',
+         'SELECT'          => 'value',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_rulerightparameters',
          'LEFT JOIN'       => [
             'glpi_rulecriterias' => [

--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -1101,7 +1101,8 @@ class SavedSearch extends CommonDBTM {
 
       $types= [];
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'itemtype',
+         'SELECT'          => 'itemtype',
+         'DISTINCT'        => true,
          'FROM'            => static::getTable()
       ]);
       while ($data = $iterator->next()) {

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -472,8 +472,11 @@ class Session {
       }
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_profiles.id',
-         'FIELDS'          => ['glpi_profiles.name'],
+         'SELECT'          => [
+            'glpi_profiles.id',
+            'glpi_profiles.name'
+         ],
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_profiles_users',
          'INNER JOIN'      => [
             'glpi_profiles'   => [

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -726,8 +726,11 @@ class Software extends CommonDBTM {
       global $CFG_GLPI, $DB;
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_softwares.id',
-         'FIELDS'          => ['glpi_softwares.name'],
+         'SELECT'          => [
+            'glpi_softwares.id',
+            'glpi_softwares.name'
+         ],
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_softwares',
          'INNER JOIN'      => [
             'glpi_softwarelicenses' => [

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -5546,7 +5546,8 @@ class Ticket extends CommonITILObject {
       }
 
       $criteria = [
-         'SELECT DISTINCT' => 'glpi_tickets.id',
+         'SELECT'          => 'glpi_tickets.id',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_tickets',
          'LEFT JOIN'       => [
             'glpi_tickets_users'    => [

--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -358,7 +358,8 @@ class Transfer extends CommonDBTM {
 
             if (count($this->needtobe_transfer['Computer'])) {
                $iterator = $DB->request([
-                  'SELECT DISTINCT' => 'items_id',
+                  'SELECT'          => 'items_id',
+                  'DISTINCT'        => true,
                   'FROM'            => 'glpi_computers_items',
                   'WHERE'           => [
                      'itemtype'     => $itemtype,
@@ -536,11 +537,12 @@ class Transfer extends CommonDBTM {
                   $devicetable     = getTableForItemType($devicetype);
                   $fk              = getForeignKeyFieldForTable($devicetable);
                   $iterator = $DB->request([
-                     'SELECT DISTINCT' => "$itemdevicetable.$fk",
-                     'FIELDS'          => [
+                     'SELECT'          => [
+                        "$itemdevicetable.$fk",
                         "$devicetable.entities_id",
                         "$devicetable.is_recursive"
                      ],
+                     'DISTINCT'        => true,
                      'FROM'            => $itemdevicetable,
                      'LEFT JOIN'       => [
                         $devicetable   => [
@@ -3243,7 +3245,8 @@ class Transfer extends CommonDBTM {
                         // Can be transfer without copy ? = all linked items need to be transfer (so not copy)
                         $canbetransfer = true;
                         $type_iterator = $DB->request([
-                           'SELECT DISTINCT' => 'itemtype',
+                           'SELECT'          => 'itemtype',
+                           'DISTINCT'        => true,
                            'FROM'            => $itemdevicetable,
                            'WHERE'           => [$fk => $item_ID]
                         ]);

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -1325,7 +1325,8 @@ class User extends CommonDBTM {
 
       // Search in DB the ldap_field we need to search for in LDAP
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'ldap_field',
+         'SELECT'          => 'ldap_field',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_groups',
          'WHERE'           => ['NOT' => ['ldap_field' => '']],
          'ORDER'           => 'ldap_field'
@@ -3310,7 +3311,8 @@ class User extends CommonDBTM {
       global $DB;
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_groups_users.groups_id',
+         'SELECT'          => 'glpi_groups_users.groups_id',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_groups_users',
          'INNER JOIN'      => [
             'glpi_groups'  => [
@@ -3621,7 +3623,8 @@ class User extends CommonDBTM {
       if ($count) {
          $criteria['COUNT DISTINCT'] = 'glpi_users.*';
       } else {
-         $criteria['SELECT DISTINCT'] = 'glpi_users.*';
+         $criteria['SELECT'] = 'glpi_users.*';
+         $criteria['DISTINCT'] = true;
       }
 
       if ($joinprofile) {

--- a/tests/functionnal/Document_Item.php
+++ b/tests/functionnal/Document_Item.php
@@ -124,7 +124,8 @@ class Document_Item extends DbTestCase {
 
    public function testGetDistinctTypesParams() {
       $expected = [
-         'SELECT DISTINCT' => 'itemtype',
+         'SELECT'          => 'itemtype',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_documents_items',
          'WHERE'           => [
             'OR'  => [
@@ -141,7 +142,8 @@ class Document_Item extends DbTestCase {
 
       $extra_where = ['date_mod' => ['>', '2000-01-01']];
       $expected = [
-         'SELECT DISTINCT' => 'itemtype',
+         'SELECT'          => 'itemtype',
+         'DISTINCT'        => true,
          'FROM'            => 'glpi_documents_items',
          'WHERE'           => [
             'OR'  => [

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -159,10 +159,10 @@ class DBmysqlIterator extends DbTestCase {
 
 
    public function testFields() {
-      $it = $this->it->execute('foo', ['DISTINCT FIELDS' => 'bar']);
+      $it = $this->it->execute('foo', ['FIELDS' => 'bar', 'DISTINCT' => true]);
       $this->string($it->getSql())->isIdenticalTo('SELECT DISTINCT `bar` FROM `foo`');
 
-      $it = $this->it->execute('foo', ['DISTINCT FIELDS' => 'bar', 'FIELDS' => 'baz']);
+      $it = $this->it->execute('foo', ['FIELDS' => ['bar', 'baz'], 'DISTINCT' => true]);
       $this->string($it->getSql())->isIdenticalTo('SELECT DISTINCT `bar`, `baz` FROM `foo`');
 
       $it = $this->it->execute('foo', ['FIELDS' => 'bar']);
@@ -198,14 +198,51 @@ class DBmysqlIterator extends DbTestCase {
       $it = $this->it->execute('foo', ['FIELDS' => ['MAX' => 'bar AS cpt']]);
       $this->string($it->getSql())->isIdenticalTo('SELECT MAX(`bar`) AS cpt FROM `foo`');
 
+      // Backward compability tests
       $this->exception(
          function() {
             $it = $this->it->execute('foo', ['DISTINCT FIELDS' => ['bar', 'baz']]);
-            $this->string($it->getSql())->isIdenticalTo('SELECT `bar`, `baz` FROM `foo`');
+            $this->string($it->getSql())->isIdenticalTo('SELECT DISTINCT `bar`, `baz` FROM `foo`');
          }
       )
          ->isInstanceOf('RuntimeException')
-         ->message->contains('DISTINCT selection can only take one field!');
+         ->message->contains('"SELECT DISTINCT" and "DISTINCT FIELDS" are depreciated.');
+
+      $this->exception(
+         function() {
+            $it = $this->it->execute('foo', ['DISTINCT FIELDS' => ['bar'], 'FIELDS' => ['baz']]);
+            $this->string($it->getSql())->isIdenticalTo('SELECT DISTINCT `bar`, `baz` FROM `foo`');
+         }
+      )
+         ->isInstanceOf('RuntimeException')
+         ->message->contains('"SELECT DISTINCT" and "DISTINCT FIELDS" are depreciated.');
+
+      $this->exception(
+         function() {
+            $it = $this->it->execute('foo', ['DISTINCT FIELDS' => 'bar', 'FIELDS' => ['baz']]);
+            $this->string($it->getSql())->isIdenticalTo('SELECT DISTINCT `bar`, `baz` FROM `foo`');
+         }
+      )
+         ->isInstanceOf('RuntimeException')
+         ->message->contains('"SELECT DISTINCT" and "DISTINCT FIELDS" are depreciated.');
+
+      $this->exception(
+         function() {
+            $it = $this->it->execute('foo', ['DISTINCT FIELDS' => ['bar'], 'FIELDS' => 'baz']);
+            $this->string($it->getSql())->isIdenticalTo('SELECT DISTINCT `bar`, `baz` FROM `foo`');
+         }
+      )
+         ->isInstanceOf('RuntimeException')
+         ->message->contains('"SELECT DISTINCT" and "DISTINCT FIELDS" are depreciated.');
+
+      $this->exception(
+         function() {
+            $it = $this->it->execute('foo', ['DISTINCT FIELDS' => 'bar', 'FIELDS' => 'baz']);
+            $this->string($it->getSql())->isIdenticalTo('SELECT DISTINCT `bar`, `baz` FROM `foo`');
+         }
+      )
+         ->isInstanceOf('RuntimeException')
+         ->message->contains('"SELECT DISTINCT" and "DISTINCT FIELDS" are depreciated.');
    }
 
 
@@ -264,7 +301,7 @@ class DBmysqlIterator extends DbTestCase {
       $it = $this->it->execute('foo', ['COUNT' => 'cpt']);
       $this->string($it->getSql())->isIdenticalTo('SELECT COUNT(*) AS cpt FROM `foo`');
 
-      $it = $this->it->execute('foo', ['COUNT' => 'cpt', 'SELECT DISTINCT' => 'bar']);
+      $it = $this->it->execute('foo', ['COUNT' => 'cpt', 'SELECT' => 'bar', 'DISTINCT' => true]);
       $this->string($it->getSql())->isIdenticalTo('SELECT COUNT(DISTINCT `bar`) AS cpt FROM `foo`');
 
       $it = $this->it->execute('foo', ['COUNT' => 'cpt', 'FIELDS' => ['name', 'version']]);
@@ -287,6 +324,16 @@ class DBmysqlIterator extends DbTestCase {
 
       $it = $this->it->execute('foo', ['FIELDS' => ['foo.bar', 'COUNT' => ['foo.baz', 'foo.qux']]]);
       $this->string($it->getSql())->isIdenticalTo('SELECT `foo`.`bar`, COUNT(`foo`.`baz`), COUNT(`foo`.`qux`) FROM `foo`');
+
+      // Backward compability tests
+      $this->exception(
+         function() {
+            $it = $this->it->execute('foo', ['COUNT' => 'cpt', 'SELECT DISTINCT' => 'bar']);
+            $this->string($it->getSql())->isIdenticalTo('SELECT COUNT(DISTINCT `bar`) AS cpt FROM `foo`');
+         }
+      )
+         ->isInstanceOf('RuntimeException')
+         ->message->contains('"SELECT DISTINCT" and "DISTINCT FIELDS" are depreciated.');
    }
 
    public function testCountDistinct() {
@@ -790,8 +837,9 @@ class DBmysqlIterator extends DbTestCase {
       $union = new \QueryUnion($union_crit, false, 'theunion');
       $raw_query = 'SELECT DISTINCT `theunion`.`field` FROM ((SELECT * FROM `table1`) UNION ALL (SELECT * FROM `table2`)) AS `theunion`';
       $crit = [
-         'SELECT DISTINCT' => 'theunion.field',
-         'FROM'            => $union,
+         'SELECT'    => 'theunion.field',
+         'DISTINCT'  => true,
+         'FROM'      => $union,
       ];
       $it = $this->it->execute($crit);
       $this->string($it->getSql())->isIdenticalTo($raw_query);
@@ -799,8 +847,9 @@ class DBmysqlIterator extends DbTestCase {
       $union = new \QueryUnion($union_crit, true);
       $raw_query = 'SELECT DISTINCT `theunion`.`field` FROM ((SELECT * FROM `table1`) UNION (SELECT * FROM `table2`))';
       $crit = [
-         'SELECT DISTINCT' => 'theunion.field',
-         'FROM'            => $union,
+         'SELECT'    => 'theunion.field',
+         'DISTINCT'  => true,
+         'FROM'      => $union,
       ];
       $it = $this->it->execute($crit);
       $this->string($it->getSql())->isIdenticalTo($raw_query);
@@ -871,8 +920,11 @@ class DBmysqlIterator extends DbTestCase {
 
       $union = new \QueryUnion([$subquery1, $subquery2], false, 'allactors');
       $it = $this->it->execute([
-         'SELECT DISTINCT' => 'users_id',
-         'FIELDS'          => ['type'],
+         'FIELDS'          => [
+            'users_id',
+            'type'
+         ],
+         'DISTINCT'        => true,
          'FROM'            => $union
       ]);
       $this->string($it->getSql())->isIdenticalTo($raw_query);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | 
| Fixed tickets | ---

Current implementation of SELECT DISTINCT :
```
'SELECT DISTINCT' => 'field1',
'FIELDS'          => ['field2', 'field3']
```

Proposed new implementation :
```
'SELECT'   => ['field1', 'field2', 'field3'],
'DISTINCT' => true
```

The current implementation will still work after this changes but will raise a warning.