### PR TITLE
Use composer command to unset platform on CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,8 @@ commands:
             composer --version
             echo "node version: $(node --version)"
             echo "npm version: $(npm --version)"
-            perl -i -0 -p -e 's/,?\s*"platform"\:\s*\{[^\}]*}//i' composer.json
             mv composer.lock composer.lock.bak
+            composer config --unset platform
             bin/console dependencies install --ci
       - save_cache:
           key: composer-cache-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_script:
   - phpenv config-rm xdebug.ini || true
   - ./tests/LDAP/ldap_run.sh
   - composer self-update
-  - sed -e '/"php":/d' -i composer.json
   - rm -f composer.lock
+  - composer config --unset platform
   - nvm install --lts=dubnium # update node to dubnium LTS version (node v10.x + npm v6.9.0)
   - bin/console dependencies install --ci
   - mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Use composer `config --unset` command to remove platform configuration instead of using search and replace using sed or perl.