### PR TITLE
Do not check inactive plugins unless on plugins page

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -233,21 +233,22 @@ class Plugin extends CommonDBTM {
    /**
     * Check plugins states and detect new plugins.
     *
-    * @param boolean $scan_for_new_plugins
+    * @param boolean $scan_inactive_and_new_plugins
     *
     * @return void
     */
-   public function checkStates($scan_for_new_plugins = false) {
+   public function checkStates($scan_inactive_and_new_plugins = false) {
 
       $directories = [];
 
       // Add known plugins to the check list
-      $known_plugins = $this->find();
+      $condition = $scan_inactive_and_new_plugins ? [] : ['state' => self::ACTIVATED];
+      $known_plugins = $this->find($condition);
       foreach ($known_plugins as $plugin) {
          $directories[] = $plugin['directory'];
       }
 
-      if ($scan_for_new_plugins) {
+      if ($scan_inactive_and_new_plugins) {
          // Add found directories to the check list
          $plugins_directory = GLPI_ROOT."/plugins";
          $directory_handle  = opendir($plugins_directory);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This is not a big deal, but init of plugin list check state update of all known plugins, not only active one. This check is useless if user is not on plugins page, as computed data will no be used.

This PR makes the check on inactive plugins only made when displaying the plugins page.