### PR TITLE
Fix undefined action in LDAP sync command; see #5860

### DIFF
--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -1845,7 +1845,7 @@ class AuthLDAP extends CommonDBTM {
                                    'timestamp'  => $user_infos[$userfound[$field_for_sync]]['timestamp'],
                                    'date_sync'  => $tmpuser->fields['date_sync'],
                                    'dn'         => $user['user_dn']];
-               } else if (($values['action'] == self::ACTION_ALL)
+               } else if (($values['mode'] == self::ACTION_ALL)
                           || (($ldap_users[$user[$field_for_db]] - strtotime($user['date_sync'])) > 0)) {
                   //If entry was modified or if script should synchronize all the users
                   $glpi_users[] = ['id'         => $user['id'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

See https://github.com/glpi-project/glpi/issues/5860#issuecomment-490036333

In old `ldap_mass_sync.php` script, this notice was not trigerred as `$options` passed to the method was containing script arguments + method options. So it was containing both `action` and `mode` set to `AuthLDAP::ACTION_ALL`.