### PR TITLE
move right checks to CommonGLPI

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -41,6 +41,8 @@ if (!defined('GLPI_ROOT')) {
  */
 class Auth extends CommonGLPI {
 
+   static $rightname = 'config';
+
    //Errors
    private $errors = [];
    /** User class variable
@@ -85,15 +87,6 @@ class Auth extends CommonGLPI {
       $this->user = new User();
    }
 
-   /**
-    *
-    * @return boolean
-    *
-    * @since 0.85
-    */
-   static function canView() {
-      return Session::haveRight('config', READ);
-   }
 
    static function getMenuContent() {
 

--- a/inc/backup.class.php
+++ b/inc/backup.class.php
@@ -48,15 +48,6 @@ class Backup extends CommonGLPI {
    const CHECKUPDATE = 1024;
 
 
-
-   /**
-    * @since 0.85.3
-    **/
-   static function canView() {
-      return Session::haveRight(self::$rightname, READ);
-   }
-
-
    static function getTypeName($nb = 0) {
       return __('Maintenance');
    }

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -134,13 +134,6 @@ class CommonDBTM extends CommonGLPI {
    static protected $plugins_forward_entity = [];
 
    /**
-    * Rightname used to check rights to do actions on item.
-    *
-    * @var string
-    */
-   static $rightname = '';
-
-   /**
     * Flag to determine whether or not table name of item has a notepad.
     *
     * @var boolean
@@ -1882,69 +1875,6 @@ class CommonDBTM extends CommonGLPI {
 
 
    /**
-    * Have I the global right to "create" the Object
-    * May be overloaded if needed (ex KnowbaseItem)
-    *
-    * @return boolean
-   **/
-   static function canCreate() {
-
-      if (static::$rightname) {
-         return Session::haveRight(static::$rightname, CREATE);
-      }
-      return false;
-   }
-
-
-   /**
-    * Have I the global right to "delete" the Object
-    *
-    * May be overloaded if needed
-    *
-    * @return boolean
-   **/
-   static function canDelete() {
-
-      if (static::$rightname) {
-         return Session::haveRight(static::$rightname, DELETE);
-      }
-      return false;
-   }
-
-
-   /**
-    * Have I the global right to "purge" the Object
-    *
-    * May be overloaded if needed
-    *
-    * @return boolean
-    **/
-   static function canPurge() {
-
-      if (static::$rightname) {
-         return Session::haveRight(static::$rightname, PURGE);
-      }
-      return false;
-   }
-
-
-   /**
-    * Have I the global right to "update" the Object
-    *
-    * Default is calling canCreate
-    * May be overloaded if needed
-    *
-    * @return boolean
-   **/
-   static function canUpdate() {
-
-      if (static::$rightname) {
-         return Session::haveRight(static::$rightname, UPDATE);
-      }
-   }
-
-
-   /**
     * Have I the right to "create" the Object
     *
     * Default is true and check entity if the objet is entity assign
@@ -2022,24 +1952,6 @@ class CommonDBTM extends CommonGLPI {
          }
       }
       return true;
-   }
-
-
-   /**
-    * Have I the global right to "view" the Object
-    *
-    * Default is true and check entity if the objet is entity assign
-    *
-    * May be overloaded if needed
-    *
-    * @return boolean
-   **/
-   static function canView() {
-
-      if (static::$rightname) {
-         return Session::haveRight(static::$rightname, READ);
-      }
-      return false;
    }
 
 

--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -56,6 +56,13 @@ class CommonGLPI {
    public $taborientation          = 'horizontal';
 
    /**
+    * Rightname used to check rights to do actions on item.
+    *
+    * @var string
+    */
+   static $rightname = '';
+
+    /**
     * Need to get item to show tab
     *
     * @var boolean
@@ -84,6 +91,82 @@ class CommonGLPI {
    **/
    static function getType() {
       return get_called_class();
+   }
+
+
+   /**
+    * Have I the global right to "create" the Object
+    * May be overloaded if needed (ex KnowbaseItem)
+    *
+    * @return boolean
+   **/
+   static function canCreate() {
+      if (static::$rightname) {
+         return Session::haveRight(static::$rightname, CREATE);
+      }
+      return false;
+   }
+
+
+   /**
+    * Have I the global right to "view" the Object
+    *
+    * Default is true and check entity if the objet is entity assign
+    *
+    * May be overloaded if needed
+    *
+    * @return boolean
+   **/
+   static function canView() {
+      if (static::$rightname) {
+         return Session::haveRight(static::$rightname, READ);
+      }
+      return false;
+   }
+
+
+   /**
+    * Have I the global right to "update" the Object
+    *
+    * Default is calling canCreate
+    * May be overloaded if needed
+    *
+    * @return boolean
+   **/
+   static function canUpdate() {
+      if (static::$rightname) {
+         return Session::haveRight(static::$rightname, UPDATE);
+      }
+   }
+
+
+   /**
+    * Have I the global right to "delete" the Object
+    *
+    * May be overloaded if needed
+    *
+    * @return boolean
+   **/
+   static function canDelete() {
+      if (static::$rightname) {
+         return Session::haveRight(static::$rightname, DELETE);
+      }
+      return false;
+   }
+
+
+   /**
+    * Have I the global right to "purge" the Object
+    *
+    * May be overloaded if needed
+    *
+    * @return boolean
+   **/
+   static function canPurge() {
+      if (static::$rightname) {
+         return Session::haveRight(static::$rightname, PURGE);
+      }
+      return false;
    }
 
 

--- a/inc/report.class.php
+++ b/inc/report.class.php
@@ -45,15 +45,6 @@ class Report extends CommonGLPI{
    static $rightname         = 'reports';
 
 
-
-   /**
-    * @since 0.85.3
-   **/
-   static function canView() {
-      return Session::haveRight(self::$rightname, READ);
-   }
-
-
    static function getTypeName($nb = 0) {
       return _n('Report', 'Reports', $nb);
    }

--- a/inc/stat.class.php
+++ b/inc/stat.class.php
@@ -42,11 +42,6 @@ class Stat extends CommonGLPI {
    static $rightname = 'statistic';
 
 
-   static function canView() {
-      return Session::haveRight(self::$rightname, READ);
-   }
-
-
    static function getTypeName($nb = 0) {
       return __('Statistics');
    }


### PR DESCRIPTION
Discussion about some itemtypes inherited from CommonGLPI beause they don't have a table in DB.

Those itemtypes implement right management but the right management code is located in CommonDBTM. It seems more accurate to implement can* methods in CommonGLPI and keep Can*Item() in CommonDBTM.



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
