### PR TITLE
Form element type was always overrided

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -5514,10 +5514,12 @@ class CommonDBTM extends CommonGLPI {
       } else if ($column['Field'] == 'comment' || $column['Field'] == 'content') {
          $element['type'] = 'textarea';
       } else {
-         switch ($column['Type']) {
-            default:
-               $element['type'] = 'text';
-               break;
+         if (!isset($element['type']) || empty($element['type'])) {
+            switch ($column['Type']) {
+               default:
+                  $element['type'] = 'text';
+                  break;
+            }
          }
       }
       if (isset($this->fields[$column['Field']])) {


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Without this change, it is not possible to define a type in CommonDBTM form definition.
