### PR TITLE
faster load of groups in session

### DIFF
--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -541,8 +541,8 @@ class Session {
          ] + getEntitiesRestrictCriteria(
             Group::getTable(),
             'entities_id',
-            $_SESSION['glpiactiveentities'],
-            true
+            $_SESSION['glpiactive_entity'],
+            $_SESSION['glpiactive_entity_recursive']
          )
       ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Found on a customer instance with 40k entities, on login the group loading part stucks because of the restrict criteria.

I'm not sure why we load all entities of current user against current active entity (with is_recursive)

On the mentioned case, i came from timeout (120s) from fpm to 2-3s of login resolution.
