### PR TITLE
Fix entity update propagation for CommonDBRelation items

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -1506,14 +1506,17 @@ class CommonDBTM extends CommonGLPI {
                'FROM'   => $item->getTable()
             ];
 
+            $OR = [];
             if ($item->isField('itemtype')) {
-               $query['WHERE'] = [
+               $OR[] = [
                   'itemtype'  => $this->getType(),
                   'items_id'  => $this->getID()
                ];
-            } else {
-               $query['WHERE'] = [$this->getForeignKeyField() => $this->getID()];
             }
+            if ($item->isField($this->getForeignKeyField())) {
+               $OR[] = [$this->getForeignKeyField() => $this->getID()];
+            }
+            $query['WHERE'][] = ['OR' => $OR];
 
             $input = ['entities_id' => $this->getEntityID()];
             if ($this->maybeRecursive()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When transfering an element linked to a document from an entity to another, the document is also moved to the new entity.
The `forwardEntityInformations` function will in this case update only elements matching ``` `itemtype` = 'Document' AND `items_id` = 'X' ```. With this change, it will also update elements matching ``` `documents_id` = 'X' ```.

To reproduce the problem:
 - create a change,
 - attach a document,
 - transfer the change to another entity.
-> The `Document_Item` is linked to the wrong entity.