### PR TITLE
(9.5) Fix encryption labels

### DIFF
--- a/inc/item_disk.class.php
+++ b/inc/item_disk.class.php
@@ -574,9 +574,9 @@ class Item_Disk extends CommonDBChild {
     */
    static function getAllEncryptionStatus() {
       return [
-         self::ENCRYPTION_STATUS_NO          => __('Encrypted'),
-         self::ENCRYPTION_STATUS_YES         => __('Partially encrypted'),
-         self::ENCRYPTION_STATUS_PARTIALLY   => __('Not encrypted')
+         self::ENCRYPTION_STATUS_NO          => __('Not encrypted'),
+         self::ENCRYPTION_STATUS_PARTIALLY   => __('Partially encrypted'),
+         self::ENCRYPTION_STATUS_YES         => __('Encrypted'),
       ];
    }
 


### PR DESCRIPTION
This fix was already applied on master but not on 9.5 : [5f2f58bc9a ](https://github.com/glpi-project/glpi/commit/5f2f58bc9a132d1b665568afc6099df0aa429167#diff-91553145e3a5d893310019d5fb8e5413L633).

I've also swapped the order so "Not encrypted" is the default value (this seem more logical to me, i will apply it to master too if you agree).
Or maybe an empty value would be even better as the default value ?

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
