### PR TITLE
Add ITILFollowup case in Search::addDefaultWhere()

### DIFF
--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -117,7 +117,7 @@ class ITILFollowup  extends CommonDBChild {
           && Session::haveRight(self::$rightname, self::SEEPUBLIC)) {
          return true;
       }
-      if ($this->fields['itemtype'] == "Ticket") {
+      if ($itilobject instanceof Ticket) {
          if ($this->fields["users_id"] === Session::getLoginUserID()) {
             return true;
          }
@@ -1072,5 +1072,145 @@ class ITILFollowup  extends CommonDBChild {
             }
       }
       parent::processMassiveActionsForOneItemtype($ma, $item, $ids);
+   }
+
+   /**
+    * Build parent condition for ITILFollowup, used in addDefaultWhere
+    *
+    * @param string $itemtype
+    * @param string $target
+    * @param string $user_table
+    * @param string $group_table keys
+    *
+    * @return string
+    *
+    * @throws InvalidArgumentException
+    */
+   public static function buildParentCondition(
+      $itemtype,
+      $target,
+      $user_table,
+      $group_table
+   ) {
+      // An ITILFollowup parent can only by a CommonItilObject
+      if (!is_a($itemtype, "CommonITILObject", true)) {
+         throw new InvalidArgumentException(
+            "'$itemtype' is not a CommonITILObject"
+         );
+      }
+
+      // Can see all items, no need to go further
+      if (Session::haveRight($itemtype, $itemtype::READALL)) {
+         return "(`itemtype` = '$itemtype') ";
+      }
+
+      $user   = Session::getLoginUserID();
+      $groups = "'" . implode("','", $_SESSION['glpigroups']) . "'";
+
+      // Avoid empty IN ()
+      if ($groups == "''") {
+         $groups = '-1';
+      }
+
+      // We need to do some specific checks for tickets
+      if ($itemtype == "ticket") {
+         // Default condition
+         $condition = "(`itemtype` = '$itemtype' AND (0 = 1 ";
+
+         if (Session::haveRight($itemtype, $itemtype::READMY)) {
+            // Add tickets where the users is requester, observer or recipient
+            // Subquery for requester/observer user
+            $user_query = "SELECT `$target`
+               FROM `$user_table`
+               WHERE `users_id` = '$user' AND type IN (1, 3)";
+            $condition .= "OR `items_id` IN ($user_query) ";
+
+            // Subquery for recipient
+            $recipient_query = "SELECT `id`
+               FROM `glpi_{$itemtype}s`
+               WHERE `users_id_recipient` = '$user'";
+            $condition .= "OR `items_id` IN ($recipient_query) ";
+         }
+
+         if (Session::haveRight($itemtype, $itemtype::READGROUP)) {
+            // Add tickets where the users is in a requester or observer group
+            // Subquery for requester/observer group
+            $group_query = "SELECT `$target`
+               FROM `$group_table`
+               WHERE `users_id` = '$user' AND type IN (1, 3)";
+            $condition .= "OR `items_id` IN ($group_query) ";
+         }
+
+         if (Session::haveRightsOr($itemtype, [
+            $itemtype::OWN,
+            $itemtype::READASSIGN
+         ])) {
+            // Add tickets where the users is assigned
+            // Subquery for assigned user
+            $user_query = "SELECT `$target`
+               FROM `$user_table`
+               WHERE `users_id` = '$user' AND type = 2";
+            $condition .= "OR `items_id` IN ($user_query) ";
+         }
+
+         if (Session::haveRight($itemtype, $itemtype::READASSIGN)) {
+            // Add tickets where the users is part of an assigned group
+            // Subquery for assigned group
+            $group_query = "SELECT `$target`
+               FROM `$group_table`
+               WHERE `users_id` = '$user' AND type = 2";
+            $condition .= "OR `items_id` IN ($group_query) ";
+
+            if (Session::haveRight('ticket', Ticket::ASSIGN)) {
+               // Add new tickets
+               $tickets_query = "SELECT `id`
+                  FROM `glpi_{$itemtype}s`
+                  WHERE `status` = '" . CommonITILObject::INCOMING . "'";
+               $condition .= "OR `items_id` IN ($tickets_query) ";
+            }
+         }
+
+         if (Session::haveRightsOr('ticketvalidation', [
+            TicketValidation::VALIDATEINCIDENT,
+            TicketValidation::VALIDATEREQUEST
+         ])) {
+            // Add tickets where the users is the validator
+            // Subquery for validator
+            $validation_query = "SELECT `$target`
+               FROM `glpi_ticketvalidations`
+               WHERE `users_id_validate` = '$user'";
+            $condition .= "OR `items_id` IN ($validation_query) ";
+         }
+
+         return $condition .= ")) ";
+      } else {
+         if (Session::haveRight($itemtype, $itemtype::READMY)) {
+            // Subquery for affected/assigned/observer user
+            $user_query = "SELECT `$target`
+               FROM `$user_table`
+               WHERE `users_id` = '$user'";
+
+            // Subquery for affected/assigned/observer group
+            $group_query = "SELECT `$target`
+               FROM `$group_table`
+               WHERE `groups_id` IN ($groups)";
+
+            // Subquery for recipient
+            $recipient_query = "SELECT `id`
+               FROM `glpi_{$itemtype}s`
+               WHERE `users_id_recipient` = '$user'";
+
+            return "(
+               `itemtype` = '$itemtype' AND (
+                  `items_id` IN ($user_query) OR
+                  `items_id` IN ($group_query) OR
+                  `items_id` IN ($recipient_query)
+               )
+            ) ";
+         } else {
+            // Can't see any items
+            return "(`itemtype` = '$itemtype' AND 0 = 1) ";
+         }
+      }
    }
 }

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -117,7 +117,7 @@ class ITILFollowup  extends CommonDBChild {
           && Session::haveRight(self::$rightname, self::SEEPUBLIC)) {
          return true;
       }
