### PR TITLE
Add missing rights

### DIFF
--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -7095,6 +7095,20 @@ INSERT INTO `glpi_profilerights` VALUES ('875','5','personalization','3');
 INSERT INTO `glpi_profilerights` VALUES ('876','6','personalization','3');
 INSERT INTO `glpi_profilerights` VALUES ('877','7','personalization','3');
 INSERT INTO `glpi_profilerights` VALUES ('878','8','personalization','3');
+INSERT INTO `glpi_profilerights` VALUES ('879','1','rule_asset','0');
+INSERT INTO `glpi_profilerights` VALUES ('880','2','rule_asset','0');
+INSERT INTO `glpi_profilerights` VALUES ('881','3','rule_asset','0');
+INSERT INTO `glpi_profilerights` VALUES ('882','5','rule_asset','0');
+INSERT INTO `glpi_profilerights` VALUES ('883','6','rule_asset','0');
+INSERT INTO `glpi_profilerights` VALUES ('884','7','rule_asset','0');
+INSERT INTO `glpi_profilerights` VALUES ('885','8','rule_asset','0');
+INSERT INTO `glpi_profilerights` VALUES ('886','1','global_validation','0');
+INSERT INTO `glpi_profilerights` VALUES ('887','2','global_validation','0');
+INSERT INTO `glpi_profilerights` VALUES ('888','3','global_validation','0');
+INSERT INTO `glpi_profilerights` VALUES ('889','4','global_validation','0');
+INSERT INTO `glpi_profilerights` VALUES ('890','5','global_validation','0');
+INSERT INTO `glpi_profilerights` VALUES ('891','6','global_validation','0');
+INSERT INTO `glpi_profilerights` VALUES ('892','7','global_validation','0');
 
 ### Dump table glpi_profiles
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5098 

Follows #5215 because I missed that some rights were outright missing by default while I was copying over the correct values for rights from test profiles.
As @ConteZero said, these missing rights mess up determining which profiles are more privileged.

The "global_validation" right appears unused at least in the core, but I have left it in for now just in case.