### PR TITLE
Fix translated data in installation process

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2440,7 +2440,10 @@ class Toolbox {
          echo "Errors occurred inserting default database";
       } else {
          //dataset
+         Session::loadLanguage($lang, false); // Load default language locales to translate empty data
          $tables = require_once(__DIR__ . '/../install/empty_data.php');
+         Session::loadLanguage('', false); // Load back session language
+
          foreach ($tables as $table => $data) {
              $stmt = $DB->prepare($DB->buildInsert($table, $data[0]));
             foreach ($data as $row) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Initial data contains translated values (see https://github.com/glpi-project/glpi/blob/master/install/empty_data.php#L2316). These values should be translated using default language set by user.