### PR TITLE
Fix default COLLATE used by MySQL connection

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -118,7 +118,18 @@ class DBmysql {
          $this->connected = false;
          $this->error     = 1;
       } else {
-         $this->dbh->set_charset(isset($this->dbenc) ? $this->dbenc : "utf8");
+         $dbenc = isset($this->dbenc) ? $this->dbenc : "utf8";
+         $this->dbh->set_charset($dbenc);
+         if ($dbenc === "utf8") {
+            // The mysqli::set_charset function will make COLLATE to be defined to the default one for used charset.
+            //
+            // For 'utf8' charset, default one is 'utf8_general_ci',
+            // so we have to redefine it to 'utf8_unicode_ci'.
+            //
+            // If encoding used by connection is not the default one (i.e utf8), then we assume
+            // that we cannot be sure of used COLLATE and that using the default one is the best option.
+            $this->dbh->query("SET NAMES 'utf8' COLLATE 'utf8_unicode_ci';");
+         }
 
          if (GLPI_FORCE_EMPTY_SQL_MODE) {
             $this->dbh->query("SET SESSION sql_mode = ''");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

As we use `utf8_unicode_ci`, and as using `mysqli::set_charset()` function redefines `COLLATE` to the default one for given charset, which is `utf8_general_ci`, we have to explicitely define it using `SET NAMES` query.

This is valid if used charset is `utf8`. If charset is defined with another value, I guess the best option is to let `COLLATE` to the default value.

See https://www.php.net/manual/en/mysqli.set-charset.php#121067