### PR TITLE
Fixes issue on notifications where 'Ticket' was hardcoded

### DIFF
--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1204,7 +1204,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
                     $objettype.'.url'                   => __('URL'),
                     $objettype.'.category'              => __('Category'),
                     $objettype.'.content'               => __('Description'),
-                    $objettype.'.description'           => sprintf(__('%1$s: %2$s'), __('Ticket'),
+                    $objettype.'.description'           => sprintf(__('%1$s: %2$s'), $this->obj->getTypeName(1),
                                                                    __('Description')),
                     $objettype.'.status'                => __('Status'),
                     $objettype.'.urgency'               => __('Urgency'),


### PR DESCRIPTION
In notifications for Changes, the text behind the ##lang.change.description## was 'Ticket: Description' instead of 'Change: Description'.
Same issue for Problem notifications.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
