### PR TITLE
Optimize config loading by reducing number of SQL queries

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2723,8 +2723,14 @@ class Config extends CommonDBTM {
 
       global $CFG_GLPI, $DB;
 
-      $get_prior_to_078_config  = function() use ($DB) {
-         if (!$DB->tableExists('glpi_config')) {
+      $config_tables_iterator = $DB->listTables('glpi_config%');
+      $config_tables = [];
+      foreach ($config_tables_iterator as $config_table) {
+         $config_tables[] = $config_table['TABLE_NAME'];
+      }
+
+      $get_prior_to_078_config  = function() use ($DB, $config_tables) {
+         if (!in_array('glpi_config', $config_tables)) {
             return false;
          }
 
@@ -2737,32 +2743,32 @@ class Config extends CommonDBTM {
          return false;
       };
 
-      $get_078_to_084_config    = function() use ($DB) {
-         if (!$DB->tableExists('glpi_configs') || $DB->fieldExists('glpi_configs', 'context')) {
+      $get_078_to_latest_config    = function() use ($DB, $config_tables) {
+         if (!in_array('glpi_configs', $config_tables)) {
             return false;
          }
 
-         $config = new Config();
-         $config->forceTable('glpi_configs');
-         if ($config->getFromDB(1)) {
-            return $config->fields;
-         }
+         Config::forceTable('glpi_configs');
 
-         return false;
-      };
-
-      $get_085_to_latest_config = function() use ($DB) {
-         if (!$DB->tableExists('glpi_configs') || !$DB->fieldExists('glpi_configs', 'context')) {
+         $iterator = $DB->request(['FROM' => 'glpi_configs']);
+         if ($iterator->count() === 0) {
             return false;
          }
 
-         $config = new Config();
-         $config->forceTable('glpi_configs');
-         if ($config->getFromDB(1)) {
-            return Config::getConfigurationValues('core');
+         if ($iterator->count() === 1) {
+            // 1 row = 0.78 to 0.84 config table schema
+            return $iterator->next();
          }
 
-         return false;
+         // multiple rows = 0.85+ config
+         $config = [];
+         while ($row = $iterator->next()) {
+            if ('core' !== $row['context']) {
+               continue;
+            }
+            $config[$row['name']] = $row['value'];
+         }
+         return $config;
       };
 
       $functions = [];
@@ -2770,14 +2776,12 @@ class Config extends CommonDBTM {
          // Try with old config table first : for update process management from < 0.80 to >= 0.80.
          $functions = [
             $get_prior_to_078_config,
-            $get_078_to_084_config,
-            $get_085_to_latest_config,
+            $get_078_to_latest_config,
          ];
       } else {
          // Normal load process : use normal config table. If problem try old one.
          $functions = [
-            $get_085_to_latest_config,
-            $get_078_to_084_config,
+            $get_078_to_latest_config,
             $get_prior_to_078_config,
          ];
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Configuration loading, which is made on every request, takes, unless an error occurs, at least 5 requests and at worse 8 requests.
This PR reduces number of request to 2.