### PR TITLE
Changed regex for process of FOREACH and IF in templates

### DIFF
--- a/inc/notificationtemplate.class.php
+++ b/inc/notificationtemplate.class.php
@@ -349,7 +349,7 @@ class NotificationTemplate extends CommonDBTM {
       $string = Toolbox::unclean_cross_side_scripting_deep($string);
 
       //First of all process the FOREACH tag
-      if (preg_match_all("/##FOREACH[ ]?(FIRST|LAST)?[ ]?([0-9]*)?[ ]?([a-zA-Z-0-9\.]*)##/i",
+      if (preg_match_all("/##FOREACH[ ]?(FIRST|LAST)?[ ]?([0-9]*)?[ ]?([a-z-0-9\._]*)##/i",
                          $string, $out)) {
 
          foreach ($out[3] as $id => $tag_infos) {
@@ -411,7 +411,7 @@ class NotificationTemplate extends CommonDBTM {
    **/
    static function processIf($string, $data) {
 
-      if (preg_match_all("/##IF([a-z\.]*)[=]?(.*?)##/i", $string, $out)) {
+      if (preg_match_all("/##IF([a-z-0-9\._]*)[=]?(.*?)##/i", $string, $out)) {
          foreach ($out[1] as $key => $tag_infos) {
             $if_field = $tag_infos;
             //Get the field tag value (if one)


### PR DESCRIPTION
To be able to have tags like ##FOREACHmy_tag.var_tag##
For process() added an underscore to the FOREACH regex, and deleted the A-Z (as the flag i is specified)
For processIf() fixed the IF regex to be identical to the one used in process().

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
