### PR TITLE
Fix images URL for ITIL objects having quote(') char; fixes #5457

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 The present file will list all changes made to the project; according to the
 [Keep a Changelog](http://keepachangelog.com/) project.
 
-## [9.4.2] unreleased
+## [9.4.3] unreleased
+
+## [9.4.2] 2019-04-11
 
 ### API changes
 

--- a/inc/console/database/updatecommand.class.php
+++ b/inc/console/database/updatecommand.class.php
@@ -170,8 +170,8 @@ class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionComma
       } else if ($force) {
          // Replay last update script even if there is no schema change.
          // It can be used in dev environment when update script has been updated/fixed.
-         include_once(GLPI_ROOT . '/install/update_941_942.php');
-         update941to942();
+         include_once(GLPI_ROOT . '/install/update_942_943.php');
+         update942to943();
 
          $output->writeln('<info>' . __('Last migration replayed.') . '</info>');
       }

--- a/inc/define.php
+++ b/inc/define.php
@@ -31,7 +31,7 @@
 */
 
 // Current version of GLPI
-define('GLPI_VERSION', '9.4.2');
+define('GLPI_VERSION', '9.4.3');
 if (substr(GLPI_VERSION, -4) === '-dev') {
    //for dev version
    define('GLPI_PREVER', str_replace('-dev', '', GLPI_VERSION));
@@ -41,7 +41,7 @@ if (substr(GLPI_VERSION, -4) === '-dev') {
    );
 } else {
    //for stable version
-   define("GLPI_SCHEMA_VERSION", '9.4.2');
+   define("GLPI_SCHEMA_VERSION", '9.4.3');
 }
 define('GLPI_MIN_PHP', '5.6.0'); // Must also be changed in top of index.php
 define('GLPI_YEAR', '2019');

--- a/inc/update.class.php
+++ b/inc/update.class.php
@@ -448,6 +448,10 @@ class Update extends CommonGLPI {
          case "9.4.1.1":
             include_once "{$updir}update_941_942.php";
             update941to942();
+
+         case "9.4.2":
+            include_once "{$updir}update_942_943.php";
+            update942to943();
             break;
 
          case GLPI_VERSION:

--- a/install/update_941_942.php
+++ b/install/update_941_942.php
@@ -119,7 +119,7 @@ function update941to942() {
             ]
          );
          foreach ($elements_to_fix as $data) {
-            $data['content'] = $fix_content_fct($data['content'], $data['items_id'], $itil_fkey);
+            $data['content'] = $DB->escape($fix_content_fct($data['content'], $data['items_id'], $itil_fkey));
             $DB->update($itil_element_table, $data, ['id' => $data['id']]);
          }
       }
@@ -135,7 +135,7 @@ function update941to942() {
          ]
       );
       foreach ($tasks_to_fix as $data) {
-         $data['content'] = $fix_content_fct($data['content'], $data[$itil_fkey], $itil_fkey);
+         $data['content'] = $DB->escape($fix_content_fct($data['content'], $data[$itil_fkey], $itil_fkey));
          $DB->update($task_table, $data, ['id' => $data['id']]);
       }
    }

--- a/install/update_942_943.php
+++ b/install/update_942_943.php
@@ -31,37 +31,24 @@
  */
 
 /**
- * Update from 9.4.0 to 9.4.1
+ * Update from 9.4.2 to 9.4.3
  *
  * @return bool for success (will die for most error)
 **/
-function update940to941() {
+function update942to943() {
    global $DB, $migration;
 
    $updateresult     = true;
 
    //TRANS: %s is the number of new version
-   $migration->displayTitle(sprintf(__('Update to %s'), '9.4.1'));
-   $migration->setVersion('9.4.1');
-
-   /** Add a search option for profile id */
-   $migration->addPostQuery($DB->buildUpdate(
-      'glpi_displaypreferences',
-      [
-         'num' => '5'
-      ],
-      [
-         'num' => '2',
-         'itemtype' => 'Profile'
-      ]
-   ));
+   $migration->displayTitle(sprintf(__('Update to %s'), '9.4.3'));
+   $migration->setVersion('9.4.3');
 
    /** Fix URL of images inside ITIL objects contents */
-   // There is an exact copy of this process in "update941to942()".
-   // First version of this migration was working
-   // on MariaDB but not on MySQL due to usage of "\d" in a REGEXP expression.
-   // It has been fixed here for people who had not yet updated to 9.4.1 but have been put there
-   // for people already having updated to 9.4.1.
+   // This is an exact copy of the same process used in "update940to941()" and "update941to942()"
+   // which was not working for elements having a simple quote in their content.
+   // It has been fixed there for people who had not yet updated to 9.4.1 / 9.4.2 but have to
+   // be put back here for people already having updated to 9.4.1 / 9.4.2.
    $migration->displayMessage(sprintf(__('Fix URL of images in ITIL tasks, followups ans solutions.')));
 
    // Search for contents that does not contains the itil object parameter after the docid parameter
@@ -136,12 +123,6 @@ function update940to941() {
       }
    }
    /** /Fix URL of images inside ITIL objects contents */
-
-   // Create a dedicated token for rememberme process
-   if (!$DB->fieldExists('glpi_users', 'cookie_token')) {
-      $migration->addField('glpi_users', 'cookie_token', 'string', ['after' => 'api_token_date']);
-      $migration->addField('glpi_users', 'cookie_token_date', 'datetime', ['after' => 'cookie_token']);
-   }
 
    // ************ Keep it at the end **************
    $migration->executeMigration();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5457 

Migrations done in #5472 and #5750 were not working if contents to update contains a `'` char.

```
Bmysql::query() in /var/www/test/inc/dbmysql.class.php line 177
  *** MySQL query error:
  SQL: UPDATE `glpi_itilfollowups` SET `id` = '3254', `items_id` = '145', `content` = '<p>J'ai reproduis le bug...</p>' WHERE `id` = '3254'
  Error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'ai reproduis le bug...</p>' at line 1
  Backtrace :
  inc/dbmysql.class.php:937                          
  install/update_940_941.php:119                     DBmysql->update()
  inc/update.class.php:445                           update940to941()
  inc/console/database/updatecommand.class.php:164   Update->doUpdates()
  vendor/symfony/console/Command/Command.php:255     Glpi\Console\Database\UpdateCommand->execute()
  vendor/symfony/console/Application.php:953         Symfony\Component\Console\Command\Command->run()
  inc/console/application.class.php:196              Symfony\Component\Console\Application->doRunCommand()
  vendor/symfony/console/Application.php:248         Glpi\Console\Application->doRunCommand()
  vendor/symfony/console/Application.php:148         Symfony\Component\Console\Application->doRun()
  bin/console:72                                     Symfony\Component\Console\Application->run()
```