### PR TITLE
fix: global_validation status on ticket update

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1245,7 +1245,9 @@ class Ticket extends CommonITILObject {
       }
 
       //Action for send_validation rule : do validation before clean
-      $this->manageValidationAdd($input);
+      if ($this->manageValidationAdd($input)) {
+         $input['global_validation'] = TicketValidation::WAITING;
+      }
 
       // Clean actors fields added for rules
       foreach ($tocleanafterrules as $key => $val) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 17575

On ticket update, the goal is to ensure that the global_validation is waiting if a validation has been sent by business rules.

This fix is not necessary on ticket creation, because the business rules are played after adding in DB.
