### PR TITLE
Always use DB configured implementation

### DIFF
--- a/front/backup.php
+++ b/front/backup.php
@@ -169,8 +169,8 @@ function get_content($DB, $table, $from, $limit) {
 
 /**  Get structure of a table
  *
- * @param DBmysql $DB     DB object
- * @param string  $table  table name
+ * @param \Glpi\AbstractDatabase $DB     DB object
+ * @param string                 $table  table name
 **/
 function get_def($DB, $table) {
 
@@ -190,9 +190,9 @@ function get_def($DB, $table) {
 
 /**  Restore a mysql dump
  *
- * @param DBmysql $DB        DB object
- * @param string  $dumpFile  dump file
- * @param integer $duree     max delay before refresh
+ * @param \Glpi\AbstractDatabase $DB        DB object
+ * @param string                 $dumpFile  dump file
+ * @param integer                $duree     max delay before refresh
 **/
 function restoreMySqlDump($DB, $dumpFile, $duree) {
    global $DB, $TPSCOUR, $offset, $cpt;
@@ -308,10 +308,10 @@ function restoreMySqlDump($DB, $dumpFile, $duree) {
 
 /**  Backup a glpi DB
  *
- * @param DBmysql $DB        DB object
- * @param string  $dumpFile  dump file
- * @param integer $duree     max delay before refresh
- * @param integer $rowlimit  rowlimit to backup in one time
+ * @param \Glpi\AbstractDatabase $DB        DB object
+ * @param string                 $dumpFile  dump file
+ * @param integer                $duree     max delay before refresh
+ * @param integer                $rowlimit  rowlimit to backup in one time
 **/
 function backupMySql($DB, $dumpFile, $duree, $rowlimit) {
    global $TPSCOUR, $offsettable, $offsetrow, $cpt;

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -87,7 +87,7 @@ abstract class API extends CommonGLPI {
     * Constructor
     *
     * @var array $CFG_GLPI
-    * @var DBmysql $DB
+    * @var \Glpi\AbstractDatabase $DB
     *
     * @return void
     */

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -127,7 +127,7 @@ class Auth extends CommonGLPI {
    /**
     * Check user existence in DB
     *
-    * @var DBmysql $DB
+    * @var \Glpi\AbstractDatabase $DB
     *
     * @param array $options conditions : array('name'=>'glpi')
     *                                    or array('email' => 'test at test.com')
@@ -326,7 +326,7 @@ class Auth extends CommonGLPI {
     * If not found or can't connect to DB updates the instance variable err
     * with an eventual error message
     *
-    * @var DBmysql $DB
+    * @var \Glpi\AbstractDatabase $DB
     * @param string $name     User Login
     * @param string $password User Password
     *

--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -545,7 +545,7 @@ class AuthLDAP extends CommonDBTM {
    /**
     * Show config replicates form
     *
-    * @var DBmysql $DB
+    * @var \Glpi\AbstractDatabase $DB
     *
     * @return void
     */
@@ -3271,7 +3271,7 @@ class AuthLDAP extends CommonDBTM {
    /**
     * Get number of servers
     *
-    * @var DBmysql $DB
+    * @var \Glpi\AbstractDatabase $DB
     *
     * @return integer
     */
@@ -3384,7 +3384,7 @@ class AuthLDAP extends CommonDBTM {
    /**
     * Get default ldap
     *
-    * @var DBmysql $DB DB instance
+    * @var \Glpi\AbstractDatabase $DB DB instance
     *
     * @return integer
     */

--- a/inc/certificate.class.php
+++ b/inc/certificate.class.php
@@ -729,7 +729,7 @@ class Certificate extends CommonDBTM {
                   ],
                   [
                      'RAW' => [
-                        'DATEDIFF(' . DBmysql::quoteName('glpi_certificates.date_expiration') . ', CURDATE())' => ['<', $before]
+                        'DATEDIFF(' . $DB->quoteName('glpi_certificates.date_expiration') . ', CURDATE())' => ['<', $before]
                      ]
                   ],
                   'glpi_certificates.entities_id' => $entity,

--- a/inc/commondevice.class.php
+++ b/inc/commondevice.class.php
@@ -192,7 +192,7 @@ abstract class CommonDevice extends CommonDropdown {
          [
             'SELECT'    => [
                'itemtype',
-               new QueryExpression('GROUP_CONCAT(DISTINCT ' . DBmysql::quoteName('items_id') . ') AS ids'),
+               new QueryExpression('GROUP_CONCAT(DISTINCT ' . $DB->quoteName('items_id') . ') AS ids'),
             ],
             'FROM'      => $linktable,
             'WHERE'     => [

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -519,6 +519,7 @@ abstract class CommonITILObject extends CommonDBTM {
     * @return integer
    **/
    private function countActiveObjectsFor(CommonITILActor $linkclass, $id, $role) {
+      global $DB;
 
       $itemtable = $this->getTable();
       $itemfk    = $this->getForeignKeyField();
@@ -527,7 +528,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       return countElementsInTable(
          [$itemtable, $linktable], [
-            "$linktable.$itemfk"    => new \QueryExpression(DBmysql::quoteName("$itemtable.id")),
+            "$linktable.$itemfk"    => new \QueryExpression($DB->quoteName("$itemtable.id")),
             "$linktable.$field"     => $id,
             "$linktable.type"       => $role,
             "$itemtable.is_deleted" => 0,

--- a/inc/computer_softwareversion.class.php
+++ b/inc/computer_softwareversion.class.php
@@ -899,7 +899,7 @@ class Computer_SoftwareVersion extends CommonDBRelation {
                         'OR' => [
                            'AND' => [
                               'glpi_softwarelicenses.softwareversions_id_use' => 0,
-                              'glpi_softwarelicenses.softwareversions_id_buy' => new \QueryExpression(DBmysql::quoteName('glpi_softwareversions.id')),
+                              'glpi_softwarelicenses.softwareversions_id_buy' => new \QueryExpression($DB->quoteName('glpi_softwareversions.id')),
                            ]
                         ]
                      ]

--- a/inc/contract.class.php
+++ b/inc/contract.class.php
@@ -1211,7 +1211,7 @@ class Contract extends CommonDBTM {
             'WHERE'     => [
                [
                   'RAW' => [
-                     DBmysql::quoteName('glpi_contracts.alert') . ' & ' . pow(2, Alert::NOTICE) => ['>', 0]
+                     $DB->quoteName('glpi_contracts.alert') . ' & ' . pow(2, Alert::NOTICE) => ['>', 0]
                   ]
                ],
                'glpi_alerts.date'           => null,
@@ -1226,8 +1226,8 @@ class Contract extends CommonDBTM {
                   'RAW' => [
                      'DATEDIFF(
                          ADDDATE(
-                            ' . DBmysql::quoteName('glpi_contracts.begin_date') . ',
-                            INTERVAL ' . DBmysql::quoteName('glpi_contracts.duration') . ' MONTH
+                            ' . $DB->quoteName('glpi_contracts.begin_date') . ',
+                            INTERVAL ' . $DB->quoteName('glpi_contracts.duration') . ' MONTH
                          ),
                          CURDATE()
                       )' => ['>', 0]
@@ -1237,10 +1237,10 @@ class Contract extends CommonDBTM {
                   'RAW' => [
                      'DATEDIFF(
                          ADDDATE(
-                            ' . DBmysql::quoteName('glpi_contracts.begin_date') . ',
+                            ' . $DB->quoteName('glpi_contracts.begin_date') . ',
                             INTERVAL (
-                               ' . DBmysql::quoteName('glpi_contracts.duration') . '
-                               - ' . DBmysql::quoteName('glpi_contracts.notice') . '
+                               ' . $DB->quoteName('glpi_contracts.duration') . '
+                               - ' . $DB->quoteName('glpi_contracts.notice') . '
                             ) MONTH
                          ),
                          CURDATE()
@@ -1272,7 +1272,7 @@ class Contract extends CommonDBTM {
             'WHERE'     => [
                [
                   'RAW' => [
-                     DBmysql::quoteName('glpi_contracts.alert') . ' & ' . pow(2, Alert::END) => ['>', 0]
+                     $DB->quoteName('glpi_contracts.alert') . ' & ' . pow(2, Alert::END) => ['>', 0]
                   ]
                ],
                'glpi_alerts.date'           => null,
@@ -1286,8 +1286,8 @@ class Contract extends CommonDBTM {
                   'RAW' => [
                      'DATEDIFF(
                          ADDDATE(
-                            ' . DBmysql::quoteName('glpi_contracts.begin_date') . ',
-                            INTERVAL ' . DBmysql::quoteName('glpi_contracts.duration') . ' MONTH
+                            ' . $DB->quoteName('glpi_contracts.begin_date') . ',
+                            INTERVAL ' . $DB->quoteName('glpi_contracts.duration') . ' MONTH
                          ),
                          CURDATE()
                       )' => ['<', $before]

--- a/inc/dbconnection.class.php
+++ b/inc/dbconnection.class.php
@@ -141,7 +141,7 @@ class DBConnection extends CommonDBTM {
     *
     * @param integer $server host number (default NULL)
     *
-    * @return DBmysql object
+    * @return AbstractDatabase object
    **/
    static function getDBSlaveConf($server = null): AbstractDatabase {
 
@@ -209,7 +209,7 @@ class DBConnection extends CommonDBTM {
     * Get Connection to slave, if exists,
     * and if configured to be used for read only request
     *
-    * @return DBmysql object
+    * @return AbstractDatabase object
    **/
    static function getReadConnection() {
       global $DB, $CFG_GLPI;

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -597,7 +597,7 @@ class Document extends CommonDBTM {
    /**
     * Check if file of current instance can be viewed from a Reminder.
     *
-    * @global DBmysql $DB
+    * @global \Glpi\AbstractDatabase $DB
     * @return boolean
     *
     * @TODO Use DBmysqlIterator instead of raw SQL
@@ -659,7 +659,7 @@ class Document extends CommonDBTM {
     * Check if file of current instance can be viewed from a KnowbaseItem.
     *
     * @global array $CFG_GLPI
-    * @global DBmysql $DB
+    * @global \Glpi\AbstractDatabase $DB
     * @return boolean
     */
    private function canViewFileFromKnowbaseItem() {
@@ -742,7 +742,7 @@ class Document extends CommonDBTM {
    /**
     * Check if file of current instance can be viewed from a KnowbaseItem.
     *
-    * @global DBmysql $DB
+    * @global \Glpi\AbstractDatabase $DB
     * @param integer $tickets_id
     * @return boolean
     */

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -419,7 +419,7 @@ class KnowbaseItem extends CommonDBVisible {
       unset($criteria['WHERE']);
       $criteria['FROM'] = self::getTable();
 
-      $it = new \DBmysqlIterator(null);
+      $it = new \DBmysqlIterator($DB);
       $it->buildQuery($criteria);
       $sql = $it->getSql();
       $sql = str_replace(
@@ -448,7 +448,7 @@ class KnowbaseItem extends CommonDBVisible {
       unset($criteria['LEFT JOIN']);
       $criteria['FROM'] = self::getTable();
 
-      $it = new \DBmysqlIterator(null);
+      $it = new \DBmysqlIterator($DB);
       $it->buildQuery($criteria);
       $sql = $it->getSql();
       $sql = str_replace(

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -460,7 +460,7 @@ class Profile extends CommonDBTM {
          'FROM'   => 'glpi_profilerights',
          'COUNT'  => 'cpt',
          'WHERE'  => [
-            'glpi_profilerights.profiles_id' => new \QueryExpression(\DBmysql::quoteName('glpi_profiles.id')),
+            'glpi_profilerights.profiles_id' => new \QueryExpression($DB->quoteName('glpi_profiles.id')),
             'OR'                             => $right_subqueries
          ]
       ]);

--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -188,7 +188,7 @@ class Reminder extends CommonDBVisible {
       unset($criteria['WHERE']);
       $criteria['FROM'] = self::getTable();
 
-      $it = new \DBmysqlIterator(null);
+      $it = new \DBmysqlIterator($DB);
       $it->buildQuery($criteria);
       $sql = $it->getSql();
       $sql = trim(str_replace(
@@ -206,13 +206,14 @@ class Reminder extends CommonDBVisible {
    **/
    static function addVisibilityRestrict() {
       //not deprecated because used in Search
+      global $DB;
 
       //get and clean criteria
       $criteria = self::getVisibilityCriteria();
       unset($criteria['LEFT JOIN']);
       $criteria['FROM'] = self::getTable();
 
-      $it = new \DBmysqlIterator(null);
+      $it = new \DBmysqlIterator($DB);
       $it->buildQuery($criteria);
       $sql = $it->getSql();
       $sql = preg_replace('/.*WHERE /', '', $sql);

--- a/inc/rssfeed.class.php
+++ b/inc/rssfeed.class.php
@@ -206,7 +206,7 @@ class RSSFeed extends CommonDBVisible {
       unset($criteria['WHERE']);
       $criteria['FROM'] = self::getTable();
 
-      $it = new \DBmysqlIterator(null);
+      $it = new \DBmysqlIterator($DB);
       $it->buildQuery($criteria);
       $sql = $it->getSql();
       $sql = str_replace(
@@ -225,13 +225,14 @@ class RSSFeed extends CommonDBVisible {
    **/
    static function addVisibilityRestrict() {
       //not deprecated because used in Search
+      global $DB;
 
       //get and clean criteria
       $criteria = self::getVisibilityCriteria();
       unset($criteria['LEFT JOIN']);
       $criteria['FROM'] = self::getTable();
 
-      $it = new \DBmysqlIterator(null);
+      $it = new \DBmysqlIterator($DB);
       $it->buildQuery($criteria);
       $sql = $it->getSql();
       $sql = preg_replace('/.*WHERE /', '', $sql);

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -2725,7 +2725,7 @@ class Rule extends CommonDBTM {
             $this->getTable()
          ],
          'WHERE'  => [
-            getTableForItemType($this->ruleactionclass).".".$this->rules_id_field   => new \QueryExpression(DBmysql::quoteName($this->getTable().'.id')),
+            getTableForItemType($this->ruleactionclass).".".$this->rules_id_field   => new \QueryExpression($DB->quoteName($this->getTable().'.id')),
             $this->getTable().'.sub_type'                                           => get_class($this)
 
          ]

--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -1466,6 +1466,7 @@ class SavedSearch extends CommonDBTM {
    **/
    static function addVisibilityRestrict() {
       //not deprecated because used in Search
+      global $DB;
 
       if (Session::haveRight('config', UPDATE)) {
          return [];
@@ -1476,7 +1477,7 @@ class SavedSearch extends CommonDBTM {
       unset($criteria['LEFT JOIN']);
       $criteria['FROM'] = self::getTable();
 
-      $it = new \DBmysqlIterator(null);
+      $it = new \DBmysqlIterator($DB);
       $it->buildQuery($criteria);
       $sql = $it->getSql();
       $sql = preg_replace('/.*WHERE /', '', $sql);

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5063,7 +5063,7 @@ JAVASCRIPT;
          if (isset($joinparams['condition'])) {
             $condition = $joinparams['condition'];
             if (is_array($condition)) {
-               $it = new DBmysqlIterator(null);
+               $it = new DBmysqlIterator($this->db);
                $condition = $it->analyseCrit($condition);
                $this->addQueryParams($it->getParameters());
             }

--- a/install/install.php
+++ b/install/install.php
@@ -441,7 +441,7 @@ function step4 ($databasename, $newdatabasename) {
       $TempDB = \Glpi\DatabaseFactory::create();
 
       // try to create the DB
-      if ($link->query("CREATE DATABASE IF NOT EXISTS ".$TempDB::quoteName($newdatabasename))) {
+      if ($link->query("CREATE DATABASE IF NOT EXISTS ".$TempDB->quoteName($newdatabasename))) {
          echo "<p>".__('Database created')."</p>";
       } else { // can't create database
          echo __('Error in creating database!');

--- a/install/update_0803_083.php
+++ b/install/update_0803_083.php
@@ -860,7 +860,7 @@ function update0803to083() {
       // Get rules
       $query = [
          'SELECT' => new \QueryExpression(
-            "GROUP_CONCAT(" . DBmysql::quoteName("id") . ") AS " . DBmysql::quoteName("ids")
+            "GROUP_CONCAT(" . $DB->quoteName("id") . ") AS " . $DB->quoteName("ids")
          ),
          'FROM'   => "glpi_rules",
          'WHERE' => [
@@ -1099,8 +1099,8 @@ function update0803to083() {
    // Clean unused slalevels
    $DB->deleteOrDie("glpi_slalevels_tickets", [
          (new \QueryExpression(
-            "(" . DBmysql::quoteName("glpi_slalevels_tickets.tickets_id") . " ," .
-            DBmysql::quoteName("glpi_slalevels_tickets.slalevels_id") . ") NOT IN " .
+            "(" . $DB->quoteName("glpi_slalevels_tickets.tickets_id") . " ," .
+            $DB->quoteName("glpi_slalevels_tickets.slalevels_id") . ") NOT IN " .
             (new \QuerySubQuery([
                'SELECT' => [
                   "glpi_tickets.id",

--- a/install/update_0831_084.php
+++ b/install/update_0831_084.php
@@ -239,7 +239,7 @@ function update0831to084() {
       // Get rules
       $rulesIterator = $DB->request([
          'SELECT'    => new \QueryExpression(
-            "GROUP_CONCAT(" . DBmysql::quoteName("id") . ") AS " . DBmysql::quoteName("ids")
+            "GROUP_CONCAT(" . $DB->quoteName("id") . ") AS " . $DB->quoteName("ids")
          ),
          'FROM'      => "glpi_rules",
          'WHERE'     => ['sub_type' => $ruletype],
@@ -1177,7 +1177,7 @@ function update0831to084() {
    // Delete OCS rules
    $DB->query("SET SESSION group_concat_max_len = 4194304;");
    $rulesIterator = $DB->request([
-      'SELECT' => new \QueryExpression("GROUP_CONCAT(" . DBmysql::quoteName('id') .") AS " . DBmysql::quoteName("rules_id")),
+      'SELECT' => new \QueryExpression("GROUP_CONCAT(" . $DB->quoteName('id') .") AS " . $DB->quoteName("rules_id")),
       'FROM' => "glpi_rules",
       'WHERE' => [
          'sub_type' => "RuleImportEntity"
@@ -1238,7 +1238,7 @@ function update0831to084() {
 
    // Give history entries to plugin
    $DB->updateOrDie("glpi_logs", [
-         'linked_action' => new \QueryExpression(DBmysql::quoteName('linked_action') . " + 1000"),
+         'linked_action' => new \QueryExpression($DB->quoteName('linked_action') . " + 1000"),
          'itemtype_link' => "PluginOcsinventoryngOcslink"
       ], [
          'linked_action' => [8, 9, 10, 11]
@@ -1378,7 +1378,7 @@ function update0831to084() {
       // Get rules
       $data = $DB->request([
          'SELECT' => new \QueryExpression(
-            "GROUP_CONCAT(" . DBmysql::quoteName('id') .") AS " . DBmysql::quoteName("rules_id")
+            "GROUP_CONCAT(" . $DB->quoteName('id') .") AS " . $DB->quoteName("rules_id")
          ),
          'FROM' => "glpi_rules",
          'WHERE' => [
@@ -2090,7 +2090,7 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
       // Then, populate it from domains (beware that "domains" can be FQDNs and Windows workgroups)
       $iterator = $DB->request([
          'SELECT'    => [
-            new \QueryExpression("LOWER(" . DBmysql::quoteName('name') . ") AS " . DBmysql::quoteName("name")),
+            new \QueryExpression("LOWER(" . $DB->quoteName('name') . ") AS " . $DB->quoteName("name")),
             "comment"
          ],
          'DISTINCT'  => true,
@@ -2202,8 +2202,8 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
       $iterator = $DB->request([
          'SELECT'    => [
             new \QueryExpression(
-               "INET_NTOA(INET_ATON(" . DBmysql::quoteName("ip") . ")&INET_ATON(" .
-               DBmysql::quoteName("netmask") . ")) AS " . DBmysql::quoteName("address")
+               "INET_NTOA(INET_ATON(" . $DB->quoteName("ip") . ")&INET_ATON(" .
+               $DB->quoteName("netmask") . ")) AS " . $DB->quoteName("address")
             ),
             "netmask",
             "gateway",
@@ -2256,8 +2256,8 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
                   'FROM'   => "origin_glpi_networkports",
                   'WHERE'  => [
                      new \QueryExpression(
-                        "INET_NTOA(INET_ATON(". DBmysql::quoteName("ip") . ")&INET_ATON(".
-                        DBmysql::quoteName("netmask") . ")) = " . $DB->quoteValue($address)
+                        "INET_NTOA(INET_ATON(". $DB->quoteName("ip") . ")&INET_ATON(".
+                        $DB->quoteName("netmask") . ")) = " . $DB->quoteValue($address)
                      ),
                      'netmask'      => $netmask,
                      'gateway'      => $gateway,
@@ -2281,8 +2281,8 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
                   'FROM'   => "origin_glpi_networkports",
                   'WHERE'  => [
                      new \QueryExpression(
-                        "INET_NTOA(INET_ATON(". DBmysql::quoteName("ip") . ")&INET_ATON(".
-                        DBmysql::quoteName("netmask") . ")) = " .
+                        "INET_NTOA(INET_ATON(". $DB->quoteName("ip") . ")&INET_ATON(".
+                        $DB->quoteName("netmask") . ")) = " .
                         $DB->quoteValue($entry['address'])
                      ),
                      'netmask'      => $netmask,
@@ -2472,7 +2472,7 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
                                       'Index mac field and transform address mac to lower'));
 
    $DB->updateOrDie("glpi_networkports", [
-         'mac' => new \QueryExpression("LOWER(" . DBmysql::quoteName("mac") .")")
+         'mac' => new \QueryExpression("LOWER(" . $DB->quoteName("mac") .")")
       ],
       [true],
       "0.84 transform MAC to lower case"
@@ -2718,8 +2718,8 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
             'FROM'   => 'glpi_ipaddresses',
             'WHERE'  => [
                new \QueryExpression(
-                  "(". DBmysql::quoteName("glpi_ipaddresses.binary_3") . "& " .
-                  $DB->quoteValue($netmask) . ") AS " . DBmysql::quoteName($address)
+                  "(". $DB->quoteName("glpi_ipaddresses.binary_3") . "& " .
+                  $DB->quoteValue($netmask) . ") AS " . $DB->quoteName($address)
                ),
                'glpi_ipaddresses.version' => 4
             ],

--- a/install/update_084_085.php
+++ b/install/update_084_085.php
@@ -192,7 +192,7 @@ function update084to085() {
    foreach ($profileRightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . User::IMPORTEXTAUTHUSERS
+               $DB->quoteName("rights") . " | " . User::IMPORTEXTAUTHUSERS
             ),
          ], [
             'profiles_id'  => $profrights['profiles_id'],
@@ -237,7 +237,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . RuleTicket::PARENT
+               $DB->quoteName("rights") . " | " . RuleTicket::PARENT
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -264,7 +264,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . KnowbaseItem::KNOWBASEADMIN
+               $DB->quoteName("rights") . " | " . KnowbaseItem::KNOWBASEADMIN
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -291,7 +291,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . KnowbaseItem::READFAQ
+               $DB->quoteName("rights") . " | " . KnowbaseItem::READFAQ
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -311,7 +311,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . KnowbaseItem::READFAQ . " | " .
+               $DB->quoteName("rights") . " | " . KnowbaseItem::READFAQ . " | " .
                KnowbaseItem::PUBLISHFAQ
             )
          ], [
@@ -339,7 +339,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . User::READAUTHENT
+               $DB->quoteName("rights") . " | " . User::READAUTHENT
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -359,7 +359,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . User::READAUTHENT . " | ". User::UPDATEAUTHENT
+               $DB->quoteName("rights") . " | " . User::READAUTHENT . " | ". User::UPDATEAUTHENT
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -386,7 +386,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . Entity::READHELPDESK
+               $DB->quoteName("rights") . " | " . Entity::READHELPDESK
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -406,7 +406,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
          $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . Entity::READHELPDESK . " | " .
+               $DB->quoteName("rights") . " | " . Entity::READHELPDESK . " | " .
                Entity::UPDATEHELPDESK
             )
          ], [
@@ -434,7 +434,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . ReservationItem::RESERVEANITEM
+               $DB->quoteName("rights") . " | " . ReservationItem::RESERVEANITEM
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -487,7 +487,7 @@ function update084to085() {
 
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
-            'rights' => new \QueryExpression(DBmysql::quoteName("rights") . " | " . UPDATE)
+            'rights' => new \QueryExpression($DB->quoteName("rights") . " | " . UPDATE)
          ], [
             'profiles_id' => $profrights['profiles_id'],
             'name' => "ticket"
@@ -512,7 +512,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . DELETE . " | " . PURGE
+               $DB->quoteName("rights") . " | " . DELETE . " | " . PURGE
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -537,7 +537,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . Ticket::READALL
+               $DB->quoteName("rights") . " | " . Ticket::READALL
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -562,7 +562,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . Ticket::READGROUP
+               $DB->quoteName("rights") . " | " . Ticket::READGROUP
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -587,7 +587,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . Ticket::READASSIGN
+               $DB->quoteName("rights") . " | " . Ticket::READASSIGN
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -612,7 +612,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . Ticket::ASSIGN
+               $DB->quoteName("rights") . " | " . Ticket::ASSIGN
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -637,7 +637,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . Ticket::STEAL
+               $DB->quoteName("rights") . " | " . Ticket::STEAL
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -662,7 +662,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . Ticket::OWN
+               $DB->quoteName("rights") . " | " . Ticket::OWN
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -687,7 +687,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . Ticket::CHANGEPRIORITY
+               $DB->quoteName("rights") . " | " . Ticket::CHANGEPRIORITY
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -731,7 +731,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . ITILFollowup::ADDMYTICKET
+               $DB->quoteName("rights") . " | " . ITILFollowup::ADDMYTICKET
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -756,7 +756,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . ITILFollowup::ADDGROUPTICKET
+               $DB->quoteName("rights") . " | " . ITILFollowup::ADDGROUPTICKET
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -781,7 +781,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . ITILFollowup::SEEPUBLIC
+               $DB->quoteName("rights") . " | " . ITILFollowup::SEEPUBLIC
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -803,7 +803,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . ITILFollowup::SEEPUBLIC . " | " .
+               $DB->quoteName("rights") . " | " . ITILFollowup::SEEPUBLIC . " | " .
                ITILFollowup::SEEPRIVATE
             )
          ], [
@@ -826,7 +826,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . READ . " | " . ITILFollowup::UPDATEALL
+               $DB->quoteName("rights") . " | " . READ . " | " . ITILFollowup::UPDATEALL
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -851,7 +851,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . READ . " | " . ITILFollowup::UPDATEMY
+               $DB->quoteName("rights") . " | " . READ . " | " . ITILFollowup::UPDATEMY
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -876,7 +876,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . PURGE
+               $DB->quoteName("rights") . " | " . PURGE
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -920,7 +920,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . READ . " | " . TicketTask::UPDATEALL  .
+               $DB->quoteName("rights") . " | " . READ . " | " . TicketTask::UPDATEALL  .
                " | " . PURGE
             )
          ], [
@@ -946,7 +946,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . TicketTask::SEEPUBLIC
+               $DB->quoteName("rights") . " | " . TicketTask::SEEPUBLIC
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -971,7 +971,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . TicketTask::SEEPUBLIC . " | " .
+               $DB->quoteName("rights") . " | " . TicketTask::SEEPUBLIC . " | " .
                TicketTask::SEEPRIVATE
             )
          ], [
@@ -1016,7 +1016,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . TicketValidation::CREATEREQUEST . " | " .
+               $DB->quoteName("rights") . " | " . TicketValidation::CREATEREQUEST . " | " .
                PURGE
             )
          ], [
@@ -1042,7 +1042,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . TicketValidation::CREATEINCIDENT . " | " .
+               $DB->quoteName("rights") . " | " . TicketValidation::CREATEINCIDENT . " | " .
                PURGE
             )
          ], [
@@ -1068,7 +1068,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . TicketValidation::VALIDATEREQUEST
+               $DB->quoteName("rights") . " | " . TicketValidation::VALIDATEREQUEST
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -1093,7 +1093,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . TicketValidation::VALIDATEINCIDENT
+               $DB->quoteName("rights") . " | " . TicketValidation::VALIDATEINCIDENT
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -1168,7 +1168,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . Planning::READGROUP
+               $DB->quoteName("rights") . " | " . Planning::READGROUP
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -1193,7 +1193,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . Planning::READALL
+               $DB->quoteName("rights") . " | " . Planning::READALL
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -1230,7 +1230,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . Problem::READALL
+               $DB->quoteName("rights") . " | " . Problem::READALL
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -1255,7 +1255,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . CREATE . " | " . UPDATE . " | " . PURGE
+               $DB->quoteName("rights") . " | " . CREATE . " | " . UPDATE . " | " . PURGE
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -1280,7 +1280,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . DELETE
+               $DB->quoteName("rights") . " | " . DELETE
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -1305,7 +1305,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . DisplayPreference::PERSONAL
+               $DB->quoteName("rights") . " | " . DisplayPreference::PERSONAL
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -1326,7 +1326,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . DisplayPreference::GENERAL
+               $DB->quoteName("rights") . " | " . DisplayPreference::GENERAL
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -1351,7 +1351,7 @@ function update084to085() {
    foreach ($profilerightsIterator as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . Backup::CHECKUPDATE
+               $DB->quoteName("rights") . " | " . Backup::CHECKUPDATE
             )
          ], [
             'profiles_id' => $profrights['profiles_id'],
@@ -1429,7 +1429,7 @@ function update084to085() {
       foreach ($tables as $table) {
          $DB->updateOrDie("glpi_profilerights", [
                'rights' => new \QueryExpression(
-                  DBmysql::quoteName("rights") . " | " . READNOTE
+                  $DB->quoteName("rights") . " | " . READNOTE
                )
             ], [
                'profiles_id' => $profrights['profiles_id'],
@@ -1450,7 +1450,7 @@ function update084to085() {
       foreach ($tables as $table) {
          $DB->updateOrDie("glpi_profilerights", [
                'rights' => new \QueryExpression(
-                  DBmysql::quoteName("rights") . " | " . READNOTE . " | " . UPDATENOTE
+                  $DB->quoteName("rights") . " | " . READNOTE . " | " . UPDATENOTE
                )
             ], [
                'profiles_id' => $profrights['profiles_id'],
@@ -2259,7 +2259,7 @@ function update084to085() {
          $DB->update("glpi_slas", [
                'definition_time' => "minute",
                'resolution_time' => new \QueryExpression(
-                  DBmysql::quoteName("resolution_time") . "/60"
+                  $DB->quoteName("resolution_time") . "/60"
                )
             ], [
                'id' => $a_ids
@@ -2279,7 +2279,7 @@ function update084to085() {
          $DB->update("glpi_slas", [
                'definition_time' => "hour",
                'resolution_time' => new \QueryExpression(
-                  DBmysql::quoteName("resolution_time") . "/3600"
+                  $DB->quoteName("resolution_time") . "/3600"
                )
             ], [
                'id' => $a_ids
@@ -2298,7 +2298,7 @@ function update084to085() {
          $DB->update("glpi_slas", [
                'definition_time' => "day",
                'resolution_time' => new \QueryExpression(
-                  DBmysql::quoteName("resolution_time") . "/86400"
+                  $DB->quoteName("resolution_time") . "/86400"
                )
             ], [
                'id' => $a_ids
@@ -3010,7 +3010,7 @@ function update084to085() {
                'SELECT' => ["id", "notepad"],
                'FROM'   => $t,
                'WHERE'  => [
-                  new \QueryExpression(DBmysql::quoteName("notepad") . " IS NOT NULL"),
+                  new \QueryExpression($DB->quoteName("notepad") . " IS NOT NULL"),
                   ["notepad" => ["<>", ""]]
                ]
             ]);

--- a/install/update_0905_91.php
+++ b/install/update_0905_91.php
@@ -178,7 +178,7 @@ function update0905to91() {
 
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . $DB->quoteValue(UNLOCK)
+               $DB->quoteName("rights") . " | " . $DB->quoteValue(UNLOCK)
             )
          ], [
             'profiles_id'  => 4,
@@ -696,7 +696,7 @@ function update0905to91() {
    foreach ($DB->request("glpi_profilerights", "`name` = 'ticket'") as $profrights) {
       $DB->updateOrDie("glpi_profilerights", [
             'rights' => new \QueryExpression(
-               DBmysql::quoteName("rights") . " | " . $DB->quoteValue(Ticket::SURVEY)
+               $DB->quoteName("rights") . " | " . $DB->quoteValue(Ticket::SURVEY)
             )
          ], [
             'profiles_id'  => $profrights['profiles_id'],

--- a/install/update_91_92.php
+++ b/install/update_91_92.php
@@ -91,7 +91,7 @@ function update91to92() {
    //First time the dropdown is changed from CommonDropdown to CommonTreeDropdown
    if ($tree) {
       $DB->updateOrDie("glpi_softwarelicensetypes", [
-            'completename' =>  new \QueryExpression(DBmysql::quoteName("name")),
+            'completename' =>  new \QueryExpression($DB->quoteName("name")),
             'is_recursive' => "1"
          ],
          [true],
@@ -103,7 +103,7 @@ function update91to92() {
    $DB->updateOrDie("glpi_profilerights", [
          'rights' => new \QueryExpression($DB->quoteName("rights") . " | " . READ)
       ], [
-         new \QueryExpression(DBmysql::quoteName("rights") . " & " . $DB->quoteValue(UPDATE)),
+         new \QueryExpression($DB->quoteName("rights") . " & " . $DB->quoteValue(UPDATE)),
          'name' => "device"
       ],
       "grant READ right on components to profiles having UPDATE right"
@@ -185,7 +185,7 @@ function update91to92() {
 
    $DB->updateOrDie("glpi_profilerights", [
          'rights' => new \QueryExpression(
-            DBmysql::quoteName("rights") . " | " . $DB->quoteValue( KnowbaseItem::COMMENTS)
+            $DB->quoteName("rights") . " | " . $DB->quoteValue( KnowbaseItem::COMMENTS)
          )
       ],
       ['name' => "knowbase"],
@@ -613,7 +613,7 @@ function update91to92() {
    $migration->migrationOneTable("glpi_softwarelicenses");
    if ($new) {
       $DB->updateOrDie("glpi_softwarelicenses", [
-            'completename' => new \QueryExpression(DBmysql::quoteName("name"))
+            'completename' => new \QueryExpression($DB->quoteName("name"))
          ],
          [true],
          "9.2 copy name to completename for software licenses"
@@ -2186,31 +2186,31 @@ Regards,',
          $migration->addField($tl_table, "timeline_position", "tinyint(1) NOT NULL DEFAULT '0'");
          $where = [
             "$tl_table.tickets_id"  => new \QueryExpression(
-               DBmysql::quoteName("glpi_tickets_users.tickets_id")
+               $DB->quoteName("glpi_tickets_users.tickets_id")
             ),
             "$tl_table.users_id"    => new \QueryExpression(
-               DBmysql::quoteName("glpi_tickets_users.users_id")
+               $DB->quoteName("glpi_tickets_users.users_id")
             ),
          ];
          if (!$DB->fieldExists($tl_table, 'tickets_id')) {
             $where = [
                "$tl_table.itemtype"    => "Ticket",
                "$tl_table.items_id"    => new \QueryExpression(
-                  DBmysql::quoteName("glpi_tickets_users.tickets_id")
+                  $DB->quoteName("glpi_tickets_users.tickets_id")
                ),
                "$tl_table.users_id"    => new \QueryExpression(
-                  DBmysql::quoteName("glpi_tickets_users.users_id")
+                  $DB->quoteName("glpi_tickets_users.users_id")
                ),
             ];
          }
 
          $update = new \QueryExpression(
-            DBmysql::quoteName($tl_table) . ", " . DBmysql::quoteName("glpi_tickets_users")
+            $DB->quoteName($tl_table) . ", " . $DB->quoteName("glpi_tickets_users")
          );
          $set = [
             "$tl_table.timeline_position" => new \QueryExpression("IF(" .
-               DBmysql::quoteName("glpi_tickets_users.type") . " NOT IN (1,3) AND " .
-               DBmysql::quoteName("glpi_tickets_users.type") . " IN (2), 4, 1)"
+               $DB->quoteName("glpi_tickets_users.type") . " NOT IN (1,3) AND " .
+               $DB->quoteName("glpi_tickets_users.type") . " IN (2), 4, 1)"
             )
          ];
          $migration->addPostQuery(
@@ -2220,38 +2220,38 @@ Regards,',
 
          $where = [
             "$tl_table.tickets_id"           => new \QueryExpression(
-               DBmysql::quoteName("glpi_groups_tickets.tickets_id")
+               $DB->quoteName("glpi_groups_tickets.tickets_id")
             ),
             "glpi_groups_users.groups_id"    => new \QueryExpression(
-               DBmysql::quoteName("glpi_groups_tickets.groups_id")
+               $DB->quoteName("glpi_groups_tickets.groups_id")
             ),
             "$tl_table.users_id"             => new \QueryExpression(
-               DBmysql::quoteName("glpi_groups_users.users_id")
+               $DB->quoteName("glpi_groups_users.users_id")
             ),
          ];
          if (!$DB->fieldExists($tl_table, 'tickets_id')) {
             $where = [
                "$tl_table.itemtype"             => "Ticket",
                "$tl_table.items_id"             => new \QueryExpression(
-                  DBmysql::quoteName("glpi_groups_tickets.tickets_id")
+                  $DB->quoteName("glpi_groups_tickets.tickets_id")
                ),
                "glpi_groups_users.groups_id"    => new \QueryExpression(
-                  DBmysql::quoteName("glpi_groups_tickets.groups_id")
+                  $DB->quoteName("glpi_groups_tickets.groups_id")
                ),
                "$tl_table.users_id"             => new \QueryExpression(
-                  DBmysql::quoteName("glpi_groups_users.users_id")
+                  $DB->quoteName("glpi_groups_users.users_id")
                ),
             ];
          }
 
          $update = new \QueryExpression(
-            DBmysql::quoteName($tl_table) . ", " . DBmysql::quoteName("glpi_groups_tickets") .
-            ", " . DBmysql::quoteName("glpi_groups_users")
+            $DB->quoteName($tl_table) . ", " . $DB->quoteName("glpi_groups_tickets") .
+            ", " . $DB->quoteName("glpi_groups_users")
          );
          $set = [
             "$tl_table.timeline_position" => new \QueryExpression("IF(" .
-               DBmysql::quoteName("glpi_groups_tickets.type") . " NOT IN (1,3) AND " .
-               DBmysql::quoteName("glpi_groups_tickets.type") . " IN (2), 4, 1)"
+               $DB->quoteName("glpi_groups_tickets.type") . " NOT IN (1,3) AND " .
+               $DB->quoteName("glpi_groups_tickets.type") . " IN (2), 4, 1)"
             )
          ];
          $migration->addPostQuery(

--- a/src/Glpi/AbstractDatabase.php
+++ b/src/Glpi/AbstractDatabase.php
@@ -743,7 +743,7 @@ abstract class AbstractDatabase
      *
      * @return string
      */
-    public static function quoteName($name): string
+    public function quoteName($name): string
     {
        //handle verbatim names
         if ($name instanceof \QueryExpression) {
@@ -757,14 +757,14 @@ abstract class AbstractDatabase
             );
         }
         if (count($names) == 2) {
-            $name = self::quoteName($names[0]);
-            $name .= ' AS ' . self::quoteName($names[1]);
+            $name = $this->quoteName($names[0]);
+            $name .= ' AS ' . $this->quoteName($names[1]);
             return $name;
         } else {
             if (strpos($name, '.')) {
                 $n = explode('.', $name, 2);
-                $table = self::quoteName($n[0]);
-                $field = ($n[1] === '*') ? $n[1] : self::quoteName($n[1]);
+                $table = $this->quoteName($n[0]);
+                $field = ($n[1] === '*') ? $n[1] : $this->quoteName($n[1]);
                 return "$table.$field";
             }
             $quote = static::getQuoteNameChar();

--- a/src/Glpi/Kernel.php
+++ b/src/Glpi/Kernel.php
@@ -48,7 +48,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
-use DBmysql;
 use Plugin;
 use Session;
 
@@ -277,7 +276,7 @@ class Kernel
      */
     private function defineSyntheticServices(ContainerInterface $container)
     {
-        $container->set(DBmysql::class, $this->getDbInstance());
+        $container->set('database', $this->getDbInstance());
         $container->set(ConfigParams::class, $this->getConfigParamsInstance());
         $container->set('environment', $this->getEnvironmentInstance());
     }

--- a/src/resources/services.yaml
+++ b/src/resources/services.yaml
@@ -115,9 +115,9 @@ services:
 
 #### Legacy services below
 
-    # DBmysql service is synthetic as it may sometime be unavailable (before install process)
+    # database service is synthetic as it may sometime be unavailable (before install process)
     # and therefore will be added during container compilation process
-    DBmysql:
+    database:
         synthetic: true
 
     # Following services are manually declared as they cannot be included using an include/exclude rule

--- a/status.php
+++ b/status.php
@@ -33,6 +33,8 @@
 define('DO_NOT_CHECK_HTTP_REFERER', 1);
 include ('./inc/includes.php');
 
+global $DB;
+
 // Force in normal mode
 $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
 
@@ -200,11 +202,11 @@ if (($ok_master || $ok_slave )
          'state'  => CronTask::STATE_RUNNING,
          'OR'     => [
             new \QueryExpression(
-               '(unix_timestamp(' . DBmysql::quoteName('lastrun') . ') + 2 * '.
-               DBmysql::quoteName('frequency') .' < unix_timestamp(now()))'
+               '(unix_timestamp(' . $DB->quoteName('lastrun') . ') + 2 * '.
+               $DB->quoteName('frequency') .' < unix_timestamp(now()))'
             ),
             new \QueryExpression(
-               '(unix_timestamp(' . DBmysql::quoteName('lastrun') . ') + 2 * '.
+               '(unix_timestamp(' . $DB->quoteName('lastrun') . ') + 2 * '.
                HOUR_TIMESTAMP . ' < unix_timestamp(now()))'
             )
          ]

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -467,7 +467,8 @@ class DbUtils extends DbTestCase {
       // See all, really all
       $_SESSION['glpishowallentities'] = 1; // will be restored by setEntity call
 
-      $it = new \DBmysqlIterator(null);
+      global $DB;
+      $it = new \DBmysqlIterator($DB);
 
       $it->execute('glpi_computers', $this->testedInstance->getEntitiesRestrictCriteria('glpi_computers'));
       $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `glpi_computers`');

--- a/tests/units/Glpi/Kernel.php
+++ b/tests/units/Glpi/Kernel.php
@@ -60,8 +60,8 @@ class Kernel extends \GLPITestCase {
       $this->object($container)->isInstanceOf(\Psr\Container\ContainerInterface::class);
 
       // Check Glpi synthetic services
-      $this->boolean($container->has(\DBmysql::class))->isTrue();
-      $this->object($container->get(\DBmysql::class))->isInstanceOf(\DBmysql::class);
+      $this->boolean($container->has('database'))->isTrue();
+      $this->object($container->get('database'))->isInstanceOf(\Glpi\AbstractDatabase::class);
    }
 
    /**
@@ -78,11 +78,12 @@ services:
         autowire: true
         public: true
 
-    DBmysql:
+    database:
         synthetic: true
 
     fake_service:
         class: FakeService
+        arguments: ['@database']
 YAML
             ],
             'FakeService.php' => <<<PHP
@@ -90,7 +91,7 @@ YAML
 class FakeService {
    private \$db;
 
-   public function __construct(\DBMysql \$db) {
+   public function __construct(\Glpi\AbstractDatabase \$db) {
       \$this->db = \$db;
    }
 
@@ -118,7 +119,7 @@ PHP
       $this->boolean($container->has('fake_service'))->isTrue();
       $service = $container->get('fake_service');
       $this->object($service)->isInstanceOf('FakeService');
-      $this->object($service->getDb())->isInstanceOf(\DBmysql::class);
+      $this->object($service->getDb())->isInstanceOf(\Glpi\AbstractDatabase::class);
    }
 
    /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. DBmysqlIterator requires now a DB implementation as constructor argument (cannot be `null` anymore).
2. `Glpi\AbstractDatabase::quoteName` in not static anymore.
3. `DBmysql` service has been renamed to `database`.