### PR TITLE
Remove warning when NOTUPDATED plugin version changed

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -340,7 +340,7 @@ class Plugin extends CommonDBTM {
          $input              = $informations;
          $input['id']        = $plugin->fields['id'];
          $input['directory'] = $directory;
-         if (!in_array($plugin->fields['state'], [self::ANEW, self::NOTINSTALLED])) {
+         if (!in_array($plugin->fields['state'], [self::ANEW, self::NOTINSTALLED, self::NOTUPDATED])) {
             // mark it as 'updatable' unless it was not installed
             trigger_error(
                sprintf(

--- a/tests/functionnal/Plugin.php
+++ b/tests/functionnal/Plugin.php
@@ -428,6 +428,38 @@ class Plugin extends DbTestCase {
    }
 
    /**
+    * Test state checking on a valid directory corresponding to a known and NOT UPDATED plugin
+    * with a different version.
+    * Should results in keeping plugin state to "NOTUPDATED".
+    */
+   public function testCheckPluginStateForNotUpdatededAndUpdatablePlugin() {
+
+      $initial_data = [
+         'directory' => $this->test_plugin_directory,
+         'name'      => 'Test plugin',
+         'version'   => '1.0',
+         'state'     => \Plugin::NOTUPDATED,
+      ];
+      $setup_informations = [
+         'name'    => 'Test plugin NG',
+         'version' => '2.0',
+      ];
+      $expected_data = array_merge(
+         $initial_data,
+         $setup_informations,
+         [
+            'state' => \Plugin::NOTUPDATED,
+         ]
+      );
+
+      $this->doTestCheckPluginState(
+         $initial_data,
+         $setup_informations,
+         $expected_data
+      );
+   }
+
+   /**
     * Test state checking on a valid directory corresponding to a known plugin that has been renamed.
     * Should results in changing plugin directory to new value and state to "NOTUPDATED".
     */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a new version is found for a plugin that already has `NOTUPDATED` state, a warning should not be trigerred.