### PR TITLE
Use Ticket->update() entry point for addme_assign

### DIFF
--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -168,14 +168,15 @@ if (isset($_POST["add"])) {
    Html::redirect(Ticket::getFormURLWithID($_POST['tickets_id']));
 
 } else if (isset($_POST['addme_assign'])) {
-   $ticket_user = new Ticket_User();
-
    $track->check($_POST['tickets_id'], READ);
-   $input = ['tickets_id'       => $_POST['tickets_id'],
-                  'users_id'         => Session::getLoginUserID(),
-                  'use_notification' => 1,
-                  'type'             => CommonITILActor::ASSIGN];
-   $ticket_user->add($input);
+   $track->update([
+      'id' => $_POST['tickets_id'],
+      '_itil_assign' => [
+         '_type' => "user",
+         'users_id' => Session::getLoginUserID(),
+         'use_notification' => 1,
+      ]
+   ]);
    Event::log($_POST['tickets_id'], "ticket", 4, "tracking",
               //TRANS: %s is the user login
               sprintf(__('%s adds an actor'), $_SESSION["glpiname"]));


### PR DESCRIPTION
Internal ref: 17720

# Problem
Assigning yourself to a ticket with the "addme_assign" button doesn't trigger ticket rules targeting the assigned tech field.

It seems that it is caused because addme_assign was creating a new Ticket_User object manually instead of updating the ticket with the "_itil_assign" flag.
This meant that the code dealing with ticketrules was not executed in the correct order and couldn't trigger the rules correctly.

# Solution
Do not create a Ticket_User, update the ticket with the  "_itil_assign" flag the same way it's done when assigning a tech without this button.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes