### PR TITLE
Add enable/disable maintenance CLI commands; closes #5256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The present file will list all changes made to the project; according to the
 - Encrypted file systems support.
 - Mails collected from suppliers can be marked as private on an entity basis.
 - Ability to add custom CSS in entity configuration.
+- CLI commands to enable and disable maintenance mode.
 
 ### Changed
 

--- a/inc/console/maintenance/disablemaintenancemodecommand.class.php
+++ b/inc/console/maintenance/disablemaintenancemodecommand.class.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Maintenance;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use Config;
+use Glpi\Console\AbstractCommand;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DisableMaintenanceModeCommand extends AbstractCommand {
+
+   protected function configure() {
+      parent::configure();
+
+      $this->setName('glpi:maintenance:disable_maintenance_mode');
+      $this->setAliases(
+         [
+            'glpi:maintenance:off',
+            'maintenance:off',
+         ]
+      );
+      $this->setDescription(__('Disable maintenance mode'));
+   }
+
+   protected function execute(InputInterface $input, OutputInterface $output) {
+
+      $config = new Config();
+      $config->setConfigurationValues('core', ['maintenance_mode' => '0']);
+
+      $output->writeln('<info>' . __('Maintenance mode disabled.') . '</info>');
+
+      return 0; // Success
+   }
+}

--- a/inc/console/maintenance/enablemaintenancemodecommand.class.php
+++ b/inc/console/maintenance/enablemaintenancemodecommand.class.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Maintenance;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use Config;
+use Glpi\Console\AbstractCommand;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class EnableMaintenanceModeCommand extends AbstractCommand {
+
+   protected function configure() {
+      parent::configure();
+
+      $this->setName('glpi:maintenance:enable_maintenance_mode');
+      $this->setAliases(
+         [
+            'glpi:maintenance:on',
+            'maintenance:on',
+         ]
+      );
+      $this->setDescription(__('Enable maintenance mode'));
+
+      $this->addOption(
+         'text',
+         't',
+         InputOption::VALUE_OPTIONAL,
+         __('Text to display during maintenance')
+      );
+   }
+
+   protected function execute(InputInterface $input, OutputInterface $output) {
+
+      global $CFG_GLPI;
+
+      $values = [
+         'maintenance_mode' => '1'
+      ];
+      if ($input->hasOption('text')) {
+         $values['maintenance_text'] = $input->getOption('text');
+      }
+      $config = new Config();
+      $config->setConfigurationValues('core', $values);
+
+      $message = sprintf(
+         __('Maintenance mode activated. Backdoor using: %s'),
+         $CFG_GLPI['url_base'] . '/index.php?skipMaintenance=1'
+      );
+      $output->writeln('<info>' . $message . '</info>');
+
+      return 0; // Success
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5256 

Commands:
 - `bin/console glpi:maintenance:enable_maintenance_mode` or `bin/console glpi:maintenance:on` or `bin/console maintenance:on` to enable maintenance mode,
 - `bin/console glpi:maintenance:disable_maintenance_mode` or `bin/console glpi:maintenance:off` or `bin/console maintenance:off` to disable maintenance mode.

Maintenance text can be passed as an option for enable command:
 - `bin/console maintenance:on --text="We are currently upgrading GLPI. Take a coffee and come back later."` to  customize displayed text,
 - `bin/console maintenance:on --text=""` to remove previously defined text,
 - `bin/console maintenance:on` to enable without redefining text.