### PR TITLE
fix(ruleright): increase max actions count

### DIFF
--- a/inc/ruleright.class.php
+++ b/inc/ruleright.class.php
@@ -51,8 +51,7 @@ class RuleRight extends Rule {
     * @see Rule::maxActionsCount()
    **/
    function maxActionsCount() {
-      // Unlimited
-      return 4;
+      return 7;
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

Max use case (7 actions instead of 4):
- add an habilitation (3 actions): entity / profil / recursive
- enable/disable a user (1 action)
- set defaults values (3 actions): default group, default entity, default profil

Independent action:
- To be unaware of import (1 action)