### PR TITLE
Instanciate cache during container compilation

### DIFF
--- a/apirest.php
+++ b/apirest.php
@@ -40,9 +40,11 @@ define('DO_NOT_CHECK_HTTP_REFERER', 1);
 ini_set('session.use_cookies', 0);
 
 include_once (GLPI_ROOT . "/inc/based_config.php");
+include_once(GLPI_ROOT . '/inc/db.function.php');
 
-//init cache
-$GLPI_CACHE = Config::getCache('cache_db');
+// Load kernel and expose container in global var
+global $CONTAINER;
+$CONTAINER = (new Glpi\Kernel())->getContainer();
 
 $api = new APIRest;
 $api->call();

--- a/apixmlrpc.php
+++ b/apixmlrpc.php
@@ -39,9 +39,11 @@ define('GLPI_ROOT', __DIR__);
 define('DO_NOT_CHECK_HTTP_REFERER', 1);
 
 include_once (GLPI_ROOT . "/inc/based_config.php");
+include_once(GLPI_ROOT . '/inc/db.function.php');
 
-//init cache
-$GLPI_CACHE = Config::getCache('cache_db');
+// Load kernel and expose container in global var
+global $CONTAINER;
+$CONTAINER = (new Glpi\Kernel())->getContainer();
 
 $api = new APIXmlrpc;
 $api->call();

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -165,20 +165,6 @@ class CommonDBTM extends CommonGLPI {
 
 
    /**
-    * Get known tables
-    *
-    * @return array
-    */
-   public static function getTablesOf() {
-      global $GLPI_CACHE;
-      if ($GLPI_CACHE != null && $GLPI_CACHE->has('table_of')) {
-         return $GLPI_CACHE->get('table_of');
-      }
-      return [];
-   }
-
-
-   /**
     * Return the table used to store this object
     *
     * @param string $classname Force class (to avoid late_binding on inheritance)
@@ -186,8 +172,6 @@ class CommonDBTM extends CommonGLPI {
     * @return string
    **/
    static function getTable($classname = null) {
-      global $GLPI_CACHE;
-
       if ($classname === null) {
          $classname = get_called_class();
       }
@@ -196,43 +180,12 @@ class CommonDBTM extends CommonGLPI {
          return '';
       }
 
-      $glpi_tables = self::getTablesOf();
-      if (!isset($glpi_tables[$classname]) || empty($glpi_tables[$classname])) {
-         $glpi_tables[$classname] = getTableForItemType($classname);
-         if ($GLPI_CACHE != null) {
-            $GLPI_CACHE->set('table_of', $glpi_tables);
-         }
-      }
-
-      return $glpi_tables[$classname];
+      return getTableForItemType($classname);
    }
-
-
-   /**
-    * Get known foreign keys
-    *
-    * @return array
-    */
-   public static function getForeignKeyFieldsOf() {
-      global $GLPI_CACHE;
-      if ($GLPI_CACHE->has('foreign_key_field_of')) {
-         return $GLPI_CACHE->get('foreign_key_field_of');
-      }
-      return [];
-   }
-
 
    static function getForeignKeyField() {
-      global $GLPI_CACHE;
 
-      $fkeys = self::getForeignKeyFieldsOf();
-      $classname = get_called_class();
-      if (!isset($fkeys[$classname]) || empty($fkeys[$classname])) {
-         $fkeys[$classname] = getForeignKeyFieldForTable(static::getTable());
-         $GLPI_CACHE->set('foreign_key_field_of', $fkeys);
-      }
-
-      return $fkeys[$classname];
+      return getForeignKeyFieldForTable(static::getTable());
    }
 
    /**

--- a/inc/commontreedropdown.class.php
+++ b/inc/commontreedropdown.class.php
@@ -186,11 +186,9 @@ abstract class CommonTreeDropdown extends CommonDropdown {
          // Parent changes => clear ancestors and update its level and completename
          if ($input[$this->getForeignKeyField()] != $this->fields[$this->getForeignKeyField()]) {
             $input["ancestors_cache"] = '';
-            if (Toolbox::useCache()) {
-               $ckey = $this->getTable() . '_ancestors_cache_' . $this->getID();
-               if ($GLPI_CACHE->has($ckey)) {
-                  $GLPI_CACHE->delete($ckey);
-               }
+            $ckey = $this->getTable() . '_ancestors_cache_' . $this->getID();
+            if ($GLPI_CACHE->has($ckey)) {
+               $GLPI_CACHE->delete($ckey);
             }
             return $this->adaptTreeFieldsFromUpdateOrAdd($input);
          }
@@ -213,7 +211,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       global $DB, $GLPI_CACHE;
 
       //drop from sons cache when needed
-      if ($changeParent && Toolbox::useCache()) {
+      if ($changeParent) {
          $ckey = $this->getTable() . '_ancestors_cache_' . $ID;
          if ($GLPI_CACHE->has($ckey)) {
             $GLPI_CACHE->delete($ckey);
@@ -307,7 +305,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       );
 
       //drop from sons cache when needed
-      if ($cache && Toolbox::useCache()) {
+      if ($cache) {
          foreach ($ancestors as $ancestor) {
             $ckey = $this->getTable() . '_sons_cache_' . $ancestor;
             if ($GLPI_CACHE->has($ckey)) {
@@ -331,16 +329,14 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       global $GLPI_CACHE;
 
       //add sons cache when needed
-      if (Toolbox::useCache()) {
-         $ancestors = getAncestorsOf($this->getTable(), $this->getID());
-         foreach ($ancestors as $ancestor) {
-            $ckey = $this->getTable() . '_sons_cache_' . $ancestor;
-            if ($GLPI_CACHE->has($ckey)) {
-               $sons = $GLPI_CACHE->get($ckey);
-               if (!isset($sons[$this->getID()])) {
-                  $sons[$this->getID()] = (string)$this->getID();
-                  $GLPI_CACHE->set($ckey, $sons);
-               }
+      $ancestors = getAncestorsOf($this->getTable(), $this->getID());
+      foreach ($ancestors as $ancestor) {
+         $ckey = $this->getTable() . '_sons_cache_' . $ancestor;
+         if ($GLPI_CACHE->has($ckey)) {
+            $sons = $GLPI_CACHE->get($ckey);
+            if (!isset($sons[$this->getID()])) {
+               $sons[$this->getID()] = (string)$this->getID();
+               $GLPI_CACHE->set($ckey, $sons);
             }
          }
       }

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1596,53 +1596,46 @@ class Config extends CommonDBTM {
       }
 
       echo "<tr><th colspan='4'>" . __('User data cache') . "</th></tr>";
-      if (Toolbox::useCache()) {
-         $ext = strtolower(get_class($GLPI_CACHE));
-         $ext = substr($ext, strrpos($ext, '\\')+1);
-         if (in_array($ext, ['apcu', 'memcache', 'memcached', 'wincache', 'redis'])) {
-            $msg = sprintf(__s('The "%s" cache extension is installed'), $ext);
-         } else {
-            $msg = sprintf(__s('"%s" cache system is used'), $ext);
-         }
-         echo "<tr><td>" . $msg . "</td>
-               <td>" . phpversion($ext) . "</td>
-               <td></td>
-               <td class='icons_block'><i class='fa fa-check-circle ok' title='$msg'></i><span class='sr-only'>$msg</span></td></tr>";
-
-         if ($ext != 'filesystem' && $GLPI_CACHE instanceof AvailableSpaceCapableInterface && $GLPI_CACHE instanceof TotalSpaceCapableInterface) {
-            $free = $GLPI_CACHE->getAvailableSpace();
-            $max  = $GLPI_CACHE->getTotalSpace();
-            $used = $max - $free;
-            $rate = round(100.0 * $used / $max);
-            $max  = Toolbox::getSize($max);
-            $used = Toolbox::getSize($used);
-
-            echo "<tr><td>" . __('Memory') . "</td>
-            <td>" . sprintf(__('%1$s / %2$s'), $used, $max) . "</td><td>";
-            Html::displayProgressBar('100', $rate, ['simple'       => true,
-                                                    'forcepadding' => false]);
-            $class   = 'info-circle missing';
-            $msg     = sprintf(__s('%1$ss memory usage is too high'), $ext);
-            if ($rate < 80) {
-               $class   = 'check-circle ok';
-               $msg     = sprintf(__s('%1$s memory usage is correct'), $ext);
-            }
-            echo "</td><td class='icons_block'><i title='$msg' class='fa fa-$class'></td></tr>";
-         }
-
-         if ($GLPI_CACHE instanceof FlushableInterface) {
-            if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
-               echo "<tr><td></td><td colspan='3'>";
-               echo "<a class='vsubmit' href='config.form.php?reset_cache=1'>";
-               echo __('Reset');
-               echo "</a></td></tr>\n";
-            }
-         }
+      $ext = strtolower(get_class($GLPI_CACHE));
+      $ext = substr($ext, strrpos($ext, '\\')+1);
+      if (in_array($ext, ['apcu', 'memcache', 'memcached', 'wincache', 'redis'])) {
+         $msg = sprintf(__s('The "%s" cache extension is installed'), $ext);
       } else {
-         $ext = 'APCu'; // Default cache, can be improved later
-         $msg = sprintf(__s('%s extension is not present'), $ext);
-         echo "<tr><td colspan='3'>" . sprintf(__('Installing the "%s" extension may improve GLPI performance'), $ext) . "</td>
-               <td><i class='fa fa-info-circle missing' title='$msg'></i><span class='sr-only'>$msg</span></td></tr>";
+         $msg = sprintf(__s('"%s" cache system is used'), $ext);
+      }
+      echo "<tr><td>" . $msg . "</td>
+            <td>" . phpversion($ext) . "</td>
+            <td></td>
+            <td class='icons_block'><i class='fa fa-check-circle ok' title='$msg'></i><span class='sr-only'>$msg</span></td></tr>";
+
+      if ($ext != 'filesystem' && $GLPI_CACHE instanceof AvailableSpaceCapableInterface && $GLPI_CACHE instanceof TotalSpaceCapableInterface) {
+         $free = $GLPI_CACHE->getAvailableSpace();
+         $max  = $GLPI_CACHE->getTotalSpace();
+         $used = $max - $free;
+         $rate = round(100.0 * $used / $max);
+         $max  = Toolbox::getSize($max);
+         $used = Toolbox::getSize($used);
+
+         echo "<tr><td>" . __('Memory') . "</td>
+         <td>" . sprintf(__('%1$s / %2$s'), $used, $max) . "</td><td>";
+         Html::displayProgressBar('100', $rate, ['simple'       => true,
+                                                 'forcepadding' => false]);
+         $class   = 'info-circle missing';
+         $msg     = sprintf(__s('%1$ss memory usage is too high'), $ext);
+         if ($rate < 80) {
+            $class   = 'check-circle ok';
+            $msg     = sprintf(__s('%1$s memory usage is correct'), $ext);
+         }
+         echo "</td><td class='icons_block'><i title='$msg' class='fa fa-$class'></td></tr>";
+      }
+
+      if ($GLPI_CACHE instanceof FlushableInterface) {
+         if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
+            echo "<tr><td></td><td colspan='3'>";
+            echo "<a class='vsubmit' href='config.form.php?reset_cache=1'>";
+            echo __('Reset');
+            echo "</a></td></tr>\n";
+         }
       }
 
       echo "</table></div>\n";
@@ -2970,7 +2963,7 @@ class Config extends CommonDBTM {
       }
 
       //use memory adapter when called from tests
-      if (defined('TU_USER') && !defined('CACHED_TESTS')) {
+      if (defined('TU_USER')) {
          $opt['adapter'] = 'memory';
       }
       //force FS adapter for translations for tests

--- a/inc/config.php
+++ b/inc/config.php
@@ -35,15 +35,13 @@ if (!defined('GLPI_ROOT')) {
 }
 
 // Be sure to use global objects if this file is included outside normal process
-global $CFG_GLPI, $CONTAINER, $GLPI, $GLPI_CACHE;
+global $CFG_GLPI, $CONTAINER, $GLPI;
 
 include_once (GLPI_ROOT."/inc/based_config.php");
 include_once (GLPI_ROOT."/inc/define.php");
 include_once (GLPI_ROOT."/inc/dbconnection.class.php");
 
 //init cache
-$GLPI_CACHE = Config::getCache('cache_db');
-
 Session::setPath();
 Session::start();
 
@@ -235,8 +233,6 @@ if (!$conf_exists) {
       }
       exit();
    }
-
-   $GLPI_CACHE = Config::getCache('cache_db');
 }
 
 // Load kernel and expose container in global var

--- a/inc/dbutils.class.php
+++ b/inc/dbutils.class.php
@@ -675,12 +675,10 @@ final class DbUtils {
       $ckey = $table . '_sons_cache_' . $IDf;
       $sons = false;
 
-      if (Toolbox::useCache()) {
-         if ($GLPI_CACHE->has($ckey)) {
-            $sons = $GLPI_CACHE->get($ckey);
-            if ($sons !== null) {
-               return $sons;
-            }
+      if ($GLPI_CACHE->has($ckey)) {
+         $sons = $GLPI_CACHE->get($ckey);
+         if ($sons !== null) {
+            return $sons;
          }
       }
 
@@ -761,9 +759,7 @@ final class DbUtils {
          }
       }
 
-      if (Toolbox::useCache()) {
-         $GLPI_CACHE->set($ckey, $sons);
-      }
+      $GLPI_CACHE->set($ckey, $sons);
 
       return $sons;
    }
@@ -787,12 +783,10 @@ final class DbUtils {
       }
       $ancestors = [];
 
-      if (Toolbox::useCache()) {
-         if ($GLPI_CACHE->has($ckey)) {
-            $ancestors = $GLPI_CACHE->get($ckey);
-            if ($ancestors !== null) {
-               return $ancestors;
-            }
+      if ($GLPI_CACHE->has($ckey)) {
+         $ancestors = $GLPI_CACHE->get($ckey);
+         if ($ancestors !== null) {
+            return $ancestors;
          }
       }
 
@@ -876,9 +870,7 @@ final class DbUtils {
          }
       }
 
-      if (Toolbox::useCache()) {
-         $GLPI_CACHE->set($ckey, $ancestors);
-      }
+      $GLPI_CACHE->set($ckey, $ancestors);
 
       return $ancestors;
    }

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -130,11 +130,9 @@ class Entity extends CommonTreeDropdown {
 
       //Cleaning sons calls getAncestorsOf and thus... Re-create cache. Call it before clean.
       $this->cleanParentsSons();
-      if (Toolbox::useCache()) {
-         $ckey = $this->getTable() . '_ancestors_cache_' . $this->getID();
-         if ($GLPI_CACHE->has($ckey)) {
-            $GLPI_CACHE->delete($ckey);
-         }
+      $ckey = $this->getTable() . '_ancestors_cache_' . $this->getID();
+      if ($GLPI_CACHE->has($ckey)) {
+         $GLPI_CACHE->delete($ckey);
       }
       return true;
    }

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -715,9 +715,6 @@ class Migration {
 
       $this->storeConfig();
 
-      // as some tables may have be renamed, unset session matching between tables and classes
-      $GLPI_CACHE->delete('table_of');
-
       // end of global message
       $this->displayMessage(__('Task completed.'));
    }

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -1659,7 +1659,7 @@ class Plugin extends CommonDBTM {
     */
    public static function getPlugins() {
       global $GLPI_CACHE;
-      if ($GLPI_CACHE && $GLPI_CACHE->has('plugins')) {
+      if ($GLPI_CACHE->has('plugins')) {
          return $GLPI_CACHE->get('plugins');
       }
       return [];

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -539,7 +539,6 @@ class Profile extends CommonDBTM {
 
 
    function post_getEmpty() {
-      global $GLPI_CACHE;
 
       $this->fields["interface"] = "helpdesk";
       $this->fields["name"]      = __('Without name');

--- a/inc/profileright.class.php
+++ b/inc/profileright.class.php
@@ -57,22 +57,22 @@ class ProfileRight extends CommonDBChild {
 
       $rights = [];
 
-      if (!$GLPI_CACHE->has('all_possible_rights')
-          || count($GLPI_CACHE->get('all_possible_rights')) == 0) {
-
-         $iterator = $DB->request([
-            'SELECT'          => 'name',
-            'DISTINCT'        => true,
-            'FROM'            => self::getTable()
-         ]);
-         while ($right = $iterator->next()) {
-            // By default, all rights are NULL ...
-            $rights[$right['name']] = '';
-         }
-         $GLPI_CACHE->set('all_possible_rights', $rights);
-      } else {
-         $rights = $GLPI_CACHE->get('all_possible_rights');
+      if ($GLPI_CACHE->has('all_possible_rights')
+         && count($GLPI_CACHE->get('all_possible_rights')) > 0) {
+         return $GLPI_CACHE->get('all_possible_rights');
       }
+
+      $iterator = $DB->request([
+         'SELECT'          => 'name',
+         'DISTINCT'        => true,
+         'FROM'            => self::getTable()
+      ]);
+      while ($right = $iterator->next()) {
+         // By default, all rights are NULL ...
+         $rights[$right['name']] = '';
+      }
+      $GLPI_CACHE->set('all_possible_rights', $rights);
+
       return $rights;
    }
 

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3009,11 +3009,11 @@ class Toolbox {
     * @since 9.2
     *
     * @return boolean
+    * @deprecated
     */
    public static function useCache() {
-      global $GLPI_CACHE;
-      return $GLPI_CACHE != null
-         && (!defined('TU_USER') || defined('CACHED_TESTS'));
+
+      Toolbox::deprecated('Cache system is now always enabled.');
    }
 
    /**

--- a/install/update.php
+++ b/install/update.php
@@ -37,9 +37,6 @@ if (!defined('GLPI_ROOT')) {
 include_once (GLPI_ROOT . "/inc/based_config.php");
 include_once (GLPI_ROOT . "/inc/db.function.php");
 
-$GLPI_CACHE = Config::getCache('cache_db');
-$GLPI_CACHE->clear(); // Force cache cleaning to prevent usage of outdated cache data
-
 $translation_cache = Config::getCache('cache_trans');
 $translation_cache->clear(); // Force cache cleaning to prevent usage of outdated cache data
 
@@ -70,7 +67,7 @@ function test_connect() {
 
 //update database
 function doUpdateDb() {
-   global $DB, $GLPI_CACHE, $migration, $update;
+   global $DB, $migration, $update;
 
    $currents            = $update->getCurrents();
    $current_version     = $currents['version'];
@@ -86,7 +83,6 @@ function doUpdateDb() {
    }
 
    $update->doUpdates($current_version);
-   $GLPI_CACHE->clear();
 }
 
 //Debut du script

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -37,7 +37,7 @@ use Zend\Cache\Psr\SimpleCache\SimpleCacheDecorator;
 class GLPITestCase extends atoum {
    private $int;
    private $str;
-   protected $cached_methods = [];
+   protected $apcu_cached_methods = [];
    protected $nscache;
 
    public function setUp() {
@@ -50,15 +50,12 @@ class GLPITestCase extends atoum {
    }
 
    public function beforeTestMethod($method) {
-      if (in_array($method, $this->cached_methods)) {
+      if (in_array($method, $this->apcu_cached_methods)) {
          $this->nscache = 'glpitestcache' . GLPI_VERSION;
          global $GLPI_CACHE;
          //run with cache
-         define('CACHED_TESTS', true);
-         //ZendCache does not works with PHP5 acpu...
-         $adapter = (version_compare(PHP_VERSION, '7.0.0') >= 0) ? 'apcu' : 'apc';
          $storage = \Zend\Cache\StorageFactory::factory([
-            'adapter'   => $adapter,
+            'adapter'   => 'apcu',
             'options'   => [
                'namespace' => $this->nscache
             ]
@@ -68,13 +65,8 @@ class GLPITestCase extends atoum {
    }
 
    public function afterTestMethod($method) {
-      if (in_array($method, $this->cached_methods)) {
-         global $GLPI_CACHE;
-         if ($GLPI_CACHE != null) {
-            $GLPI_CACHE->clear();
-         }
-         $GLPI_CACHE = false;
-      }
+      global $GLPI_CACHE;
+      $GLPI_CACHE->clear();
    }
 
    /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -42,14 +42,11 @@ define('GLPI_ROOT', __DIR__ . '/../');
 if (!file_exists(GLPI_CONFIG_DIR . '/db.yaml')) {
    die("\nConfiguration file for tests not found\n\nrun: bin/console glpi:database:install --config-dir=./tests ...\n\n");
 }
-global $CFG_GLPI, $GLPI_CACHE, $IS_TWIG;
+global $CFG_GLPI, $IS_TWIG;
 $IS_TWIG = false;
 
 include_once (GLPI_ROOT . "/inc/define.php");
 include __DIR__ . '/../inc/autoload.function.php';
-
-//init cache
-$GLPI_CACHE = Config::getCache('cache_db');
 
 include_once __DIR__ . '/../inc/includes.php';
 include_once __DIR__ . '/GLPITestCase.php';

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -187,11 +187,6 @@ class CommonDBTM extends DbTestCase {
       unset($_SESSION['glpiactive_entity']);
       $this->array($comp->fields)
          ->integer['entities_id']->isIdenticalTo(12);
-
-      /* do not work
-      $_SESSION['glpi_table_of']['Computer'] = '';
-      $this->boolean($comp->getEmpty())->isFalse();
-      unset($_SESSION['glpi_table_of']);*/
    }
 
    /**

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -37,7 +37,7 @@ use \DbTestCase;
 /* Test for inc/dbutils.class.php */
 
 class DbUtils extends DbTestCase {
-   protected $cached_methods = [
+   protected $apcu_cached_methods = [
       'testGetAncestorsOfCached',
       'testGetSonsOfCached'
    ];

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -37,7 +37,7 @@ use \DbTestCase;
 /* Test for inc/entity.class.php */
 
 class Entity extends DbTestCase {
-   protected $cached_methods = [
+   protected $apcu_cached_methods = [
       'testChangeEntityParentCached'
    ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I added checks on `Toolbox::useCache()` at every place we use the global `$GLPI_CACHE` object.
The idea it to make everything working without cache, in order to instanciate cache during DI container initialization (and not prior to).
Next step will be to fetch cache parameters from container itself.