### PR TITLE
PHP 7.2  count compliance

### DIFF
--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -192,7 +192,7 @@ class Project extends CommonDBTM {
          $menu['project']['title'] = Project::getTypeName(Session::getPluralNumber());
          $menu['project']['page']  = ProjectTask::getSearchURL(false);
 
-         if (count($links)) {
+         if (isset($links) && count($links)) {
             $menu['project']['links'] = $links;
          }
 

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -192,10 +192,6 @@ class Project extends CommonDBTM {
          $menu['project']['title'] = Project::getTypeName(Session::getPluralNumber());
          $menu['project']['page']  = ProjectTask::getSearchURL(false);
 
-         if (isset($links) && count($links)) {
-            $menu['project']['links'] = $links;
-         }
-
          return $menu;
       }
       return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Compliance for count()

 *** PHP Warning(2): count(): Parameter must be an array or an object that implements Countable
  Backtrace :
  inc/project.class.php:195                          
  inc/commonglpi.class.php:301                       Project::getAdditionalMenuContent()
  inc/html.class.php:1427                            CommonGLPI::getMenuContent()
  inc/html.class.php:6191                            Html::generateMenuSession()
  inc/html.class.php:1531                            Html::displayMainMenu()
  front/planning.php:137                             Html::header()

And perhaps several others to do, but this one thrown me this backtrace.
