### PR TITLE
fix call to hooks of plugins when using API

### DIFF
--- a/inc/includes.php
+++ b/inc/includes.php
@@ -99,9 +99,10 @@ if (!isset($PLUGINS_INCLUDED)) {
    $plugin->init();
 
    $plugins_list = $plugin->getPlugins();
+   $withHooks = isApi();
    if (count($plugins_list)) {
       foreach ($plugins_list as $name) {
-         Plugin::load($name);
+         Plugin::load($name, $withHooks);
       }
       // For plugins which require action after all plugin init
       Plugin::doHook("post_init");


### PR DESCRIPTION
If the API is consumed, plugin hooks must occur. This means that plugins must be loaded with hooks.