### PR TITLE
Fix broken images on compiled CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ phpunit.xml
 /nbproject
 .composer.hash
 /**/*.min.css
+/css_compiled/
 /css/compiled/
 !/css/tiny_mce/**/*.min.css
 /**/*.min.js

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -6852,6 +6852,6 @@ class Html {
     * @return string
     */
    public static function getScssCompileDir() {
-      return GLPI_ROOT . '/css/compiled';
+      return GLPI_ROOT . '/css_compiled';
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

CSS path if no compiled CSS exists is `/front/css.php?file=*.css` (1 dir level in URL) and compiled CSS path was `/css/compiled/*.css` (2 dir levels in URL).
As dir level count in URL structure is not the same, all relative links of images were broken. Using a single dir level path for compiled CSS fixes the problem.

I fixed it in 9.5 version as CSS compilation in release process was broken in 9.4 (see https://github.com/glpi-project/glpi/pull/5988)