### PR TITLE
Drop useless checks on existence of glpi_networkinterfaces table

### DIFF
--- a/inc/networkportmigration.class.php
+++ b/inc/networkportmigration.class.php
@@ -293,17 +293,15 @@ class NetworkPortMigration extends CommonDBChild {
       echo "<$gateway_cell>" . $this->fields['gateway'] . "</$gateway_cell></tr>\n";
 
       echo "<tr class='tab_bg_1'><td>". __('Network interface') ."</td><$interface_cell>\n";
-      if ($DB->tableExists('glpi_networkinterfaces')) {
-         $query = "SELECT `name`
-                   FROM `glpi_networkinterfaces`
-                   WHERE `id`='".$this->fields['networkinterfaces_id']."'";
-         $result = $DB->query($query);
-         if ($DB->numrows($result) > 0) {
-            $row = $DB->fetch_assoc($result);
-            echo $row['name'];
-         } else {
-            echo __('Unknown interface');
-         }
+      $query = "SELECT `name`
+                FROM `glpi_networkinterfaces`
+                WHERE `id`='".$this->fields['networkinterfaces_id']."'";
+      $result = $DB->query($query);
+      if ($DB->numrows($result) > 0) {
+         $row = $DB->fetch_assoc($result);
+         echo $row['name'];
+      } else {
+         echo __('Unknown interface');
       }
       echo "</$interface_cell>";
       echo "<$interface_cell></$interface_cell>";
@@ -450,15 +448,13 @@ class NetworkPortMigration extends CommonDBChild {
          'name'               => IPAddress::getTypeName(1)
       ];
 
-      if ($DB->tableExists('glpi_networkinterfaces')) {
-         $tab[] = [
-            'id'                 => '24',
-            'table'              => 'glpi_networkinterfaces',
-            'field'              => 'name',
-            'datatype'           => 'dropdown',
-            'name'               => __('Network interface')
-         ];
-      }
+      $tab[] = [
+         'id'                 => '24',
+         'table'              => 'glpi_networkinterfaces',
+         'field'              => 'name',
+         'datatype'           => 'dropdown',
+         'name'               => __('Network interface')
+      ];
 
       return $tab;
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Checks on existence of `glpi_networkinterfaces` table seems useless here as this part of code should not be used prior to migrations.