### PR TITLE
Fix transfered documents date in ITIL timeline and list view

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -919,7 +919,7 @@ abstract class API extends CommonGLPI {
             $doc_iterator = $DB->request([
                'SELECT'    => [
                   'glpi_documents_items.id AS assocID',
-                  'glpi_documents_items.date_mod AS assocdate',
+                  'glpi_documents_items.date_creation AS assocdate',
                   'glpi_entities.id AS entityID',
                   'glpi_entities.completename AS entity',
                   'glpi_documentcategories.completename AS headings',

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6355,13 +6355,14 @@ abstract class CommonITILObject extends CommonDBTM {
          $document_obj->getFromDB($document_item['documents_id']);
 
          $item = $document_obj->fields;
+         $item['date']     = $document_item['date_creation'];
          // #1476 - set date_mod and owner to attachment ones
          $item['date_mod'] = $document_item['date_mod'];
          $item['users_id'] = $document_item['users_id'];
 
          $item['timeline_position'] = $document_item['timeline_position'];
 
-         $timeline[$document_item['date_mod']."_document_".$document_item['documents_id']]
+         $timeline[$document_item['date_creation']."_document_".$document_item['documents_id']]
             = ['type' => 'Document_Item', 'item' => $item];
       }
 

--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -734,7 +734,7 @@ class Document_Item extends CommonDBRelation{
       $criteria = [
          'SELECT'    => [
             'glpi_documents_items.id AS assocID',
-            'glpi_documents_items.date_mod AS assocdate',
+            'glpi_documents_items.date_creation AS assocdate',
             'glpi_entities.id AS entityID',
             'glpi_entities.completename AS entity',
             'glpi_documentcategories.completename AS headings',

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -2752,10 +2752,12 @@ CREATE TABLE `glpi_documents_items` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `users_id` int(11) DEFAULT '0',
   `timeline_position` tinyint(1) NOT NULL DEFAULT '0',
+  `date_creation` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`documents_id`,`itemtype`,`items_id`),
   KEY `item` (`itemtype`,`items_id`,`entities_id`,`is_recursive`),
-  KEY `users_id` (`users_id`)
+  KEY `users_id` (`users_id`),
+  KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -221,6 +221,7 @@ function update94to95() {
 
    $ADDTODISPLAYPREF['cluster'] = [31, 19];
    /** /Clusters */
+
    /** ITIL templates */
    //rename tables
    foreach ([
@@ -282,6 +283,25 @@ function update94to95() {
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
       $DB->queryOrDie($query, "add table glpi_itilfollowuptemplates");
    }
+   /** /add templates for followups */
+
+   /** Add "date_creation" field on document_items */
+   if (!$DB->fieldExists('glpi_documents_items', 'date_creation')) {
+      $migration->addField('glpi_documents_items', 'date_creation', 'datetime');
+      $migration->addPostQuery(
+         $DB->buildUpdate(
+            'glpi_documents_items',
+            [
+               'date_creation' => new \QueryExpression(
+                  $DB->quoteName('date_mod')
+               )
+            ],
+            [true]
+         )
+      );
+      $migration->addKey('glpi_documents_items', 'date_creation');
+   }
+   /** /Add "date_creation" field on document_items */
 
    // ************ Keep it at the end **************
    foreach ($ADDTODISPLAYPREF as $type => $tab) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 17242

When a document is transfered, related document_items are updated with the new entity ID. This updates changes the date_mod field, which is used as displayed date in timeline and in document_items lists.
The side effect of this is that after a transfer of an ITIL object, all documents of the timeline are displayed at top of it, as they are the only one that does not uses their creation date for ordering.

Adding a creation_date field fixes the problem.