### PR TITLE
Using a cache to know whether a table exits or not

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -67,6 +67,9 @@ class DBmysql {
 
    private $cache_disabled = false;
 
+   // Ticket GitHub #5273, to avoid requesting DB each time.
+   static $table_exists_arr = [];
+
    /**
     * Constructor / Connect to the MySQL Database
     *
@@ -875,17 +878,31 @@ class DBmysql {
     * @return boolean
     **/
    public function tableExists($tablename) {
+
+      if (!isset($_SESSION['glpi_plugins']) ||
+         (isset($_SESSION['glpi_plugins']) && $_SESSION['glpi_plugins'] == [])) {
+         self::$table_exists_arr = [];
+      }
+
+      if (!isset($_POST["install"]) &&
+          file_exists(GLPI_CONFIG_DIR . "/config_db.php") &&
+          isset(self::$table_exists_arr[$tablename])) {
+         return self::$table_exists_arr[$tablename];
+      }
+
       // Get a list of tables contained within the database.
       $result = $this->listTables("%$tablename%");
 
       if (count($result)) {
          while ($data = $result->next()) {
             if ($data['TABLE_NAME'] === $tablename) {
+               self::$table_exists_arr[$tablename] = true;
                return true;
             }
          }
       }
 
+      self::$table_exists_arr[$tablename] = false;
       return false;
    }
 


### PR DESCRIPTION
Using a cache to know whether a table exits or not, instead of requesting DB each time.

It partially fixes the bug of having the same queries sent too many times to database in the same HTTP request, which slow down considerably the application.
The correction consists of saving the DB return values of some queries into a static (class) variable (cache).

A part of the issue 5273 was solved otherwise by community on subsequent versions, so this PR contains only the part that was left unsolved.


Q | A
-- | --
Bug fix? | no
New feature? | yes
BC breaks? | no
Deprecations? | no
Tests pass? | yes
Fixed tickets | glpi-project#5273


