### PR TITLE
Fix ancestors/sons too long cache keys

### DIFF
--- a/inc/commontreedropdown.class.php
+++ b/inc/commontreedropdown.class.php
@@ -187,7 +187,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
          if ($input[$this->getForeignKeyField()] != $this->fields[$this->getForeignKeyField()]) {
             $input["ancestors_cache"] = '';
             if (Toolbox::useCache()) {
-               $ckey = $this->getTable() . '_ancestors_cache_' . $this->getID();
+               $ckey = 'ancestors_cache_' . md5($this->getTable() . $this->getID());
                $GLPI_CACHE->delete($ckey);
             }
             return $this->adaptTreeFieldsFromUpdateOrAdd($input);
@@ -212,7 +212,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       //drop from sons cache when needed
       if ($changeParent && Toolbox::useCache()) {
-         $ckey = $this->getTable() . '_ancestors_cache_' . $ID;
+         $ckey = 'ancestors_cache_' . md5($this->getTable() . $ID);
          $GLPI_CACHE->delete($ckey);
       }
 
@@ -305,7 +305,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       //drop from sons cache when needed
       if ($cache && Toolbox::useCache()) {
          foreach ($ancestors as $ancestor) {
-            $ckey = $this->getTable() . '_sons_cache_' . $ancestor;
+            $ckey = 'sons_cache_' . md5($this->getTable() . $ancestor);
             if ($GLPI_CACHE->has($ckey)) {
                $sons = $GLPI_CACHE->get($ckey);
                if (isset($sons[$this->getID()])) {
@@ -335,7 +335,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       if (Toolbox::useCache()) {
          $ancestors = getAncestorsOf($this->getTable(), $this->getID());
          foreach ($ancestors as $ancestor) {
-            $ckey = $this->getTable() . '_sons_cache_' . $ancestor;
+            $ckey = 'sons_cache_' . md5($this->getTable() . $ancestor);
             if ($GLPI_CACHE->has($ckey)) {
                $sons = $GLPI_CACHE->get($ckey);
                if (!isset($sons[$this->getID()])) {

--- a/inc/dbutils.class.php
+++ b/inc/dbutils.class.php
@@ -670,7 +670,7 @@ final class DbUtils {
    public function getSonsOf($table, $IDf) {
       global $DB, $GLPI_CACHE;
 
-      $ckey = $table . '_sons_cache_' . $IDf;
+      $ckey = 'sons_cache_' . md5($this->getTable() . $IDf);
       $sons = false;
 
       if (Toolbox::useCache()) {
@@ -777,11 +777,11 @@ final class DbUtils {
    public function getAncestorsOf($table, $items_id) {
       global $DB, $GLPI_CACHE;
 
-      $ckey = $table . '_ancestors_cache_';
+      $ckey = 'ancestors_cache_';
       if (is_array($items_id)) {
-         $ckey .= md5(implode('|', $items_id));
+         $ckey .= md5($table . implode('|', $items_id));
       } else {
-         $ckey .= $items_id;
+         $ckey .= md5($table . $items_id);
       }
       $ancestors = [];
 

--- a/inc/dbutils.class.php
+++ b/inc/dbutils.class.php
@@ -670,7 +670,7 @@ final class DbUtils {
    public function getSonsOf($table, $IDf) {
       global $DB, $GLPI_CACHE;
 
-      $ckey = 'sons_cache_' . md5($this->getTable() . $IDf);
+      $ckey = 'sons_cache_' . md5($table . $IDf);
       $sons = false;
 
       if (Toolbox::useCache()) {

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -131,7 +131,7 @@ class Entity extends CommonTreeDropdown {
       //Cleaning sons calls getAncestorsOf and thus... Re-create cache. Call it before clean.
       $this->cleanParentsSons();
       if (Toolbox::useCache()) {
-         $ckey = $this->getTable() . '_ancestors_cache_' . $this->getID();
+         $ckey = 'ancestors_cache_' . md5($this->getTable() . $this->getID());
          $GLPI_CACHE->delete($ckey);
       }
       return true;

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -630,51 +630,54 @@ class DbUtils extends DbTestCase {
       //- if $cache === 1; we expect cache to be empty before call, and populated after
       //- if $hit   === 1; we expect cache to be populated
 
-      $ckey = $this->nscache . ':glpi_entities_ancestors_cache_';
+      $ckey_prefix = $this->nscache . ':ancestors_cache_';
+      $ckey_ent0   = $ckey_prefix . md5('glpi_entities' . $ent0);
+      $ckey_ent1   = $ckey_prefix . md5('glpi_entities' . $ent1);
+      $ckey_ent2   = $ckey_prefix . md5('glpi_entities' . $ent2);
 
       //test on ent0
       $expected = [0 => '0'];
       if ($cache === true && $hit === false) {
-         $this->boolean(apcu_exists($ckey . $ent0))->isFalse();
+         $this->boolean(apcu_exists($ckey_ent0))->isFalse();
       } else if ($cache === true && $hit === true) {
-         $this->array(apcu_fetch("$ckey$ent0"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent0))->isIdenticalTo($expected);
       }
 
       $ancestors = getAncestorsOf('glpi_entities', $ent0);
       $this->array($ancestors)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$ckey$ent0"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent0))->isIdenticalTo($expected);
       }
 
       //test on ent1
       $expected = [0 => '0', 1 => "$ent0"];
       if ($cache === true && $hit === false) {
-         $this->boolean(apcu_exists($ckey . $ent1))->isFalse();
+         $this->boolean(apcu_exists($ckey_ent1))->isFalse();
       } else if ($cache === true && $hit === true) {
-         $this->array(apcu_fetch("$ckey$ent1"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent1))->isIdenticalTo($expected);
       }
 
       $ancestors = getAncestorsOf('glpi_entities', $ent1);
       $this->array($ancestors)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$ckey$ent1"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent1))->isIdenticalTo($expected);
       }
 
       //test on ent2
       $expected = [0 => '0', 1 => "$ent0"];
       if ($cache === true && $hit === false) {
-         $this->boolean(apcu_exists($ckey . $ent2))->isFalse();
+         $this->boolean(apcu_exists($ckey_ent2))->isFalse();
       } else if ($cache === true && $hit === true) {
-         $this->array(apcu_fetch("$ckey$ent2"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent2))->isIdenticalTo($expected);
       }
 
       $ancestors = getAncestorsOf('glpi_entities', $ent2);
       $this->array($ancestors)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$ckey$ent2"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent2))->isIdenticalTo($expected);
       }
 
       //test with new sub entity
@@ -689,17 +692,18 @@ class DbUtils extends DbTestCase {
          ]);
          $this->integer($new_id)->isGreaterThan(0);
       }
+      $ckey_new_id = $ckey_prefix . md5('glpi_entities' . $new_id);
 
       $expected = [0 => '0', $ent0 => "$ent0", $ent1 => "$ent1"];
       if ($cache === true) {
-         $this->array(apcu_fetch("$ckey$new_id"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_new_id))->isIdenticalTo($expected);
       }
 
       $ancestors = getAncestorsOf('glpi_entities', $new_id);
       $this->array($ancestors)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$ckey$new_id"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_new_id))->isIdenticalTo($expected);
       }
 
       //test with another new sub entity
@@ -712,33 +716,34 @@ class DbUtils extends DbTestCase {
          ]);
          $this->integer($new_id2)->isGreaterThan(0);
       }
+      $ckey_new_id2 = $ckey_prefix . md5('glpi_entities' . $new_id2);
 
       $expected = [0 => '0', $ent0 => "$ent0", $ent2 => "$ent2"];
       if ($cache === true) {
-         $this->array(apcu_fetch("$ckey$new_id2"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_new_id2))->isIdenticalTo($expected);
       }
 
       $ancestors = getAncestorsOf('glpi_entities', $new_id2);
       $this->array($ancestors)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$ckey$new_id2"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_new_id2))->isIdenticalTo($expected);
       }
 
       //test on multiple entities
       $expected = [0 => '0', $ent0 => "$ent0", $ent1 => "$ent1", $ent2 => "$ent2"];
-      $newckey = $ckey . md5("$new_id|$new_id2");
+      $ckey_new_all = $ckey_prefix . md5('glpi_entities' . $new_id . '|' . $new_id2);
       if ($cache === true && $hit === false) {
-         $this->boolean(apcu_exists($newckey))->isFalse();
+         $this->boolean(apcu_exists($ckey_new_all))->isFalse();
       } else if ($cache === true && $hit === true) {
-         $this->array(apcu_fetch($newckey))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_new_all))->isIdenticalTo($expected);
       }
 
       $ancestors = getAncestorsOf('glpi_entities', [$new_id, $new_id2]);
       $this->array($ancestors)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch($newckey))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_new_all))->isIdenticalTo($expected);
       }
    }
 
@@ -789,51 +794,54 @@ class DbUtils extends DbTestCase {
       //- if $cache === 1; we expect cache to be empty before call, and populated after
       //- if $hit   === 1; we expect cache to be populated
 
-      $ckey = $this->nscache . ':glpi_entities_sons_cache_';
+      $ckey_prefix = $this->nscache . ':sons_cache_';
+      $ckey_ent0 = $ckey_prefix . md5('glpi_entities' . $ent0);
+      $ckey_ent1 = $ckey_prefix . md5('glpi_entities' . $ent1);
+      $ckey_ent2 = $ckey_prefix . md5('glpi_entities' . $ent2);
 
       //test on ent0
       $expected = [$ent0 => "$ent0", $ent1 => "$ent1", $ent2 => "$ent2"];
       if ($cache === true && $hit === false) {
-         $this->boolean(apcu_exists($ckey . $ent0))->isFalse();
+         $this->boolean(apcu_exists($ckey_ent0))->isFalse();
       } else if ($cache === true && $hit === true) {
-         $this->array(apcu_fetch("$ckey$ent0"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent0))->isIdenticalTo($expected);
       }
 
       $sons = $this->testedInstance->getSonsOf('glpi_entities', $ent0);
       $this->array($sons)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$ckey$ent0"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent0))->isIdenticalTo($expected);
       }
 
       //test on ent1
       $expected = [$ent1 => "$ent1"];
       if ($cache === true && $hit === false) {
-         $this->boolean(apcu_exists($ckey . $ent1))->isFalse();
+         $this->boolean(apcu_exists($ckey_ent1))->isFalse();
       } else if ($cache === true && $hit === true) {
-         $this->array(apcu_fetch("$ckey$ent1"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent1))->isIdenticalTo($expected);
       }
 
       $sons = $this->testedInstance->getSonsOf('glpi_entities', $ent1);
       $this->array($sons)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$ckey$ent1"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent1))->isIdenticalTo($expected);
       }
 
       //test on ent2
       $expected = [$ent2 => "$ent2"];
       if ($cache === true && $hit === false) {
-         $this->boolean(apcu_exists($ckey . $ent2))->isFalse();
+         $this->boolean(apcu_exists($ckey_ent2))->isFalse();
       } else if ($cache === true && $hit === true) {
-         $this->array(apcu_fetch("$ckey$ent2"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent2))->isIdenticalTo($expected);
       }
 
       $sons = $this->testedInstance->getSonsOf('glpi_entities', $ent2);
       $this->array($sons)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$ckey$ent2"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent2))->isIdenticalTo($expected);
       }
 
       //test with new sub entity
@@ -851,14 +859,14 @@ class DbUtils extends DbTestCase {
 
       $expected = [$ent1 => $ent1, $new_id => "$new_id"];
       if ($cache === true) {
-         $this->array(apcu_fetch("$ckey$ent1"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent1))->isIdenticalTo($expected);
       }
 
       $sons = $this->testedInstance->getSonsOf('glpi_entities', $ent1);
       $this->array($sons)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$ckey$ent1"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent1))->isIdenticalTo($expected);
       }
 
       //test with another new sub entity
@@ -874,27 +882,27 @@ class DbUtils extends DbTestCase {
 
       $expected = [$ent1 => $ent1, $new_id => "$new_id", $new_id2 => "$new_id2"];
       if ($cache === true) {
-         $this->array(apcu_fetch("$ckey$ent1"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent1))->isIdenticalTo($expected);
       }
 
       $sons = $this->testedInstance->getSonsOf('glpi_entities', $ent1);
       $this->array($sons)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$ckey$ent1"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent1))->isIdenticalTo($expected);
       }
 
       //drop sub entity
       $expected = [$ent1 => $ent1, $new_id2 => "$new_id2"];
       $this->boolean($entity->delete(['id' => $new_id], true))->isTrue();
       if ($cache === true) {
-         $this->array(apcu_fetch("$ckey$ent1"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent1))->isIdenticalTo($expected);
       }
 
       $expected = [$ent1 => $ent1];
       $this->boolean($entity->delete(['id' => $new_id2], true))->isTrue();
       if ($cache === true) {
-         $this->array(apcu_fetch("$ckey$ent1"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ckey_ent1))->isIdenticalTo($expected);
       }
    }
 

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -123,6 +123,8 @@ class Entity extends DbTestCase {
 
       $ackey_prefix = $this->nscache . ':ancestors_cache_';
       $sckey_prefix = $this->nscache . ':sons_cache_';
+      $sckey_ent1   = $sckey_prefix . md5('glpi_entities' . $ent1);
+      $sckey_ent2   = $sckey_prefix . md5('glpi_entities' . $ent2);
 
       $entity = new \Entity();
       $new_id = (int)$entity->add([
@@ -131,7 +133,6 @@ class Entity extends DbTestCase {
       ]);
       $this->integer($new_id)->isGreaterThan(0);
       $ackey_new_id = $ackey_prefix . md5('glpi_entities' . $new_id);
-      $sckey_new_id = $sckey_prefix . md5('glpi_entities' . $new_id);
 
       $expected = [0 => '0', $ent0 => "$ent0", $ent1 => "$ent1"];
       if ($cache === true) {
@@ -151,7 +152,7 @@ class Entity extends DbTestCase {
       $this->array($sons)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch($sckey_new_id))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($sckey_ent1))->isIdenticalTo($expected);
       }
 
       //change parent entity
@@ -179,7 +180,7 @@ class Entity extends DbTestCase {
       $this->array($sons)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch($sckey_new_id))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($sckey_ent1))->isIdenticalTo($expected);
       }
 
       $expected = [$ent2 => $ent2, $new_id => "$new_id"];
