### PR TITLE
fix display of progressbars in search list

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5171,8 +5171,7 @@ JAVASCRIPT;
          case "glpi_changes.time_to_resolve" :
          case "glpi_tickets.time_to_own" :
          case "glpi_tickets.internal_time_to_own" :
-            if (($ID <> 151) && ($ID <> 158)
-                && ($ID <> 181) && ($ID <> 186)
+            if (!in_array($ID, [151, 158, 181, 186])
                 && !empty($data[$ID][0]['name'])
                 && ($data[$NAME][0]['status'] != CommonITILObject::WAITING)
                 && ($data[$NAME][0]['name'] < $_SESSION['glpi_currenttime'])) {
@@ -5538,8 +5537,7 @@ JAVASCRIPT;
             case "glpi_tickets.internal_time_to_own" :
             case "glpi_tickets.internal_time_to_resolve" :
                // Due date + progress
-               if (($ID == 151) || ($ID == 158)
-                   ||($ID == 181) ||($ID == 186)) {
+               if (in_array($orig_id, [151, 158, 181, 186])) {
                   $out = Html::convDateTime($data[$ID][0]['name']);
 
                   // No due date in waiting status
@@ -5639,8 +5637,8 @@ JAVASCRIPT;
                      $bar_color = 'yellow';
                   }
 
-                  if (!isset($searchopt[$ID]['datatype'])) {
-                     $searchopt[$ID]['datatype'] = 'progressbar';
+                  if (!isset($so['datatype'])) {
+                     $so['datatype'] = 'progressbar';
                   }
 
                   $progressbar_data = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

2 issues (is did some cleaning so it's not  so obvious):
-> [151, 158, etc] is now set in original id
-> add `progressbar` in `datatype` was set on the wrong variable (`$so` vs `$searchoption[$ID]`)