### PR TITLE
Ticket merge enhancements for 9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The present file will list all changes made to the project; according to the
 #### Added
 
 - new display hook `timeline_actions` to add new buttons to timeline forms
+- Ability to copy document links while merging tickets
 
 #### Deprecated
 

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -375,7 +375,9 @@ class ITILFollowup  extends CommonDBChild {
       $itemtype = $input['itemtype'];
       $input['timeline_position'] = $itemtype::getTimelinePosition($input["items_id"], $this->getType(), $input["users_id"]);
 
-      $input["date"] = $_SESSION["glpi_currenttime"];
+      if (!isset($input['date'])) {
+         $input["date"] = $_SESSION["glpi_currenttime"];
+      }
       return $input;
    }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2698,20 +2698,25 @@ class Ticket extends CommonITILObject {
                'used'         => $ma->items['Ticket'],
                'displaywith'  => ['id']
             ];
-            echo "<div><p>";
-            echo __('Ticket')."&nbsp;";
+            echo "<table class='center-h'><tr>";
+            echo "<td>".__('Ticket')."</td><td colspan='3'>";
             Ticket::dropdown($mergeparam);
-            echo "</p><p>".__('Merge Followups')."&nbsp;";
+            echo "</td></tr><tr><td>".__('Merge Followups')."</td><td>";
             Html::showCheckbox([
                'name'    => 'with_followups',
                'checked' => false
             ]);
-            echo "</p><p>";
+            echo "</td><td>".__('Merge Documents')."</td><td>";
+            Html::showCheckbox([
+               'name'    => 'with_documents',
+               'checked' => false
+            ]);
+            echo "</td></tr><tr><td colspan='4'>";
             echo Html::submit(_x('button', 'Merge'), [
                'name'      => 'merge',
                'confirm'   => __('Confirm the merge? This ticket will be deleted!')
             ]);
-            echo "</p></div>";
+            echo "</td></tr></table>";
             return true;
       }
       return parent::showMassiveActionsSubForm($ma);
@@ -2731,6 +2736,7 @@ class Ticket extends CommonITILObject {
                try {
                   $DB->beginTransaction();
                   $fup = new ITILFollowup();
+                  $document_item = new Document_Item();
                   $input2 = [];
 
                   foreach ($input as $key => $val) {
@@ -2749,6 +2755,8 @@ class Ticket extends CommonITILObject {
                         'content'         => $item->fields['name']."\n\n".$item->fields['content'],
                         'users_id'        => $item->fields['users_id_recipient'],
                         'date_creation'   => $item->fields['date_creation'],
+                        'date_mod'        => $item->fields['date_mod'],
+                        'date'            => $item->fields['date_creation'],
                         'sourceitems_id'  => $item->getID()
                      ];
 
@@ -2766,11 +2774,31 @@ class Ticket extends CommonITILObject {
                         foreach ($tomerge as $key => $fup2) {
                            $fup2['items_id'] = $input['_mergeticket'];
                            $fup2['sourceitems_id'] = $item->getID();
-                           $fup2['date_creation'] = $item->fields['date_creation'];
-                           $fup2['date_mod'] = $item->fields['date_mod'];
                            unset($fup2['id']);
                            if (!$fup->add($fup2)) {
                               //Cannot add followup. Abort/fail the merge
+                              throw new \RuntimeException(ERROR_ON_ACTION, MassiveAction::ACTION_KO);
+                           }
+                        }
+                     }
+
+                     if (isset($input['with_documents'])) {
+                        // Create new links for any Documents
+                        $tomerge = $document_item->find([
+                           'items_id' => $id,
+                           'itemtype' => 'Ticket'
+                        ]);
+
+                        foreach ($tomerge as $key => $document_item2) {
+                           $document_item->deleteByCriteria([
+                              'documents_id' => $document_item2['documents_id'],
+                              'items_id' => $input['_mergeticket'],
+                              'itemtype' => 'Ticket'
+                           ]);
+                           $document_item2['items_id'] = $input['_mergeticket'];
+                           unset($document_item2['id']);
+                           if (!$document_item->add($document_item2)) {
+                              //Cannot add document. Abort/fail the merge
                               throw new \RuntimeException(ERROR_ON_ACTION, MassiveAction::ACTION_KO);
                            }
                         }
@@ -2781,13 +2809,23 @@ class Ticket extends CommonITILObject {
                      $linkparams = [
                         'link'         => Ticket_Ticket::SON_OF,
                         'tickets_id_1' => $id,
-                        'tickets_id_2' => $input['_mergeticket']
+                        'tickets_id_2' => $input['_mergeticket'],
+                        '_disablenotif' => true
                      ];
 
+                     // Remove existing links
                      $tt->deleteByCriteria([
-                        'tickets_id_1' => $input['_mergeticket'],
-                        'tickets_id_2' => $id,
-                        'link' => Ticket_Ticket::SON_OF]);
+                        'OR' => [
+                           'AND' => [
+                              'tickets_id_1' => $input['_mergeticket'],
+                              'tickets_id_2' => $id
+                           ],
+                           'AND' => [
+                              'tickets_id_2' => $input['_mergeticket'],
+                              'tickets_id_1' => $id
+                           ]
+                        ]
+                     ]);
 
                      if (!$tt->add($linkparams)) {
                         //Cannot link tickets. Abort/fail the merge
@@ -2795,15 +2833,20 @@ class Ticket extends CommonITILObject {
                      }
 
                      //Close then delete this ticket
-                     if (!$item->update(['id' => $id, 'status' => CommonITILObject::CLOSED]) ||
-                        !$item->delete(['id' => $id])) {
+                     $item_update = $item->update([
+                        'id' => $id,
+                        'status' => CommonITILObject::CLOSED,
+                        '_disablenotif' => true
+                     ]);
+                     if (!$item_update ||
+                        !$item->delete(['id' => $id, '_disablenotif' => true])) {
                         throw new \RuntimeException(ERROR_ON_ACTION, MassiveAction::ACTION_KO);
                      }
 
                      $DB->commit();
                      $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
-                     Event::log($input['_mergeticket'], "ticket", 4, "tracking",
-                        sprintf(__('%s merges ticket %s into %s'), $_SESSION["glpiname"],
+                     Event::log($input['_mergeticket'], 'ticket', 4, 'tracking',
+                        sprintf(__('%s merges ticket %s into %s'), $_SESSION['glpiname'],
                         $id, $input['_mergeticket']));
                   } else {
                      throw new \RuntimeException(ERROR_RIGHT, MassiveAction::ACTION_NORIGHT);
@@ -2814,6 +2857,7 @@ class Ticket extends CommonITILObject {
                   $ma->addMessage($item->getErrorMessage($e->getMessage()));
                }
             }
+
             return;
       }
       parent::processMassiveActionsForOneItemtype($ma, $item, $ids);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5542

A few fixes and enhancements that can be made on 9.4. Other changes are being done on master only because of DB changes and a new function definition.

Change: Ability to copy document links when merging
Fix: Preserve timeline order after merge
Fix: Suppress delete ticket notification