### PR TITLE
Fix missing $GLPI_CACHE in installation page

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -40,6 +40,10 @@ Config::detectRootDoc();
 $GLPI = new GLPI();
 $GLPI->initLogger();
 
+// $GLPI_CACHE is indirectly used in Session::loadLanguage() to retrieve list of plugins.
+global $GLPI_CACHE;
+$GLPI_CACHE = Config::getCache('cache_db');
+
 //Print a correct  Html header for application
 function header_html($etape) {
    global $CFG_GLPI;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since commit https://github.com/glpi-project/glpi/commit/5b9affbc3fbf0e08df5a10fa5c0f07ff713d05b0#diff-914d92bd95159c81411f15f65416774bL1675 , we do not check if `$GLPI_CACHE` is defined before using it, assuming that GLPI has always a cache service available (which should be the case).

This cache service was not initialized on installation page.