### PR TITLE
Allow elvanto/litemoji 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "paragonie/random_compat": "^2.0",
         "monolog/monolog": "^1.23",
         "sebastian/diff": "^1.4 || ^2.0 || ^3.0",
-        "elvanto/litemoji": "^1.4",
+        "elvanto/litemoji": "^1.4 || ^2.0",
         "symfony/console": "^3.4",
         "leafo/scssphp": "^0.7.7"
     },


### PR DESCRIPTION
API is unchanged, upstream only drop support for PHP < 5.6
