### PR TITLE
Fix prevention of plugins loading in console

### DIFF
--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -423,7 +423,7 @@ class Application extends BaseApplication {
       $input = new ArgvInput();
 
       try {
-         $command = $this->get($this->getCommandName($input));
+         $command = $this->find($this->getCommandName($input));
          if ($command instanceof ForceNoPluginsOptionCommandInterface) {
             return !$command->getNoPluginsOptionValue();
          }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Symfony console permits to use non official aliases for console commands. In this case, if alias is not ambiguous, command was executed but prevention of plugins loading was not working.

To reproduce: use `bin/console db:up` having an active plugin that produces a PHP error