### PR TITLE
Fix recursive groups loading in sub-entities; fixes #6136

### DIFF
--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -542,7 +542,7 @@ class Session {
             Group::getTable(),
             'entities_id',
             $_SESSION['glpiactiveentities'],
-            $_SESSION['glpiactive_entity_recursive']
+            true
          )
       ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6136 

Fully revert commit 452e7393e7c9006043430a6c55b13746ebbf4652 (partially reverted in 220d94a66e45fbce07274c739c4b2a6938f7a804).
We have to force recursivity in groups loading to be sure to load groups that are defined in parent entities with recursive flag set to true.