### PR TITLE
Add old DCIM and new clusters to global search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The present file will list all changes made to the project; according to the
 - Mails collected from suppliers can be marked as private on an entity basis.
 - Ability to add custom CSS in entity configuration.
 - CLI commands to enable and disable maintenance mode.
+- Add datacenter items to global search
 
 ### Changed
 

--- a/inc/define.php
+++ b/inc/define.php
@@ -394,7 +394,8 @@ $CFG_GLPI["globalsearch_types"]           = ['Computer', 'Contact', 'Contract',
                                              'Printer', 'Software', 'SoftwareLicense',
                                              'Ticket', 'Problem', 'Change',
                                              'User', 'Group', 'Project', 'Supplier',
-                                             'Budget', 'Certificate', 'Line'];
+                                             'Budget', 'Certificate', 'Line', 'Datacenter',
+                                             'DCRoom', 'Enclosure', 'PDU', 'Rack', 'Cluster'];
 
 // New config options which can be missing during migration
 $CFG_GLPI["number_format"]  = 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Backport of #5168 from 10.0.0 to 9.5.0. Also adds missing clusters itemtype to global search.