### PR TITLE
fix(dicosoft): escape software name

### DIFF
--- a/inc/ruledictionnarysoftwarecollection.class.php
+++ b/inc/ruledictionnarysoftwarecollection.class.php
@@ -173,7 +173,7 @@ class RuleDictionnarySoftwareCollection extends RuleCollection {
                //Find all the softwares in the database with the same name and manufacturer
                $sql = "SELECT `id`
                        FROM `glpi_softwares`
-                       WHERE `name` = '" . $input["name"] . "'
+                       WHERE `name` = '" . $DB->escape($input["name"]) . "'
                              AND `manufacturers_id` = '" . $input["manufacturers_id"] . "'";
                $res_soft = $DB->query($sql);
 

--- a/inc/ruledictionnarysoftwarecollection.class.php
+++ b/inc/ruledictionnarysoftwarecollection.class.php
@@ -174,7 +174,7 @@ class RuleDictionnarySoftwareCollection extends RuleCollection {
                $sql = "SELECT `id`
                        FROM `glpi_softwares`
                        WHERE `name` = '" . $DB->escape($input["name"]) . "'
-                             AND `manufacturers_id` = '" . $input["manufacturers_id"] . "'";
+                             AND `manufacturers_id` = '" . (int)$input["manufacturers_id"] . "'";
                $res_soft = $DB->query($sql);
 
                if ($DB->numrows($res_soft) > 0) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

```txt
glpisqllog.ERROR: DBmysql::query() in /var/www/glpi/inc/dbmysql.class.php line 177
  *** MySQL query error:
  SQL: SELECT `id`
                       FROM `glpi_softwares`
                       WHERE `name` = 'Infra. d'app. de la couche Données Microsoft SQL Server 2008 R2'
                             AND `manufacturers_id` = '15'
  Error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'app. de la couche Données Microsoft SQL Server 2008 R2'
                       ' at line 3
  Backtrace :
  ...ruledictionnarysoftwarecollection.class.php:178
  front/rule.common.php:84                           RuleDictionnarySoftwareCollection->replayRulesOnExistingDB()
  front/ruledictionnarysoftware.php:37               include()
  {"user":"2@S045-015-037","mem_usage":"0.036\", 9.02Mio)"}
```
