### PR TITLE
Fix undefined offset on CSS compilation

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -5525,7 +5525,6 @@ div#viewgraph {
 .grid-stack .grid-stack-item {
    z-index: 3;
    opacity: 1;
-   filter: Alpha(Opacity = 100);
 }
 
 .clear_picture .grid-stack .grid-stack-item {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

With new version of scssphp component, usage of IE8- filters produces a PHP notice.
This filter is for IE8-, I guess we can remove it.

To reproduce, call CSS with nocache param while having debug mode active:  http://127.0.0.1/front/css.php?file=css/styles&debug&v=9.5.0-dev&nocache