### PR TITLE
Remove logic from removed solution tab; fixes #5450

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,19 @@
 The present file will list all changes made to the project; according to the
 [Keep a Changelog](http://keepachangelog.com/) project.
 
-## [9.4.1] unrelease
+## [9.4.1] unreleased
 
-### Added
+### API changes
+
+#### Added
 
 - new display hook `timeline_actions` to add new buttons to timeline forms
 
-## [9.4] 2019-02-11
+#### Removed
+
+- Drop `CommonITILObject::showSolutions()`.
+
+## [9.4.0] 2019-02-11
 
 ### Added
 

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -217,13 +217,6 @@ class Change extends CommonITILObject {
                   $item->showAnalysisForm();
                   break;
 
-               case 2 :
-                  if (!isset($_GET['load_kb_sol'])) {
-                     $_GET['load_kb_sol'] = 0;
-                  }
-                  $item->showSolutions($_GET['load_kb_sol']);
-                  break;
-
                case 3 :
                   $item->showPlanForm();
                   break;

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -4447,27 +4447,6 @@ abstract class CommonITILObject extends CommonDBTM {
       }
    }
 
-
-   /**
-    * Form to add a solution to an ITIL object
-    *
-    * @param $knowbase_id_toload integer  load a kb article as solution (0 = no load by default)
-    *                                     (default 0)
-   **/
-   function showSolutions($knowbase_id_toload = 0) {
-
-      $solution = new ITILSolution();
-      $solution->showSummary($this);
-      if (ITILSolution::countFor($this->getType(), $this->getID()) > 0) {
-         $rand = mt_rand();
-         Html::file(['editor_id' => "solution$rand",
-                     'showtitle' => false,
-                     'multiple' => true]);
-      } else {
-         $solution->showForm(null, ['item' => $this]);
-      }
-   }
-
    /**
     * Form to add a solution to an ITIL object
     *

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -203,13 +203,6 @@ class Problem extends CommonITILObject {
                   $item->showAnalysisForm();
                   break;
 
-               case 2 :
-                  if (!isset($_GET['load_kb_sol'])) {
-                     $_GET['load_kb_sol'] = 0;
-                  }
-                  $item->showSolutions($_GET['load_kb_sol']);
-                  break;
-
                case 4 :
                   $item->showStats();
                   break;

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -829,18 +829,6 @@ class Ticket extends CommonITILObject {
                   echo "</div>";
                   break;
 
-               case 2 :
-                  if (!isset($_GET['load_kb_sol'])) {
-                     $_GET['load_kb_sol'] = 0;
-                  }
-                  $item->showSolutionForm($_GET['load_kb_sol']);
-
-                  if ($item->canApprove()) {
-                     $fup = new ITILFollowup();
-                     $fup->showApprobationForm($item);
-                  }
-                  break;
-
                case 3 :
                   $satisfaction = new TicketSatisfaction();
                   if (($item->fields['status'] == self::CLOSED)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5450 

The `solutions` tab does not exists anymore. The old logic that is not used anymore is calling a function that was dropped in 9.4.0.
I dropped the method as it cannot work anymore, considering that it should have been dropped in 9.4.0, at the same timle we dropped all methods related to old solution tab.