### PR TITLE
Fix CS job configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
       - run:
           name: PHP CS
           command: |
-            vendor/bin/phpcs -d memory_limit=512M -p -n --extensions=php --standard=PSR2 ./src ./public/index.php && vendor/bin/phpcs -d memory_limit=512M -p --extensions=php --standard=vendor/glpi-project/coding-standard/GlpiStandard/ --ignore=/.git,/config,/files,/lib,/node_modules,/plugins,/src,/tests/config,/vendor,/public/index.php ./
+            vendor/bin/phpcs -d memory_limit=512M -p -n --extensions=php --standard=PSR2 ./src ./public/index.php && vendor/bin/phpcs -d memory_limit=512M -p -n --extensions=php --standard=vendor/glpi-project/coding-standard/GlpiStandard/ --ignore=/.git/,/config/,/files/,/lib/,/node_modules/,/plugins/,/public/index.php,/src/,/tests/config/,/vendor/ ./
       - run:
           name: ESLint
           command: |

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2803,14 +2803,14 @@ class Config extends CommonDBTM {
          // 1 row = 0.78 to 0.84 config table schema
          $values = $iterator->next();
       } else {
-          // multiple rows = 0.85+ config
-          $values = [];
-          while ($row = $iterator->next()) {
-             if ('core' !== $row['context']) {
-                continue;
-             }
-             $values[$row['name']] = $row['value'];
-          }
+         // multiple rows = 0.85+ config
+         $values = [];
+         while ($row = $iterator->next()) {
+            if ('core' !== $row['context']) {
+               continue;
+            }
+            $values[$row['name']] = $row['value'];
+         }
       }
 
       $CFG_GLPI = array_merge($CFG_GLPI, $values);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`config.class.php` was ignored as it was matching `/config` ignore element. Adding slashes to directories names fixes this.