@@ -187,7 +188,7 @@ class Entity extends DbTestCase {
       $this->array($sons)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch($sckey_new_id))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($sckey_ent2))->isIdenticalTo($expected);
       }
 
       //clean new entity

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -121,8 +121,8 @@ class Entity extends DbTestCase {
       $ent1 = getItemByTypeName('Entity', '_test_child_1', true);
       $ent2 = getItemByTypeName('Entity', '_test_child_2', true);
 
-      $ackey = $this->nscache . ':glpi_entities_ancestors_cache_';
-      $sckey = $this->nscache . ':glpi_entities_sons_cache_';
+      $ackey_prefix = $this->nscache . ':ancestors_cache_';
+      $sckey_prefix = $this->nscache . ':sons_cache_';
 
       $entity = new \Entity();
       $new_id = (int)$entity->add([
@@ -130,17 +130,19 @@ class Entity extends DbTestCase {
          'entities_id'  => $ent1
       ]);
       $this->integer($new_id)->isGreaterThan(0);
+      $ackey_new_id = $ackey_prefix . md5('glpi_entities' . $new_id);
+      $sckey_new_id = $sckey_prefix . md5('glpi_entities' . $new_id);
 
       $expected = [0 => '0', $ent0 => "$ent0", $ent1 => "$ent1"];
       if ($cache === true) {
-         $this->array(apcu_fetch("$ackey$new_id"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ackey_new_id))->isIdenticalTo($expected);
       }
 
       $ancestors = getAncestorsOf('glpi_entities', $new_id);
       $this->array($ancestors)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$ackey$new_id"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ackey_new_id))->isIdenticalTo($expected);
       }
 
       $expected = [$ent1 => $ent1, $new_id => "$new_id"];
@@ -149,7 +151,7 @@ class Entity extends DbTestCase {
       $this->array($sons)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$sckey$ent1"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($sckey_new_id))->isIdenticalTo($expected);
       }
 
       //change parent entity
@@ -162,14 +164,14 @@ class Entity extends DbTestCase {
 
       $expected = [0 => '0', $ent0 => "$ent0", $ent2 => "$ent2"];
       if ($cache === true) {
-         $this->array(apcu_fetch("$ackey$new_id"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ackey_new_id))->isIdenticalTo($expected);
       }
 
       $ancestors = getAncestorsOf('glpi_entities', $new_id);
       $this->array($ancestors)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$ackey$new_id"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($ackey_new_id))->isIdenticalTo($expected);
       }
 
       $expected = [$ent1 => $ent1];
@@ -177,7 +179,7 @@ class Entity extends DbTestCase {
       $this->array($sons)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$sckey$ent1"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($sckey_new_id))->isIdenticalTo($expected);
       }
 
       $expected = [$ent2 => $ent2, $new_id => "$new_id"];
@@ -185,7 +187,7 @@ class Entity extends DbTestCase {
       $this->array($sons)->isIdenticalTo($expected);
 
       if ($cache === true && $hit === false) {
-         $this->array(apcu_fetch("$sckey$ent2"))->isIdenticalTo($expected);
+         $this->array(apcu_fetch($sckey_new_id))->isIdenticalTo($expected);
       }
 
       //clean new entity


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/pluginsGLPI/fields/issues/299

Cache key used to store ancestors/sons of `CommonTreeDropdown` elements can be too long if related to a plugin itemtype (see https://github.com/pluginsGLPI/fields/issues/299).