### PR TITLE
Fix JOINs in delete and update queries building; fixes #5478

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -892,18 +892,19 @@ class DBmysql {
          throw new \RuntimeException('Cannot run an UPDATE query without WHERE clause!');
       }
 
-      $query  = "UPDATE ". self::quoteName($table) ." SET ";
+      $query  = "UPDATE ". self::quoteName($table);
 
+      //JOINS
+      $it = new DBmysqlIterator($this);
+      $query .= $it->analyzeJoins($joins);
+
+      $query .= " SET ";
       foreach ($params as $field => $value) {
          $query .= self::quoteName($field) . " = ".$this->quoteValue($value).", ";
       }
       $query = rtrim($query, ', ');
 
-      $it = new DBmysqlIterator($this);
       $query .= " WHERE " . $it->analyseCrit($clauses['WHERE']);
-
-      //JOINS
-      $query .= $it->analyzeJoins($joins);
 
       // ORDER BY
       if (isset($clauses['ORDER']) && !empty($clauses['ORDER'])) {
@@ -1020,8 +1021,8 @@ class DBmysql {
       $query  = "DELETE FROM ". self::quoteName($table);
 
       $it = new DBmysqlIterator($this);
-      $query .= " WHERE " . $it->analyseCrit($where);
       $query .= $it->analyzeJoins($joins);
+      $query .= " WHERE " . $it->analyseCrit($where);
 
       return $query;
    }

--- a/tests/database/DBmysql.php
+++ b/tests/database/DBmysql.php
@@ -90,9 +90,10 @@ class DBmysql extends \GLPITestCase {
       ], ['id' => 1]);
       $this->string($built)->isIdenticalTo($expected);
 
-      $expected = "UPDATE `glpi_computers` SET `name` = '_join_computer1' WHERE `glpi_locations`.`name` = 'test' AND `glpi_computertypes`.`name` = 'laptop'";
+      $expected = "UPDATE `glpi_computers`";
       $expected .= " LEFT JOIN `glpi_locations` ON (`glpi_computers`.`locations_id` = `glpi_locations`.`id`)";
       $expected .= " LEFT JOIN `glpi_computertypes` ON (`glpi_computers`.`computertypes_id` = `glpi_computertypes`.`id`)";
+      $expected .= " SET `name` = '_join_computer1' WHERE `glpi_locations`.`name` = 'test' AND `glpi_computertypes`.`name` = 'laptop'";
       $built = $DB->buildUpdate('glpi_computers', ['name' => '_join_computer1'], [
          'glpi_locations.name' => 'test',
          'glpi_computertypes.name' => 'laptop'
@@ -121,9 +122,10 @@ class DBmysql extends \GLPITestCase {
       $built = $DB->buildDelete('glpi_tickets', ['id' => 1]);
       $this->string($built)->isIdenticalTo($expected);
 
-      $expected = "DELETE FROM `glpi_computers` WHERE `glpi_locations`.`name` = 'test' AND `glpi_computertypes`.`name` = 'laptop'";
+      $expected = "DELETE FROM `glpi_computers`";
       $expected .= " LEFT JOIN `glpi_locations` ON (`glpi_computers`.`locations_id` = `glpi_locations`.`id`)";
       $expected .= " LEFT JOIN `glpi_computertypes` ON (`glpi_computers`.`computertypes_id` = `glpi_computertypes`.`id`)";
+      $expected .= " WHERE `glpi_locations`.`name` = 'test' AND `glpi_computertypes`.`name` = 'laptop'";
       $built = $DB->buildDelete('glpi_computers', [
          'glpi_locations.name' => 'test',
          'glpi_computertypes.name' => 'laptop'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5478 

In MySQL, JOINS are part of `table_references` element of query (see https://dev.mysql.com/doc/refman/5.6/en/join.html), so they must be appended just next to the main table name.
`SELECT * FROM a JOIN b ...`
`DELETE FROM a JOIN b ...`
`UPDATE a JOIN b ...`