### PR TITLE
fix: visibility of recall value

### DIFF
--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1665,7 +1665,8 @@ abstract class CommonITILTask  extends CommonDBTM {
 
          echo "<tr class='tab_bg_1'><td>"._x('Planning', 'Reminder')."</td><td class='center'>";
          PlanningRecall::dropdown(['itemtype' => $this->getType(),
-                                        'items_id' => $this->getID()]);
+                                        'items_id' => $this->getID(),
+                                        'users_id' => $this->getField('users_id')]);
          echo "</td><td colspan='2'></td></tr>";
       }
 


### PR DESCRIPTION
Fix visibility of recall value when user is not the user of task

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6233 
