### PR TITLE
Fix reservation item restore action

### DIFF
--- a/front/reservationitem.form.php
+++ b/front/reservationitem.form.php
@@ -69,9 +69,9 @@ if (isset($_POST["add"])) {
               sprintf(__('%s purges an item'), $_SESSION["glpiname"]));
    Html::back();
 
-} else if (isset($_POST["backToStock"])) {
+} else if (isset($_POST["restore"])) {
    $ri->check($_POST["id"], PURGE);
-   $ri->backToStock($_POST);
+   $ri->restore($_POST);
 
    Event::log($_POST['id'], "reservationitem", 4, "inventory",
               //TRANS: %s is the user login


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I did not find how to restore a reservation item, but it is clear that there is no "backToStock" action for a reservation item. I think change made on this file in commit bda8f7f10ac9425fca1a788b731b6be5f65a2ba7 was an error.
