### PR TITLE
Use 'bin/console dependencies install' in CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,12 +55,18 @@ commands:
           keys:
             - composer-install-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.lock" }}
             - composer-install-{{ .Environment.CIRCLE_JOB }}
+      - restore_cache:
+          keys:
+            - npm-cache-{{ .Environment.CIRCLE_JOB }}
       - run:
-          name: composer install
+          name: Install dependencies
           command: |
+            composer --version
+            echo "node version: $(node --version)"
+            echo "npm version: $(npm --version)"
             sed -e '/"php":/d' -i composer.json
             mv composer.lock composer.lock.bak
-            composer install --optimize-autoloader --prefer-dist --no-interaction --no-progress --no-suggest
+            bin/console dependencies install --ci
       - save_cache:
           key: composer-cache-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
@@ -69,27 +75,10 @@ commands:
           key: composer-install-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.lock.bak" }}
           paths:
             - ./vendor
-      - restore_cache:
-          keys:
-            - npm-cache-{{ .Environment.CIRCLE_JOB }}
-      - restore_cache:
-          keys:
-            - npm-install-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
-            - npm-install-{{ .Environment.CIRCLE_JOB }}
-      - run:
-          name: npm install
-          command: |
-            mv package-lock.json package-lock.json.bak
-            npm install
-            php -r "file_put_contents('.package.hash', sha1_file('package-lock.json'));"
       - save_cache:
           key: npm-cache-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
             - /home/circleci/.npm/_cacache/
-      - save_cache:
-          key: npm-install-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json.bak" }}
-          paths:
-            - ./node_modules
 
   # Run test suite command.
   run_test_suite:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,9 @@ before_script:
   - composer self-update
   - sed -e '/"php":/d' -i composer.json
   - rm -f composer.lock
-  - composer install --optimize-autoloader
   - nvm install stable # update node
   - npm update -g npm # update npm
-  - npm ci
-  - npm run-script build-dev
+  - bin/console dependencies install --ci
   - mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql
   - mysql -u root -e 'create database glpitest;'
   - bin/console glpi:database:install --config-dir=./tests --no-interaction --db-name=glpitest --db-user=root

--- a/bin/console
+++ b/bin/console
@@ -31,17 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
-// Handle specific dependencies update command that cannot be made upon symfony console
-if (isset($_SERVER['argv']) && ['dependencies', 'install'] === array_slice($_SERVER['argv'], 1, 2)) {
-   chdir(dirname(__FILE__, 2));
-   passthru('composer install');
-   passthru('npm install');
-   file_put_contents('.package.hash', sha1_file('package-lock.json'));
-   passthru('npm run-script build-dev');
-   exit();
-}
-
-// If "config-dir" option is used in command line, defines GLPI_CONFIG_DIR with its value
+// Extract command line arguments
 $options = [];
 if (isset($_SERVER['argv'])) {
    for ($i = 1; $i < count($_SERVER['argv']); $i++) {
@@ -51,6 +41,25 @@ if (isset($_SERVER['argv'])) {
    }
 }
 
+// Handle specific dependencies update command that cannot be made upon symfony console
+if (isset($_SERVER['argv']) && ['dependencies', 'install'] === array_slice($_SERVER['argv'], 1, 2)) {
+   $composer_command = 'composer install --optimize-autoloader --no-interaction --no-suggest';
+   $npm_command = 'npm install';
+
+   if (array_key_exists('ci', $options) && true === $options['ci']) {
+      $composer_command .= ' --prefer-dist --no-progress';
+      $npm_command = 'npm ci';
+   }
+
+   chdir(dirname(__FILE__, 2));
+   passthru($composer_command);
+   passthru($npm_command);
+   file_put_contents('.package.hash', sha1_file('package-lock.json'));
+   passthru('npm run-script build-dev');
+   exit();
+}
+
+// If "config-dir" option is used in command line, defines GLPI_CONFIG_DIR with its value
 if (array_key_exists('config-dir', $options)) {
    $config_dir = $options['config-dir'];
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
         "unorm": "^1.5.0"
     },
     "scripts": {
-        "postinstall": "php -r \"file_put_contents('.package.hash', sha1_file('package-lock.json'));\"",
         "build": "webpack --config webpack.config.js --mode=production",
         "build-dev": "webpack --config webpack.config.js --mode=development"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Use `bin/console dependencies install` in CI builds
2. Use `npm ci` to prevent errors like:
  ![image](https://user-images.githubusercontent.com/33253653/56190165-eeedd380-6029-11e9-8073-9d4232269ba7.png)
3. Remove cache on `./node_modules` as `npm ci` clears it on each execution.
4. Remove `postinstall` script as it acts on an outdated `package-lock.json` file:
  ![image](https://user-images.githubusercontent.com/33253653/56190291-28beda00-602a-11e9-95d6-a590d1febbda.png)
