### PR TITLE
 Add cache on tableExists

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -883,7 +883,11 @@ class DBmysql {
          return true;
       }
 
-      $result = $this->listTables("%$tablename%");
+      // Retrieve all tables if cache is empty but enabled, in order to fill cache
+      // with all known tables
+      $retrieve_all = !$this->cache_disabled && empty($cache);
+
+      $result = $this->listTables($retrieve_all ? 'glpi_%' : $tablename);
       $found_tables = [];
       while ($data = $result->next()) {
          $found_tables[] = $data['TABLE_NAME'];

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -869,21 +869,32 @@ class DBmysql {
     * Check if a table exists
     *
     * @since 9.2
+    * @since 9.5 Added $usecache parameter.
     *
-    * @param string $tablename Table name
+    * @param string  $tablename Table name
+    * @param boolean $usecache  If use table list cache
     *
     * @return boolean
     **/
-   public function tableExists($tablename) {
-      // Get a list of tables contained within the database.
-      $result = $this->listTables("%$tablename%");
+   public function tableExists($tablename, $usecache = true) {
 
-      if (count($result)) {
-         while ($data = $result->next()) {
-            if ($data['TABLE_NAME'] === $tablename) {
-               return true;
-            }
-         }
+      static $cache = [];
+      if (!$this->cache_disabled && $usecache && in_array($tablename, $cache)) {
+         return true;
+      }
+
+      $result = $this->listTables("%$tablename%");
+      $found_tables = [];
+      while ($data = $result->next()) {
+         $found_tables[] = $data['TABLE_NAME'];
+      }
+
+      if (!$this->cache_disabled) {
+         $cache = array_unique(array_merge($cache, $found_tables));
+      }
+
+      if (in_array($tablename, $found_tables)) {
+         return true;
       }
 
       return false;

--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -481,7 +481,7 @@ class DBmysqlIterator implements Iterator, Countable {
     * @return void
     */
    function __destruct () {
-      if ($this->res) {
+      if ($this->res instanceof \mysqli_result) {
          $this->conn->freeResult($this->res);
       }
    }
@@ -707,7 +707,7 @@ class DBmysqlIterator implements Iterator, Countable {
     * @return string[]|null fetch_assoc() of first results row
     */
    public function next() {
-      if (!$this->res) {
+      if (!($this->res instanceof \mysqli_result)) {
          return false;
       }
       $this->row = $this->conn->fetchAssoc($this->res);
@@ -721,7 +721,7 @@ class DBmysqlIterator implements Iterator, Countable {
     * @return boolean
     */
    public function valid() {
-      return $this->res && $this->row;
+      return $this->res instanceof \mysqli_result && $this->row;
    }
 
    /**
@@ -730,7 +730,7 @@ class DBmysqlIterator implements Iterator, Countable {
     * @return integer
     */
    public function numrows() {
-      return ($this->res ? $this->conn->numrows($this->res) : 0);
+      return ($this->res instanceof \mysqli_result ? $this->conn->numrows($this->res) : 0);
    }
 
    /**
@@ -741,7 +741,7 @@ class DBmysqlIterator implements Iterator, Countable {
     * @return integer
     */
    public function count() {
-      return ($this->res ? $this->conn->numrows($this->res) : 0);
+      return ($this->res instanceof \mysqli_result ? $this->conn->numrows($this->res) : 0);
    }
 
    /**

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -531,6 +531,8 @@ class Plugin extends CommonDBTM {
    **/
    function install($ID) {
 
+      global $DB;
+
       $message = '';
       $type = ERROR;
 
@@ -542,6 +544,7 @@ class Plugin extends CommonDBTM {
          }
 
          self::load($this->fields['directory'], true);
+         $DB->disableTableCaching(); //prevents issues on table/fieldExists upgrading from old versions
          $function   = 'plugin_' . $this->fields['directory'] . '_install';
          if (function_exists($function)) {
             $this->setLoaded('temp', $this->fields['directory']);  // For autoloader

--- a/install/update.php
+++ b/install/update.php
@@ -50,7 +50,7 @@ $GLPI = new GLPI();
 $GLPI->initLogger();
 
 $DB = new DB();
-$DB->disableTableCaching(); //prevents issues on fieldExists upgrading from old versions
+$DB->disableTableCaching(); //prevents issues on table/fieldExists upgrading from old versions
 
 $update = new Update($DB);
 $update->initSession();

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -190,10 +190,10 @@ class Migration extends \GLPITestCase {
       $this->array($this->queries)->isIdenticalTo([
          0 => 'SELECT `table_name` AS `TABLE_NAME` FROM `information_schema`.`tables`' .
                ' WHERE `table_schema` = \'' . $DB->dbdefault .
-               '\' AND `table_type` = \'BASE TABLE\' AND `table_name` LIKE \'%table1%\'',
+               '\' AND `table_type` = \'BASE TABLE\' AND `table_name` LIKE \'table1\'',
          1 => 'SELECT `table_name` AS `TABLE_NAME` FROM `information_schema`.`tables`' .
                ' WHERE `table_schema` = \'' . $DB->dbdefault  .
-               '\' AND `table_type` = \'BASE TABLE\' AND `table_name` LIKE \'%table2%\''
+               '\' AND `table_type` = \'BASE TABLE\' AND `table_name` LIKE \'table2\''
              ]);
 
       //try to backup existant tables


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I added cache on `tableExists` method to prevent making useless request on `information_schema.tables` table. On first call, if cache is enabled, the whole `glpi_%` table list is retrieve, to fill the cache.

I also add a call on `$DB->disableTableCaching();` prior to plugins installation method calls, in order to prevent problems on plugins with this modification.