### PR TITLE
Fix tests on TicketRecurrent::computeNextCreationDate()

### DIFF
--- a/tests/functionnal/TicketRecurrent.php
+++ b/tests/functionnal/TicketRecurrent.php
@@ -180,7 +180,7 @@ class TicketRecurrent extends DbTestCase {
             'periodicity'    => '2MONTH',
             'create_before'  => 0,
             'calendars_id'   => 0,
-            'expected_value' => date('Y-m-01 00:00:00', strtotime('+ 2 month')),
+            'expected_value' => date('Y-m-01 00:00:00', strtotime($start_of_current_month . ' + 2 month')),
          ],
 
          // Valid case 7: ticket created every year with no anticipation and no calendar
@@ -190,7 +190,7 @@ class TicketRecurrent extends DbTestCase {
             'periodicity'    => '1YEAR',
             'create_before'  => 0,
             'calendars_id'   => 0,
-            'expected_value' => date('Y-m-01 00:00:00', strtotime('+ 1 year')),
+            'expected_value' => date('Y-m-01 00:00:00', strtotime($start_of_current_month . ' + 1 year')),
          ],
       ];
 
@@ -261,7 +261,7 @@ class TicketRecurrent extends DbTestCase {
       }
 
       $next_time = strtotime(date('Y-m-d H:05:00'));
-      if ((int)date('i') > 5) {
+      if ((int)date('i') >= 5) {
          $next_time = strtotime('+ 1 hour', $next_time);
       }
       if (in_array(date('w', $next_time), ['0', '6'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Fix cases where adding months or a years results in having a date higher than month days count (i.e. `July 31 + 2 month = October 1`, `February 29, 2020 + 1 year = March 1, 2021`.
2. Fix a case that was failing when test was executed on 5th minute of current hour.