### PR TITLE
Fix rights migration in case some profiles already has right

### DIFF
--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -491,5 +491,22 @@ class Migration extends \GLPITestCase {
          ]
       ]);
       $this->integer(count($right1))->isEqualTo(8);
+
+      //Test adding a READ right only on profiles where it has not been set yet
+      $DB->delete('glpi_profilerights', [
+         'profiles_id' => [1, 2, 3, 4],
+         'name' => 'testright4'
+      ]);
+
+      $this->migration->addRight('testright4', READ | UPDATE, []);
+
+      $right4 = $DB->request([
+         'FROM' => 'glpi_profilerights',
+         'WHERE'  => [
+            'name'   => 'testright4',
+            'rights' => READ | UPDATE
+         ]
+      ]);
+      $this->integer(count($right4))->isEqualTo(4);
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Investigating on #5372, I saw that migration will completely skip definition of a new right if at least one profile has it. I update the logic to set the new right on all profiles where it has not been set yet.

I see 2 cases that can be fixed by this.
1. Migration stops in the middle of `Migration::addRight()` method, due to an intervention of the evil one. Right has been set on some profiles, but not all, and will not be set to othersif migration is replayed.
2. Someone forgot to add right on migration and peolple starts to define the right using a form. In this case, we cannot fix missing profiles with `Migration::addRight()` method.