### PR TITLE
Checkout code only once on circleci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,11 @@ version: 2
 
 shared: &shared
   steps:
-    - checkout
+    - attach_workspace:
+        at: /home/circleci
+    - run:
+        name: Install codebase
+        command: cp -a /home/circleci/codebase/. ./
     - run:
         name: Dependencies
         command: |
@@ -77,6 +81,17 @@ shared: &shared
 #          composer testldap
 
 jobs:
+  checkout:
+    docker:
+      - image: circleci/buildpack-deps
+    steps:
+      - checkout:
+          path: /home/circleci/codebase
+      - run: rm -rf /home/circleci/codebase/.git
+      - persist_to_workspace:
+          root: /home/circleci
+          paths:
+            - codebase
   "php7.0":
     <<: *shared
     docker:
@@ -108,10 +123,19 @@ workflows:
   version: 2
   tests_all:
     jobs:
-      - php7.0
-      - php7.1
-      - php7.2
-      - php7.3
+      - checkout
+      - php7.0:
+          requires:
+            - checkout
+      - php7.1:
+          requires:
+            - checkout
+      - php7.2:
+          requires:
+            - checkout
+      - php7.3:
+          requires:
+            - checkout
   scheduled_build:
     triggers:
       - schedule:
@@ -121,4 +145,7 @@ workflows:
               only:
                 - master
     jobs:
-      - phplatest
+      - checkout
+      - phplatest:
+          requires:
+            - checkout


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Code checkout is currently done for every job. As our repository is huge, it fetches 450MB and takes between 20 and 30 seconds for each job (so near to 2GB / 2 minutes as we have 4 jobs).

This PR purpose is to have a checkout job that saves checkouted code into workspace in order to reuse codebase in all tests jobs.