### PR TITLE
Fix displaying of chevrons in tree dropdowns; fixes #6083

### DIFF
--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -2904,7 +2904,6 @@ class Dropdown {
                } else {
                   $outputval = $data[$field];
                }
-               $outputval = Toolbox::unclean_cross_side_scripting_deep($outputval);
 
                $ID         = $data['id'];
                $addcomment = "";
@@ -2956,7 +2955,7 @@ class Dropdown {
          }
       }
 
-      $ret['results'] = $datas;
+      $ret['results'] = Toolbox::unclean_cross_side_scripting_deep($datas);
       $ret['count']   = $count;
 
       return ($json === true) ? json_encode($ret) : $ret;

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -288,16 +288,17 @@ class Toolbox {
    **/
    static function clean_cross_side_scripting_deep($value) {
 
+      if ((array) $value === $value) {
+         return array_map([__CLASS__, 'clean_cross_side_scripting_deep'], $value);
+      }
+
+      if (!is_string($value)) {
+         return $value;
+      }
+
       $in  = ['<', '>'];
       $out = ['&lt;', '&gt;'];
-
-      $value = ((array) $value === $value)
-                  ? array_map([__CLASS__, 'clean_cross_side_scripting_deep'], $value)
-                  : (is_null($value)
-                        ? null : (is_resource($value)
-                                     ? $value : str_replace($in, $out, $value)));
-
-      return $value;
+      return str_replace($in, $out, $value);
    }
 
 
@@ -312,16 +313,17 @@ class Toolbox {
    **/
    static function unclean_cross_side_scripting_deep($value) {
 
+      if ((array) $value === $value) {
+         return array_map([__CLASS__, 'unclean_cross_side_scripting_deep'], $value);
+      }
+
+      if (!is_string($value)) {
+         return $value;
+      }
+
       $in  = ['<', '>'];
       $out = ['&lt;', '&gt;'];
-
-      $value = ((array) $value === $value)
-                  ? array_map([__CLASS__, 'unclean_cross_side_scripting_deep'], $value)
-                  : (is_null($value)
-                        ? null : (is_resource($value)
-                                     ? $value : str_replace($out, $in, $value)));
-
-      return $value;
+      return str_replace($out, $in, $value);
    }
 
 
@@ -339,17 +341,14 @@ class Toolbox {
    static function unclean_html_cross_side_scripting_deep($value) {
       include_once(GLPI_HTMLAWED);
 
-      $in  = ['<', '>'];
-      $out = ['&lt;', '&gt;'];
-
-      $value = ((array) $value === $value)
-                  ? array_map([__CLASS__, 'unclean_html_cross_side_scripting_deep'], $value)
-                  : (is_null($value)
-                      ? null : (is_resource($value)
-                                  ? $value : str_replace($out, $in, $value)));
+      if ((array) $value === $value) {
+         $value = array_map([__CLASS__, 'unclean_html_cross_side_scripting_deep'], $value);
+      } else {
+         $value = self::unclean_cross_side_scripting_deep($value);
+      }
 
       // revert unclean inside <pre>
-      if (!is_array($value)) {
+      if (is_string($value)) {
          $count = preg_match_all('/(<pre[^>]*>)(.*?)(<\/pre>)/is', $value, $matches);
          for ($i = 0; $i < $count; ++$i) {
             $complete       = $matches[0][$i];

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -357,11 +357,11 @@ class Toolbox extends \GLPITestCase {
 
    protected function cleanProvider() {
       return [
-         ['mystring', 'mystring'],
-         ['<strong>string</strong>', '&lt;strong&gt;string&lt;/strong&gt;'],
+         ['mystring', 'mystring', null, 15, 0.56, false],
+         ['<strong>string</strong>', '&lt;strong&gt;string&lt;/strong&gt;', null, 15, 0.56, false],
          [
-            ['<strong>string</strong>', 'string', '<p>my</p>'],
-            ['&lt;strong&gt;string&lt;/strong&gt;', 'string', '&lt;p&gt;my&lt;/p&gt;']
+            [null, '<strong>string</strong>', 3.2, 'string', true, '<p>my</p>', 9798],
+            [null, '&lt;strong&gt;string&lt;/strong&gt;', 3.2, 'string', true, '&lt;p&gt;my&lt;/p&gt;', 9798]
          ]
       ];
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6083 

Chevrons are badly displayed in dropdowns.

A test case:
 - have an entity with a name containing `>` or `<`,
 - have a location with a name containing `>` or `<`,
 - open a new location form and see how parent location list is displayed.