### PR TITLE
Fix manual input on date(time)pickers; fixes #4951

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -2631,7 +2631,7 @@ class Html {
                   showButtonPanel: true,
                   changeMonth: true,
                   changeYear: true,
-                  showOn: 'button',
+                  showOn: 'both',
                   showWeek: true,
                   buttonText: '<i class=\'far fa-calendar-alt\'></i>'";
 
@@ -2838,7 +2838,7 @@ class Html {
                   showButtonPanel: true,
                   changeMonth: true,
                   changeYear: true,
-                  showOn: 'button',
+                  showOn: 'both',
                   showWeek: true,
                   controlType: 'select',
                   buttonText: '<i class=\'far fa-calendar-alt\'></i>'";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4951 

Manual input in datetimepicker will not be converted to configured format if the picker component is not "opened".
Changing the `showOn` param to `both` makes the component opened when focusing on corresponding field, and not only when clicking on the calendar icon.