### PR TITLE
Fix KB tree count; fixes #5616

### DIFF
--- a/inc/knowbase.class.php
+++ b/inc/knowbase.class.php
@@ -253,9 +253,9 @@ JAVASCRIPT;
       $items_subquery = new QuerySubQuery(
          array_merge_recursive(
             [
-               'COUNT' => 'cpt',
-               'FROM'  => KnowbaseItem::getTable(),
-               'WHERE' => [
+               'SELECT' => ['COUNT DISTINCT' => KnowbaseItem::getTableField('id') . ' as cpt'],
+               'FROM'   => KnowbaseItem::getTable(),
+               'WHERE'  => [
                   KnowbaseItem::getTableField($cat_fk) => new QueryExpression(
                      DB::quoteName(KnowbaseItemCategory::getTableField('id'))
                   ),
@@ -304,9 +304,9 @@ JAVASCRIPT;
       $root_items_count = $DB->request(
          array_merge_recursive(
             [
-               'COUNT' => 'cpt',
-               'FROM'  => KnowbaseItem::getTable(),
-               'WHERE' => [
+               'SELECT' => ['COUNT DISTINCT' => KnowbaseItem::getTableField('id') . ' as cpt'],
+               'FROM'   => KnowbaseItem::getTable(),
+               'WHERE'  => [
                   KnowbaseItem::getTableField($cat_fk) => 0,
                ]
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5616 

LEFT JOIN added by visibility criterai may lead in having multiple lines for a unique KB item. For example, if an item targets multiple profiles, the query will produce a line for each profile.
Counting on DISTINCT id fixes count result.