### PR TITLE
Prevent hook execution if plugin not loaded; follow #5413

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -1036,6 +1036,10 @@ class Plugin extends CommonDBTM {
          $itemtype = get_class($param);
          if (isset($PLUGIN_HOOKS[$name]) && is_array($PLUGIN_HOOKS[$name])) {
             foreach ($PLUGIN_HOOKS[$name] as $plug => $tab) {
+               if (!Plugin::isPluginLoaded($plug)) {
+                  continue;
+               }
+
                if (isset($tab[$itemtype])) {
                   if (file_exists(GLPI_ROOT . "/plugins/$plug/hook.php")) {
                      include_once(GLPI_ROOT . "/plugins/$plug/hook.php");
@@ -1050,6 +1054,10 @@ class Plugin extends CommonDBTM {
       } else { // Standard hook call
          if (isset($PLUGIN_HOOKS[$name]) && is_array($PLUGIN_HOOKS[$name])) {
             foreach ($PLUGIN_HOOKS[$name] as $plug => $function) {
+               if (!Plugin::isPluginLoaded($plug)) {
+                  continue;
+               }
+
                if (file_exists(GLPI_ROOT . "/plugins/$plug/hook.php")) {
                   include_once(GLPI_ROOT . "/plugins/$plug/hook.php");
                }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In #5413, filtering was done only on some hooks calls.