### PR TITLE
 fix content-type CSV export

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -7349,7 +7349,7 @@ JAVASCRIPT;
             header('Pragma: private'); /// IE BUG + SSL
             header('Cache-control: private, must-revalidate'); /// IE BUG + SSL
             header("Content-disposition: filename=glpi.csv");
-            header('Content-type: application/octetstream');
+            header('Content-type: text/csv');
             // zero width no break space (for excel)
             echo"\xEF\xBB\xBF";
             break;


### PR DESCRIPTION
This RP fix issue with content type on csv export.
When we try to open file with Excel we have this

![image](https://user-images.githubusercontent.com/7335054/64324075-f6f0e480-cfc5-11e9-9d99-5f305c7eb0ca.png)

now we have
![image](https://user-images.githubusercontent.com/7335054/64324145-125bef80-cfc6-11e9-9306-a5220df80fd6.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
