### PR TITLE
Fix 'NOTUPDATED' state after plugin uninstall

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -357,11 +357,14 @@ class Plugin extends CommonDBTM {
       if ($informations['version'] != $plugin->fields['version']
           || $directory != $plugin->fields['directory']) {
          // Plugin known version differs from informations or plugin has been renamed,
-         // mark it as 'updatable'
+         // update informations in database
          $input              = $informations;
          $input['id']        = $plugin->fields['id'];
          $input['directory'] = $directory;
-         $input['state']     = self::NOTUPDATED;
+         if (!in_array($plugin->fields['state'], [self::ANEW, self::NOTINSTALLED])) {
+            // mark it as 'updatable' unless it was not installed
+            $input['state']     = self::NOTUPDATED;
+         }
 
          $this->update($input);
 
@@ -475,7 +478,6 @@ class Plugin extends CommonDBTM {
          $this->update([
             'id'      => $ID,
             'state'   => self::NOTINSTALLED,
-            'version' => ''
          ]);
          $this->setUnloadedByName($this->fields['directory']);
 

--- a/tests/functionnal/Plugin.php
+++ b/tests/functionnal/Plugin.php
@@ -362,10 +362,11 @@ class Plugin extends DbTestCase {
    }
 
    /**
-    * Test state checking on a valid directory corresponding to a known plugin with a different version.
+    * Test state checking on a valid directory corresponding to a known and installed plugin
+    * with a different version.
     * Should results in changing plugin state to "NOTUPDATED".
     */
-   public function testCheckPluginStateForUpdatablePlugin() {
+   public function testCheckPluginStateForInstalledAndUpdatablePlugin() {
 
       $initial_data = [
          'directory' => $this->test_plugin_directory,
@@ -382,6 +383,38 @@ class Plugin extends DbTestCase {
          $setup_informations,
          [
             'state' => \Plugin::NOTUPDATED,
+         ]
+      );
+
+      $this->doTestCheckPluginState(
+         $initial_data,
+         $setup_informations,
+         $expected_data
+      );
+   }
+
+   /**
+    * Test state checking on a valid directory corresponding to a known and NOT installed plugin
+    * with a different version.
+    * Should results in keeping plugin state to "NOTINSTALLED".
+    */
+   public function testCheckPluginStateForNotInstalledAndUpdatablePlugin() {
+
+      $initial_data = [
+         'directory' => $this->test_plugin_directory,
+         'name'      => 'Test plugin',
+         'version'   => '1.0',
+         'state'     => \Plugin::NOTINSTALLED,
+      ];
+      $setup_informations = [
+         'name'    => 'Test plugin NG',
+         'version' => '2.0',
+      ];
+      $expected_data = array_merge(
+         $initial_data,
+         $setup_informations,
+         [
+            'state' => \Plugin::NOTINSTALLED,
          ]
       );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a plugin in unistalled, its version was set to `''`. The check process was so considering that found version was different from know version and changed its state to "NOTUPDATED".

1. The version has not to be removed on unistall, as it will be put back to its current value on page redisplay.
2. Now the state is not changed to NOTUPDATED if plugin is not installed.