### PR TITLE
Add ability to defines custom options for PDO connection

### DIFF
--- a/src/Glpi/Database/AbstractDatabase.php
+++ b/src/Glpi/Database/AbstractDatabase.php
@@ -84,6 +84,15 @@ abstract class AbstractDatabase
     protected $dbdefault;
 
     /**
+     * Options used by connection.
+     *
+     * @see PDO::__construct()
+     *
+     * @var array
+     */
+    protected $options;
+
+    /**
      * Database handler.
      *
      * @var PDO
@@ -162,6 +171,8 @@ abstract class AbstractDatabase
         $this->dbuser = $params['user'];
         $this->dbpassword = $params['pass'];
         $this->dbdefault = $params['dbname'];
+
+        $this->options = array_key_exists('options', $params) ? $params['options'] : [];
 
         $this->connect($server);
     }

--- a/src/Glpi/Database/MySql.php
+++ b/src/Glpi/Database/MySql.php
@@ -65,7 +65,8 @@ class MySql extends AbstractDatabase
         $this->dbh = new PDO(
             "$dsn;dbname={$this->dbdefault};charset=$charset",
             $this->dbuser,
-            rawurldecode($this->dbpassword)
+            rawurldecode($this->dbpassword),
+            $this->options
         );
         $this->dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         if (GLPI_FORCE_EMPTY_SQL_MODE) {

--- a/src/Glpi/DatabaseFactory.php
+++ b/src/Glpi/DatabaseFactory.php
@@ -58,7 +58,7 @@ class DatabaseFactory
         Toolbox::checkDbConfig();
         if ($db_config === null) {
             if (file_exists(GLPI_CONFIG_DIR . '/db.yaml')) {
-                $db_config = Yaml::parseFile(GLPI_CONFIG_DIR . '/db.yaml');
+                $db_config = Yaml::parseFile(GLPI_CONFIG_DIR . '/db.yaml', Yaml::PARSE_CONSTANT);
                 if ($slave === true) {
                     if (!file_exists(GLPI_CONFIG_DIR . '/db.slave.yaml')) {
                         throw new \RuntimeException('cannot run a slave database without config!');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Follows #5892.

In order to give ability to connect to MySQL server using a secure connection, I add ability to define options used when creating PDO handler. As options may differs from a driver to another, using an array that directly defines options using PHP constants seems to be the most evolutive way to do.

```yaml
driver: mysql
host: 127.0.0.1
user: glpi
pass: glpi
dbname: glpi
options:
  !php/const:PDO::MYSQL_ATTR_SSL_KEY: /path/to/client-key.pem
  !php/const:PDO::MYSQL_ATTR_SSL_CERT: /path/to/client-cert.pem
  !php/const:PDO::MYSQL_ATTR_SSL_CA: /path/to/ca-cert.pem
```
