### PR TITLE
Fix uninitialized DB on plugin init

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -98,7 +98,7 @@ class Plugin extends CommonDBTM {
 
       $GLPI_CACHE->set('plugins', []);
 
-      if (!$DB->connected) {
+      if (!isset($DB) || !$DB->connected) {
          // Cannot init plugins list if DB is not connected
          return;
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In command console, we can have an error on plugin init. To reproduce, DB config file have to be missing and cache have to be empty (see https://travis-ci.org/pluginsGLPI/fields/jobs/503602074#L559).
