### PR TITLE
Fix missing space on collected mails; fixes #6241

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -1098,7 +1098,7 @@ class MailCollector  extends CommonDBTM {
       // and rich text mode is enabled (otherwise remove them)
       $string = str_replace(
          ["\r\n", "\n", "\r"],
-         $this->body_is_html ? '' : $br_marker,
+         $this->body_is_html ? ' ' : $br_marker,
          $string
       );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6241 

With some mail clients, CRLF is not surrounded by spaces. So when CRLF are removed, there is no space left between words located before and after it.