### PR TITLE
Dependency injection and event dispatcher on items CRUD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ shared: &shared
 #          composer testldap
     - run:
         name: Coding standards
-        command: if [[ $(php --version|grep "7\.3") ]]; then vendor/bin/phpcs -d memory_limit=512M -p --standard=vendor/glpi-project/coding-standard/GlpiStandard/ --ignore=/vendor/,/plugins/,/files/,/lib/,/config/,/tests/config,/css/tiny_mce,/.git ./; else echo "No CS for this version"; fi
+        command: if [[ $(php --version|grep "7\.3") ]]; then vendor/bin/phpcs -d memory_limit=512M -p -n --standard=PSR2 ./src && vendor/bin/phpcs -d memory_limit=512M -p --standard=vendor/glpi-project/coding-standard/GlpiStandard/ --ignore=/vendor/,/plugins/,/files/,/lib/,/config/,/tests/config,/css/tiny_mce,/.git,/src ./; else echo "No CS for this version"; fi
     - run:
         name: sensiolabs/security-checker
         command: vendor/bin/security-checker security:check

--- a/bin/console
+++ b/bin/console
@@ -65,6 +65,9 @@ include_once(GLPI_ROOT . '/inc/based_config.php');
 include_once(GLPI_ROOT . '/inc/db.function.php');
 @include_once(GLPI_CONFIG_DIR . '/config_db.php');
 
+// Load kernel and expose container in global var
+$CONTAINER = (new Glpi\Kernel())->getContainer();
+
 // Run console application
 use Glpi\Console\Application;
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,10 @@
         "zendframework/zend-console": "^2.7",
         "elvanto/litemoji": "^1.4",
         "symfony/console": "^3.4",
-        "leafo/scssphp": "^0.7.7"
+        "leafo/scssphp": "^0.7.7",
+        "symfony/dependency-injection": "^3.4",
+        "symfony/yaml": "^3.4",
+        "symfony/config": "^3.4"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "~6",
@@ -58,6 +61,11 @@
         "optimize-autoloader": true,
         "platform": {
             "php": "7.0.8"
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Glpi\\": "src/Glpi/"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "leafo/scssphp": "^0.7.7",
         "symfony/dependency-injection": "^3.4",
         "symfony/yaml": "^3.4",
-        "symfony/config": "^3.4"
+        "symfony/config": "^3.4",
+        "symfony/event-dispatcher": "^3.4"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "~6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a241828ab82a1ee6fc047d1c1bf53be7",
+    "content-hash": "48c6ab05b1c936e2527df188eaf4e81d",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1176,6 +1176,69 @@
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
             "time": "2019-01-05T12:26:58+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v3.4.21",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "d1cdd46c53c264a2bd42505bd0e8ce21423bd0e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d1cdd46c53c264a2bd42505bd0e8ce21423bd0e2",
+                "reference": "d1cdd46c53c264a2bd42505bd0e8ce21423bd0e2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "~3.3|~4.0",
+                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/stopwatch": "~2.8|~3.0|~4.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-01-01T18:08:36+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -3423,69 +3486,6 @@
                 "standards"
             ],
             "time": "2018-09-23T23:08:17+00:00"
-        },
-        {
-            "name": "symfony/event-dispatcher",
-            "version": "v3.4.21",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "d1cdd46c53c264a2bd42505bd0e8ce21423bd0e2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d1cdd46c53c264a2bd42505bd0e8ce21423bd0e2",
-                "reference": "d1cdd46c53c264a2bd42505bd0e8ce21423bd0e2",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<3.3"
-            },
-            "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "~3.3|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/stopwatch": "~2.8|~3.0|~4.0"
-            },
-            "suggest": {
-                "symfony/dependency-injection": "",
-                "symfony/http-kernel": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony EventDispatcher Component",
-            "homepage": "https://symfony.com",
-            "time": "2019-01-01T18:08:36+00:00"
         },
         {
             "name": "symfony/finder",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c6a3bc6bba6c77f649ab1c012e53e69",
+    "content-hash": "a241828ab82a1ee6fc047d1c1bf53be7",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -918,17 +918,81 @@
             "time": "2018-08-02T05:43:58+00:00"
         },
         {
-            "name": "symfony/console",
-            "version": "v3.4.20",
+            "name": "symfony/config",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "8f80fc39bbc3b7c47ee54ba7aa2653521ace94bb"
+                "url": "https://github.com/symfony/config.git",
+                "reference": "17c5d8941eb75a03d19bc76a43757738632d87b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/8f80fc39bbc3b7c47ee54ba7aa2653521ace94bb",
-                "reference": "8f80fc39bbc3b7c47ee54ba7aa2653521ace94bb",
+                "url": "https://api.github.com/repos/symfony/config/zipball/17c5d8941eb75a03d19bc76a43757738632d87b3",
+                "reference": "17c5d8941eb75a03d19bc76a43757738632d87b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/filesystem": "~2.8|~3.0|~4.0",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3",
+                "symfony/finder": "<3.3"
+            },
+            "require-dev": {
+                "symfony/dependency-injection": "~3.3|~4.0",
+                "symfony/event-dispatcher": "~3.3|~4.0",
+                "symfony/finder": "~3.3|~4.0",
+                "symfony/yaml": "~3.0|~4.0"
+            },
+            "suggest": {
+                "symfony/yaml": "To use the yaml reference dumper"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Config Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-01-01T13:45:19+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v3.4.21",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "a700b874d3692bc8342199adfb6d3b99f62cc61a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a700b874d3692bc8342199adfb6d3b99f62cc61a",
+                "reference": "a700b874d3692bc8342199adfb6d3b99f62cc61a",
                 "shasum": ""
             },
             "require": {
@@ -984,20 +1048,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-26T12:48:07+00:00"
+            "time": "2019-01-04T04:42:43+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.20",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "a2233f555ddf55e5600f386fba7781cea1cb82d3"
+                "reference": "26d7f23b9bd0b93bee5583e4d6ca5cb1ab31b186"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/a2233f555ddf55e5600f386fba7781cea1cb82d3",
-                "reference": "a2233f555ddf55e5600f386fba7781cea1cb82d3",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/26d7f23b9bd0b93bee5583e4d6ca5cb1ab31b186",
+                "reference": "26d7f23b9bd0b93bee5583e4d6ca5cb1ab31b186",
                 "shasum": ""
             },
             "require": {
@@ -1040,7 +1104,186 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-27T12:43:10+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v3.4.21",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "928a38b18bd632d67acbca74d0b2eed09915e83e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/928a38b18bd632d67acbca74d0b2eed09915e83e",
+                "reference": "928a38b18bd632d67acbca74d0b2eed09915e83e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "symfony/config": "<3.3.7",
+                "symfony/finder": "<3.3",
+                "symfony/proxy-manager-bridge": "<3.4",
+                "symfony/yaml": "<3.4"
+            },
+            "provide": {
+                "psr/container-implementation": "1.0"
+            },
+            "require-dev": {
+                "symfony/config": "~3.3|~4.0",
+                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/config": "",
+                "symfony/expression-language": "For using expressions in service container configuration",
+                "symfony/finder": "For using double-star glob patterns or when GLOB_BRACE portability is required",
+                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DependencyInjection Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-01-05T12:26:58+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v3.4.21",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde",
+                "reference": "c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-01-01T13:45:19+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1100,6 +1343,65 @@
                 "shim"
             ],
             "time": "2018-09-21T13:07:52+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.4.21",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "554a59a1ccbaac238a89b19c8e551a556fd0e2ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/554a59a1ccbaac238a89b19c8e551a556fd0e2ea",
