### PR TITLE
Fix planning diplay when user does not have reminder rights

### DIFF
--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -234,8 +234,7 @@ class Reminder extends CommonDBVisible {
 
       if (!Session::haveRight(self::$rightname, READ)) {
          return [
-            'LEFT JOIN' => [],
-            'WHERE'     => ['glpi_reminders.users_id' => Session::getLoginUserID()],
+            'WHERE' => ['glpi_reminders.users_id' => Session::getLoginUserID()],
          ];
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes the following error: 
```
glpiphplog.ERROR: Toolbox::userErrorHandlerNormal() in /var/www/html/glpi/9.4-git/inc/toolbox.class.php line 659
  *** PHP User Error(256): BAD JOIN, value must be [ table => criteria ]
  Backtrace :
  :                                                  
  inc/dbmysqliterator.class.php:619                  trigger_error()
  inc/dbmysqliterator.class.php:281                  DBmysqlIterator->analyzeJoins()
  inc/dbmysqliterator.class.php:94                   DBmysqlIterator->buildQuery()
  inc/dbmysql.class.php:569                          DBmysqlIterator->execute()
  inc/reminder.class.php:980                         DBmysql->request()
  inc/planning.class.php:1952                        Reminder::populatePlanning()
  inc/planning.class.php:1854                        Planning::constructEventsArraySingleLine()
  ajax/planning.php:43                               Planning::constructEventsArray()
  {"user":"2@LU002"} 
```