### PR TITLE
Fix writing of cache footprint file on some Windows env

### DIFF
--- a/inc/cache/simplecache.class.php
+++ b/inc/cache/simplecache.class.php
@@ -318,6 +318,7 @@ class SimpleCache extends SimpleCacheDecorator {
          $is_locked = flock($handle, LOCK_EX);
 
          $result = ftruncate($handle, 0)
+            && rewind($handle)
             && fwrite($handle, $json)
             && fflush($handle);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I do not know why, but on some Windows env, it appears that file pointer is not at position when writing cache footprint informations. It should, as file is open with the `c` flag, but it is not, and file si writtent with lots of leading `NUL` chars. Using `rewind` fixes this issue.