### PR TITLE
Fix stripping of initial contents in mail collector; fixes #5432

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -964,87 +964,36 @@ class MailCollector  extends CommonDBTM {
                $tkt['content'] = sprintf(__('From %s'), $head[$this->getRequesterField()])."\n\n".$tkt['content'];
             }
 
-            $content        = explode("\n", $tkt['content']);
-            $tkt['content'] = "";
-            $to_keep        = [];
-
-            $begin_strip     = -1;
-            $end_strip       = -1;
             $header_tag      = NotificationTargetTicket::HEADERTAG;
             $header_pattern  = $header_tag . '.*' . $header_tag;
             $footer_tag      = NotificationTargetTicket::FOOTERTAG;
             $footer_pattern  = $footer_tag . '.*' . $footer_tag;
-            foreach ($content as $ID => $val) {
-               // Get first tag for begin
-               if ($begin_strip < 0) {
-                  if (preg_match('/' . $header_pattern . '/', $val)) {
-                     $begin_strip = $ID;
-                  }
-               }
-               // Get last tag for end
-               if ($begin_strip >= 0) {
-                  if (preg_match('/' . $footer_pattern . '/', $val)) {
-                     $end_strip = $ID;
-                     continue;
-                  }
-               }
-            }
 
-            if ($begin_strip >= 0 && $end_strip >= 0 && $begin_strip === $end_strip) {
-               // If header and footer tag are on same line,
-               // remove contents between header and footer tag
-               $content[$begin_strip] = preg_replace(
-                  '/' . $header_pattern . '.*' . $footer_pattern . '/',
+            $has_header_line = preg_match('/' . $header_pattern . '/s', $tkt['content']);
+            $has_footer_line = preg_match('/' . $footer_pattern . '/s', $tkt['content']);
+
+            if ($has_header_line && $has_footer_line) {
+               // Strip all contents between header and footer line
+               $tkt['content'] = preg_replace(
+                  '/' . $header_pattern . '.*' . $footer_pattern . '/s',
                   '',
-                  $content[$begin_strip]
+                  $tkt['content']
                );
-            } else {
-               if ($begin_strip >= 0) {
-                  // Remove contents between header and end of line
-                  $content[$begin_strip] = preg_replace(
-                     '/' . $header_pattern . '.*$/',
-                     '',
-                     $content[$begin_strip]
-                  );
-               }
-               if ($end_strip >= 0) {
-                  // Remove contents between beginning of line and footer
-                  $content[$end_strip] = preg_replace(
-                     '/^.*' . $footer_pattern . '/',
-                     '',
-                     $content[$end_strip]
-                  );
-               }
+            } else if ($has_header_line) {
+               // Strip all contents between header line and end of message
+               $tkt['content'] = preg_replace(
+                  '/' . $header_pattern . '.*$/s',
+                  '',
+                  $tkt['content']
+               );
+            } else if ($has_footer_line) {
+               // Strip all contents between begin of message and footer line
+               $tkt['content'] = preg_replace(
+                  '/^.*' . $footer_pattern . '/s',
+                  '',
+                  $tkt['content']
+               );
             }
-
-            if ($begin_strip >= 0) {
-               $length = count($content);
-               // Use end strip if set
-               if (($end_strip >= 0) && ($end_strip < $length)) {
-                  $length = $end_strip;
-               }
-
-               for ($i = ($begin_strip+1); $i < $length; $i++) {
-                  unset($content[$i]);
-               }
-            }
-
-            $to_keep = [];
-            // Aditional clean for thunderbird
-            foreach ($content as $ID => $val) {
-               if (!isset($val[0]) || ($val[0] != '>')) {
-                  $to_keep[$ID] = $ID;
-               }
-            }
-
-            $tkt['content'] = "";
-            foreach ($to_keep as $ID) {
-               $tkt['content'] .= $content[$ID]."\n";
-            }
-
-            // Do not play rules for followups : WRONG : play rules only for refuse options
-            //$play_rules = false;
-
          } else {
             // => to handle link in Ticket->post_addItem()
             $tkt['_linkedto'] = $tkt['tickets_id'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5432 

Sometimes, depending on used format for response (plain text or HTML), and on used mail client, header and footer line can be split into multiple lines. This makes stripping of initial contents failing in mailcollector.

On previous logic, the stripping logic was working line by line. With this new logic, the stripping is done on the whole message in a unique regex replacement.

Side-effect is that contents like in 2 following cases will be stripped too:
```
=-=-=-=
this is my contents and it is surrounded by header line marks
=-=-=-=
```
```
=_=_=_=
this is my contents and it is surrounded by footer line marks
=_=_=_=
```