### PR TITLE
Fix user preferences loading; fixes #5372

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -155,7 +155,7 @@ class User extends CommonDBTM {
 
       if (isset($this->fields['id'])) {
          foreach ($CFG_GLPI['user_pref_field'] as $f) {
-            if (is_null($this->fields[$f]) || !Session::haveRight('personalization', UPDATE)) {
+            if (is_null($this->fields[$f])) {
                $this->fields[$f] = $CFG_GLPI[$f];
             }
          }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5372 

Preference computation for any user should not take care of rights.
1. On session init, rights are not yet loded, so all preferences are overwritten by global config.
2. On user edition, values should be the same, whenever you have update rights or not.