### PR TITLE
Fix missing filepath on transfered documents

### DIFF
--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -194,8 +194,10 @@ class Document extends CommonDBTM {
    function prepareInputForAdd($input) {
       global $CFG_GLPI, $DB;
 
-      // security (don't accept filename from $_POST)
-      unset($input['filename']);
+      // security (don't accept filename from $_REQUEST)
+      if (array_key_exists('filename', $_REQUEST)) {
+         unset($input['filename']);
+      }
 
       if ($uid = Session::getLoginUserID()) {
          $input["users_id"] = Session::getLoginUserID();
@@ -228,6 +230,9 @@ class Document extends CommonDBTM {
       } else if (isset($input["upload_file"]) && !empty($input["upload_file"])) {
          // Move doc from upload dir
          $upload_ok = $this->moveUploadedDocument($input, $input["upload_file"]);
+      } else if (isset($input['filepath']) && file_exists(GLPI_DOC_DIR.'/'.$input['filepath'])) {
+         // Document is created using an existing document file
+         $upload_ok = true;
       }
 
       // Tag
@@ -320,8 +325,10 @@ class Document extends CommonDBTM {
    **/
    function prepareInputForUpdate($input) {
 
-      // security (don't accept filename from $_POST)
-      unset($input['filename']);
+      // security (don't accept filename from $_REQUEST)
+      if (array_key_exists('filename', $_REQUEST)) {
+         unset($input['filename']);
+      }
 
       if (isset($input['current_filepath'])) {
          if (isset($input["_filename"]) && !empty($input["_filename"]) == 1) {

--- a/tests/functionnal/Document.php
+++ b/tests/functionnal/Document.php
@@ -101,20 +101,21 @@ class Document extends DbTestCase {
 
    public function testPrepareInputForAdd() {
       $input = [
-         'filename'   => 'A name'
+         'filename'   => 'A_name.pdf'
       ];
 
       $doc = $this->newTestedInstance;
-
       $this->array($this->testedInstance->prepareInputForAdd($input))
-         ->hasSize(1)
-        ->hasKey('tag');
+         ->hasSize(3)
+         ->hasKeys(['tag', 'filename', 'name'])
+         ->variable['filename']->isEqualTo('A_name.pdf')
+         ->variable['name']->isEqualTo('A_name.pdf');
 
       $this->login();
       $uid = getItemByTypeName('User', TU_USER, true);
       $this->array($this->testedInstance->prepareInputForAdd($input))
-         ->hasSize(2)
-         ->hasKeys(['users_id', 'tag'])
+         ->hasSize(4)
+         ->hasKeys(['users_id', 'tag', 'filename', 'name'])
          ->variable['users_id']->isEqualTo($uid);
 
       $item = new \Computer();
@@ -135,8 +136,8 @@ class Document extends DbTestCase {
       $input['upload_file'] = 'filename.ext';
 
       $this->array($mdoc->prepareInputForAdd($input))
-         ->hasSize(5)
-         ->hasKeys(['users_id', 'tag', 'itemtype', 'items_id', 'name'])
+         ->hasSize(6)
+         ->hasKeys(['users_id', 'tag', 'itemtype', 'items_id', 'filename', 'name'])
          ->variable['users_id']->isEqualTo($uid)
          ->string['itemtype']->isIdenticalTo('Computer')
          ->variable['items_id']->isEqualTo($cid)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Internal id: 16618

During transfer from an entity to another, filename of documents is erased.

This PR prevent the removal of `$input['filename']` if it was not present in `$_REQUEST` and also consider that upload of file is ok if filepath is already known and matches an existing file.