### PR TITLE
Handle empty JOIN arrays in SQL computation

### DIFF
--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -597,26 +597,27 @@ class DBmysqlIterator implements Iterator, Countable {
             $jointype = 'LEFT JOIN';
          }
 
-         if ($jointables != null && is_array($jointables)) {
-            foreach ($jointables as $jointablekey => $jointablecrit) {
-               if (isset($jointablecrit['TABLE'])) {
-                  //not a "simple" FKEY
-                  $jointablekey = $jointablecrit['TABLE'];
-                  unset($jointablecrit['TABLE']);
-               } else if (is_numeric($jointablekey) || $jointablekey == 'FKEY' || $jointablekey == 'ON') {
-                  throw new \RuntimeException('BAD JOIN');
-               }
-
-               if ($jointablekey instanceof \QuerySubquery) {
-                  $jointablekey = $jointablekey->getQuery();
-               } else {
-                  $jointablekey = DBmysql::quoteName($jointablekey);
-               }
-
-               $query .= " $jointype $jointablekey ON (" . $this->analyseCrit($jointablecrit) . ")";
-            }
-         } else {
+         if (!is_array($jointables)) {
             trigger_error("BAD JOIN, value must be [ table => criteria ]", E_USER_ERROR);
+            continue;
+         }
+
+         foreach ($jointables as $jointablekey => $jointablecrit) {
+            if (isset($jointablecrit['TABLE'])) {
+               //not a "simple" FKEY
+               $jointablekey = $jointablecrit['TABLE'];
+               unset($jointablecrit['TABLE']);
+            } else if (is_numeric($jointablekey) || $jointablekey == 'FKEY' || $jointablekey == 'ON') {
+               throw new \RuntimeException('BAD JOIN');
+            }
+
+            if ($jointablekey instanceof \QuerySubquery) {
+               $jointablekey = $jointablekey->getQuery();
+            } else {
+               $jointablekey = DBmysql::quoteName($jointablekey);
+            }
+
+            $query .= " $jointype $jointablekey ON (" . $this->analyseCrit($jointablecrit) . ")";
          }
       }
       return $query;

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -301,6 +301,9 @@ class DBmysqlIterator extends DbTestCase {
 
 
    public function testJoins() {
+      $it = $this->it->execute('foo', ['LEFT JOIN' => []]);
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo`');
+
       $it = $this->it->execute('foo', ['LEFT JOIN' => ['bar' => ['FKEY' => ['bar' => 'id', 'foo' => 'fk']]]]);
       $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` LEFT JOIN `bar` ON (`bar`.`id` = `foo`.`fk`)');
 
@@ -333,8 +336,14 @@ class DBmysqlIterator extends DbTestCase {
          'LEFT JOIN `baz` ON (`baz`.`id` = `foo`.`baz_id`)'
       );
 
+      $it = $this->it->execute('foo', ['INNER JOIN' => []]);
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo`');
+
       $it = $this->it->execute('foo', ['INNER JOIN' => ['bar' => ['FKEY' => ['bar' => 'id', 'foo' => 'fk']]]]);
       $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` INNER JOIN `bar` ON (`bar`.`id` = `foo`.`fk`)');
+
+      $it = $this->it->execute('foo', ['RIGHT JOIN' => []]);
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo`');
 
       $it = $this->it->execute('foo', ['RIGHT JOIN' => ['bar' => ['FKEY' => ['bar' => 'id', 'foo' => 'fk']]]]);
       $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` RIGHT JOIN `bar` ON (`bar`.`id` = `foo`.`fk`)');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In PHP `[] != null` returns false. So if `* JOIN` contains an empty array, the an error is trigerred.

This PR just made the empty array to be ignored.