### PR TITLE
Fix invalid is_private condition for change/problem tasks

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6248,7 +6248,7 @@ abstract class CommonITILObject extends CommonDBTM {
       $restrict_fup['itemtype'] = self::getType();
       $restrict_fup['items_id'] = $this->getID();
 
-      if (!Session::haveRight("task", CommonITILTask::SEEPRIVATE)) {
+      if ($task_obj->maybePrivate() && !Session::haveRight("task", CommonITILTask::SEEPRIVATE)) {
          $restrict_task = [
             'OR' => [
                'is_private'   => 0,

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -653,7 +653,7 @@ abstract class CommonITILTask  extends CommonDBTM {
       $name = _n('Task', 'Tasks', Session::getPluralNumber());
 
       $task_condition = '';
-      if (!Session::haveRight("task", CommonITILTask::SEEPRIVATE)) {
+      if ($task->maybePrivate() && !Session::haveRight("task", CommonITILTask::SEEPRIVATE)) {
          $task_condition = "AND (`NEWTABLE`.`is_private` = 0
                                  OR `NEWTABLE`.`users_id` = '".Session::getLoginUserID()."')";
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Internal id: 16967

1) Fix an error while displaying timeline of a problem/change without having `CommonITILTask::SEEPRIVATE` rights.
```
  *** MySQL query error:
  SQL: SELECT * FROM `glpi_problemtasks` WHERE `problems_id` = '2' AND (`is_private` = '0' OR `users_id` = '5') ORDER BY `date` DESC
  Error: Unknown column 'is_private' in 'where clause'
  Backtrace :
  inc/dbmysqliterator.class.php:95                   
  inc/dbmysql.class.php:569                          DBmysqlIterator->execute()
  inc/commondbtm.class.php:525                       DBmysql->request()
  inc/commonitilobject.class.php:6274                CommonDBTM->find()
  inc/commonitilobject.class.php:6392                CommonITILObject->getTimelineItems()
  inc/problem.class.php:213                          CommonITILObject->showTimeline()
  inc/commonglpi.class.php:485                       Problem::displayTabContentForItem()
  ajax/common.tabs.php:92                            CommonGLPI::displayStandardTab()
```

2) Fix an error while displaying problem/change search result containing a task related column without having `CommonITILTask::SEEPRIVATE` rights.
```
  *** MySQL query error:
  SQL: SELECT DISTINCT `glpi_problems`.`id` AS id, 'normal' AS currentuser,
                        `glpi_problems`.`entities_id`, `glpi_problems`.`is_recursive`,  `glpi_problems`.`name` AS `ITEM_Problem_1`,
                        `glpi_problems`.`id` AS `ITEM_Problem_1_id`,
                        `glpi_problems`.`id` AS `ITEM_Problem_1_id`, `glpi_problems`.`content` AS `ITEM_Problem_1_content`, `glpi_problems`.`status` AS `ITEM_Problem_1_status`, `glpi_entities`.`completename` AS `ITEM_Problem_80`,   GROUP_CONCAT(DISTINCT CONCAT(IFNULL(`glpi_problemtasks_a95fd98edbd46090dff2143b9ae7975e`.`content`, '__NULL__'),
                                               '$#$',`glpi_problemtasks_a95fd98edbd46090dff2143b9ae7975e`.`id`) ORDER BY `glpi_problemtasks_a95fd98edbd46090dff2143b9ae7975e`.`id` SEPARATOR '$$##$$')
                              AS `ITEM_Problem_26`,
                  
                  `glpi_problems`.`status` AS `ITEM_Problem_12`,  `glpi_problems`.`date_mod` AS `ITEM_Problem_19` FROM `glpi_problems` LEFT JOIN `glpi_problems_users`  AS `glpi_problems_users_d1524bb2ea1d461ab90aed3b5f0e7e60`
                                             ON (`glpi_problems`.`id` = `glpi_problems_users_d1524bb2ea1d461ab90aed3b5f0e7e60`.`problems_id`
                                                 AND `glpi_problems_users_d1524bb2ea1d461ab90aed3b5f0e7e60`.`type` = 1 ) LEFT JOIN `glpi_problems_users`  AS `glpi_problems_users_d86d1fe2a1ea996e3820de82e6aa57e8`
                                             ON (`glpi_problems`.`id` = `glpi_problems_users_d86d1fe2a1ea996e3820de82e6aa57e8`.`problems_id`
                                                 AND `glpi_problems_users_d86d1fe2a1ea996e3820de82e6aa57e8`.`type` = 3 ) LEFT JOIN `glpi_problems_users`  AS `glpi_problems_users_819efb92c8b927b345e489211ec8e43b`
                                             ON (`glpi_problems`.`id` = `glpi_problems_users_819efb92c8b927b345e489211ec8e43b`.`problems_id`
                                                 AND `glpi_problems_users_819efb92c8b927b345e489211ec8e43b`.`type` = 2 )LEFT JOIN `glpi_entities` 
                                          ON (`glpi_problems`.`entities_id` = `glpi_entities`.`id`
                                              ) LEFT JOIN `glpi_problemtasks`  AS `glpi_problemtasks_a95fd98edbd46090dff2143b9ae7975e`
                                             ON (`glpi_problems`.`id` = `glpi_problemtasks_a95fd98edbd46090dff2143b9ae7975e`.`problems_id`
                                                 AND (`glpi_problemtasks_a95fd98edbd46090dff2143b9ae7975e`.`is_private` = 0
                                 OR `glpi_problemtasks_a95fd98edbd46090dff2143b9ae7975e`.`users_id` = '5') ) WHERE ( `glpi_problems_users_d1524bb2ea1d461ab90aed3b5f0e7e60`.users_id = '5'
                                 OR `glpi_problems_users_d86d1fe2a1ea996e3820de82e6aa57e8`.users_id = '5'
                                 OR `glpi_problems_users_819efb92c8b927b345e489211ec8e43b`.users_id = '5'
                                 OR `glpi_problems`.`users_id_recipient` = '5')  AND `glpi_problems`.`is_deleted` = 0  AND (   `glpi_problems`.`status` IN ('1','7','2','3','4') ) GROUP BY `glpi_problems`.`id` ORDER BY ITEM_Problem_19 DESC 
  Error: Unknown column 'glpi_problemtasks_a95fd98edbd46090dff2143b9ae7975e.is_private' in 'on clause'
  Backtrace :
  inc/search.class.php:1191                          
  inc/search.class.php:98                            Search::constructData()
  inc/search.class.php:80                            Search::showList()
  front/problem.php:39                               Search::show()
```