### PR TITLE
Fix array union with duplicate keys

### DIFF
--- a/inc/db.function.php
+++ b/inc/db.function.php
@@ -651,11 +651,11 @@ function getEntitiesRestrictRequest($separator = "AND", $table = "", $field = ""
 function getEntitiesRestrictCriteria($table = '', $field = '', $value = '',
                                      $is_recursive = false, $complete_request = false) {
    $dbu = new DbUtils();
-   return $dbu->getEntitiesRestrictCriteria(
+   return [$dbu->getEntitiesRestrictCriteria(
       $table,
       $field,
       $value,
       $is_recursive,
       $complete_request
-   );
+   )];
 }

--- a/inc/db.function.php
+++ b/inc/db.function.php
@@ -662,7 +662,7 @@ function getEntitiesRestrictCriteria($table = '', $field = '', $value = '',
    // Add another layer to the array to prevent losing duplicates keys if the
    // result of the function in merged with another array
    if (count($res)) {
-      return [$res];
+      $res = [-1 => $res];
    }
-   return [];
+   return $res;
 }

--- a/inc/db.function.php
+++ b/inc/db.function.php
@@ -662,7 +662,7 @@ function getEntitiesRestrictCriteria($table = '', $field = '', $value = '',
    // Add another layer to the array to prevent losing duplicates keys if the
    // result of the function in merged with another array
    if (count($res)) {
-      $res = [-1 => $res];
+      $res = [crc32(serialize($res)) => $res];
    }
    return $res;
 }

--- a/inc/db.function.php
+++ b/inc/db.function.php
@@ -651,11 +651,18 @@ function getEntitiesRestrictRequest($separator = "AND", $table = "", $field = ""
 function getEntitiesRestrictCriteria($table = '', $field = '', $value = '',
                                      $is_recursive = false, $complete_request = false) {
    $dbu = new DbUtils();
-   return [$dbu->getEntitiesRestrictCriteria(
+   $res = $dbu->getEntitiesRestrictCriteria(
       $table,
       $field,
       $value,
       $is_recursive,
       $complete_request
-   )];
+   );
+
+   // Add another layer to the array to prevent losing duplicates keys if the
+   // result of the function in merged with another array
+   if (count($res)) {
+      return [$res];
+   }
+   return [];
 }

--- a/inc/db.function.php
+++ b/inc/db.function.php
@@ -660,7 +660,7 @@ function getEntitiesRestrictCriteria($table = '', $field = '', $value = '',
    );
 
    // Add another layer to the array to prevent losing duplicates keys if the
-   // result of the function in merged with another array
+   // result of the function is merged with another array
    if (count($res)) {
       $res = [crc32(serialize($res)) => $res];
    }

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -497,7 +497,7 @@ class DbUtils extends DbTestCase {
          ->isIdenticalTo("WHERE ( `glpi_computers`.`entities_id` IN ('1', '2', '3')  ) ");
       $it->execute('glpi_computers', getEntitiesRestrictCriteria('glpi_computers'));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (\'1\', \'2\', \'3\')');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`glpi_computers`.`entities_id` IN (\'1\', \'2\', \'3\'))');
 
       // Root entity
       $this->setEntity('_test_root_entity', false);
@@ -513,7 +513,7 @@ class DbUtils extends DbTestCase {
          ->isIdenticalTo("WHERE ( `glpi_computers`.`entities_id` IN ('1')  ) ");
       $it->execute('glpi_computers', getEntitiesRestrictCriteria('glpi_computers'));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (\'1\')');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`glpi_computers`.`entities_id` IN (\'1\'))');
 
       // Child
       $this->setEntity('_test_child_1', false);
@@ -529,7 +529,7 @@ class DbUtils extends DbTestCase {
          ->isIdenticalTo("WHERE ( `glpi_computers`.`entities_id` IN ('2')  ) ");
       $it->execute('glpi_computers', getEntitiesRestrictCriteria('glpi_computers'));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `glpi_computers`.`entities_id` IN (\'2\')');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`glpi_computers`.`entities_id` IN (\'2\'))');
 
       // Child without table
       $this->string($this->testedInstance->getEntitiesRestrictRequest('WHERE'))
@@ -543,7 +543,7 @@ class DbUtils extends DbTestCase {
          ->isIdenticalTo("WHERE ( `entities_id` IN ('2')  ) ");
       $it->execute('glpi_computers', getEntitiesRestrictCriteria());
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE `entities_id` IN (\'2\')');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`entities_id` IN (\'2\'))');
 
       // Child + parent
       $this->setEntity('_test_child_2', false);
@@ -559,7 +559,7 @@ class DbUtils extends DbTestCase {
          ->isIdenticalTo("WHERE ( `glpi_computers`.`entities_id` IN ('3')  OR (`glpi_computers`.`is_recursive`='1' AND `glpi_computers`.`entities_id` IN ('0','1')) ) ");
       $it->execute('glpi_computers', getEntitiesRestrictCriteria('glpi_computers', '', '', true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`glpi_computers`.`entities_id` IN (\'3\') OR (`glpi_computers`.`is_recursive` = \'1\' AND `glpi_computers`.`entities_id` IN (\'0\', \'1\')))');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE ((`glpi_computers`.`entities_id` IN (\'3\') OR (`glpi_computers`.`is_recursive` = \'1\' AND `glpi_computers`.`entities_id` IN (\'0\', \'1\'))))');
 
       //Child + parent on glpi_entities
       $it->execute('glpi_entities', $this->testedInstance->getEntitiesRestrictCriteria('glpi_entities', '', '', true));
@@ -569,7 +569,7 @@ class DbUtils extends DbTestCase {
       //keep testing old method from db.function
       $it->execute('glpi_entities', getEntitiesRestrictCriteria('glpi_entities', '', '', true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE (`glpi_entities`.`id` IN (\'3\', \'0\', \'1\'))');
+         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE ((`glpi_entities`.`id` IN (\'3\', \'0\', \'1\')))');
 
       //Child + parent -- automatic recusrivity detection
       $it->execute('glpi_computers', $this->testedInstance->getEntitiesRestrictCriteria('glpi_computers', '', '', 'auto'));
@@ -579,7 +579,7 @@ class DbUtils extends DbTestCase {
       //keep testing old method from db.function
       $it->execute('glpi_computers', getEntitiesRestrictCriteria('glpi_computers', '', '', 'auto'));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`glpi_computers`.`entities_id` IN (\'3\') OR (`glpi_computers`.`is_recursive` = \'1\' AND `glpi_computers`.`entities_id` IN (\'0\', \'1\')))');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE ((`glpi_computers`.`entities_id` IN (\'3\') OR (`glpi_computers`.`is_recursive` = \'1\' AND `glpi_computers`.`entities_id` IN (\'0\', \'1\'))))');
 
       // Child + parent without table
       $this->string($this->testedInstance->getEntitiesRestrictRequest('WHERE', '', '', '', true))
@@ -601,15 +601,15 @@ class DbUtils extends DbTestCase {
          ->isIdenticalTo("WHERE ( `entities_id` IN ('3')  OR (`is_recursive`='1' AND `entities_id` IN ('0','1')) ) ");
       $it->execute('glpi_computers', getEntitiesRestrictCriteria('', '', '', true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE (`entities_id` IN (\'3\') OR (`is_recursive` = \'1\' AND `entities_id` IN (\'0\', \'1\')))');
+         ->isIdenticalTo('SELECT * FROM `glpi_computers` WHERE ((`entities_id` IN (\'3\') OR (`is_recursive` = \'1\' AND `entities_id` IN (\'0\', \'1\'))))');
 
       $it->execute('glpi_entities', getEntitiesRestrictCriteria('glpi_entities', '', 3, true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE (`glpi_entities`.`id` IN (\'3\', \'0\', \'1\'))');
+         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE ((`glpi_entities`.`id` IN (\'3\', \'0\', \'1\')))');
 
       $it->execute('glpi_entities', getEntitiesRestrictCriteria('glpi_entities', '', 7, true));
       $this->string($it->getSql())
-         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE `glpi_entities`.`id` = \'7\'');
+         ->isIdenticalTo('SELECT * FROM `glpi_entities` WHERE (`glpi_entities`.`id` = \'7\')');
    }
 
    /**


### PR DESCRIPTION
Internal ref : 17475


This is how I came upon this bug : 
Ajax request on getDropdownValue.php requesting categories with the following criteria: 
- User active entities id = [1]
- Looking for is_helpdeskvisible categories
- Looking for either is_request or is_incident categories

When building the condition, the $where var looks like this before applying entity check : 
![image](https://user-images.githubusercontent.com/42734840/61633399-4b970500-ac8f-11e9-9eaf-b88453ff2d99.png)

On the other hand, the entity check returning by getEntitiesRestrictCriteria() looks like this :
![image](https://user-images.githubusercontent.com/42734840/61633553-9fa1e980-ac8f-11e9-881e-b27fa2c5a700.png)

Both variable are array that contains an "OR" key, because of this the "OR" key from getEntitiesRestrictCriteria is lost after the union of the two arrays done here :
```php
$where = $where + getEntitiesRestrictCriteria(
  $table,
  '',
  $post["entity_restrict"],
  $recur
);
```

To fix this I added another layer to the array returned by getEntitiesRestrictCriteria() to avoid losing duplicated keys.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
