### PR TITLE
Fix console commands exit code

### DIFF
--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -193,7 +193,7 @@ class Application extends BaseApplication {
 
       $begin_time = microtime(true);
 
-      parent::doRunCommand($command, $input, $output);
+      $result = parent::doRunCommand($command, $input, $output);
 
       if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERY_VERBOSE) {
          $output->writeln(
@@ -209,6 +209,8 @@ class Application extends BaseApplication {
             )
          );
       }
+
+      return $result;
    }
 
    /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Exit code of a console command was always 0, regardless of result code returned by `execute` method of the command.

Before:
![image](https://user-images.githubusercontent.com/33253653/58873851-833df380-86c7-11e9-9f81-76428dbb1109.png)

After:
![image](https://user-images.githubusercontent.com/33253653/58873823-71f4e700-86c7-11e9-95bc-1050269b049b.png)
