### PR TITLE
Do not use multiple processes to run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ shared: &shared
           bin/console glpi:database:update --config-dir=./tests --no-interaction |grep -q "No migration needed." || (echo "glpi:database:update command FAILED" && exit 1)
     - run:
         name: Unit tests
-        command: php vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --configurations tests/telemetry.php --bootstrap-file tests/bootstrap.php --no-code-coverage -d tests/units
+        command: php vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --configurations tests/telemetry.php --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/units
     - run:
         name: Database tests
         command: php vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --configurations tests/telemetry.php --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/database


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I wonder if launching unit tests using multiple processes can be the root cause of following error. I do not find documentation about the default value, so I do not know if, by default, atoum uses multiple sub-processes.
```
> There is 1 uncompleted method:
=> tests\units\QueryParam::testQueryParam() with exit code 255:
==> output(1099) "Fatal error: Uncaught RuntimeException: Toolbox::userErrorHandlerNormal() in /home/circleci/project/inc/toolbox.class.php line 660
==>   *** PHP Warning(2): unlink(/home/circleci/project/tests/files/_log/event.log): No such file or directory
==>   Backtrace :
==>   :                                                  
==>   /home/circleci/project/tests/bootstrap.php:589     unlink()
==>   ...ject/vendor/atoum/atoum/classes/includer.php:50 include_once()
==>   ...ject/vendor/atoum/atoum/classes/includer.php:53 mageekguy\atoum\includer->mageekguy\atoum\{closure}()
==>   -:1                                                mageekguy\atoum\includer->includePath()
==>   in /home/circleci/project/inc/toolbox.class.php:435
==> Stack trace:
==> #0 /home/circleci/project/inc/toolbox.class.php(466): Toolbox::log(Object(Monolog\Logger), 400, Array)
==> #1 /home/circleci/project/inc/toolbox.class.php(660): Toolbox::logError('  *** PHP Warni...')
==> #2 [internal function]: Toolbox::userErrorHandlerNormal(2, 'unlink(/home/ci...', '/home/circleci/...', 589, Array)
==> #3 /home/circleci/proj in /home/circleci/project/inc/toolbox.class.php on line 435"
```