### PR TITLE
Fix undefined sendprivate in notification set by collector; fixes #5650

### DIFF
--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -809,7 +809,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
 
                //Assign to a supplier
                case Notification::SUPPLIER :
-                  $this->addSupplier($this->options['sendprivate']);
+                  $this->addSupplier($this->isPrivate());
                   break;
 
                case Notification::REQUESTER_GROUP :


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5650 

Currently, the `sendprivate` option is only defined when the notification is "add/update/delete followup" or  "add/update/delete task".

If suppliers is in notification targets for "ticket update" notification and someone updates a ticket, this option is not defined and following notice is triggered: `PHP Notice: Undefined index: sendprivate in .../inc/notificationtargetcommonitilobject.class.php at line 812`.

As this filter is only made for followups and tasks, this has no functionnal impact.