### PR TITLE
Add supervisor search option for User

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -3267,6 +3267,17 @@ class User extends CommonDBTM {
          ]
       ];
 
+      $tab[] = [
+         'id'                 => '99',
+         'table'              => 'glpi_users',
+         'field'              => 'name',
+         'linkfield'          => 'users_id_supervisor',
+         'name'               => __('Responsible'),
+         'datatype'           => 'dropdown',
+         'massiveaction'      => false,
+         'joinparams'         => ['condition' => "AND 1=1"]
+      ];
+
       // add objectlock search options
       $tab = array_merge($tab, ObjectLock::rawSearchOptionsToAdd(get_class($this)));
 


### PR DESCRIPTION
Users have a new supervisor (or Responsible) property; but the search option is missing

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
