### PR TITLE
Force reloading of active plugin list on each request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ The present file will list all changes made to the project; according to the
 
 - new display hook `timeline_actions` to add new buttons to timeline forms
 
+#### Deprecated
+
+The following methods have been deprecated:
+
+- `Plugin::hasBeenInit()`
+
 #### Removed
 
 - Drop `CommonITILObject::showSolutions()`.

--- a/front/plugin.php
+++ b/front/plugin.php
@@ -37,7 +37,7 @@ Session::checkRight("config", UPDATE);
 // This has to be called before search process is called, in order to add
 // "new" plugins in DB to be able to display them.
 $plugin = new Plugin();
-$plugin->checkStates();
+$plugin->checkStates(true);
 
 Html::header(__('Setup'), $_SERVER['PHP_SELF'], "config", "plugin");
 

--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -383,8 +383,6 @@ class Application extends BaseApplication {
       }
 
       $plugin = new Plugin();
-      $plugin->init();
-
       $plugins_list = $plugin->getPlugins();
       if (count($plugins_list) > 0) {
          foreach ($plugins_list as $name) {

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -96,9 +96,6 @@ if (!isset($PLUGINS_INCLUDED)) {
    $PLUGINS_INCLUDED = 1;
    $LOADED_PLUGINS   = [];
    $plugin           = new Plugin();
-   if (!$plugin->hasBeenInit()) {
-      $plugin->init();
-   }
 
    $plugins_list = $plugin->getPlugins();
    if (count($plugins_list)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | - 

Prior to GLPI 9.4, plugin list was fully checked on each new session (so possibly each minute in case of cron was launched from crontab).

On GLPI 9.4.0, check is not only done on cache initialization or when displaying the plugin page.

With this change, check will be done on each page but only to check that active plugins are still meeting their requirements and have not be updated. The full check (to discover new plugins and check inactive ones) will only be made when display the plugins list.