### PR TITLE
 Make CSS cacheable by browsers and proxies

### DIFF
--- a/front/css.php
+++ b/front/css.php
@@ -45,4 +45,15 @@ include_once GLPI_ROOT . '/inc/config.php';
 $css = Html::compileScss($_GET);
 
 header('Content-Type: text/css');
+
+$is_cacheable = !isset($_GET['debug']) && !isset($_GET['nocache']);
+if ($is_cacheable) {
+   // Makes CSS cacheable by browsers and proxies
+   $max_age = WEEK_TIMESTAMP;
+   header_remove('Pragma');
+   header('Cache-Control: public');
+   header('Cache-Control: max-age=' . $max_age);
+   header('Expires: ' . gmdate('D, d M Y H:i:s \G\M\T', time() + $max_age));
+}
+
 echo $css;

--- a/front/find_num.php
+++ b/front/find_num.php
@@ -46,7 +46,12 @@ echo "<html lang=\"{$CFG_GLPI["languages"][$_SESSION['glpilanguage']][3]}\">";
     <title>GLPI</title>
 
 <?php
-echo Html::scss('main_styles');
+echo Html::scss('css/styles');
+if (isset($_SESSION['glpihighcontrast_css']) && $_SESSION['glpihighcontrast_css']) {
+   echo Html::scss('css/highcontrast');
+}
+$theme = isset($_SESSION['glpipalette']) ? $_SESSION['glpipalette'] : 'auror';
+echo Html::scss('css/palettes/' . $theme);
 echo Html::script($CFG_GLPI["root_doc"].'/script.js');
 ?>
 

--- a/index.php
+++ b/index.php
@@ -83,7 +83,12 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
    echo "<meta name='viewport' content='width=device-width, initial-scale=1'/>";
 
    // Appel CSS
-   echo Html::scss('main_styles');
+   echo Html::scss('css/styles');
+   if (isset($_SESSION['glpihighcontrast_css']) && $_SESSION['glpihighcontrast_css']) {
+      echo Html::scss('css/highcontrast');
+   }
+   $theme = isset($_SESSION['glpipalette']) ? $_SESSION['glpipalette'] : 'auror';
+   echo Html::scss('css/palettes/' . $theme);
    // font awesome icons
    echo Html::css('public/lib/fontawesome-free/css/all.css');
 

--- a/tools/compilescsscommand.class.php
+++ b/tools/compilescsscommand.class.php
@@ -82,7 +82,7 @@ class CompileScssCommand extends Command {
       $files = $input->getOption('file');
 
       if (empty($files)) {
-         $files[] = 'main_styles'; // Compile main styles if no file option is set.
+         $files[] = 'css/styles'; // Compile main styles if no file option is set.
       }
 
       foreach ($files as $file) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Make CSS cacheable by browsers and proxies (unless in debug mode).
This requires to have a response that does not depend on session (i.e. display settings), so I had to split main styles from palette and highcontrast.