### PR TITLE
Fix sending of saved search notification to owner; fixes #5835

### DIFF
--- a/inc/savedsearch_alert.class.php
+++ b/inc/savedsearch_alert.class.php
@@ -339,6 +339,7 @@ class SavedSearch_Alert extends CommonDBChild {
                   $auth->user = $user;
                   $auth->auth_succeded = true;
                   Session::init($auth);
+                  $_SESSION['glpinotification_to_myself'] = true; // Force sending of notification
                   $cli_logged = $savedsearch->fields['users_id'];
                }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5835 

This is not the cleaner solution, but as the cron already changes session data, it will not make things worse.