### PR TITLE
Display timezone config only if available and add warnings

### DIFF
--- a/inc/central.class.php
+++ b/inc/central.class.php
@@ -181,9 +181,7 @@ class Central extends CommonGLPI {
                count($myisam_tables)
             );
          }
-         if (!$DB->areTimezonesActives()) {
-            $warnings[] = __('Timezone required data is not accessible or has not been initialized. Please check GLPI installation guide.');
-         } else {
+         if ($DB->areTimezonesAvailable()) {
             $not_tstamp = $DB->notTzMigrated();
             if ($not_tstamp > 0) {
                 $warnings[] = sprintf(

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1201,16 +1201,24 @@ class Config extends CommonDBTM {
       echo "</td>";
       echo "<td><label for='dropdown_timezone$rand'>" . __('Timezone') . "</label></td>";
       echo "<td>";
-      $timezones = $DB->getTimezones();
-      Dropdown::showFromArray(
-         'timezone',
-         $timezones, [
-            'value'                 => $data["timezone"],
-            'display_emptychoice'   => true,
-            'emptylabel'            => __('Use server configuration')
-         ]
-      );
-      echo "</td></tr>";
+      $tz_warning = '';
+      $tz_available = $DB->areTimezonesAvailable($tz_warning);
+      if ($tz_available) {
+         $timezones = $DB->getTimezones();
+         Dropdown::showFromArray(
+            'timezone',
+            $timezones, [
+               'value'                 => $data["timezone"],
+               'display_emptychoice'   => true,
+               'emptylabel'            => __('Use server configuration')
+            ]
+         );
+      } else {
+         echo "<img src=\"{$CFG_GLPI['root_doc']}/pics/warning_min.png\">";
+         echo $tz_warning;
+      }
+      echo "</td>";
+      echo "</tr>";
 
       if ($oncentral) {
          echo "<tr class='tab_bg_1'><th colspan='4'>".__('Assistance')."</th></tr>";
@@ -1855,6 +1863,15 @@ class Config extends CommonDBTM {
       self::displayCheckExtensions(true);
 
       self::displayCheckDbEngine(true);
+
+      $tz_warning = '';
+      $tz_available = $DB->areTimezonesAvailable($tz_warning);
+      if (!$tz_available) {
+         echo "<img src=\"{$CFG_GLPI['root_doc']}/pics/warning_min.png\"> " . $tz_warning . "\n";
+      } else {
+         echo "<img src=\"{$CFG_GLPI['root_doc']}/pics/ok_min.png\">";
+         echo __('Timezones seems not loaded in database') . "\n";
+      }
 
       self::checkWriteAccessToDirs(true);
       toolbox::checkSELinux(true);

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -1054,6 +1054,21 @@ class Toolbox {
             $error = $suberr;
          }
          echo "</tr>";
+
+         //timezone data check
+         echo "<tr class='tab_bg_1'><td class='b left'>" . __('Testing DB timezone data') . "</td>";
+         global $DB;
+         $tz_warning = '';
+         $tz_available = $DB->areTimezonesAvailable($tz_warning);
+         if (!$tz_available) {
+            echo "<td><img src=\"{$CFG_GLPI['root_doc']}/pics/warning_min.png\">" . $tz_warning . "</td>";
+         } else {
+            echo "<td>";
+            echo "<img src=\"{$CFG_GLPI['root_doc']}/pics/ok_min.png\">";
+            echo __('Timezones seems not loaded in database');
+            echo "</td>";
+         }
+         echo "</tr>";
       }
 
       // memory test
@@ -2369,7 +2384,7 @@ class Toolbox {
     * @return void
    **/
    static function createSchema($lang = 'en_GB') {
-      global $CFG_GLPI, $DB;
+      global $DB;
 
       include_once (GLPI_CONFIG_DIR . "/config_db.php");
 
@@ -2381,9 +2396,10 @@ class Toolbox {
          Config::setConfigurationValues(
             'core',
             [
-               'language'  => $lang,
-               'version'   => GLPI_VERSION,
-               'dbversion' => GLPI_SCHEMA_VERSION
+               'language'      => $lang,
+               'version'       => GLPI_VERSION,
+               'dbversion'     => GLPI_SCHEMA_VERSION,
+               'use_timezones' => $DB->areTimezonesAvailable()
             ]
          );
          $DB->updateOrDie(

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -2098,17 +2098,27 @@ class User extends CommonDBTM {
          echo "<tr class='tab_bg_1'><td></td><td></td></tr>";
       }
 
-      echo "<tr class='tab_bg_1'>";
-      echo "<td><label for='timezone'>".__('Time zone')."</label></td><td>";
-      $timezones = $DB->getTimezones();
-      Dropdown::showFromArray(
-         'timezone',
-         $timezones, [
-            'value'                 => $this->fields["timezone"],
-            'display_emptychoice'   => true
-         ]
-      );
-      echo "</td></tr>";
+      $tz_warning = '';
+      $tz_available = $DB->areTimezonesAvailable($tz_warning);
+      if ($tz_available || Session::haveRight("config", READ)) {
+         echo "<tr class='tab_bg_1'>";
+         echo "<td><label for='timezone'>".__('Time zone')."</label></td><td>";
+         if ($tz_available) {
+            $timezones = $DB->getTimezones();
+            Dropdown::showFromArray(
+               'timezone',
+               $timezones, [
+                  'value'                 => $this->fields["timezone"],
+                  'display_emptychoice'   => true
+               ]
+            );
+         } else if (Session::haveRight("config", READ)) {
+            // Display a warning but only if user is more or less an admin
+            echo "<img src=\"{$CFG_GLPI['root_doc']}/pics/warning_min.png\">";
+            echo $tz_warning;
+         }
+         echo "</td></tr>";
+      }
 
       echo "<tr class='tab_bg_1'>";
       if (!GLPI_DEMO_MODE) {
@@ -2569,17 +2579,27 @@ class User extends CommonDBTM {
             echo "<tr class='tab_bg_1'><td colspan='2'></td></tr>";
          }
 
-         echo "<tr class='tab_bg_1'>";
-         echo "<td><label for='timezone'>".__('Time zone')."</label></td><td>";
-         $timezones = $DB->getTimezones();
-         Dropdown::showFromArray(
-            'timezone',
-            $timezones, [
-               'value'                 => $this->fields["timezone"],
-               'display_emptychoice'   => true
-            ]
-         );
-         echo "</td></tr>";
+         $tz_warning = '';
+         $tz_available = $DB->areTimezonesAvailable($tz_warning);
+         if ($tz_available || Session::haveRight("config", READ)) {
+            echo "<tr class='tab_bg_1'>";
+            echo "<td><label for='timezone'>".__('Time zone')."</label></td><td>";
+            if ($tz_available) {
+               $timezones = $DB->getTimezones();
+               Dropdown::showFromArray(
+                  'timezone',
+                  $timezones, [
+                     'value'                 => $this->fields["timezone"],
+                     'display_emptychoice'   => true
+                  ]
+               );
+            } else if (Session::haveRight("config", READ)) {
+               // Display a warning but only if user is more or less an admin
+               echo "<img src=\"{$CFG_GLPI['root_doc']}/pics/warning_min.png\">";
+               echo $tz_warning;
+            }
+            echo "</td></tr>";
+         }
 
          $phonerand = mt_rand();
          echo "<tr class='tab_bg_1'><td><label for='textfield_phone$phonerand'>" .  __('Phone') . "</label></td><td>";

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -855,8 +855,8 @@ class CommonDBTM extends DbTestCase {
    public function testTimezones() {
       global $DB;
 
-      //check if timezones are active
-      $this->boolean($DB->areTimezonesActives())->isTrue();
+      //check if timezones are available
+      $this->boolean($DB->areTimezonesAvailable())->isTrue();
       $this->array($DB->getTimezones())->size->isGreaterThan(0);
 
       //login with default TZ


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It seems possible that in some cases, GLPI sysadmin will not be able to give access to `mysql.time_zone_name` table (e.g. on shared hosting).

To handle this, I added a configuration value that will defines if timezones have to be used or not, and that will be automatically set during install/update process. I added ability to enable/disable timezones usage in system config page with warning that will inform about the reason why timezones usage is not possible.

I also removed display of used timezone configuration when timezones usage is not enabled.