### PR TITLE
Add 'status' criterion on tickets business rules

### DIFF
--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -469,6 +469,9 @@ class RuleTicket extends Rule {
       $criterias['priority']['name']                        = __('Priority');
       $criterias['priority']['type']                        = 'dropdown_priority';
 
+      $criterias['status']['name']                          = __('Status');
+      $criterias['status']['type']                          = 'dropdown_status';
+
       $criterias['_mailgate']['table']                      = 'glpi_mailcollectors';
       $criterias['_mailgate']['field']                      = 'name';
       $criterias['_mailgate']['name']                       = __('Mails receiver');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Combined with #5915 , following rule prevents new tickets to have a `Processing (assigned)` status when no actor is assign in form and actors are defined by business rules or autoassign based on hardware/category.

![image](https://user-images.githubusercontent.com/33253653/57854828-770df700-77e9-11e9-9dd5-79e04326c1e2.png)
![image](https://user-images.githubusercontent.com/33253653/57854863-8a20c700-77e9-11e9-9533-331440356ab0.png)
![image](https://user-images.githubusercontent.com/33253653/57854882-94db5c00-77e9-11e9-958c-299dae305ab6.png)
