### PR TITLE
Fix linking when merging tickets

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2789,10 +2789,18 @@ class Ticket extends CommonITILObject {
                      //Add relation (this is parent of merge target)
                      $tt = new Ticket_Ticket();
                      $linkparams = [
-                        'link'         => Ticket_Ticket::PARENT_OF,
+                        'link'         => Ticket_Ticket::SON_OF,
                         'tickets_id_1' => $id,
                         'tickets_id_2' => $input['_mergeticket']
                      ];
+
+                     $existinglinks = Ticket_Ticket::getLinkedTicketsTo($id);
+                     foreach ($existinglinks as $ttkey => $link) {
+                        if ($link['link'] == Ticket_Ticket::PARENT_OF) {
+                           //Remove conflicting link
+                           $tt->delete(['id' => $ttkey]);
+                        }
+                     }
                      if (!$tt->add($linkparams)) {
                         //Cannot link tickets. Abort/fail the merge
                         throw new \RuntimeException(ERROR_ON_ACTION, MassiveAction::ACTION_KO);

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2794,13 +2794,11 @@ class Ticket extends CommonITILObject {
                         'tickets_id_2' => $input['_mergeticket']
                      ];
 
-                     $existinglinks = Ticket_Ticket::getLinkedTicketsTo($id);
-                     foreach ($existinglinks as $ttkey => $link) {
-                        if ($link['link'] == Ticket_Ticket::PARENT_OF) {
-                           //Remove conflicting link
-                           $tt->delete(['id' => $ttkey]);
-                        }
-                     }
+                     $tt->deleteByCriteria([
+                        'tickets_id_1' => $input['_mergeticket'],
+                        'tickets_id_2' => $id,
+                        'link' => Ticket_Ticket::SON_OF]);
+
                      if (!$tt->add($linkparams)) {
                         //Cannot link tickets. Abort/fail the merge
                         throw new \RuntimeException(ERROR_ON_ACTION, MassiveAction::ACTION_KO);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Merge target should become parent of merged ticket instead of son.
If there is a an opposite link between tickets already, merge would of failed while adding the new link. So, delete the old link first.