### PR TITLE
Fix for Undefined index: list

### DIFF
--- a/inc/commontreedropdown.class.php
+++ b/inc/commontreedropdown.class.php
@@ -480,6 +480,12 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       $nb            = count($fields);
       $entity_assign = $this->isEntityAssign();
 
+      foreach ($fields as &$field) {
+         if (!isset($field['list'])) {
+            $field['list'] = false;
+         }
+      }
+      
       // Minimal form for quick input.
       if (static::canCreate()) {
          $link = $this->getFormURL();


### PR DESCRIPTION
Default value for $field['list'] to prevent PHP notice when not defined by getAdditionalFields().

[2019-07-09 15:45:44] glpiphplog.ERROR: Toolbox::userErrorHandlerNormal() in C:\Projects\GLPI\9.4\inc\toolbox.class.php line 659
  *** PHP Notice(8): Undefined index: list
  Backtrace :
  inc\commontreedropdown.class.php:527               
  inc\commontreedropdown.class.php:92                CommonTreeDropdown->showChildren()
  inc\commonglpi.class.php:485                       CommonTreeDropdown::displayTabContentForItem()
  ajax\common.tabs.php:92                            CommonGLPI::displayStandardTab()
  {"user":"2@XXXXXX"}


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
