### PR TITLE
Remove useless cache on node_modules for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,10 +72,6 @@ commands:
       - restore_cache:
           keys:
             - npm-cache-{{ .Environment.CIRCLE_JOB }}
-      - restore_cache:
-          keys:
-            - npm-install-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
-            - npm-install-{{ .Environment.CIRCLE_JOB }}
       - run:
           name: npm install
           command: |
@@ -86,10 +82,6 @@ commands:
           key: npm-cache-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
             - /home/circleci/.npm/_cacache/
-      - save_cache:
-          key: npm-install-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
 
   # Run test suite command.
   run_test_suite:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Cache on nodes_modules is useless due to usage of `npm ci`:
![image](https://user-images.githubusercontent.com/33253653/55961998-57c2fd80-5c70-11e9-9369-529be73853f1.png)
