### PR TITLE
Fix translator init

### DIFF
--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -603,18 +603,19 @@ class Session {
          $_SESSION['glpipluralnumber'] = $CFG_GLPI["languages"][$trytoload][5];
       }
       $TRANSLATE = new Zend\I18n\Translator\Translator;
+      $TRANSLATE->setLocale($trytoload);
+
       $cache = Config::getCache('cache_trans', 'core', false);
       if ($cache !== false) {
          $TRANSLATE->setCache($cache);
       }
+
       $TRANSLATE->addTranslationFile('gettext', GLPI_ROOT.$newfile, 'glpi', $trytoload);
 
       // Load plugin dicts
       foreach (Plugin::getPlugins() as $plug) {
          Plugin::loadLang($plug, $forcelang, $trytoload);
       }
-
-      $TRANSLATE->setLocale($trytoload);
 
       return $trytoload;
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

After pruning my local cache, I had following error while using the console.
It appears if a message is translated prior to defining the locale.

This bug has been introduced after the 9.4.0 release. It happens as plugins `get_version` hooks, called in plugins states checks, uses sometimes translation functions.

```
Fatal error: Uncaught Zend\I18n\Exception\ExtensionNotLoadedException: Zend\I18n\Translator component requires the intl PHP extension in /var/www/glpi/vendor/zendframework/zend-i18n/src/Translator/Translator.php:259
Stack trace:
#0 /var/www/glpi/vendor/zendframework/zend-i18n/src/Translator/Translator.php(355): Zend\I18n\Translator\Translator->getLocale()
#1 /var/www/glpi/inc/autoload.function.php(109): Zend\I18n\Translator\Translator->translate('Inventory numbe...', 'geninventorynum...')
#2 /var/www/glpi/plugins/geninventorynumber/setup.php(74): __('Inventory numbe...', 'geninventorynum...')
#3 /var/www/glpi/inc/plugin.class.php(1184): plugin_version_geninventorynumber()
#4 /var/www/glpi/inc/plugin.class.php(299): Plugin::getInfo('geninventorynum...')
#5 /var/www/glpi/inc/plugin.class.php(267): Plugin->checkPluginState('geninventorynum...')
#6 /var/www/glpi/inc/plugin.class.php(106): Plugin->checkStates()
#7 /var/www/glpi/inc/plugin.class.php(1693): Plugin->init()
#8 /var/www/glpi/inc/session.class.php(613): Plugin::getP in /var/www/glpi/vendor/zendframework/zend-i18n/src/Translator/Translator.php on line 259
```