### PR TITLE
Enhance performances on getAncestorsOf calls with multiple items

### DIFF
--- a/inc/dbutils.class.php
+++ b/inc/dbutils.class.php
@@ -629,10 +629,7 @@ final class DbUtils {
       if ($is_recursive) {
          $ancestors = [];
          if (is_array($value)) {
-            foreach ($value as $val) {
-               $ancestors = array_unique(array_merge($this->getAncestorsOf('glpi_entities', $val),
-                     $ancestors));
-            }
+            $ancestors = $this->getAncestorsOf("glpi_entities", $value);
             $ancestors = array_diff($ancestors, $value);
 
          } else if (strlen($value) == 0) {

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -889,22 +889,16 @@ class Session {
          return false;
       }
 
-      if (!$is_recursive) {
-         return in_array($ID, $_SESSION['glpiactiveentities']);
-      }
-
       if (in_array($ID, $_SESSION['glpiactiveentities'])) {
          return true;
       }
 
-      /// Recursive object
-      foreach ($_SESSION['glpiactiveentities'] as $ent) {
-         if (in_array($ID, getAncestorsOf("glpi_entities", $ent))) {
-            return true;
-         }
+      if (!$is_recursive) {
+         return false;
       }
 
-      return false;
+      /// Recursive object
+      return in_array($ID, getAncestorsOf("glpi_entities", $_SESSION['glpiactiveentities']));
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Using `DbUtils::getAncestorsOf()` method passing an array of values will result in better performances as it will limit hits on cache storage.
This is actually what is done on `getEntitiesRestrictRequest` method (see https://github.com/glpi-project/glpi/blob/9.4/bugfixes/inc/dbutils.class.php#L546).