### PR TITLE
Make errors displayed in cron if called from CLI

### DIFF
--- a/front/cron.php
+++ b/front/cron.php
@@ -44,6 +44,11 @@ if (!is_writable(GLPI_LOCK_DIR)) {
    exit (1);
 }
 
+if (isCommandLine()) {
+   // Force debug mode in command line mode to output errors
+   Toolbox::setDebugMode(Session::DEBUG_MODE);
+}
+
 if (!isCommandLine()) {
    //The advantage of using background-image is that cron is called in a separate
    //request and thus does not slow down output of the main page as it would if called


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

For now, cron called from command line is exiting without diplaying anything if a fatal error occurs. So people facing cron issues cannot provide error backtrace and it makes problems hard to debug.

Forcing debug mode when cron is called from CLI will make the backtrace displayed in case of an exception or a fatal error.

For example
```diff
diff --git a/inc/crontask.class.php b/inc/crontask.class.php
index cde8ffec21..e3e9812526 100644
--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -783,6 +783,9 @@ class CronTask extends CommonDBTM{
    static public function launch($mode, $max = 1, $name = '') {
       global $CFG_GLPI;
 
+      $obj = null;
+      $obj->method();
+
       // No cron in maintenance mode
       if (isset($CFG_GLPI['maintenance_mode']) && $CFG_GLPI['maintenance_mode']) {
          Toolbox::logInFile('cron', __('Maintenance mode enabled, running tasks is disabled')."\n");

```
will output
```
$ /usr/local/bin/php /var/www/glpi/front/cron.php

Fatal error: Uncaught Error: Call to a member function method() on null in /var/www/glpi/inc/crontask.class.php:787
Stack trace:
#0 /var/www/glpi/front/cron.php(88): CronTask::launch(2, '5')
#1 {main}
  thrown in /var/www/glpi/inc/crontask.class.php on line 787
```