### PR TITLE
Fix uniqueness and cleaning of datacenter pictures

### DIFF
--- a/inc/commondropdown.class.php
+++ b/inc/commondropdown.class.php
@@ -406,7 +406,7 @@ abstract class CommonDropdown extends CommonDBTM {
 
             case 'picture' :
                if (!empty($this->fields[$field['name']])) {
-                  echo Html::image($this->fields[$field['name']], [
+                  echo Html::image(Toolbox::getPictureUrl($this->fields[$field['name']]), [
                      'style' => 'max-width: 300px; max-height: 150px;',
                      'class' => 'picture_square'
                   ]);

--- a/inc/dcroom.class.php
+++ b/inc/dcroom.class.php
@@ -150,7 +150,7 @@ class DCRoom extends CommonDBTM {
       echo "<td><label for=''>" . __('Background picture (blueprint)') . "</label></td><td>";
 
       if (!empty($this->fields['blueprint'])) {
-         echo Html::image($this->fields['blueprint'], [
+         echo Html::image(Toolbox::getPictureUrl($this->fields['blueprint']), [
             'style' => 'max-width: 100px; max-height: 50px;',
             'class' => 'picture_square'
          ]);
@@ -184,38 +184,36 @@ class DCRoom extends CommonDBTM {
       return $this->manageBlueprint($input);
    }
 
+   function cleanDBonPurge() {
+      Toolbox::deletePicture($this->fields['blueprint']);
+   }
+
    /**
     * Add/remove blueprint picture
     * @param  array $input the form input
     * @return array        the altered input
     */
    function manageBlueprint($input) {
-      global $CFG_GLPI;
-
       if (isset($input["_blank_blueprint"])
           && $input["_blank_blueprint"]) {
          $input['blueprint'] = '';
+
+         if (array_key_exists('blueprint', $this->fields)) {
+            Toolbox::deletePicture($this->fields['blueprint']);
+         }
       }
 
       if (isset($input["_blueprint"])) {
-         $filename = array_shift($input["_blueprint"]);
-         $src      = GLPI_TMP_DIR."/".$filename;
-         $prefix   = '';
-         if (isset($input["_prefix_blueprint"])) {
-            $prefix = array_shift($input["_prefix_blueprint"]);
-         }
-         $filename = str_replace($prefix, '', $filename);
-         $dest     = GLPI_PICTURE_DIR."/".$filename;
-         $moved    = false;
+         $blueprint = array_shift($input["_blueprint"]);
 
-         if (is_file($dest)) {
-            @unlink($dest);
+         if ($dest = Toolbox::savePicture(GLPI_TMP_DIR . '/' . $blueprint)) {
+            $input['blueprint'] = $dest;
+         } else {
+            Session::addMessageAfterRedirect(__('Unable to save picture file.'), true, ERROR);
          }
-         $moved = rename($src, $dest);
 
-         if ($moved) {
-            $input['blueprint'] = $CFG_GLPI["root_doc"].
-                                  "/front/document.send.php?file=_pictures/$filename";
+         if (array_key_exists('blueprint', $this->fields)) {
+            Toolbox::deletePicture($this->fields['blueprint']);
          }
       }
 

--- a/inc/item_rack.class.php
+++ b/inc/item_rack.class.php
@@ -246,10 +246,10 @@ class Item_Rack extends CommonDBRelation {
             }
 
             if (!empty($item->model->fields['picture_front'])) {
-               $gs_item['picture_f'] = $item->model->fields['picture_front'];
+               $gs_item['picture_f'] = Toolbox::getPictureUrl($item->model->fields['picture_front']);
             }
             if (!empty($item->model->fields['picture_rear'])) {
-               $gs_item['picture_r'] = $item->model->fields['picture_rear'];
+               $gs_item['picture_r'] = Toolbox::getPictureUrl($item->model->fields['picture_rear']);
             }
          } else {
             $item->model = null;

--- a/inc/pdu_rack.class.php
+++ b/inc/pdu_rack.class.php
@@ -611,11 +611,12 @@ JAVASCRIPT;
                $item_rand = mt_rand();
 
                if ($picture) {
+                  $picture_url = Toolbox::getPictureUrl($picture);
                   $picture_c = 'with_picture';
                   echo "<style>
                      #item_$item_rand:after {
                         width: ".($height * 21 - 9) ."px;
-                        background: $bg_color url($picture) 0 0/100% no-repeat;
+                        background: $bg_color url($picture_url) 0 0/100% no-repeat;
                      }
                   </style>";
                }

--- a/inc/rack.class.php
+++ b/inc/rack.class.php
@@ -681,9 +681,10 @@ class Rack extends CommonDBTM {
       $blueprint = "";
       $blueprint_ctrl = "";
       if (strlen($room->fields['blueprint'])) {
+         $blueprint_url = Toolbox::getPictureUrl($room->fields['blueprint']);
          $blueprint = "
             <div class='blueprint'
-                 style='background: url({$room->fields['blueprint']}) no-repeat top left/100% 100%;
+                 style='background: url({$blueprint_url}) no-repeat top left/100% 100%;
                         height: ".$grid_h."px;></div>";
          $blueprint_ctrl = "<span class='mini_toggle active'
                                   id='toggle_blueprint'>".__('Blueprint')."</span>";

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -4929,12 +4929,11 @@ class User extends CommonDBTM {
    static function getURLForPicture($picture) {
       global $CFG_GLPI;
 
-      // prevent xss
-      $picture = Html::cleanInputText($picture);
-
-      if (!empty($picture)) {
-         return $CFG_GLPI["root_doc"]."/front/document.send.php?file=_pictures/$picture";
+      $url = Toolbox::getPictureUrl($picture);
+      if (null !== $url) {
+         return $url;
       }
+
       return $CFG_GLPI["root_doc"]."/pics/picture.png";
    }
 

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -303,6 +303,57 @@ function update94to95() {
    }
    /** /Add "date_creation" field on document_items */
 
+   /** Make datacenter pictures path relative */
+   $doc_send_url = '/front/document.send.php?file=_pictures/';
+
+   $fix_picture_fct = function($path) use ($doc_send_url) {
+      // Keep only part of URL corresponding to relative path inside GLPI_PICTURE_DIR
+      return preg_replace('/^.*' . preg_quote($doc_send_url, '/') . '(.+)$/', '$1', $path);
+   };
+
+   $common_dc_model_tables = [
+      'glpi_computermodels',
+      'glpi_enclosuremodels',
+      'glpi_monitormodels',
+      'glpi_networkequipmentmodels',
+      'glpi_pdumodels',
+      'glpi_peripheralmodels',
+   ];
+   foreach ($common_dc_model_tables as $table) {
+      $elements_to_fix = $DB->request(
+         [
+            'SELECT'    => ['id', 'picture_front', 'picture_rear'],
+            'FROM'      => $table,
+            'WHERE'     => [
+               'OR' => [
+                  'picture_front' => ['LIKE', '%' . $doc_send_url . '%'],
+                  'picture_rear' => ['LIKE', '%' . $doc_send_url . '%'],
+               ],
+            ],
+         ]
+      );
+      foreach ($elements_to_fix as $data) {
+         $data['picture_front'] = $DB->escape($fix_picture_fct($data['picture_front']));
+         $data['picture_rear']  = $DB->escape($fix_picture_fct($data['picture_rear']));
+         $DB->update($table, $data, ['id' => $data['id']]);
+      }
+   }
+
+   $elements_to_fix = $DB->request(
+      [
+         'SELECT'    => ['id', 'blueprint'],
+         'FROM'      => 'glpi_dcrooms',
+         'WHERE'     => [
+            'blueprint' => ['LIKE', '%' . $doc_send_url . '%'],
+         ],
+      ]
+   );
+   foreach ($elements_to_fix as $data) {
+      $data['blueprint'] = $DB->escape($fix_picture_fct($data['blueprint']));
+      $DB->update('glpi_dcrooms', $data, ['id' => $data['id']]);
+   }
+   /** /Make datacenter pictures path relative */
+
    // ************ Keep it at the end **************
    foreach ($ADDTODISPLAYPREF as $type => $tab) {
       $rank = 1;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,6 +33,7 @@
 error_reporting(E_ALL);
 
 define('GLPI_CACHE_DIR', __DIR__ . '/files/_cache');
+define('GLPI_PICTURE_DIR', __DIR__ . '/files/_pictures');
 define('GLPI_CONFIG_DIR', __DIR__);
 define('GLPI_LOG_DIR', __DIR__ . '/files/_log');
 define('GLPI_URI', (getenv('GLPI_URI') ?: 'http://localhost:8088'));
@@ -42,6 +43,7 @@ define('GLPI_ROOT', __DIR__ . '/../');
 
 is_dir(GLPI_LOG_DIR) or mkdir(GLPI_LOG_DIR, 0755, true);
 is_dir(GLPI_CACHE_DIR) or mkdir(GLPI_CACHE_DIR, 0755, true);
+is_dir(GLPI_PICTURE_DIR) or mkdir(GLPI_PICTURE_DIR, 0755, true);
 
 if (!file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {
    die("\nConfiguration file for tests not found\n\nrun: bin/console glpi:database:install --config-dir=./tests ...\n\n");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Multiple problems are fixed by this PR:
1. Pictures filenames were not altered on storage, which mean that any file already store with this filename was replaced, even if used by another element.
2. Files were not cleaned on item purge of when image was cleared from form.

Uniqueness of filenames is also important for browser caching features.