### PR TITLE
Put back ordering feature on global search; fixes #5717

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3140,10 +3140,6 @@ JAVASCRIPT;
    static function addOrderBy($itemtype, $ID, $order) {
       global $CFG_GLPI;
 
-      if ($itemtype == 'AllAssets') {
-         return '';
-      }
-
       // Security test for order
       if ($order != "ASC") {
          $order = "DESC";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5717 

Global search ordering was disabled in 765efb64584b7956a8fc7fae9d802b219b3edbf7. Guess something has been fixed as I cannot repoduce the error.