### PR TITLE
Fix SQL error on asset transfer

### DIFF
--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -565,8 +565,8 @@ class Transfer extends CommonDBTM {
                $DB->delete(
                   'glpi_contracts_items',
                   [
-                     "$itemtable.id" => null,
-                     'itemtype'      => $itemtype
+                     "$itemtable.id"                 => null,
+                     "glpi_contracts_items.itemtype" => $itemtype
                   ],
                   [
                      'LEFT JOIN' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix following errors:
```
[2019-03-28 11:29:26] glpisqllog.ERROR: DBmysql::query() in /var/www/html/glpi/inc/dbmysql.class.php line 177
  *** MySQL query error:
  SQL: DELETE `glpi_contracts_items` FROM `glpi_contracts_items` LEFT JOIN `glpi_items_devicepcis` ON (`glpi_contracts_items`.`items_id` = `glpi_items_devicepcis`.`id` AND `itemtype` = 'Item_DevicePci') WHERE `glpi_items_devicepcis`.`id` IS NULL
  Error: Column 'itemtype' in on clause is ambiguous
  Backtrace :
  inc/dbmysql.class.php:1044                         
  inc/transfer.class.php:575                         DBmysql->delete()
  inc/transfer.class.php:174                         Transfer->simulateTransfer()
  front/transfer.action.php:46                       Transfer->moveItems()
  {"user":"11@bermatap04"} 
[2019-03-28 11:29:26] glpisqllog.ERROR: DBmysql::query() in /var/www/html/glpi/inc/dbmysql.class.php line 177
  *** MySQL query error:
  SQL: DELETE `glpi_contracts_items` FROM `glpi_contracts_items` LEFT JOIN `glpi_items_devicecontrols` ON (`glpi_contracts_items`.`items_id` = `glpi_items_devicecontrols`.`id` AND `itemtype` = 'Item_DeviceControl') WHERE `glpi_items_devicecontrols`.`id` IS NULL
  Error: Column 'itemtype' in on clause is ambiguous
  Backtrace :
  inc/dbmysql.class.php:1044                         
  inc/transfer.class.php:575                         DBmysql->delete()
  inc/transfer.class.php:174                         Transfer->simulateTransfer()
  front/transfer.action.php:46                       Transfer->moveItems()
  {"user":"11@bermatap04","mem_usage":"0.001\", 7.39Mio)"} 
[2019-03-28 11:29:26] glpisqllog.ERROR: DBmysql::query() in /var/www/html/glpi/inc/dbmysql.class.php line 177
  *** MySQL query error:
  SQL: DELETE `glpi_contracts_items` FROM `glpi_contracts_items` LEFT JOIN `glpi_items_deviceharddrives` ON (`glpi_contracts_items`.`items_id` = `glpi_items_deviceharddrives`.`id` AND `itemtype` = 'Item_DeviceHardDrive') WHERE `glpi_items_deviceharddrives`.`id` IS NULL
  Error: Column 'itemtype' in on clause is ambiguous
  Backtrace :
  inc/dbmysql.class.php:1044                         
  inc/transfer.class.php:575                         DBmysql->delete()
  inc/transfer.class.php:174                         Transfer->simulateTransfer()
  front/transfer.action.php:46                       Transfer->moveItems()
  {"user":"11@bermatap04","mem_usage":"0.001\", 7.39Mio)"} 
[2019-03-28 11:29:26] glpisqllog.ERROR: DBmysql::query() in /var/www/html/glpi/inc/dbmysql.class.php line 177
  *** MySQL query error:
  SQL: DELETE `glpi_contracts_items` FROM `glpi_contracts_items` LEFT JOIN `glpi_items_devicedrives` ON (`glpi_contracts_items`.`items_id` = `glpi_items_devicedrives`.`id` AND `itemtype` = 'Item_DeviceDrive') WHERE `glpi_items_devicedrives`.`id` IS NULL
  Error: Column 'itemtype' in on clause is ambiguous
  Backtrace :
  inc/dbmysql.class.php:1044                         
  inc/transfer.class.php:575                         DBmysql->delete()
  inc/transfer.class.php:174                         Transfer->simulateTransfer()
  front/transfer.action.php:46                       Transfer->moveItems()
  {"user":"11@bermatap04","mem_usage":"0.001\", 7.39Mio)"} 
[2019-03-28 11:29:26] glpisqllog.ERROR: DBmysql::query() in /var/www/html/glpi/inc/dbmysql.class.php line 177
  *** MySQL query error:
  SQL: DELETE `glpi_contracts_items` FROM `glpi_contracts_items` LEFT JOIN `glpi_items_deviceprocessors` ON (`glpi_contracts_items`.`items_id` = `glpi_items_deviceprocessors`.`id` AND `itemtype` = 'Item_DeviceProcessor') WHERE `glpi_items_deviceprocessors`.`id` IS NULL
  Error: Column 'itemtype' in on clause is ambiguous
  Backtrace :
  inc/dbmysql.class.php:1044                         
  inc/transfer.class.php:575                         DBmysql->delete()
  inc/transfer.class.php:174                         Transfer->simulateTransfer()
  front/transfer.action.php:46                       Transfer->moveItems()
  {"user":"11@bermatap04","mem_usage":"0.001\", 7.39Mio)"} 
[2019-03-28 11:29:26] glpisqllog.ERROR: DBmysql::query() in /var/www/html/glpi/inc/dbmysql.class.php line 177
  *** MySQL query error:
  SQL: DELETE `glpi_contracts_items` FROM `glpi_contracts_items` LEFT JOIN `glpi_items_devicefirmwares` ON (`glpi_contracts_items`.`items_id` = `glpi_items_devicefirmwares`.`id` AND `itemtype` = 'Item_DeviceFirmware') WHERE `glpi_items_devicefirmwares`.`id` IS NULL
  Error: Column 'itemtype' in on clause is ambiguous
  Backtrace :
  inc/dbmysql.class.php:1044                         
  inc/transfer.class.php:575                         DBmysql->delete()
  inc/transfer.class.php:174                         Transfer->simulateTransfer()
  front/transfer.action.php:46                       Transfer->moveItems()
  {"user":"11@bermatap04","mem_usage":"0.001\", 7.39Mio)"} 
```