### PR TITLE
Fix deletions using joins; fixes #5478

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -1018,7 +1018,7 @@ class DBmysql {
          throw new \RuntimeException('Cannot run an DELETE query without WHERE clause!');
       }
 
-      $query  = "DELETE FROM ". self::quoteName($table);
+      $query  = "DELETE " . self::quoteName($table) . " FROM ". self::quoteName($table);
 
       $it = new DBmysqlIterator($this);
       $query .= $it->analyzeJoins($joins);

--- a/tests/database/DBmysql.php
+++ b/tests/database/DBmysql.php
@@ -93,8 +93,8 @@ class DBmysql extends \GLPITestCase {
       $expected = "UPDATE `glpi_computers`";
       $expected .= " LEFT JOIN `glpi_locations` ON (`glpi_computers`.`locations_id` = `glpi_locations`.`id`)";
       $expected .= " LEFT JOIN `glpi_computertypes` ON (`glpi_computers`.`computertypes_id` = `glpi_computertypes`.`id`)";
-      $expected .= " SET `name` = '_join_computer1' WHERE `glpi_locations`.`name` = 'test' AND `glpi_computertypes`.`name` = 'laptop'";
-      $built = $DB->buildUpdate('glpi_computers', ['name' => '_join_computer1'], [
+      $expected .= " SET `glpi_computers`.`name` = '_join_computer1' WHERE `glpi_locations`.`name` = 'test' AND `glpi_computertypes`.`name` = 'laptop'";
+      $built = $DB->buildUpdate('glpi_computers', ['glpi_computers.name' => '_join_computer1'], [
          'glpi_locations.name' => 'test',
          'glpi_computertypes.name' => 'laptop'
       ], [
@@ -118,11 +118,11 @@ class DBmysql extends \GLPITestCase {
    public function testBuildDelete() {
       global $DB;
 
-      $expected = "DELETE FROM `glpi_tickets` WHERE `id` = '1'";
+      $expected = "DELETE `glpi_tickets` FROM `glpi_tickets` WHERE `id` = '1'";
       $built = $DB->buildDelete('glpi_tickets', ['id' => 1]);
       $this->string($built)->isIdenticalTo($expected);
 
-      $expected = "DELETE FROM `glpi_computers`";
+      $expected = "DELETE `glpi_computers` FROM `glpi_computers`";
       $expected .= " LEFT JOIN `glpi_locations` ON (`glpi_computers`.`locations_id` = `glpi_locations`.`id`)";
       $expected .= " LEFT JOIN `glpi_computertypes` ON (`glpi_computers`.`computertypes_id` = `glpi_computertypes`.`id`)";
       $expected .= " WHERE `glpi_locations`.`name` = 'test' AND `glpi_computertypes`.`name` = 'laptop'";

--- a/tests/units/DB.php
+++ b/tests/units/DB.php
@@ -225,27 +225,27 @@ class DB extends \GLPITestCase {
             'table', [
                'id'  => 1
             ],
-            'DELETE FROM `table` WHERE `id` = \'1\''
+            'DELETE `table` FROM `table` WHERE `id` = \'1\''
          ], [
             'table', [
                'id'  => [1, 2]
             ],
-            'DELETE FROM `table` WHERE `id` IN (\'1\', \'2\')'
+            'DELETE `table` FROM `table` WHERE `id` IN (\'1\', \'2\')'
          ], [
             'table', [
                'NOT'  => ['id' => [1, 2]]
             ],
-            'DELETE FROM `table` WHERE  NOT (`id` IN (\'1\', \'2\'))'
+            'DELETE `table` FROM `table` WHERE  NOT (`id` IN (\'1\', \'2\'))'
          ], [
             'table', [
                'NOT'  => ['id' => [new \QueryParam(), new \QueryParam()]]
             ],
-            'DELETE FROM `table` WHERE  NOT (`id` IN (?, ?))'
+            'DELETE `table` FROM `table` WHERE  NOT (`id` IN (?, ?))'
          ], [
             'table', [
                'NOT'  => ['id' => [new \QueryParam('idone'), new \QueryParam('idtwo')]]
             ],
-            'DELETE FROM `table` WHERE  NOT (`id` IN (:idone, :idtwo))'
+            'DELETE `table` FROM `table` WHERE  NOT (`id` IN (:idone, :idtwo))'
          ]
       ];
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5478 

Table name is mandatory beween DELETE and FROM when deletion is using joins (and is just useless when only one table is used).

I assume that we only want to delete data from the main table.