### PR TITLE
Simplify legacy configuration loading

### DIFF
--- a/front/backup.php
+++ b/front/backup.php
@@ -498,7 +498,6 @@ if (isset($_GET["xmlnow"]) && ($_GET["xmlnow"] != "")) {
 if (isset($_GET["file"]) && ($_GET["file"] != "") && is_file(GLPI_DUMP_DIR . "/" . $_GET["file"])) {
    $filepath = realpath(GLPI_DUMP_DIR . "/" . $_GET['file']);
    if (is_file($filepath) && Toolbox::startsWith($filepath, GLPI_DUMP_DIR)) {
-      $_SESSION['TRY_OLD_CONFIG_FIRST'] = true;
       init_time(); //initialise le temps
 
       //debut de fichier

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2686,11 +2686,8 @@ class Config extends CommonDBTM {
          'name'      => 'version'
       ];
 
-      if (!$DB->tableExists('glpi_configs')) {
-         $select  = 'version';
-         $table   = 'glpi_config';
-         $where   = ['id' => 1];
-      } else if ($DB->fieldExists('glpi_configs', 'version')) {
+      if ($DB->fieldExists('glpi_configs', 'version')) {
+         // 0.78 to 0.84 config table schema
          $select  = 'version';
          $where   = ['id' => 1];
       }

--- a/inc/config.php
+++ b/inc/config.php
@@ -91,16 +91,7 @@ if (!$conf_exists) {
 
    //Options from DB, do not touch this part.
 
-   $older_to_latest = !isset($_GET['donotcheckversion']) // use normal config table on restore process
-       && (isset($TRY_OLD_CONFIG_FIRST) // index case
-       || (isset($_SESSION['TRY_OLD_CONFIG_FIRST']) && $_SESSION['TRY_OLD_CONFIG_FIRST'])); // backup case
-
-
-   if (isset($_SESSION['TRY_OLD_CONFIG_FIRST'])) {
-      unset($_SESSION['TRY_OLD_CONFIG_FIRST']);
-   }
-
-   if (!Config::loadLegacyConfiguration($older_to_latest)) {
+   if (!Config::loadLegacyConfiguration()) {
       echo "Error accessing config table";
       exit();
    }

--- a/index.php
+++ b/index.php
@@ -57,7 +57,6 @@ if (!file_exists(GLPI_CONFIG_DIR . "/db.yaml")) {
    die();
 
 } else {
-   $TRY_OLD_CONFIG_FIRST = true;
    include (GLPI_ROOT . "/inc/includes.php");
    $_SESSION["glpicookietest"] = 'testcookie';
 

--- a/public/index.php
+++ b/public/index.php
@@ -55,7 +55,6 @@ if (!file_exists(GLPI_CONFIG_DIR . "/db.yaml") && !file_exists(GLPI_CONFIG_DIR .
     Html::redirect("../install/install.php");
     die();
 } else {
-    $TRY_OLD_CONFIG_FIRST = true;
     include(GLPI_ROOT . "/inc/includes.php");
 
     RunTracy\Helpers\Profiler\Profiler::start('initApp');

--- a/src/Glpi/Kernel.php
+++ b/src/Glpi/Kernel.php
@@ -407,7 +407,7 @@ class Kernel
 
         $db = $this->getDbInstance();
         if ($db->isConnected()) {
-            \Config::loadLegacyConfiguration(false);
+            \Config::loadLegacyConfiguration();
         }
 
         return new ConfigParams($CFG_GLPI);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

As we do not handle anymore the old config table in master, things can be simplified to gain readability and remove a useless SQL request.