### PR TITLE
Fix cache instanciation exception catching

### DIFF
--- a/src/Glpi/Cache/SimpleCacheFactory.php
+++ b/src/Glpi/Cache/SimpleCacheFactory.php
@@ -32,8 +32,6 @@
 
 namespace Glpi\Cache;
 
-use Zend\Cache\Exception\ExceptionInterface;
-
 /**
  * Glpi simple cache factory.
  *
@@ -104,7 +102,7 @@ class SimpleCacheFactory
 
         try {
             $storage = $this->storageFactory->factory($cfg);
-        } catch (ExceptionInterface $e) {
+        } catch (\Exception $e) {
             if ($isAdapterComputed && 'filesystem' !== $cfg['adapter']) {
                 // Fallback to 'filesystem' adapter if adapter was not explicitely defined in config
                 trigger_error(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I do not understand why exception was not catched, as `Zend\Cache\Exception\ExtensionNotLoadedException` implements `Zend\Cache\Exception\ExceptionInterface`.

I had this error:
```
Fatal error: Uncaught Zend\Cache\Exception\ExtensionNotLoadedException: ext/apcu is disabled - see 'apc.enabled' and 'apc.enable_cli' in /var/www/glpi/vendor/zendframework/zend-cache/src/Storage/Adapter/Apcu.php:52
Stack trace:
#0 /var/www/glpi/vendor/zendframework/zend-servicemanager/src/Factory/InvokableFactory.php(30): Zend\Cache\Storage\Adapter\Apcu->__construct()
#1 /var/www/glpi/vendor/zendframework/zend-servicemanager/src/ServiceManager.php(764): Zend\ServiceManager\Factory\InvokableFactory->__invoke(Object(Zend\ServiceManager\ServiceManager), 'Zend\\Cache\\Stor...', NULL)
#2 /var/www/glpi/vendor/zendframework/zend-servicemanager/src/ServiceManager.php(200): Zend\ServiceManager\ServiceManager->doCreate('Zend\\Cache\\Stor...')
#3 /var/www/glpi/vendor/zendframework/zend-servicemanager/src/AbstractPluginManager.php(152): Zend\ServiceManager\ServiceManager->get('Zend\\Cache\\Stor...')
#4 /var/www/glpi/vendor/zendframework/zend-cache/src/StorageFactory.php(147): Zend\ServiceManager\AbstractPluginManager->get('apcu')
#5  in /var/www/glpi/vendor/zendframework/zend-servicemanager/src/ServiceManager.php on line 771
```