### PR TITLE
Fix escaping of optgroups in dropdowns; fixes #5646

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -938,11 +938,13 @@ var templateResult = function(result) {
       var text = result.text;
       if (text.indexOf('>') !== -1 || text.indexOf('<') !== -1) {
          // escape text, if it contains chevrons (can already be escaped prior to this point :/)
-         text = jQuery.fn.select2.defaults.defaults.escapeMarkup(result.text);
+         text = jQuery.fn.select2.defaults.defaults.escapeMarkup(text);
       };
 
       if (!result.id) {
-         return text;
+         // If result has no id, then it is used as an optgroup and is not used for matches
+         _elt.html(text);
+         return _elt;
       }
 
       var _term = query.term || '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5646

Here is the explaination: if `templateResult` returns a string, `select2` component escape it, if it returns a html element, it is just used as it is.
So as we returned strings for optgroup, a double escaping was made. Returning the built html element fixes this.

Introduced in 9.4.1 by #5468.