### PR TITLE
Fix missing cleanup of Change_Item/Item_Problem when deleting assets

### DIFF
--- a/inc/certificate.class.php
+++ b/inc/certificate.class.php
@@ -59,7 +59,6 @@ class Certificate extends CommonDBTM {
       $this->deleteChildrenAndRelationsFromDb(
          [
             Certificate_Item::class,
-            Change_Item::class,
          ]
       );
    }

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -910,6 +910,16 @@ class CommonDBTM extends CommonGLPI {
          $note->cleanDBonItemDelete($this->getType(), $this->fields['id']);
       }
 
+      if (in_array($this->getType(), $CFG_GLPI['ticket_types'])) {
+         //delete relation beetween item and changes/problems
+         $this->deleteChildrenAndRelationsFromDb(
+            [
+               Change_Item::class,
+               Item_Problem::class,
+            ]
+         );
+      }
+
       if (in_array($this->getType(), $CFG_GLPI['rackable_types'])) {
          //delete relation beetween rackable type and its rack
          $item_rack = new Item_Rack();

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -293,7 +293,6 @@ class Computer extends CommonDBTM {
       $this->deleteChildrenAndRelationsFromDb(
          [
             Certificate_Item::class,
-            Change_Item::class,
             Computer_Item::class,
             Computer_SoftwareLicense::class,
             Computer_SoftwareVersion::class,
@@ -301,7 +300,6 @@ class Computer extends CommonDBTM {
             ComputerVirtualMachine::class,
             Item_Disk::class,
             Item_OperatingSystem::class,
-            Item_Problem::class,
             Item_Project::class,
          ]
       );

--- a/inc/dcroom.class.php
+++ b/inc/dcroom.class.php
@@ -473,14 +473,4 @@ class DCRoom extends CommonDBTM {
       }
       return $positions;
    }
-
-
-   function cleanDBonPurge() {
-
-      $this->deleteChildrenAndRelationsFromDb(
-         [
-            Change_Item::class,
-         ]
-      );
-   }
 }

--- a/inc/enclosure.class.php
+++ b/inc/enclosure.class.php
@@ -361,7 +361,6 @@ class Enclosure extends CommonDBTM {
 
       $this->deleteChildrenAndRelationsFromDb(
          [
-            Change_Item::class,
             Item_Enclosure::class,
          ]
       );

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -142,9 +142,7 @@ class Monitor extends CommonDBTM {
 
       $this->deleteChildrenAndRelationsFromDb(
          [
-            Change_Item::class,
             Computer_Item::class,
-            Item_Problem::class,
             Item_Project::class,
          ]
       );

--- a/inc/networkequipment.class.php
+++ b/inc/networkequipment.class.php
@@ -99,10 +99,8 @@ class NetworkEquipment extends CommonDBTM {
       $this->deleteChildrenAndRelationsFromDb(
          [
             Certificate_Item::class,
-            Change_Item::class,
             Item_OperatingSystem::class,
             Item_Project::class,
-            Item_Problem::class,
          ]
       );
 

--- a/inc/pdu.class.php
+++ b/inc/pdu.class.php
@@ -327,7 +327,6 @@ class PDU extends CommonDBTM {
 
       $this->deleteChildrenAndRelationsFromDb(
          [
-            Change_Item::class,
             Pdu_Plug::class,
             PDU_Rack::class,
          ]

--- a/inc/peripheral.class.php
+++ b/inc/peripheral.class.php
@@ -141,8 +141,6 @@ class Peripheral extends CommonDBTM {
          [
             Certificate_Item::class,
             Computer_Item::class,
-            Item_Problem::class,
-            Change_Item::class,
             Item_Project::class,
          ]
       );

--- a/inc/phone.class.php
+++ b/inc/phone.class.php
@@ -137,8 +137,6 @@ class Phone extends CommonDBTM {
       $this->deleteChildrenAndRelationsFromDb(
          [
             Computer_Item::class,
-            Item_Problem::class,
-            Change_Item::class,
             Item_Project::class,
          ]
       );

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -242,9 +242,7 @@ class Printer  extends CommonDBTM {
       $this->deleteChildrenAndRelationsFromDb(
          [
             Certificate_Item::class,
-            Change_Item::class,
             Computer_Item::class,
-            Item_Problem::class,
             Item_Project::class,
          ]
       );

--- a/inc/rack.class.php
+++ b/inc/rack.class.php
@@ -1061,7 +1061,6 @@ JAVASCRIPT;
 
       $this->deleteChildrenAndRelationsFromDb(
          [
-            Change_Item::class,
             Item_Rack::class,
             PDU_Rack::class,
          ]

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -185,8 +185,6 @@ class Software extends CommonDBTM {
 
       $this->deleteChildrenAndRelationsFromDb(
          [
-            Change_Item::class,
-            Item_Problem::class,
             Item_Project::class,
             SoftwareVersion::class,
          ]

--- a/inc/softwarelicense.class.php
+++ b/inc/softwarelicense.class.php
@@ -161,7 +161,6 @@ class SoftwareLicense extends CommonTreeDropdown {
       $this->deleteChildrenAndRelationsFromDb(
          [
             Certificate_Item::class,
-            Change_Item::class,
             Computer_SoftwareLicense::class,
          ]
       );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

On many elements, purge was not cleaning `Item_Problem` related elements. As associable elements to Changes and Problems are listed in `$CFG_GLPI['ticket_types']`, I refactored logic to be sure that new elements (as Clusters for example) will be cleaned in the future.