### PR TITLE
Fix HAVING in search

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -532,6 +532,7 @@ class Search {
 
          if (isset($criteria['field'])
             && isset($searchopt[$criteria['field']]["usehaving"])
+            || (isset($criteria['meta']) && $criteria['meta'] && $criteria['link'] == "AND NOT")
          ) {
             return true;
          }
@@ -1045,7 +1046,6 @@ class Search {
                      $criterion['searchtype'],
                      $criterion['value']
                   );
-
                   $sql .= $new_where;
                   continue;
                }

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -701,7 +701,7 @@ class Search {
             $WHERE = "";
 
             // Each field specified in the HAVING must be in the SELECT aswell
-            $regex = "/`.*?`.`.*?`/";
+            $regex = "/`glpi_\w*?`\.`.*?`/";
             $matches = [];
             preg_match_all($regex, $HAVING, $matches);
             if (isset($matches[0])) {

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -511,6 +511,35 @@ class Search {
       return $data;
    }
 
+   /**
+    * Search for a "usehaving" field in the searchOption of for each criteria
+    *
+    * @param $criterias List of criterias
+    * @param $searchopt List of searchOptions
+    *
+    * @return bool
+    */
+   public static function hasHaving($criterias, $searchopt) {
+      foreach ($criterias as $criteria) {
+         // Search recursively for groups
+         if (isset($criteria['criteria'])) {
+            $hasHaving = self::hasHaving($criteria['criteria'], $searchopt);
+            if ($hasHaving) {
+               return true;
+            }
+            continue;
+         }
+
+         if (isset($criteria['field'])
+            && isset($searchopt[$criteria['field']]["usehaving"])
+         ) {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
 
    /**
     * Construct SQL request depending of search parameters
@@ -663,6 +692,25 @@ class Search {
       if (count($data['search']['criteria'])) {
          $WHERE  = self::constructCriteriaSQL($data['search']['criteria'], $data, $searchopt);
          $HAVING = self::constructCriteriaSQL($data['search']['criteria'], $data, $searchopt, true);
+
+         // Check if a criteria was meant to be used as a having field
+         $hasHaving = self::hasHaving($data['search']['criteria'], $searchopt);
+         if ($hasHaving) {
+            $HAVING = $WHERE;
+            $WHERE = "";
+
+            // Each field specified in the HAVING must be in the SELECT aswell
+            $regex = "/`.*?`.`.*?`/";
+            $matches = [];
+            preg_match_all($regex, $HAVING, $matches);
+            if (isset($matches[0])) {
+               foreach ($matches[0] as $havingElement) {
+                  if (strpos($SELECT, $havingElement) === false) {
+                     $SELECT .= " $havingElement, ";
+                  }
+               }
+            }
+         }
 
          // if criteria (with meta flag) need additional join/from sql
          self::constructAdditionalSqlForMetacriteria($data['search']['criteria'], $SELECT, $FROM, $already_link_tables, $data);
@@ -987,15 +1035,19 @@ class Search {
             } else if (isset($searchopt[$criterion['field']]["usehaving"])
                        || ($meta && "AND NOT" === $criterion['link'])) {
                if (!$is_having) {
-                  // the having part will be managed in a second pass
-                  continue;
-               }
+                  // Add the having in the where as the whole WHERE will be
+                  // converted into an HAVING later
+                  $new_where = self::addHaving(
+                     $LINK,
+                     $NOT,
+                     $itemtype,
+                     $criterion['field'],
+                     $criterion['searchtype'],
+                     $criterion['value']
+                  );
 
-               $new_having = self::addHaving($LINK, $NOT, $itemtype,
-                                             $criterion['field'], $criterion['searchtype'],
-                                             $criterion['value']);
-               if ($new_having !== false) {
-                  $sql .= $new_having;
+                  $sql .= $new_where;
+                  continue;
                }
             } else {
                if ($is_having) {

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -519,7 +519,7 @@ class Search {
     *
     * @return bool
     */
-   public static function hasHaving($criterias, $searchopt) {
+   private static function hasHaving($criterias, $searchopt) {
       foreach ($criterias as $criteria) {
          // Search recursively for groups
          if (isset($criteria['criteria'])) {

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -310,6 +310,44 @@ class Search extends DbTestCase {
                      ->contains("LEFT JOIN `glpi_entities`  AS `glpi_entities_");
    }
 
+   public function testHaving() {
+      $search_params = [
+         'reset'        => 'reset',
+         'is_deleted'   => 0,
+         'start'        => 0,
+         'search'       => 'Search',
+         'criteria'     => [
+            0 => [
+               'field'      => 1,
+               'searchtype' => 'contains',
+               'value'      => 'vm'
+            ],
+            1 => [
+               'link'       => 'OR',
+               'field'      => 18,
+               'searchtype' => 'contains',
+               'value'      => 4
+            ],
+         ]
+      ];
+
+      $data = $this->doSearch('Computer', $search_params);
+
+      // check for sql error (data key missing or empty)
+      $this->array($data)
+         ->hasKey('data')
+         ->array['last_errors']->isIdenticalTo([])
+         ->array['data']->isNotEmpty();
+
+      // Check having
+      $this->array($data)
+         ->hasKey('sql')
+         ->array['sql']
+         ->hasKey('search')
+         ->string['search']
+         ->contains("HAVING    (`glpi_computers`.`name`  LIKE '%vm%'  )  OR (`ITEM_Computer_18` = 4) ");
+   }
+
    public function testNestedAndMetaComputer() {
       $search_params = [
          'reset'      => 'reset',

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -416,7 +416,7 @@ class Search extends DbTestCase {
          ->contains("(`glpi_users`.`id` = '2')")
          ->contains("OR (`glpi_users`.`id` = '3')")
          // match having
-         ->matches("/HAVING\s*\(`ITEM_Budget_2`\s+<>\s+5\)\s+AND\s+\(\(`ITEM_Printer_1`\s+NOT LIKE\s+'%HP%'\s+OR\s+`ITEM_Printer_1`\s+IS NULL\)\s*\)/");
+         ->matches("/HAVING.*\(`ITEM_Budget_2`\s+<>\s+5\)\s+AND\s+\(\(`ITEM_Printer_1`\s+NOT LIKE\s+'%HP%'\s+OR\s+`ITEM_Printer_1`\s+IS NULL\)\s*\)/");
    }
 
    function testViewCriterion() {


### PR DESCRIPTION
Search that use an aggregate function (e.g. "Computer - number of CPU") lead to incorrect results as the condition is split between the `WHERE` and `HAVING` clause.

For example, if we search for "A = count(x) OR b = 1", the generated request will be like this:
```sql
SELECT ...
FROM ...
WHERE b = 1
GROUP BY ...
HAVING a = count(x)
```
To be correct, the request need to be like this instead:
```sql
SELECT ...
FROM ...
GROUP BY ...
HAVING b = 1 OR a = count(x)
```

The proposed changes do 3 actions to get the correct request:
- When building the request, add the `HAVING` conditions directly in the `WHERE` clause
- Once the `WHERE` is fully built, copy it into into the `HAVING` clause then remove it
- Check that every fields specified into the `HAVING` clause exists in the `SELECT` clause (and add them if not)


The last action in needed because: 
>The SQL standard requires that `HAVING` must reference only columns in the `GROUP BY` clause or columns used in aggregate functions. However, MySQL supports an extension to this behavior, and permits `HAVING` to refer to columns in the `SELECT` list and columns in outer subqueries as well.

**This also mean that this will only work with MySQL.**

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
