### PR TITLE
Revert "Fix missing $GLPI_CACHE in installation page"; fixes #5583

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -44,10 +44,6 @@ Config::detectRootDoc();
 $GLPI = new GLPI();
 $GLPI->initLogger();
 
-// $GLPI_CACHE is indirectly used in Session::loadLanguage() to retrieve list of plugins.
-global $GLPI_CACHE;
-$GLPI_CACHE = Config::getCache('cache_db');
-
 //Print a correct  Html header for application
 function header_html($etape) {
    global $CFG_GLPI;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5583 

Commit 9a76df99ae48b335055dd68d6361ea90959465ba should have not been merged on master as cache is not instanciated by Kernel instanciation.