### PR TITLE
Apply root entity custom CSS on public pages (login, logout, ...)

### DIFF
--- a/ajax/entityCustomCssCode.php
+++ b/ajax/entityCustomCssCode.php
@@ -48,7 +48,8 @@ if (isset($_POST['enable_custom_css']) && isset($_POST['entities_id'])) {
       $custom_css_code = Entity::getUsedConfig(
          'enable_custom_css',
          $entity->fields['entities_id'],
-         'custom_css_code'
+         'custom_css_code',
+         ''
       );
    } else {
       $custom_css_code = $entity->fields['custom_css_code'];

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -2133,7 +2133,8 @@ class Entity extends CommonTreeDropdown {
       $custom_css_code = self::getUsedConfig(
          'enable_custom_css',
          $this->fields['id'],
-         'custom_css_code'
+         'custom_css_code',
+         ''
       );
 
       if (empty($custom_css_code)) {

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1352,9 +1352,14 @@ class Html {
 
       // Custom CSS for active entity
       $entity = new Entity();
-      if ($entity->getFromDB($_SESSION['glpiactive_entity'])) {
-         echo $entity->getCustomCssTag();
+      if (isset($_SESSION['glpiactive_entity'])) {
+         // Apply active entity styles
+         $entity->getFromDB($_SESSION['glpiactive_entity']);
+      } else {
+         // Apply root entity styles
+         $entity->getFromDB('0');
       }
+      echo $entity->getCustomCssTag();
 
       // AJAX library
       echo Html::script('public/lib/base.js');

--- a/index.php
+++ b/index.php
@@ -92,6 +92,11 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
    // external libs CSS
    echo Html::css('public/lib/base.css');
 
+   // Custom CSS for root entity
+   $entity = new Entity();
+   $entity->getFromDB('0');
+   echo $entity->getCustomCssTag();
+
    // CFG
    echo Html::scriptBlock("
       var CFG_GLPI  = {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Follow #5938.

Apply root entity custom CSS when there is no active entity in session (login/logout page for instance).