### PR TITLE
Enhance tree ancestors/sons caching performances

### DIFF
--- a/inc/commontreedropdown.class.php
+++ b/inc/commontreedropdown.class.php
@@ -175,7 +175,6 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
 
    function prepareInputForUpdate($input) {
-      global $GLPI_CACHE;
 
       if (isset($input[$this->getForeignKeyField()])) {
          // Can't move a parent under a child
@@ -187,8 +186,8 @@ abstract class CommonTreeDropdown extends CommonDropdown {
          if ($input[$this->getForeignKeyField()] != $this->fields[$this->getForeignKeyField()]) {
             $input["ancestors_cache"] = '';
             if (Toolbox::useCache()) {
-               $ckey = $this->getTable() . '_ancestors_cache_' . $this->getID();
-               $GLPI_CACHE->delete($ckey);
+               $dbu = new DbUtils();
+               $dbu->unsetAncestorsOfCache($this->getTable(), $this->getID());
             }
             return $this->adaptTreeFieldsFromUpdateOrAdd($input);
          }
@@ -208,12 +207,12 @@ abstract class CommonTreeDropdown extends CommonDropdown {
     * @param $changeParent
    **/
    function regenerateTreeUnderID($ID, $updateName, $changeParent) {
-      global $DB, $GLPI_CACHE;
+      global $DB;
 
       //drop from sons cache when needed
       if ($changeParent && Toolbox::useCache()) {
-         $ckey = $this->getTable() . '_ancestors_cache_' . $ID;
-         $GLPI_CACHE->delete($ckey);
+         $dbu = new DbUtils();
+         $dbu->unsetAncestorsOfCache($this->getTable(), $ID);
       }
 
       if (($updateName) || ($changeParent)) {
@@ -280,7 +279,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
     * @return void
     */
    protected function cleanParentsSons($id = null, $cache = true) {
-      global $DB, $GLPI_CACHE;
+      global $DB;
 
       if ($id === null) {
          $id = $this->getID();
@@ -304,19 +303,12 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       //drop from sons cache when needed
       if ($cache && Toolbox::useCache()) {
+         $dbu = new DbUtils();
          foreach ($ancestors as $ancestor) {
-            $ckey = $this->getTable() . '_sons_cache_' . $ancestor;
-            if ($GLPI_CACHE->has($ckey)) {
-               $sons = $GLPI_CACHE->get($ckey);
-               if (isset($sons[$this->getID()])) {
-                  unset($sons[$this->getID()]);
-                  $GLPI_CACHE->set($ckey, $sons);
-               }
-            } else {
-               // If cache key does not exists in current context (UI using APCu), it may exists
-               // in another context (CLI using filesystem). So we force deletion of cache in all contexts
-               // to be sure to not use a stale value.
-               $GLPI_CACHE->delete($ckey);
+            $cached_sons = $dbu->getSonsOfCache($this->getTable(), $ancestor);
+            if (null !== $cached_sons && isset($cached_sons[$this->getID()])) {
+               unset($cached_sons[$this->getID()]);
+               $dbu->setSonsOfCache($this->getTable(), $ancestor, $cached_sons);
             }
          }
       }
@@ -329,24 +321,16 @@ abstract class CommonTreeDropdown extends CommonDropdown {
     * @return void
     */
    protected function addSonInParents() {
-      global $GLPI_CACHE;
 
       //add sons cache when needed
       if (Toolbox::useCache()) {
+         $dbu = new DbUtils();
          $ancestors = getAncestorsOf($this->getTable(), $this->getID());
          foreach ($ancestors as $ancestor) {
-            $ckey = $this->getTable() . '_sons_cache_' . $ancestor;
-            if ($GLPI_CACHE->has($ckey)) {
-               $sons = $GLPI_CACHE->get($ckey);
-               if (!isset($sons[$this->getID()])) {
-                  $sons[$this->getID()] = (string)$this->getID();
-                  $GLPI_CACHE->set($ckey, $sons);
-               }
-            } else {
-               // If cache key does not exists in current context (UI using APCu), it may exists
-               // in another context (CLI using filesystem). So we force deletion of cache in all contexts
-               // to be sure to not use a stale value.
-               $GLPI_CACHE->delete($ckey);
+            $cached_sons = $dbu->getSonsOfCache($this->getTable(), $ancestor);
+            if (null !== $cached_sons && !isset($cached_sons[$this->getID()])) {
+               $cached_sons[$this->getID()] = (string)$this->getID();
+               $dbu->setSonsOfCache($this->getTable(), $ancestor, $cached_sons);
             }
          }
       }

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -125,7 +125,6 @@ class Entity extends CommonTreeDropdown {
     * @since 0.84
    **/
    function pre_deleteItem() {
-      global $GLPI_CACHE;
 
       // Security do not delete root entity
       if ($this->input['id'] == 0) {
@@ -135,8 +134,8 @@ class Entity extends CommonTreeDropdown {
       //Cleaning sons calls getAncestorsOf and thus... Re-create cache. Call it before clean.
       $this->cleanParentsSons();
       if (Toolbox::useCache()) {
-         $ckey = $this->getTable() . '_ancestors_cache_' . $this->getID();
-         $GLPI_CACHE->delete($ckey);
+         $dbu = new DbUtils();
+         $dbu->unsetAncestorsOfCache($this->getTable(), $this->getID());
       }
       return true;
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

For each item, ancestors and sons cache is currently stored into a dedicated cache variable. On instances with a huge amount of entities, it can lead to have a huge amount of cache storage reading on each request.
Solution proposed here is:
1. Mutualize storage of sons and ancestors of elements into two cache variables `sons_of_cache` and `ancestors_of_cache`.
2. Load cached values into a static variable to not have to read cache storage multiple times on each request.