### PR TITLE
Make items unlocking async; fixes #5799

### DIFF
--- a/inc/objectlock.class.php
+++ b/inc/objectlock.class.php
@@ -314,7 +314,6 @@ class ObjectLock extends CommonDBTM {
                      //debugger;
                       $.ajax({
                           url: '".$CFG_GLPI['root_doc']."/ajax/unlockobject.php',
-                          async: false,
                           cache: false,
                           data: 'unlock=1&id=$id'
                           });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5799 

Synchronous request made on beforeunload will be [deprecated soon in Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=952452#c48).

Doing an async request should not be a problem, as the lock mechanism used by PHP to handle session data should prevent having a mixup in request handling order in most cases. Indeed, when the unlock request will be received by the PHP server, session opening will add a lock on session file until unlock is done, so the request made to refresh the ticket page will wait for unlock to be done.

Unless for really specific case where network problems or configuration could lead to have request received by server not in same order as send by the client, it should not be a problem. For thoose specific cases, user will have to manually click on "Unlock this item" to bypass this issue.