### PR TITLE
Force usage of relative path for images stored in rich text

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -5703,6 +5703,11 @@ class Html {
       $out = "";
 
       if (count($doc_data)) {
+         $base_path = $CFG_GLPI['root_doc'];
+         if (isCommandLine()) {
+            $base_path = parse_url($CFG_GLPI['url_base'], PHP_URL_PATH);
+         }
+
          foreach ($doc_data as $id => $image) {
             // Add only image files : try to detect mime type
             $ok       = false;
@@ -5714,21 +5719,17 @@ class Html {
             }
             if (isset($image['tag'])) {
                if ($ok || empty($mime)) {
-                  $glpi_root = $CFG_GLPI['root_doc'];
-                  if (isCommandLine() && isset($CFG_GLPI['url_base'])) {
-                     $glpi_root = $CFG_GLPI['url_base'];
-                  }
                   // Replace tags by image in textarea
                   if ($addLink) {
                      $out .= '<a '
-                             . 'href="' . $glpi_root . '/front/document.send.php?docid=' . $id . $more_link . '" '
+                             . 'href="' . $base_path . '/front/document.send.php?docid=' . $id . $more_link . '" '
                              . 'target="_blank" '
                              . '>';
                   }
                   $out .= '<img '
                           . 'alt="' . $image['tag'] . '" '
                           . 'width="' . $width . '" '
-                          . 'src="' . $glpi_root . '/front/document.send.php?docid=' . $id.$more_link . '" '
+                          . 'src="' . $base_path . '/front/document.send.php?docid=' . $id.$more_link . '" '
                           . '/>';
                   if ($addLink) {
                      $out .= '</a>';

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2660,6 +2660,11 @@ class Toolbox {
       }
 
       if (count($doc_data)) {
+         $base_path = $CFG_GLPI['root_doc'];
+         if (isCommandLine()) {
+            $base_path = parse_url($CFG_GLPI['url_base'], PHP_URL_PATH);
+         }
+
          foreach ($doc_data as $id => $image) {
             if (isset($image['tag'])) {
                // Add only image files : try to detect mime type
@@ -2676,7 +2681,7 @@ class Toolbox {
                   $itil_url_param = null !== $itil_object
                      ? "&{$itil_object->getForeignKeyField()}={$itil_object->fields['id']}"
                      : "";
-                  $img = "<img alt='".$image['tag']."' src='".$CFG_GLPI['root_doc'].
+                  $img = "<img alt='".$image['tag']."' src='".$base_path.
                           "/front/document.send.php?docid=".$id.$itil_url_param."'/>";
 
                   // 1 - Replace direct tag (with prefix and suffix) by the image

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -42,15 +42,13 @@ class Toolbox extends DbTestCase {
     * Data provider for self::testConvertTagToImage().
     */
    protected function convertTagToImageProvider() {
-      global $CFG_GLPI;
-
       $data = [];
 
       foreach ([\Computer::class, \Change::class, \Problem::class, \Ticket::class] as $itemtype) {
          $item = new $itemtype();
          $item->fields['id'] = mt_rand(1, 50);
 
-         $img_url = $CFG_GLPI['url_base'] . '/front/document.send.php?docid={docid}'; //{docid} to replace by generated doc id
+         $img_url = '/front/document.send.php?docid={docid}'; //{docid} to replace by generated doc id
          if ($item instanceof \CommonITILObject) {
             $img_url .= '&' . $item->getForeignKeyField() . '=' . $item->fields['id'];
          }
@@ -118,5 +116,71 @@ class Toolbox extends DbTestCase {
       $this->string(
          \Toolbox::convertTagToImage($content_text, $item, [$doc_id => ['tag' => $img_tag]])
       )->isEqualTo($expected_result);
+   }
+
+   /**
+    * Data provider for self::testBaseUrlInConvertTagToImage().
+    */
+   protected function convertTagToImageBaseUrlProvider() {
+      $item = new \Ticket();
+      $item->fields['id'] = mt_rand(1, 50);
+
+      $img_url = '/front/document.send.php?docid={docid}'; //{docid} to replace by generated doc id
+      $img_url .= '&tickets_id=' . $item->fields['id'];
+
+      return [
+         [
+            'url_base'     => 'http://glpi.domain.org',
+            'item'         => $item,
+            'expected_url' => $img_url,
+         ],
+         [
+            'url_base'     => 'http://www.domain.org/glpi/v9.4/',
+            'item'         => $item,
+            'expected_url' => '/glpi/v9.4/' . $img_url,
+         ],
+      ];
+   }
+
+   /**
+    * Check base url handling in conversion of tags to images.
+    *
+    * @dataProvider convertTagToImageBaseUrlProvider
+    */
+   public function testBaseUrlInConvertTagToImage($url_base, $item, $expected_url) {
+
+      $img_tag = uniqid('', true);
+
+      // Create document in DB
+      $document = new \Document();
+      $doc_id = $document->add([
+         'name'     => 'basic document',
+         'filename' => 'img.png',
+         'mime'     => 'image/png',
+         'tag'      => $img_tag,
+      ]);
+      $this->integer((int)$doc_id)->isGreaterThan(0);
+
+      $content_text   = '<img id="' . $img_tag. '" width="10" height="10" />';
+      $expected_url   = str_replace('{docid}', $doc_id, $expected_url);
+      $expected_result = '<a href="' . $expected_url . '" target="_blank" ><img alt="' . $img_tag. '" width="10" src="' . $expected_url. '" /></a>';
+
+      // Processed data is expected to be escaped
+      $content_text = \Toolbox::addslashes_deep($content_text);
+      $expected_result = \Html::entities_deep($expected_result);
+
+      // Save old config
+      global $CFG_GLPI;
+      $old_url_base = $CFG_GLPI['url_base'];
+
+      // Get result
+      $CFG_GLPI['url_base'] = $url_base;
+      $result = \Toolbox::convertTagToImage($content_text, $item, [$doc_id => ['tag' => $img_tag]]);
+
+      // Restore config
+      $CFG_GLPI['url_base'] = $old_url_base;
+
+      // Validate result
+      $this->string($result)->isEqualTo($expected_result);
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Depending on context, stored URL for images in rich text uses relative path (when contents comes from web UI), or uses an absolute path (when contents comes from CLI context).

If `url_base` change, all generated contents from CLI (i.e. mailcollector) prior to this change are still served using old URL.

This PR makes stored URL using a relative path, to be sure that URL will still be valid on domain change.

This only fix the case were only the domain change. If the path on domain change, all existing URL in database will still have to be fixed.