### PR TITLE
Fix self join with linkfield

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3918,7 +3918,7 @@ JAVASCRIPT;
       $inittable = $table;
       $addtable  = '';
       if (($table != 'asset_types')
-          && ($table != getTableForItemType($itemtype))
+         //  && ($table != getTableForItemType($itemtype))
           && ($searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table))) {
          $addtable = "_".$searchopt[$ID]["linkfield"];
          $table   .= $addtable;

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3918,7 +3918,7 @@ JAVASCRIPT;
       $inittable = $table;
       $addtable  = '';
       if (($table != 'asset_types')
-         //  && ($table != getTableForItemType($itemtype))
+          && (($table != getTableForItemType($itemtype)) || isset($searchopt[$ID]['is_self_join']))
           && ($searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table))) {
          $addtable = "_".$searchopt[$ID]["linkfield"];
          $table   .= $addtable;


### PR DESCRIPTION
A very rare type of searchOption fail with the currently fail because of different alias in the `LEFT JOIN` and `WHERE` clauses (see #6203).

These changed introduce a new flag `is_self_join` that resolve this problem and make sure the correct alias is used in the `WHERE` clause.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
