### PR TITLE
support for QueryExpression in SELECT statement

### DIFF
--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -367,6 +367,8 @@ class DBmysqlIterator implements Iterator, Countable {
       if (is_numeric($t)) {
          if ($f instanceof \AbstractQuery) {
             return $f->getQuery();
+         } else if ($f instanceof \QueryExpression) {
+            return $f->getValue();
          } else {
             return DBmysql::quoteName($f);
          }

--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -254,6 +254,8 @@ class DBmysqlIterator implements Iterator, Countable {
          } else if ($table) {
             if ($table instanceof \AbstractQuery) {
                $table = $table->getQuery();
+            } else if ($table instanceof \QueryExpression) {
+               $table = $table->getValue();
             } else {
                $table = DBmysql::quoteName($table);
             }

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -204,6 +204,20 @@ class DBmysqlIterator extends DbTestCase {
       $this->string($it->getSql())->isIdenticalTo('SELECT IF(bar IS NOT NULL, 1, 0) AS baz FROM `foo`');
    }
 
+   public function testFrom() {
+      $this->it->buildQuery(['FIELDS' => 'bar', 'FROM' => 'foo']);
+      $this->string($this->it->getSql())->isIdenticalTo('SELECT `bar` FROM `foo`');
+
+      $this->it->buildQuery(['FIELDS' => 'bar', 'FROM' => 'foo as baz']);
+      $this->string($this->it->getSql())->isIdenticalTo('SELECT `bar` FROM `foo` AS `baz`');
+
+      $this->it->buildQuery(['FIELDS' => 'bar', 'FROM' => ['foo', 'baz']]);
+      $this->string($this->it->getSql())->isIdenticalTo('SELECT `bar` FROM `foo`, `baz`');
+
+      $this->it->buildQuery(['FIELDS' => 'c', 'FROM' => new \QueryExpression("(SELECT CONCAT('foo', 'baz') as c) as t")]);
+      $this->string($this->it->getSql())->isIdenticalTo("SELECT `c` FROM (SELECT CONCAT('foo', 'baz') as c) as t");
+   }
+
 
    public function testOrder() {
       $it = $this->it->execute('foo', ['ORDERBY' => 'bar']);

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -199,6 +199,9 @@ class DBmysqlIterator extends DbTestCase {
 
       $it = $this->it->execute('foo', ['FIELDS' => ['MAX' => 'bar AS cpt']]);
       $this->string($it->getSql())->isIdenticalTo('SELECT MAX(`bar`) AS cpt FROM `foo`');
+
+      $it = $this->it->execute('foo', ['FIELDS' => new \QueryExpression('IF(bar IS NOT NULL, 1, 0) AS baz')]);
+      $this->string($it->getSql())->isIdenticalTo('SELECT IF(bar IS NOT NULL, 1, 0) AS baz FROM `foo`');
    }
 
 


### PR DESCRIPTION
Formcreator uses SQL IF() expression in a SELECT statement. To convert this raw query into a built query, I suggest this change.

https://github.com/pluginsGLPI/formcreator/blob/develop/inc/form_profile.class.php#L111


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
