### PR TITLE
Remove useless lib paragonie/random_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "zendframework/zend-serializer": "^2.8",
         "michelf/php-markdown": "^1.6",
         "true/punycode": "^2.1",
-        "paragonie/random_compat": "^2.0",
         "monolog/monolog": "^1.23",
         "sebastian/diff": "^1.4 || ^2.0 || ^3.0",
         "elvanto/litemoji": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51447d53d0c023937285579a8d5e6528",
+    "content-hash": "7cb3ac76ea088e6faef924ed0e9a9b53",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -505,55 +505,6 @@
                 "routing"
             ],
             "time": "2018-02-13T20:26:39+00:00"
-        },
-        {
-            "name": "paragonie/random_compat",
-            "version": "v2.0.18",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "0a58ef6e3146256cc3dc7cc393927bcc7d1b72db"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/0a58ef6e3146256cc3dc7cc393927bcc7d1b72db",
-                "reference": "0a58ef6e3146256cc3dc7cc393927bcc7d1b72db",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.*|5.*"
-            },
-            "suggest": {
-                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "lib/random.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com",
-                    "homepage": "https://paragonie.com"
-                }
-            ],
-            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
-            "keywords": [
-                "csprng",
-                "polyfill",
-                "pseudorandom",
-                "random"
-            ],
-            "time": "2019-01-03T20:59:08+00:00"
         },
         {
             "name": "phpmailer/phpmailer",

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1961,12 +1961,6 @@ class Config extends CommonDBTM {
                [ 'name'    => 'runcmf/runtracy',
                  'check'   => 'RunTracy\Middlewares\TracyMiddleware' ],
       ];
-      if ($all || PHP_VERSION_ID < 70000) {
-         $deps[] = [
-            'name'    => 'paragonie/random_compat',
-            'check'   => 'random_int'
-         ];
-      }
       if (Toolbox::canUseCAS()) {
          $deps[] = [
             'name'    => 'phpCas',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`paragonie/random_compat` was used to be able to use `random_*` function in PHP 5.x. As we support only PHP 7.0+, these functions are now available directly in PHP core.