### PR TITLE
Request type dropdown: show default mail source for tickets

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -6873,7 +6873,12 @@ class Ticket extends CommonITILObject {
                if (isset($field_id_or_search_options['joinparams']) && Toolbox::in_array_recursive('glpi_itilfollowups', $field_id_or_search_options['joinparams'])) {
                   $opt = ['is_itilfollowup' => 1];
                } else {
-                  $opt = ['is_ticketheader' => 1];
+                  $opt = [
+                     'OR' => [
+                        'is_mail_default' => 1,
+                        'is_ticketheader' => 1
+                     ]
+                  ];
                }
                if ($field_id_or_search_options['linkfield']  == $name) {
                   $opt['is_active'] = 1;


### PR DESCRIPTION
Internal ref: 17710

The request type dropdown only show sources marked as `is_ticketheader`.
It it however possible to create tickets with a source that doesn't have this flag if they came from a mail collector (flagged as `is_mail_default`).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | pending
