### PR TITLE
Use ESLint for JS files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ shared: &shared
           rm -f composer.lock
           composer install --optimize-autoloader
     - run:
+        name: npm install
+        command: |
+          npm install
+    - run:
         name: PHP Parallel Lint
         command: vendor/bin/parallel-lint  --exclude files --exclude plugins --exclude vendor --exclude tools/vendor .
     - run:
@@ -29,7 +33,9 @@ shared: &shared
         command: vendor/bin/security-checker security:check
     - run:
         name: Coding standards
-        command: if [[ $(php --version|grep "7\.3") ]]; then vendor/bin/phpcs -d memory_limit=512M -p -n --standard=PSR2 ./src && vendor/bin/phpcs -d memory_limit=512M -p --standard=vendor/glpi-project/coding-standard/GlpiStandard/ --ignore=/vendor/,/plugins/,/files/,/lib/,/config/,/tests/config,/css/tiny_mce,/.git,/src ./; else echo "No CS for this version"; fi
+        command: |
+          if [[ $(php --version|grep "7\.3") ]]; then vendor/bin/phpcs -d memory_limit=512M -p -n --extensions=php --standard=PSR2 ./src && vendor/bin/phpcs -d memory_limit=512M -p --extensions=php --standard=vendor/glpi-project/coding-standard/GlpiStandard/ --ignore=/.git,/config,/files,/lib,/node_modules,/plugins,/src,/tests/config,/vendor ./; else echo "No CS for this version"; fi
+          if [[ $(php --version|grep "7\.3") ]]; then node_modules/.bin/eslint ./js && echo "ESLint found no errors"; else echo "No CS for this version"; fi
     - run:
         name: Update DB
         command: |

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,50 @@
+{
+    "env": {
+        "browser": true,
+        "jquery": true
+    },
+    "extends": "eslint:recommended",
+    "globals": {
+        "CFG_GLPI": true,
+        "tinyMCE": true
+    },
+    "parserOptions": {
+        "ecmaVersion": 5
+    },
+    "rules": {
+        "indent": [
+            "error",
+            3,
+            {
+                "SwitchCase": 1
+            }
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "no-console": [
+            "error",
+            {
+                "allow": [
+                    "warn",
+                    "error"
+                ]
+            }
+        ],
+        "no-unused-vars": [
+            "error",
+            {
+                "vars": "local"
+            }
+        ],
+        "quotes": [
+            "off",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ phpunit.xml
 # ignore incomplete locale, fallback to ru.js
 # see https://github.com/glpi-project/glpi/issues/3788
 /lib/tiny_mce/langs/ru_RU.js
+/node_modules/

--- a/js/common.js
+++ b/js/common.js
@@ -207,8 +207,8 @@ function checkAsCheckboxes(reference_id, container_id) {
  * Usage: $form.find('input[type="checkbox"]').shiftSelectable();
  */
 $.fn.shiftSelectable = function() {
-   var lastChecked,
-       $boxes = this;
+   var lastChecked;
+   var $boxes = this;
 
    // prevent html selection
    document.onkeydown = function(e) {
@@ -234,11 +234,11 @@ $.fn.shiftSelectable = function() {
 
       if (evt.shiftKey) {
          evt.preventDefault();
-         var start = $boxes.index(selected_checkbox),
-             end = $boxes.index(lastChecked);
+         var start = $boxes.index(selected_checkbox);
+         var end = $boxes.index(lastChecked);
          $boxes.slice(Math.min(start, end), Math.max(start, end) + 1)
-               .prop('checked', $(lastChecked).is(':checked'))
-               .trigger('change');
+            .prop('checked', $(lastChecked).is(':checked'))
+            .trigger('change');
       }
 
       lastChecked = selected_checkbox;
@@ -259,8 +259,8 @@ function showHideDiv(id, img_name, img_src_close, img_src_open) {
 
    if (img_name !== '') {
       var _awesome = img_src_close.match(/^fa-/);
-      var _deco,
-          _img;
+      var _deco;
+      var _img;
       if (!_awesome) {
          _img = $('img[name=' + img_name + ']');
          if (_elt.is(':visible')) {
@@ -375,9 +375,9 @@ function submitGetLink(target, fields) {
       myInput.setAttribute("value", fields[name]);
       myForm.appendChild(myInput);
    }
-    document.body.appendChild(myForm);
-    myForm.submit();
-    document.body.removeChild(myForm);
+   document.body.appendChild(myForm);
+   myForm.submit();
+   document.body.removeChild(myForm);
 }
 
 
@@ -426,13 +426,13 @@ function massiveUpdateCheckbox(criterion, reference) {
    if (typeof(value) == 'undefined') {
       return false;
    }
-    $(criterion).each(function() {
+   $(criterion).each(function() {
       if (typeof(reference) == 'undefined') {
          value = !$(this).prop('checked');
       }
-        $(this).prop('checked', value);
-    });
-    return true;
+      $(this).prop('checked', value);
+   });
+   return true;
 }
 
 /**
@@ -821,9 +821,11 @@ var initMap = function(parent_elt, map_id, height) {
 
    //add map, set a default arbitrary location
    parent_elt.append($('<div id="'+map_id+'" style="height: ' + height + '"></div>'));
+   /* global L */
    var map = L.map(map_id, {fullscreenControl: true}).setView([43.6112422, 3.8767337], 6);
 
    //setup tiles and © messages
+   /* global L */
    L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
       attribution: '&copy; <a href=\'http://osm.org/copyright\'>OpenStreetMap</a> contributors'
    }).addTo(map);
@@ -838,7 +840,7 @@ var showMapForLocation = function(elt) {
       return;
    }
 
-   _dialog = $('<div id="location_map_dialog"/>');
+   var _dialog = $('<div id="location_map_dialog"/>');
    _dialog.appendTo('body').dialog({
       close: function() {
          $(this).dialog('destroy').remove();
@@ -867,9 +869,11 @@ var showMapForLocation = function(elt) {
          });
       } else {
          var _markers = [];
-         _marker = L.marker([data.lat, data.lng]);
+         /* global L */
+         var _marker = L.marker([data.lat, data.lng]);
          _markers.push(_marker);
 
+         /* global L */
          var _group = L.featureGroup(_markers).addTo(map_elt);
          map_elt.fitBounds(
             _group.getBounds(), {
@@ -923,8 +927,6 @@ var templateResult = function(result) {
 
    var _elt = $('<span></span>');
    _elt.attr('title', result.title);
-
-   var markup=[result.text];
 
    var _term = query.term || '';
    var markup = markMatch(result.text, _term);
@@ -988,4 +990,4 @@ var getTextWithoutDiacriticalMarks = function (text) {
    // The U+0300 -> U+036F range corresponds to diacritical chars.
    // They are removed to keep only chars without their diacritical mark.
    return text.replace(/[\u0300-\u036f]/g, '');
-}
+};

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -51,6 +51,7 @@ function uploadFile(file, editor, input_name) {
                returnTag = '';
                var tag = getFileTag(element);
                //if is an image add tag
+               /* global isImage */
                if (isImage(file)) {
                   returnTag = tag.tag;
                }
@@ -96,7 +97,7 @@ var getFileTag = function(data) {
          returnString = data[0];
       },
       error: function (request) {
-         console.log(request.responseText);
+         console.warn(request.responseText);
          returnString=false;
       }
    });
@@ -109,7 +110,6 @@ var getFileTag = function(data) {
  *
  * @param      {JSON}    file          The file
  * @param      {String}  tag           The tag
- * @param      {String}  filecontainer The dom id of the list file container
  * @param      {Object}  editor        The TinyMCE editor instance
  * @param      {String}  input_name    Name of generated input hidden (default filename)
  */
@@ -121,6 +121,7 @@ var displayUploadedFile = function(file, tag, editor, input_name) {
    // find the nearest fileupload_info where to append file list
    var current_dom_point = $(editor.targetElm);
    var iteration = 0;
+   var filecontainer;
    do {
       current_dom_point = current_dom_point.parent();
       filecontainer = current_dom_point.find('.fileupload_info');
@@ -128,15 +129,19 @@ var displayUploadedFile = function(file, tag, editor, input_name) {
    } while (filecontainer.length <= 0 && iteration < 30);
 
    if (filecontainer.length) {
-      var ext  = file.name.split('.').pop();
+      var ext = file.name.split('.').pop();
 
-      var p    = $('<p/>')
-                  .attr('id',file.id)
-                  .html(getExtIcon(ext)+'&nbsp;'+
-                        '<b>'+file.display+'</b>'+
-                        '&nbsp;('+
-                        getSize(file.size)+')&nbsp;')
-                  .appendTo(filecontainer);
+      /* global getExtIcon getSize */
+      var p = $('<p/>')
+         .attr('id',file.id)
+         .html(
+            getExtIcon(ext)
+            + '&nbsp;'
+            + '<b>'+file.display
+            + '</b>'
+            + '&nbsp;('
+            + getSize(file.size)+')&nbsp;'
+         ).appendTo(filecontainer);
 
       // File
       $('<input/>')
@@ -230,8 +235,11 @@ var insertImgFromFile = function(editor, fileImg, tag) {
                imgHeight = imgHeight * ratio;     // Reset height to match scaled image
             }
 
-            editor.execCommand('mceInsertContent', false,
-                               "<img width='"+imgWidth+"' height='"+imgHeight+"'' id='"+tag.replace(regex,'')+"' src='"+imageUrl+"'>");
+            editor.execCommand(
+               'mceInsertContent',
+               false,
+               "<img width='"+imgWidth+"' height='"+imgHeight+"'' id='"+tag.replace(regex,'')+"' src='"+imageUrl+"'>"
+            );
 
             // loading done, remove indicator
             editor.setProgressState(false);
@@ -240,7 +248,7 @@ var insertImgFromFile = function(editor, fileImg, tag) {
       reader.readAsDataURL(fileImg);
 
    } else {
-      console.log('thanks to update your browser to get preview of image');
+      console.warn('thanks to update your browser to get preview of image');
    }
 };
 
@@ -263,6 +271,7 @@ var dataURItoBlob = function(dataURI) {
    var mimeString = dataURI.split(',')[0].split(':')[1].split(';')[0];
 
    // write the bytes of the string to a typed array
+   /* global Uint8Array */
    var ia = new Uint8Array(byteString.length);
    for (var i = 0; i < byteString.length; i++) {
       ia[i] = byteString.charCodeAt(i);
@@ -281,7 +290,7 @@ var dataURItoBlob = function(dataURI) {
 * @return     String mimeType   return mimeType of data
 */
 var isImageFromPaste = function(content) {
-   return content.match(new RegExp('<img.*data:image\/')) !== null;
+   return content.match(new RegExp('<img.*data:image/')) !== null;
 };
 
 /**
@@ -329,11 +338,12 @@ var insertImageInTinyMCE = function(editor, image) {
  * to check if a file upload can be proceeded
  * @param  {[Object]} editor TinyMCE editor
  */
-if (typeof tinymce != 'undefined') {
-   tinymce.PluginManager.add('glpi_upload_doc', function(editor) {
+if (typeof tinyMCE != 'undefined') {
+   tinyMCE.PluginManager.add('glpi_upload_doc', function(editor) {
       editor.on('drop', function(event) {
          if (event.dataTransfer
              && event.dataTransfer.files.length > 0) {
+            /* global stopEvent */
             stopEvent(event);
 
             // for each dropped files
@@ -346,6 +356,7 @@ if (typeof tinymce != 'undefined') {
       editor.on('PastePreProcess', function(event) {
          //Check if data is an image
          if (isImageFromPaste(event.content)) {
+            /* global stopEvent */
             stopEvent(event);
 
             //extract base64 data
@@ -359,6 +370,7 @@ if (typeof tinymce != 'undefined') {
             }
 
          } else if (isImageBlobFromPaste(event.content)) {
+            /* global stopEvent */
             stopEvent(event);
 
             var src = extractSrcFromImgTag(event.content);
@@ -388,18 +400,18 @@ $(function() {
    $(document).bind('dragover', function (event) {
       event.preventDefault();
 
-      var dropZone = $('.dropzone'),
-          foundDropzone,
-          timeout = window.dropZoneTimeout;
+      var dropZone = $('.dropzone');
+      var foundDropzone;
+      var timeout = window.dropZoneTimeout;
 
       if (!timeout) {
-            dropZone.addClass('dragin');
+         dropZone.addClass('dragin');
       } else {
          clearTimeout(timeout);
       }
 
-      var found = false,
-          node = event.target;
+      var found = false;
+      var node = event.target;
 
       do {
          if ($(node).hasClass('draghoverable')) {
@@ -424,17 +436,18 @@ $(function() {
       $('.draghoverable').removeClass('draghover');
 
       // if file present, insert it in filelist
-      if (typeof event.originalEvent.dataTransfer.files) {
+      if (typeof event.originalEvent.dataTransfer.files !== 'undefined') {
          $.each(event.originalEvent.dataTransfer.files, function(index, element) {
             var input_name = null;
             var input_file = $(event.target).find('input[type=file][name]');
             if (input_file.length) {
                input_name = input_file.attr('name').replace('[]', '');
             }
-            uploadFile(element,
-                       {targetElm: $(event.target).find('.fileupload_info')},
-                       input_name
-                      );
+            uploadFile(
+               element,
+               {targetElm: $(event.target).find('.fileupload_info')},
+               input_name
+            );
          });
       }
    });

--- a/js/fuzzysearch.js
+++ b/js/fuzzysearch.js
@@ -28,6 +28,7 @@
  * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
  * ---------------------------------------------------------------------
  */
+
 $(document).ready(function() {
    var list = [];
 
@@ -42,8 +43,6 @@ $(document).ready(function() {
 
    // when the shortcut for fuzzy is called
    $(document).bind('keyup', 'alt+ctrl+g', function() {
-      console.log('start fuzzy search');
-
       // retrieve html of fuzzy input
       $.get(CFG_GLPI.root_doc+'/ajax/fuzzysearch.php', {
          'action': 'getHtml'
@@ -83,7 +82,7 @@ $(document).ready(function() {
                   }
                   break;
             }
-         })
+         });
 
          // when a key is pressed in fuzzy input, launch match
          $("#fuzzysearch input").focus()
@@ -117,6 +116,7 @@ $(document).ready(function() {
       $("#fuzzysearch .results").empty();
 
       // launch fuzzy search on this list
+      /* global fuzzy */
       var results = fuzzy.filter(input_text, list, fuzzy_options);
 
       // append new results

--- a/js/log_filters.js
+++ b/js/log_filters.js
@@ -35,6 +35,7 @@ $(function() {
 
    var showFilters = function (event) {
       event.preventDefault();
+      /* global reloadTab */
       reloadTab('filters[active]=1');
    };
 
@@ -43,23 +44,24 @@ $(function() {
       // Without this workaround, orphan dropdowns remains in page when reloading tab.
       $('.log_history_filter_row .select2-hidden-accessible').on('select2:unselecting', function(ev) {
          if (ev.params.args.originalEvent) {
-             ev.params.args.originalEvent.stopPropagation();
+            ev.params.args.originalEvent.stopPropagation();
          }
       });
 
-      $('.log_history_filter_row [name^="filters\["]').on('input', handleFilterChange);
-      $('.log_history_filter_row select[name^="filters\["]').on('change', handleFilterChange);
+      $('.log_history_filter_row [name^="filters\\["]').on('input', handleFilterChange);
+      $('.log_history_filter_row select[name^="filters\\["]').on('change', handleFilterChange);
    };
 
-   var handleFilterChange = function (event) {
+   var handleFilterChange = function () {
       // Prevent dropdown to remain in page after tab has been reload.
       $('.log_history_filter_row .select2-hidden-accessible').select2('close');
 
-      reloadTab($('[name^="filters\["]').serialize());
+      /* global reloadTab */
+      reloadTab($('[name^="filters\\["]').serialize());
    };
 
-   $('.glpi_tabs').on('tabsload', function(event) {
-       bindShowFiltersBtn();
-       bindFilterChange();
+   $('.glpi_tabs').on('tabsload', function() {
+      bindShowFiltersBtn();
+      bindFilterChange();
    });
 });

--- a/js/notifications_ajax.js
+++ b/js/notifications_ajax.js
@@ -11,7 +11,6 @@
       var _this = this;
       var _queue = $('<div />');
       var _queue_audio = $('<div />');
-      var _interval = null;
 
       this.options = $.extend({}, GLPINotificationsAjax.default, options);
 
@@ -88,7 +87,7 @@
          var ajax = $.getJSON(CFG_GLPI.root_doc + '/ajax/notifications_ajax.php');
          ajax.done(function (data) {
             if (data) {
-               for (i = 0; i < data.length; i++) {
+               for (var i = 0; i < data.length; i++) {
                   var item = data[i];
                   _this.showNotification(item.id, item.title, item.body, item.url);
                }
@@ -123,7 +122,6 @@
 
       this.startMonitoring = function() {
          this.checkConcurrence();
-         _interval = setInterval(this.checkConcurrence.bind(this), this.options.interval);
       };
 
       this.checkPermission = function () {

--- a/js/rack.js
+++ b/js/rack.js
@@ -57,12 +57,13 @@ var initRack = function() {
          $('#viewgraph').toggleClass('clear_text');
       })
       .on("click", ".cell_add", function() {
+         /* global grid_rack_units */
          var index = grid_rack_units - $(this).index();
-         var side = ($(this).parents('.rack_side').hasClass('rack_front')
-                        ? 0  // front
-                        : 1); // rear
-         var current_grid = $(this).parents('.grid-stack').data('gridstack');
+         var side = $(this).parents('.rack_side').hasClass('rack_front')
+            ? 0  // front
+            : 1; // rear
 
+         /* global grid_link_url grid_rack_id */
          $.ajax({
             url : grid_link_url,
             data: {
@@ -103,8 +104,7 @@ var initRack = function() {
    });
 
    $('.grid-stack')
-      .on('dragstart', function(event, ui) {
-         var grid    = this;
+      .on('dragstart', function(event) {
          var element = $(event.target);
          var node    = element.data('_gridstack_node');
 
@@ -115,8 +115,7 @@ var initRack = function() {
          // disable qtip
          element.qtip('hide', true);
       })
-      .on('click', function(event, ui) {
-         var grid    = this;
+      .on('click', function(event) {
          var element = $(event.target);
          var el_url  = element.find('.itemrack_name').attr('href');
 
@@ -148,8 +147,10 @@ var initRack = function() {
       $('.indexes').append('<li>' + i + '</li>');
 
       // append cells for adding new items
-      $('.racks_add')
-         .append('<div class=\"cell_add\"><span class="tipcontent">'+grid_rack_add_tip+'</span></div>');
+      /* global grid_rack_add_tip */
+      $('.racks_add').append(
+         '<div class="cell_add"><span class="tipcontent">'+grid_rack_add_tip+'</span></div>'
+      );
    }
 
    // lock all item (prevent pushing down elements)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1019 @@
+{
+    "name": "@glpi/glpi",
+    "requires": true,
+    "lockfileVersion": 1,
+    "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "acorn": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+            "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==",
+            "dev": true
+        },
+        "acorn-jsx": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+            "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+            "dev": true
+        },
+        "ajv": {
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+            "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ansi-escapes": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+            "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "astral-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "callsites": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+            "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+            "dev": true
+        },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
+        "chardet": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "dev": true
+        },
+        "circular-json": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+            "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+            "dev": true
+        },
+        "cli-cursor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "^2.0.0"
+            }
+        },
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+            "dev": true
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "cross-spawn": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+            "dev": true,
+            "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+            }
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "doctrine": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "eslint": {
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.1.tgz",
+            "integrity": "sha512-54NV+JkTpTu0d8+UYSA8mMKAG4XAsaOrozA9rCW7tgneg1mevcL7wIotPC+fZ0SkWwdhNqoXoxnQCTBp7UvTsg==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "ajv": "^6.5.3",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^4.0.1",
+                "doctrine": "^2.1.0",
+                "eslint-scope": "^4.0.0",
+                "eslint-utils": "^1.3.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^5.0.0",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.0.0",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^6.1.0",
+                "js-yaml": "^3.12.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.5",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "regexpp": "^2.0.1",
+                "semver": "^5.5.1",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "^2.0.1",
+                "table": "^5.0.2",
+                "text-table": "^0.2.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ignore": {
+                    "version": "4.0.6",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "eslint-scope": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+            "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+            "dev": true,
+            "requires": {
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+            }
+        },
+        "eslint-utils": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+            "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+            "dev": true
+        },
+        "eslint-visitor-keys": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+            "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+            "dev": true
+        },
+        "espree": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
+            "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+            "dev": true,
+            "requires": {
+                "acorn": "^6.0.2",
+                "acorn-jsx": "^5.0.0",
+                "eslint-visitor-keys": "^1.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+                    "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==",
+                    "dev": true
+                }
+            }
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
+        "esquery": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+            "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^4.0.0"
+            }
+        },
+        "esrecurse": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^4.1.0"
+            }
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "external-editor": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+            "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+            "dev": true,
+            "requires": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+            }
+        },
+        "fast-deep-equal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "figures": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.5"
+            }
+        },
+        "file-entry-cache": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+            "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+            "dev": true,
+            "requires": {
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
+            }
+        },
+        "flat-cache": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+            "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+            "dev": true,
+            "requires": {
+                "circular-json": "^0.3.1",
+                "graceful-fs": "^4.1.2",
+                "rimraf": "~2.6.2",
+                "write": "^0.2.1"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "globals": {
+            "version": "11.10.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+            "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
+            "dev": true
+        },
+        "graceful-fs": {
+            "version": "4.1.15",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+            "dev": true
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "import-fresh": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+            "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+            "dev": true,
+            "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                }
+            }
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "inquirer": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+            "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^3.0.0",
+                "figures": "^2.0.0",
+                "lodash": "^4.17.10",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^6.1.0",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^5.0.0",
+                "through": "^2.3.6"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+                    "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+                            "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.12.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+            "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+            }
+        },
+        "lodash": {
+            "version": "4.17.11",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "dev": true
+        },
+        "mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                }
+            }
+        },
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "dev": true
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "onetime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "^1.0.0"
+            }
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true,
+            "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "parent-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+            "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
+        },
+        "pluralize": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+            "dev": true
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
+        },
+        "regexpp": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+            "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+            "dev": true
+        },
+        "restore-cursor": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "dev": true,
+            "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "rimraf": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "run-async": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "dev": true,
+            "requires": {
+                "is-promise": "^2.1.0"
+            }
+        },
+        "rxjs": {
+            "version": "6.3.3",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+            "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.9.0"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+            "dev": true
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "slice-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
+            "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.0",
+                "astral-regex": "^1.0.0",
+                "is-fullwidth-code-point": "^2.0.0"
+            },
+            "dependencies": {
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                }
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        },
+        "table": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/table/-/table-5.2.1.tgz",
+            "integrity": "sha512-qmhNs2GEHNqY5fd2Mo+8N1r2sw/rvTAAvBZTaTx+Y7PHLypqyrxr1MdIu0pLw6Xvl/Gi4ONu/sdceP8vvUjkyA==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.6.1",
+                "lodash": "^4.17.11",
+                "slice-ansi": "2.0.0",
+                "string-width": "^2.1.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
+        },
+        "tslib": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+            "dev": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2"
+            }
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "write": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+            "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+            "dev": true,
+            "requires": {
+                "mkdirp": "^0.5.1"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "@glpi/glpi",
+    "version": "",
+    "private": true,
+    "description": "GLPI dependencies",
+    "license": "GPL-2.0",
+    "dependencies": {},
+    "devDependencies": {
+        "acorn": "^6.0.5",
+        "eslint": "^5.12.1"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

JS files were checked by PHPCS. I replaced this check to use ESLint, and I fixed found errors.