### PR TITLE
avoid fatal when tranfering documents

### DIFF
--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -1974,14 +1974,18 @@ class Transfer extends CommonDBTM {
                         $NOT = array_merge($NOT, $this->noneedtobe_transfer[$dtype]);
                      }
 
+                     $where = [
+                        'documents_id' => $item_ID,
+                        'itemtype'     => $dtype
+                     ];
+                     if (count($NOT)) {
+                        $where['NOT'] = ['items_id' => $NOT];
+                     }
+
                      $result = $DB->request([
                         'COUNT'  => 'cpt',
                         'FROM'   => 'glpi_documents_items',
-                        'WHERE'  => [
-                           'documents_id' => $item_ID,
-                           'itemtype'     => $dtype,
-                           'NOT'          => ['items_id' => $NOT]
-                        ]
+                        'WHERE'  => $where
                      ])->next();
 
                      if ($result['cpt'] > 0) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Internal ref: 17415 & 17414

backtrace:
```

Fatal error: Uncaught RuntimeException: Empty IN are not allowed in inc/dbmysqliterator.class.php:546 Stack trace:
#0 inc/dbmysqliterator.class.php(516): DBmysqlIterator->analyzeCriterion(Array)
#1 inc/dbmysqliterator.class.php(506): DBmysqlIterator->analyseCrit(Array)
#2 inc/dbmysqliterator.class.php(288): DBmysqlIterator->analyseCrit(Array)
#3 inc/dbmysqliterator.class.php(94): DBmysqlIterator->buildQuery('`glpi_documents...', Array, false)
#4 inc/dbmysql.class.php(580): DBmysqlIterator->execute(Array, '', false)
#5 inc/transfer.class.php(1985): DBmysql->request(Array)
#6 inc/transfer.class.php(1110): Transfer->transferDocuments('Peripheral', '1210755', '1210755')
#7 inc/transfer.class.php(203): Transfer->transferItem('Peripheral', '1210755', '1210755')
#8 front/transfer.action.php(46): Transfer->moveItems(Array, '17', Array)
#9 {main} thrown in inc/dbmysqliterator.class.php on line 546
```
