### PR TITLE
Remove usage of forceTable

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -209,21 +209,6 @@ class CommonDBTM extends CommonGLPI {
 
 
    /**
-    * force table value (used for config management for old versions)
-    *
-    * @param string $table name of the table to be forced
-    *
-    * @return void
-   **/
-   static function forceTable($table) {
-      global $GLPI_CACHE;
-      $glpi_tables = self::getTablesOf();
-      $glpi_tables[get_called_class()] = $table;
-      $GLPI_CACHE->set('table_of', $glpi_tables);
-   }
-
-
-   /**
     * Get known foreign keys
     *
     * @return array

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2755,7 +2755,6 @@ class Config extends CommonDBTM {
          }
 
          $config = new Config();
-         $config->forceTable('glpi_configs');
          if ($config->getFromDB(1)) {
             return $config->fields;
          }
@@ -2769,7 +2768,6 @@ class Config extends CommonDBTM {
          }
 
          $config = new Config();
-         $config->forceTable('glpi_configs');
          if ($config->getFromDB(1)) {
             return Config::getConfigurationValues('core');
          }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I am working on ability to setup application prior to initialization of cache service. This `CommonDBTM::forceTable`, which is used in application setup, is not usefull anymore (was used for compatibility with old `glpi_config` table) and cannot work without the cache service.