### PR TITLE
Fix images URL for ITIL objects; fixes #5457

### DIFF
--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -318,9 +318,6 @@ class ITILSolution extends CommonDBChild {
 
    function post_addItem() {
 
-      // Replace inline pictures
-      $this->input = $this->addFiles($this->input, ['force_update' => true]);
-
       //adding a solution mean the ITIL object is now solved
       //and maybe closed (according to entitiy configuration)
       if ($this->item == null) {
@@ -329,6 +326,11 @@ class ITILSolution extends CommonDBChild {
       }
 
       $item = $this->item;
+
+      // Replace inline pictures
+      $this->input["_job"] = $this->item;
+      $this->input = $this->addFiles($this->input, ['force_update' => true]);
+
       $status = $item::SOLVED;
 
       //handle autoclose, for tickets only

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2665,17 +2665,19 @@ class Toolbox {
                // Add only image files : try to detect mime type
                if ($document->getFromDB($id)
                    && strpos($document->fields['mime'], 'image/') !== false) {
-                  // append ticket reference in image link
-                  $ticket_url_param = "";
-                  if ($item instanceof Ticket) {
-                     $ticket_url_param = "&tickets_id=".$item->fields['id'];
+                  // append itil object reference in image link
+                  $itil_object = null;
+                  if ($item instanceof CommonITILObject) {
+                     $itil_object = $item;
+                  } else if (isset($item->input['_job'])
+                             && $item->input['_job'] instanceof CommonITILObject) {
+                     $itil_object = $item->input['_job'];
                   }
-                  if (isset($item->input['_job'])
-                      && $item->input['_job'] instanceof Ticket) {
-                     $ticket_url_param = "&tickets_id=".$item->input['_job']->fields['id'];
-                  }
+                  $itil_url_param = null !== $itil_object
+                     ? "&{$itil_object->getForeignKeyField()}={$itil_object->fields['id']}"
+                     : "";
                   $img = "<img alt='".$image['tag']."' src='".$CFG_GLPI['root_doc'].
-                          "/front/document.send.php?docid=".$id.$ticket_url_param."'/>";
+                          "/front/document.send.php?docid=".$id.$itil_url_param."'/>";
 
                   // 1 - Replace direct tag (with prefix and suffix) by the image
                   $content_text = preg_replace('/'.Document::getImageTag($image['tag']).'/',
@@ -2705,7 +2707,7 @@ class Toolbox {
                      // replace image
                      $new_image =  Html::convertTagFromRichTextToImageTag($image['tag'],
                                                                           $width, $height,
-                                                                          true, $ticket_url_param);
+                                                                          true, $itil_url_param);
                      $content_text = preg_replace(
                         $regex,
                         $new_image,

--- a/tests/functionnal/Document.php
+++ b/tests/functionnal/Document.php
@@ -454,13 +454,30 @@ class Document extends DbTestCase {
    }
 
    /**
-    * Check visibility of document attached to tickets.
+    * Data provider for self::testCanViewItilFile().
     */
-   public function testCanViewTicketFile() {
+   protected function itilTypeProvider() {
+      return [
+         [
+            'itemtype' => \Change::class,
+         ],
+         [
+            'itemtype' => \Problem::class,
+         ],
+         [
+            'itemtype' => \Ticket::class,
+         ],
+      ];
+   }
 
-      global $CFG_GLPI;
+   /**
+    * Check visibility of document attached to ITIL objects.
+    *
+    * @dataProvider itilTypeProvider
+    */
+   public function testCanViewItilFile($itemtype) {
 
-      $CFG_GLPI['use_rich_text'] = 1;
+      $this->login('glpi', 'glpi'); // Login with glpi to prevent link to post-only
 
       $basicDocument = new \Document();
       $this->integer(
@@ -480,11 +497,12 @@ class Document extends DbTestCase {
          ])
       )->isGreaterThan(0);
 
-      $this->login('glpi', 'glpi'); // Login with glpi to prevent link to post-only
-      $ticket = new \Ticket();
+      $item = new $itemtype();
+      $fkey = $item->getForeignKeyField();
+
       $this->integer(
-         (int)$ticket->add([
-            'name'     => 'New ticket',
+         (int)$item->add([
+            'name'     => 'New ' . $itemtype,
             'content'  => '<img src="/front/document.send.php?docid=' . $inlinedDocument->getID() . '" />',
          ])
       )->isGreaterThan(0);
@@ -493,28 +511,34 @@ class Document extends DbTestCase {
       $this->integer(
          (int)$document_item->add([
             'documents_id' => $basicDocument->getID(),
-            'items_id'     => $ticket->getID(),
-            'itemtype'     => \Ticket::class,
+            'items_id'     => $item->getID(),
+            'itemtype'     => $itemtype,
          ])
       )->isGreaterThan(0);
 
-      // post-only cannot see documents if not able to view ticket (ticket content)
+      // post-only cannot see documents if not able to view ITIL (ITIL content)
       $this->login('post-only', 'postonly');
-      $this->boolean($basicDocument->canViewFile(['tickets_id' => $ticket->getID()]))->isFalse();
-      $this->boolean($inlinedDocument->canViewFile(['tickets_id' => $ticket->getID()]))->isFalse();
+      $_SESSION["glpiactiveprofile"][$item::$rightname] = READ; // force READ write for tested ITIL type
+      $this->boolean($basicDocument->canViewFile())->isFalse();
+      $this->boolean($inlinedDocument->canViewFile())->isFalse();
+      $this->boolean($basicDocument->canViewFile([$fkey => $item->getID()]))->isFalse();
+      $this->boolean($inlinedDocument->canViewFile([$fkey => $item->getID()]))->isFalse();
 
-      // post-only can see documents linked to its own tickets (ticket content)
-      $ticket_user = new \Ticket_User();
+      // post-only can see documents linked to its own ITIL (ITIL content)
+      $itil_user_class = $itemtype . '_User';
+      $itil_user = new $itil_user_class();
       $this->integer(
-         (int)$ticket_user->add([
-            'tickets_id' => $ticket->getID(),
-            'type'       => \CommonITILActor::OBSERVER,
-            'users_id'   => \Session::getLoginUserID(),
+         (int)$itil_user->add([
+            $fkey      => $item->getID(),
+            'type'     => \CommonITILActor::OBSERVER,
+            'users_id' => \Session::getLoginUserID(),
          ])
       )->isGreaterThan(0);
 
-      $this->boolean($basicDocument->canViewFile(['tickets_id' => $ticket->getID()]))->isTrue();
-      $this->boolean($inlinedDocument->canViewFile(['tickets_id' => $ticket->getID()]))->isTrue();
+      $this->boolean($basicDocument->canViewFile())->isFalse(); // False without params
+      $this->boolean($inlinedDocument->canViewFile())->isFalse(); // False without params
+      $this->boolean($basicDocument->canViewFile([$fkey => $item->getID()]))->isTrue();
+      $this->boolean($inlinedDocument->canViewFile([$fkey => $item->getID()]))->isTrue();
    }
 
    /**
@@ -523,29 +547,53 @@ class Document extends DbTestCase {
    protected function ticketChildClassProvider() {
       return [
          [
-            'class' => \ITILSolution::class,
+            'itil_itemtype'  => \Change::class,
+            'child_itemtype' => \ITILSolution::class,
          ],
          [
-            'class' => \TicketTask::class,
+            'itil_itemtype'  => \Change::class,
+            'child_itemtype' => \ChangeTask::class,
          ],
          [
-            'class' => \ITILFollowup::class,
+            'itil_itemtype'  => \Change::class,
+            'child_itemtype' => \ITILFollowup::class,
+         ],
+         [
+            'itil_itemtype'  => \Problem::class,
+            'child_itemtype' => \ITILSolution::class,
+         ],
+         [
+            'itil_itemtype'  => \Problem::class,
+            'child_itemtype' => \ProblemTask::class,
+         ],
+         [
+            'itil_itemtype'  => \Problem::class,
+            'child_itemtype' => \ITILFollowup::class,
+         ],
+         [
+            'itil_itemtype'  => \Ticket::class,
+            'child_itemtype' => \ITILSolution::class,
+         ],
+         [
+            'itil_itemtype'  => \Ticket::class,
+            'child_itemtype' => \TicketTask::class,
+         ],
+         [
+            'itil_itemtype'  => \Ticket::class,
+            'child_itemtype' => \ITILFollowup::class,
          ],
       ];
    }
 
    /**
-    * Check visibility of document inlined in tickets followup.
+    * Check visibility of document inlined in ITIL followup, tasks, solutions.
     *
     * @dataProvider ticketChildClassProvider
     */
-   public function testCanViewTicketChildFile($childClass) {
-
-      global $CFG_GLPI;
-
-      $CFG_GLPI['use_rich_text'] = 1;
+   public function testCanViewTicketChildFile($itil_itemtype, $child_itemtype) {
 
       $this->login('glpi', 'glpi'); // Login with glpi to prevent link to post-only
+
       $inlinedDocument = new \Document();
       $this->integer(
          (int)$inlinedDocument->add([
@@ -555,39 +603,44 @@ class Document extends DbTestCase {
          ])
       )->isGreaterThan(0);
 
-      $ticket = new \Ticket();
+      $itil = new $itil_itemtype();
+      $fkey = $itil->getForeignKeyField();
       $this->integer(
-         (int)$ticket->add([
-            'name'     => 'New ticket',
+         (int)$itil->add([
+            'name'     => 'New ' . $itil_itemtype,
             'content'  => 'No image in content',
          ])
       )->isGreaterThan(0);
 
-      $child = new $childClass();
+      $child = new $child_itemtype();
       $this->integer(
          (int)$child->add([
             'content'    => '<img src="/front/document.send.php?docid=' . $inlinedDocument->getID() . '" />',
-            'tickets_id' => $ticket->getID(),
-            'items_id'   => $ticket->getID(),
-            'itemtype'   => \Ticket::class,
+            $fkey        => $itil->getID(),
+            'items_id'   => $itil->getID(),
+            'itemtype'   => $itil_itemtype,
             'users_id'   => '2', // user "glpi"
          ])
       )->isGreaterThan(0);
 
-      // post-only cannot see documents if not able to view ticket
+      // post-only cannot see documents if not able to view ITIL
       $this->login('post-only', 'postonly');
-      $this->boolean($inlinedDocument->canViewFile(['tickets_id' => $ticket->getID()]))->isFalse();
+      $_SESSION["glpiactiveprofile"][$itil::$rightname] = READ; // force READ write for tested ITIL type
+      $this->boolean($inlinedDocument->canViewFile())->isFalse();
+      $this->boolean($inlinedDocument->canViewFile([$fkey => $itil->getID()]))->isFalse();
 
-      // post-only can see documents linked to its own tickets
-      $ticket_user = new \Ticket_User();
+      // post-only can see documents linked to its own ITIL
+      $itil_user_class = $itil_itemtype . '_User';
+      $itil_user = new $itil_user_class();
       $this->integer(
-         (int)$ticket_user->add([
-            'tickets_id' => $ticket->getID(),
+         (int)$itil_user->add([
+            $fkey => $itil->getID(),
             'type'       => \CommonITILActor::OBSERVER,
             'users_id'   => \Session::getLoginUserID(),
          ])
       )->isGreaterThan(0);
 
-      $this->boolean($inlinedDocument->canViewFile(['tickets_id' => $ticket->getID()]))->isTrue();
+      $this->boolean($inlinedDocument->canViewFile())->isFalse(); // False without params
+      $this->boolean($inlinedDocument->canViewFile([$fkey => $itil->getID()]))->isTrue();
    }
 }

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use \DbTestCase;
+
+/* Test for inc/toolbox.class.php */
+
+class Toolbox extends DbTestCase {
+
+   /**
+    * Data provider for self::testConvertTagToImage().
+    */
+   protected function convertTagToImageProvider() {
+      global $CFG_GLPI;
+
+      $data = [];
+
+      foreach ([\Computer::class, \Change::class, \Problem::class, \Ticket::class] as $itemtype) {
+         $item = new $itemtype();
+         $item->fields['id'] = mt_rand(1, 50);
+
+         $img_url = $CFG_GLPI['url_base'] . '/front/document.send.php?docid={docid}'; //{docid} to replace by generated doc id
+         if ($item instanceof \CommonITILObject) {
+            $img_url .= '&' . $item->getForeignKeyField() . '=' . $item->fields['id'];
+         }
+
+         $data[] = [
+            'item'         => $item,
+            'expected_url' => $img_url,
+         ];
+
+         if ($item instanceof \CommonITILObject) {
+            $fup = new \ITILFollowup();
+            $fup->input['_job'] = $item;
+            $data[] = [
+               'item'         => $fup,
+               'expected_url' => $img_url,
+            ];
+
+            $solution = new \ITILSolution();
+            $solution->input['_job'] = $item;
+            $data[] = [
+               'item'         => $solution,
+               'expected_url' => $img_url,
+            ];
+
+            $task_itemtype = $itemtype . 'Task';
+            $task = new $task_itemtype();
+            $task->input['_job'] = $item;
+            $data[] = [
+               'item'         => $task,
+               'expected_url' => $img_url,
+            ];
+         }
+      }
+
+      return $data;
+   }
+
+   /**
+    * Check conversion of tags to images.
+    *
+    * @dataProvider convertTagToImageProvider
+    */
+   public function testConvertTagToImage($item, $expected_url) {
+
+      $img_tag = uniqid('', true);
+
+      // Create document in DB
+      $document = new \Document();
+      $doc_id = $document->add([
+         'name'     => 'basic document',
+         'filename' => 'img.png',
+         'mime'     => 'image/png',
+         'tag'      => $img_tag,
+      ]);
+      $this->integer((int)$doc_id)->isGreaterThan(0);
+
+      $content_text   = '<img id="' . $img_tag. '" width="10" height="10" />';
+      $expected_url   = str_replace('{docid}', $doc_id, $expected_url);
+      $expected_result = '<a href="' . $expected_url . '" target="_blank" ><img alt="' . $img_tag. '" width="10" src="' . $expected_url. '" /></a>';
+
+      // Processed data is expected to be escaped
+      $content_text = \Toolbox::addslashes_deep($content_text);
+      $expected_result = \Html::entities_deep($expected_result);
+
+      $this->string(
+         \Toolbox::convertTagToImage($content_text, $item, [$doc_id => ['tag' => $img_tag]])
+      )->isEqualTo($expected_result);
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5457 

1. Generated URL for images in Ticket solution were not containing the tickets_id, so access rights were not checked based ticket rights.

2. Access to documents contained in any element (followup, task, document, solution) of Change or Problem were not checking access rights against this element. So any user that has no access to all documents were not able to see images/documents in Change or Problem.

TODO:
 - [x] migration
 - [x] tests