### PR TITLE
Remove trailing slash of url_base config; fixes #5619

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -137,6 +137,12 @@ class Config extends CommonDBTM {
          return false;
       }
 
+      // Trim automatically endig slash for url_base config as, for all existing occurences,
+      // this URL will be prepended to something that starts with a slash.
+      if (isset($input["url_base"]) && !empty($input["url_base"])) {
+         $input["url_base"] = rtrim($input["url_base"], '/');
+      }
+
       if (isset($input['allow_search_view']) && !$input['allow_search_view']) {
          // Global search need "view"
          $input['allow_search_global'] = 0;

--- a/inc/console/database/updatecommand.class.php
+++ b/inc/console/database/updatecommand.class.php
@@ -170,8 +170,8 @@ class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionComma
       } else if ($force) {
          // Replay last update script even if there is no schema change.
          // It can be used in dev environment when update script has been updated/fixed.
-         include_once(GLPI_ROOT . '/install/update_940_941.php');
-         update940to941();
+         include_once(GLPI_ROOT . '/install/update_941_942.php');
+         update941to942();
 
          $output->writeln('<info>' . __('Last migration replayed.') . '</info>');
       }

--- a/inc/define.php
+++ b/inc/define.php
@@ -31,7 +31,7 @@
 */
 
 // Current version of GLPI
-define('GLPI_VERSION', '9.4.1.1');
+define('GLPI_VERSION', '9.4.2');
 if (substr(GLPI_VERSION, -4) === '-dev') {
    //for dev version
    define('GLPI_PREVER', str_replace('-dev', '', GLPI_VERSION));
@@ -41,7 +41,7 @@ if (substr(GLPI_VERSION, -4) === '-dev') {
    );
 } else {
    //for stable version
-   define("GLPI_SCHEMA_VERSION", '9.4.1');
+   define("GLPI_SCHEMA_VERSION", '9.4.2');
 }
 define('GLPI_MIN_PHP', '5.6.0'); // Must also be changed in top of index.php
 define('GLPI_YEAR', '2019');

--- a/inc/update.class.php
+++ b/inc/update.class.php
@@ -441,6 +441,11 @@ class Update extends CommonGLPI {
          case "9.4.0":
             include_once "{$updir}update_940_941.php";
             update940to941();
+
+         case "9.4.1":
+         case "9.4.1.1":
+            include_once "{$updir}update_941_942.php";
+            update941to942();
             break;
 
          case GLPI_VERSION:

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -1342,7 +1342,7 @@ INSERT INTO `glpi_configs` VALUES ('174','core','notifications_ajax','0');
 INSERT INTO `glpi_configs` VALUES ('175','core','notifications_ajax_check_interval', '5');
 INSERT INTO `glpi_configs` VALUES ('176','core','notifications_ajax_sound', NULL);
 INSERT INTO `glpi_configs` VALUES ('177','core','notifications_ajax_icon_url', '/pics/glpi.png');
-INSERT INTO `glpi_configs` VALUES ('178','core','dbversion','9.3-dev');
+INSERT INTO `glpi_configs` VALUES ('178','core','dbversion','9.4.2');
 INSERT INTO `glpi_configs` VALUES ('179','core','smtp_max_retries','5');
 INSERT INTO `glpi_configs` VALUES ('180','core','smtp_sender', NULL);
 INSERT INTO `glpi_configs` VALUES ('181','core','from_email', NULL);

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -1342,7 +1342,7 @@ INSERT INTO `glpi_configs` VALUES ('174','core','notifications_ajax','0');
 INSERT INTO `glpi_configs` VALUES ('175','core','notifications_ajax_check_interval', '5');
 INSERT INTO `glpi_configs` VALUES ('176','core','notifications_ajax_sound', NULL);
 INSERT INTO `glpi_configs` VALUES ('177','core','notifications_ajax_icon_url', '/pics/glpi.png');
-INSERT INTO `glpi_configs` VALUES ('178','core','dbversion','9.4.2');
+INSERT INTO `glpi_configs` VALUES ('178','core','dbversion','FILLED AT INSTALL');
 INSERT INTO `glpi_configs` VALUES ('179','core','smtp_max_retries','5');
 INSERT INTO `glpi_configs` VALUES ('180','core','smtp_sender', NULL);
 INSERT INTO `glpi_configs` VALUES ('181','core','from_email', NULL);

--- a/install/update_941_942.php
+++ b/install/update_941_942.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * Update from 9.4.1 to 9.4.2
+ *
+ * @return bool for success (will die for most error)
+**/
+function update941to942() {
+   global $DB, $migration;
+
+   $updateresult     = true;
+
+   //TRANS: %s is the number of new version
+   $migration->displayTitle(sprintf(__('Update to %s'), '9.4.2'));
+   $migration->setVersion('9.4.2');
+
+   /* Remove trailing slash from 'url_base' config */
+   $migration->addPostQuery(
+      $DB->buildUpdate(
+         'glpi_configs',
+         [
+            'value' => new \QueryExpression(
+               'TRIM(TRAILING ' . $DB->quoteValue('/') . ' FROM ' . $DB->quoteName('value') . ')'
+            )
+         ],
+         [
+            'context' => 'core',
+            'name'    => 'url_base'
+         ]
+      )
+   );
+   /* /Remove trailing slash from 'url_base' config */
+
+   // ************ Keep it at the end **************
+   $migration->executeMigration();
+
+   return $updateresult;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5619 

`url_base` config is always used prepended to a path containing a leading `/`.
If admin inputs a `url_base` corresponding to a domain + an ending slash, generated URL will contains a path begining with two `/`. If we use `parse_url` method to get use only the path generated (see https://github.com/glpi-project/glpi/blob/9.4/bugfixes/inc/toolbox.class.php#L2665), we will use something like `//front/document.send.php`.
This will be interpreted by browser as an URL relative to the current scheme (`http(s):` + `//front/document.send.php`), instead of an URL relative to the current domain (`http(s)://domain` + `/front/document.send.php`).