### PR TITLE
Saves and restores cron context during call of SavedSearch_Alert::cronSavedSearchesAlerts

### DIFF
--- a/inc/savedsearch_alert.class.php
+++ b/inc/savedsearch_alert.class.php
@@ -305,9 +305,9 @@ class SavedSearch_Alert extends CommonDBChild {
 
    /**
     * Summary of saveContext
-    * 
+    *
     * Save $_SESSION and $CFG_GLPI into the returned array
-    * 
+    *
     * @return array[] which contains a copy of $_SESSION and $CFG_GLPI
     */
    static private function saveContext() {
@@ -320,17 +320,17 @@ class SavedSearch_Alert extends CommonDBChild {
 
    /**
     * Summary of restoreContext
-    * 
+    *
     * restore former $_SESSION and $CFG_GLPI
     * to be sure that logs will be in GLPI default datetime and language
     * and that session is restored for the next crontaskaction
-    * 
-    * @param mixed $session is the array returned by saveContext
+    *
+    * @param mixed $context is the array returned by saveContext
     */
-   static private function restoreContext($session) {
+   static private function restoreContext($context) {
       global $CFG_GLPI;
-      $_SESSION = $session['$_SESSION'];
-      $CFG_GLPI = $session['$CFG_GLPI'];
+      $_SESSION = $context['$_SESSION'];
+      $CFG_GLPI = $context['$CFG_GLPI'];
       Session::loadLanguage();
       Plugin::doHook("init_session");
    }
@@ -360,7 +360,7 @@ class SavedSearch_Alert extends CommonDBChild {
 
          // Will save $_SESSION and $CFG_GLPI cron context into an array
          $context = self::saveContext();
-         
+
          while ($row = $iterator->next()) {
             //execute saved search to get results
             try {
@@ -426,7 +426,7 @@ class SavedSearch_Alert extends CommonDBChild {
                //  and that notifications are sent even if $_SESSION['glpinotification_to_myself'] is false
                //  and to restore default cron $_SESSION and $CFG_GLPI global variables for next cron task
                self::restoreContext($context);
-               
+
                if ($notify) {
                   $event = 'alert' . ($savedsearch->getField('is_private') ? '' : '_' . $savedsearch->getID());
                   $alert = new self();

--- a/inc/savedsearch_alert.class.php
+++ b/inc/savedsearch_alert.class.php
@@ -359,7 +359,7 @@ class SavedSearch_Alert extends CommonDBChild {
          }
 
          // Will save $_SESSION and $CFG_GLPI cron context into an array
-         $context = self::saveSession();
+         $context = self::saveContext();
          
          while ($row = $iterator->next()) {
             //execute saved search to get results

--- a/inc/savedsearch_alert.class.php
+++ b/inc/savedsearch_alert.class.php
@@ -304,6 +304,38 @@ class SavedSearch_Alert extends CommonDBChild {
    }
 
    /**
+    * Summary of saveContext
+    * 
+    * Save $_SESSION and $CFG_GLPI into the returned array
+    * 
+    * @return array[] which contains a copy of $_SESSION and $CFG_GLPI
+    */
+   static private function saveContext() {
+      global $CFG_GLPI;
+      $SavedContext = [];
+      $SavedContext['$_SESSION'] = $_SESSION;
+      $SavedContext['$CFG_GLPI'] = $CFG_GLPI;
+      return $SavedContext;
+   }
+
+   /**
+    * Summary of restoreContext
+    * 
+    * restore former $_SESSION and $CFG_GLPI
+    * to be sure that logs will be in GLPI default datetime and language
+    * and that session is restored for the next crontaskaction
+    * 
+    * @param mixed $session is the array returned by saveContext
+    */
+   static private function restoreContext($session) {
+      global $CFG_GLPI;
+      $_SESSION = $session['$_SESSION'];
+      $CFG_GLPI = $session['$CFG_GLPI'];
+      Session::loadLanguage();
+      Plugin::doHook("init_session");
+   }
+
+   /**
     * Send saved searches alerts
     *
     * @param Crontask $task Crontask instance
@@ -321,17 +353,19 @@ class SavedSearch_Alert extends CommonDBChild {
       if ($iterator->numrows()) {
          $savedsearch = new SavedSearch();
 
-         $cli_logged = null;
          if (!isset($_SESSION['glpiname'])) {
             //required from search class
             $_SESSION['glpiname'] = 'crontab';
          }
 
+         // Will save $_SESSION and $CFG_GLPI cron context into an array
+         $context = self::saveSession();
+         
          while ($row = $iterator->next()) {
             //execute saved search to get results
             try {
                $savedsearch->getFromDB($row['savedsearches_id']);
-               if (isCommandLine() && $cli_logged != $savedsearch->fields['users_id']) {
+               if (isCommandLine()) {
                   //search requires a logged in user...
                   $user = new User();
                   $user->getFromDB($savedsearch->fields['users_id']);
@@ -340,7 +374,6 @@ class SavedSearch_Alert extends CommonDBChild {
                   $auth->auth_succeded = true;
                   Session::init($auth);
                   $_SESSION['glpinotification_to_myself'] = true; // Force sending of notification
-                  $cli_logged = $savedsearch->fields['users_id'];
                }
 
                $data = $savedsearch->execute(true);
@@ -389,6 +422,12 @@ class SavedSearch_Alert extends CommonDBChild {
                   $value
                );
 
+               // Will restore previously saved $_SESSION and $CFG_GLPI:
+               //  To be sure that logs will be in GLPI with default datetime and language
+               //  and that notifications are sent even if $_SESSION['glpinotification_to_myself'] is false
+               //  and to restore default cron $_SESSION and $CFG_GLPI global variables for next cron task
+               self::restoreContext($context);
+               
                if ($notify) {
                   $event = 'alert' . ($savedsearch->getField('is_private') ? '' : '_' . $savedsearch->getID());
                   $alert = new self();
@@ -398,6 +437,7 @@ class SavedSearch_Alert extends CommonDBChild {
                   $task->addVolume(1);
                }
             } catch (\Exception $e) {
+               self::restoreContext($context);
                Toolbox::logError($e);
             }
          }

--- a/inc/savedsearch_alert.class.php
+++ b/inc/savedsearch_alert.class.php
@@ -312,10 +312,10 @@ class SavedSearch_Alert extends CommonDBChild {
     */
    static private function saveContext() {
       global $CFG_GLPI;
-      $SavedContext = [];
-      $SavedContext['$_SESSION'] = $_SESSION;
-      $SavedContext['$CFG_GLPI'] = $CFG_GLPI;
-      return $SavedContext;
+      $context = [];
+      $context['$_SESSION'] = $_SESSION;
+      $context['$CFG_GLPI'] = $CFG_GLPI;
+      return $context;
    }
 
    /**

--- a/inc/savedsearch_alert.class.php
+++ b/inc/savedsearch_alert.class.php
@@ -373,7 +373,6 @@ class SavedSearch_Alert extends CommonDBChild {
                   $auth->user = $user;
                   $auth->auth_succeded = true;
                   Session::init($auth);
-                  $_SESSION['glpinotification_to_myself'] = true; // Force sending of notification
                }
 
                $data = $savedsearch->execute(true);


### PR DESCRIPTION
To be sure that logs will be in GLPI with default datetime and language
and that notifications are sent even if $_SESSION['glpinotification_to_myself'] is false
and to restore default cron $_SESSION and $CFG_GLPI global variables for next cron task

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6037 
