### PR TITLE
Fix dev dependencies install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,15 +79,15 @@ commands:
       - run:
           name: npm install
           command: |
-            # use npm ci instead of npm install to make sure that it will install exact packages
-            # described in package-lock.json, without any additionnal checks
-            npm ci
+            mv package-lock.json package-lock.json.bak
+            npm install
+            php -r "file_put_contents('.package.hash', sha1_file('package-lock.json'));"
       - save_cache:
           key: npm-cache-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
             - /home/circleci/.npm/_cacache/
       - save_cache:
-          key: npm-install-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
+          key: npm-install-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json.bak" }}
           paths:
             - ./node_modules
 

--- a/bin/console
+++ b/bin/console
@@ -32,9 +32,11 @@
  */
 
 // Handle specific dependencies update command that cannot be made upon symfony console
-if (isset($_SERVER['argv']) && ['bin/console', 'dependencies', 'install'] === $_SERVER['argv']) {
+if (isset($_SERVER['argv']) && ['dependencies', 'install'] === array_slice($_SERVER['argv'], 1, 2)) {
+   chdir(dirname(__FILE__, 2));
    passthru('composer install');
    passthru('npm install');
+   file_put_contents('.package.hash', sha1_file('package-lock.json'));
    passthru('npm run-script build-dev');
    exit();
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Fix command run from outside GLPI root dir
  Running `/path/to/glpi/bin/console dependencies install` was not working.
2. Fix generation of package.hash file
  `postinstall` script is ran prior to `package-lock.json` file update, so the generated hash was not up to date.