### PR TITLE
Prevent hook execution if plugin not loaded; follow #5413 and #5473

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -4558,6 +4558,9 @@ abstract class CommonITILObject extends CommonDBTM {
       //Types of the plugins (keep the plugin hook for right check)
       if (isset($PLUGIN_HOOKS['assign_to_ticket'])) {
          foreach (array_keys($PLUGIN_HOOKS['assign_to_ticket']) as $plugin) {
+            if (!Plugin::isPluginLoaded($plugin)) {
+               continue;
+            }
             $ptypes = Plugin::doOneHook($plugin, 'AssignToTicket', $ptypes);
          }
       }

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1293,6 +1293,10 @@ class Html {
       if (isset($PLUGIN_HOOKS['add_css']) && count($PLUGIN_HOOKS['add_css'])) {
 
          foreach ($PLUGIN_HOOKS["add_css"] as $plugin => $files) {
+            if (!Plugin::isPluginLoaded($plugin)) {
+               continue;
+            }
+
             $version = Plugin::getInfo($plugin, 'version');
 
             if (!is_array($files)) {
@@ -1408,6 +1412,9 @@ class Html {
          if (isset($PLUGIN_HOOKS["menu_toadd"]) && count($PLUGIN_HOOKS["menu_toadd"])) {
 
             foreach ($PLUGIN_HOOKS["menu_toadd"] as $plugin => $items) {
+               if (!Plugin::isPluginLoaded($plugin)) {
+                  continue;
+               }
                if (count($items)) {
                   foreach ($items as $key => $val) {
                      if (is_array($val)) {
@@ -1484,7 +1491,7 @@ class Html {
     * @param $option    option corresponding to the page displayed (default '')
    **/
    static function header($title, $url = '', $sector = "none", $item = "none", $option = "") {
-      global $CFG_GLPI, $PLUGIN_HOOKS, $HEADER_LOADED, $DB;
+      global $CFG_GLPI, $HEADER_LOADED, $DB;
 
       // If in modal : display popHeader
       if (isset($_REQUEST['_in_modal']) && $_REQUEST['_in_modal']) {
@@ -1727,7 +1734,7 @@ class Html {
     * @param $url    not used anymore (default '')
    **/
    static function helpHeader($title, $url = '') {
-      global $CFG_GLPI, $HEADER_LOADED, $PLUGIN_HOOKS;
+      global $CFG_GLPI, $HEADER_LOADED;
 
       // Print a nice HTML-head for help page
       if ($HEADER_LOADED) {
@@ -1880,7 +1887,7 @@ class Html {
     * @param $iframed indicate if page loaded in iframe - css target (default false)
    **/
    static function popHeader($title, $url = '', $iframed = false) {
-      global $CFG_GLPI, $PLUGIN_HOOKS, $HEADER_LOADED;
+      global $CFG_GLPI, $HEADER_LOADED;
 
       // Print a nice HTML-head for every page
       if ($HEADER_LOADED) {
@@ -5930,6 +5937,9 @@ class Html {
       if (isset($PLUGIN_HOOKS['add_javascript']) && count($PLUGIN_HOOKS['add_javascript'])) {
 
          foreach ($PLUGIN_HOOKS["add_javascript"] as $plugin => $files) {
+            if (!Plugin::isPluginLoaded($plugin)) {
+               continue;
+            }
             $version = Plugin::getInfo($plugin, 'version');
             if (!is_array($files)) {
                $files = [$files];
@@ -6346,6 +6356,9 @@ class Html {
             && count($PLUGIN_HOOKS["helpdesk_menu_entry"])) {
 
             foreach ($PLUGIN_HOOKS["helpdesk_menu_entry"] as $plugin => $active) {
+               if (!Plugin::isPluginLoaded($plugin)) {
+                  continue;
+               }
                if ($active) {
                   $infos = Plugin::getInfo($plugin);
                   $link = "";

--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -574,6 +574,9 @@ class MassiveAction {
          // Plugin Specific actions
          if (isset($PLUGIN_HOOKS['use_massive_action'])) {
             foreach ($PLUGIN_HOOKS['use_massive_action'] as $plugin => $val) {
+               if (!Plugin::isPluginLoaded($plugin)) {
+                  continue;
+               }
                $plug_actions = Plugin::doOneHook($plugin, 'MassiveActions', $itemtype);
 
                if (is_array($plug_actions) && count($plug_actions)) {

--- a/inc/report.class.php
+++ b/inc/report.class.php
@@ -133,6 +133,9 @@ class Report extends CommonGLPI{
       $optgroup = [];
       if (isset($PLUGIN_HOOKS["reports"]) && is_array($PLUGIN_HOOKS["reports"])) {
          foreach ($PLUGIN_HOOKS["reports"] as $plug => $pages) {
+            if (!Plugin::isPluginLoaded($plug)) {
+               continue;
+            }
             if (is_array($pages) && count($pages)) {
                foreach ($pages as $page => $name) {
                   $names[$plug.'/'.$page] = ["name" => $name,

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -1701,6 +1701,9 @@ class Rule extends CommonDBTM {
       $input = $this->prepareInputDataForProcess($input, $params);
       if (isset($PLUGIN_HOOKS['use_rules'])) {
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+            if (!Plugin::isPluginLoaded($plugin)) {
+               continue;
+            }
             if (is_array($val) && in_array($this->getType(), $val)) {
                $results = Plugin::doOneHook($plugin, "rulePrepareInputDataForProcess",
                                             ['input'  => $input,
@@ -1737,6 +1740,9 @@ class Rule extends CommonDBTM {
          $params['criterias_results'] = $this->criterias_results;
          $params['rule_itemtype']     = $this->getType();
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+            if (!Plugin::isPluginLoaded($plugin)) {
+               continue;
+            }
             if (is_array($val) && in_array($this->getType(), $val)) {
                $results = Plugin::doOneHook($plugin, "executeActions", ['output' => $output,
                                                                         'params' => $params,
@@ -2569,6 +2575,9 @@ class Rule extends CommonDBTM {
          $params['criterias_results'] = $this->criterias_results;
          $params['rule_itemtype']     = $this->getType();
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+            if (!Plugin::isPluginLoaded($plugin)) {
+               continue;
+            }
             if (is_array($val) && in_array($this->getType(), $val)) {
                $results = Plugin::doOneHook($plugin, "preProcessRulePreviewResults",
                                             ['output' => $output,
@@ -2672,6 +2681,9 @@ class Rule extends CommonDBTM {
       $toreturn = $params;
       if (isset($PLUGIN_HOOKS['use_rules'])) {
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+            if (!Plugin::isPluginLoaded($plugin)) {
+               continue;
+            }
             if (is_array($val) && in_array($itemtype, $val)) {
                $results = Plugin::doOneHook($plugin, $hook, ['rule_itemtype' => $itemtype,
                                                                   'values'        => $params]);

--- a/inc/rulecollection.class.php
+++ b/inc/rulecollection.class.php
@@ -1695,6 +1695,9 @@ class RuleCollection extends CommonDBTM {
       $input = $this->prepareInputDataForProcess($input, $params);
       if (isset($PLUGIN_HOOKS['use_rules'])) {
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+            if (!Plugin::isPluginLoaded($plugin)) {
+               continue;
+            }
             if (is_array($val) && in_array($this->getRuleClassName(), $val)) {
                $results = Plugin::doOneHook($plugin, 'ruleCollectionPrepareInputDataForProcess',
                                              ['rule_itemtype' => $this->getRuleClassName(),
@@ -1863,6 +1866,9 @@ class RuleCollection extends CommonDBTM {
       if (isset($PLUGIN_HOOKS['use_rules'])) {
          $params['rule_itemtype'] = $this->getType();
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+            if (!Plugin::isPluginLoaded($plugin)) {
+               continue;
+            }
             if (is_array($val) && in_array($this->getType(), $val)) {
                $results = Plugin::doOneHook($plugin, "preProcessRuleCollectionPreviewResults",
                                             ['output' => $output,

--- a/inc/ruleimportcomputer.class.php
+++ b/inc/ruleimportcomputer.class.php
@@ -256,6 +256,9 @@ class RuleImportComputer extends Rule {
       //Add plugin global criteria
       if (isset($PLUGIN_HOOKS['use_rules'])) {
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+            if (!Plugin::isPluginLoaded($plugin)) {
+               continue;
+            }
             if (is_array($val) && in_array($this->getType(), $val)) {
                $global_criteria = Plugin::doOneHook($plugin, "ruleImportComputer_addGlobalCriteria",
                                                     $global_criteria);
@@ -350,6 +353,9 @@ class RuleImportComputer extends Rule {
 
       if (isset($PLUGIN_HOOKS['use_rules'])) {
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+            if (!Plugin::isPluginLoaded($plugin)) {
+               continue;
+            }
             if (is_array($val) && in_array($this->getType(), $val)) {
                $params      = ['where_entity' => $where_entity,
                                     'input'        => $input,

--- a/inc/ruleimportcomputercollection.class.php
+++ b/inc/ruleimportcomputercollection.class.php
@@ -49,8 +49,6 @@ class RuleImportComputerCollection extends RuleCollection {
     * @return boolean
    **/
    function canList() {
-      global $PLUGIN_HOOKS;
-
       if (Plugin::haveImport()) {
          return static::canView();
       }

--- a/inc/ruleimportentity.class.php
+++ b/inc/ruleimportentity.class.php
@@ -121,6 +121,9 @@ class RuleImportEntity extends Rule {
       if ($criteria['field'] == '_source') {
          $tab = [];
          foreach ($PLUGIN_HOOKS['import_item'] as $plug => $types) {
+            if (!Plugin::isPluginLoaded($plug)) {
+               continue;
+            }
             $tab[$plug] = Plugin::getInfo($plug, 'name');
          }
          Dropdown::showFromArray($name, $tab);

--- a/inc/ruleimportentitycollection.class.php
+++ b/inc/ruleimportentitycollection.class.php
@@ -47,8 +47,6 @@ class RuleImportEntityCollection extends RuleCollection {
     * @see RuleCollection::canList()
    **/
    function canList() {
-      global $PLUGIN_HOOKS;
-
       if (Plugin::haveImport()) {
          return static::canView();
       }

--- a/inc/stat.class.php
+++ b/inc/stat.class.php
@@ -1439,6 +1439,9 @@ class Stat extends CommonGLPI {
       $optgroup = [];
       if (isset($PLUGIN_HOOKS["stats"]) && is_array($PLUGIN_HOOKS["stats"])) {
          foreach ($PLUGIN_HOOKS["stats"] as $plug => $pages) {
+            if (!Plugin::isPluginLoaded($plug)) {
+               continue;
+            }
             if (is_array($pages) && count($pages)) {
                foreach ($pages as $page => $name) {
                   $names[$plug.'/'.$page] = ["name" => $name,

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -1830,7 +1830,7 @@ class Toolbox {
     * @param $where string: where to redirect ?
    **/
    static function manageRedirect($where) {
-      global $CFG_GLPI, $PLUGIN_HOOKS;
+      global $CFG_GLPI;
 
       if (!empty($where)) {
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5409 

1. Some hooks are not functions calls, so the filtering introduced in #5413 and #5473 is not applied.

2. Filtering introduced on `Plugin::doOneHook()` in #5473 makes the function returning `false`. This return value is not always handled correclty, so I added a check prior to this function execution, to be sure to not deal with unexpected `false` value.