### PR TITLE
Observer group condition

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -3319,7 +3319,7 @@ abstract class CommonITILObject extends CommonDBTM {
          'name'               => __('Watcher group'),
          'forcegroupby'       => true,
          'massiveaction'      => false,
-         'condition'          => ['is_requester' => 1],
+         'condition'          => ['is_watcher' => 1],
          'joinparams'         => [
             'beforejoin'         => [
                'table'              => getTableForItemType($this->grouplinkclass),

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -587,7 +587,7 @@ class RuleTicket extends Rule {
       $actions['_groups_id_observer']['table']              = 'glpi_groups';
       $actions['_groups_id_observer']['name']               = __('Watcher group');
       $actions['_groups_id_observer']['type']               = 'dropdown';
-      $actions['_groups_id_observer']['condition']          = ['is_requester' => 1];
+      $actions['_groups_id_observer']['condition']          = ['is_watcher' => 1];
       $actions['_groups_id_observer']['force_actions']      = ['assign', 'append'];
       $actions['_groups_id_observer']['permitseveral']      = ['append'];
       $actions['_groups_id_observer']['appendto']           = '_additional_groups_observers';


### PR DESCRIPTION
When we search for a "Watcher Group" (in ticket seach or in a new rule action), GLPI show the groups with "is_requester" to 1.

Wouldn't it be more logical to filter on "is_watcher" instead ?

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Internal ref | 17042
