### PR TITLE
Fix AND NOT on meta criterion; fixes #5763

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -980,17 +980,16 @@ class Search {
                if (strlen($sub_sql)) {
                   $sql .= "$LINK ($sub_sql)";
                }
-            } else if (isset($searchopt[$criterion['field']]["usehaving"])) {
+            } else if (isset($searchopt[$criterion['field']]["usehaving"])
+                       || ($meta && "AND NOT" === $criterion['link'])) {
                if (!$is_having) {
                   // the having part will be managed in a second pass
                   continue;
                }
 
-               // Find key
-               $item_num = array_search($criterion['field'], $data['tocompute']);
                $new_having = self::addHaving($LINK, $NOT, $itemtype,
                                              $criterion['field'], $criterion['searchtype'],
-                                             $criterion['value'], $meta);
+                                             $criterion['value']);
                if ($new_having !== false) {
                   $sql .= $new_having;
                }
@@ -3035,11 +3034,10 @@ JAVASCRIPT;
     * @param integer $ID             ID of the item to search
     * @param string  $searchtype     search type ('contains' or 'equals')
     * @param string  $val            value search
-    * @param string  $meta           is it a meta item ?
     *
     * @return select string
    **/
-   static function addHaving($LINK, $NOT, $itemtype, $ID, $searchtype, $val, $meta) {
+   static function addHaving($LINK, $NOT, $itemtype, $ID, $searchtype, $val) {
 
       $searchopt  = &self::getOptions($itemtype);
       if (!isset($searchopt[$ID]['table'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5763 

I put back a condition to force usage of HAVING when using the `AND NOT` on a metacriteria. See https://github.com/glpi-project/glpi/blob/9.3/bugfixes/inc/search.class.php#L823 for 9.3.x corresponding code.