### PR TITLE
Fix relation search queries

### DIFF
--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -184,7 +184,7 @@ abstract class CommonDBRelation extends CommonDBConnexity {
          }
       }
       if ($request === true) {
-         $conditions[] = $where1;
+         $conditions[] = ['AND' => $where1];
          $it = new \DBMysqlIterator($DB);
          $fields[]     = new \QueryExpression(
             'IF('.$it->analyseCrit($where1).', 1, 0) AS is_1'
@@ -210,7 +210,7 @@ abstract class CommonDBRelation extends CommonDBConnexity {
          }
       }
       if ($request === true) {
-         $conditions[] = $where2;
+         $conditions[] = ['AND' => $where2];
          $it = new \DBMysqlIterator($DB);
          $fields[]     = new \QueryExpression(
             'IF('.$it->analyseCrit($where2).', 1, 0) AS is_2'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Computation of criteria to find related items in `CommonDBRelation` is using an `OR` operator instead of and `AND` operator in itemtype+items_id criterias building.

So, for example, when searching for associated `Item_Device` elements to delete when deleting a computer, criteria are ```WHERE `itemtype` = 'Computer' OR `items_id` = '15'``` instead of ```WHERE `itemtype` = 'Computer' AND `items_id` = '15'```. This is due to cascading of this operator: https://github.com/glpi-project/glpi/blob/9.4/bugfixes/inc/commondbrelation.class.php#L227 .
So when you delete a computer, all `Item_Device` elements are deleted, whatever they are linked to the deleted computer or to another one.