### PR TITLE
Fix add followup/task massive action; fixes #5532

### DIFF
--- a/inc/change_ticket.class.php
+++ b/inc/change_ticket.class.php
@@ -121,7 +121,7 @@ class Change_Ticket extends CommonDBRelation{
          case 'add_task' :
             $tasktype = 'TicketTask';
             if ($ttype = getItemForItemtype($tasktype)) {
-               $ttype->showFormMassiveAction();
+               $ttype->showMassiveActionAddTaskForm();
                return true;
             }
             return false;

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -2690,7 +2690,7 @@ abstract class CommonITILObject extends CommonDBTM {
             $itemtype = $ma->getItemtype(true);
             $tasktype = $itemtype.'Task';
             if ($ttype = getItemForItemtype($tasktype)) {
-               $ttype->showFormMassiveAction();
+               $ttype->showMassiveActionAddTaskForm();
                return true;
             }
             return false;

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1656,6 +1656,52 @@ abstract class CommonITILTask  extends CommonDBTM {
 
 
    /**
+    * Form for Ticket or Problem Task on Massive action
+    */
+   function showMassiveActionAddTaskForm() {
+      echo "<table class='tab_cadre_fixe'>";
+      echo '<tr><th colspan=4>'.__('Add a new task').'</th></tr>';
+
+      echo "<tr class='tab_bg_2'>";
+      echo "<td>".__('Category')."</td>";
+      echo "<td>";
+      TaskCategory::dropdown(['condition' => ['is_active' => 1]]);
+      echo "</td>";
+      echo "</tr>";
+
+      echo "<tr class='tab_bg_2'>";
+      echo "<td>".__('Description')."</td>";
+      echo "<td><textarea name='content' cols='50' rows='6'></textarea></td>";
+      echo "</tr>";
+
+      echo "<tr class='tab_bg_2'>";
+      echo "<td>".__('Duration')."</td>";
+      echo "<td>";
+      $toadd = [];
+      for ($i=9; $i<=100; $i++) {
+         $toadd[] = $i*HOUR_TIMESTAMP;
+      }
+      Dropdown::showTimeStamp("actiontime", ['min'             => 0,
+                                             'max'             => 8*HOUR_TIMESTAMP,
+                                             'addfirstminutes' => true,
+                                             'inhours'         => true,
+                                             'toadd'           => $toadd]);
+      echo "</td>";
+      echo "</tr>";
+
+      echo "<tr class='tab_bg_2'>";
+      echo "<td class='center' colspan='2'>";
+      if ($this->maybePrivate()) {
+         echo "<input type='hidden' name='is_private' value='".$_SESSION['glpitask_private']."'>";
+      }
+      echo "<input type='submit' name='add' value=\""._sx('button', 'Add')."\" class='submit'>";
+      echo "</td>";
+      echo "</tr>";
+
+      echo "</table>";
+   }
+
+   /**
     * Get tasks list
     *
     * @since 9.2

--- a/inc/problem_ticket.class.php
+++ b/inc/problem_ticket.class.php
@@ -154,7 +154,7 @@ class Problem_Ticket extends CommonDBRelation{
          case 'add_task' :
             $tasktype = 'TicketTask';
             if ($ttype = getItemForItemtype($tasktype)) {
-               $ttype->showFormMassiveAction();
+               $ttype->showMassiveActionAddTaskForm();
                return true;
             }
             return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5532 

Methods were dropped in 9.4.0 but were still in use.

I restore them and enhance a little the rendering.