### PR TITLE
Add QueryExpression support in order clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The present file will list all changes made to the project; according to the
 
 ### API changes
 
+#### Changes
+
+- `DBmysqlIterator::handleOrderClause()` supports QueryExpressions
+
 #### Deprecated
 
 - `DBMysql::fetch_array()`

--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -319,16 +319,22 @@ class DBmysqlIterator implements Iterator, Countable {
 
       $cleanorderby = [];
       foreach ($clause as $o) {
-         $fields = explode(',', $o);
-         foreach ($fields as $field) {
-            $new = '';
-            $tmp = explode(' ', trim($field));
-            $new .= DBmysql::quoteName($tmp[0]);
-            // ASC OR DESC added
-            if (isset($tmp[1]) && in_array($tmp[1], ['ASC', 'DESC'])) {
-               $new .= ' '.$tmp[1];
+         if (is_string($o)) {
+            $fields = explode(',', $o);
+            foreach ($fields as $field) {
+               $new = '';
+               $tmp = explode(' ', trim($field));
+               $new .= DBmysql::quoteName($tmp[0]);
+               // ASC OR DESC added
+               if (isset($tmp[1]) && in_array($tmp[1], ['ASC', 'DESC'])) {
+                  $new .= ' ' . $tmp[1];
+               }
+               $cleanorderby[] = $new;
             }
-            $cleanorderby[] = $new;
+         } else if ($o instanceof QueryExpression) {
+            $cleanorderby[] = $o->getValue();
+         } else {
+            trigger_error("Invalid order clause", E_USER_ERROR);
          }
       }
 

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -244,6 +244,18 @@ class DBmysqlIterator extends DbTestCase {
 
       $it = $this->it->execute('foo', ['ORDER' => 'bar DESC, baz ASC']);
       $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `foo` ORDER BY `bar` DESC, `baz` ASC');
+
+      $it = $this->it->execute('foo', ['ORDER' => new \QueryExpression("CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END")]);
+      $this->string($it->getSql())->isIdenticalTo("SELECT * FROM `foo` ORDER BY CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END");
+
+      $it = $this->it->execute('foo', ['ORDER' => [new \QueryExpression("CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END"), 'bar ASC']]);
+      $this->string($it->getSql())->isIdenticalTo("SELECT * FROM `foo` ORDER BY CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END, `bar` ASC");
+
+      $it = $this->it->execute('foo', ['ORDER' => [new \QueryExpression("CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END"), 'bar ASC, baz DESC']]);
+      $this->string($it->getSql())->isIdenticalTo("SELECT * FROM `foo` ORDER BY CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END, `bar` ASC, `baz` DESC");
+
+      $it = $this->it->execute('foo', ['ORDER' => [new \QueryExpression("CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END"), 'bar ASC', 'baz DESC']]);
+      $this->string($it->getSql())->isIdenticalTo("SELECT * FROM `foo` ORDER BY CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END, `bar` ASC, `baz` DESC");
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Support both strings and QueryExpressions in order clause to allow using CASE statements.