### PR TITLE
Fix plugini init on database failure

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -94,7 +94,11 @@ class Plugin extends CommonDBTM {
     * @return void
    **/
    function init() {
-      global $GLPI_CACHE;
+      global $DB, $GLPI_CACHE;
+
+      if (!$DB->connected || !$DB->tableExists(self::getTable())) {
+         return;
+      }
 
       $this->checkStates();
       $plugins                  = $this->find(['state' => self::ACTIVATED]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If plugin initialization is made when db is not available, it will fail.