### PR TITLE
add another html char for apostrophe (saw it in gmail mail)

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -829,8 +829,8 @@ class Toolbox {
                        ? null : (is_resource($value)
                        ? $value : $DB->escape(
                           str_replace(
-                             ['&#039;', '&#39;', '&quot'],
-                             ["'", "'", "'"],
+                             ['&#039;', '&#39;', '&#x27;', '&quot'],
+                             ["'", "'", "'", "'"],
                              $value
                           )
                        ))


### PR DESCRIPTION
Credit to Halexsandro de Freitas Sales for finding this one

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Replicated the issue in 9.3.4, when collected email is in html (and contains `&#27;` instead apostrophes) and glpi is in text mode, sql error occurs.

in 9.4.x, rich text mode is now the only mode available, so the bug should not be present anymore, but as the fix is easy and i'm not entirely sure we don't have more place to triggers it, i prefer to submit this one.
