### PR TITLE
Revert plugin autoinit from commit 5b9affbc; fixes #5637

### DIFF
--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -383,6 +383,8 @@ class Application extends BaseApplication {
       }
 
       $plugin = new Plugin();
+      $plugin->init();
+
       $plugins_list = $plugin->getPlugins();
       if (count($plugins_list) > 0) {
          foreach ($plugins_list as $name) {

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -96,6 +96,7 @@ if (!isset($PLUGINS_INCLUDED)) {
    $PLUGINS_INCLUDED = 1;
    $LOADED_PLUGINS   = [];
    $plugin           = new Plugin();
+   $plugin->init();
 
    $plugins_list = $plugin->getPlugins();
    if (count($plugins_list)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5637 

Part of #5611 .

The purpose of #5447 was to check on each request that active plugins can stay active, as with intoruction of cache usage in 9.4.0 this check was done only on initialization of cache or on plugins page visit.

The way plugins were "auto-initialized" was a problem in following cases. This PR only revert this part, and keep checks on active plugins on each request.

1) Plugin A list plugin B as requirement
In this case, following path is used while calling `getPlugins()`:  `init()` -> `checkStates()` -> `checkPluginState` -> `checkVersions()` -> `checkGlpiPlugins()` -> `isInstalled()` -> `isActivated()` -> `getPlugins()` -> ...
This makes a loop and fails.

2) Plugin check if it is itself activated on its `check_prerequisites` function (FusionInventory case)
In this case, following path is used while calling `getPlugins()`:  `init()` -> `checkStates()` -> `checkPluginState` -> `plugin_x_check_prerequisites()` -> `isActivated()` -> `getPlugins()` -> ...
This makes also a loop and fails.