### PR TITLE
Fix update to 9.4 failing on old OCS SO display prefs

### DIFF
--- a/install/update_93_94.php
+++ b/install/update_93_94.php
@@ -201,23 +201,22 @@ function update93to94() {
    $migration->addConfig(['cas_version' => 'CAS_VERSION_2_0']);
 
    /** Drop old embed ocs search options */
-   $migration->addPostQuery(
-      $DB->buildDelete(
-         'glpi_displaypreferences', [
-            'itemtype'  => 'Computer',
-            'num'       => [
-               100,
-               101,
-               102,
-               103,
-               104,
-               105,
-               106,
-               110,
-               111
-            ]
+   $DB->deleteOrDie(
+      'glpi_displaypreferences',
+      [
+         'itemtype'  => 'Computer',
+         'num'       => [
+            100,
+            101,
+            102,
+            103,
+            104,
+            105,
+            106,
+            110,
+            111
          ]
-      )
+      ]
    );
    /** /Drop old embed ocs search options */
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5658

Previous fix done in #5748 was not working. Indeed, deletion cannot be made on migration run (on pre or post query) as `Factorize components search options on Computers, Printers and NetworkEquipments` update is done immediately.