### PR TITLE
Permit insert title and link for top level menu issue #5664

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1437,6 +1437,12 @@ class Html {
                   if ($data = $type::getMenuContent()) {
                      // Multi menu entries management
                      if (isset($data['is_multi_entries']) && $data['is_multi_entries']) {
+                        if (isset($data['title']) && $data['title']) {
+                           $menu[$category]['title'] = $data['title'];
+                        }
+                        if (isset($data['default']) && $data['default']) {
+                           $menu[$category]['default'] = $data['default'];
+                        }
                         if (!isset($menu[$category]['content'])) {
                            $menu[$category]['content'] = [];
                         }
@@ -1448,7 +1454,7 @@ class Html {
                }
             }
             // Define default link :
-            if (isset($menu[$category]['content']) && count($menu[$category]['content'])) {
+            if (! isset($menu[$category]['default'] && isset($menu[$category]['content']) && count($menu[$category]['content'])) {
                foreach ($menu[$category]['content'] as $val) {
                   if (isset($val['page'])) {
                      $menu[$category]['default'] = $val['page'];

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1429,10 +1429,10 @@ class Html {
                   }
                }
             }
-            // Setup menu is always last
-            $setup = $menu['config'];
-            unset($menu['config']);
-            $menu['config'] = $setup;
+            // Move Setup menu ('config') to the last position in $menu (always last menu),
+            // in case some plugin inserted a new top level menu
+            $categories = array_keys($menu);
+            $menu += array_splice($menu, array_search('config', $categories, true), 1);
          }
 
          foreach ($menu as $category => $datas) {
@@ -1441,18 +1441,18 @@ class Html {
                   if ($data = $type::getMenuContent()) {
                      // Multi menu entries management
                      if (isset($data['is_multi_entries']) && $data['is_multi_entries']) {
-                        if (isset($data['title']) && $data['title']) {
-                           $menu[$category]['title'] = $data['title'];
-                        }
-                        if (isset($data['default']) && $data['default']) {
-                           $menu[$category]['default'] = $data['default'];
-                        }
                         if (!isset($menu[$category]['content'])) {
                            $menu[$category]['content'] = [];
                         }
                         $menu[$category]['content'] += $data;
                      } else {
                         $menu[$category]['content'][strtolower($type)] = $data;
+                     }
+                     if (!isset($menu[$category]['title']) && isset($data['title'])) {
+                        $menu[$category]['title'] = $data['title'];
+                     }
+                     if (!isset($menu[$category]['default']) && isset($data['default'])) {
+                        $menu[$category]['default'] = $data['default'];
                      }
                   }
                }

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1429,6 +1429,10 @@ class Html {
                   }
                }
             }
+            // Setup menu is always last
+            $setup = $menu['config'];
+            unset($menu['config']);
+            $menu['config'] = $setup;
          }
 
          foreach ($menu as $category => $datas) {

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1454,7 +1454,7 @@ class Html {
                }
             }
             // Define default link :
-            if (! isset($menu[$category]['default'] && isset($menu[$category]['content']) && count($menu[$category]['content'])) {
+            if (! isset($menu[$category]['default']) && isset($menu[$category]['content']) && count($menu[$category]['content'])) {
                foreach ($menu[$category]['content'] as $val) {
                   if (isset($val['page'])) {
                      $menu[$category]['default'] = $val['page'];


### PR DESCRIPTION
As discussed, in issue #5664 , @cedric-anne . This solved the lacking title property in a plugin top-level menu.