### PR TITLE
Add canViewItem check in API

### DIFF
--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -117,7 +117,7 @@ class ITILFollowup  extends CommonDBChild {
           && Session::haveRight(self::$rightname, self::SEEPUBLIC)) {
          return true;
       }
-      if ($itilobject == "Ticket") {
+      if ($this->fields['itemtype'] == "Ticket") {
          if ($this->fields["users_id"] === Session::getLoginUserID()) {
             return true;
          }

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -347,7 +347,7 @@ class APIRest extends APIBaseClass {
       $ticketTMF = new \TicketTemplateMandatoryField();
 
       $tt_id = $ticketTemplate->add([
-         'entities_id' => 0,
+         'entities_id' => 1,
          'name'        => 'test'
       ]);
       $this->boolean((bool)$tt_id)->isTrue();

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -347,7 +347,7 @@ class APIRest extends APIBaseClass {
       $ticketTMF = new \TicketTemplateMandatoryField();
 
       $tt_id = $ticketTemplate->add([
-         'entities_id' => 1,
+         'entities_id' => getItemByTypeName('Entity', '_test_child_1', true),
          'name'        => 'test'
       ]);
       $this->boolean((bool)$tt_id)->isTrue();


### PR DESCRIPTION
Internal ref : 16937

- Add canViewItem check to the API 
- Fix the canViewItem of ITILFollowup which had an unused condition (comparing an object to the string "Ticket").

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | pending