### PR TITLE
Fix plugin init and requirements check; fixes #5637

### DIFF
--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -383,14 +383,7 @@ class Application extends BaseApplication {
       }
 
       $plugin = new Plugin();
-      $plugins_list = $plugin->getPlugins();
-      if (count($plugins_list) > 0) {
-         foreach ($plugins_list as $name) {
-            Plugin::load($name);
-         }
-         // For plugins which require action after all plugin init
-         Plugin::doHook("post_init");
-      }
+      $plugin->init();
    }
 
    /**

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -95,16 +95,9 @@ if (!isset($PLUGINS_INCLUDED)) {
    // PLugin already included
    $PLUGINS_INCLUDED = 1;
    $LOADED_PLUGINS   = [];
-   $plugin           = new Plugin();
 
-   $plugins_list = $plugin->getPlugins();
-   if (count($plugins_list)) {
-      foreach ($plugins_list as $name) {
-         Plugin::load($name);
-      }
-      // For plugins which require action after all plugin init
-      Plugin::doHook("post_init");
-   }
+   $plugin = new Plugin();
+   $plugin->init();
 }
 
 

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -614,6 +614,8 @@ class Session {
       $TRANSLATE->addTranslationFile('gettext', GLPI_ROOT.$newfile, 'glpi', $trytoload);
 
       // Load plugin dicts
+      // This is only required when language loading is made for a language switch (in notification process).
+      // Indeed, loading of plugin languages is made by global plugin loading process.
       if ($with_plugins) {
          foreach (Plugin::getPlugins() as $plug) {
             Plugin::loadLang($plug, $forcelang, $trytoload);

--- a/tests/functionnal/Plugin.php
+++ b/tests/functionnal/Plugin.php
@@ -332,7 +332,8 @@ class Plugin extends DbTestCase {
       $this->doTestCheckPluginState(
          $initial_data,
          null,
-         $expected_data
+         $expected_data,
+         'Unable to load plugin "' . $this->test_plugin_directory . '" informations. Its state has been changed to "To be cleaned".'
       );
    }
 
@@ -388,7 +389,8 @@ class Plugin extends DbTestCase {
       $this->doTestCheckPluginState(
          $initial_data,
          $setup_informations,
-         $expected_data
+         $expected_data,
+         'Plugin "' . $this->test_plugin_directory . '" version changed. It has be deactivated as its update process has to be launched.'
       );
    }
 
@@ -420,7 +422,8 @@ class Plugin extends DbTestCase {
       $this->doTestCheckPluginState(
          $initial_data,
          $setup_informations,
-         $expected_data
+         $expected_data,
+         'Plugin "' . $this->test_plugin_directory . '" version changed. It has be deactivated as its update process has to be launched.'
       );
    }
 
@@ -481,7 +484,8 @@ class Plugin extends DbTestCase {
       $this->doTestCheckPluginState(
          $initial_data,
          $setup_informations,
-         $expected_data
+         $expected_data,
+         'Plugin "' . $this->test_plugin_directory . '" prerequisites are not matched. It has be deactivated.'
       );
    }
 
@@ -514,7 +518,8 @@ class Plugin extends DbTestCase {
       $this->doTestCheckPluginState(
          $initial_data,
          $setup_informations,
-         $expected_data
+         $expected_data,
+         'Plugin "' . $this->test_plugin_directory . '" prerequisites are not matched. It has be deactivated.'
       );
    }
 
@@ -547,7 +552,8 @@ class Plugin extends DbTestCase {
       $this->doTestCheckPluginState(
          $initial_data,
          $setup_informations,
-         $expected_data
+         $expected_data,
+         'Plugin "' . $this->test_plugin_directory . '" prerequisites are not matched. It has be deactivated.'
       );
    }
 
@@ -587,13 +593,14 @@ class Plugin extends DbTestCase {
     * the plugin directory on each time. Not doing this will prevent updating the `init` function of
     * the plugin on each test.
     *
-    * @param array|null $initial_data       Initial data in DB, null for none.
-    * @param array|null $setup_informations Informations hosted by setup file, null for none.
-    * @param array|null $expected_data      Expected data in DB, null for none.
+    * @param array|null  $initial_data       Initial data in DB, null for none.
+    * @param array|null  $setup_informations Informations hosted by setup file, null for none.
+    * @param array|null  $expected_data      Expected data in DB, null for none.
+    * @param string|null $expected_warning   Expected warning message, null for none.
     *
     * @return void
     */
-   private function doTestCheckPluginState($initial_data, $setup_informations, $expected_data) {
+   private function doTestCheckPluginState($initial_data, $setup_informations, $expected_data, $expected_warning = null) {
 
       $plugin_directory = $this->test_plugin_directory;
       $test_plugin_path = $this->getTestPluginPath();
@@ -617,7 +624,18 @@ class Plugin extends DbTestCase {
       );
 
       // Check state
-      $plugin->checkPluginState($plugin_directory);
+      if (null !== $expected_warning) {
+         $this->when(
+            function () use ($plugin, $plugin_directory) {
+               $plugin->checkPluginState($plugin_directory);
+            }
+         )->error()
+            ->withType(E_USER_WARNING)
+            ->withMessage($expected_warning)
+               ->exists();
+      } else {
+         $plugin->checkPluginState($plugin_directory);
+      }
 
       // Assert that data in DB matches expected
       if (null !== $expected_data) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5637 

If a plugin A lists another plugin B in its requirements, and if cache is empty, then the requirement check will always fail if plugin A id is lower than plugin B id. This is due to the fact that the check is made upon cached plugin list, which will not be fully populated when check is done.

I reintroduced manual call of `$plugin->init()` call to be able to control when init is done.

This will also this kind of issues https://github.com/fusioninventory/fusioninventory-for-glpi/issues/2789.