### PR TITLE
Prevent usage of github API for leafo/scssphp package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,8 +74,15 @@
     },
     "repositories": {
         "leafo/scssphp": {
-            "type": "vcs",
-            "url": "https://github.com/leafo/scssphp"
+            "type": "package",
+            "package": {
+                "name": "leafo/scssphp",
+                "version": "0.8.2",
+                "dist": {
+                    "url": "https://github.com/leafo/scssphp/archive/v0.8.2.zip",
+                    "type": "zip"
+                }
+            }
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a79700f6d4199cd2b90d4ea2b9534504",
+    "content-hash": "69fb18ddc073b030232c047bc2b2eb73",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -110,14 +110,9 @@
         {
             "name": "leafo/scssphp",
             "version": "v0.8.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/leafo/scssphp.git",
-                "reference": "1b168bfee60889547e1fe55b9afdf055f6d3c58d"
-            },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/leafo/scssphp/zipball/1b168bfee60889547e1fe55b9afdf055f6d3c58d",
+                "url": "https://github.com/leafo/scssphp/archive/v0.8.2.zip",
                 "reference": "1b168bfee60889547e1fe55b9afdf055f6d3c58d",
                 "shasum": ""
             },
@@ -2927,12 +2922,12 @@
             "version": "v1.6.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mikey179/vfsStream.git",
+                "url": "https://github.com/bovigo/vfsStream.git",
                 "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
                 "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
                 "shasum": ""
             },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This will prevent composer operations to ask for a github API token.