### PR TITLE
fix loading of groups in sub entities

### DIFF
--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -541,7 +541,7 @@ class Session {
          ] + getEntitiesRestrictCriteria(
             Group::getTable(),
             'entities_id',
-            $_SESSION['glpiactive_entity'],
+            $_SESSION['glpiactiveentities'],
             $_SESSION['glpiactive_entity_recursive']
          )
       ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Internal ref 17443

Since 452e7393e7c9006043430a6c55b13746ebbf4652, performance issue was finally fixed by 663de28

If a group is in a sub entity, he will not be loaded with root entity at default.
The consequence is the group tab in central page doesn't show any tickets for these groups