### PR TITLE
Improved display consistency for deleted Computer_Item objects

### DIFF
--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -1768,10 +1768,7 @@ abstract class CommonDBRelation extends CommonDBConnexity {
       }
 
       if (!count($where)) {
-         $where = [
-            static::getTable() . '.' . static::$items_id_1  => $items_id,
-            static::getTable() . '.' . 'is_deleted'         => 0
-         ];
+         $where = [static::getTable() . '.' . static::$items_id_1  => $items_id];
       }
 
       $params = [
@@ -1791,6 +1788,10 @@ abstract class CommonDBRelation extends CommonDBConnexity {
          ],
          'ORDER'     => $item->getTable() . '.' . $order_col
       ];
+
+      if ($DB->fieldExists(static::getTable(), 'is_deleted')) {
+         $params['WHERE'][static::getTable() . '.is_deleted'] = 0;
+      }
 
       if ($DB->fieldExists(static::getTable(), 'itemtype')) {
          $params['WHERE'][static::getTable() . '.itemtype'] = $itemtype;

--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -1768,7 +1768,10 @@ abstract class CommonDBRelation extends CommonDBConnexity {
       }
 
       if (!count($where)) {
-         $where = [static::getTable() . '.' . static::$items_id_1  => $items_id];
+         $where = [
+            static::getTable() . '.' . static::$items_id_1  => $items_id,
+            static::getTable() . '.' . 'is_deleted'         => 0
+         ];
       }
 
       $params = [

--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -1774,7 +1774,8 @@ abstract class CommonDBRelation extends CommonDBConnexity {
       $params = [
          'SELECT' => [
             $item->getTable() . '.*',
-            static::getTable() . '.id AS linkid'
+            static::getTable() . '.id AS linkid',
+            static::getTable() . '.is_deleted AS link_is_deleted',
          ],
          'FROM'   => $item->getTable(),
          'WHERE'  => $where,

--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -1774,8 +1774,7 @@ abstract class CommonDBRelation extends CommonDBConnexity {
       $params = [
          'SELECT' => [
             $item->getTable() . '.*',
-            static::getTable() . '.id AS linkid',
-            static::getTable() . '.is_deleted AS link_is_deleted',
+            static::getTable() . '.id AS linkid'
          ],
          'FROM'   => $item->getTable(),
          'WHERE'  => $where,

--- a/inc/computer_item.class.php
+++ b/inc/computer_item.class.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * ---------------------------------------------------------------------
  * GLPI - Gestionnaire Libre de Parc Informatique
@@ -391,17 +390,9 @@ class Computer_Item extends CommonDBRelation{
                echo "</td>";
             }
             echo "<td class='center'>".$data['assoc_itemtype']::getTypeName(1)."</td>";
-
-            // Highlight this link if the linked item OR the link is deleted
-            if ($data['link_is_deleted']
-                  || (isset($data['is_deleted']) && $data['is_deleted'])
-               ) {
-               $class = "tab_bg_2_2";
-            } else {
-               $class = "";
-            }
-
-            echo "<td class='$class'>".$name."</td>";
+            echo "<td ".
+                  ((isset($data['is_deleted']) && $data['is_deleted'])?"class='tab_bg_2_2'":"").
+                 ">".$name."</td>";
             if (Plugin::haveImport()) {
                echo "<td>".Dropdown::getYesNo($data['is_dynamic'])."</td>";
             }
@@ -451,40 +442,28 @@ class Computer_Item extends CommonDBRelation{
       // Is global connection ?
       $global  = $item->getField('is_global');
 
-      $used = [];
-
-      // Array of Computer_Item data
-      $computers = [];
-
+      $used    = [];
+      $compids = [];
+      $dynamic = [];
       $result = $DB->request(
          [
-            'SELECT' => ['id', 'computers_id', 'is_dynamic', 'is_deleted'],
+            'SELECT' => ['id', 'computers_id', 'is_dynamic'],
             'FROM'   => self::getTable(),
             'WHERE'  => [
                'itemtype'   => $item->getType(),
                'items_id'   => $ID,
+               'is_deleted' => 0,
             ]
          ]
       );
-
-      // Set Computer_Item data retrieved from db
       foreach ($result as $data) {
-         $computers[$data['id']] = [
-            'computers_id' => $data['computers_id'],
-            'is_dynamic'   => $data['is_dynamic'],
-            'is_deleted'   => $data['is_deleted'],
-         ];
+         $compids[$data['id']] = $data['computers_id'];
+         $dynamic[$data['id']] = $data['is_dynamic'];
          $used['Computer'][]   = $data['computers_id'];
       }
-
-      // Number of links
-      $number = count($computers);
-      // Number of link that are not deleted
-      $numberNotDeleted = count(array_filter($computers, function($item) {
-         return !$item['is_deleted'];
-      }));
+      $number = count($compids);
       if ($canedit
-          && ($global || !$numberNotDeleted)
+          && ($global || !$number)
           && !(!empty($withtemplate) && ($withtemplate == 2))) {
          echo "<div class='firstbloc'>";
          echo "<form name='computeritem_form$rand' id='computeritem_form$rand' method='post'
@@ -548,9 +527,8 @@ class Computer_Item extends CommonDBRelation{
          $header_end .= "</tr>";
          echo $header_begin.$header_top.$header_end;
 
-         // Print a row for each Computer_Item
-         foreach ($computers as $key => $fields) {
-            $comp->getFromDB($fields['computers_id']);
+         foreach ($compids as $key => $compid) {
+            $comp->getFromDB($compid);
 
             echo "<tr class='tab_bg_1'>";
 
@@ -559,17 +537,11 @@ class Computer_Item extends CommonDBRelation{
                Html::showMassiveActionCheckBox(__CLASS__, $key);
                echo "</td>";
             }
-
-            // Highlight this link if the linked computer OR the link is deleted
-            if ($comp->getField('is_deleted') || $fields['is_deleted']) {
-               $class = "tab_bg_2_2";
-            } else {
-               $class = "";
-            }
-
-            echo "<td class='$class'>".$comp->getLink()."</td>";
+            echo "<td ".
+                  ($comp->getField('is_deleted')?"class='tab_bg_2_2'":"").
+                 ">".$comp->getLink()."</td>";
             if (Plugin::haveImport()) {
-               echo "<td>".Dropdown::getYesNo($fields['is_dynamic'])."</td>";
+               echo "<td>".Dropdown::getYesNo($dynamic[$key])."</td>";
             }
             echo "<td class='center'>".Dropdown::getDropdownName("glpi_entities",
                                                                $comp->getField('entities_id'));


### PR DESCRIPTION
Fix regression, Computer_Item used to be filtered on is_deleted but this was lost during the raw queries migration.

Related : #4705 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | pending