### PR TITLE
Compile all CSS during release build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,10 @@ jobs:
           name: ESLint
           command: |
             node_modules/.bin/eslint ./js && node_modules/.bin/eslint --env=node --parser-options=ecmaVersion:6 --rule 'indent: ["error", 4]' ./webpack.config.js && echo "ESLint found no errors"
+      - run:
+          name: Check CSS compilation
+          command: |
+            bin/console build:compile_scss
 
   # PHP 7.0 test suite.
   php_7_0_test_suite:

--- a/tools/compilescsscommand.class.php
+++ b/tools/compilescsscommand.class.php
@@ -82,7 +82,22 @@ class CompileScssCommand extends Command {
       $files = $input->getOption('file');
 
       if (empty($files)) {
-         $files[] = 'css/styles'; // Compile main styles if no file option is set.
+         $root_path = realpath(GLPI_ROOT);
+
+         $css_dir_iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root_path . '/css'),
+            RecursiveIteratorIterator::SELF_FIRST
+         );
+         /** @var SplFileInfo $file */
+         foreach ($css_dir_iterator as $file) {
+            if (!$file->isReadable() || !$file->isFile() || $file->getExtension() !== 'scss') {
+               continue;
+            }
+
+            $files[] = str_replace($root_path . '/', '', dirname($file->getRealPath()))
+               . '/'
+               . preg_replace('/^_?(.*)\.scss$/', '$1', $file->getBasename());
+         }
       }
 
       foreach ($files as $file) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Our release process, that uses the `build:compile_scss` with no args was only compiling the main styles. Result is that palettes and highcontrast CSS are always served using the `css.php`, even in production.

I changed this behaviour to compile all `.scss` files found recursivly inside the `/css` directory.

On master branch, this may produce useless compiled files (some are only used in imports, not as standalone), but it can be reworked later.

Before:
![image](https://user-images.githubusercontent.com/33253653/58871444-47ecf600-86c2-11e9-87c0-0c3d8f3e76ec.png)

After:
![image](https://user-images.githubusercontent.com/33253653/58871519-74087700-86c2-11e9-82e9-1a65e2a884d6.png)
