### PR TITLE
Add  ssl connect option to mysql/mariadb databases

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -54,14 +54,56 @@ class DBmysql {
 
    // Slave management
    public $slave              = false;
-   // DB is using ssl
+
+   /**
+    * Defines if connection must use SSL.
+    *
+    * @var boolean
+    */
    public $dbssl              = false;
-   // ssl key path
-   public $dbsslkey           = "";
-   // ssl cert path
-   public $dbsslcert          = "";
-   // ssl ca path
-   public $dbsslca            = "";
+
+   /**
+    * The path name to the key file (used in case of SSL connection).
+    *
+    * @see mysqli::ssl_set()
+    * @var string|null
+    */
+   public $dbsslkey           = null;
+
+   /**
+    * The path name to the certificate file (used in case of SSL connection).
+    *
+    * @see mysqli::ssl_set()
+    * @var string|null
+    */
+   public $dbsslcert          = null;
+
+   /**
+    * The path name to the certificate authority file (used in case of SSL connection).
+    *
+    * @see mysqli::ssl_set()
+    * @var string|null
+    */
+   public $dbsslca            = null;
+
+   /**
+    * The pathname to a directory that contains trusted SSL CA certificates in PEM format
+    * (used in case of SSL connection).
+    *
+    * @see mysqli::ssl_set()
+    * @var string|null
+    */
+   public $dbsslcapath        = null;
+
+   /**
+    * A list of allowable ciphers to use for SSL encryption (used in case of SSL connection).
+    *
+    * @see mysqli::ssl_set()
+    * @var string|null
+    */
+   public $dbsslcacipher      = null;
+
+
    /** Is it a first connection ?
     * Indicates if the first connection attempt is successful or not
     * if first attempt fail -> display a warning which indicates that glpi is in readonly
@@ -104,8 +146,8 @@ class DBmysql {
              $this->dbsslkey,
              $this->dbsslcert,
              $this->dbsslca,
-             null,
-             null
+             $this->dbsslcapath,
+             $this->dbsslcacipher
           );
       }
 

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -58,7 +58,7 @@ class DBmysql {
    public $dbssl              = false;
    // ssl key path
    public $dbsslkey           = "";
-   // ssl cert path 
+   // ssl cert path
    public $dbsslcert          = "";
    // ssl ca path
    public $dbsslca            = "";
@@ -96,15 +96,18 @@ class DBmysql {
     */
    function connect($choice = null) {
       $this->connected = false;
-        $this->dbh = @new mysqli();
-        $this->dbh->init();
-        if ($this->dbssl) {
-                mysqli_ssl_set($this->dbh, $this->dbsslkey,
-                    $this->dbsslcert,
-                    $this->dbsslca,
-                    null,
-                    null);
-        }
+      $this->dbh = @new mysqli();
+      $this->dbh->init();
+      if ($this->dbssl) {
+          mysqli_ssl_set(
+             $this->dbh,
+             $this->dbsslkey,
+             $this->dbsslcert,
+             $this->dbsslca,
+             null,
+             null
+          );
+      }
 
       if (is_array($this->dbhost)) {
          // Round robin choice
@@ -120,11 +123,11 @@ class DBmysql {
          // Host
          $this->dbh->real_connect($host, $this->dbuser, rawurldecode($this->dbpassword), $this->dbdefault);
       } else if (intval($hostport[1])>0) {
-	      // Host:port
-	       $this->dbh->real_connect($hostport[0], $this->dbuser, rawurldecode($this->dbpassword), $this->dbdefault, $hostport[1]);
+         // Host:port
+          $this->dbh->real_connect($hostport[0], $this->dbuser, rawurldecode($this->dbpassword), $this->dbdefault, $hostport[1]);
       } else {
-	       // :Socket
-	       $this->dbh->real_connect($hostport[0], $this->dbuser, rawurldecode($this->dbpassword), $this->dbdefault, ini_get('mysqli.default_port'), $hostport[1]);
+          // :Socket
+          $this->dbh->real_connect($hostport[0], $this->dbuser, rawurldecode($this->dbpassword), $this->dbdefault, ini_get('mysqli.default_port'), $hostport[1]);
       }
 
       if ($this->dbh->connect_error) {


### PR DESCRIPTION
Permit to add config of ssl connection in config_db.php

like this for example

> public $dbssl=True;
> 
> public $dbsslkey = '/etc/maria/ssl/key.pem';
> 
> public $dbsslcert = '/etc/maria/ssl/cert.pem';
> 
> public $dbsslca = '/etc/maria/ssl/cert.pem';
> 


Q | A
-- | --
Bug fix? | no
New feature? | yes
BC breaks? | no
Deprecations? | no
Tests pass? | yes
Fixed tickets |  

