### PR TITLE
visibility tab for reminder should be displayed only on CREATE right

### DIFF
--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -532,7 +532,7 @@ class Reminder extends CommonDBVisible {
          $nb = 0;
          switch ($item->getType()) {
             case 'Reminder' :
-               if (Session::haveRight('reminder_public', UPDATE)) {
+               if (Session::haveRight('reminder_public', CREATE)) {
                   if ($_SESSION['glpishow_count_on_tabs']) {
                      $nb = $item->countVisibilities();
                   }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Internal ref: 15653
