### PR TITLE
Prevent hook execution if plugin not loaded; follow #5413

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -1042,6 +1042,10 @@ class Plugin extends CommonDBTM {
          $itemtype = get_class($param);
          if (isset($PLUGIN_HOOKS[$name]) && is_array($PLUGIN_HOOKS[$name])) {
             foreach ($PLUGIN_HOOKS[$name] as $plug => $tab) {
+               if (!Plugin::isPluginLoaded($plug)) {
+                  continue;
+               }
+
                if (isset($tab[$itemtype])) {
                   if (file_exists(GLPI_ROOT . "/plugins/$plug/hook.php")) {
                      include_once(GLPI_ROOT . "/plugins/$plug/hook.php");
@@ -1056,6 +1060,10 @@ class Plugin extends CommonDBTM {
       } else { // Standard hook call
          if (isset($PLUGIN_HOOKS[$name]) && is_array($PLUGIN_HOOKS[$name])) {
             foreach ($PLUGIN_HOOKS[$name] as $plug => $function) {
+               if (!Plugin::isPluginLoaded($plug)) {
+                  continue;
+               }
+
                if (file_exists(GLPI_ROOT . "/plugins/$plug/hook.php")) {
                   include_once(GLPI_ROOT . "/plugins/$plug/hook.php");
                }

--- a/tests/units/Glpi/EventSubscriber/Item/ItemEventHookMapper.php
+++ b/tests/units/Glpi/EventSubscriber/Item/ItemEventHookMapper.php
@@ -100,7 +100,10 @@ class ItemEventHookMapper extends \GLPITestCase {
     * @dataProvider provideMapping
     */
    public function testMapping($event, $expectedHook) {
-      global $PLUGIN_HOOKS;
+      global $CONTAINER, $PLUGIN_HOOKS;
+
+      // Force plugin 'test' to be considered as active
+      $CONTAINER->get('application_cache')->set('plugins', ['test']);
 
       $this->newTestedInstance(new \mock\Plugin());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Same as #5473 adapted for master branch.