### PR TITLE
Remove forced renewal of rememberme token

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -869,7 +869,7 @@ class Auth extends CommonGLPI {
       }
 
       if ($this->auth_succeded && $CFG_GLPI['login_remember_time'] > 0 && $remember_me) {
-         $token = $this->user->getAuthToken('cookie_token', true);
+         $token = $this->user->getAuthToken('cookie_token');
 
          if ($token) {
             //Cookie name (Allow multiple GLPI)

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -4767,11 +4767,10 @@ class User extends CommonDBTM {
     * @since 9.4
     *
     * @param string $field the field storing the token
-    * @param boolean $force_new force generation of a new token
     *
     * @return string|false token or false in case of error
     */
-   public function getAuthToken($field = 'personal_token', $force_new = false) {
+   public function getAuthToken($field = 'personal_token') {
       global $CFG_GLPI;
 
       if ($this->isNewItem()) {
@@ -4790,7 +4789,7 @@ class User extends CommonDBTM {
       }
 
       // token exists, is not oudated, and we may use it
-      if (!empty($this->fields[$field]) && !$force_new && !$outdated) {
+      if (!empty($this->fields[$field]) && !$outdated) {
          return $this->fields[$field];
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | maybe #5751

If user use multiple machines or browsers, login on a machine A will make rememberme cookie in machine B invalid.