### PR TITLE
fix(planning): fix planning recall not save on update scheduling

### DIFF
--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -298,6 +298,11 @@ abstract class CommonITILTask  extends CommonDBTM {
                                                $this->fields["begin"]);
       }
 
+      if (isset($this->input['_planningrecall'])) {
+         $this->input['_planningrecall']['items_id'] = $this->fields['id'];
+         PlanningRecall::manageDatas($this->input['_planningrecall']);
+      }
+
       $update_done = false;
       $itemtype    = $this->getItilObjectItemType();
       $item        = new $itemtype();
@@ -1384,6 +1389,11 @@ abstract class CommonITILTask  extends CommonDBTM {
          // Create item
          $options[$fkfield] = $item->getField('id');
          $this->check(-1, CREATE, $options);
+      }
+
+      //prevent null fields due to getFromDB
+      if (is_null($this->fields['begin'])) {
+         $this->fields['begin'] = "";
       }
 
       $rand = mt_rand();


### PR DESCRIPTION
When opening a task already created the field 'begin' is reset to null by the function getFromDB.

It's no longer possible to create a schedule reminder after creating a task.

This PR prevent this


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6250 

