### PR TITLE
Fix default language at install

### DIFF
--- a/inc/console/database/installcommand.class.php
+++ b/inc/console/database/installcommand.class.php
@@ -142,8 +142,9 @@ class InstallCommand extends Command implements ForceNoPluginsOptionCommandInter
       $this->addOption(
          'default-language',
          'L',
-         InputOption::VALUE_REQUIRED,
-         __('Default language of GLPI')
+         InputOption::VALUE_OPTIONAL,
+         __('Default language of GLPI'),
+         'en_GB'
       );
 
       $this->addOption(

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2389,7 +2389,7 @@ class Toolbox {
          $DB->updateOrDie(
             'glpi_users', [
                'language' => 'NULL'
-            ], [0], "4203"
+            ], [true], "4203"
          );
 
          if (defined('GLPI_SYSTEM_CRON')) {

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2386,11 +2386,6 @@ class Toolbox {
                'dbversion' => GLPI_SCHEMA_VERSION
             ]
          );
-         $DB->updateOrDie(
-            'glpi_users', [
-               'language' => 'NULL'
-            ], [true], "4203"
-         );
 
          if (defined('GLPI_SYSTEM_CRON')) {
             // Downstream packages may provide a good system cron

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8966,12 +8966,12 @@ CREATE TABLE `glpi_users` (
 
 INSERT INTO `glpi_users` (`id`, `name`, `password`, `list_limit`, `authtype`, `last_login`, `date_mod`)
    VALUES ('2','glpi','$2y$10$rXXzbc2ShaiCldwkw4AZL.n.9QSH7c0c9XJAyyjrbL9BwmWditAYm','20','1','2014-06-18 08:02:24','2014-06-18 08:02:24');
-INSERT INTO `glpi_users` (`id`, `name`, `password`, `language`, `list_limit`, `authtype`)
-   VALUES ('3','post-only','$2y$10$dTMar1F3ef5X/H1IjX9gYOjQWBR1K4bERGf4/oTPxFtJE/c3vXILm','en_GB','20','1');
-INSERT INTO `glpi_users` (`id`, `name`, `password`, `language`, `list_limit`, `authtype`)
-   VALUES ('4','tech','$2y$10$.xEgErizkp6Az0z.DHyoeOoenuh0RcsX4JapBk2JMD6VI17KtB1lO','en_GB','20','1');
-INSERT INTO `glpi_users` (`id`, `name`, `password`, `language`, `list_limit`, `authtype`)
-   VALUES ('5','normal','$2y$10$Z6doq4zVHkSPZFbPeXTCluN1Q/r0ryZ3ZsSJncJqkN3.8cRiN0NV.','en_GB','20','1');
+INSERT INTO `glpi_users` (`id`, `name`, `password`, `list_limit`, `authtype`)
+   VALUES ('3','post-only','$2y$10$dTMar1F3ef5X/H1IjX9gYOjQWBR1K4bERGf4/oTPxFtJE/c3vXILm','20','1');
+INSERT INTO `glpi_users` (`id`, `name`, `password`, `list_limit`, `authtype`)
+   VALUES ('4','tech','$2y$10$.xEgErizkp6Az0z.DHyoeOoenuh0RcsX4JapBk2JMD6VI17KtB1lO','20','1');
+INSERT INTO `glpi_users` (`id`, `name`, `password`, `list_limit`, `authtype`)
+   VALUES ('5','normal','$2y$10$Z6doq4zVHkSPZFbPeXTCluN1Q/r0ryZ3ZsSJncJqkN3.8cRiN0NV.','20','1');
 
 ### Dump table glpi_usertitles
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Even if it was marked as required, `default-language` default value was null if option was not passed to command. This null value was used on `Toolbox::createSchema()` and saved into global configuration, which may lead to unexpected behaviour.

2. Update of users language was not working due to `[0]` condition.