### PR TITLE
Fix usage of reference for $already_link_tables in hooks; fixes #6354

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -1213,26 +1213,29 @@ class Plugin extends CommonDBTM {
    /**
     * This function executes a hook for 1 plugin.
     *
-    * @param string $plugname Name of the plugin
-    * @param string $hook     function to be called (may be an array for call a class method)
-    * @param mixed  ...$args  [optional] One or more arguments passed to hook function
+    * @param string          $plugname Name of the plugin
+    * @param string|callable $hook     suffix used to build function to be called ("plugin_myplugin_{$hook}")
+    *                                  or callable function
+    * @param mixed           ...$args  [optional] One or more arguments passed to hook function
     *
     * @return mixed $data
    **/
    static function doOneHook($plugname, $hook, ...$args) {
 
-      $plugname=strtolower($plugname);
+      $plugname = strtolower($plugname);
 
       if (!Plugin::isPluginLoaded($plugname)) {
          return;
       }
 
-      if (!is_array($hook)) {
-         $hook = "plugin_" . $plugname . "_" . $hook;
-         if (file_exists(GLPI_ROOT . "/plugins/$plugname/hook.php")) {
-            include_once(GLPI_ROOT . "/plugins/$plugname/hook.php");
-         }
+      if (file_exists(GLPI_ROOT . "/plugins/$plugname/hook.php")) {
+         include_once(GLPI_ROOT . "/plugins/$plugname/hook.php");
       }
+
+      if (is_string($hook) && !is_callable($hook)) {
+         $hook = "plugin_" . $plugname . "_" . $hook;
+      }
+
       if (is_callable($hook)) {
          return call_user_func_array($hook, $args);
       }

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -4825,11 +4825,14 @@ JAVASCRIPT;
          default :
             // Plugin can override core definition for its type
             if ($plug = isPluginItemType($itemtype)) {
-               $out = Plugin::doOneHook(
-                  $plug['plugin'],
-                  'addDefaultJoin',
-                  $itemtype, $ref_table, $already_link_tables
-               );
+               $plugin_name   = $plug['plugin'];
+               $hook_function = 'plugin_' . $plugin_name . '_addDefaultJoin';
+               $hook_closure  = function () use ($hook_function, $itemtype, $ref_table, &$already_link_tables) {
+                  if (is_callable($hook_function)) {
+                     return $hook_function($itemtype, $ref_table, $already_link_tables);
+                  }
+               };
+               $out = Plugin::doOneHook($plug['plugin'], $hook_closure);
                if (!empty($out)) {
                   return $out;
                }
@@ -4921,22 +4924,27 @@ JAVASCRIPT;
 
       // Plugin can override core definition for its type
       if ($plug = isPluginItemType($itemtype)) {
-         $specific_leftjoin = Plugin::doOneHook(
-            $plug['plugin'],
-            'addLeftJoin',
-            $itemtype, $ref_table, $new_table, $linkfield, $already_link_tables
-         );
+         $plugin_name   = $plug['plugin'];
+         $hook_function = 'plugin_' . $plugin_name . '_addLeftJoin';
+         $hook_closure  = function () use ($hook_function, $itemtype, $ref_table, $new_table, $linkfield, &$already_link_tables) {
+            if (is_callable($hook_function)) {
+               return $hook_function($itemtype, $ref_table, $new_table, $linkfield, $already_link_tables);
+            }
+         };
+         $specific_leftjoin = Plugin::doOneHook($plug['plugin'], $hook_closure);
       }
 
       // Link with plugin tables : need to know left join structure
       if (empty($specific_leftjoin)
           && preg_match("/^glpi_plugin_([a-z0-9]+)/", $new_table, $matches)) {
          if (count($matches) == 2) {
-            $specific_leftjoin = Plugin::doOneHook(
-               $matches[1],
-               'addLeftJoin',
-               $itemtype, $ref_table, $new_table, $linkfield, $already_link_tables
-            );
+            $plugin_name   = $matches[1];
+            $hook_function = 'plugin_' . $plugin_name . '_addLeftJoin';
+            $hook_closure  = function () use ($hook_function, $itemtype, $ref_table, $new_table, $linkfield, &$already_link_tables) {
+               if (is_callable($hook_function)) {
+                  return $hook_function($itemtype, $ref_table, $new_table, $linkfield, $already_link_tables);
+               }
+            };
          }
       }
       if (!empty($linkfield)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6354 

