### PR TITLE
Fix uninitialized container in update/maintenance mode

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -49,6 +49,9 @@ Config::detectRootDoc();
 $conf_exists = Toolbox::checkDbConfig();
 
 if (!$conf_exists) {
+   // Load kernel and expose container in global var
+   $CONTAINER = (new Glpi\Kernel())->getContainer();
+
    Session::loadLanguage();
    // no translation
    if (!isCommandLine()) {
@@ -120,6 +123,9 @@ if (!$conf_exists) {
          $_SESSION["glpi$field"] = $CFG_GLPI[$field];
       }
    }
+
+   // Load kernel and expose container in global var
+   $CONTAINER = (new Glpi\Kernel())->getContainer();
 
    // Check maintenance mode
    // TODO: maintenance may be a middleware, to not block command line
@@ -233,6 +239,3 @@ if (!$conf_exists) {
       exit();
    }
 }
-
-// Load kernel and expose container in global var
-$CONTAINER = (new Glpi\Kernel())->getContainer();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

As cache service is retrieve in global services container, this one must be initialized prior to `Session::loadLanguage();`, which uses cache for translations and plugins loading.