### PR TITLE
Prevent useless set to "tobecleaned" of a plugin already in this state

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -326,6 +326,11 @@ class Plugin extends CommonDBTM {
          }
 
          // Plugin is known but we are unable to load informations, it should be cleaned
+         if ($plugin->fields['state'] == self::TOBECLEANED) {
+            // unless its state is already self::TOBECLEANED
+            return;
+         }
+
          trigger_error(
             sprintf(
                'Unable to load plugin "%s" informations. Its state has been changed to "To be cleaned".',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Part of #5611 .

I noticed that if a plugin was already "to be cleaned", it was updated on each global state check (on plugins page display).
This has only a small impact on performances and only while displaying the plugins page.