### PR TITLE
Lower all "linkID" to fix inconsistencies;  closes #6127

### DIFF
--- a/inc/calendar_holiday.class.php
+++ b/inc/calendar_holiday.class.php
@@ -76,7 +76,7 @@ class Calendar_Holiday extends CommonDBRelation {
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_calendars_holidays.id AS linkID',
+         'SELECT DISTINCT' => 'glpi_calendars_holidays.id AS linkid',
          'FIELDS'          => 'glpi_holidays.*',
          'FROM'            => 'glpi_calendars_holidays',
          'LEFT JOIN'       => [
@@ -155,7 +155,7 @@ class Calendar_Holiday extends CommonDBRelation {
             echo "<tr class='tab_bg_1'>";
             if ($canedit) {
                echo "<td>";
-               Html::showMassiveActionCheckBox(__CLASS__, $data["linkID"]);
+               Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
                echo "</td>";
             }
             echo "<td><a href='".Toolbox::getItemTypeFormURL('Holiday')."?id=".$data['id']."'>".

--- a/inc/change_problem.class.php
+++ b/inc/change_problem.class.php
@@ -124,7 +124,7 @@ class Change_Problem extends CommonDBRelation{
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_changes_problems.id AS linkID',
+         'SELECT DISTINCT' => 'glpi_changes_problems.id AS linkid',
          'FIELDS'          => 'glpi_changes.*',
          'FROM'            => 'glpi_changes_problems',
          'LEFT JOIN'       => [
@@ -200,7 +200,7 @@ class Change_Problem extends CommonDBRelation{
             Session::addToNavigateListItems('Change', $data["id"]);
             Change::showShort($data['id'], ['row_num'                => $i,
                                                  'type_for_massiveaction' => __CLASS__,
-                                                 'id_for_massiveaction'   => $data['linkID']]);
+                                                 'id_for_massiveaction'   => $data['linkid']]);
             $i++;
          }
          Change::commonListHeader(Search::HTML_OUTPUT, 'mass'.__CLASS__.$rand);
@@ -234,7 +234,7 @@ class Change_Problem extends CommonDBRelation{
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_changes_problems.id AS linkID',
+         'SELECT DISTINCT' => 'glpi_changes_problems.id AS linkid',
          'FIELDS'          => 'glpi_problems.*',
          'FROM'            => 'glpi_changes_problems',
          'LEFT JOIN'       => [
@@ -303,7 +303,7 @@ class Change_Problem extends CommonDBRelation{
             Session::addToNavigateListItems('Problem', $data["id"]);
             Problem::showShort($data['id'], ['row_num'               => $i,
                                                  'type_for_massiveaction' => __CLASS__,
-                                                 'id_for_massiveaction'   => $data['linkID']]);
+                                                 'id_for_massiveaction'   => $data['linkid']]);
             $i++;
          }
          Problem::commonListHeader(Search::HTML_OUTPUT, 'mass'.__CLASS__.$rand);

--- a/inc/change_ticket.class.php
+++ b/inc/change_ticket.class.php
@@ -238,7 +238,7 @@ class Change_Ticket extends CommonDBRelation{
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_changes_tickets.id AS linkID',
+         'SELECT DISTINCT' => 'glpi_changes_tickets.id AS linkid',
          'FIELDS'          => 'glpi_tickets.*',
          'FROM'            => 'glpi_changes_tickets',
          'LEFT JOIN'       => [
@@ -323,7 +323,7 @@ class Change_Ticket extends CommonDBRelation{
             Ticket::showShort($data['id'], ['followups'              => false,
                                                  'row_num'                => $i,
                                                  'type_for_massiveaction' => __CLASS__,
-                                                 'id_for_massiveaction'   => $data['linkID']]);
+                                                 'id_for_massiveaction'   => $data['linkid']]);
             $i++;
          }
          Ticket::commonListHeader(Search::HTML_OUTPUT, 'mass'.__CLASS__.$rand);
@@ -355,7 +355,7 @@ class Change_Ticket extends CommonDBRelation{
       $rand    = mt_rand();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => 'glpi_changes_tickets.id AS linkID',
+         'SELECT DISTINCT' => 'glpi_changes_tickets.id AS linkid',
          'FIELDS'          => 'glpi_changes.*',
          'FROM'            => 'glpi_changes_tickets',
          'LEFT JOIN'       => [
@@ -431,7 +431,7 @@ class Change_Ticket extends CommonDBRelation{
             Session::addToNavigateListItems('Change', $data["id"]);
             Change::showShort($data['id'], ['row_num'                => $i,
                                                  'type_for_massiveaction' => __CLASS__,
-                                                 'id_for_massiveaction'   => $data['linkID']]);
+                                                 'id_for_massiveaction'   => $data['linkid']]);
             $i++;
          }
          Change::commonListHeader(Search::HTML_OUTPUT, 'mass'.__CLASS__.$rand);

--- a/inc/computer_softwareversion.class.php
+++ b/inc/computer_softwareversion.class.php
@@ -907,7 +907,7 @@ class Computer_SoftwareVersion extends CommonDBRelation {
          [
             'SELECT'       => [
                'glpi_softwarelicenses.*',
-               'glpi_computers_softwarelicenses.id AS linkID',
+               'glpi_computers_softwarelicenses.id AS linkid',
                'glpi_softwares.name AS softname',
                'glpi_softwareversions.name AS version',
                'glpi_states.name AS state'
@@ -1143,7 +1143,7 @@ class Computer_SoftwareVersion extends CommonDBRelation {
    */
    private static function displaySoftsByLicense($data, $computers_id, $withtemplate, $canedit) {
 
-      $ID = $data['linkID'];
+      $ID = $data['linkid'];
 
       $link_item = Toolbox::getItemTypeFormURL('SoftwareLicense');
       $link      = $link_item."?id=".$data['id'];

--- a/inc/group_user.class.php
+++ b/inc/group_user.class.php
@@ -83,7 +83,7 @@ class Group_User extends CommonDBRelation{
          'SELECT' => [
             'glpi_groups.*',
             'glpi_groups_users.id AS IDD',
-            'glpi_groups_users.id AS linkID',
+            'glpi_groups_users.id AS linkid',
             'glpi_groups_users.is_dynamic AS is_dynamic',
             'glpi_groups_users.is_manager AS is_manager',
             'glpi_groups_users.is_userdelegate AS is_userdelegate'
@@ -129,7 +129,7 @@ class Group_User extends CommonDBRelation{
          'SELECT' => [
             'glpi_users.*',
             'glpi_groups_users.id AS IDD',
-            'glpi_groups_users.id AS linkID',
+            'glpi_groups_users.id AS linkid',
             'glpi_groups_users.is_dynamic AS is_dynamic',
             'glpi_groups_users.is_manager AS is_manager',
             'glpi_groups_users.is_userdelegate AS is_userdelegate'
@@ -392,7 +392,7 @@ class Group_User extends CommonDBRelation{
       $iterator = $DB->request([
          'SELECT DISTINCT' => 'glpi_users.id',
          'SELECT'       => [
-            'glpi_groups_users.id AS linkID',
+            'glpi_groups_users.id AS linkid',
             'glpi_groups_users.groups_id',
             'glpi_groups_users.is_dynamic AS is_dynamic',
             'glpi_groups_users.is_manager AS is_manager',
@@ -550,7 +550,7 @@ class Group_User extends CommonDBRelation{
             echo "\n<tr class='tab_bg_".($user->isDeleted() ? '1_2' : '1')."'>";
             if ($canedit) {
                echo "<td width='10'>";
-               Html::showMassiveActionCheckBox(__CLASS__, $data["linkID"]);
+               Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
                echo "</td>";
             }
             echo "<td>".$user->getLink();

--- a/inc/itil_project.class.php
+++ b/inc/itil_project.class.php
@@ -137,7 +137,7 @@ class Itil_Project extends CommonDBRelation {
          $itemTable = $itemtype::getTable();
 
          $iterator = $DB->request([
-            'SELECT DISTINCT' => "$selfTable.id AS linkID",
+            'SELECT DISTINCT' => "$selfTable.id AS linkid",
             'FIELDS'          => "$itemTable.*",
             'FROM'            => $selfTable,
             'LEFT JOIN'       => [
@@ -240,7 +240,7 @@ class Itil_Project extends CommonDBRelation {
                   [
                      'row_num'                => $i,
                      'type_for_massiveaction' => __CLASS__,
-                     'id_for_massiveaction'   => $data['linkID']
+                     'id_for_massiveaction'   => $data['linkid']
                   ]
                );
                $i++;
@@ -279,7 +279,7 @@ class Itil_Project extends CommonDBRelation {
       $projectTable = Project::getTable();
 
       $iterator = $DB->request([
-         'SELECT DISTINCT' => "$selfTable.id AS linkID",
+         'SELECT DISTINCT' => "$selfTable.id AS linkid",
          'FIELDS'          => "$projectTable.*",
          'FROM'            => $selfTable,
          'LEFT JOIN'       => [
@@ -368,7 +368,7 @@ class Itil_Project extends CommonDBRelation {
                [
                   'row_num'               => $i,
                   'type_for_massiveaction' => __CLASS__,
-                  'id_for_massiveaction'   => $data['linkID']
+                  'id_for_massiveaction'   => $data['linkid']
                ]
             );
             $i++;

--- a/inc/networkportinstantiation.class.php
+++ b/inc/networkportinstantiation.class.php
@@ -492,10 +492,10 @@ class NetworkPortInstantiation extends CommonDBChild {
 
             $deviceNames = [0 => ""]; // First option : no network card
             foreach ($DB->request($query) as $availableDevice) {
-               $linkID               = $availableDevice['link_id'];
-               $deviceNames[$linkID] = $availableDevice['name'];
+               $linkid               = $availableDevice['link_id'];
+               $deviceNames[$linkid] = $availableDevice['name'];
                if (isset($availableDevice['mac'])) {
-                  $deviceNames[$linkID] = sprintf(__('%1$s - %2$s'), $deviceNames[$linkID],
+                  $deviceNames[$linkid] = sprintf(__('%1$s - %2$s'), $deviceNames[$linkid],
                                                   $availableDevice['mac']);
                }
 
@@ -507,7 +507,7 @@ class NetworkPortInstantiation extends CommonDBChild {
                }
                //addslashes_deep($deviceInformations);
                // Fill the javascript array
-               echo "  deviceAttributs[$linkID] = {".implode(', ', $deviceInformations)."};\n";
+               echo "  deviceAttributs[$linkid] = {".implode(', ', $deviceInformations)."};\n";
             }
 
             // And add the javascript function that updates the other fields

--- a/inc/problem_ticket.class.php
+++ b/inc/problem_ticket.class.php
@@ -347,7 +347,7 @@ class Problem_Ticket extends CommonDBRelation{
             Ticket::showShort($data['id'], ['followups'              => false,
                                                  'row_num'                => $i,
                                                  'type_for_massiveaction' => __CLASS__,
-                                                 'id_for_massiveaction'   => $data['linkID']]);
+                                                 'id_for_massiveaction'   => $data['linkid']]);
             $i++;
          }
          Ticket::commonListHeader(Search::HTML_OUTPUT, 'mass'.__CLASS__.$rand);
@@ -446,7 +446,7 @@ class Problem_Ticket extends CommonDBRelation{
             Session::addToNavigateListItems('Problem', $data["id"]);
             Problem::showShort($data['id'], ['row_num'                => $i,
                                                   'type_for_massiveaction' => __CLASS__,
-                                                  'id_for_massiveaction'   => $data['linkID']]);
+                                                  'id_for_massiveaction'   => $data['linkid']]);
             $i++;
          }
          Problem::commonListHeader(Search::HTML_OUTPUT, 'mass'.__CLASS__.$rand);

--- a/inc/profile_user.class.php
+++ b/inc/profile_user.class.php
@@ -299,7 +299,7 @@ class Profile_User extends CommonDBRelation {
       $iterator = $DB->request([
          'SELECT'       => [
             "glpi_users.*",
-            "$putable.id AS linkID",
+            "$putable.id AS linkid",
             "$putable.is_recursive",
             "$putable.is_dynamic",
             "$ptable.id AS pid",
@@ -390,7 +390,7 @@ class Profile_User extends CommonDBRelation {
             }
             if ($canedit) {
                echo "<td width='10'>";
-               Html::showMassiveActionCheckBox(__CLASS__, $data["linkID"]);
+               Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
                echo "</td>";
             }
 
@@ -453,7 +453,7 @@ class Profile_User extends CommonDBRelation {
          'SELECT DISTINCT' => "$utable.*",
          'FIELDS'          => [
             "$putable.entities_id AS entity",
-            "$putable.id AS linkID",
+            "$putable.id AS linkid",
             "$putable.is_dynamic",
             "$putable.is_recursive"
          ],
@@ -555,7 +555,7 @@ class Profile_User extends CommonDBRelation {
 
             if ($canedit_entity) {
                echo "<td width='10'>";
-               Html::showMassiveActionCheckBox(__CLASS__, $data["linkID"]);
+               Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
                echo "</td>";
             }
 

--- a/inc/ticket_ticket.class.php
+++ b/inc/ticket_ticket.class.php
@@ -177,7 +177,7 @@ class Ticket_Ticket extends CommonDBRelation {
       $ticket    = new Ticket();
       $tick      = new Ticket();
       if (is_array($tickets) && count($tickets)) {
-         foreach ($tickets as $linkID => $data) {
+         foreach ($tickets as $linkid => $data) {
             if ($ticket->getFromDB($data['tickets_id'])) {
                $icons =  Ticket::getStatusIcon($ticket->fields['status']);
                if ($canupdate) {
@@ -185,7 +185,7 @@ class Ticket_Ticket extends CommonDBRelation {
                       && ($tick->fields['status'] != CommonITILObject::CLOSED)) {
                      $icons .= '&nbsp;'.Html::getSimpleForm(static::getFormURL(), 'purge',
                                                             _x('button', 'Delete permanently'),
-                                                         ['id'         => $linkID,
+                                                         ['id'         => $linkid,
                                                           'tickets_id' => $ID],
                                                          'fa-times-circle');
                   }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6127 

Both camel and lower case were used... I've converted all to lower case.
