### PR TITLE
Fix overwrite of status set by business rules

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -829,10 +829,11 @@ abstract class CommonITILObject extends CommonDBTM {
                          || $useractors->can(-1, CREATE, $input['_itil_assign'])) {
                         $useractors->add($input['_itil_assign']);
                         $input['_forcenotif']                  = true;
-                        if ((!isset($input['status'])
+                        if (((!isset($input['status'])
                              && in_array($this->fields['status'], $this->getNewStatusArray()))
                             || (isset($input['status'])
-                                && in_array($input['status'], $this->getNewStatusArray()))) {
+                                && in_array($input['status'], $this->getNewStatusArray())))
+                            && !$this->isStatusComputationBlocked($input)) {
                            if (in_array(self::ASSIGNED, array_keys($this->getAllStatusArray()))) {
                               $input['status'] = self::ASSIGNED;
                            }
@@ -850,10 +851,11 @@ abstract class CommonITILObject extends CommonDBTM {
                          || $groupactors->can(-1, CREATE, $input['_itil_assign'])) {
                         $groupactors->add($input['_itil_assign']);
                         $input['_forcenotif']                  = true;
-                        if ((!isset($input['status'])
+                        if (((!isset($input['status'])
                              && (in_array($this->fields['status'], $this->getNewStatusArray())))
                             || (isset($input['status'])
-                                && (in_array($input['status'], $this->getNewStatusArray())))) {
+                                && (in_array($input['status'], $this->getNewStatusArray()))))
+                            && !$this->isStatusComputationBlocked($input)) {
                            if (in_array(self::ASSIGNED, array_keys($this->getAllStatusArray()))) {
                               $input['status'] = self::ASSIGNED;
                            }
@@ -872,10 +874,11 @@ abstract class CommonITILObject extends CommonDBTM {
                          || $supplieractors->can(-1, CREATE, $input['_itil_assign'])) {
                         $supplieractors->add($input['_itil_assign']);
                         $input['_forcenotif']                  = true;
-                        if ((!isset($input['status'])
+                        if (((!isset($input['status'])
                              && (in_array($this->fields['status'], $this->getNewStatusArray())))
                             || (isset($input['status'])
-                                && (in_array($input['status'], $this->getNewStatusArray())))) {
+                                && (in_array($input['status'], $this->getNewStatusArray()))))
+                            && !$this->isStatusComputationBlocked($input)) {
                            if (in_array(self::ASSIGNED, array_keys($this->getAllStatusArray()))) {
                               $input['status'] = self::ASSIGNED;
                            }
@@ -7056,5 +7059,18 @@ abstract class CommonITILObject extends CommonDBTM {
    public function isTakeIntoAccountComputationBlocked($input) {
       return array_key_exists('_do_not_compute_takeintoaccount', $input)
          && $input['_do_not_compute_takeintoaccount'];
+   }
+
+   /**
+    * Check if input contains a flag set to prevent status computation.
+    *
+    * @param array $input
+    *
+    * @return boolean
+    */
+   public function isStatusComputationBlocked(array $input) {
+
+      return array_key_exists('_do_not_compute_status', $input)
+         && $input['_do_not_compute_status'];
    }
 }

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -195,6 +195,12 @@ class RuleTicket extends Rule {
                case "assign" :
                   $output[$action->fields["field"]] = $action->fields["value"];
 
+                  // Special case of status
+                  if ($action->fields["field"] === 'status') {
+                     // Add a flag to remember that status was forced by rule
+                     $output['_do_not_compute_status'] = true;
+                  }
+
                   // Special case of users_id_requester
                   if ($action->fields["field"] === '_users_id_requester') {
                      // Add groups of requester

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1953,6 +1953,7 @@ class Ticket extends CommonITILObject {
       }
 
       // Replay setting auto assign if set in rules engine or by auto_assign_mode
+      // Do not force status if status has been set by rules
       if (((isset($input["_users_id_assign"])
            && ((!is_array($input['_users_id_assign']) &&  $input["_users_id_assign"] > 0)
                || is_array($input['_users_id_assign']) && count($input['_users_id_assign']) > 0))
@@ -1962,8 +1963,8 @@ class Ticket extends CommonITILObject {
            || (isset($input["_suppliers_id_assign"])
            && ((!is_array($input['_suppliers_id_assign']) && $input["_suppliers_id_assign"] > 0)
                || is_array($input['_suppliers_id_assign']) && count($input['_suppliers_id_assign']) > 0)))
-          && (in_array($input['status'], $this->getNewStatusArray()))) {
-
+          && (in_array($input['status'], $this->getNewStatusArray()))
+          && !$this->isStatusComputationBlocked($input)) {
          $input["status"] = self::ASSIGNED;
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Action "Status | Assign | New" in business rules is not working if, at the same time, a new actor is assigned to the ticket.