-      if ($itilobject == "Ticket") {
+      if ($this->fields['itemtype'] == "Ticket") {
          if ($this->fields["users_id"] === Session::getLoginUserID()) {
             return true;
          }

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -1144,7 +1144,7 @@ class ITILFollowup  extends CommonDBChild {
             // Subquery for requester/observer group
             $group_query = "SELECT `$target`
                FROM `$group_table`
-               WHERE `users_id` = '$user' AND type IN ($requester, $obs)";
+               WHERE `groups_id` IN ($groups) AND type IN ($requester, $obs)";
             $condition .= "OR `items_id` IN ($group_query) ";
          }
 
@@ -1165,7 +1165,7 @@ class ITILFollowup  extends CommonDBChild {
             // Subquery for assigned group
             $group_query = "SELECT `$target`
                FROM `$group_table`
-               WHERE `users_id` = '$user' AND type = $assign";
+               WHERE `groups_id` IN ($groups) AND type = $assign";
             $condition .= "OR `items_id` IN ($group_query) ";
 
             if (Session::haveRight('ticket', Ticket::ASSIGN)) {

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3926,7 +3926,6 @@ JAVASCRIPT;
             ]);
             $condition .= ")";
 
-            error_log($condition);
             break;
 
          default :

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3901,7 +3901,7 @@ JAVASCRIPT;
 
             // Filter for "ticket" parents
             $condition .= ITILFollowup::buildParentCondition(
-               "ticket",
+               "Ticket",
                'tickets_id',
                "glpi_tickets_users",
                "glpi_groups_tickets"
@@ -3910,7 +3910,7 @@ JAVASCRIPT;
 
             // Filter for "change" parents
             $condition .= ITILFollowup::buildParentCondition(
-               "change",
+               "Change",
                'changes_id',
                "glpi_changes_users",
                "glpi_changes_groups"
@@ -3919,7 +3919,7 @@ JAVASCRIPT;
 
             // Fitler for "problem" parents
             $condition .= ITILFollowup::buildParentCondition(
-               "problem",
+               "Problem",
                'problems_id',
                "glpi_problems_users",
                "glpi_groups_problems"

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3877,6 +3877,37 @@ JAVASCRIPT;
             $condition = SavedSearch::addVisibilityRestrict();
             break;
 
+         case 'ITILFollowup':
+            // Filer on is_private
+            $allowed_is_private = [];
+            if (Session::haveRight(ITILFollowup::$rightname, ITILFollowup::SEEPRIVATE)) {
+               $allowed_is_private[] = 1;
+            }
+            if (Session::haveRight(ITILFollowup::$rightname, ITILFollowup::SEEPUBLIC)) {
+               $allowed_is_private[] = 0;
+            }
+
+            // If the user can't see public and private
+            if (!count($allowed_is_private)) {
+               $condition = "0 = 1";
+               break;
+            }
+
+            $in = "IN ('" . implode("','", $allowed_is_private) . "')";
+            $condition = "`glpi_itilfollowups`.`is_private` $in";
+
+            if (!Session::haveRight("ticket", Ticket::READALL)) {
+               // TODO: Filter items_id on allowed tickets (itemtype = "Ticket")
+            }
+            if (!Session::haveRight("change", Change::READALL)) {
+               // TODO: Filter items_id on allowed changes (itemtype = "Change")
+            }
+            if (!Session::haveRight("problem", Problem::READALL)) {
+               // TODO: Filter items_id on allowed problems (itemtype = "Problem")
+            }
+
+            break;
+
          default :
             // Plugin can override core definition for its type
             if ($plug = isPluginItemType($itemtype)) {

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -347,7 +347,7 @@ class APIRest extends APIBaseClass {
       $ticketTMF = new \TicketTemplateMandatoryField();
 
       $tt_id = $ticketTemplate->add([
-         'entities_id' => 0,
+         'entities_id' => getItemByTypeName('Entity', '_test_child_1', true),
          'name'        => 'test'
       ]);
       $this->boolean((bool)$tt_id)->isTrue();


### PR DESCRIPTION
Following #6116
Internal ref : 16937

Add ITILFollowup case in Search::addDefaultWhere().
This change is made to filter correctly the followups in API::getItems()
Currently only check public/private visiblity, need to also check parent item visibility...

Bonus fix : 
- Fix the canViewItem of ITILFollowup which had an unused condition (comparing an object to the string "Ticket").


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | pending