### PR TITLE
Allow to disable stats computation after a followup is added

### DIFF
--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -208,7 +208,7 @@ class ITILFollowup  extends CommonDBChild {
 
       $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
 
-      // Check if stats should be computer after this change
+      // Check if stats should be computed after this change
       $no_stat = isset($this->input['_do_not_compute_takeintoaccount']);
 
       $parentitem = $this->input['_job'];

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -208,9 +208,15 @@ class ITILFollowup  extends CommonDBChild {
 
       $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
 
+      // Check if stats should be computer after this change
+      $no_stat = isset($this->input['_do_not_compute_takeintoaccount']);
+
       $parentitem = $this->input['_job'];
-      $parentitem->updateDateMod($this->input["items_id"], false,
-                                          $this->input["users_id"]);
+      $parentitem->updateDateMod(
+         $this->input["items_id"],
+         $no_stat,
+         $this->input["users_id"]
+      );
 
       if (isset($this->input["_close"])
           && $this->input["_close"]

--- a/tests/functionnal/ITILFollowup.php
+++ b/tests/functionnal/ITILFollowup.php
@@ -225,35 +225,44 @@ class ITILFollowup extends DbTestCase {
 
       // Normal behaviior, no flag specified
       $ticketID = $this->getNewITILObject('Ticket');
+      $this->integer($ticketID);
 
       $ITILFollowUp = new \ITILFollowup();
-      $ITILFollowUp->add([
+      $this->integer($ITILFollowUp->add([
          'date'                            => $_SESSION['glpi_currenttime'],
          'users_id'                        => \Session::getLoginUserID(),
          'content'                         => "Functionnal test",
          'items_id'                        => $ticketID,
          'itemtype'                        => \Ticket::class,
-      ]);
+      ]));
 
-      $ticket->getFromDB($ticketID);
+      $this->boolean($ticket->getFromDB($ticketID))
+         ->isTrue();
       $this->integer((int) $ticket->fields['takeintoaccount_delay_stat'])
          ->isGreaterThan(0);
 
       // Now using the _do_not_compute_takeintoaccount flag
       $ticketID = $this->getNewITILObject('Ticket');
+      $this->integer($ticketID);
 
       $ITILFollowUp = new \ITILFollowup();
-      $ITILFollowUp->add([
+      $this->integer($ITILFollowUp->add([
          'date'                            => $_SESSION['glpi_currenttime'],
          'users_id'                        => \Session::getLoginUserID(),
          'content'                         => "Functionnal test",
          '_do_not_compute_takeintoaccount' => true,
          'items_id'                        => $ticketID,
          'itemtype'                        => \Ticket::class,
-      ]);
+      ]));
 
-      $ticket->getFromDB($ticketID);
+      $this->boolean($ticket->getFromDB($ticketID))
+         ->isTrue();
+
       $this->integer((int) $ticket->fields['takeintoaccount_delay_stat'])
          ->isEqualTo(0);
+
+      // Reset conf
+      $_SESSION['glpiset_default_tech']      = $oldConf['glpiset_default_tech'];
+      $_SESSION['glpiset_default_requester'] = $oldConf['glpiset_default_requester'];
    }
 }


### PR DESCRIPTION
This change was needed because the formcreator plugin need to add a followup to a ticket without triggering the take into account time computation.

Internal ref : 17135
Linked PR on formcreator repository: [#1425](https://github.com/pluginsGLPI/formcreator/pull/1425)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | pending
