### PR TITLE
Fix status update of duplicated tickets solved w/o solution; fixes #4989

### DIFF
--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -331,6 +331,11 @@ class ITILSolution extends CommonDBChild {
       $this->input["_job"] = $this->item;
       $this->input = $this->addFiles($this->input, ['force_update' => true]);
 
+      // Add solution to duplicates
+      if ($this->item->getType() == 'Ticket' && !isset($this->input['_linked_ticket'])) {
+         Ticket_Ticket::manageLinkedTicketsOnSolved($this->item->getID(), $this);
+      }
+
       $status = $item::SOLVED;
 
       //handle autoclose, for tickets only
@@ -352,9 +357,6 @@ class ITILSolution extends CommonDBChild {
          'id'     => $this->item->getID(),
          'status' => $status
       ]);
-      if ($this->item->getType() == 'Ticket' && !isset($this->input['_linked_ticket'])) {
-         Ticket_Ticket::manageLinkedTicketsOnSolved($this->item->getID(), $this);
-      }
       parent::post_addItem();
    }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1541,6 +1541,14 @@ class Ticket extends CommonITILObject {
    function post_updateItem($history = 1) {
       global $CFG_GLPI;
 
+      // Put same status on duplicated tickets when solving or closing (autoclose on solve)
+      if (isset($this->input['status'])
+          && in_array('status', $this->updates)
+          && (in_array($this->input['status'], $this->getSolvedStatusArray())
+              || in_array($this->input['status'], $this->getClosedStatusArray()))) {
+         Ticket_Ticket::manageLinkedTicketsOnSolved($this->getID());
+      }
+
       $donotif = count($this->updates);
 
       if (isset($this->input['_forcenotif'])) {

--- a/inc/ticket_ticket.class.php
+++ b/inc/ticket_ticket.class.php
@@ -383,35 +383,61 @@ class Ticket_Ticket extends CommonDBRelation {
 
 
    /**
-    * Affect the same solution for duplicates tickets
+    * Affect the same solution/status for duplicates tickets.
     *
-    * @param integer  $ID       ID of the ticket id
-    * @param Solution $solution Ticket's solution
+    * @param integer           $ID        ID of the ticket id
+    * @param ITILSolution|null $solution  Ticket's solution
     *
-    * @return nothing do the change
+    * @return void
    **/
-   static function manageLinkedTicketsOnSolved($ID, $solution) {
-      $ticket = new Ticket();
+   static function manageLinkedTicketsOnSolved($ID, $solution = null) {
 
-      if ($ticket->getfromDB($ID)) {
+      $ticket = new Ticket();
+      if (!$ticket->getfromDB($ID)) {
+         return;
+      }
+      $tickets = self::getLinkedTicketsTo($ID);
+
+      if (false === $tickets) {
+         return;
+      }
+
+      $tickets = array_filter(
+         $tickets,
+         function ($data) {
+            $linked_ticket = new Ticket();
+            $linked_ticket->getFromDB($data['tickets_id']);
+            return $linked_ticket->can($data['tickets_id'], UPDATE)
+                && ($data['link'] == self::DUPLICATE_WITH)
+                && ($linked_ticket->fields['status'] != CommonITILObject::SOLVED)
+                && ($linked_ticket->fields['status'] != CommonITILObject::CLOSED);
+         }
+      );
+
+      if (null === $solution) {
+         // Change status without adding a solution
+         // This will be done if a ticket is solved/closed without a solution
+         foreach ($tickets as $data) {
+            $linked_ticket = new Ticket();
+            $linked_ticket->update(
+               [
+                  'id'     => $data['tickets_id'],
+                  'status' => $ticket->fields['status']
+               ]
+            );
+         }
+      } else {
+         // Add same solution to duplicates
          $solution_data = $solution->fields;
          unset($solution_data['id']);
          unset($solution_data['date_creation']);
          unset($solution_data['date_mod']);
 
-         $tickets = self::getLinkedTicketsTo($ID);
-         if (count($tickets)) {
-            foreach ($tickets as $data) {
-               $solution_data['items_id'] = $data['tickets_id'];
-               $solution_data['_linked_ticket'] = true;
-               if ($ticket->can($solution_data['items_id'], UPDATE)
-                   && ($data['link'] == self::DUPLICATE_WITH)
-                   && ($ticket->fields['status'] != CommonITILObject::SOLVED)
-                   && ($ticket->fields['status'] != CommonITILObject::CLOSED)) {
-                  $new_solution = new ITILSolution();
-                  $new_solution->add($solution_data);
-               }
-            }
+         foreach ($tickets as $data) {
+            $solution_data['items_id'] = $data['tickets_id'];
+            $solution_data['_linked_ticket'] = true;
+            $new_solution = new ITILSolution();
+            $new_solution->add($solution_data);
          }
       }
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4989 

Solving a ticket that having duplicates should solve them. This was not working when someone solved a ticket without adding a solution.
