### PR TITLE
Fix warning on temp files cleaning cron; fixes #5449

### DIFF
--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -1598,7 +1598,8 @@ class CronTask extends CommonDBTM{
          if (basename($filename) == "remove.txt" && is_dir(GLPI_ROOT.'/.git')) {
             continue;
          }
-         if ((filemtime($filename) + $maxlifetime) < time()) {
+         if (is_file($filename) && is_writable($filename)
+             && (filemtime($filename) + $maxlifetime) < time()) {
             if (@unlink($filename)) {
                $nb++;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5449 

We may refactor this cron to recursivly delete files and directories. For now, I consider that keeping empty directories is not a serious issue.