### PR TITLE
Fix central planning date range; fixes #5411

### DIFF
--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -564,13 +564,11 @@ class Planning extends CommonGLPI {
             center: 'title',
             right:  'month,agendaWeek,agendaDay,listFull'
          }";
-         $default_date = 'null';
       } else {
          $default_view = "listFull";
          $header = "false";
          $pl_height = "'auto'";
          $rand = rand();
-         $default_date = "moment().subtract(5, 'years')";
       }
 
       echo "<div id='planning$rand'></div>";
@@ -618,7 +616,6 @@ class Planning extends CommonGLPI {
             weekNumbers: ".($fullview?'true':'false').",
             defaultView: '$default_view',
             timeFormat:  'H:mm',
-            defaultDate: $default_date,
             eventLimit:  true, // show 'more' button when too mmany events
             minTime:     '".$CFG_GLPI['planning_begin']."',
             maxTime:     '".$CFG_GLPI['planning_end']."',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5411 

Commit 92ec5cc4840bd07d890a3851b4c8a917a5b7bd6d uses `visibleRange` option, to set a range from `defaultDate -5 years` to `defaultDate + 5 years`, but for central page, `defaultDate` was already set to `now -5 years`.