### PR TITLE
Fix QueryUnion missing aliases

### DIFF
--- a/inc/queryunion.class.php
+++ b/inc/queryunion.class.php
@@ -108,9 +108,12 @@ class QueryUnion extends AbstractQuery {
          $keyword .= ' ALL';
       }
       $query = '(' . implode(" $keyword ", $queries) . ')';
-      if ($this->alias !== null) {
-         $query .= ' AS ' . $DB->quoteName($this->alias);
-      }
+
+      $alias = $this->alias !== null
+         ? $this->alias
+         : 'union_' . md5($query);
+      $query .= ' AS ' . $DB->quoteName($alias);
+
       return $query;
    }
 }

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -760,12 +760,14 @@ class DBmysqlIterator extends DbTestCase {
          ['FROM' => 'table2']
       ];
       $union = new \QueryUnion($union_crit);
-      $raw_query = 'SELECT * FROM ((SELECT * FROM `table1`) UNION ALL (SELECT * FROM `table2`))';
+      $union_raw_query = '((SELECT * FROM `table1`) UNION ALL (SELECT * FROM `table2`))';
+      $raw_query = 'SELECT * FROM ' . $union_raw_query . ' AS `union_' . md5($union_raw_query) . '`';
       $it = $this->it->execute(['FROM' => $union]);
       $this->string($it->getSql())->isIdenticalTo($raw_query);
 
       $union = new \QueryUnion($union_crit, true);
-      $raw_query = 'SELECT * FROM ((SELECT * FROM `table1`) UNION (SELECT * FROM `table2`))';
+      $union_raw_query = '((SELECT * FROM `table1`) UNION (SELECT * FROM `table2`))';
+      $raw_query = 'SELECT * FROM ' . $union_raw_query . ' AS `union_' . md5($union_raw_query) . '`';
       $it = $this->it->execute(['FROM' => $union]);
       $this->string($it->getSql())->isIdenticalTo($raw_query);
 
@@ -784,7 +786,8 @@ class DBmysqlIterator extends DbTestCase {
       $this->string($it->getSql())->isIdenticalTo($raw_query);
 
       $union = new \QueryUnion($union_crit, true);
-      $raw_query = 'SELECT DISTINCT `theunion`.`field` FROM ((SELECT * FROM `table1`) UNION (SELECT * FROM `table2`))';
+      $union_raw_query = '((SELECT * FROM `table1`) UNION (SELECT * FROM `table2`))';
+      $raw_query = 'SELECT DISTINCT `theunion`.`field` FROM ' . $union_raw_query . ' AS `union_' . md5($union_raw_query) . '`';
       $crit = [
          'SELECT DISTINCT' => 'theunion.field',
          'FROM'            => $union,
@@ -967,10 +970,8 @@ class DBmysqlIterator extends DbTestCase {
                      LEFT JOIN `glpi_entities` ON (`ADDR`.`entities_id` = `glpi_entities`.`id`)
                      WHERE `LINK`.`ipnetworks_id` = '42')";
 
-      $query = implode(' UNION ALL ', $queries);
-      $query = "SELECT * FROM (" . preg_replace('/\s+/', ' ', $query) . ")";
-
-      $raw_query = $query;
+      $union_raw_query = '(' . preg_replace('/\s+/', ' ', implode(' UNION ALL ', $queries)) . ')';
+      $raw_query = 'SELECT * FROM ' . $union_raw_query . ' AS `union_' . md5($union_raw_query) . '`';
 
       //New build way
       $queries = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #5461

When `QueryUnion` is used in a `FROM` clause, it must have an alias or MySQL will return following error: `Error: Every derived table must have its own alias`.

[MySQL doc](https://dev.mysql.com/doc/refman/5.6/en/derived-tables.html) says 
`The [AS] tbl_name clause is mandatory because every table in a FROM clause must have a name. Any columns in the derived table must have unique names.`.

I propose to generate an alias no specific alias has been defined.