### PR TITLE
Fix duplicated inlined image transformation in mail collector

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2715,8 +2715,8 @@ class Toolbox {
                      if (empty($new_image)) {
                         $new_image = '#'.$image['tag'].'#';
                      }
-                     $content_text = preg_replace(
-                        $regex,
+                     $content_text = str_replace(
+                        $match_img,
                         $new_image,
                         Html::entity_decode_deep($content_text)
                      );

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -295,4 +295,39 @@ class Toolbox extends DbTestCase {
          \Toolbox::convertTagToImage($content_text, $item, [$doc_id_2 => ['tag' => $img_tag]])
       )->isEqualTo($expected_result_2);
    }
+
+   /**
+    * Check conversion of tags to images when content contains multiple times same inlined image.
+    */
+   public function testConvertTagToImageWithDuplicatedInlinedImg() {
+
+      $img_tag = uniqid('', true);
+
+      $item = new \Ticket();
+      $item->fields['id'] = mt_rand(1, 50);
+
+      // Create multiple documents in DB
+      $document = new \Document();
+      $doc_id = $document->add([
+         'name'     => 'img 1',
+         'filename' => 'img.png',
+         'mime'     => 'image/png',
+         'tag'      => $img_tag,
+      ]);
+      $this->integer((int)$doc_id)->isGreaterThan(0);
+
+      $content_text     = '<img id="' . $img_tag . '" width="10" height="10" />';
+      $content_text    .= $content_text;
+      $expected_url     = '/front/document.send.php?docid=' . $doc_id . '&tickets_id=' . $item->fields['id'];
+      $expected_result  = '<a href="' . $expected_url . '" target="_blank" ><img alt="' . $img_tag . '" width="10" src="' . $expected_url . '" /></a>';
+      $expected_result .= $expected_result;
+
+      // Processed data is expected to be escaped
+      $content_text = \Toolbox::addslashes_deep($content_text);
+      $expected_result = \Html::entities_deep($expected_result);
+
+      $this->string(
+         \Toolbox::convertTagToImage($content_text, $item, [$doc_id => ['tag' => $img_tag]])
+      )->isEqualTo($expected_result);
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This one is a really specific case I encountered during tests.

If an image is present twice inside a same mail, generated HTML is malformed, as the `img` tags is surrounded by as much as `a` tags as the count of duplication of the image.

First commit contains a test that show the error (see https://circleci.com/gh/glpi-project/glpi/23295), second commit contains the fix.

With `preg_replace`, `img` tag will match even after its replacement, as it will still contains the tag in its `alt` attribute.
With `str_replace`, replacement will be done only once as it will not match previously found string after first replacement.