### PR TITLE
Fix saved search headers

### DIFF
--- a/front/savedsearch.form.php
+++ b/front/savedsearch.form.php
@@ -65,7 +65,11 @@ if (isset($_POST["add"])) {
    $savedsearch->createNotif();
    Html::back();
 } else {//print computer information
-   Html::header(SavedSearch::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "savedsearch");
+   if (Session::getCurrentInterface() == "helpdesk") {
+      Html::helpHeader(SavedSearch::getTypeName(Session::getPluralNumber()));
+   } else {
+      Html::header(SavedSearch::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'tools', 'savedsearch');
+   }
    //show computer form to add
    $savedsearch->display(['id' => $_GET["id"]]);
    Html::footer();

--- a/front/savedsearch.php
+++ b/front/savedsearch.php
@@ -34,7 +34,11 @@ if (!defined('GLPI_ROOT')) {
    include ('../inc/includes.php');
 }
 
-Html::header(__('Saved searches'), $_SERVER['PHP_SELF'], 'tools', 'savedsearch');
+if (Session::getCurrentInterface() == "helpdesk") {
+   Html::helpHeader(SavedSearch::getTypeName(Session::getPluralNumber()));
+} else {
+   Html::header(SavedSearch::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'tools', 'savedsearch');
+}
 
 $savedsearch = new SavedSearch();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Central headers would always be used for saved search forms even though helpdesk users always have access to private searches.