### PR TITLE
Revert "Make errors displayed in cron if called from CLI"

### DIFF
--- a/front/cron.php
+++ b/front/cron.php
@@ -44,11 +44,6 @@ if (!is_writable(GLPI_LOCK_DIR)) {
    exit (1);
 }
 
-if (isCommandLine()) {
-   // Force debug mode in command line mode to output errors
-   Toolbox::setDebugMode(Session::DEBUG_MODE);
-}
-
 if (!isCommandLine()) {
    //The advantage of using background-image is that cron is called in a separate
    //request and thus does not slow down output of the main page as it would if called


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5673 

There is a `--debug` option that can be used when launching scripts from CLI, I didn't know about that.