### PR TITLE
Fix instance UUID retrieval in cache instanciation

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2927,7 +2927,7 @@ class Config extends CommonDBTM {
     * @return Zend\Cache\Psr\SimpleCache\SimpleCacheDecorator|Zend\Cache\Storage\StorageInterface object
     */
    public static function getCache($optname, $context = 'core', $psr16 = true) {
-      global $DB, $CFG_GLPI;
+      global $DB;
 
       /* Tested configuration values
        *
@@ -2970,8 +2970,8 @@ class Config extends CommonDBTM {
 
       if (!isset($opt['options']['namespace'])) {
          $namespace = "glpi_${optname}_" . GLPI_VERSION;
-         if (isset($CFG_GLPI['instance_uuid'])) {
-            $namespace .= $CFG_GLPI['instance_uuid'];
+         if ($DB && $DB->connected) {
+            $namespace .= Telemetry::getInstanceUuid();
          }
          $opt['options']['namespace'] = $namespace;
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In 9.2.4 (commit 3dca2d38b1c71165c5e5462303ae6a9c12e5bdd7), the instance UUID has been added to prevent conflict on cache between multiple instances of GLPI.
The problem is that if no UUID exists (Telemetry not active for instance), it does not generate one, so the problem persists.