### PR TITLE
Correctly handle buffered schema changes during table rename

### DIFF
--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -600,6 +600,20 @@ class Migration {
          if (class_exists($itemtype)) {
             $itemtype::forceTable($newtable);
          }
+
+         // Update target of "buffered" schema updates
+         if (isset($this->change[$oldtable])) {
+            $this->change[$newtable] = $this->change[$oldtable];
+            unset($this->change[$oldtable]);
+         }
+         if (isset($this->fulltexts[$oldtable])) {
+            $this->fulltexts[$newtable] = $this->fulltexts[$oldtable];
+            unset($this->fulltexts[$oldtable]);
+         }
+         if (isset($this->uniques[$oldtable])) {
+            $this->uniques[$newtable] = $this->uniques[$oldtable];
+            unset($this->uniques[$oldtable]);
+         }
       } else {
          if (Toolbox::startsWith($oldtable, 'glpi_plugin_')
             || Toolbox::startsWith($newtable, 'glpi_plugin_')

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -38,8 +38,19 @@ namespace tests\units;
  */
 class Migration extends \GLPITestCase {
 
+   /**
+    * @var \DB
+    */
    private $db;
+
+   /**
+    * @var \Migration
+    */
    private $migration;
+
+   /**
+    * @var string[]
+    */
    private $queries;
 
    public function beforeTestMethod($method) {
@@ -526,5 +537,76 @@ class Migration extends \GLPITestCase {
          ]
       ]);
       $this->integer(count($right4))->isEqualTo(4);
+   }
+
+   public function testRenameTable() {
+
+      global $DB;
+      $DB = $this->db;
+
+      $this->calling($this->db)->tableExists = function ($table) {
+         return $table === 'glpi_oldtable';
+      };
+      $this->calling($this->db)->fieldExists = function ($table, $field) {
+         return $table === 'glpi_oldtable' && $field !== 'bool_field';
+      };
+
+      $queries = [];
+      $this->queries = &$queries;
+      $this->calling($this->db)->query = function ($query) use (&$queries) {
+         if ($query === 'SHOW INDEX FROM `glpi_oldtable`') {
+            // Make DbUtils::isIndex return false
+            return false;
+         }
+         $queries[] = $query;
+         return true;
+      };
+
+      // Case 1, rename with no buffered changes
+      $this->queries = [];
+
+      $this->migration->renameTable('glpi_oldtable', 'glpi_newtable');
+
+      $this->array($this->queries)->isIdenticalTo(
+         [
+            "RENAME TABLE `glpi_oldtable` TO `glpi_newtable`",
+         ]
+      );
+
+      // Case 2, rename after changes were already applied
+      $this->queries = [];
+
+      $this->migration->addField('glpi_oldtable', 'bool_field', 'bool');
+      $this->migration->addKey('glpi_oldtable', 'id', 'id', 'UNIQUE');
+      $this->migration->addKey('glpi_oldtable', 'fulltext_key', 'fulltext_key', 'FULLTEXT');
+      $this->migration->migrationOneTable('glpi_oldtable');
+      $this->migration->renameTable('glpi_oldtable', 'glpi_newtable');
+
+      $this->array($this->queries)->isIdenticalTo(
+         [
+            "ALTER TABLE `glpi_oldtable` ADD `bool_field` TINYINT(1) NOT NULL DEFAULT '0'   ",
+            "ALTER TABLE `glpi_oldtable` ADD FULLTEXT `fulltext_key` (`fulltext_key`)",
+            "ALTER TABLE `glpi_oldtable` ADD UNIQUE `id` (`id`)",
+            "RENAME TABLE `glpi_oldtable` TO `glpi_newtable`",
+         ]
+      );
+
+      // Case 3, apply changes after renaming
+      $this->queries = [];
+
+      $this->migration->addField('glpi_oldtable', 'bool_field', 'bool');
+      $this->migration->addKey('glpi_oldtable', 'id', 'id', 'UNIQUE');
+      $this->migration->addKey('glpi_oldtable', 'fulltext_key', 'fulltext_key', 'FULLTEXT');
+      $this->migration->renameTable('glpi_oldtable', 'glpi_newtable');
+      $this->migration->migrationOneTable('glpi_newtable');
+
+      $this->array($this->queries)->isIdenticalTo(
+         [
+            "RENAME TABLE `glpi_oldtable` TO `glpi_newtable`",
+            "ALTER TABLE `glpi_newtable` ADD `bool_field` TINYINT(1) NOT NULL DEFAULT '0'   ",
+            "ALTER TABLE `glpi_newtable` ADD FULLTEXT `fulltext_key` (`fulltext_key`)",
+            "ALTER TABLE `glpi_newtable` ADD UNIQUE `id` (`id`)",
+         ]
+      );
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If any changes on a specific table are buffered in migration, renaming of this table will not take care of them and they will not be applied.