### PR TITLE
Disable ability to add DI configuration from plugins

### DIFF
--- a/src/Glpi/Kernel.php
+++ b/src/Glpi/Kernel.php
@@ -278,6 +278,20 @@ class Kernel
     */
     private function loadPluginsServices(ContainerBuilder $container)
     {
+        // FIXME
+        // Following logic will not work for many reasons:
+        //
+        // 1. Active state of plugins dependes on DB informations, which are verfified by container caching logic.
+        // This mean that container cache will not be considered as outdated when a plugin state changed.
+        //
+        // 2. Plugin state check requires to have a cache and a db service up, prior to container compilation.
+        // This is risky as it chain services instanciations before container config is fully loaded.
+        //
+        // 3. Loading plugin files directly in container will give them ability to override container parameters. Not sur it is wanted.
+        // To prevent this, maybe we should use a `use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;`
+        // to load plugins.
+        return;
+
         $db = $this->getDbInstance();
         if (!$db->isConnected()) {
             return;

--- a/tests/units/Glpi/Kernel.php
+++ b/tests/units/Glpi/Kernel.php
@@ -272,14 +272,6 @@ YAML
       // Autoload does not work for files inside vfsStream
       include_once(vfsStream::url('glpi/src/Glpi/EventSubscriber/MyEventSubscriber.php'));
 
-      // Force active plugin list
-      global $GLPI_CACHE;
-      $GLPI_CACHE = new \Glpi\Cache\SimpleCache(
-          \Zend\Cache\StorageFactory::factory(['adapter' => 'memory'])
-      );
-      $GLPI_CACHE->set('plugins_init', true);
-      $GLPI_CACHE->set('plugins', ['random']);
-
       $kernel = new \Glpi\Kernel(vfsStream::url('glpi'), vfsStream::url('glpi/nocache'));
 
       $container = $kernel->getContainer();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Loading DI configuration from plugins is not working as excpected for now.
We need to rework some parts of code before being able to do it  in the right way.

I did not completely remove the code, as we may want to reuse some parts later.