### PR TITLE
Fix ticket cost in project

### DIFF
--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -365,14 +365,14 @@ class ProjectTask extends CommonDBChild {
          'INNER JOIN'   => [
             'glpi_projecttasks'  => [
                'ON' => [
-                  'glpi_projecttasks_tickets'   => 'projects_id',
+                  'glpi_projecttasks_tickets'   => 'projecttasks_id',
                   'glpi_projecttasks'           => 'id'
                ]
             ]
          ],
          'FIELDS' =>  'tickets_id',
          'WHERE'        => [
-            'glpi_projecttasks_tickets.projects_id'   => $ID
+            'glpi_projecttasks.projects_id'   => $ID
          ]
       ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix following error:
```
glpisqllog.ERROR: DBmysql::query() in /var/www/glpi/inc/dbmysql.class.php line 210
  *** MySQL query error:
  SQL: SELECT `tickets_id` FROM `glpi_projecttasks_tickets` INNER JOIN `glpi_projecttasks` ON (`glpi_projecttasks_tickets`.`projects_id` = `glpi_projecttasks`.`id`) WHERE `glpi_projecttasks_tickets`.`projects_id` = '1'
  Error: Unknown column 'glpi_projecttasks_tickets.projects_id' in 'where clause'
  Backtrace :
  inc/dbmysqliterator.class.php:95                   
  inc/dbmysql.class.php:766                          DBmysqlIterator->execute()
  inc/projecttask.class.php:375                      DBmysql->request()
  inc/commonitilcost.class.php:490                   ProjectTask::getAllTicketsForProject()
  inc/projectcost.class.php:428                      CommonITILCost::showForObject()
  inc/projectcost.class.php:108                      ProjectCost::showForProject()
  inc/commonglpi.class.php:485                       ProjectCost::displayTabContentForItem()
  inc/commonglpi.class.php:452                       CommonGLPI::displayStandardTab()
  ajax/common.tabs.php:92                            CommonGLPI::displayStandardTab()
  {"user":"2@15a2f29a53ff"} 
```