### PR TITLE
Sorting dropdown lists used in search filters.

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2541,6 +2541,13 @@ JAVASCRIPT;
          $value = $criteria['field'];
       }
 
+      // sorts the dropdown list elements so they will appear in order for user.
+      foreach ($values as $key => $val) {
+         if (is_array($values[$key]) && count($values[$key]) > 1) {
+            asort($values[$key], SORT_NATURAL | SORT_FLAG_CASE);
+         }
+      }
+
       $rand = Dropdown::showFromArray("criteria{$prefix}[$num][field]", $values, [
          'value' => $value,
          'width' => '170px'


### PR DESCRIPTION
Some users want to see elements sorted into some dropdown that are used in the search filter tool bar.

These elements don't come necessarily from DB .
asort() permits to the elements to keep their key values unchanged after sort.

Q | A
-- | --
Bug fix? | no
New feature? | yes
BC breaks? | no
Deprecations? | no
Tests pass? | yes
Fixed tickets | glpi-project#5714

