### PR TITLE
Add ability to reset translation cache

### DIFF
--- a/front/config.form.php
+++ b/front/config.form.php
@@ -52,7 +52,8 @@ if (!empty($_GET['reset_opcache'])) {
 }
 if (!empty($_GET['reset_cache'])) {
    $config->checkGlobal(UPDATE);
-   if ($GLPI_CACHE->clear()) {
+   $cache = isset($_GET['optname']) ? Config::getCache($_GET['optname']) : $GLPI_CACHE;
+   if ($cache->clear()) {
       Session::addMessageAfterRedirect(__('Cache reset successful'));
    }
    Html::redirect(Toolbox::getItemTypeFormURL('Config'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The Zend Translator component do not check for file changes if a cache storage has been set. So if someone changes data of an already cached override translation file, cache has to be cleared to take into account new translations.

I added a reset button for translation cache.
![image](https://user-images.githubusercontent.com/33253653/58254958-3a537a00-7d6c-11e9-9218-79d93b41deb8.png)

I also changed 2 elements on the performances tab:
 1. As of 9.4 cache is always instanciated, I removed the `if (Toolbox::useCache()) {` condition related to application cache.
 2. As this tab is displayed only if user has ability to update config, I removed the `if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {` condition that was necessary to display the "reset" button.