### PR TITLE
Force trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 sudo: required
+dist: trusty
 
 env:
   - DB=mysql


### PR DESCRIPTION
Dunno why on my builds travis use xenial and not trusty...

Anyways, this seems better to explicitely set version since there are compatibility issues