### PR TITLE
fix unescaped column name in API

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1265,7 +1265,7 @@ abstract class API extends CommonGLPI {
                 FROM `$table`
                 $join
                 WHERE $where
-                ORDER BY ".$params['sort']." ".$params['order']."
+                ORDER BY `".$params['sort']."` ".$params['order']."
                 LIMIT ".$params['start'].", ".$params['list_limit'];
       if ($result = $DB->query($query)) {
          while ($data = $DB->fetch_assoc($result)) {


### PR DESCRIPTION
if the column is a reserved word of SQL, the query fails

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
