### PR TITLE
clear some deprecated warnings (dropdown and itilactor searchoptions)

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -6803,15 +6803,19 @@ class Ticket extends CommonITILObject {
       if (isset($field_id_or_search_options['linkfield'])) {
          switch ($field_id_or_search_options['linkfield']) {
             case 'requesttypes_id':
-               $opt = 'is_ticketheader = 1';
                if (isset($field_id_or_search_options['joinparams']) && Toolbox::in_array_recursive('glpi_itilfollowups', $field_id_or_search_options['joinparams'])) {
-                  $opt = 'is_itilfollowup = 1';
+                  $opt = ['is_itilfollowup' => 1];
+               } else {
+                  $opt = ['is_ticketheader' => 1];
                }
                if ($field_id_or_search_options['linkfield']  == $name) {
-                  $opt .= ' AND is_active = 1';
+                  $opt['is_active'] = 1;
                }
                if (isset( $options['condition'] )) {
-                  $opt .=  ' AND '.$options['condition'];
+                  if (!is_array($options['condition'])) {
+                     $options['condition'] = [$options['condition']];
+                  }
+                  $opt = array_merge($opt, $options['condition']);
                }
                $options['condition'] = $opt;
                break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

```log
[2019-02-20 09:45:19] glpiphplog.NOTICE: Dropdown::show() in /.../glpi/inc/dropdown.class.php line 84
Using a string in condition option is deprecated.  {"user":"2@LU002"} 
2019-02-20 09:45:19 [2@LU002]
  Backtrace :
  inc/toolbox.class.php:558                          Toolbox::backtrace()
  inc/dropdown.class.php:84                          Toolbox::deprecated()
  inc/commondbtm.class.php:3836                      Dropdown::show()
  inc/commondbtm.class.php:4748                      CommonDBTM::dropdown()
  inc/ticket.class.php:6820                          CommonDBTM->getValueToSelect()
  inc/search.class.php:2982                          Ticket->getValueToSelect()
  inc/search.class.php:2876                          Search::displaySearchoptionValue()
  inc/search.class.php:2561                          Search::displaySearchoption()
  inc/search.class.php:2264                          Search::displayCriteria()
  inc/search.class.php:76                            Search::showGenericSearch()
  front/ticket.php:45                                Search::show()
```