### PR TITLE
Fix user import from LDAP

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -138,7 +138,7 @@ class Auth extends CommonGLPI {
       global $DB;
 
       $result = $DB->request('glpi_users',
-         ['AND'      => [$options],
+         ['WHERE'    => $options,
          'LEFT JOIN' => ['glpi_useremails' => ['FKEY' => ['glpi_users'      => 'id',
                                                           'glpi_useremails' => 'users_id']]]]);
       // Check if there is a row


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Unless I miss something, adding a user from LDAP directoris was not working anymore, as the query made to check if it was already existing had no restrictions, so was always returning `yes`.