### PR TITLE
Fix qTip compatiblity with jQuery 3.x

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1317,6 +1317,7 @@ class Html {
 
       // AJAX library
       echo Html::script('public/lib/jquery/jquery.js');
+      echo Html::script('public/lib/jquery-migrate/jquery-migrate.js');
       echo Html::script('public/lib/jquery-ui-dist/jquery-ui.js');
 
       // PLugins jquery

--- a/index.php
+++ b/index.php
@@ -88,6 +88,7 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
    echo Html::css('public/lib/fontawesome-free/css/all.css');
 
    echo Html::script('public/lib/jquery/jquery.js');
+   echo Html::script('public/lib/jquery-migrate/jquery-migrate.js');
    echo Html::script('public/lib/select2/js/select2.full.js');
    echo Html::css('public/lib/select2/css/select2.css');
    echo Html::script('js/common.js');

--- a/install/install.php
+++ b/install/install.php
@@ -56,6 +56,7 @@ function header_html($etape) {
 
     // LIBS
    echo Html::script("public/lib/jquery/jquery.js");
+   echo Html::script('public/lib/jquery-migrate/jquery-migrate.js');
    echo Html::script('public/lib/jquery-ui-dist/jquery-ui.js');
    echo Html::script("public/lib/select2/js/select2.full.js");
    echo Html::script("js/common.js");

--- a/install/update.php
+++ b/install/update.php
@@ -109,6 +109,7 @@ echo "<meta http-equiv='Content-Style-Type' content='text/css'>";
 echo "<title>Setup GLPI</title>";
 //JS
 echo Html::script("public/lib/jquery/jquery.js");
+echo Html::script('public/lib/jquery-migrate/jquery-migrate.js');
 echo Html::script('public/lib/jquery-ui-dist/jquery-ui.js');
 // CSS
 echo "<link rel='stylesheet' href='../css/style_install.css' type='text/css' media='screen' >";

--- a/package-lock.json
+++ b/package-lock.json
@@ -3894,6 +3894,11 @@
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
             "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
         },
+        "jquery-migrate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/jquery-migrate/-/jquery-migrate-3.0.1.tgz",
+            "integrity": "sha512-NYlhcFnRh4Bv9jvadPlcAKQdVGRE0+TSgFYxQ+ZnCxUUHbwd+SjbOg+Xvu1Oea9mpQJ+2VB1eCfcBORWNQsHaA=="
+        },
         "jquery-mousewheel": {
             "version": "3.1.13",
             "resolved": "https://registry.npmjs.org/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "fuzzy": "^0.1.3",
         "gridstack": "^0.4.0",
         "jquery": "^3.3.1",
+        "jquery-migrate": "^3.0.1",
         "jquery-mousewheel": "^3.1.13",
         "jquery-prettytextdiff": "^1.0.4",
         "jquery-ui": "^1.12.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,6 +112,12 @@ var libs = {
             from: 'jquery.js',
         }
     ],
+    'jquery-migrate': [
+        {
+            context: 'dist',
+            from: 'jquery-migrate.js',
+        }
+    ],
     'jquery-mousewheel': [
         {
             from: 'jquery.mousewheel.js',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

qTip lib has not been updated since 2016 and is not fully compatible with jQuery 3.

Usage of jquery-migrate lib fix this point, but we should consider using another lib for our tooltips.