### PR TITLE
Remove second run of PHP Parallel lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,10 +170,6 @@ jobs:
     steps:
       - build
       - run:
-          name: PHP Parallel Lint
-          command: |
-            vendor/bin/parallel-lint  --exclude files --exclude plugins --exclude vendor --exclude tools/vendor .
-      - run:
           name: sensiolabs/security-checker
           command: |
             vendor/bin/security-checker security:check


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`PHP Parallel Lint` is already runned in the `build` step.