### PR TITLE
Add DCRoom to external link item types

### DIFF
--- a/inc/dcroom.class.php
+++ b/inc/dcroom.class.php
@@ -57,6 +57,7 @@ class DCRoom extends CommonDBTM {
          ->addStandardTab('Infocom', $ong, $options)
          ->addStandardTab('Contract_Item', $ong, $options)
          ->addStandardTab('Document_Item', $ong, $options)
+         ->addStandardTab('Link', $ong, $options)
          ->addStandardTab('Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)

--- a/inc/define.php
+++ b/inc/define.php
@@ -292,7 +292,8 @@ $CFG_GLPI["ticket_types"]                 = ['Computer', 'Monitor', 'NetworkEqui
 $CFG_GLPI["link_types"]                   = ['Budget', 'CartridgeItem', 'Computer',
                                                   'ConsumableItem', 'Contact', 'Contract', 'Monitor',
                                                   'NetworkEquipment', 'Peripheral', 'Phone',
-                                                  'Printer', 'Software', 'Supplier', 'User', 'Certificate'];
+                                                  'Printer', 'Software', 'Supplier', 'User', 'Certificate',
+                                                  'DCRoom'];
 
 $CFG_GLPI["dictionnary_types"]            = ['ComputerModel', 'ComputerType', 'Manufacturer',
                                                   'MonitorModel', 'MonitorType',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | ?
| Deprecations? | ?
| Tests pass?   | yes, atoum tests passed.
| Fixed tickets | n/a

Just wanted to be able to attach an external link to a server room object.