### PR TITLE
Fix novalidate-cert flag even if TLS is not explicitely set

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2256,8 +2256,7 @@ class Toolbox {
       if (isset($input['server_ssl']) && !empty($input['server_ssl'])) {
          $out .= $input['server_ssl'];
       }
-      if (isset($input['server_cert']) && !empty($input['server_cert'])
-          && (!empty($input['server_ssl']) || !empty($input['server_tls']))) {
+      if (isset($input['server_cert']) && !empty($input['server_cert'])) {
          $out .= $input['server_cert'];
       }
       if (isset($input['server_tls']) && !empty($input['server_tls'])) {

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -212,7 +212,7 @@ class MailCollector extends DbTestCase {
       $this->integer($this->mailgate_id)->isGreaterThan(0);
 
       $this->boolean($collector->getFromDB($this->mailgate_id))->isTrue();
-      $this->string($collector->fields['host'])->isIdenticalTo('{127.0.0.1:143/imap}');
+      $this->string($collector->fields['host'])->isIdenticalTo('{127.0.0.1:143/imap/novalidate-cert}');
       $collector->connect();
       $this->variable($collector->fields['errors'])->isEqualTo(0);
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Even if `/tls` flag is not explicitely set, connection may use START-TLS. So definition of `/novalidate-cert` may be required even if no TLS behaviour has been defined by admin.