### PR TITLE
Fix OLA recomputation after exiting pending status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 The present file will list all changes made to the project; according to the
 [Keep a Changelog](http://keepachangelog.com/) project.
 
-## [9.4.4] unreleased
+## [9.4.5] unreleased
+
+## [9.4.4] 2019-09-24
 
 ### API changes
 

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -1192,12 +1192,12 @@ abstract class CommonITILObject extends CommonDBTM {
 
             // Compute new internal_time_to_resolve
             $this->updates[]                          = "internal_time_to_resolve";
-            $this->fields['internal_time_to_resolve'] = $ola->computeDate($this->fields['date'],
+            $this->fields['internal_time_to_resolve'] = $ola->computeDate($this->fields['ola_ttr_begin_date'],
                                                                           $this->fields["ola_waiting_duration"]);
             // Add current level to do
             $ola->addLevelToDo($this, $this->fields["olalevels_id_ttr"]);
 
-         } else if (in_array("internal_time_to_resolve", $this->fields)) {
+         } else if (array_key_exists("internal_time_to_resolve", $this->fields)) {
             // Change doesn't have internal_time_to_resolve
             // Using calendar
             if (($calendars_id > 0)

--- a/inc/console/database/updatecommand.class.php
+++ b/inc/console/database/updatecommand.class.php
@@ -170,8 +170,8 @@ class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionComma
       } else if ($force) {
          // Replay last update script even if there is no schema change.
          // It can be used in dev environment when update script has been updated/fixed.
-         include_once(GLPI_ROOT . '/install/update_942_943.php');
-         update942to943();
+         include_once(GLPI_ROOT . '/install/update_943_945.php');
+         update943to945();
 
          $output->writeln('<info>' . __('Last migration replayed.') . '</info>');
       }

--- a/inc/define.php
+++ b/inc/define.php
@@ -31,7 +31,7 @@
 */
 
 // Current version of GLPI
-define('GLPI_VERSION', '9.4.4');
+define('GLPI_VERSION', '9.4.5');
 if (substr(GLPI_VERSION, -4) === '-dev') {
    //for dev version
    define('GLPI_PREVER', str_replace('-dev', '', GLPI_VERSION));
@@ -41,7 +41,7 @@ if (substr(GLPI_VERSION, -4) === '-dev') {
    );
 } else {
    //for stable version
-   define("GLPI_SCHEMA_VERSION", '9.4.3');
+   define("GLPI_SCHEMA_VERSION", '9.4.5');
 }
 define('GLPI_MIN_PHP', '5.6.0'); // Must also be changed in top of index.php
 define('GLPI_YEAR', '2019');

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -439,6 +439,7 @@ class Ticket extends CommonITILObject {
          $ola->setTicketCalendar($calendars_id);
          if ($ola->fields['type'] == SLM::TTR) {
             $data["olalevels_id_ttr"] = OlaLevel::getFirstOlaLevel($olas_id);
+            $data['ola_ttr_begin_date'] = $date;
          }
          // Compute time_to_resolve
          $data[$dateField]             = $ola->computeDate($date);

--- a/inc/update.class.php
+++ b/inc/update.class.php
@@ -452,6 +452,11 @@ class Update extends CommonGLPI {
          case "9.4.2":
             include_once "{$updir}update_942_943.php";
             update942to943();
+
+         case "9.4.3":
+         case "9.4.4":
+            include_once "{$updir}update_943_945.php";
+            update943to945();
             break;
 
          case GLPI_VERSION:

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8568,6 +8568,7 @@ CREATE TABLE `glpi_tickets` (
   `olas_id_tto` int(11) NOT NULL DEFAULT '0',
   `olas_id_ttr` int(11) NOT NULL DEFAULT '0',
   `olalevels_id_ttr` int(11) NOT NULL DEFAULT '0',
+  `ola_ttr_begin_date` datetime DEFAULT NULL,
   `internal_time_to_resolve` datetime DEFAULT NULL,
   `internal_time_to_own` datetime DEFAULT NULL,
   `waiting_duration` int(11) NOT NULL DEFAULT '0',

--- a/install/update_943_945.php
+++ b/install/update_943_945.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * Update from 9.4.3 to 9.4.5
+ *
+ * @return bool for success (will die for most error)
+**/
+function update943to945() {
+   global $DB, $migration;
+
+   $updateresult     = true;
+
+   //TRANS: %s is the number of new version
+   $migration->displayTitle(sprintf(__('Update to %s'), '9.4.5'));
+   $migration->setVersion('9.4.5');
+
+   /** Add OLA TTR begin date field to Tickets */
+   $iterator = new DBmysqlIterator(null);
+   $migration->addField(
+      'glpi_tickets',
+      'ola_ttr_begin_date',
+      'datetime',
+      [
+         'after'     => 'olalevels_id_ttr',
+         'update'    => $DB->quoteName('date'), // Assign ticket creation date by default
+         'condition' => 'WHERE ' . $iterator->analyseCrit(['NOT' => ['olas_id_ttr' => '0']])
+      ]
+   );
+   /** /Add OLA TTR begin date field to Tickets */
+
+   // ************ Keep it at the end **************
+   $migration->executeMigration();
+
+   return $updateresult;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Internal id:17908

Two bugs occuring when changing status from pending to processing.
1. When using OLA, TTR was recomputed from ticket creation date instead of being recomputed from OLA definition date.
2. When internal TTR was manually set, it was not recomputed when exiting pending status.

I created migration from 9.4.3 to 9.4.4 but can be easilly postponed to 9.4.5.