### PR TITLE
Revert "Fix writing of cache footprint file on some Windows env"

### DIFF
--- a/inc/cache/simplecache.class.php
+++ b/inc/cache/simplecache.class.php
@@ -318,7 +318,6 @@ class SimpleCache extends SimpleCacheDecorator {
          $is_locked = flock($handle, LOCK_EX);
 
          $result = ftruncate($handle, 0)
-            && rewind($handle)
             && fwrite($handle, $json)
             && fflush($handle);
 


### PR DESCRIPTION
Reverts glpi-project/glpi#6310

We did not figure it that customer was running GLPI on `PHP 7.3.0RC4` (in production). Bug was due to https://bugs.php.net/bug.php?id=77081 .