### PR TITLE
fix cut param and display of forcegroupby items in search (incorrect …

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -304,12 +304,11 @@ class Config extends CommonDBTM {
       echo "</tr>";
 
       echo "<tr class='tab_bg_2'>";
-      echo "<td><label for='dropdown_cut$rand'>" . __('Default characters limit (summary text boxes)') . "</label></td><td>";
-      Dropdown::showNumber('cut', ['value' => $CFG_GLPI["cut"],
-                                   'min'   => 50,
-                                   'max'   => 500,
-                                   'step'  => 50,
-                                   'rand'  => $rand]);
+      echo "<td><label for='cut$rand'>" . __('Default characters limit (summary text boxes)') . "</label></td><td>";
+      echo Html::input('cut', [
+         'value' => $CFG_GLPI["cut"],
+         'id'    => "cut$rand"
+      ]);
       echo "</td><td><label for='dropdown_url_maxlength$rand'>" . __('Default url length limit') . "</td><td>";
       Dropdown::showNumber('url_maxlength', ['value' => $CFG_GLPI["url_maxlength"],
                                              'min'   => 20,

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3365,7 +3365,7 @@ class Html {
             //for compatibility. Use fontawesome instead.
             $out .= "<img id='tooltip$rand' src='".$param['img']."' class='pointer'>";
          } else {
-            $out .= "<span id='tooltip$rand' class='fa {$param['awesome-class']} pointer'></span>";
+            $out .= "<span id='tooltip$rand' class='far {$param['awesome-class']} pointer'></span>";
          }
 
          if (!empty($param['link'])) {

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -163,7 +163,7 @@ class Search {
             });
 
          var _loadMap = function(map_elt, itemtype) {
-            L.AwesomeMarkers.Icon.prototype.options.prefix = 'fa';
+            L.AwesomeMarkers.Icon.prototype.options.prefix = 'far';
             var _micon = 'circle';
 
             var stdMarker = L.AwesomeMarkers.icon({
@@ -5968,7 +5968,7 @@ JAVASCRIPT;
                         ];
                         if (Toolbox::strlen($text) > $CFG_GLPI['cut']) {
                            $popup_params += [
-                              'awesome-class'   => 'fa-comments-o',
+                              'awesome-class'   => 'fa-comments',
                               'autoclose'       => false,
                               'onclick'         => true
                            ];
@@ -6971,6 +6971,7 @@ JAVASCRIPT;
             break;
 
          default :
+            global $CFG_GLPI;
             $out = "<td $extraparam valign='top'>";
 
             if (!preg_match('/'.self::LBHR.'/', $value)) {
@@ -6981,7 +6982,8 @@ JAVASCRIPT;
                $line_delimiter = '<hr>';
             }
 
-            if (count($values) > 1) {
+            if (count($values) > 1
+                && Toolbox::strlen($value) > $CFG_GLPI['cut']) {
                $value = '';
                foreach ($values as $v) {
                   $value .= $v.$line_delimiter;
@@ -6991,7 +6993,7 @@ JAVASCRIPT;
                $value = '<div class="fup-popup">'.$value.'</div>';
                $valTip = "&nbsp;".Html::showToolTip(
                   $value, [
-                     'awesome-class'   => 'fa-comments-o',
+                     'awesome-class'   => 'fa-comments',
                      'display'         => false,
                      'autoclose'       => false,
                      'onclick'         => true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

The main issue was the bad font-awesome class.

Before: 
![image](https://user-images.githubusercontent.com/418844/52408026-21cb9680-2ad2-11e9-849f-0323449cce81.png)

After:
![image](https://user-images.githubusercontent.com/418844/52408045-3314a300-2ad2-11e9-9aac-757cc0424a25.png)

Changed the param in config to permits easier setup and have the previous behavior
Ex with cut = 1500000
![image](https://user-images.githubusercontent.com/418844/52408079-4f184480-2ad2-11e9-859f-01ad7ba0523d.png)


