### PR TITLE
Fix ancestors and sons cache invalidation

### DIFF
--- a/inc/commontreedropdown.class.php
+++ b/inc/commontreedropdown.class.php
@@ -188,9 +188,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
             $input["ancestors_cache"] = '';
             if (Toolbox::useCache()) {
                $ckey = $this->getTable() . '_ancestors_cache_' . $this->getID();
-               if ($GLPI_CACHE->has($ckey)) {
-                  $GLPI_CACHE->delete($ckey);
-               }
+               $GLPI_CACHE->delete($ckey);
             }
             return $this->adaptTreeFieldsFromUpdateOrAdd($input);
          }
@@ -215,9 +213,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       //drop from sons cache when needed
       if ($changeParent && Toolbox::useCache()) {
          $ckey = $this->getTable() . '_ancestors_cache_' . $ID;
-         if ($GLPI_CACHE->has($ckey)) {
-            $GLPI_CACHE->delete($ckey);
-         }
+         $GLPI_CACHE->delete($ckey);
       }
 
       if (($updateName) || ($changeParent)) {
@@ -316,6 +312,11 @@ abstract class CommonTreeDropdown extends CommonDropdown {
                   unset($sons[$this->getID()]);
                   $GLPI_CACHE->set($ckey, $sons);
                }
+            } else {
+               // If cache key does not exists in current context (UI using APCu), it may exists
+               // in another context (CLI using filesystem). So we force deletion of cache in all contexts
+               // to be sure to not use a stale value.
+               $GLPI_CACHE->delete($ckey);
             }
          }
       }
@@ -341,6 +342,11 @@ abstract class CommonTreeDropdown extends CommonDropdown {
                   $sons[$this->getID()] = (string)$this->getID();
                   $GLPI_CACHE->set($ckey, $sons);
                }
+            } else {
+               // If cache key does not exists in current context (UI using APCu), it may exists
+               // in another context (CLI using filesystem). So we force deletion of cache in all contexts
+               // to be sure to not use a stale value.
+               $GLPI_CACHE->delete($ckey);
             }
          }
       }

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -132,9 +132,7 @@ class Entity extends CommonTreeDropdown {
       $this->cleanParentsSons();
       if (Toolbox::useCache()) {
          $ckey = $this->getTable() . '_ancestors_cache_' . $this->getID();
-         if ($GLPI_CACHE->has($ckey)) {
-            $GLPI_CACHE->delete($ckey);
-         }
+         $GLPI_CACHE->delete($ckey);
       }
       return true;
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Internal id: 16959

This one is a bit tricky.

To reproduce:

0. Use a cache that is not shared across UI and CLI (e.g. APCu for UI and filesystem fot CLI).
1. Create a group tree of 3 levels (e.g. "group lvl1" > "group lvl2" > "group lvl3.1").
2. Create a SLA rule that do something if currently assigned group is under a group (e.g. "group lvl2").
3. Create a ticket that matches SLA rule (e.g. assigned group is "group lvl3.1").
4. Wait for the cron to pass, and see that SLA rule match.
5. Create a new group under the group used for the SLA rule (e.g. "group lvl3.2" under "group lvl2").
6. Create a ticket that is assigned to this new group (e.g. assigned group is "group lvl3.2").
7. Wait for the cron to pass, and see that SLA rule **DOES NOT** match.

Explaination:
Prior to step 4, `glpi_groups_sons_cache_XXX` for the "group lvl2" is not initialized.
On step 4, cache is initialized on cron context.
On step 5, UI consider that there is no cache for `glpi_groups_sons_cache_XXX` as the value that was initailized in cron context is not available in UI context, so cache is not updated nor invalidated.
On step 6, as cache was not updated, the last created group is not returned by `getSonsOf` method.

Fix:
1. Force generation of sons cache if it does not exists on current context (that will update the footprint file and invalidate cached values on other contexts).
2. Delete ancestors cache without checking if it exists (that will update the footprint file and invalidate cached values on other contexts).

I tried to produce a fix with a limited impact on code, but I think we should refactor a little this part to factorize operations on cache.