### PR TITLE
Fix 'implode(): Passing glue string after array is deprecated.'

### DIFF
--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -503,7 +503,7 @@ class Migration {
       // si pas de nom d'index, on prend celui du ou des champs
       if (!$indexname) {
          if (is_array($fields)) {
-            $indexname = implode($fields, "_");
+            $indexname = implode("_", $fields);
          } else {
             $indexname = $fields;
          }
@@ -512,9 +512,9 @@ class Migration {
       if (!isIndex($table, $indexname)) {
          if (is_array($fields)) {
             if ($len) {
-               $fields = "`".implode($fields, "`($len), `")."`($len)";
+               $fields = "`".implode("`($len), `", $fields)."`($len)";
             } else {
-               $fields = "`".implode($fields, "`, `")."`";
+               $fields = "`".implode("`, `", $fields)."`";
             }
          } else if ($len) {
             $fields = "`$fields`($len)";
@@ -662,7 +662,7 @@ class Migration {
       global $DB;
 
       if (isset($this->change[$table])) {
-         $query = "ALTER TABLE `$table` ".implode($this->change[$table], " ,\n")." ";
+         $query = "ALTER TABLE `$table` ".implode(" ,\n", $this->change[$table])." ";
          $this->displayMessage( sprintf(__('Change of the database layout - %s'), $table));
          $DB->queryOrDie($query, $this->version." multiple alter in $table");
          unset($this->change[$table]);

--- a/inc/ruleimportcomputer.class.php
+++ b/inc/ruleimportcomputer.class.php
@@ -299,7 +299,7 @@ class RuleImportComputer extends Rule {
 
       //Build the request to check if the machine exists in GLPI
       if (is_array($input['entities_id'])) {
-         $where_entity = implode($input['entities_id'], ',');
+         $where_entity = implode(',', $input['entities_id']);
       } else {
          $where_entity = $input['entities_id'];
       }

--- a/install/update_0723_078.php
+++ b/install/update_0723_078.php
@@ -2591,7 +2591,7 @@ function update0723to078() {
    foreach ($changes as $table => $tab) {
       $migration->displayMessage(sprintf(__('Change of the database layout - %s'), $table));
       $query = "ALTER TABLE `$table`
-                ".implode($tab, " ,\n").";";
+                ".implode(" ,\n", $tab).";";
       $DB->queryOrDie($query, "0.78 multiple alter in $table");
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Related to https://www.php.net/manual/fr/migration74.deprecated.php#migration74.deprecated.core.implode-reverse-parameters in PHP 7.4.

Detected with Github Actions test suite.