### PR TITLE
Prevent indirect plugins loading on install/update process

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -50,7 +50,7 @@ Session::start();
 Config::detectRootDoc();
 
 if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
-   Session::loadLanguage();
+   Session::loadLanguage('', false);
    // no translation
    if (!isCommandLine()) {
       Html::nullHeader("DB Error", $CFG_GLPI["root_doc"]);
@@ -149,7 +149,7 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
       }
 
       if (!isset($_SESSION["glpiskipMaintenance"]) || !$_SESSION["glpiskipMaintenance"]) {
-         Session::loadLanguage();
+         Session::loadLanguage('', false);
          if (isCommandLine()) {
             echo __('Service is down for maintenance. It will be back shortly.');
             echo "\n";
@@ -174,7 +174,7 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
    if ((!isset($CFG_GLPI['dbversion']) || (trim($CFG_GLPI["dbversion"]) != GLPI_SCHEMA_VERSION))
        && !isset($_GET["donotcheckversion"])) {
 
-      Session::loadLanguage();
+      Session::loadLanguage('', false);
 
       if (isCommandLine()) {
          echo __('The version of the database is not compatible with the version of the installed files. An update is necessary.');

--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -355,7 +355,7 @@ class Application extends BaseApplication {
 
       $_SESSION['glpilanguage'] = $lang;
 
-      Session::loadLanguage();
+      Session::loadLanguage('', $this->usePlugins());
    }
 
    /**

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -558,11 +558,12 @@ class Session {
     * Get the default language from current user in $_SESSION["glpilanguage"].
     * And load the dict that correspond.
     *
-    * @param string $forcelang Force to load a specific lang (default '')
+    * @param string  $forcelang     Force to load a specific lang
+    * @param boolean $with_plugins  Whether to load plugin languages or not
     *
     * @return void
    **/
-   static function loadLanguage($forcelang = '') {
+   static function loadLanguage($forcelang = '', $with_plugins = true) {
       global $LANG, $CFG_GLPI, $TRANSLATE;
 
       $file = "";
@@ -613,8 +614,10 @@ class Session {
       $TRANSLATE->addTranslationFile('gettext', GLPI_ROOT.$newfile, 'glpi', $trytoload);
 
       // Load plugin dicts
-      foreach (Plugin::getPlugins() as $plug) {
-         Plugin::loadLang($plug, $forcelang, $trytoload);
+      if ($with_plugins) {
+         foreach (Plugin::getPlugins() as $plug) {
+            Plugin::loadLang($plug, $forcelang, $trytoload);
+         }
       }
 
       return $trytoload;

--- a/install/install.php
+++ b/install/install.php
@@ -40,10 +40,6 @@ Config::detectRootDoc();
 $GLPI = new GLPI();
 $GLPI->initLogger();
 
-// $GLPI_CACHE is indirectly used in Session::loadLanguage() to retrieve list of plugins.
-global $GLPI_CACHE;
-$GLPI_CACHE = Config::getCache('cache_db');
-
 //Print a correct  Html header for application
 function header_html($etape) {
    global $CFG_GLPI;
@@ -582,7 +578,7 @@ if (isset($_POST["language"])) {
    $_SESSION["glpilanguage"] = $_POST["language"];
 }
 
-Session::loadLanguage();
+Session::loadLanguage('', false);
 
 /**
  * @since 0.84.2

--- a/install/update.php
+++ b/install/update.php
@@ -510,7 +510,7 @@ $HEADER_LOADED = true;
 
 Session::start();
 
-Session::loadLanguage();
+Session::loadLanguage('', false);
 
 // Send UTF8 Headers
 header("Content-Type: text/html; charset=UTF-8");

--- a/install/update_content.php
+++ b/install/update_content.php
@@ -252,7 +252,7 @@ function UpdateContent($DB, $duree, $rowlimit, $conv_utf8, $complete_utf8) {
 
 //########################### Script start ################################
 
-Session::loadLanguage();
+Session::loadLanguage('', false);
 
 // Send UTF8 Headers
 header("Content-Type: text/html; charset=UTF-8");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | sometimes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5603

Sometimes, plugins includes indirectly the update check process via their `setup.php` file, used when initializing plugins. This makes the update form displayed in the middle of the update process, which block the ability to update using UI.

Changes made here prevent loading of plugins in install/update/maintenance process (that was made by the translation files loading process).