### PR TITLE
Fix "Unparenthesized 'a?b:c?d:e' is deprecated." on DBmysql::quoteName()

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -766,7 +766,7 @@ class DBmysql {
             $field = ($n[1] === '*') ? $n[1] : self::quoteName($n[1]);
             return "$table.$field";
          }
-         return ($name[0]=='`' ? $name : ($name === '*') ? $name : "`$name`");
+         return ($name[0] == '`' ? $name : ($name === '*' ? $name : "`$name`"));
       }
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

See https://travis-ci.org/fusioninventory/fusioninventory-for-glpi/jobs/542662538#L617