### PR TITLE
Fix console init when db is not reachable

### DIFF
--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -240,22 +240,19 @@ class Application extends BaseApplication {
       global $DB;
       $this->db = $DB;
 
-      if (!$this->db->connected) {
-         return;
-      }
-
-      ob_start();
-      $checkdb = Config::displayCheckDbEngine();
-      $message = ob_get_clean();
-      if ($checkdb > 0) {
-         throw new RuntimeException($message);
+      if ($this->db->connected) {
+         ob_start();
+         $checkdb = Config::displayCheckDbEngine();
+         $message = ob_get_clean();
+         if ($checkdb > 0) {
+            throw new RuntimeException($message);
+         }
       }
 
       // Default value for use mode
       $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
 
       // Assign config
-      global $CFG_GLPI;
       $this->config = &$CFG_GLPI;
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Application console `$this->config` was not initialized if DB connexion was not established.
```
Warning: array_key_exists() expects parameter 2 to be array, null given in /home/circleci/project/inc/console/application.class.php on line 281
```