### PR TITLE
Fix Iterator mock in Migration::addConfig() test

### DIFF
--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -163,14 +163,22 @@ class Migration extends \GLPITestCase {
 
       //test with one existing value => only new key should be inserted
       $this->queries = [];
-      $dbresult = [[
-         'id'        => '42',
-         'context'   => 'core',
-         'name'      => 'one',
-         'value'     => 'setted value'
-      ]];
-      $it = new \ArrayIterator($dbresult);
-      $this->calling($this->db)->request = $it;
+      $this->calling($this->db)->request = function ($table) {
+         // Call using 'glpi_configs' value for first parameter
+         // corresponds to the call made to retrieve exisintg values
+         // -> returns a value for config 'one'
+         if ('glpi_configs' === $table) {
+            $dbresult = [[
+               'id'        => '42',
+               'context'   => 'core',
+               'name'      => 'one',
+               'value'     => 'setted value'
+            ]];
+            return new \ArrayIterator($dbresult);
+         }
+         // Other calls corresponds to call made in Config::setConfigurationValues()
+         return new \ArrayIterator();
+      };
 
       $DB = $this->db;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

On PHP 7.4-RC1, following notice appears while running unit tests.
```
=> tests\units\Migration::testAddConfig():
==> Error E_NOTICE in /var/glpi/tests/units/Migration.php on line 180, generated by file /var/glpi/inc/commondbtm.class.php on line 339:
Trying to access array offset on value of type null
```

The reason is that the call made to `CommonDBTM::getFromDBByCrit()` by `Config::setConfigurationValues()` in this test is receiving an `ArrayIterator` from $DB mock.
This `ArrayIterator` should be empty (as we try to set a configuration value that should not exists for this test), but it is no, so:
  - `if (count($iter) == 1)` is a valid,
  - `$row = $iter->next()` equals `null` (`DBmysqlIterator::next()` returns a value, which is not expected by [Iterator interface](https://www.php.net/manual/fr/iterator.next.php#refsect1-iterator.next-returnvalues)),
  - `$row['id']` triggers a notice.

Fix is just to adapt mocked result for `$DB->request()`:
 - list of simulated existing values for this call: https://github.com/glpi-project/glpi/blob/9.5/bugfixes/inc/migration.class.php#L1009
 - empty result for other calls.
