### PR TITLE
Fix rich-text drop feature

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3558,7 +3558,6 @@ class Html {
             remove_script_host: false,
             entity_encoding: 'raw',
             paste_data_images: $('.fileupload').length,
-            paste_block_drop: true,
             menubar: false,
             statusbar: false,
             skin_url: '".$CFG_GLPI['root_doc']."/css/tiny_mce/skins/light',

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -331,18 +331,6 @@ var insertImageInTinyMCE = function(editor, image) {
  */
 if (typeof tinymce != 'undefined') {
    tinymce.PluginManager.add('glpi_upload_doc', function(editor) {
-      editor.on('drop', function(event) {
-         if (event.dataTransfer
-             && event.dataTransfer.files.length > 0) {
-            stopEvent(event);
-
-            // for each dropped files
-            $.each(event.dataTransfer.files, function(index, element) {
-               insertImageInTinyMCE(editor, element);
-            });
-         }
-      });
-
       editor.on('PastePreProcess', function(event) {
          //Check if data is an image
          if (isImageFromPaste(event.content)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This PR adds ability to move elements inside the editor.

Drag/drop was prevented by: https://github.com/glpi-project/glpi/compare/9.4/bugfixes...cedric-anne:9.4/fix-rich-text-drop?expand=1#diff-298092ebe134c5b9ccbc7042328fb02cL3561

Handling on images on `drop` event was making duplication of images as a dropped content is also using the `paste` process, so the image was inserted on `drop` then a second time on `PastePreProcess`.