### PR TITLE
fix regex used to match ticket's id in mail headers

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -923,6 +923,7 @@ class MailCollector  extends CommonDBTM {
       }
 
       // prepare match to find ticket id in headers
+      // pattern: GLPI-{itemtype}-{items_id}
       // ex: GLPI-Ticket-26739
       $ref_match = "GLPI-[A-Z]\w+-([0-9]+)";
 

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -922,9 +922,13 @@ class MailCollector  extends CommonDBTM {
          $tkt['content'] = $body;
       }
 
+      // prepare match to find ticket id in headers
+      // ex: GLPI-Ticket-26739
+      $ref_match = "GLPI-[A-Z]\w+-([0-9]+)";
+
       // See In-Reply-To field
       if (isset($head['in_reply_to'])) {
-         if (preg_match($glpi_message_match, $head['in_reply_to'], $match)) {
+         if (preg_match($ref_match, $head['in_reply_to'], $match)) {
             $tkt['tickets_id'] = intval($match[1]);
          }
       }
@@ -932,7 +936,7 @@ class MailCollector  extends CommonDBTM {
       // See in References
       if (!isset($tkt['tickets_id'])
           && isset($head['references'])) {
-         if (preg_match($glpi_message_match, $head['references'], $match)) {
+         if (preg_match($ref_match, $head['references'], $match)) {
             $tkt['tickets_id'] = intval($match[1]);
          }
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Internal ref 16418

previous var `$glpi_message_match` contains `/GLPI-([0-9]+)\.[0-9]+\.[0-9]+@\w*/` used to match `Message-ID` header (ex: `Message-ID: <GLPI-16439.1552060193.21162695@vm000175>`).

Another way to fix could be to edit here: https://github.com/glpi-project/glpi/blob/9.4/bugfixes/inc/notificationeventmailing.class.php#L130-L131 and set the content returned by `NotificationTargetTicket::getMessageID()`

For this alternative, pros are unifying id in headers, cons is we change current headers and we potentially break some integrations
