### PR TITLE
Fix bad display of timeline when item contains ending </div>

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6595,7 +6595,7 @@ abstract class CommonITILObject extends CommonDBTM {
             echo "</p>";
 
             echo "<div class='rich_text_container'>";
-            echo html_entity_decode($content);
+            echo Html::setRichTextContent('', $content, '', true);
             echo "</div>";
 
             if (!empty($long_text)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Internal id: 16405

If a followup contains an ending `</div>` inside its contents, it will break display of the timeline.

`Html::setRichTextContent()` method is used to display the ticket description, so now all elements on timeline will be displayed using same method.

To reproduce: 
 - create a ticket
 - add a followup containing `Test this: </div>`

![image](https://user-images.githubusercontent.com/33253653/55227042-ba4edf00-5216-11e9-804e-cfe8b39ba0da.png)

