### PR TITLE
Check cache integrity across execution contexts; fixes #5368

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /vendor/
 phpunit.xml
 /tests/code-coverage/
+/tests/files/
 /config/based_config.php
 /config/config.php
 /config/define.php

--- a/inc/cache/simplecache.class.php
+++ b/inc/cache/simplecache.class.php
@@ -1,0 +1,323 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Cache;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use Zend\Cache\Psr\SimpleCache\SimpleCacheDecorator;
+use Zend\Cache\Storage\StorageInterface;
+
+class SimpleCache extends SimpleCacheDecorator {
+
+   /**
+    * Determines if footprints must be checked.
+    *
+    * @var boolean
+    */
+   private $check_footprints;
+
+   /**
+    * Footprint file path, if existing.
+    *
+    * @var string|null
+    */
+   private $footprint_file;
+
+   /**
+    * Footprint fallback storage used if footprint file is not available.
+    *
+    * @var array
+    */
+   private $footprint_fallback_storage = [];
+
+   public function __construct(StorageInterface $storage, $cache_dir, $check_footprints = true) {
+      parent::__construct($storage);
+
+      $this->check_footprints = $check_footprints;
+      if ($this->check_footprints) {
+         $this->footprint_file = $cache_dir . '/' . $storage->getOptions()->getNamespace() . '.json';
+         $this->checkFootprintFileIntegrity();
+      }
+   }
+
+   public function get($key, $default = null) {
+      $cached_value = parent::get($key, $default);
+
+      if (!$this->check_footprints) {
+         return $cached_value;
+      }
+
+      if ($this->getCachedFootprint($key) !== $this->computeFootprint($cached_value)) {
+         // If footprint changed, value is no more valid.
+         return $default;
+      }
+
+      return $cached_value;
+   }
+
+   public function set($key, $value, $ttl = null) {
+      if ($this->check_footprints) {
+         $this->setFootprint($key, $value);
+      }
+
+      return parent::set($key, $value, $ttl);
+   }
+
+   public function delete($key) {
+      if ($this->check_footprints) {
+         $this->setFootprint($key, null);
+      }
+
+      return parent::delete($key);
+   }
+
+   public function clear() {
+      if ($this->check_footprints) {
+         $this->setAllCachedFootprints([]);
+      }
+
+      return parent::clear();
+   }
+
+   public function getMultiple($keys, $default = null) {
+      $cached_values = parent::getMultiple($keys, $default);
+
+      if ($this->check_footprints) {
+         foreach ($cached_values as $key => $cached_value) {
+            if ($this->getCachedFootprint($key) !== $this->computeFootprint($cached_value)) {
+               // If footprint changed, value is no more valid.
+               $cached_values[$key] = $default;
+            }
+         }
+      }
+
+      return $cached_values;
+   }
+
+   public function setMultiple($values, $ttl = null) {
+      if ($this->check_footprints) {
+         $this->setMultipleFootprints($values);
+      }
+
+      return parent::setMultiple($values, $ttl);
+   }
+
+   public function deleteMultiple($keys) {
+      if ($this->check_footprints) {
+         $values = array_combine($keys, array_fill(0, count($keys), null));
+         $this->setMultipleFootprints($values);
+      }
+
+      return parent::deleteMultiple($keys);
+   }
+
+   public function has($key) {
+      if (!parent::has($key)) {
+         return false;
+      }
+
+      if (!$this->check_footprints) {
+         return true;
+      }
+
+      // Cache value is not usable if stale, consider it has not existing.
+      return $this->getCachedFootprint($key) === $this->computeFootprint(parent::get($key));
+   }
+
+   /**
+    * Returns the computed footprint of a value.
+    *
+    * @param mixed $value
+    *
+    * @return string
+    */
+   private function computeFootprint($value) {
+      return sha1(serialize($value));
+   }
+
+   /**
+    * Returns known footprint for a cached item.
+    *
+    * @param string $key
+    *
+    * @return string|null
+    */
+   private function getCachedFootprint($key) {
+      $footprints = $this->getAllCachedFootprints();
+
+      return array_key_exists($key, $footprints) ? $footprints[$key] : null;
+   }
+
+   /**
+    * Defines footprint for cache item.
+    *
+    * @param string $key     Key of the cached item.
+    * @param mixed  $values  Value of the cached item.
+    *
+    * @return void
+    */
+   private function setFootprint($key, $value) {
+      $this->setMultipleFootprints([$key => $value]);
+   }
+
+   /**
+    * Defines footprint for multiple cache items.
+    *
+    * @param array $values  Associative array of cached items, where keys corresponds to the
+    *                       cache key of the item and value is its cached value.
+    *
+    * @return void
+    */
+   private function setMultipleFootprints(array $values) {
+      $footprints = $this->getAllCachedFootprints();
+
+      foreach ($values as $key => $value) {
+         $footprints[$key] = $this->computeFootprint($value);
+      }
+
+      $this->setAllCachedFootprints($footprints);
+   }
+
+   /**
+    * Check footprint file integrity, to ensure that it can be used securely.
+    *
+    * @return void
+    */
+   private function checkFootprintFileIntegrity() {
+      if ((file_exists($this->footprint_file) && !is_writable($this->footprint_file))
+          || (!file_exists($this->footprint_file) && !is_writable(dirname($this->footprint_file)))) {
+         trigger_error(
+            sprintf('Cannot write "%s" cache footprint file. Cache performance can be lowered.', $this->footprint_file),
+            E_USER_WARNING
+         );
+         $this->footprint_file = null;
+         return;
+      }
+
+      if (!file_exists($this->footprint_file)) {
+         // Create empty array in file if not exists.
+         $this->setAllCachedFootprints([]);
+         return;
+      }
+
+      $file_contents = file_get_contents($this->footprint_file);
+      if (empty($file_contents)) {
+         // Create empty array in file if empty.
+         $this->setAllCachedFootprints([]);
+         return;
+      }
+
+      $footprints = json_decode($file_contents, true);
+      if (json_last_error() !== JSON_ERROR_NONE || !is_array($footprints)) {
+         // Clear footprint file if not a valid JSON.
+         trigger_error(
+            sprintf('Cache footprint file "%s" contents was invalid, it has been cleaned.', $this->footprint_file),
+            E_USER_WARNING
+         );
+         $this->setAllCachedFootprints([]);
+      }
+   }
+
+   /**
+    * Returns all cache footprints.
+    *
+    * @return array  Associative array of cached items footprints, where keys corresponds to the
+    *                cache key of the item and value is its footprint.
+    */
+   private function getAllCachedFootprints() {
+      if (null !== $this->footprint_file) {
+         $file_contents = file_get_contents($this->footprint_file);
+         $footprints = json_decode($file_contents, true);
+
+         if (json_last_error() !== JSON_ERROR_NONE || !is_array($footprints)) {
+            // Should happen only if file has been corrupted after cache instanciation,
+            // launch integrity tests again to trigger warnings and fix file contents.
+            $this->checkFootprintFileIntegrity();
+            return [];
+         }
+
+         return $footprints;
+      }
+
+      return $this->footprint_fallback_storage;
+   }
+
+   /**
+    * Save all cache footprints.
+    *
+    * @param array $footprints  Associative array of cached items footprints, where keys corresponds to the
+    *                           cache key of the item and value is its footprint.
+    *
+    * @return void
+    */
+   private function setAllCachedFootprints($footprints) {
+      if (null !== $this->footprint_file) {
+         // Remove null values to prevent storage of deleted footprints
+         array_filter(
+            $footprints,
+            function($val) {
+               return null !== $val;
+            }
+         );
+
+         $json = json_encode($footprints, JSON_PRETTY_PRINT);
+
+         $handle = fopen($this->footprint_file, 'c');
+
+         $is_locked = flock($handle, LOCK_EX); // Lock the file, if possible (depends on used FS)
+
+         $result = ftruncate($handle, 0)
+            && fwrite($handle, $json)
+            && fflush($handle);
+
+         if ($is_locked) {
+            // Unlock the file if it has been locked
+            flock($handle, LOCK_UN);
+         }
+
+         fclose($handle);
+
+         if ($result !== false) {
+            return;
+         } else {
+            // Should happen only if file is not writable anymore (rights problems or no more disk space),
+            // fallback to singleton storage.
+            $this->footprint_file = null;
+         }
+      }
+
+      $this->footprint_fallback_storage = $footprints;
+   }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,12 +32,16 @@
 
 error_reporting(E_ALL);
 
+define('GLPI_CACHE_DIR', __DIR__ . '/files/_cache');
 define('GLPI_CONFIG_DIR', __DIR__);
 define('GLPI_LOG_DIR', __DIR__ . '/files/_log');
 define('GLPI_URI', (getenv('GLPI_URI') ?: 'http://localhost:8088'));
 define('TU_USER', '_test_user');
 define('TU_PASS', 'PhpUnit_4');
 define('GLPI_ROOT', __DIR__ . '/../');
+
+is_dir(GLPI_LOG_DIR) or mkdir(GLPI_LOG_DIR, 0755, true);
+is_dir(GLPI_CACHE_DIR) or mkdir(GLPI_CACHE_DIR, 0755, true);
 
 if (!file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {
    die("\nConfiguration file for tests not found\n\nrun: bin/console glpi:database:install --config-dir=./tests ...\n\n");
@@ -501,8 +505,6 @@ function loadDataset() {
                                            'url_base_api' => GLPI_URI . '/apirest.php']);
    $CFG_GLPI['url_base']      = GLPI_URI;
    $CFG_GLPI['url_base_api']  = GLPI_URI . '/apirest.php';
-
-   is_dir(GLPI_LOG_DIR) or mkdir(GLPI_LOG_DIR, 0755, true);
 
    $conf = Config::getConfigurationValues('phpunit');
    if (isset($conf['dataset']) && $conf['dataset']==$data['_version']) {

--- a/tests/units/Glpi/Cache/SimpleCache.php
+++ b/tests/units/Glpi/Cache/SimpleCache.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+*/
+
+namespace tests\units\Glpi\Cache;
+
+use org\bovigo\vfs\vfsStream;
+
+/* Test for inc/cache/simplecache.class.php */
+
+class SimpleCache extends \GLPITestCase {
+
+   /**
+    * Test case: cache dir is empty and writable, footprint file should be created and used.
+    */
+   public function testCacheWithEmptyWritableCacheDir() {
+      $cache_dir = vfsStream::url('glpi/cache');
+      $cache_namespace = uniqid(true);
+
+      vfsStream::setup(
+         'glpi',
+         null,
+         [
+            'cache' => [],
+         ]
+      );
+
+      $footprint_file = vfsStream::url('glpi/cache/' . $cache_namespace . '.json');
+
+      $this->newTestedInstance(
+         new \mock\Zend\Cache\Storage\Adapter\Memory(['namespace' => $cache_namespace]),
+         $cache_dir
+      );
+
+      // File has been initialized
+      $this->string(file_get_contents($footprint_file))->isEqualTo('[]');
+
+      $this->testOperationsOnCache($footprint_file);
+   }
+
+   /**
+    * Test case: footprint file exists, is writable and empty, it should be initialized and used.
+    */
+   public function testCacheWithEmptyFootprintFile() {
+      $cache_dir = vfsStream::url('glpi/cache');
+      $cache_namespace = uniqid(true);
+
+      vfsStream::setup(
+         'glpi',
+         null,
+         [
+            'cache' => [
+               $cache_namespace . '.json' => ''
+            ],
+         ]
+      );
+
+      $footprint_file = vfsStream::url('glpi/cache/' . $cache_namespace . '.json');
+
+      $this->newTestedInstance(
+         new \mock\Zend\Cache\Storage\Adapter\Memory(['namespace' => $cache_namespace]),
+         $cache_dir
+      );
+
+      // File has initialized
+      $this->string(file_get_contents($footprint_file))->isEqualTo('[]');
+
+      $this->testOperationsOnCache($footprint_file);
+   }
+
+   /**
+    * Test case: footprint file exists and is writable, it should be used.
+    */
+   public function testCacheWithExistingFootprintFile() {
+      $cache_dir = vfsStream::url('glpi/cache');
+      $cache_namespace = uniqid(true);
+
+      $existing_footprint = '{"existing_key":"752c14ea195c460bac3c3b7896975ee9fd15eeb7"}';
+
+      vfsStream::setup(
+         'glpi',
+         null,
+         [
+            'cache' => [
+               $cache_namespace . '.json' => $existing_footprint
+            ],
+         ]
+      );
+
+      $footprint_file = vfsStream::url('glpi/cache/' . $cache_namespace . '.json');
+
+      $this->newTestedInstance(
+         new \mock\Zend\Cache\Storage\Adapter\Memory(['namespace' => $cache_namespace]),
+         $cache_dir
+      );
+
+      // File has not been erased
+      $this->string(file_get_contents($footprint_file))->isEqualTo($existing_footprint);
+
+      $this->testOperationsOnCache($footprint_file);
+   }
+
+   /**
+    * Test case: footprint file is corrupted, it should be regenerated.
+    */
+   public function testCacheWithCorruptedFootprintFile() {
+      $self = $this;
+      $cache_dir = vfsStream::url('glpi/cache');
+      $cache_namespace = uniqid(true);
+
+      vfsStream::setup(
+         'glpi',
+         null,
+         [
+            'cache' => [
+               $cache_namespace . '.json' => 'invalid json'
+            ],
+         ]
+      );
+
+      $footprint_file = vfsStream::url('glpi/cache/' . $cache_namespace . '.json');
+
+      $this->when(
+         function() use ($self, $cache_dir, $cache_namespace) {
+            $self->newTestedInstance(
+               new \mock\Zend\Cache\Storage\Adapter\Memory(['namespace' => $cache_namespace]),
+               $cache_dir
+            );
+         }
+      )->error()
+         ->withType(E_USER_WARNING)
+         ->withMessage('Cache footprint file "' . $footprint_file . '" contents was invalid, it has been cleaned.')
+            ->exists();
+
+      // File has been regenerated
+      $this->string(file_get_contents($footprint_file))->isEqualTo('[]');
+
+      $this->testOperationsOnCache($footprint_file);
+   }
+
+   /**
+    * Test case: cache dir is not writable, footprint file cannot be used.
+    */
+   public function testCacheWithoutFootprintFile() {
+      $cache_dir = vfsStream::url('glpi/cache');
+      $cache_namespace = uniqid(true);
+
+      $root_directory = vfsStream::setup(
+         'glpi',
+         null,
+         [
+            'cache' => [],
+         ]
+      );
+
+      // Simulate existing cache with footprint.
+      $this->newTestedInstance(
+         new \mock\Zend\Cache\Storage\Adapter\Memory(['namespace' => $cache_namespace]),
+         $cache_dir
+      );
+
+      $this->boolean($this->testedInstance->set('footprinted', 'some value'))->isTrue();
+      $this->boolean($this->testedInstance->has('footprinted'))->isTrue();
+
+      $root_directory->getChild('cache/' . $cache_namespace . '.json')->chmod(0500); // Make file not writable
+
+      $footprint_file = vfsStream::url('glpi/cache/' . $cache_namespace . '.json');
+
+      $self = $this;
+      $this->when(
+         function() use ($self, $cache_dir, $cache_namespace) {
+            $self->newTestedInstance(
+               new \mock\Zend\Cache\Storage\Adapter\Memory(['namespace' => $cache_namespace]),
+               $cache_dir
+            );
+         }
+      )->error()
+         ->withType(E_USER_WARNING)
+         ->withMessage('Cannot write "' . $footprint_file . '" cache footprint file. Cache performance can be lowered.')
+            ->exists();
+
+      // Previously set value is not valid anymore as footprint file is not usable and cannot be trusted.
+      $this->boolean($this->testedInstance->has('footprinted'))->isFalse();
+
+      $this->testOperationsOnCache(null);
+   }
+
+   /**
+    * Test all possible cache operations.
+    *
+    * @param string|null $footprint_file
+    */
+   private function testOperationsOnCache($footprint_file) {
+      // Different scalar types to test.
+      $values = [
+         'null'         => null,
+         'string'       => 'some value',
+         'true'         => true,
+         'false'        => false,
+         'negative int' => -10,
+         'positive int' => 15,
+         'zero'         => 0,
+         'float'        => 15.358,
+         'simple array' => ['a', 'b', 'c'],
+         'assoc array'  => ['some' => 'value', 'from' => 'assoc', 'array' => null]
+      ];
+
+      // Test single set/get/has/delete
+      foreach ($values as $key => $value) {
+         // Not yet existing
+         $this->boolean($this->testedInstance->has($key))->isFalse();
+
+         // Can be set if not existing
+         $this->boolean($this->testedInstance->set($key, $value))->isTrue();
+
+         // Is existing after being set
+         $this->boolean($this->testedInstance->has($key))->isTrue();
+
+         // Cached value is equal to value that was set
+         $this->variable($this->testedInstance->get($key))->isEqualTo($value);
+
+         // Overwriting an existing value works
+         $rand = mt_rand();
+         $this->boolean($this->testedInstance->set($key, $rand))->isTrue();
+         $this->variable($this->testedInstance->get($key))->isEqualTo($rand);
+
+         // Can delete a value
+         $this->boolean($this->testedInstance->delete($key))->isTrue();
+      }
+
+      // Test multiple set/get
+      $this->testedInstance->setMultiple($values);
+      foreach ($values as $key => $value) {
+         // Cached value exists and is equal to value that was set
+         $this->boolean($this->testedInstance->has($key))->isTrue();
+         $this->variable($this->testedInstance->get($key))->isEqualTo($value);
+      }
+
+      // Test only on partial result to be sure that "*Multiple" methods acts only on targetted elements
+      $some_keys = array_rand($values, 4);
+      $some_values = array_intersect_key($values, array_fill_keys($some_keys, null));
+
+      $this->array($this->testedInstance->getMultiple($some_keys))->isEqualTo($some_values);
+
+      $this->testedInstance->deleteMultiple($some_keys);
+      foreach ($some_keys as $key) {
+         // Cached value should not exists as it has been deleted
+         $this->boolean($this->testedInstance->has($key))->isFalse();
+      }
+
+      // Test global clear
+      $this->testedInstance->clear();
+      foreach (array_keys($values) as $key) {
+         // Cached value should not exists as it has been deleted
+         $this->boolean($this->testedInstance->has($key))->isFalse();
+      }
+
+      // Test that footprint changes made cache stale
+      if (null !== $footprint_file) {
+         $this->boolean($this->testedInstance->set('another_key', 'another value'))->isTrue();
+         $this->boolean($this->testedInstance->has('another_key'))->isTrue();
+         file_put_contents($footprint_file, '{"another_key":"752c14ea195c460bac3c3b7896975ee9fd15eeb7"}');
+         $this->boolean($this->testedInstance->has('another_key'))->isFalse();
+      }
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5368 

There are several cases that can lead to have different cache storages, depending on the execution context.
1. APCu cache is not shared across processes, so cache used by CLI will not be shared with cache used by web server.
2. APCu extension may not be activated for CLI execution ([which is the default behaviour](http://php.net/manual/fr/apcu.configuration.php#ini.apcu.enable-cli)). So in this case CLI will use FS cache and Web will use APCu cache.

The problem is that execution context A will not be aware that the cache should be invalidated on the execution context B, and, even if he knows, he may not be able to do it (for instance if it cannot access to same APCu memory space).

This PR introduces a synchronization file where cached values footprints are stored. If footprint changed, then it means that cache was updated in another context, and should be considered as stale.