### PR TITLE
Make circleci config compatible with 2.1 version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,32 +79,32 @@ jobs:
           root: /home/circleci
           paths:
             - codebase
-  "php5.6":
+  php_5_6_test_suite:
     <<: *shared
     docker:
       - image: glpi/circleci-env-core:php_5.6_fpm-node
       - image: circleci/mariadb:10.1
-  "php7.0":
+  php_7_0_test_suite:
     <<: *shared
     docker:
       - image: glpi/circleci-env-core:php_7.0_fpm-node
       - image: circleci/mariadb:10.2
-  "php7.1":
+  php_7_1_test_suite:
     <<: *shared
     docker:
       - image: glpi/circleci-env-core:php_7.1_fpm-node
       - image: circleci/mariadb:10.3
-  "php7.2":
+  php_7_2_test_suite:
     <<: *shared
     docker:
       - image: glpi/circleci-env-core:php_7.2_fpm-node
       - image: circleci/mariadb:10.3
-  "php7.3":
+  php_7_3_test_suite:
     <<: *shared
     docker:
       - image: glpi/circleci-env-core:php_7.3_fpm-node
       - image: circleci/mariadb:10.3
-  "phplatest":
+  php_latest_test_suite:
     <<: *shared
     docker:
       - image: glpi/circleci-env-core:php_latest_fpm-node
@@ -116,19 +116,19 @@ workflows:
   tests_all:
     jobs:
       - checkout
-      - php5.6:
+      - php_5_6_test_suite:
           requires:
             - checkout
-      - php7.0:
+      - php_7_0_test_suite:
           requires:
             - checkout
-      - php7.1:
+      - php_7_1_test_suite:
           requires:
             - checkout
-      - php7.2:
+      - php_7_2_test_suite:
           requires:
             - checkout
-      - php7.3:
+      - php_7_3_test_suite:
           requires:
             - checkout
   scheduled_build:
@@ -141,6 +141,6 @@ workflows:
                 - master
     jobs:
       - checkout
-      - phplatest:
+      - php_latest_test_suite:
           requires:
             - checkout


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This PR fixes incompatibility with version 2.1 configurations in CircleCI. I need to be able to activate 2.1 version for another PR.

Error were:
```
$ circleci config validate
Error: ERROR IN CONFIG FILE:
[#/jobs] 5 schema violations found
Any string key is allowed as job name.
1. [#/jobs/php7.3] string [php7.3] does not match pattern ^[A-Za-z][A-Za-z\s\d_-]*$
2. [#/jobs/php5.6] string [php5.6] does not match pattern ^[A-Za-z][A-Za-z\s\d_-]*$
3. [#/jobs/php7.0] string [php7.0] does not match pattern ^[A-Za-z][A-Za-z\s\d_-]*$
4. [#/jobs/php7.1] string [php7.1] does not match pattern ^[A-Za-z][A-Za-z\s\d_-]*$
5. [#/jobs/php7.2] string [php7.2] does not match pattern ^[A-Za-z][A-Za-z\s\d_-]*$
```