### PR TITLE
[Feature] rich text field/editor for task template content field

### DIFF
--- a/inc/tasktemplate.class.php
+++ b/inc/tasktemplate.class.php
@@ -55,11 +55,7 @@ class TaskTemplate extends CommonDropdown {
 
    function getAdditionalFields() {
 
-      return [['name'  => 'content',
-                         'label' => __('Content'),
-                         'type'  => 'textarea',
-                         'rows' => 10],
-                   ['name'  => 'taskcategories_id',
+      return [['name'  => 'taskcategories_id',
                          'label' => __('Task category'),
                          'type'  => 'dropdownValue',
                          'list'  => true],
@@ -78,6 +74,9 @@ class TaskTemplate extends CommonDropdown {
                    ['name'  => 'groups_id_tech',
                          'label' => __('Group'),
                          'type'  => 'groups_id_tech'],
+                   ['name'  => 'content',
+                         'label' => __('Content'),
+                         'type'  => 'tinymce'],
                   ];
    }
 
@@ -112,6 +111,16 @@ class TaskTemplate extends CommonDropdown {
    function displaySpecificTypeField($ID, $field = []) {
 
       switch ($field['type']) {
+         case 'tinymce' :
+            // Display empty field
+            echo "&nbsp;</td></tr>";
+            // And a new line to have a complete display
+            echo "<tr class='center'><td colspan='5'>";
+            $rand = mt_rand();
+            Html::initEditorSystem($field['name'].$rand);
+            echo "<textarea id='".$field['name']."$rand' name='".$field['name']."' rows='3'>".
+                   $this->fields[$field['name']]."</textarea>";
+            break;
          case 'state' :
             Planning::dropdownState("state", $this->fields["state"]);
             break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

As the solution template uses rich text for formatting the content, it would be great to use richt text in task templates. Because all task contents are in rich text already.
To use tables in templates you have to use rich text.

Greetings pxlcore