### PR TITLE
Remove useless zendframework/zend-console lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "paragonie/random_compat": "^2.0",
         "monolog/monolog": "^1.23",
         "sebastian/diff": "^1.4 || ^2.0 || ^3.0",
-        "zendframework/zend-console": "^2.7",
         "elvanto/litemoji": "^1.4",
         "symfony/console": "^3.4",
         "leafo/scssphp": "^0.7.7"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "974f77a63a127b7d34c9e110b225f70b",
+    "content-hash": "522e336579e329013cb76f5c0dd1dea3",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1292,59 +1292,6 @@
                 "zf"
             ],
             "time": "2018-05-01T21:58:00+00:00"
-        },
-        {
-            "name": "zendframework/zend-console",
-            "version": "2.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-console.git",
-                "reference": "e8aa08da83de3d265256c40ba45cd649115f0e18"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-console/zipball/e8aa08da83de3d265256c40ba45cd649115f0e18",
-                "reference": "e8aa08da83de3d265256c40ba45cd649115f0e18",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0",
-                "zendframework/zend-stdlib": "^2.7.7 || ^3.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
-                "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-filter": "^2.7.2",
-                "zendframework/zend-json": "^2.6 || ^3.0",
-                "zendframework/zend-validator": "^2.10.1"
-            },
-            "suggest": {
-                "zendframework/zend-filter": "To support DefaultRouteMatcher usage",
-                "zendframework/zend-validator": "To support DefaultRouteMatcher usage"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7.x-dev",
-                    "dev-develop": "2.8.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Console\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Build console applications using getopt syntax or routing, complete with prompts",
-            "keywords": [
-                "ZendFramework",
-                "console",
-                "zf"
-            ],
-            "time": "2018-01-25T19:08:04+00:00"
         },
         {
             "name": "zendframework/zend-eventmanager",

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1918,8 +1918,6 @@ class Config extends CommonDBTM {
                  'check'   => 'Sabre\\VObject\\Component' ],
                [ 'name'    => 'zendframework/zend-cache',
                  'check'   => 'Zend\\Cache\\Module' ],
-               [ 'name'    => 'zendframework/zend-console',
-                 'check'   => 'Zend\\Console\\Console' ],
                [ 'name'    => 'zendframework/zend-i18n',
                  'check'   => 'Zend\\I18n\\Module' ],
                [ 'name'    => 'zendframework/zend-serializer',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Zend\Console was introduced in #4175 but its usage has been removed in #4652 .