### PR TITLE
Fix infocom comment update history; fixes #535

### DIFF
--- a/inc/log.class.php
+++ b/inc/log.class.php
@@ -143,9 +143,8 @@ class Log extends CommonDBTM {
                   $changes          =  [$id_search_option, addslashes($oldval), $values[$key]];
                }
 
-            } else if (($val2['linkfield'] == $key)
-                || (($key == $val2['field'])
-                    && ($val2['table'] == $item->getTable()))) {
+            } else if (($val2['linkfield'] == $key && $real_type === $item->getType())
+                       || ($key == $val2['field'] && $val2['table'] == $item->getTable())) {
                // Linkfield or standard field not massive action enable
                $id_search_option = $key2; // Give ID of the $SEARCHOPTION
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #535

`id_search_option` used for history on item update is computed by getting matching search option of object where log should be added. SO was considering as matching when `linkfield` value was the same as updated field name. In case of Infocom `comment` updating, the matching SO was the one used for Computer `comment` field .
I added a check to be sure that we only consider a match on `linkfield` when item on which log is added is the same as the updated item.

For information, `$real_type` is based on `$item->getLogTypeID()` function result, which correspond to the parent item in case of `Infocom` update.