### PR TITLE
Replace security die by an error trigerring

### DIFF
--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -261,8 +261,11 @@ function glpi_autoload($classname) {
 
    // empty classname or non concerted plugin or classname containing dot (leaving GLPI main treee)
    if (empty($classname) || is_numeric($classname) || (strpos($classname, '.') !== false)) {
-      echo "Security die. trying to load a forbidden class name";
-      die(1);
+      trigger_error(
+         sprintf('Trying to load a forbidden class name "%1$s"', $classname),
+         E_USER_ERROR
+      );
+      return false;
    }
 
    if ($classname === 'phpCAS'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The security die in autoload does not generate any trace and makes things hard to debug.
I propose to replace it by a call to `trigger_error`, to log a trace from error.

Simple test: http://127.0.0.1/front/ticket.form.php?_add_fromitem&itemtype=15&items_id=1
![image](https://user-images.githubusercontent.com/33253653/57841512-f7712f80-77ca-11e9-8b29-6bfeef277f6e.png)
