### PR TITLE
apply not operator for search groups

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -978,7 +978,11 @@ class Search {
             if (isset($criterion['criteria']) && count($criterion['criteria'])) {
                $sub_sql = self::constructCriteriaSQL($criterion['criteria'], $data, $searchopt, $is_having);
                if (strlen($sub_sql)) {
-                  $sql .= "$LINK ($sub_sql)";
+                  if ($NOT) {
+                     $sql .= "$LINK NOT($sub_sql)";
+                  } else {
+                     $sql .= "$LINK ($sub_sql)";
+                  }
                }
             } else if (isset($searchopt[$criterion['field']]["usehaving"])
                        || ($meta && "AND NOT" === $criterion['link'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

in case of `NOT AND` operator on a group criterion, the generated sql doesn't include the `not` part

![image](https://user-images.githubusercontent.com/418844/57611691-b206f500-7573-11e9-9c93-7b4a70ca5bd8.png)

