### PR TITLE
Fix refused tickets list; fixes #5574

### DIFF
--- a/inc/central.class.php
+++ b/inc/central.class.php
@@ -211,7 +211,8 @@ class Central extends CommonGLPI {
 
          Ticket::showCentralList(0, "survey", false);
 
-         Ticket::showCentralList(0, "rejected", false);
+         Ticket::showCentralList(0, "validation.rejected", false);
+         Ticket::showCentralList(0, "solution.rejected", false);
          Ticket::showCentralList(0, "requestbyself", false);
          Ticket::showCentralList(0, "observed", false);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5574 

1. The 'Your rejected tickets' list was displaying tickets with a refused solution (not necessary the last one), but the link was pointing to search page filtering on tickets having a refused global validation status.
I put back the old list constructed using the global validation status.

2. I added a new list showing list of tickets assigned to the user and having their last solution refused.

3. I had to update wordings as they were ambiguous.