### PR TITLE
fix canCreate on ItilOject when empty object called

### DIFF
--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -129,6 +129,11 @@ class ITILFollowup  extends CommonDBChild {
 
 
    function canCreateItem() {
+      if (!isset($this->fields['itemtype'])
+          || strlen($this->fields['itemtype']) == 0) {
+         return false;
+      }
+
       $itilobject = new $this->fields['itemtype'];
       if (!$itilobject->can($this->getField('items_id'), READ)
         // No validation for closed tickets


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

In relation with tag plugin:
```log
[06-Feb-2019 09:41:28 Europe/Berlin] PHP Fatal error:  Uncaught Error: Class '' not found in /var/www/html/glpi/9.4-git/inc/itilfollowup.class.php:132
Stack trace:
#0 /var/www/html/glpi/9.4-git/plugins/tag/inc/tag.class.php(513): ITILFollowup->canCreateItem()
#1 /var/www/html/glpi/9.4-git/plugins/tag/inc/tag.class.php(416): PluginTagTag::showTagDropdown(Array)
#2 /var/www/html/glpi/9.4-git/inc/plugin.class.php(1057): PluginTagTag::preItemForm(Array)
#3 /var/www/html/glpi/9.4-git/inc/commondbtm.class.php(2723): Plugin::doHook('pre_item_form', Array)
#4 /var/www/html/glpi/9.4-git/inc/itilfollowup.class.php(746): CommonDBTM->showFormHeader(Array)
#5 /var/www/html/glpi/9.4-git/ajax/timeline.php(116): ITILFollowup->showForm(NULL, Array)
#6 {main}
  thrown in /var/www/html/glpi/9.4-git/inc/itilfollowup.class.php on line 132
```