### PR TITLE
Remove dead code on Project class

### DIFF
--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -192,10 +192,6 @@ class Project extends CommonDBTM {
          $menu['project']['title'] = Project::getTypeName(Session::getPluralNumber());
          $menu['project']['page']  = ProjectTask::getSearchURL(false);
 
-         if (count($links)) {
-            $menu['project']['links'] = $links;
-         }
-
          return $menu;
       }
       return false;


### PR DESCRIPTION

Deleting dead code on the Poject class that adds PHP waring to the logs

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
