### PR TITLE
Prevent saving of _no_history entry in config table; fixes #2823

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -110,6 +110,10 @@ class Config extends CommonDBTM {
 
    function prepareInputForUpdate($input) {
       global $CFG_GLPI;
+
+      // Unset _no_history to not save it as a configuration value
+      unset($input['_no_history']);
+
       // Update only an item
       if (isset($input['context'])) {
          return $input;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2823
