### PR TITLE
Fix missing inclusion of hook.php in search hooks calls

### DIFF
--- a/ajax/searchoptionvalue.php
+++ b/ajax/searchoptionvalue.php
@@ -134,14 +134,16 @@ if (isset($_POST['searchtype'])) {
             //Could display be handled by a plugin ?
             if (!$display
                 && $plug = isPluginItemType(getItemTypeForTable($searchopt['table']))) {
-               $function = 'plugin_'.$plug['plugin'].'_searchOptionsValues';
-               if (function_exists($function)) {
-                  $params = ['name'           => $inputname,
-                                  'searchtype'     => $_POST['searchtype'],
-                                  'searchoption'   => $searchopt,
-                                  'value'          => $_POST['value']];
-                  $display = $function($params);
-               }
+               $display = Plugin::doOneHook(
+                  $plug['plugin'],
+                  'searchOptionsValues',
+                  [
+                     'name'           => $inputname,
+                     'searchtype'     => $_POST['searchtype'],
+                     'searchoption'   => $searchopt,
+                     'value'          => $_POST['value']
+                  ]
+               );
             }
 
          }

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -1213,14 +1213,13 @@ class Plugin extends CommonDBTM {
    /**
     * This function executes a hook for 1 plugin.
     *
-    * @param string      $plugname         Name of the plugin
-    * @param string      $hook             function to be called (may be an array for call a class method)
-    * @param array|mixed $options          First argument passed to hook function
-    * @param mixed       $additionnal_args [optional] One or more additionnal arguments passed to hook function
+    * @param string $plugname Name of the plugin
+    * @param string $hook     function to be called (may be an array for call a class method)
+    * @param mixed  ...$args  [optional] One or more arguments passed to hook function
     *
     * @return mixed $data
    **/
-   static function doOneHook($plugname, $hook, $options = []/*, $...  */) {
+   static function doOneHook($plugname, $hook, ...$args) {
 
       $plugname=strtolower($plugname);
 
@@ -1235,12 +1234,6 @@ class Plugin extends CommonDBTM {
          }
       }
       if (is_callable($hook)) {
-         // Pass legacy $options argument as first hook argument
-         $args = [$options];
-         // Pass additionnal arguments (key 3 is for 4th argument = first additionnal argument)
-         for ($i = 3; $i < func_num_args(); $i++) {
-            $args[] = func_get_arg($i);
-         }
          return call_user_func_array($hook, $args);
       }
    }

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -1213,13 +1213,14 @@ class Plugin extends CommonDBTM {
    /**
     * This function executes a hook for 1 plugin.
     *
-    * @param $plugname        Name of the plugin
-    * @param $hook            function to be called (may be an array for call a class method)
-    * @param $options   array of params passed to the function
+    * @param string      $plugname         Name of the plugin
+    * @param string      $hook             function to be called (may be an array for call a class method)
+    * @param array|mixed $options          First argument passed to hook function
+    * @param mixed       $additionnal_args [optional] One or more additionnal arguments passed to hook function
     *
     * @return mixed $data
    **/
-   static function doOneHook($plugname, $hook, $options = []) {
+   static function doOneHook($plugname, $hook, $options = []/*, $...  */) {
 
       $plugname=strtolower($plugname);
 
@@ -1234,7 +1235,13 @@ class Plugin extends CommonDBTM {
          }
       }
       if (is_callable($hook)) {
-         return call_user_func($hook, $options);
+         // Pass legacy $options argument as first hook argument
+         $args = [$options];
+         // Pass additionnal arguments (key 3 is for 4th argument = first additionnal argument)
+         for ($i = 3; $i < func_num_args(); $i++) {
+            $args[] = func_get_arg($i);
+         }
+         return call_user_func_array($hook, $args);
       }
    }
 

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3468,6 +3468,9 @@ JAVASCRIPT;
             'addSelect',
             $itemtype, $ID, "{$itemtype}_{$ID}"
          );
+         if (!empty($out)) {
+            return $out;
+         }
       }
 
       $tocompute      = "`$table$addtable`.`$field`";

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -4054,7 +4054,7 @@ JAVASCRIPT;
          default :
             // Plugin can override core definition for its type
             if ($plug = isPluginItemType($itemtype)) {
-               $condition = Plugin::doOneHook($plug['plugin'], 'addDefaultWhere');
+               $condition = Plugin::doOneHook($plug['plugin'], 'addDefaultWhere', $itemtype);
             }
             break;
       }

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1559,13 +1559,9 @@ class Search {
          if ($data['display_type'] == self::HTML_OUTPUT) {
             // For plugin add new parameter if available
             if ($plug = isPluginItemType($data['itemtype'])) {
-               $function = 'plugin_'.$plug['plugin'].'_addParamFordynamicReport';
-
-               if (function_exists($function)) {
-                  $out = $function($data['itemtype']);
-                  if (is_array($out) && count($out)) {
-                     $parameters .= Toolbox::append_params($out, '&amp;');
-                  }
+               $out = Plugin::doOneHook($plug['plugin'], 'addParamFordynamicReport', $data['itemtype']);
+               if (is_array($out) && count($out)) {
+                  $parameters .= Toolbox::append_params($out, '&amp;');
                }
             }
             $search_config_top    = "";
@@ -3055,15 +3051,16 @@ JAVASCRIPT;
                //Could display be handled by a plugin ?
                if (!$display
                    && $plug = isPluginItemType(getItemTypeForTable($searchopt['table']))) {
-                  $function = 'plugin_'.$plug['plugin'].'_searchOptionsValues';
-                  if (function_exists($function)) {
-                     $display = $function([
+                  $display = Plugin::doOneHook(
+                     $plug['plugin'],
+                     'searchOptionsValues',
+                     [
                         'name'           => $inputname,
                         'searchtype'     => $request['searchtype'],
                         'searchoption'   => $searchopt,
                         'value'          => $request['value']
-                     ]);
-                  }
+                     ]
+                  );
                }
 
             }
@@ -3105,12 +3102,13 @@ JAVASCRIPT;
 
       // Plugin can override core definition for its type
       if ($plug = isPluginItemType($itemtype)) {
-         $function = 'plugin_'.$plug['plugin'].'_addHaving';
-         if (function_exists($function)) {
-            $out = $function($LINK, $NOT, $itemtype, $ID, $val, "{$itemtype}_{$ID}");
-            if (!empty($out)) {
-               return $out;
-            }
+         $out = Plugin::doOneHook(
+            $plug['plugin'],
+            'addHaving',
+            $LINK, $NOT, $itemtype, $ID, $val, "{$itemtype}_{$ID}"
+         );
+         if (!empty($out)) {
+            return $out;
          }
       }
 
@@ -3119,12 +3117,13 @@ JAVASCRIPT;
       if (preg_match("/^glpi_plugin_([a-z0-9]+)/", $table, $matches)) {
          if (count($matches) == 2) {
             $plug     = $matches[1];
-            $function = 'plugin_'.$plug.'_addHaving';
-            if (function_exists($function)) {
-               $out = $function($LINK, $NOT, $itemtype, $ID, $val, "{$itemtype}_{$ID}");
-               if (!empty($out)) {
-                  return $out;
-               }
+            $out = Plugin::doOneHook(
+               $plug,
+               'addHaving',
+               $LINK, $NOT, $itemtype, $ID, $val, "{$itemtype}_{$ID}"
+            );
+            if (!empty($out)) {
+               return $out;
             }
          }
       }
@@ -3255,12 +3254,13 @@ JAVASCRIPT;
 
       // Plugin can override core definition for its type
       if ($plug = isPluginItemType($itemtype)) {
-         $function = 'plugin_'.$plug['plugin'].'_addOrderBy';
-         if (function_exists($function)) {
-            $out = $function($itemtype, $ID, $order, "{$itemtype}_{$ID}");
-            if (!empty($out)) {
-               return $out;
-            }
+         $out = Plugin::doOneHook(
+            $plug['plugin'],
+            'addOrderBy',
+            $itemtype, $ID, $order, "{$itemtype}_{$ID}"
+         );
+         if (!empty($out)) {
+            return $out;
          }
       }
 
@@ -3301,12 +3301,13 @@ JAVASCRIPT;
       if (preg_match("/^glpi_plugin_([a-z0-9]+)/", $table, $matches)) {
          if (count($matches) == 2) {
             $plug     = $matches[1];
-            $function = 'plugin_'.$plug.'_addOrderBy';
-            if (function_exists($function)) {
-               $out = $function($itemtype, $ID, $order, "{$itemtype}_{$ID}");
-               if (!empty($out)) {
-                  return $out;
-               }
+            $out = Plugin::doOneHook(
+               $plug,
+               'addOrderBy',
+               $itemtype, $ID, $order, "{$itemtype}_{$ID}"
+            );
+            if (!empty($out)) {
+               return $out;
             }
          }
       }
@@ -3396,10 +3397,11 @@ JAVASCRIPT;
          default :
             // Plugin can override core definition for its type
             if ($plug = isPluginItemType($itemtype)) {
-               $function = 'plugin_'.$plug['plugin'].'_addDefaultSelect';
-               if (function_exists($function)) {
-                  $ret = $function($itemtype);
-               }
+               $ret = Plugin::doOneHook(
+                  $plug['plugin'],
+                  'addDefaultSelect',
+                  $itemtype
+               );
             }
       }
       if ($itemtable == 'glpi_entities') {
@@ -3461,13 +3463,11 @@ JAVASCRIPT;
 
       // Plugin can override core definition for its type
       if ($plug = isPluginItemType($itemtype)) {
-         $function = 'plugin_'.$plug['plugin'].'_addSelect';
-         if (function_exists($function)) {
-            $out = $function($itemtype, $ID, "{$itemtype}_{$ID}");
-            if (!empty($out)) {
-               return $out;
-            }
-         }
+         $out = Plugin::doOneHook(
+            $plug['plugin'],
+            'addSelect',
+            $itemtype, $ID, "{$itemtype}_{$ID}"
+         );
       }
 
       $tocompute      = "`$table$addtable`.`$field`";
@@ -3663,12 +3663,13 @@ JAVASCRIPT;
       if (preg_match("/^glpi_plugin_([a-z0-9]+)/", $table, $matches)) {
          if (count($matches) == 2) {
             $plug     = $matches[1];
-            $function = 'plugin_'.$plug.'_addSelect';
-            if (function_exists($function)) {
-               $out = $function($itemtype, $ID, "{$itemtype}_{$ID}");
-               if (!empty($out)) {
-                  return $out;
-               }
+            $out = Plugin::doOneHook(
+               $plug,
+               'addSelect',
+               $itemtype, $ID, "{$itemtype}_{$ID}"
+            );
+            if (!empty($out)) {
+               return $out;
             }
          }
       }
@@ -4050,11 +4051,9 @@ JAVASCRIPT;
          default :
             // Plugin can override core definition for its type
             if ($plug = isPluginItemType($itemtype)) {
-               $function = 'plugin_'.$plug['plugin'].'_addDefaultWhere';
-               if (function_exists($function)) {
-                  $condition = $function($itemtype);
-               }
+               $condition = Plugin::doOneHook($plug['plugin'], 'addDefaultWhere');
             }
+            break;
       }
 
       /* Hook to restrict user right on current itemtype */
@@ -4186,12 +4185,13 @@ JAVASCRIPT;
 
       // Plugin can override core definition for its type
       if ($plug = isPluginItemType($itemtype)) {
-         $function = 'plugin_'.$plug['plugin'].'_addWhere';
-         if (function_exists($function)) {
-            $out = $function($link, $nott, $itemtype, $ID, $val, $searchtype);
-            if (!empty($out)) {
-               return $out;
-            }
+         $out = Plugin::doOneHook(
+            $plug['plugin'],
+            'addWhere',
+            $link, $nott, $itemtype, $ID, $val, $searchtype
+         );
+         if (!empty($out)) {
+            return $out;
          }
       }
 
@@ -4453,12 +4453,13 @@ JAVASCRIPT;
       if (preg_match("/^glpi_plugin_([a-z0-9]+)/", $inittable, $matches)) {
          if (count($matches) == 2) {
             $plug     = $matches[1];
-            $function = 'plugin_'.$plug.'_addWhere';
-            if (function_exists($function)) {
-               $out = $function($link, $nott, $itemtype, $ID, $val, $searchtype);
-               if (!empty($out)) {
-                  return $out;
-               }
+            $out = Plugin::doOneHook(
+               $plug,
+               'addWhere',
+               $link, $nott, $itemtype, $ID, $val, $searchtype
+            );
+            if (!empty($out)) {
+               return $out;
             }
          }
       }
@@ -4821,12 +4822,13 @@ JAVASCRIPT;
          default :
             // Plugin can override core definition for its type
             if ($plug = isPluginItemType($itemtype)) {
-               $function = 'plugin_'.$plug['plugin'].'_addDefaultJoin';
-               if (function_exists($function)) {
-                  $out = $function($itemtype, $ref_table, $already_link_tables);
-                  if (!empty($out)) {
-                     return $out;
-                  }
+               $out = Plugin::doOneHook(
+                  $plug['plugin'],
+                  'addDefaultJoin',
+                  $itemtype, $ref_table, $already_link_tables
+               );
+               if (!empty($out)) {
+                  return $out;
                }
             }
 
@@ -4916,22 +4918,22 @@ JAVASCRIPT;
 
       // Plugin can override core definition for its type
       if ($plug = isPluginItemType($itemtype)) {
-         $function = 'plugin_'.$plug['plugin'].'_addLeftJoin';
-         if (function_exists($function)) {
-            $specific_leftjoin = $function($itemtype, $ref_table, $new_table, $linkfield,
-                                           $already_link_tables);
-         }
+         $specific_leftjoin = Plugin::doOneHook(
+            $plug['plugin'],
+            'addLeftJoin',
+            $itemtype, $ref_table, $new_table, $linkfield, $already_link_tables
+         );
       }
 
       // Link with plugin tables : need to know left join structure
       if (empty($specific_leftjoin)
           && preg_match("/^glpi_plugin_([a-z0-9]+)/", $new_table, $matches)) {
          if (count($matches) == 2) {
-            $function = 'plugin_'.$matches[1].'_addLeftJoin';
-            if (function_exists($function)) {
-               $specific_leftjoin = $function($itemtype, $ref_table, $new_table, $linkfield,
-                                              $already_link_tables);
-            }
+            $specific_leftjoin = Plugin::doOneHook(
+               $matches[1],
+               'addLeftJoin',
+               $itemtype, $ref_table, $new_table, $linkfield, $already_link_tables
+            );
          }
       }
       if (!empty($linkfield)) {
@@ -5373,12 +5375,13 @@ JAVASCRIPT;
 
       // Plugin can override core definition for its type
       if ($plug = isPluginItemType($itemtype)) {
-         $function = 'plugin_'.$plug['plugin'].'_displayConfigItem';
-         if (function_exists($function)) {
-            $out = $function($itemtype, $ID, $data, "{$itemtype}_{$ID}");
-            if (!empty($out)) {
-               return $out;
-            }
+         $out = Plugin::doOneHook(
+            $plug['plugin'],
+            'displayConfigItem',
+            $itemtype, $ID, $data, "{$itemtype}_{$ID}"
+         );
+         if (!empty($out)) {
+            return $out;
          }
       }
 
@@ -5461,12 +5464,13 @@ JAVASCRIPT;
       }
       // Plugin can override core definition for its type
       if ($plug = isPluginItemType($itemtype)) {
-         $function = 'plugin_'.$plug['plugin'].'_giveItem';
-         if (function_exists($function)) {
-            $out = $function($itemtype, $orig_id, $data, $ID);
-            if (!empty($out)) {
-               return $out;
-            }
+         $out = Plugin::doOneHook(
+            $plug['plugin'],
+            'giveItem',
+            $itemtype, $orig_id, $data, $ID
+         );
+         if (!empty($out)) {
+            return $out;
          }
       }
 
@@ -6114,12 +6118,13 @@ JAVASCRIPT;
          if (preg_match("/^glpi_plugin_([a-z0-9]+)/", $table.'.'.$field, $matches)) {
             if (count($matches) == 2) {
                $plug     = $matches[1];
-               $function = 'plugin_'.$plug.'_giveItem';
-               if (function_exists($function)) {
-                  $out = $function($itemtype, $orig_id, $data, $ID);
-                  if (!empty($out)) {
-                     return $out;
-                  }
+               $out = Plugin::doOneHook(
+                  $plug,
+                  'giveItem',
+                  $itemtype, $orig_id, $data, $ID
+               );
+               if (!empty($out)) {
+                  return $out;
                }
             }
          }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Hooks related to search features were called directly, instead of being called via the dedicated `Plugin::doOneHook()` method. In API (but maybe in other cases), hook file was not yet included, so plugin hooks were not called.