### PR TITLE
Add cache on AbstractDatabase::tableExists()

### DIFF
--- a/install/update.php
+++ b/install/update.php
@@ -47,7 +47,7 @@ $GLPI = new GLPI();
 $GLPI->initLogger();
 
 $DB = \Glpi\DatabaseFactory::create();
-$DB->disableTableCaching(); //prevents issues on fieldExists upgrading from old versions
+$DB->disableTableCaching(); //prevents issues on table/fieldExists upgrading from old versions
 
 $update = new Update($DB);
 $update->initSession();

--- a/src/Glpi/Database/AbstractDatabase.php
+++ b/src/Glpi/Database/AbstractDatabase.php
@@ -726,22 +726,36 @@ abstract class AbstractDatabase
      * Check if a table exists
      *
      * @since 9.2
+     * @since 10.0 Added $usecache parameter.
      *
-     * @param string $tablename Table name
+     * @param string  $tablename Table name
+     * @param boolean $usecache  If use table list cache
      *
      * @return boolean
      */
-    public function tableExists(string $tablename): bool
+    public function tableExists(string $tablename, $usecache = true): bool
     {
-       // Get a list of tables contained within the database.
-        $result = $this->listTables("%$tablename%");
+        static $table_cache = [];
+        if (!$this->cache_disabled && $usecache && in_array($tablename, $table_cache)) {
+            return true;
+        }
 
-        if (count($result)) {
-            while ($data = $result->next()) {
-                if ($data['TABLE_NAME'] === $tablename) {
-                    return true;
-                }
-            }
+        // Retrieve all tables if cache is empty but enabled, in order to fill cache
+        // with all known tables
+        $retrieve_all = !$this->cache_disabled && empty($table_cache);
+
+        $result = $this->listTables($retrieve_all ? 'glpi_%' : $tablename);
+        $found_tables = [];
+        while ($data = $result->next()) {
+            $found_tables[] = $data['TABLE_NAME'];
+        }
+
+        if (!$this->cache_disabled) {
+            $table_cache = array_unique(array_merge($table_cache, $found_tables));
+        }
+
+        if (in_array($tablename, $found_tables)) {
+            return true;
         }
 
         return false;

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -292,8 +292,8 @@ class Migration extends \GLPITestCase {
                ' AND `table_type` = ? AND `table_name` LIKE ?'
              ]);
       $this->array($this->qry_params)->isIdenticalTo([
-         0  => [$DB->dbdefault, 'BASE TABLE', '%table1%'],
-         1  => [$DB->dbdefault, 'BASE TABLE', '%table2%']
+         0  => [$DB->dbdefault, 'BASE TABLE', 'table1'],
+         1  => [$DB->dbdefault, 'BASE TABLE', 'table2']
       ]);
 
       //try to backup existant tables


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I added cache on `tableExists` method to prevent making useless request on `information_schema.tables` table. On first call, if cache is enabled, the whole `glpi_%` table list is retrieve, to fill the cache.

I also add a call on `$DB->disableTableCaching();` prior to plugins installation method calls, in order to prevent problems on plugins with this modification.

Replaces #5849 .