### PR TITLE
Feat: Add new field 'code' to itil categories

### DIFF
--- a/inc/itilcategory.class.php
+++ b/inc/itilcategory.class.php
@@ -67,6 +67,10 @@ class ITILCategory extends CommonTreeDropdown {
                          'label'     => __('Knowledge base'),
                          'type'      => 'dropdownValue',
                          'list'      => true],
+                   ['name'      => 'code',
+                         'label'     => __('Code representing the ticket category'),
+                         'type'      => 'text',
+                         'list'      => false],
                    ['name'      => 'is_helpdeskvisible',
                          'label'     => __('Visible in the simplified interface'),
                          'type'      => 'bool',
@@ -258,6 +262,15 @@ class ITILCategory extends CommonTreeDropdown {
          'datatype'           => 'dropdown'
       ];
 
+      $tab[] = [
+         'id'                 => '99',
+         'table'              => $this->getTable(),
+         'field'              => 'code',
+         'name'               => __('Code representing the ticket category'),
+         'massiveaction'      => false,
+         'datatype'           => 'string'
+      ];
+
       return $tab;
    }
 
@@ -281,6 +294,69 @@ class ITILCategory extends CommonTreeDropdown {
       Rule::cleanForItemCriteria($this);
    }
 
+   /**
+    * @since 9.5.0
+    *
+    * @param $value
+   **/
+   static function getITILCategoryIDByCode($value) {
+      return self::getITILCategoryIDByField("code", $value);
+   }
+
+   /**
+    * @since 9.5.0
+    *
+    * @param $field
+    * @param $value must be addslashes
+   **/
+   private static function getITILCategoryIDByField($field, $value) {
+      global $DB;
+
+      $iterator = $DB->request([
+         'SELECT' => 'id',
+         'FROM'   => self::getTable(),
+         'WHERE'  => [$field => $value]
+      ]);
+
+      if (count($iterator) == 1) {
+         $result = $iterator->next();
+         return $result['id'];
+      }
+      return -1;
+   }
+
+   /**
+    * @since 9.5.0
+   **/
+   function prepareInputForAdd($input) {
+      $input = parent::prepareInputForAdd($input);
+
+      $input['code'] = isset($input['code']) ? trim($input['code']) : '';
+      if (!empty($input["code"])
+            && ITILCategory::getITILCategoryIDByCode($input["code"]) != -1) {
+         Session::addMessageAfterRedirect(__("Code representing the ticket category is already used"),
+                                          false, ERROR);
+         return false;
+      }
+      return $input;
+   }
+
+
+   /**
+    * @since 9.5.0
+   **/
+   function prepareInputForUpdate($input) {
+      $input = parent::prepareInputForUpdate($input);
+
+      $input['code'] = isset($input['code']) ? trim($input['code']) : '';
+      if (!empty($input["code"])
+            && !in_array(ITILCategory::getITILCategoryIDByCode($input["code"]), [$input['id'],-1]) ) {
+         Session::addMessageAfterRedirect(__("Code representing the ticket category is already used"),
+                                          false, ERROR);
+         return false;
+      }
+      return $input;
+   }
 
    /**
     * @since 0.84

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -312,7 +312,7 @@ class RuleTicket extends Rule {
                   break;
 
                case 'regex_result';
-                  if ($action->fields["field"] == "_affect_itilcategorie_by_code") {
+                  if ($action->fields["field"] == "_affect_itilcategory_by_code") {
                      if (isset($this->regex_results[0])) {
                         $regexvalue = RuleAction::getRegexResultById($action->fields["value"],
                                                                      $this->regex_results[0]);
@@ -321,9 +321,9 @@ class RuleTicket extends Rule {
                      }
 
                      if (!is_null($regexvalue)) {
-                        $target_itilcategorie = ITILCategory::getITILCategoryIDByCode($regexvalue);
-                        if ($target_itilcategorie != -1) {
-                           $output["itilcategories_id"] = $target_itilcategorie;
+                        $target_itilcategory = ITILCategory::getITILCategoryIDByCode($regexvalue);
+                        if ($target_itilcategory != -1) {
+                           $output["itilcategories_id"] = $target_itilcategory;
                         }
                      }
                   }
@@ -563,9 +563,9 @@ class RuleTicket extends Rule {
       $actions['itilcategories_id']['type']                 = 'dropdown';
       $actions['itilcategories_id']['table']                = 'glpi_itilcategories';
 
-      $actions['_affect_itilcategorie_by_code']['name']           = __('Ticket category from code');
-      $actions['_affect_itilcategorie_by_code']['type']           = 'text';
-      $actions['_affect_itilcategorie_by_code']['force_actions']  = ['regex_result'];
+      $actions['_affect_itilcategory_by_code']['name']           = __('Ticket category from code');
+      $actions['_affect_itilcategory_by_code']['type']           = 'text';
+      $actions['_affect_itilcategory_by_code']['force_actions']  = ['regex_result'];
 
       $actions['type']['name']                              = __('Type');
       $actions['type']['table']                             = 'glpi_tickets';

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -563,7 +563,7 @@ class RuleTicket extends Rule {
       $actions['itilcategories_id']['type']                 = 'dropdown';
       $actions['itilcategories_id']['table']                = 'glpi_itilcategories';
 
-      $actions['_affect_itilcategorie_by_code']['name']           = __('Ticket category from CODE');
+      $actions['_affect_itilcategorie_by_code']['name']           = __('Ticket category from code');
       $actions['_affect_itilcategorie_by_code']['type']           = 'text';
       $actions['_affect_itilcategorie_by_code']['force_actions']  = ['regex_result'];
 

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -310,6 +310,24 @@ class RuleTicket extends Rule {
                      $output["items_id"][$result["itemtype"]][] = $result["id"];
                   }
                   break;
+
+               case 'regex_result';
+                  if ($action->fields["field"] == "_affect_itilcategorie_by_code") {
+                     if (isset($this->regex_results[0])) {
+                        $regexvalue = RuleAction::getRegexResultById($action->fields["value"],
+                                                                     $this->regex_results[0]);
+                     } else {
+                        $regexvalue = $action->fields["value"];
+                     }
+
+                     if (!is_null($regexvalue)) {
+                        $target_itilcategorie = ITILCategory::getITILCategoryIDByCode($regexvalue);
+                        if ($target_itilcategorie != -1) {
+                           $output["itilcategories_id"] = $target_itilcategorie;
+                        }
+                     }
+                  }
+                  break;
             }
          }
       }
@@ -356,6 +374,10 @@ class RuleTicket extends Rule {
       $criterias['itilcategories_id_cn']['name']               = __('Category').' - '.__('Complete name');
       $criterias['itilcategories_id_cn']['linkfield']          = 'itilcategories_id';
       $criterias['itilcategories_id_cn']['type']               = 'dropdown';
+
+      $criterias['itilcategories_id_code']['table']              = 'glpi_itilcategories';
+      $criterias['itilcategories_id_code']['field']              = 'code';
+      $criterias['itilcategories_id_code']['name']               = __('Code representing the ticket category');
 
       $criterias['type']['table']                           = 'glpi_tickets';
       $criterias['type']['field']                           = 'type';
@@ -540,6 +562,10 @@ class RuleTicket extends Rule {
       $actions['itilcategories_id']['name']                 = __('Category');
       $actions['itilcategories_id']['type']                 = 'dropdown';
       $actions['itilcategories_id']['table']                = 'glpi_itilcategories';
+
+      $actions['_affect_itilcategorie_by_code']['name']           = __('Ticket category from CODE');
+      $actions['_affect_itilcategorie_by_code']['type']           = 'text';
+      $actions['_affect_itilcategorie_by_code']['force_actions']  = ['regex_result'];
 
       $actions['type']['name']                              = __('Type');
       $actions['type']['table']                             = 'glpi_tickets';

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -3998,6 +3998,7 @@ CREATE TABLE `glpi_itilcategories` (
   `knowbaseitemcategories_id` int(11) NOT NULL DEFAULT '0',
   `users_id` int(11) NOT NULL DEFAULT '0',
   `groups_id` int(11) NOT NULL DEFAULT '0',
+  `code` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `ancestors_cache` longtext COLLATE utf8_unicode_ci,
   `sons_cache` longtext COLLATE utf8_unicode_ci,
   `is_helpdeskvisible` tinyint(1) NOT NULL DEFAULT '1',

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -502,6 +502,14 @@ function update94to95() {
          ]
       );
    }
+   /** /Add "code" field on glpi_itilcategories */
+   if (!$DB->fieldExists("glpi_itilcategories", "code")) {
+      $migration->addField("glpi_itilcategories", "code", "string", [
+            'after'  => "groups_id"
+         ]
+      );
+   }
+   /** /Add "code" field on glpi_itilcategories */
 
    // ************ Keep it at the end **************
    foreach ($ADDTODISPLAYPREF as $type => $tab) {

--- a/tests/functionnal/RuleTicket.php
+++ b/tests/functionnal/RuleTicket.php
@@ -33,7 +33,6 @@
 namespace tests\units;
 
 use \DbTestCase;
-use ITILCategory;
 
 /* Test for inc/ruleticket.class.php */
 
@@ -384,7 +383,7 @@ class RuleTicket extends DbTestCase {
       $act_id = $ruleaction->add($act_input = [
          'rules_id'    => $ruletid,
          'action_type' => 'regex_result',
-         'field'       => '_affect_itilcategorie_by_code',
+         'field'       => '_affect_itilcategory_by_code',
          'value'       => '#0',
       ]);
       $this->checkInput($ruleaction, $act_id, $act_input);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Addition of a new field named 'code'  in ticket categories
check if code already use by another categorie

![image](https://user-images.githubusercontent.com/7335054/60959739-08d94280-a309-11e9-8d30-26cbdb44cd50.png)

Adding searchoption
![image](https://user-images.githubusercontent.com/7335054/60959787-1bec1280-a309-11e9-8b4b-092c604a0afb.png)


Adding a new business rules action for tickets -> Ticket categorie from code with regular expression

![image](https://user-images.githubusercontent.com/7335054/60959835-2efee280-a309-11e9-840a-7ae508563a31.png)



