### PR TITLE
fix php warning on too small files

### DIFF
--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -1552,6 +1552,9 @@ class Document extends CommonDBTM {
          return false;
       }
       if (extension_loaded('exif')) {
+         if (filesize($file) < 12) {
+            return false;
+         }
          $etype = exif_imagetype($file);
          return in_array($etype, [IMAGETYPE_JPEG, IMAGETYPE_GIF, IMAGETYPE_PNG, IMAGETYPE_BMP]);
       } else {


### PR DESCRIPTION
I found myself in the same case as this user : https://www.php.net/manual/fr/function.exif-imagetype.php#79283

![image](https://user-images.githubusercontent.com/14139801/59340562-8445d500-8d06-11e9-8293-5163a18dd892.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
