### PR TITLE
Drop check on table existence in DBmysql::fieldExists() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The present file will list all changes made to the project; according to the
 
 #### Changes
 - Added `DB::truncate()` to replace raw SQL queries
+- `DB::fieldExists()` does not check table existence anymore.
 
 #### Deprecated
 

--- a/src/Glpi/AbstractDatabase.php
+++ b/src/Glpi/AbstractDatabase.php
@@ -687,10 +687,6 @@ abstract class AbstractDatabase
      */
     public function fieldExists(string $table, string $field, bool $usecache = true): bool
     {
-        if (!$this->tableExists($table)) {
-            throw new \RuntimeException("Table $table does not exists");
-        }
-
         if ($fields = $this->listFields($table, $usecache)) {
             if (isset($fields[$field])) {
                 return true;

--- a/tests/units/DBmysql.php
+++ b/tests/units/DBmysql.php
@@ -57,13 +57,12 @@ class DBmysql extends \GLPITestCase {
          function() {
             $this->boolean($this->db->fieldExists('fakeTable', 'id'))->isFalse();
          }
-      )->hasMessage('Table fakeTable does not exists');
-
+      )->message->contains("Table '{$this->db->dbdefault}.fakeTable' doesn't exist");
       $this->exception(
          function() {
             $this->boolean($this->db->fieldExists('fakeTable', 'fakeField'))->isFalse();
          }
-      )->hasMessage('Table fakeTable does not exists');
+      )->message->contains("Table '{$this->db->dbdefault}.fakeTable' doesn't exist");
    }
 
    protected function dataName() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The `DBmysql::fieldExists()` is used in many places in GLPI. Checking existence of table in this methods generates an additionnal query, and seems not really usefull.
In migrations, if things are done right, we check the existence of table prior to check the existence of a field in it.
In other parts of application, it is mostly used to check capabilities on an itemtype (has it entities_id, locations_id, ...), so checked table should always exists.