### PR TITLE
Fix FS cache fallback namespace; fixes #5368

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -3087,7 +3087,8 @@ class Config extends CommonDBTM {
             $opt = [
                'adapter'   => 'filesystem',
                'options'   => [
-                  'cache_dir' => GLPI_CACHE_DIR . '/' . $optname
+                  'cache_dir' => GLPI_CACHE_DIR . '/' . $optname,
+                  'namespace' => $namespace,
                ],
                'plugins'   => ['serializer']
             ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5368

The filesystem cache fallback namespace was not initialized, it causes integrity checks not working on specific case.

Case with APCu:
If `apc.enabled=1` and `apc.enable_cli` is not set, even on CLI context, `function_exists('apcu_fetch')` will return true. In this exact case, requesting a page on webserver will instanciate a `apcu` cache storage with a weel defined namespace, and CLI webserver will fail to instanciate the `apcu` cache storage and will instanciate a `filesystem` cache storage with no defined namespace.
As integrity checks is made based on namespace, it will not work, so fix #5447 does not work for this specific case.
