### PR TITLE
REST API: allow usage of user_token while CAS enabled

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -1092,13 +1092,13 @@ class Auth extends CommonGLPI {
          return true;
       }
 
-      // Using CAS server
-      if (!empty($CFG_GLPI["cas_host"])) {
+      // Using API login with personnal token
+      if (!empty($_REQUEST['user_token'])) {
          return true;
       }
 
-      // Using API login with personnal token
-      if (!empty($_REQUEST['user_token'])) {
+      // Using CAS server
+      if (!empty($CFG_GLPI["cas_host"])) {
          return true;
       }
 


### PR DESCRIPTION
REST API: Allow to use user_token when CAS is enabled, fixes #1849


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1849
