### PR TITLE
Always use left join for meta criteria

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1140,7 +1140,7 @@ class Search {
          if (!in_array(getTableForItemType($m_itemtype), $already_link_tables)) {
             $FROM .= self::addMetaLeftJoin($data['itemtype'], $m_itemtype,
                                            $already_link_tables,
-                                           $criterion['value'] == "NULL" || strstr($criterion['link'], "NOT"),
+                                           true,
                                            $sopt["joinparams"]);
          }
 

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1140,7 +1140,6 @@ class Search {
          if (!in_array(getTableForItemType($m_itemtype), $already_link_tables)) {
             $FROM .= self::addMetaLeftJoin($data['itemtype'], $m_itemtype,
                                            $already_link_tables,
-                                           true,
                                            $sopt["joinparams"]);
          }
 
@@ -4932,18 +4931,12 @@ JAVASCRIPT;
     * @param $from_type                   reference item type ID
     * @param $to_type                     item type to add
     * @param $already_link_tables2  array of tables already joined
-    * @param $nullornott                  Used LEFT JOIN (null generation)
-    *                                     or INNER JOIN for strict join
     *
     * @return Meta Left join string
    **/
    static function addMetaLeftJoin($from_type, $to_type, array &$already_link_tables2,
-                                   $nullornott, $joinparams = []) {
-
-      $LINK = " INNER JOIN ";
-      if ($nullornott) {
-         $LINK = " LEFT JOIN ";
-      }
+                                   $joinparams = []) {
+      $LINK = " LEFT JOIN ";
 
       $from_table = getTableForItemType($from_type);
       $from_fk    = getForeignKeyFieldForTable($from_table);

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -396,9 +396,9 @@ class Search extends DbTestCase {
 
       $this->string($data['sql']['search'])
          // join parts
-         ->matches('/INNER JOIN\s*`glpi_computers_softwareversions`\s*AS `glpi_computers_softwareversions_Software`/im')
-         ->matches('/INNER JOIN\s*`glpi_softwareversions`\s*AS `glpi_softwareversions_Software`/im')
-         ->matches('/INNER JOIN\s*`glpi_softwares`\s*ON\s*\(`glpi_softwareversions_Software`\.`softwares_id`\s*=\s*`glpi_softwares`\.`id`\)/im')
+         ->matches('/LEFT JOIN\s*`glpi_computers_softwareversions`\s*AS `glpi_computers_softwareversions_Software`/im')
+         ->matches('/LEFT JOIN\s*`glpi_softwareversions`\s*AS `glpi_softwareversions_Software`/im')
+         ->matches('/LEFT JOIN\s*`glpi_softwares`\s*ON\s*\(`glpi_softwareversions_Software`\.`softwares_id`\s*=\s*`glpi_softwares`\.`id`\)/im')
          ->matches('/LEFT JOIN\s*`glpi_infocoms`\s*ON\s*\(`glpi_computers`\.`id`\s*=\s*`glpi_infocoms`\.`items_id`\s*AND\s*`glpi_infocoms`.`itemtype`\s*=\s*\'Computer\'\)/im')
          ->matches('/LEFT JOIN\s*`glpi_budgets`\s*ON\s*\(`glpi_infocoms`\.`budgets_id`\s*=\s*`glpi_budgets`\.`id`\)/im')
          ->matches('/LEFT JOIN\s*`glpi_computers_items`\s*AS `glpi_computers_items_Printer`\s*ON\s*\(`glpi_computers_items_Printer`\.`computers_id`\s*=\s*`glpi_computers`\.`id`\s*AND\s*`glpi_computers_items_Printer`.`itemtype`\s*=\s*\'Printer\'\s*AND\s*`glpi_computers_items_Printer`.`is_deleted`\s*=\s*0\)/im')


### PR DESCRIPTION
The current behavior for meta criteria is that they are added with a "LEFT JOIN" only if the link method is NOT or AND NOT (else it is an INNER JOIN).

Why is this needed ? Shouldn't all JOINs be LEFT JOIN ?

Example of the current behavior and why is it not working as expected: 
![image](https://user-images.githubusercontent.com/42734840/62710917-75268f00-b9f8-11e9-83ac-0b36f6f5039a.png)

The generated request will have `INNER JOIN glpi_monitors` which mean that the "OR" works like an "AND" instead (if the row doesn't match the monitor criteria then it is excluded from the mysql result set which is not what we with an "OR" ...).


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
