### PR TITLE
Fix < > & chars in ITIL timeline

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6664,7 +6664,7 @@ abstract class CommonITILObject extends CommonDBTM {
             echo "</p>";
 
             echo "<div class='rich_text_container'>";
-            echo Html::setRichTextContent('', $content, '', true);
+            echo Html::getContentAsRichText($content);
             echo "</div>";
 
             if (!empty($long_text)) {
@@ -6899,7 +6899,7 @@ abstract class CommonITILObject extends CommonDBTM {
       echo "</div>";
 
       echo "<div class='rich_text_container'>";
-      echo Html::setRichTextContent('', $this->fields['content'], '', true);
+      echo Html::getContentAsRichText($this->fields['content']);
       echo "</div>";
 
       echo "</div>"; // h_content ITILContent

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3699,8 +3699,27 @@ class Html {
       // Init html editor
       Html::initEditorSystem($name, $rand, true, $readonly);
 
+      $content = self::getContentAsRichText($content);
+
+      // Re-encode content as it will be displayed as "necoded html" inside rich text editor
+      $content = Html::entities_deep($content);
+
+      return $content;
+   }
+
+   /**
+    * Get rich text content initially input inside rich text editor.
+    *
+    * @param string  $content
+    *
+    * @return string
+    *
+    * @since 9.5.0
+    */
+   static function getContentAsRichText($content) {
+
       // Neutralize non valid HTML tags
-      $content = html::clean($content, false, 1);
+      $content = self::clean($content, false, 1);
 
       // If content does not contain <br> or <p> html tag, use nl2br
       if (!preg_match("/<br\s?\/?>/", $content) && !preg_match("/<p>/", $content)) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -5259,20 +5259,19 @@ class Ticket extends CommonITILObject {
          $content = Html::cleanPostForTextArea($content);
       }
 
-      $content = Html::setRichTextContent(
-         $content_id,
-         $content,
-         $rand,
-         !$canupdate
-      );
-
       echo "<div id='content$rand_text'>";
       if ($canupdate || $can_requester) {
+         $content = Html::setRichTextContent(
+            $content_id,
+            $content,
+            $rand,
+            !$canupdate
+         );
          echo "<textarea id='$content_id' name='content' style='width:100%' rows='$rows'".
                ($tt->isMandatoryField('content') ? " required='required'" : '') . ">" .
                $content."</textarea></div>";
       } else {
-         echo Toolbox::getHtmlToDisplay($content);
+         echo Html::getContentAsRichText($content);
       }
       echo $tt->getEndHiddenFieldValue('content', $this);
 

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -296,9 +296,7 @@ class Toolbox {
          return $value;
       }
 
-      $in  = ['<', '>'];
-      $out = ['&lt;', '&gt;'];
-      return str_replace($in, $out, $value);
+      return htmlentities($value, ENT_NOQUOTES, 'UTF-8');
    }
 
 
@@ -321,9 +319,7 @@ class Toolbox {
          return $value;
       }
 
-      $in  = ['<', '>'];
-      $out = ['&lt;', '&gt;'];
-      return str_replace($out, $in, $value);
+      return html_entity_decode($value, ENT_NOQUOTES, 'UTF-8');
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #140 ?

Investigating on this issue, I found that:
 - `Toolbox::clean_cross_side_scripting_deep()` was changing `<` to `&lt;` but not changing initial `&lt;` (same for `>`), so unclean process was making no difference between `<>` and `&lt;&gt;`;
 - HTML code inside a text area should be encoded to be correctly handled by TinyMCE;
 - HTML code should not be encoded to be correctly displayed.

So my solution is to use `htmlentities` functions inside clean/unclean methods and to have a distinct handling of content displayed in timeline and the one displayed in TinyMCE.

![New Project](https://user-images.githubusercontent.com/33253653/60819161-6a7d9d80-a19f-11e9-9dcf-63d7e2a21a9c.png)
