### PR TITLE
Load Forms by FormCreator with error.

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3835,7 +3835,7 @@ class Html {
                   }
                } else {
                   if (is_object($val)) {
-                     print_r($val);
+                     //print_r($val);
                   } else {
                      echo htmlentities($val);
                   }


### PR DESCRIPTION
Fix error:  Load Forms by FormCreator with error.

[2019-05-28 08:44:06] glpiphplog.ERROR: Toolbox::userErrorHandlerNormal() in /var/www/html/glpi/inc/toolbox.class.php line 659
  *** PHP Warning(2): print_r(): Couldn't fetch mysqli
  Backtrace :
  :                                                  
  inc/html.class.php:3838                            print_r()
  inc/html.class.php:3827                            Html::printCleanArray()
  inc/html.class.php:3827                            Html::printCleanArray()
  inc/html.class.php:795                             Html::printCleanArray()
  inc/html.class.php:1643                            Html::displayDebugInfos()
  plugins/formcreator/front/form.form.php:157        Html::footer()

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
