### PR TITLE
Fix search when using NOT notcontains in HAVING

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3116,7 +3116,7 @@ JAVASCRIPT;
       }
 
       if ($searchtype == "notcontains") {
-         $nott = !$nott;
+         $NOT = !$NOT;
       }
 
       return self::makeTextCriteria("`$NAME`", $val, $NOT, $LINK);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The "NOT in a search for "NOT" "Components - Hard drive type" "not contains" "test" is not taken into account and produces a notice: `PHP Notice: Undefined variable: nott in /var/www/glpi/inc/search.class.php at line 3119`.