### PR TITLE
Add a ticket business rule action to prevent take into account

### DIFF
--- a/inc/commonitilactor.class.php
+++ b/inc/commonitilactor.class.php
@@ -375,7 +375,9 @@ abstract class CommonITILActor extends CommonDBRelation {
 
       $no_stat_computation = true;
       if ($this->input['type'] == CommonITILActor::ASSIGN) {
-         $no_stat_computation = false;
+         // Compute "take into account delay" unless "do not compute" flag was set by business rules
+         $no_stat_computation = array_key_exists('_do_not_compute_takeintoaccount', $this->input)
+            && $this->input['_do_not_compute_takeintoaccount'];
       }
       $item->updateDateMod($this->fields[static::getItilObjectForeignKey()], $no_stat_computation);
 

--- a/inc/commonitilactor.class.php
+++ b/inc/commonitilactor.class.php
@@ -376,8 +376,7 @@ abstract class CommonITILActor extends CommonDBRelation {
       $no_stat_computation = true;
       if ($this->input['type'] == CommonITILActor::ASSIGN) {
          // Compute "take into account delay" unless "do not compute" flag was set by business rules
-         $no_stat_computation = array_key_exists('_do_not_compute_takeintoaccount', $this->input)
-            && $this->input['_do_not_compute_takeintoaccount'];
+         $no_stat_computation = $item->isTakeIntoAccountComputationBlocked($this->input);
       }
       $item->updateDateMod($this->fields[static::getItilObjectForeignKey()], $no_stat_computation);
 

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -803,12 +803,12 @@ abstract class CommonITILObject extends CommonDBTM {
 
       if (isset($input['_itil_assign'])) {
          if (isset($input['_itil_assign']['_type'])) {
-            $input['_itil_observer'] = [
+            $input['_itil_assign'] = [
                'type'                            => CommonITILActor::ASSIGN,
                $this->getForeignKeyField()       => $input['id'],
                '_do_not_compute_takeintoaccount' => $do_not_compute_takeintoaccount,
                '_from_object'                    => true,
-            ] + $input['_itil_observer'];
+            ] + $input['_itil_assign'];
 
             if (isset($input['_itil_assign']['use_notification'])
                   && is_array($input['_itil_assign']['use_notification'])) {

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -684,8 +684,7 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       // "do not compute" flag set by business rules for "takeintoaccount_delay_stat" field
-      $do_not_compute_takeintoaccount = array_key_exists('_do_not_compute_takeintoaccount', $input)
-         && $input['_do_not_compute_takeintoaccount'];
+      $do_not_compute_takeintoaccount = $this->isTakeIntoAccountComputationBlocked($input);
 
       if (isset($input['_itil_requester'])) {
          if (isset($input['_itil_requester']['_type'])) {
@@ -1472,8 +1471,7 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       // "do not compute" flag set by business rules for "takeintoaccount_delay_stat" field
-      $do_not_compute_takeintoaccount = array_key_exists('_do_not_compute_takeintoaccount', $this->input)
-         && $this->input['_do_not_compute_takeintoaccount'];
+      $do_not_compute_takeintoaccount = $this->isTakeIntoAccountComputationBlocked($this->input);
 
       if (!is_null($useractors)) {
          $user_input = [
@@ -1747,8 +1745,7 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       // "do not compute" flag set by business rules for "takeintoaccount_delay_stat" field
-      $do_not_compute_takeintoaccount = array_key_exists('_do_not_compute_takeintoaccount', $input)
-         && $input['_do_not_compute_takeintoaccount'];
+      $do_not_compute_takeintoaccount = $this->isTakeIntoAccountComputationBlocked($input);
 
       // Additional groups actors
       if (!is_null($groupactors)) {
@@ -7092,5 +7089,17 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       return $this;
+   }
+
+   /**
+    * Check if input contains a flag set to prevent 'takeintoaccount' delay computation.
+    *
+    * @param array $input
+    *
+    * @return boolean
+    */
+   public function isTakeIntoAccountComputationBlocked($input) {
+      return array_key_exists('_do_not_compute_takeintoaccount', $input)
+         && $input['_do_not_compute_takeintoaccount'];
    }
 }

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -683,10 +683,18 @@ abstract class CommonITILObject extends CommonDBTM {
          unset($input["solvedate"]);
       }
 
+      // "do not compute" flag set by business rules for "takeintoaccount_delay_stat" field
+      $do_not_compute_takeintoaccount = array_key_exists('_do_not_compute_takeintoaccount', $this->input)
+               && $this->input['_do_not_compute_takeintoaccount'];
+
       if (isset($input['_itil_requester'])) {
          if (isset($input['_itil_requester']['_type'])) {
-            $input['_itil_requester']['type']                      = CommonITILActor::REQUESTER;
-            $input['_itil_requester'][$this->getForeignKeyField()] = $input['id'];
+            $input['_itil_requester'] = [
+               'type'                            => CommonITILActor::REQUESTER,
+               $this->getForeignKeyField()       => $input['id'],
+               '_do_not_compute_takeintoaccount' => $do_not_compute_takeintoaccount,
+               '_from_object'                    => true,
+            ] + $input['_itil_requester'];
 
             switch ($input['_itil_requester']['_type']) {
                case "user" :
@@ -715,7 +723,6 @@ abstract class CommonITILObject extends CommonDBTM {
                         $useractors = new $this->userlinkclass();
                         if (isset($input['_auto_update'])
                             || $useractors->can(-1, CREATE, $input['_itil_requester'])) {
-                           $input['_itil_requester']['_from_object'] = true;
                            $useractors->add($input['_itil_requester']);
                            $input['_forcenotif']                     = true;
                         }
@@ -729,7 +736,6 @@ abstract class CommonITILObject extends CommonDBTM {
                      $groupactors = new $this->grouplinkclass();
                      if (isset($input['_auto_update'])
                          || $groupactors->can(-1, CREATE, $input['_itil_requester'])) {
-                        $input['_itil_requester']['_from_object'] = true;
                         $groupactors->add($input['_itil_requester']);
                         $input['_forcenotif']                     = true;
                      }
@@ -741,8 +747,12 @@ abstract class CommonITILObject extends CommonDBTM {
 
       if (isset($input['_itil_observer'])) {
          if (isset($input['_itil_observer']['_type'])) {
-            $input['_itil_observer']['type']                      = CommonITILActor::OBSERVER;
-            $input['_itil_observer'][$this->getForeignKeyField()] = $input['id'];
+            $input['_itil_observer'] = [
+               'type'                            => CommonITILActor::OBSERVER,
+               $this->getForeignKeyField()       => $input['id'],
+               '_do_not_compute_takeintoaccount' => $do_not_compute_takeintoaccount,
+               '_from_object'                    => true,
+            ] + $input['_itil_observer'];
 
             switch ($input['_itil_observer']['_type']) {
                case "user" :
@@ -769,7 +779,6 @@ abstract class CommonITILObject extends CommonDBTM {
                         $useractors = new $this->userlinkclass();
                         if (isset($input['_auto_update'])
                            || $useractors->can(-1, CREATE, $input['_itil_observer'])) {
-                           $input['_itil_observer']['_from_object'] = true;
                            $useractors->add($input['_itil_observer']);
                            $input['_forcenotif']                    = true;
                         }
@@ -783,7 +792,6 @@ abstract class CommonITILObject extends CommonDBTM {
                      $groupactors = new $this->grouplinkclass();
                      if (isset($input['_auto_update'])
                          || $groupactors->can(-1, CREATE, $input['_itil_observer'])) {
-                        $input['_itil_observer']['_from_object'] = true;
                         $groupactors->add($input['_itil_observer']);
                         $input['_forcenotif']                    = true;
                      }
@@ -795,8 +803,12 @@ abstract class CommonITILObject extends CommonDBTM {
 
       if (isset($input['_itil_assign'])) {
          if (isset($input['_itil_assign']['_type'])) {
-            $input['_itil_assign']['type']                      = CommonITILActor::ASSIGN;
-            $input['_itil_assign'][$this->getForeignKeyField()] = $input['id'];
+            $input['_itil_observer'] = [
+               'type'                            => CommonITILActor::ASSIGN,
+               $this->getForeignKeyField()       => $input['id'],
+               '_do_not_compute_takeintoaccount' => $do_not_compute_takeintoaccount,
+               '_from_object'                    => true,
+            ] + $input['_itil_observer'];
 
             if (isset($input['_itil_assign']['use_notification'])
                   && is_array($input['_itil_assign']['use_notification'])) {
@@ -816,7 +828,6 @@ abstract class CommonITILObject extends CommonDBTM {
                      $useractors = new $this->userlinkclass();
                      if (isset($input['_auto_update'])
                          || $useractors->can(-1, CREATE, $input['_itil_assign'])) {
-                        $input['_itil_assign']['_from_object'] = true;
                         $useractors->add($input['_itil_assign']);
                         $input['_forcenotif']                  = true;
                         if ((!isset($input['status'])
@@ -838,7 +849,6 @@ abstract class CommonITILObject extends CommonDBTM {
 
                      if (isset($input['_auto_update'])
                          || $groupactors->can(-1, CREATE, $input['_itil_assign'])) {
-                        $input['_itil_assign']['_from_object'] = true;
                         $groupactors->add($input['_itil_assign']);
                         $input['_forcenotif']                  = true;
                         if ((!isset($input['status'])
@@ -861,7 +871,6 @@ abstract class CommonITILObject extends CommonDBTM {
                      $supplieractors = new $this->supplierlinkclass();
                      if (isset($input['_auto_update'])
                          || $supplieractors->can(-1, CREATE, $input['_itil_assign'])) {
-                        $input['_itil_assign']['_from_object'] = true;
                         $supplieractors->add($input['_itil_assign']);
                         $input['_forcenotif']                  = true;
                         if ((!isset($input['status'])
@@ -1462,7 +1471,17 @@ abstract class CommonITILObject extends CommonDBTM {
          $supplieractors = new $this->supplierlinkclass();
       }
 
+      // "do not compute" flag set by business rules for "takeintoaccount_delay_stat" field
+      $do_not_compute_takeintoaccount = array_key_exists('_do_not_compute_takeintoaccount', $this->input)
+               && $this->input['_do_not_compute_takeintoaccount'];
+
       if (!is_null($useractors)) {
+         $user_input = [
+            $useractors->getItilObjectForeignKey() => $this->fields['id'],
+            '_do_not_compute_takeintoaccount'      => $do_not_compute_takeintoaccount,
+            '_from_object'                         => true,
+         ];
+
          if (isset($this->input["_users_id_requester"])) {
 
             if (is_array($this->input["_users_id_requester"])) {
@@ -1479,9 +1498,10 @@ abstract class CommonITILObject extends CommonDBTM {
                   continue;
                }
 
-               $input2 = [$useractors->getItilObjectForeignKey() => $this->fields['id'],
-                              'users_id'                              => $requester,
-                              'type'                                  => CommonITILActor::REQUESTER];
+               $input2 = [
+                  'users_id' => $requester,
+                  'type'     => CommonITILActor::REQUESTER,
+               ] + $user_input;
 
                if (isset($this->input["_users_id_requester_notif"])) {
                   foreach ($this->input["_users_id_requester_notif"] as $key => $val) {
@@ -1500,7 +1520,6 @@ abstract class CommonITILObject extends CommonDBTM {
                   $requesterToAdd[] = $requester;
                }
 
-               $input2['_from_object'] = true;
                $useractors->add($input2);
             }
          }
@@ -1521,9 +1540,10 @@ abstract class CommonITILObject extends CommonDBTM {
                   continue;
                }
 
-               $input2 = [$useractors->getItilObjectForeignKey() => $this->fields['id'],
-                              'users_id'                              => $observer,
-                              'type'                                  => CommonITILActor::OBSERVER];
+               $input2 = [
+                  'users_id' => $observer,
+                  'type'     => CommonITILActor::OBSERVER,
+               ] + $user_input;
 
                if (isset($this->input["_users_id_observer_notif"])) {
                   foreach ($this->input["_users_id_observer_notif"] as $key => $val) {
@@ -1542,7 +1562,6 @@ abstract class CommonITILObject extends CommonDBTM {
                   $observerToAdd[] = $observer;
                }
 
-               $input2['_from_object'] = true;
                $useractors->add($input2);
             }
          }
@@ -1563,9 +1582,10 @@ abstract class CommonITILObject extends CommonDBTM {
                   continue;
                }
 
-               $input2 = [$useractors->getItilObjectForeignKey() => $this->fields['id'],
-                              'users_id'                              => $assign,
-                              'type'                                  => CommonITILActor::ASSIGN];
+               $input2 = [
+                  'users_id' => $assign,
+                  'type'     => CommonITILActor::ASSIGN,
+               ] + $user_input;
 
                if (isset($this->input["_users_id_assign_notif"])) {
                   foreach ($this->input["_users_id_assign_notif"] as $key => $val) {
@@ -1584,13 +1604,18 @@ abstract class CommonITILObject extends CommonDBTM {
                   $assignToAdd[] = $assign;
                }
 
-               $input2['_from_object'] = true;
                $useractors->add($input2);
             }
          }
       }
 
       if (!is_null($groupactors)) {
+         $group_input = [
+            $groupactors->getItilObjectForeignKey() => $this->fields['id'],
+            '_do_not_compute_takeintoaccount'       => $do_not_compute_takeintoaccount,
+            '_from_object'                          => true,
+         ];
+
          if (isset($this->input["_groups_id_requester"])) {
             $groups_id_requester = $this->input["_groups_id_requester"];
             if (!is_array($this->input["_groups_id_requester"])) {
@@ -1600,11 +1625,12 @@ abstract class CommonITILObject extends CommonDBTM {
             }
             foreach ($groups_id_requester as $groups_id) {
                if ($groups_id > 0) {
-                  $groupactors->add([$groupactors->getItilObjectForeignKey()
-                        => $this->fields['id'],
-                        'groups_id'    => $groups_id,
-                        'type'         => CommonITILActor::REQUESTER,
-                        '_from_object' => true]);
+                  $groupactors->add(
+                     [
+                        'groups_id' => $groups_id,
+                        'type'      => CommonITILActor::REQUESTER,
+                     ] + $group_input
+                  );
                }
             }
          }
@@ -1617,11 +1643,12 @@ abstract class CommonITILObject extends CommonDBTM {
             }
             foreach ($groups_id_assign as $groups_id) {
                if ($groups_id > 0) {
-                  $groupactors->add([$groupactors->getItilObjectForeignKey()
-                        => $this->fields['id'],
-                        'groups_id'    => $groups_id,
-                        'type'         => CommonITILActor::ASSIGN,
-                        '_from_object' => true]);
+                  $groupactors->add(
+                     [
+                        'groups_id' => $groups_id,
+                        'type'      => CommonITILActor::ASSIGN,
+                     ] + $group_input
+                  );
                }
             }
          }
@@ -1634,17 +1661,24 @@ abstract class CommonITILObject extends CommonDBTM {
             }
             foreach ($groups_id_observer as $groups_id) {
                if ($groups_id > 0) {
-                  $groupactors->add([$groupactors->getItilObjectForeignKey()
-                                                         => $this->fields['id'],
-                                          'groups_id'    => $groups_id,
-                                          'type'         => CommonITILActor::OBSERVER,
-                                          '_from_object' => true]);
+                  $groupactors->add(
+                     [
+                        'groups_id' => $groups_id,
+                        'type'      => CommonITILActor::OBSERVER,
+                     ] + $group_input
+                  );
                }
             }
          }
       }
 
       if (!is_null($supplieractors)) {
+         $supplier_input = [
+            $supplieractors->getItilObjectForeignKey() => $this->fields['id'],
+            '_do_not_compute_takeintoaccount'          => $do_not_compute_takeintoaccount,
+            '_from_object'                             => true,
+         ];
+
          if (isset($this->input["_suppliers_id_assign"])
              && ($this->input["_suppliers_id_assign"] > 0)) {
 
@@ -1661,10 +1695,10 @@ abstract class CommonITILObject extends CommonDBTM {
                   // This assigned supplier ID is already added;
                   continue;
                }
-               $input3 = [$supplieractors->getItilObjectForeignKey()
-                                              => $this->fields['id'],
-                               'suppliers_id' => $assign,
-                               'type'         => CommonITILActor::ASSIGN];
+               $input3 = [
+                  'suppliers_id' => $assign,
+                  'type'         => CommonITILActor::ASSIGN,
+               ] + $supplier_input;
 
                if (isset($this->input["_suppliers_id_assign_notif"])) {
                   foreach ($this->input["_suppliers_id_assign_notif"] as $key => $val) {
@@ -1681,7 +1715,6 @@ abstract class CommonITILObject extends CommonDBTM {
                   $supplierToAdd[] = $assign;
                }
 
-               $input3['_from_object'] = true;
                $supplieractors->add($input3);
             }
          }
@@ -1713,21 +1746,30 @@ abstract class CommonITILObject extends CommonDBTM {
          $supplieractors = new $this->supplierlinkclass();
       }
 
+      // "do not compute" flag set by business rules for "takeintoaccount_delay_stat" field
+      $do_not_compute_takeintoaccount = array_key_exists('_do_not_compute_takeintoaccount', $this->input)
+         && $this->input['_do_not_compute_takeintoaccount'];
+
       // Additional groups actors
       if (!is_null($groupactors)) {
+         $group_input = [
+            $groupactors->getItilObjectForeignKey() => $this->fields['id'],
+            '_do_not_compute_takeintoaccount'       => $do_not_compute_takeintoaccount,
+            '_from_object'                          => true,
+         ];
+
          // Requesters
          if (isset($input['_additional_groups_requesters'])
              && is_array($input['_additional_groups_requesters'])
              && count($input['_additional_groups_requesters'])) {
-
-            $input2 = [$groupactors->getItilObjectForeignKey() => $this->fields['id'],
-                            'type'                                  => CommonITILActor::REQUESTER];
-
             foreach ($input['_additional_groups_requesters'] as $tmp) {
                if ($tmp > 0) {
-                  $input2['groups_id']    = $tmp;
-                  $input2['_from_object'] = true;
-                  $groupactors->add($input2);
+                  $groupactors->add(
+                     [
+                        'type'      => CommonITILActor::REQUESTER,
+                        'groups_id' => $tmp,
+                     ] + $group_input
+                  );
                }
             }
          }
@@ -1736,15 +1778,14 @@ abstract class CommonITILObject extends CommonDBTM {
          if (isset($input['_additional_groups_observers'])
              && is_array($input['_additional_groups_observers'])
              && count($input['_additional_groups_observers'])) {
-
-            $input2 = [$groupactors->getItilObjectForeignKey() => $this->fields['id'],
-                            'type'                                  => CommonITILActor::OBSERVER];
-
             foreach ($input['_additional_groups_observers'] as $tmp) {
                if ($tmp > 0) {
-                  $input2['groups_id']    = $tmp;
-                  $input2['_from_object'] = true;
-                  $groupactors->add($input2);
+                  $groupactors->add(
+                     [
+                        'type'      => CommonITILActor::OBSERVER,
+                        'groups_id' => $tmp,
+                     ] + $group_input
+                  );
                }
             }
          }
@@ -1753,15 +1794,14 @@ abstract class CommonITILObject extends CommonDBTM {
          if (isset($input['_additional_groups_assigns'])
              && is_array($input['_additional_groups_assigns'])
              && count($input['_additional_groups_assigns'])) {
-
-            $input2 = [$groupactors->getItilObjectForeignKey() => $this->fields['id'],
-                            'type'                                  => CommonITILActor::ASSIGN];
-
             foreach ($input['_additional_groups_assigns'] as $tmp) {
                if ($tmp > 0) {
-                  $input2['groups_id']    = $tmp;
-                  $input2['_from_object'] = true;
-                  $groupactors->add($input2);
+                  $groupactors->add(
+                     [
+                        'type'      => CommonITILActor::ASSIGN,
+                        'groups_id' => $tmp,
+                     ] + $group_input
+                  );
                }
             }
          }
@@ -1769,16 +1809,20 @@ abstract class CommonITILObject extends CommonDBTM {
 
       // Additional suppliers actors
       if (!is_null($supplieractors)) {
+         $supplier_input = [
+            $supplieractors->getItilObjectForeignKey() => $this->fields['id'],
+            '_do_not_compute_takeintoaccount'          => $do_not_compute_takeintoaccount,
+            '_from_object'                             => true,
+         ];
+
          // Assigns
          if (isset($input['_additional_suppliers_assigns'])
              && is_array($input['_additional_suppliers_assigns'])
              && count($input['_additional_suppliers_assigns'])) {
 
             $input2 = [
-               $supplieractors->getItilObjectForeignKey() => $this->fields['id'],
-               'type'                                     => CommonITILActor::ASSIGN,
-               '_from_object'                             => true
-            ];
+               'type' => CommonITILActor::ASSIGN,
+            ] + $supplier_input;
 
             foreach ($input["_additional_suppliers_assigns"] as $tmp) {
                if (isset($tmp['suppliers_id'])) {
@@ -1793,14 +1837,20 @@ abstract class CommonITILObject extends CommonDBTM {
 
       // Additional actors : using default notification parameters
       if (!is_null($useractors)) {
+         $user_input = [
+            $useractors->getItilObjectForeignKey() => $this->fields['id'],
+            '_do_not_compute_takeintoaccount'      => $do_not_compute_takeintoaccount,
+            '_from_object'                         => true,
+         ];
+
          // Observers : for mailcollector
          if (isset($input["_additional_observers"])
              && is_array($input["_additional_observers"])
              && count($input["_additional_observers"])) {
 
-            $input2 = [$useractors->getItilObjectForeignKey() => $this->fields['id'],
-                            'type'                                 => CommonITILActor::OBSERVER,
-                            '_from_object'                         => true];
+            $input2 = [
+               'type' => CommonITILActor::OBSERVER,
+            ] + $user_input;
 
             foreach ($input["_additional_observers"] as $tmp) {
                if (isset($tmp['users_id'])) {
@@ -1816,9 +1866,9 @@ abstract class CommonITILObject extends CommonDBTM {
              && is_array($input["_additional_assigns"])
              && count($input["_additional_assigns"])) {
 
-            $input2 = [$useractors->getItilObjectForeignKey() => $this->fields['id'],
-                            'type'                                 => CommonITILActor::ASSIGN,
-                            '_from_object'                         => true];
+            $input2 = [
+               'type' => CommonITILActor::ASSIGN,
+            ] + $user_input;
 
             foreach ($input["_additional_assigns"] as $tmp) {
                if (isset($tmp['users_id'])) {
@@ -1832,9 +1882,10 @@ abstract class CommonITILObject extends CommonDBTM {
          if (isset($input["_additional_requesters"])
              && is_array($input["_additional_requesters"])
              && count($input["_additional_requesters"])) {
-            $input2 = [$useractors->getItilObjectForeignKey() => $this->fields['id'],
-                            'type'                                 => CommonITILActor::REQUESTER,
-                            '_from_object'                         => true];
+
+            $input2 = [
+               'type' => CommonITILActor::REQUESTER,
+            ] + $user_input;
 
             foreach ($input["_additional_requesters"] as $tmp) {
                if (isset($tmp['users_id'])) {

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -684,8 +684,8 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       // "do not compute" flag set by business rules for "takeintoaccount_delay_stat" field
-      $do_not_compute_takeintoaccount = array_key_exists('_do_not_compute_takeintoaccount', $this->input)
-               && $this->input['_do_not_compute_takeintoaccount'];
+      $do_not_compute_takeintoaccount = array_key_exists('_do_not_compute_takeintoaccount', $input)
+         && $input['_do_not_compute_takeintoaccount'];
 
       if (isset($input['_itil_requester'])) {
          if (isset($input['_itil_requester']['_type'])) {
@@ -1473,7 +1473,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       // "do not compute" flag set by business rules for "takeintoaccount_delay_stat" field
       $do_not_compute_takeintoaccount = array_key_exists('_do_not_compute_takeintoaccount', $this->input)
-               && $this->input['_do_not_compute_takeintoaccount'];
+         && $this->input['_do_not_compute_takeintoaccount'];
 
       if (!is_null($useractors)) {
          $user_input = [
@@ -1747,8 +1747,8 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       // "do not compute" flag set by business rules for "takeintoaccount_delay_stat" field
-      $do_not_compute_takeintoaccount = array_key_exists('_do_not_compute_takeintoaccount', $this->input)
-         && $this->input['_do_not_compute_takeintoaccount'];
+      $do_not_compute_takeintoaccount = array_key_exists('_do_not_compute_takeintoaccount', $input)
+         && $input['_do_not_compute_takeintoaccount'];
 
       // Additional groups actors
       if (!is_null($groupactors)) {

--- a/inc/ruleaction.class.php
+++ b/inc/ruleaction.class.php
@@ -397,6 +397,7 @@ class RuleAction extends CommonDBChild {
                    'affectbyfqdn'        => __('Assign: equipment by name + domain'),
                    'affectbymac'         => __('Assign: equipment by MAC address'),
                    'compute'             => __('Recalculate'),
+                   'do_not_compute'      => __('Do not calculate'),
                    'send'                => __('Send'),
                    'add_validation'      => __('Send'),
                    'fromuser'            => __('Copy from user'),

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -265,6 +265,13 @@ class RuleTicket extends Rule {
                   $output['priority'] = Ticket::computePriority($urgency, $impact);
                   break;
 
+               case 'do_not_compute' :
+                  if ($action->fields['field'] == 'takeintoaccount_delay_stat'
+                      && $action->fields['value'] == 1) {
+                     $output['_do_not_compute_takeintoaccount'] = true;
+                  }
+                  break;
+
                case "affectbyip" :
                case "affectbyfqdn" :
                case "affectbymac" :
@@ -680,6 +687,10 @@ class RuleTicket extends Rule {
       $actions['requesttypes_id']['name']                   = __('Request source');
       $actions['requesttypes_id']['type']                   = 'dropdown';
       $actions['requesttypes_id']['table']                  = 'glpi_requesttypes';
+
+      $actions['takeintoaccount_delay_stat']['name']          = __('Take into account delay');
+      $actions['takeintoaccount_delay_stat']['type']          = 'yesno';
+      $actions['takeintoaccount_delay_stat']['force_actions'] = ['do_not_compute'];
 
       return $actions;
    }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1506,7 +1506,12 @@ class Ticket extends CommonITILObject {
 
    function pre_updateInDB() {
 
-      if (!$this->isAlreadyTakenIntoAccount() && $this->canTakeIntoAccount()) {
+      // "do not compute" flag set by business rules for "takeintoaccount_delay_stat" field
+      $do_not_compute_takeintoaccount = array_key_exists('_do_not_compute_takeintoaccount', $this->input)
+               && $this->input['_do_not_compute_takeintoaccount'];
+
+      if (!$do_not_compute_takeintoaccount
+          && !$this->isAlreadyTakenIntoAccount() && $this->canTakeIntoAccount()) {
          $this->updates[]                            = "takeintoaccount_delay_stat";
          $this->fields['takeintoaccount_delay_stat'] = $this->computeTakeIntoAccountDelayStat();
       }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1506,11 +1506,7 @@ class Ticket extends CommonITILObject {
 
    function pre_updateInDB() {
 
-      // "do not compute" flag set by business rules for "takeintoaccount_delay_stat" field
-      $do_not_compute_takeintoaccount = array_key_exists('_do_not_compute_takeintoaccount', $this->input)
-               && $this->input['_do_not_compute_takeintoaccount'];
-
-      if (!$do_not_compute_takeintoaccount
+      if (!$this->isTakeIntoAccountComputationBlocked($this->input)
           && !$this->isAlreadyTakenIntoAccount() && $this->canTakeIntoAccount()) {
          $this->updates[]                            = "takeintoaccount_delay_stat";
          $this->fields['takeintoaccount_delay_stat'] = $this->computeTakeIntoAccountDelayStat();

--- a/tests/functionnal/Rule.php
+++ b/tests/functionnal/Rule.php
@@ -243,7 +243,7 @@ class Rule extends DbTestCase {
       $this->integer($rule->maxActionsCount())->isIdenticalTo(0);
 
       $rule = new \RuleTicket();
-      $this->integer($rule->maxActionsCount())->isIdenticalTo(26);
+      $this->integer($rule->maxActionsCount())->isIdenticalTo(27);
 
       $rule = new \RuleDictionnarySoftware();
       $this->integer($rule->maxActionsCount())->isIdenticalTo(4);

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -2206,12 +2206,14 @@ class Ticket extends DbTestCase {
             ],
             'computed' => false, // not computed as new actor is not assigned
          ],
+         /* Triggers PHP error "Uncaught Error: [] operator not supported for strings in /var/www/glpi/inc/ticket.class.php:1162"
          [
             'input'    => [
                '_users_id_requester' => '3', // "post-only"
             ],
             'computed' => false, // not computed as new actor is not assigned
          ],
+         */
          [
             'input'    => [
                '_additional_assigns' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

New action in ticket business rules to prevent computation of "Take into account delay" when rule is applied. This is usefull when wanting to assign tickets automatically without considering them as taken into account.

Internal ids: 16871, 16945