### PR TITLE
Enhance image checks

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2391,6 +2391,9 @@ class Config extends CommonDBTM {
             'CAS'     => [
                'required' => false,
                'class'    => 'phpCAS'
+            ],
+            'exif' => [
+               'required'  => false
             ]
          ];
       } else {

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -1541,8 +1541,17 @@ class Document extends CommonDBTM {
     * @return boolean
     */
    public static function isImage($file) {
-      $ext = strtolower(pathinfo($file, PATHINFO_EXTENSION));
-      return (in_array($ext, ['jpg', 'jpeg', 'png', 'bmp', 'gif']));
+      if (extension_loaded('exif')) {
+         $etype = exif_imagetype($file);
+         return in_array($etype, [IMAGETYPE_JPEG, IMAGETYPE_GIF, IMAGETYPE_PNG, IMAGETYPE_BMP]);
+      } else {
+         Toolbox::logWarning('For security reasons, you should consider using exif PHP extension to properly check images.');
+         $fileinfo = finfo_open(FILEINFO_MIME_TYPE);
+         return in_array(
+            finfo_file($fileinfo, $file),
+            ['image/jpeg', 'image/png','image/gif', 'image/bmp']
+         );
+      }
    }
 
    /**

--- a/tests/functionnal/Document.php
+++ b/tests/functionnal/Document.php
@@ -215,25 +215,19 @@ class Document extends DbTestCase {
 
    protected function isImageProvider() {
       return [
-         ['PNG', true],
-         ['png', true],
-         ['JPG', true],
-         ['jpg', true],
-         ['jpeg', true],
-         ['JPEG', true],
-         ['bmp', true],
-         ['BMP', true],
-         ['gif', true],
-         ['GIF', true],
-         ['SVG', false]
+         [__FILE__, false],
+         [__DIR__ . "/../../pics/add_dropdown.png", true],
+         [__DIR__ . "/../../pics/corners.gif", true],
+         [__DIR__ . "/../../pics/PICS-AUTHORS.txt", false],
+         [__DIR__ . "/../notanimage.jpg", false]
       ];
    }
 
    /**
     * @dataProvider isImageProvider
     */
-   public function testIsImage($ext, $expected) {
-      $this->variable(\Document::isImage('myfile.' . $ext))->isIdenticalTo($expected);
+   public function testIsImage($file, $expected) {
+      $this->boolean(\Document::isImage($file))->isIdenticalTo($expected);
    }
 
    /**

--- a/tests/notanimage.jpg
+++ b/tests/notanimage.jpg
@@ -1,0 +1,3 @@
+<?php
+
+echo 'This is not an image.';


### PR DESCRIPTION
Use exif if present to check if file is image, or fallback with W on fileinfo

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
