### PR TITLE
Fix empty assistance menu if only rights on  templates; fixes #4993

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -150,6 +150,8 @@ class Ticket extends CommonITILObject {
          $menu['create_ticket']['title']    = __('Create ticket');
          $menu['create_ticket']['page']     = static::getFormURL(false);
          return $menu;
+      } else {
+         return self::getAdditionalMenuOptions();
       }
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4993 

I do not know if it is the right solution.

With this change, the Assistance menu will be populated with a link to `TicketTemplate` item if user has right to manage TicketTemplates but not Tickets
