### PR TITLE
Prevent casting issues on XSS clean/unclean

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -288,16 +288,17 @@ class Toolbox {
    **/
    static function clean_cross_side_scripting_deep($value) {
 
+      if ((array) $value === $value) {
+         return array_map([__CLASS__, 'clean_cross_side_scripting_deep'], $value);
+      }
+
+      if (is_null($value) || is_resource($value) || is_int($value) || is_float($value)) {
+         return $value;
+      }
+
       $in  = ['<', '>'];
       $out = ['&lt;', '&gt;'];
-
-      $value = ((array) $value === $value)
-                  ? array_map([__CLASS__, 'clean_cross_side_scripting_deep'], $value)
-                  : (is_null($value)
-                        ? null : (is_resource($value)
-                                     ? $value : str_replace($in, $out, $value)));
-
-      return $value;
+      return str_replace($in, $out, $value);
    }
 
 
@@ -312,16 +313,17 @@ class Toolbox {
    **/
    static function unclean_cross_side_scripting_deep($value) {
 
+      if ((array) $value === $value) {
+         return array_map([__CLASS__, 'unclean_cross_side_scripting_deep'], $value);
+      }
+
+      if (is_null($value) || is_resource($value) || is_int($value) || is_float($value)) {
+         return $value;
+      }
+
       $in  = ['<', '>'];
       $out = ['&lt;', '&gt;'];
-
-      $value = ((array) $value === $value)
-                  ? array_map([__CLASS__, 'unclean_cross_side_scripting_deep'], $value)
-                  : (is_null($value)
-                        ? null : (is_resource($value)
-                                     ? $value : str_replace($out, $in, $value)));
-
-      return $value;
+      return str_replace($out, $in, $value);
    }
 
 
@@ -339,14 +341,11 @@ class Toolbox {
    static function unclean_html_cross_side_scripting_deep($value) {
       include_once(GLPI_HTMLAWED);
 
-      $in  = ['<', '>'];
-      $out = ['&lt;', '&gt;'];
-
-      $value = ((array) $value === $value)
-                  ? array_map([__CLASS__, 'unclean_html_cross_side_scripting_deep'], $value)
-                  : (is_null($value)
-                      ? null : (is_resource($value)
-                                  ? $value : str_replace($out, $in, $value)));
+      if ((array) $value === $value) {
+         $value = array_map([__CLASS__, 'unclean_html_cross_side_scripting_deep'], $value);
+      } else {
+         $value = self::unclean_cross_side_scripting_deep($value);
+      }
 
       // revert unclean inside <pre>
       if (!is_array($value)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Using clean/unclean "deep" methods may alter variables types (i.e. numeric types are converted to strings by `str_replace` method).
As numeric types cannot contains XSS, cleaning them is useless.

Example of var type issue: https://github.com/glpi-project/glpi/commit/37edcd15ac7d39fdb994b54796c43951d1607b34 -> https://circleci.com/gh/glpi-project/glpi/21939
