### PR TITLE
Make CircleCI build fail if composer install fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,10 +53,6 @@ commands:
             - composer-cache-{{ .Environment.CIRCLE_JOB }}
       - restore_cache:
           keys:
-            - composer-install-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.lock" }}
-            - composer-install-{{ .Environment.CIRCLE_JOB }}
-      - restore_cache:
-          keys:
             - npm-cache-{{ .Environment.CIRCLE_JOB }}
       - run:
           name: Install dependencies
@@ -64,17 +60,13 @@ commands:
             composer --version
             echo "node version: $(node --version)"
             echo "npm version: $(npm --version)"
-            sed -e '/"php":/d' -i composer.json
+            perl -i -0 -p -e 's/,?\s*"platform"\:\s*\{[^\}]*}//i' composer.json
             mv composer.lock composer.lock.bak
             bin/console dependencies install --ci
       - save_cache:
           key: composer-cache-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
             - /home/circleci/.composer/cache/
-      - save_cache:
-          key: composer-install-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.lock.bak" }}
-          paths:
-            - ./vendor
       - save_cache:
           key: npm-cache-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:

--- a/bin/console
+++ b/bin/console
@@ -52,11 +52,23 @@ if (isset($_SERVER['argv']) && ['dependencies', 'install'] === array_slice($_SER
    }
 
    chdir(dirname(__FILE__, 2));
-   passthru($composer_command);
-   passthru($npm_command);
+
+   $exit_code = 0;
+
+   passthru($composer_command, $exit_code);
+   if ($exit_code > 0) {
+      exit($exit_code);
+   }
+
+   passthru($npm_command, $exit_code);
+   if ($exit_code > 0) {
+      exit($exit_code);
+   }
+
    file_put_contents('.package.hash', sha1_file('package-lock.json'));
-   passthru('npm run-script build-dev');
-   exit();
+
+   passthru('npm run-script build-dev', $exit_code);
+   exit($exit_code);
 }
 
 // If "config-dir" option is used in command line, defines GLPI_CONFIG_DIR with its value


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I noticed that build continues even if dependencies install fails (see build https://circleci.com/gh/glpi-project/glpi/21292).

Fixes are:
 1. Remove `platform` block from composer config, but preserve PHP version requirement.
 2. Make dependencies install command exit with subcommand exit code (unless if exit code is 0).
 3. Remove installed vendor cache to be sure to have a clean vendor directory (vendors will be fetch from composer cache dir `~/.composer/cache`, so it will still be fast to install deps).