### PR TITLE
Fix search on notification event

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -4263,6 +4263,15 @@ JAVASCRIPT;
             }
             break;
 
+         case "glpi_notifications.event" :
+            if (in_array($searchtype, ['equals', 'notequals']) && strpos($val, self::SHORTSEP)) {
+               $not = 'notequals' === $searchtype ? 'NOT' : '';
+               list($itemtype_val, $event_val) = explode(self::SHORTSEP, $val);
+               return " $link $not(`$table`.`event` = '$event_val'
+                               AND `$table`.`itemtype` = '$itemtype_val')";
+            }
+            break;
+
       }
 
       //// Default cases


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Search on notification "event" field is not really working as users cannot know on which value to search on (raw event name is not displayed).
I modified the search option to give ability to the user filter on an event from its displayed label.
![image](https://user-images.githubusercontent.com/33253653/56962319-8b4dc500-6b56-11e9-9f34-9d643195d47f.png)
