### PR TITLE
Use zend filesystem cache as cache footprint storage

### DIFF
--- a/inc/cache/simplecache.class.php
+++ b/inc/cache/simplecache.class.php
@@ -75,7 +75,7 @@ class SimpleCache extends SimpleCacheDecorator {
 
       $this->check_footprints = $check_footprints;
       if ($this->check_footprints) {
-         $footprints_dir = GLPI_CACHE_DIR . '/cache_footprints';
+         $footprints_dir = $cache_dir . '/cache_footprints';
          if (!is_dir($footprints_dir) && !mkdir($footprints_dir)) {
             trigger_error(
                sprintf('Cannot write into cache footprint directory "%s".', $footprints_dir),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

See #5645.

The footprint storage handling is handmade and may be not so stable as excpected. Using the Zend cache filesystem storage may imprive stability, and also persormances, as I am pretty sure that Zend components are more optimized than my handmade system.