### PR TITLE
Fix datetime input format in dropdowns; fixes #6154

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -2869,7 +2869,7 @@ class Html {
       $js .= "$( '#showdate".$p['rand']."' ).datetimepicker({
                   altField: '#hiddendate".$p['rand']."',
                   altFormat: 'yy-mm-dd',
-                  altTimeFormat: 'HH:mm',
+                  altTimeFormat: 'HH:mm:ss',
                   pickerTimeFormat : 'HH:mm',
                   altFieldTimeOnly: false,
                   firstDay: 1,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6154 

`altTimeFormat` is used to define format of data we used in PHP logic. Absence of the `seconds` part was resulting in having no date result when using `DateTime::createFromFormat('Y-m-d H:i:s', $date)`.