+                "reference": "554a59a1ccbaac238a89b19c8e551a556fd0e2ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "tecnickcom/tcpdf",
@@ -3124,16 +3426,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.20",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "cc35e84adbb15c26ae6868e1efbf705a917be6b5"
+                "reference": "d1cdd46c53c264a2bd42505bd0e8ce21423bd0e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/cc35e84adbb15c26ae6868e1efbf705a917be6b5",
-                "reference": "cc35e84adbb15c26ae6868e1efbf705a917be6b5",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d1cdd46c53c264a2bd42505bd0e8ce21423bd0e2",
+                "reference": "d1cdd46c53c264a2bd42505bd0e8ce21423bd0e2",
                 "shasum": ""
             },
             "require": {
@@ -3183,70 +3485,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-30T18:07:24+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v3.4.20",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b49b1ca166bd109900e6a1683d9bb1115727ef2d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b49b1ca166bd109900e6a1683d9bb1115727ef2d",
-                "reference": "b49b1ca166bd109900e6a1683d9bb1115727ef2d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-ctype": "~1.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Filesystem Component",
-            "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:48:54+00:00"
+            "time": "2019-01-01T18:08:36+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.20",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "6cf2be5cbd0e87aa35c01f80ae0bf40b6798e442"
+                "reference": "3f2a2ab6315dd7682d4c16dcae1e7b95c8b8555e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/6cf2be5cbd0e87aa35c01f80ae0bf40b6798e442",
-                "reference": "6cf2be5cbd0e87aa35c01f80ae0bf40b6798e442",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/3f2a2ab6315dd7682d4c16dcae1e7b95c8b8555e",
+                "reference": "3f2a2ab6315dd7682d4c16dcae1e7b95c8b8555e",
                 "shasum": ""
             },
             "require": {
@@ -3282,78 +3534,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:48:54+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.20",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "abb46b909dd6ba0b50e10d4c10ffe6ee96dd70f2"
+                "reference": "0d41dd7d95ed179aed6a13393b0f4f97bfa2d25c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/abb46b909dd6ba0b50e10d4c10ffe6ee96dd70f2",
-                "reference": "abb46b909dd6ba0b50e10d4c10ffe6ee96dd70f2",
+                "url": "https://api.github.com/repos/symfony/process/zipball/0d41dd7d95ed179aed6a13393b0f4f97bfa2d25c",
+                "reference": "0d41dd7d95ed179aed6a13393b0f4f97bfa2d25c",
                 "shasum": ""
             },
             "require": {
@@ -3389,66 +3583,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-20T16:10:26+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v3.4.20",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "291e13d808bec481eab83f301f7bff3e699ef603"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/291e13d808bec481eab83f301f7bff3e699ef603",
-                "reference": "291e13d808bec481eab83f301f7bff3e699ef603",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-ctype": "~1.8"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:48:54+00:00"
+            "time": "2019-01-02T21:24:08+00:00"
         }
     ],
     "aliases": [],
