### PR TITLE
Prevent tools from being executed from webserver

### DIFF
--- a/tools/cachebench.php
+++ b/tools/cachebench.php
@@ -29,6 +29,12 @@
  * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
  * ---------------------------------------------------------------------
  */
+
+if (PHP_SAPI != 'cli') {
+   echo "This script must be run from command line";
+   exit();
+}
+
 define('PER_LEVEL', 8);
 define('COUNT', 1024);
 

--- a/tools/cleanhistory.php
+++ b/tools/cleanhistory.php
@@ -34,6 +34,11 @@
  *Purge history with some criteria
  */
 
+if (PHP_SAPI != 'cli') {
+   echo "This script must be run from command line";
+   exit();
+}
+
 ini_set("memory_limit", "-1");
 ini_set("max_execution_time", "0");
 

--- a/tools/convert_search_options.php
+++ b/tools/convert_search_options.php
@@ -30,6 +30,11 @@
  * ---------------------------------------------------------------------
  */
 
+if (PHP_SAPI != 'cli') {
+   echo "This script must be run from command line";
+   exit();
+}
+
 /**
  * An utility script to convert old getSearchOptions array to new ones,
  * see https://github.com/glpi-project/glpi/issues/1396

--- a/tools/fk_generate.php
+++ b/tools/fk_generate.php
@@ -30,6 +30,11 @@
  * ---------------------------------------------------------------------
  */
 
+if (PHP_SAPI != 'cli') {
+   echo "This script must be run from command line";
+   exit();
+}
+
 include ('../inc/includes.php');
 
 $DB->query("SET FOREIGN_KEY_CHECKS = '0';");

--- a/tools/generate_bigdump.php
+++ b/tools/generate_bigdump.php
@@ -30,6 +30,11 @@
  * ---------------------------------------------------------------------
  */
 
+if (PHP_SAPI != 'cli') {
+   echo "This script must be run from command line";
+   exit();
+}
+
 // This script generate and populate a complete glpi DB
 // A good way to test GLPI with a lot of data
 
@@ -37,11 +42,6 @@ define('DO_NOT_CHECK_HTTP_REFERER', 1);
 
 include (__DIR__ . '/../inc/includes.php');
 include (__DIR__ . '/generate_bigdump.function.php');
-
-if (PHP_SAPI != 'cli') {
-   echo "This script must be run from command line";
-   exit();
-}
 
 if (in_array('--help', $_SERVER['argv'])) {
    die("usage: ".$_SERVER['argv'][0]."  [ --user=glpi ] [ --pass=glpi ]\n");

--- a/tools/testmail.php
+++ b/tools/testmail.php
@@ -30,6 +30,11 @@
  * ---------------------------------------------------------------------
  */
 
+if (PHP_SAPI != 'cli') {
+   echo "This script must be run from command line";
+   exit();
+}
+
 if (isset($_SERVER['argc'])) {
    for ($i=1; $i<$_SERVER['argc']; $i++) {
       $it           = explode("=", $_SERVER['argv'][$i], 2);

--- a/tools/update_registered_ids.php
+++ b/tools/update_registered_ids.php
@@ -30,6 +30,11 @@
  * ---------------------------------------------------------------------
  */
 
+if (PHP_SAPI != 'cli') {
+   echo "This script must be run from command line";
+   exit();
+}
+
 /**
  * @since 0.85
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This will prevent execution of CLI tools when webserver is exposed to crawlers and expose files from tools directory.