### PR TITLE
fix missing assignation when populating planning for reminder

### DIFF
--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -951,7 +951,7 @@ class Reminder extends CommonDBVisible {
          'glpi_reminders.is_planned'   => 1,
          'begin'                       => ['<', $end],
          'end'                         => ['>', $begin]
-      ];
+      ] + $NASSIGN;
 
       if ($options['check_planned']) {
          $WHERE['state'] = ['!=', Planning::INFO];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Since iterator migration