### PR TITLE
fix inconsistency in method signature

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -68,13 +68,15 @@ abstract class API extends CommonGLPI {
    /**
     * Generic messages
     *
+    * @since 9.1
+    *
     * @param mixed   $response          string message or array of data to send
-    * @param integer $code              http code
+    * @param integer $httpcode          http code (see : https://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
     * @param array   $additionalheaders headers to send with http response (must be an array(key => value))
     *
     * @return void
     */
-   abstract protected function returnResponse($response, $code, $additionalheaders);
+   abstract protected function returnResponse($response, $httpcode = 200, $additionalheaders = []);
 
    /**
     * Upload and validate files from request and append to $this->parameters['input']

--- a/inc/apirest.class.php
+++ b/inc/apirest.class.php
@@ -517,16 +517,6 @@ class APIRest extends API {
    }
 
 
-   /**
-    * Generic function to send a message and an http code to client
-    *
-    * @param string  $response          message or array of data to send
-    * @param integer $httpcode          http code (default 200)
-    *                                   (see: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
-    * @param array   $additionalheaders headers to send with http response (must be an array(key => value))
-    *
-    * @return void
-    */
    public function returnResponse($response, $httpcode = 200, $additionalheaders = []) {
 
       if (empty($httpcode)) {

--- a/inc/apixmlrpc.class.php
+++ b/inc/apixmlrpc.class.php
@@ -281,17 +281,7 @@ class APIXmlrpc extends API {
       return $resource;
    }
 
-   /**
-    * Generic function to send a message and an http code to client
-    *
-    * @since 9.1
-    *
-    * @param mixed   $response          string message or array of data to send
-    * @param integer $httpcode          http code (see : https://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
-    * @param array   $additionalheaders headers to send with http response (must be an array(key => value))
-    *
-    * @return void
-    */
+
    protected function returnResponse($response, $httpcode = 200, $additionalheaders = []) {
       if (empty($httpcode)) {
          $httpcode = 200;


### PR DESCRIPTION
Hi

This fixes a signature inconsistency.

Please compare the implementations in apirest and arixmlrpc classes. 