@@ -3457,7 +3592,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0.0",
+        "php": ">=7.0.8",
         "ext-mysqli": "*",
         "ext-fileinfo": "*",
         "ext-json": "*",

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2977,8 +2977,8 @@ class Config extends CommonDBTM {
 
       if (!isset($opt['options']['namespace'])) {
          $namespace = "glpi_${optname}_" . GLPI_VERSION;
-         if ($DB && $DB->connected) {
-            $namespace .= Telemetry::getInstanceUuid();
+         if ($DB) {
+            $namespace .= md5($DB->dbhost . $DB->dbdefault);
          }
          $opt['options']['namespace'] = $namespace;
       }

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1948,6 +1948,8 @@ class Config extends CommonDBTM {
                  'check'   => 'Symfony\\Component\\Config\\FileLocator' ],
                [ 'name'    => 'symfony/dependency-injection',
                  'check'   => 'Symfony\\Component\\DependencyInjection\\Container' ],
+               [ 'name'    => 'symfony/event-dispatcher',
+                 'check'   => 'Symfony\\Component\\EventDispatcher\\EventDispatcher' ],
                [ 'name'    => 'symfony/yaml',
                  'check'   => 'Symfony\\Component\\Yaml\\Yaml' ],
       ];

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -31,10 +31,10 @@
  */
 
 use Glpi\Exception\PasswordTooWeakException;
+use Glpi\Cache\SimpleCache;
 use Zend\Cache\Storage\AvailableSpaceCapableInterface;
 use Zend\Cache\Storage\TotalSpaceCapableInterface;
 use Zend\Cache\Storage\FlushableInterface;
-use Zend\Cache\Psr\SimpleCache\SimpleCacheDecorator;
 use PHPMailer\PHPMailer\PHPMailer;
 
 if (!defined('GLPI_ROOT')) {
@@ -60,6 +60,15 @@ class Config extends CommonDBTM {
    static $rightname              = 'config';
 
    static $undisclosedFields      = ['proxy_passwd', 'smtp_passwd'];
+
+   /**
+    * Flag to prevent reloading legacy configuration if already loaded.
+    *
+    * Nota: This has been introduce when implementing the DI container, to handle transition phase.
+    *
+    * @var boolean
+    */
+   private static $legacy_config_already_loaded = false;
 
 
    static function getTypeName($nb = 0) {
@@ -1935,6 +1944,12 @@ class Config extends CommonDBTM {
                  'check'   => 'Symfony\\Component\\Console\\Application' ],
                [ 'name'    => 'leafo/scssphp',
                  'check'   => 'Leafo\ScssPhp\Compiler' ],
+               [ 'name'    => 'symfony/config',
+                 'check'   => 'Symfony\\Component\\Config\\FileLocator' ],
+               [ 'name'    => 'symfony/dependency-injection',
+                 'check'   => 'Symfony\\Component\\DependencyInjection\\Container' ],
+               [ 'name'    => 'symfony/yaml',
+                 'check'   => 'Symfony\\Component\\Yaml\\Yaml' ],
       ];
       if ($all || PHP_VERSION_ID < 70000) {
          $deps[] = [
@@ -2724,6 +2739,10 @@ class Config extends CommonDBTM {
     */
    public static function loadLegacyConfiguration($older_to_latest = true) {
 
+      if (self::$legacy_config_already_loaded) {
+         return true;
+      }
+
       global $CFG_GLPI, $DB;
 
       $get_078_to_084_config    = function() use ($DB) {
@@ -2806,6 +2825,8 @@ class Config extends CommonDBTM {
       if (isset($CFG_GLPI['root_doc'])) {
          $CFG_GLPI['typedoc_icon_dir'] = $CFG_GLPI['root_doc'] . '/pics/icones';
       }
+
+      self::$legacy_config_already_loaded = true;
 
       return true;
    }
@@ -2908,7 +2929,7 @@ class Config extends CommonDBTM {
     * @param string  $context name of the configuration context (default 'core')
     * @param boolean $psr16   Whether to return a PSR16 compliant obkect or not (since ZendTranslator is NOT PSR16 compliant).
     *
-    * @return Zend\Cache\Psr\SimpleCache\SimpleCacheDecorator|Zend\Cache\Storage\StorageInterface object
+    * @return Glpi\Cache\SimpleCache|Zend\Cache\Storage\StorageInterface object
     */
    public static function getCache($optname, $context = 'core', $psr16 = true) {
       global $DB;
@@ -3043,7 +3064,7 @@ class Config extends CommonDBTM {
       }
 
       if ($psr16) {
-         return new SimpleCacheDecorator($storage);
+         return new SimpleCache($storage);
       } else {
          return $storage;
       }

--- a/inc/config.php
+++ b/inc/config.php
@@ -35,7 +35,7 @@ if (!defined('GLPI_ROOT')) {
 }
 
 // Be sure to use global objects if this file is included outside normal process
-global $CFG_GLPI, $GLPI, $GLPI_CACHE;
+global $CFG_GLPI, $CONTAINER, $GLPI, $GLPI_CACHE;
 
 include_once (GLPI_ROOT."/inc/based_config.php");
 include_once (GLPI_ROOT."/inc/define.php");
@@ -239,3 +239,6 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
 
    $GLPI_CACHE = Config::getCache('cache_db');
 }
+
+// Load kernel and expose container in global var
+$CONTAINER = (new Glpi\Kernel())->getContainer();

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -1143,7 +1143,7 @@ class Plugin extends CommonDBTM {
     *
     * @since 0.84
     *
-    * @return String or Array (when $info is NULL)
+    * @return mixed
    **/
    static function getInfo($plugin, $info = null) {
 

--- a/src/Glpi/Cache/SimpleCache.php
+++ b/src/Glpi/Cache/SimpleCache.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Cache;
+
+use Zend\Cache\Psr\SimpleCache\SimpleCacheDecorator;
+
+/**
+ * Glpi cache decorator.
+ *
+ * This decorator aims to make transparent any future change of cache management component.
+ *
+ * @since 10.0
+ */
+class SimpleCache extends SimpleCacheDecorator
+{
+
+}

--- a/src/Glpi/Event/ItemEvent.php
+++ b/src/Glpi/Event/ItemEvent.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2019 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Event;
+
+use CommonDBTM;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * @since 10.0
+ */
+class ItemEvent extends Event
+{
+    /**
+     * Name of event trigerred when creating an empty item.
+     */
+    const ITEM_GET_EMPTY = 'item.get_empty';
+
+    /**
+     * Name of event trigerred in item creation process, after item creation in database.
+     */
+    const ITEM_POST_ADD = 'item.post_add';
+
+    /**
+     * Name of event trigerred in item deletion process, after marking item as deleted in database.
+     */
+    const ITEM_POST_DELETE = 'item.post_delete';
+
+    /**
+     * Name of event trigerred in item creation process, after processing of input data.
+     */
+    const ITEM_POST_PREPARE_ADD = 'item.post_prepare_add';
+
+    /**
+     * Name of event trigerred in item purge process, after item deletion from database.
+     */
+    const ITEM_POST_PURGE = 'item.post_purge';
+
+    /**
+     * Name of event trigerred in item restore process, after removing deleted mark in database.
+     */
+    const ITEM_POST_RESTORE = 'item.post_restore';
+
+    /**
+     * Name of event trigerred in item update process, after item update in database.
+     */
+    const ITEM_POST_UPDATE = 'item.post_update';
+
+    /**
+     * Name of event trigerred in item creation process, prior to altering input data.
+     */
+    const ITEM_PRE_ADD = 'item.pre_add';
+
+    /**
+     * Name of event trigerred in item deletion process, prior to marking item as deleted.
+     */
+    const ITEM_PRE_DELETE = 'item.pre_delete';
+
+    /**
+     * Name of event trigerred in item purge process, prior to item deletion from database.
+     */
+    const ITEM_PRE_PURGE = 'item.pre_purge';
+
+    /**
+     * Name of event trigerred in item restore process, prior to removing deleted mark in database.
+     */
+    const ITEM_PRE_RESTORE = 'item.pre_restore';
+
+    /**
+     * Name of event trigerred in item update process, prior to altering input data.
+     */
+    const ITEM_PRE_UPDATE = 'item.pre_update';
+
+    /**
+     * @var CommonDBTM
+     */
+    private $item;
+
+    /**
+     * @param CommonDBTM $item
+     */
+    public function __construct(CommonDBTM $item)
+    {
+        $this->item = $item;
+    }
+
+    /**
+     * Item on which event applies.
+     *
+     * @return CommonDBTM
+     */
+    public function getItem(): CommonDBTM
+    {
+        return $this->item;
+    }
+}

--- a/src/Glpi/EventDispatcher/EventDispatcher.php
+++ b/src/Glpi/EventDispatcher/EventDispatcher.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2019 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\EventDispatcher;
+
+use Symfony\Component\EventDispatcher\EventDispatcher as BaseEventDispatcher;
+
+/**
+ * Glpi event dispatcher.
+ *
+ * This decorator aims to make transparent any future change of event management component.
+ *
+ * @since 10.0
+ */
+class EventDispatcher extends BaseEventDispatcher
+{
+
+}

--- a/src/Glpi/EventDispatcher/EventSubscriberInterface.php
+++ b/src/Glpi/EventDispatcher/EventSubscriberInterface.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2019 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\EventDispatcher;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface as BaseEventSubscriberInterface;
+
+/**
+ * Glpi event subscriber interface.
+ *
+ * This decorator aims to make transparent any future change of event management component.
+ *
+ * @since 10.0
+ */
+interface EventSubscriberInterface extends BaseEventSubscriberInterface
+{
+
+}

--- a/src/Glpi/EventSubscriber/Item/ItemEventHookMapper.php
+++ b/src/Glpi/EventSubscriber/Item/ItemEventHookMapper.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2019 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\EventSubscriber\Item;
+
+use Glpi\Event\ItemEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Plugin;
+
+class ItemEventHookMapper implements EventSubscriberInterface
+{
+    /**
+     * @var Plugin
+     */
+    private $plugin;
+
+    /**
+     * @param Plugin $plugin
+     */
+    public function __construct(Plugin $plugin)
+    {
+        $this->plugin = $plugin;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            ItemEvent::ITEM_GET_EMPTY        => 'doItemEmptyHook',
+            ItemEvent::ITEM_POST_ADD         => 'doItemAddHook',
+            ItemEvent::ITEM_POST_DELETE      => 'doItemDeleteHook',
+            ItemEvent::ITEM_POST_PREPARE_ADD => 'doPostPrepareaddHook',
+            ItemEvent::ITEM_POST_PURGE       => 'doItemPurgeHook',
+            ItemEvent::ITEM_POST_RESTORE     => 'doItemRestoreHook',
+            ItemEvent::ITEM_POST_UPDATE      => 'doItemUpdateHook',
+            ItemEvent::ITEM_PRE_ADD          => 'doPreItemAddHook',
+            ItemEvent::ITEM_PRE_DELETE       => 'doPreItemDeleteHook',
+            ItemEvent::ITEM_PRE_PURGE        => 'doPreItemPurgeHook',
+            ItemEvent::ITEM_PRE_RESTORE      => 'doPreItemRestoreHook',
+            ItemEvent::ITEM_PRE_UPDATE       => 'doPreItemUpdateHook',
+        ];
+    }
+
+    /**
+     * Call 'item_add' hook.
+     *
+     * @param ItemEvent $event
+     *
+     * @return void
+     */
+    public function doItemAddHook(ItemEvent $event)
+    {
+        $this->plugin->doHook('item_add', $event->getItem());
+    }
+
+    /**
+     * Call 'item_delete' hook.
+     *
+     * @param ItemEvent $event
+     *
+     * @return void
+     */
+    public function doItemDeleteHook(ItemEvent $event)
+    {
+        $this->plugin->doHook('item_delete', $event->getItem());
+    }
+
+    /**
+     * Call 'item_empty' hook.
+     *
+     * @param ItemEvent $event
+     *
+     * @return void
+     */
+    public function doItemEmptyHook(ItemEvent $event)
+    {
+        $this->plugin->doHook('item_empty', $event->getItem());
+    }
+
+    /**
+     * Call 'item_purge' hook.
+     *
+     * @param ItemEvent $event
+     *
+     * @return void
+     */
+    public function doItemPurgeHook(ItemEvent $event)
+    {
+        $this->plugin->doHook('item_purge', $event->getItem());
+    }
+
+    /**
+     * Call 'item_restore' hook.
+     *
+     * @param ItemEvent $event
+     *
+     * @return void
+     */
+    public function doItemRestoreHook(ItemEvent $event)
+    {
+        $this->plugin->doHook('item_restore', $event->getItem());
+    }
+
+    /**
+     * Call 'item_update' hook.
+     *
+     * @param ItemEvent $event
+     *
+     * @return void
+     */
+    public function doItemUpdateHook(ItemEvent $event)
+    {
+        $this->plugin->doHook('item_update', $event->getItem());
+    }
+
+    /**
+     * Call 'post_prepareadd' hook.
+     *
+     * @param ItemEvent $event
+     *
+     * @return void
+     */
+    public function doPostPrepareaddHook(ItemEvent $event)
+    {
+        $this->plugin->doHook('post_prepareadd', $event->getItem());
+    }
+
+    /**
+     * Call 'pre_item_add' hook.
+     *
+     * @param ItemEvent $event
+     *
+     * @return void
+     */
+    public function doPreItemAddHook(ItemEvent $event)
+    {
+        $this->plugin->doHook('pre_item_add', $event->getItem());
+    }
+
+    /**
+     * Call 'pre_item_delete' hook.
+     *
+     * @param ItemEvent $event
+     *
+     * @return void
+     */
+    public function doPreItemDeleteHook(ItemEvent $event)
+    {
+        $this->plugin->doHook('pre_item_delete', $event->getItem());
+    }
+
+    /**
+     * Call 'pre_item_purge' hook.
+     *
+     * @param ItemEvent $event
+     *
+     * @return void
+     */
+    public function doPreItemPurgeHook(ItemEvent $event)
+    {
+        $this->plugin->doHook('pre_item_purge', $event->getItem());
+    }
+
+    /**
+     * Call 'pre_item_restore' hook.
+     *
+     * @param ItemEvent $event
+     *
+     * @return void
+     */
+    public function doPreItemRestoreHook(ItemEvent $event)
+    {
+        $this->plugin->doHook('pre_item_restore', $event->getItem());
+    }
+
+    /**
+     * Call 'pre_item_update' hook.
+     *
+     * @param ItemEvent $event
+     *
+     * @return void
+     */
+    public function doPreItemUpdateHook(ItemEvent $event)
+    {
+        $this->plugin->doHook('pre_item_update', $event->getItem());
+    }
+}

--- a/src/Glpi/Kernel.php
+++ b/src/Glpi/Kernel.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi;
+
+use Glpi\Cache\SimpleCache;
+use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Config;
+use DBmysql;
+use Plugin;
+use Session;
+
+/**
+ * Glpi Kernel.
+ *
+ * @since 10.0
+ */
+class Kernel
+{
+    /**
+     * Cache directory directory.
+     *
+     * @var string
+     */
+    private $cacheDir;
+
+    /**
+     * Container builder.
+     *
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    /**
+     * Project root directory.
+     *
+     * @var string
+     */
+    private $projectDir;
+
+    public function __construct(string $projectDir = GLPI_ROOT, string $cacheDir = GLPI_CACHE_DIR)
+    {
+        $this->cacheDir   = $cacheDir;
+        $this->projectDir = $projectDir;
+
+        $this->buildContainer();
+        $this->initGlobals();
+    }
+
+    /**
+     * Build container.
+     *
+     * @return void
+     */
+    private function buildContainer()
+    {
+        $cacheFile = $this->cacheDir . '/container.php';
+
+        if ((is_dir($this->cacheDir) && is_writable($this->cacheDir))
+            || (is_file($cacheFile) && is_writable($cacheFile))) {
+            // Use container caching feature when possible
+
+            // Files checks is always used in order to be sure that container cache in invalidated when used resources
+            // (yaml files, used classes, source directory structure, ...) changed.
+            // Files checks could be removed in production environment if cache invalidation was done on action
+            // that would alter services availability / parameters. For example:
+            // - plugin activation/deactivation,
+            // - any change on the "local" configuration file.
+            $checkFiles = true;
+
+            $file = $this->cacheDir . '/container.php';
+            $containerConfigCache = new ConfigCache($file, $checkFiles);
+
+            if (!$containerConfigCache->isFresh()) {
+                $containerBuilder = $this->getConfiguredAndCompiledContainerBuilder();
+
+                // Dump built container into cache file
+                $dumper = new PhpDumper($containerBuilder);
+                $containerConfigCache->write(
+                    $dumper->dump(array('class' => 'GlpiCachedContainer')),
+                    $containerBuilder->getResources()
+                );
+            }
+
+            // Load and use cached container
+            require_once $file;
+            $container = new \GlpiCachedContainer();
+        } else {
+            $container = $this->getConfiguredAndCompiledContainerBuilder();
+        }
+
+        // Define synthetic services that cannot be cached
+        $this->defineSyntheticServices($container);
+
+        $this->container = $container;
+    }
+
+    /**
+     * Configure container.
+     *
+     * Nota: This method was made to fits usage of Symfony\Component\HttpKernel\Kernel.
+     *
+     * @return void
+     */
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
+    {
+        $container->setParameter('kernel.project_dir', $this->getProjectDir());
+
+        $loader->load('services.yaml');
+
+        $this->loadPluginsServices($container);
+    }
+
+    /**
+     * Get GLPI root directory.
+     *
+     * Nota: This method was made to fits usage of Symfony\Component\HttpKernel\Kernel.
+     *
+     * @return string
+     */
+    public function getProjectDir(): string
+    {
+        return $this->projectDir;
+    }
+
+    /**
+     * Get GLPI services container.
+     *
+     * Nota: This method was made to fits usage of Symfony\Component\HttpKernel\Kernel.
+     *
+     * @return \Psr\Container\ContainerInterface
+     */
+    public function getContainer(): \Psr\Container\ContainerInterface
+    {
+        return $this->container;
+    }
+
+    /**
+     * Initialize global variables used by legacy code.
+     *
+     * @return void
+     */
+    private function initGlobals()
+    {
+        global $GLPI;
+        if (!($GLPI instanceof \GLPI)) {
+            $GLPI = new \GLPI();
+            $GLPI->initLogger();
+        }
+
+        global $CFG_GLPI;
+        if (!isset($CFG_GLPI["root_doc"])) {
+            Config::detectRootDoc();
+        }
+
+        if (session_status() === PHP_SESSION_NONE) {
+            if (!is_writable(GLPI_SESSION_DIR)) {
+                throw new \RuntimeException(
+                    sprintf('Cannot write in "%s" directory.', GLPI_SESSION_DIR)
+                );
+            }
+            Session::setPath();
+            Session::start();
+        }
+
+        $db = $this->container->get(
+            'db',
+            ContainerInterface::NULL_ON_INVALID_REFERENCE
+        );
+        if ($db instanceof DBmysql && $db->connected) {
+            Config::loadLegacyConfiguration(false);
+        }
+    }
+
+    /**
+     * Define synthectic services.
+     *
+     * @param ContainerInterface $container
+     *
+     * @return void
+     */
+    private function defineSyntheticServices(ContainerInterface $container)
+    {
+        // Inject DB definition.
+        $container->set(DBmysql::class, $this->getDbInstance());
+
+        // Inject cache definition
+        $container->set(SimpleCache::class, $this->getCacheInstance());
+    }
+
+    /**
+     * Returns a configured and compiled instance of container builder.
+     *
+     * @return ContainerBuilder
+     */
+    private function getConfiguredAndCompiledContainerBuilder(): ContainerBuilder
+    {
+        $containerBuilder = new ContainerBuilder();
+
+        $resourcesDir = $this->getProjectDir() . '/src/resources';
+        $loader = new YamlFileLoader($containerBuilder, new FileLocator($resourcesDir));
+        $this->configureContainer($containerBuilder, $loader);
+
+        $containerBuilder->compile();
+
+        return $containerBuilder;
+    }
+
+    /**
+    * Load plugin services.
+    *
+    * @param ContainerBuilder $container
+    *
+    * @return void
+    */
+    private function loadPluginsServices(ContainerBuilder $container)
+    {
+        $db = $this->getDbInstance();
+        if (!$db->connected) {
+            return;
+        }
+
+        // Workaround to force instanciation of cache if not yet done.
+        // TODO Make plugin service not dependant from cache service
+        $this->getCacheInstance();
+
+        $plugin = new Plugin();
+        if (!$plugin->hasBeenInit()) {
+            $plugin->init();
+        }
+
+        $projectDir = $this->getProjectDir();
+
+        $activePlugins = $plugin->getPlugins();
+        foreach ($activePlugins as $plugin) {
+            $pluginDir = $projectDir . '/plugins/' . $plugin;
+            $setupFile  = $pluginDir . '/setup.php';
+
+            if (!file_exists($setupFile)) {
+                continue;
+            }
+
+            // Includes are made inside a function to prevent included files to override
+            // variables used in this function.
+            // For example, if the included files contains a $loader variable, it will
+            // replace the $loader variable used here.
+            $include_fct = function () use ($setupFile) {
+                include_once($setupFile);
+            };
+            $include_fct();
+
+            $diConfigFiles = Plugin::getInfo($plugin, 'di-container-config');
+
+            $loader = new YamlFileLoader($container, new FileLocator($pluginDir));
+            foreach ($diConfigFiles as $configFile) {
+                $configFilePath = $pluginDir . '/' . $configFile;
+                if (!file_exists($configFilePath)) {
+                    trigger_error(
+                        sprintf(
+                            'Unable to find file "%1$s" defined in plugin "%2$s" configuration.',
+                            $configFilePath,
+                            $plugin
+                        )
+                    );
+                    continue;
+                }
+
+                $loader->load($configFilePath);
+            }
+        }
+    }
+
+    /**
+     * Get application database connection instance.
+     *
+     * If already instanciated by GLPI legacy init process, use this instance.
+     * Else, if configuration file is available, instanciate a configured DB.
+     * Else, instanciate a non configure DB to be able to compile container.
+     * Returns global variable reference that will be updated if a new connection is established.
+     *
+     * @return DBmysql
+     */
+    private function getDbInstance(): DBmysql
+    {
+        global $DB;
+        if (!($DB instanceof DBmysql)) {
+            if (class_exists('DB', false)) {
+                $DB = new \DB();
+            } else {
+                $DB = new DBmysql();
+            }
+        }
+        return $DB;
+    }
+
+    /**
+     * Get application cache instance.
+     *
+     * Returns global variable reference to update service if variable is redefined
+     *
+     * @return DBmysql
+     */
+    private function getCacheInstance(): SimpleCache
+    {
+        global $GLPI_CACHE;
+        if (!($GLPI_CACHE instanceof SimpleCache)) {
+            $GLPI_CACHE = Config::getCache('cache_db');
+        }
+        return $GLPI_CACHE;
+    }
+}

--- a/src/Glpi/Kernel.php
+++ b/src/Glpi/Kernel.php
@@ -95,7 +95,7 @@ class Kernel
         $cacheFile = $this->cacheDir . '/container.php';
 
         if ((is_dir($this->cacheDir) && is_writable($this->cacheDir))
-            || (is_file($cacheFile) && is_writable($cacheFile))) {
+            || (is_file($cacheFile) && is_readable($cacheFile) && is_writable($cacheFile))) {
             // Use container caching feature when possible
 
             // Files checks is always used in order to be sure that container cache in invalidated when used resources
@@ -106,8 +106,7 @@ class Kernel
             // - any change on the "local" configuration file.
             $checkFiles = true;
 
-            $file = $this->cacheDir . '/container.php';
-            $containerConfigCache = new ConfigCache($file, $checkFiles);
+            $containerConfigCache = new ConfigCache($cacheFile, $checkFiles);
 
             if (!$containerConfigCache->isFresh()) {
                 $containerBuilder = $this->getConfiguredAndCompiledContainerBuilder();
@@ -121,7 +120,7 @@ class Kernel
             }
 
             // Load and use cached container
-            require_once $file;
+            require_once $cacheFile;
             $container = new \GlpiCachedContainer();
         } else {
             $container = $this->getConfiguredAndCompiledContainerBuilder();

--- a/src/resources/services.yaml
+++ b/src/resources/services.yaml
@@ -39,7 +39,10 @@ services:
     # this creates a service per class whose id is the fully-qualified class name
     Glpi\:
         resource: '%kernel.project_dir%/src/Glpi/*'
-        exclude: '%kernel.project_dir%/src/Glpi/Kernel.php'
+        exclude: '%kernel.project_dir%/src/Glpi/{Event,Kernel.php}'
+
+#### Vendor services bellow
+
 
 #### Glpi services bellow
 
@@ -56,3 +59,7 @@ services:
     # and therefore will be added during container compilation process
     DBmysql:
         synthetic: true
+
+    # Following services are manually declared as they cannot be included using an include/exclude rule
+    Plugin:
+        class: 'Plugin'

--- a/src/resources/services.yaml
+++ b/src/resources/services.yaml
@@ -1,0 +1,58 @@
+#
+# ---------------------------------------------------------------------
+# GLPI - Gestionnaire Libre de Parc Informatique
+# Copyright (C) 2015-2019 Teclib' and contributors.
+#
+# http://glpi-project.org
+#
+# based on GLPI - Gestionnaire Libre de Parc Informatique
+# Copyright (C) 2003-2014 by the INDEPNET Development Team.
+#
+# ---------------------------------------------------------------------
+#
+# LICENSE
+#
+# This file is part of GLPI.
+#
+# GLPI is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# GLPI is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+# ---------------------------------------------------------------------
+#
+
+services:
+    _defaults:
+        autowire: true      # Automatically injects dependencies in services.
+        autoconfigure: true # Automatically registers services based on their signature (event subscribers).
+        public: true        # Make all services public to make them accessible using "$container->get()".
+
+    # makes classes in src/Glpi/ available to be used as services
+    # this creates a service per class whose id is the fully-qualified class name
+    Glpi\:
+        resource: '%kernel.project_dir%/src/Glpi/*'
+        exclude: '%kernel.project_dir%/src/Glpi/Kernel.php'
+
+#### Glpi services bellow
+
+    # Glpi\Cache\SimpleCache service is synthetic as it may be instanciate prior to container compilation
+    Glpi\Cache\SimpleCache:
+        synthetic: true
+
+#### Vendor services bellow
+
+
+#### Legacy services bellow
+
+    # DBmysql service is synthetic as it may sometime be unavailable (before install process)
+    # and therefore will be added during container compilation process
+    DBmysql:
+        synthetic: true

--- a/tests/units/Glpi/EventSubscriber/Item/ItemEventHookMapper.php
+++ b/tests/units/Glpi/EventSubscriber/Item/ItemEventHookMapper.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+*/
+
+namespace tests\units\Glpi\EventSubscriber\Item;
+
+/* Test for src/Glpi/EventSubscriber/Item/ItemEventHookMapper.php */
+
+class ItemEventHookMapper extends \GLPITestCase {
+
+   /**
+    * Mapping between item events and hooks.
+    *
+    * @return string[][]
+    */
+   public function provideMapping() {
+      return [
+         [
+            'event' => \Glpi\Event\ItemEvent::ITEM_GET_EMPTY,
+            'hook'  => 'item_empty',
+         ],
+         [
+            'event' => \Glpi\Event\ItemEvent::ITEM_POST_ADD,
+            'hook'  => 'item_add',
+         ],
+         [
+            'event' => \Glpi\Event\ItemEvent::ITEM_POST_DELETE,
+            'hook'  => 'item_delete',
+         ],
+         [
+            'event' => \Glpi\Event\ItemEvent::ITEM_POST_PREPARE_ADD,
+            'hook'  => 'post_prepareadd',
+         ],
+         [
+            'event' => \Glpi\Event\ItemEvent::ITEM_POST_PURGE,
+            'hook'  => 'item_purge',
+         ],
+         [
+            'event' => \Glpi\Event\ItemEvent::ITEM_POST_RESTORE,
+            'hook'  => 'item_restore',
+         ],
+         [
+            'event' => \Glpi\Event\ItemEvent::ITEM_POST_UPDATE,
+            'hook'  => 'item_update',
+         ],
+         [
+            'event' => \Glpi\Event\ItemEvent::ITEM_PRE_ADD,
+            'hook'  => 'pre_item_add',
+         ],
+         [
+            'event' => \Glpi\Event\ItemEvent::ITEM_PRE_DELETE,
+            'hook'  => 'pre_item_delete',
+         ],
+         [
+            'event' => \Glpi\Event\ItemEvent::ITEM_PRE_PURGE,
+            'hook'  => 'pre_item_purge',
+         ],
+         [
+            'event' => \Glpi\Event\ItemEvent::ITEM_PRE_RESTORE,
+            'hook'  => 'pre_item_restore',
+         ],
+         [
+            'event' => \Glpi\Event\ItemEvent::ITEM_PRE_UPDATE,
+            'hook'  => 'pre_item_update',
+         ],
+      ];
+   }
+
+   /**
+    * Test that hook mapping is correct.
+    *
+    * @dataProvider provideMapping
+    */
+   public function testMapping($event, $expectedHook) {
+      global $PLUGIN_HOOKS;
+
+      $this->newTestedInstance(new \mock\Plugin());
+
+      $dispatcher = new \mock\Glpi\EventDispatcher\EventDispatcher();
+      $dispatcher->addSubscriber($this->testedInstance);
+
+      $self = $this;
+      $item = new \Computer();
+      $callbackCalled = false;
+      $callback = function($param) use ($self, $item, &$callbackCalled, $expectedHook) {
+         // Retrieve called hook from backtrace.
+         $calledHook = '';
+         $backtrace = debug_backtrace();
+         foreach ($backtrace as $call) {
+            if ('doHook' === $call['function'] && 'Plugin' === $call['class']) {
+               $calledHook = $call['args'][0];
+               break;
+            }
+         }
+
+         $self->string($calledHook)->isEqualTo($expectedHook);
+         $self->object($param)->isEqualTo($item);
+
+         $callbackCalled = true;
+      };
+
+      $PLUGIN_HOOKS[$expectedHook]['test'] = ['Computer' => $callback];
+      $dispatcher->dispatch($event, new \Glpi\Event\ItemEvent($item));
+      $this->boolean($callbackCalled)->isTrue();
+   }
+}

--- a/tests/units/Glpi/Kernel.php
+++ b/tests/units/Glpi/Kernel.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+*/
+
+namespace tests\units\Glpi;
+
+use org\bovigo\vfs\vfsStream;
+
+/* Test for src/Glpi/Kernel.php */
+
+class Kernel extends \GLPITestCase {
+
+   /**
+    * Test container compilation with empty configuration.
+    */
+   public function testContainerCompilation() {
+
+      $structure = [
+         'src' => [
+            'resources' => [
+                'services.yaml' => ''
+            ],
+         ],
+      ];
+      $directory = vfsStream::setup('glpi', null, $structure);
+      // Make a not writable dir to prevent cache on container compilation
+      $directory->addChild(vfsStream::newDirectory('nocache', 0555));
+
+      $kernel = new \Glpi\Kernel(vfsStream::url('glpi'), vfsStream::url('glpi/nocache'));
+
+      $container = $kernel->getContainer();
+      $this->object($container)->isInstanceOf(\Psr\Container\ContainerInterface::class);
+
+      // Check Glpi synthetic services
+      $this->boolean($container->has(\DBmysql::class))->isTrue();
+      $this->object($container->get(\DBmysql::class))->isInstanceOf(\DBmysql::class);
+      $this->boolean($container->has(\Glpi\Cache\SimpleCache::class))->isTrue();
+      $this->object($container->get(\Glpi\Cache\SimpleCache::class))->isInstanceOf(\Glpi\Cache\SimpleCache::class);
+   }
+
+   /**
+    * Test compilation of services configured in src/resources/service.yaml file.
+    */
+   public function testContainerConfiguredServicesCompilation() {
+
+      $structure = [
+         'src' => [
+            'resources' => [
+                'services.yaml' => <<<YAML
+services:
+    _defaults:
+        autowire: true
+        public: true
+
+    DBmysql:
+        synthetic: true
+
+    fake_service:
+        class: FakeService
+YAML
+            ],
+            'FakeService.php' => <<<PHP
+<?php
+class FakeService {
+   private \$db;
+
+   public function __construct(\DBMysql \$db) {
+      \$this->db = \$db;
+   }
+
+   public function getDb() {
+      return \$this->db;
+   }
+}
+PHP
+            ,
+         ],
+      ];
+      $directory = vfsStream::setup('glpi', null, $structure);
+      // Make a not writable dir to prevent cache on container compilation
+      $directory->addChild(vfsStream::newDirectory('nocache', 0555));
+
+      // Autoload does not work for files inside vfsStream
+      include_once(vfsStream::url('glpi/src/FakeService.php'));
+
+      $kernel = new \Glpi\Kernel(vfsStream::url('glpi'), vfsStream::url('glpi/nocache'));
+
+      $container = $kernel->getContainer();
+      $this->object($container)->isInstanceOf(\Psr\Container\ContainerInterface::class);
+
+      // Check Glpi service declared in services.yaml
+      $this->boolean($container->has('fake_service'))->isTrue();
+      $service = $container->get('fake_service');
+      $this->object($service)->isInstanceOf('FakeService');
+      $this->object($service->getDb())->isInstanceOf(\DBmysql::class);
+   }
+
+   /**
+    * Test compilation of services configured in a plugin.
+    */
+   public function testContainerPluginServicesCompilation() {
+
+      $structure = [
+         'src' => [
+            'resources' => [
+                'services.yaml' =>  <<<YAML
+services:
+    DBmysql:
+        synthetic: true
+        public: true
+YAML
+            ],
+         ],
+         'plugins' => [
+            'random' => [
+               'di' => [
+                  'services.yaml' => <<<YAML
+services:
+    _defaults:
+        autowire: true
+        public: true
+
+    random_service:
+        class: RandomPlugin\\MyService
+
+YAML
+               ],
+               'src' => [
+                   'RandomPlugin' => [
+                      'MyService.php' => <<<PHP
+<?php
+namespace RandomPlugin;
+class MyService {
+   private \$db;
+
+   public function __construct(\\DBMysql \$db) {
+      \$this->db = \$db;
+   }
+
+   public function getDb() {
+      return \$this->db;
+   }
+}
+PHP
+                  ],
+               ],
+               'setup.php' => <<<PHP
+<?php
+function plugin_version_random() {
+   return [
+     'di-container-config' => [
+        'di/services.yaml'
+     ]
+   ];
+}
+PHP
+            ]
+         ]
+      ];
+      $directory = vfsStream::setup('glpi', null, $structure);
+      // Make a not writable dir to prevent cache on container compilation
+      $directory->addChild(vfsStream::newDirectory('nocache', 0555));
+
+      // Autoload does not work for files inside vfsStream
+      include_once(vfsStream::url('glpi/plugins/random/src/RandomPlugin/MyService.php'));
+
+      // Force active plugin list
+      global $GLPI_CACHE;
+      $GLPI_CACHE = new \Glpi\Cache\SimpleCache(
+          \Zend\Cache\StorageFactory::factory(['adapter' => 'memory'])
+      );
+      $GLPI_CACHE->set('plugins_init', true);
+      $GLPI_CACHE->set('plugins', ['random']);
+
+      $kernel = new \Glpi\Kernel(vfsStream::url('glpi'), vfsStream::url('glpi/nocache'));
+
+      $container = $kernel->getContainer();
+      $this->object($container)->isInstanceOf(\Psr\Container\ContainerInterface::class);
+
+      // Check plugin services
+      $this->boolean($container->has('random_service'))->isTrue();
+      $service = $container->get('random_service');
+      $this->object($service)->isInstanceOf('RandomPlugin\\MyService');
+      $this->object($service->getDb())->isInstanceOf(\DBmysql::class);
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2925 (at least partially)

This PR introduce a DI container.
- Legacy code/classes can use the `$CONTAINER` global variable,
- New classes (that should be put in `src/Glpi` directory) will be automatically instanciated as services and dependencies will be automatically passed to constructor if parameters are well typed.

I also added an event dispacher that is used, for now, to dispatch events on items CRUD.