### PR TITLE
Fix warning on missing images

### DIFF
--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -1548,6 +1548,9 @@ class Document extends CommonDBTM {
     * @return boolean
     */
    public static function isImage($file) {
+      if (!file_exists($file)) {
+         return false;
+      }
       if (extension_loaded('exif')) {
          $etype = exif_imagetype($file);
          return in_array($etype, [IMAGETYPE_JPEG, IMAGETYPE_GIF, IMAGETYPE_PNG, IMAGETYPE_BMP]);

--- a/tests/functionnal/Document.php
+++ b/tests/functionnal/Document.php
@@ -220,7 +220,8 @@ class Document extends DbTestCase {
          [__DIR__ . "/../../pics/add_dropdown.png", true],
          [__DIR__ . "/../../pics/corners.gif", true],
          [__DIR__ . "/../../pics/PICS-AUTHORS.txt", false],
-         [__DIR__ . "/../notanimage.jpg", false]
+         [__DIR__ . "/../notanimage.jpg", false],
+         [__DIR__ . "/../notafile.jpg", false]
       ];
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Prevent a warning to be trigerred if an image still linked in DB has been dropped from filesystem.