### PR TITLE
fontawesome regular icon are paid

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3365,7 +3365,7 @@ class Html {
             //for compatibility. Use fontawesome instead.
             $out .= "<img id='tooltip$rand' src='".$param['img']."' class='pointer'>";
          } else {
-            $out .= "<span id='tooltip$rand' class='far {$param['awesome-class']} pointer'></span>";
+            $out .= "<span id='tooltip$rand' class='fas {$param['awesome-class']} pointer'></span>";
          }
 
          if (!empty($param['link'])) {


### PR DESCRIPTION
follow #5342 

I forced tooltips to use far (regular) class and most of icons in font-awesome are paid for regular.
So it's better with fas (solid)