### PR TITLE
Fix duplicated inlined images; fixes #5844

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The present file will list all changes made to the project; according to the
 
 ## [9.4.3] unreleased
 
+### API changes
+
+#### Deprecated
+
+The following methods have been deprecated:
+
+- `Html::convertTagFromRichTextToImageTag()`
+
 ## [9.4.2] 2019-04-11
 
 ### API changes

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -5695,17 +5695,21 @@ class Html {
    /**
     * Convert tag to image
     *
-    * @since 9.2
-    *
     * @param string|array $tag       the tag identifier of the document
     * @param int          $width     witdh of the final image
     * @param int          $height    height of the final image
     * @param bool         $addLink   boolean, do we need to add an anchor link
     * @param string       $more_link append to the link (ex &test=true)
     *
-    * @return nothing
+    * @return string
+    *
+    * @since 9.2
+    * @deprecated 9.4.3
    **/
    public static function convertTagFromRichTextToImageTag($tag, $width, $height, $addLink = true, $more_link = "") {
+
+      Toolbox::deprecated('Use getImageHtmlTagForDocument');
+
       global $CFG_GLPI;
 
       $doc = new Document();
@@ -5750,6 +5754,67 @@ class Html {
          return $out;
       }
       return '#'.$tag.'#';
+   }
+
+
+   /**
+    * Get image html tag for image document.
+    *
+    * @param int    $document_id  identifier of the document
+    * @param int    $width        witdh of the final image
+    * @param int    $height       height of the final image
+    * @param bool   $addLink      boolean, do we need to add an anchor link
+    * @param string $more_link    append to the link (ex &test=true)
+    *
+    * @return string
+    *
+    * @since 9.4.3
+   **/
+   public static function getImageHtmlTagForDocument($document_id, $width, $height, $addLink = true, $more_link = "") {
+      global $CFG_GLPI;
+
+      $document = new Document();
+      if (!$document->getFromDB($document_id)) {
+         return '';
+      }
+
+      $base_path = $CFG_GLPI['root_doc'];
+      if (isCommandLine()) {
+         $base_path = parse_url($CFG_GLPI['url_base'], PHP_URL_PATH);
+      }
+
+      // Add only image files : try to detect mime type
+      $ok   = false;
+      $mime = '';
+      if (isset($document->fields['filepath'])) {
+         $fullpath = GLPI_DOC_DIR."/".$document->fields['filepath'];
+         $mime = Toolbox::getMime($fullpath);
+         $ok   = Toolbox::getMime($fullpath, 'image');
+      }
+
+      if (!($ok || empty($mime))) {
+         return '';
+      }
+
+      $out = '';
+      if ($addLink) {
+         $out .= '<a '
+                 . 'href="' . $base_path . '/front/document.send.php?docid=' . $document_id . $more_link . '" '
+                 . 'target="_blank" '
+                 . '>';
+      }
+      $out .= '<img ';
+      if (isset($document->fields['tag'])) {
+         $out .= 'alt="' . $document->fields['tag'] . '" ';
+      }
+      $out .= 'width="' . $width . '" '
+              . 'src="' . $base_path . '/front/document.send.php?docid=' . $document_id . $more_link . '" '
+              . '/>';
+      if ($addLink) {
+         $out .= '</a>';
+      }
+
+      return $out;
    }
 
    /**

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2710,9 +2710,16 @@ class Toolbox {
                      }
 
                      // replace image
-                     $new_image =  Html::convertTagFromRichTextToImageTag($image['tag'],
-                                                                          $width, $height,
-                                                                          true, $itil_url_param);
+                     $new_image =  Html::getImageHtmlTagForDocument(
+                        $id,
+                        $width,
+                        $height,
+                        true,
+                        $itil_url_param
+                     );
+                     if (empty($new_image)) {
+                        $new_image = '#'.$image['tag'].'#';
+                     }
                      $content_text = preg_replace(
                         $regex,
                         $new_image,

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -183,4 +183,116 @@ class Toolbox extends DbTestCase {
       // Validate result
       $this->string($result)->isEqualTo($expected_result);
    }
+
+   /**
+    * Check conversion of tags to images when contents contains multiple inlined images.
+    */
+   public function testConvertTagToImageWithMultipleInlinedImg() {
+
+      $img_tag_1 = uniqid('', true);
+      $img_tag_2 = uniqid('', true);
+      $img_tag_3 = uniqid('', true);
+
+      $item = new \Ticket();
+      $item->fields['id'] = mt_rand(1, 50);
+
+      // Create multiple documents in DB
+      $document = new \Document();
+      $doc_id_1 = $document->add([
+         'name'     => 'document 1',
+         'filename' => 'img1.png',
+         'mime'     => 'image/png',
+         'tag'      => $img_tag_1,
+      ]);
+      $this->integer((int)$doc_id_1)->isGreaterThan(0);
+
+      $document = new \Document();
+      $doc_id_2 = $document->add([
+         'name'     => 'document 2',
+         'filename' => 'img2.png',
+         'mime'     => 'image/png',
+         'tag'      => $img_tag_2,
+      ]);
+      $this->integer((int)$doc_id_2)->isGreaterThan(0);
+
+      $document = new \Document();
+      $doc_id_3 = $document->add([
+         'name'     => 'document 3',
+         'filename' => 'img3.png',
+         'mime'     => 'image/png',
+         'tag'      => $img_tag_3,
+      ]);
+      $this->integer((int)$doc_id_3)->isGreaterThan(0);
+
+      $doc_data = [
+         $doc_id_1 => ['tag' => $img_tag_1],
+         $doc_id_2 => ['tag' => $img_tag_2],
+         $doc_id_3 => ['tag' => $img_tag_3],
+      ];
+
+      $content_text    = '';
+      $expected_result = '';
+      foreach ($doc_data as $doc_id => $doc) {
+         $expected_url    = '/front/document.send.php?docid=' . $doc_id . '&tickets_id=' . $item->fields['id'];
+         $content_text    .= '<img id="' . $doc['tag'] . '" width="10" height="10" />';
+         $expected_result .= '<a href="' . $expected_url . '" target="_blank" ><img alt="' . $doc['tag'] . '" width="10" src="' . $expected_url . '" /></a>';
+      }
+
+      // Processed data is expected to be escaped
+      $content_text = \Toolbox::addslashes_deep($content_text);
+      $expected_result = \Html::entities_deep($expected_result);
+
+      $this->string(
+         \Toolbox::convertTagToImage($content_text, $item, $doc_data)
+      )->isEqualTo($expected_result);
+   }
+
+   /**
+    * Check conversion of tags to images when multiple document matches same tag.
+    */
+   public function testConvertTagToImageWithMultipleDocMatchesSameTag() {
+
+      $img_tag = uniqid('', true);
+
+      $item = new \Ticket();
+      $item->fields['id'] = mt_rand(1, 50);
+
+      // Create multiple documents in DB
+      $document = new \Document();
+      $doc_id_1 = $document->add([
+         'name'     => 'duplicated document 1',
+         'filename' => 'img.png',
+         'mime'     => 'image/png',
+         'tag'      => $img_tag,
+      ]);
+      $this->integer((int)$doc_id_1)->isGreaterThan(0);
+
+      $document = new \Document();
+      $doc_id_2 = $document->add([
+         'name'     => 'duplicated document 2',
+         'filename' => 'img.png',
+         'mime'     => 'image/png',
+         'tag'      => $img_tag,
+      ]);
+      $this->integer((int)$doc_id_2)->isGreaterThan(0);
+
+      $content_text    = '<img id="' . $img_tag . '" width="10" height="10" />';
+      $expected_url_1    = '/front/document.send.php?docid=' . $doc_id_1 . '&tickets_id=' . $item->fields['id'];
+      $expected_result_1 = '<a href="' . $expected_url_1 . '" target="_blank" ><img alt="' . $img_tag . '" width="10" src="' . $expected_url_1 . '" /></a>';
+      $expected_url_2    = '/front/document.send.php?docid=' . $doc_id_2 . '&tickets_id=' . $item->fields['id'];
+      $expected_result_2 = '<a href="' . $expected_url_2 . '" target="_blank" ><img alt="' . $img_tag . '" width="10" src="' . $expected_url_2 . '" /></a>';
+
+      // Processed data is expected to be escaped
+      $content_text = \Toolbox::addslashes_deep($content_text);
+      $expected_result_1 = \Html::entities_deep($expected_result_1);
+      $expected_result_2 = \Html::entities_deep($expected_result_2);
+
+      $this->string(
+         \Toolbox::convertTagToImage($content_text, $item, [$doc_id_1 => ['tag' => $img_tag]])
+      )->isEqualTo($expected_result_1);
+
+      $this->string(
+         \Toolbox::convertTagToImage($content_text, $item, [$doc_id_2 => ['tag' => $img_tag]])
+      )->isEqualTo($expected_result_2);
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5844 

If multiple entries exists in documents for a same inlined image, inlined tag should be replaced by only one document entry.