### PR TITLE
check same rights for followups in all ITIL objects

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -170,8 +170,18 @@ abstract class CommonITILObject extends CommonDBTM {
     *
     * @return boolean
     */
-   function canAddFollowups() {
-      return Session::haveRight(static::$rightname, UPDATE) and Session::haveRight('followup', CREATE);
+    function canAddFollowups() {
+      return ((Session::haveRight("followup", ITILFollowup::ADDMYTICKET)
+               && ($this->isUser(CommonITILActor::REQUESTER, Session::getLoginUserID())
+                   || (isset($this->fields["users_id_recipient"])
+                        && ($this->fields["users_id_recipient"] === Session::getLoginUserID()))))
+              || Session::haveRight('followup', ITILFollowup::ADDALLTICKET)
+              || (Session::haveRight('followup', ITILFollowup::ADDGROUPTICKET)
+                  && isset($_SESSION["glpigroups"])
+                  && $this->haveAGroup(CommonITILActor::REQUESTER, $_SESSION['glpigroups']))
+              || $this->isUser(CommonITILActor::ASSIGN, Session::getLoginUserID())
+              || (isset($_SESSION["glpigroups"])
+                  && $this->haveAGroup(CommonITILActor::ASSIGN, $_SESSION['glpigroups'])));
    }
 
 

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -170,7 +170,7 @@ abstract class CommonITILObject extends CommonDBTM {
     *
     * @return boolean
     */
-    function canAddFollowups() {
+   function canAddFollowups() {
       return ((Session::haveRight("followup", ITILFollowup::ADDMYTICKET)
                && ($this->isUser(CommonITILActor::REQUESTER, Session::getLoginUserID())
                    || (isset($this->fields["users_id_recipient"])

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2555,21 +2555,6 @@ class Ticket extends CommonITILObject {
    }
 
 
-   function canAddFollowups() {
-
-      return ((Session::haveRight("followup", ITILFollowup::ADDMYTICKET)
-               && ($this->isUser(CommonITILActor::REQUESTER, Session::getLoginUserID())
-                   || (isset($this->fields["users_id_recipient"])
-                        && ($this->fields["users_id_recipient"] === Session::getLoginUserID()))))
-              || Session::haveRight('followup', ITILFollowup::ADDALLTICKET)
-              || (Session::haveRight('followup', ITILFollowup::ADDGROUPTICKET)
-                  && isset($_SESSION["glpigroups"])
-                  && $this->haveAGroup(CommonITILActor::REQUESTER, $_SESSION['glpigroups']))
-              || $this->isUser(CommonITILActor::ASSIGN, Session::getLoginUserID())
-              || (isset($_SESSION["glpigroups"])
-                  && $this->haveAGroup(CommonITILActor::ASSIGN, $_SESSION['glpigroups'])));
-   }
-
    /**
     * Check if user can add followups to the ticket.
     *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?  | hope yes

Internal ref : 17062

For changes and problems, you need to have UPDATE right on the main object to add followups.
I move rights from ticket to CommonItilObject to have the same behavior in all ITIL objects

![image](https://user-images.githubusercontent.com/418844/64846538-2f6b7080-d60d-11e9-981a-d262653b485f.png)

Following this fix, we may rename the constants to be named relative to itil objects not ticket (Ex ADDMYTICKET -> ADDMY) but it's out of the need for this fix.