### PR TITLE
API - Use maybeRecurvise in GET requests

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1250,7 +1250,7 @@ abstract class API extends CommonGLPI {
                                              $itemtype::getTable(),
                                              '',
                                              $_SESSION['glpiactiveentities'],
-                                             false,
+                                             $item->maybeRecursive(),
                                              true);
 
          if ($item instanceof SavedSearch) {


### PR DESCRIPTION
The API doesn't check for entity recursion when trying to access a collection though a GET request.

For exemple, if i have a `PluginFormcreatorForm` object in a child entity of root with `is_recursive = 1`, the request `/apirest.php/PluginFormcreatorForm` will not find it.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
