### PR TITLE
Fix redirect when URL contains $CFG_GLPI['root_doc']; fixes #6027

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -495,7 +495,11 @@ class Html {
       global $CFG_GLPI;
 
       $dest     = $CFG_GLPI["root_doc"] . "/index.php";
-      $url_dest = str_replace($CFG_GLPI["root_doc"], '', $_SERVER['REQUEST_URI']);
+      $url_dest = preg_replace(
+         '/^' . preg_quote($CFG_GLPI["root_doc"], '/') . '/',
+         '',
+         $_SERVER['REQUEST_URI']
+      );
       $dest    .= "?redirect=".rawurlencode($url_dest);
 
       if (!empty($params)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6027 

If `$_SERVER['REQUEST_URI']` contains `$CFG_GLPI['root_doc']` value somewhere else than in its beginning, usage of `str_replace` was resulting in removal of this URL part.

Example: `$CFG_GLPI['root_doc']` is `/ti` and `$_SERVER['REQUEST_URI']` is `/ti/front/ticket.php`.
`str_replace($CFG_GLPI["root_doc"], '', $_SERVER['REQUEST_URI'])` => `/frontcket.php`

Using preg_replace to only remove `$CFG_GLPI["root_doc"]` when it is located at beginning of `$_SERVER['REQUEST_URI']` fixes this.