### PR TITLE
Fix SCSS compilation output path in release process

### DIFF
--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -91,7 +91,7 @@ echo "Minify stylesheets and javascripts"
 $INIT_PWD/vendor/bin/robo minify --load-from tools
 
 echo "Compile SCSS"
-$INIT_PWD/bin/console build:compile_scss
+./bin/console build:compile_scss
 
 echo "Compile locale files"
 ./tools/locale/update_mo.pl


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Current release script compile SCSS into a wrong path, so release archive does not contains the compiled SCSS.

I did not fix this into 9.4 version as there is a bad behaviour on 9.4 branch that prevent anyone to use another palette than auror and to use high contrast mode if CSS has been compiled from CLI as the `main_styles` CSS uses same identifier whenerver palette / highcontrast mode changed. This has been fixed in 9.5 branch by #5872.