### PR TITLE
Fix error handling in unit tests

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -723,25 +723,15 @@ class Toolbox {
 
       // If debug mode activated : display some information
       if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
-         // display_errors only need for for E_ERROR, E_PARSE, ... which cannot be catched
          // Recommended development settings
          ini_set('display_errors', 'On');
-         error_reporting(E_ALL | E_STRICT);
+         error_reporting(E_ALL);
          set_error_handler(['Toolbox','userErrorHandlerDebug']);
-
-      } else {
+      } else if (!defined('TU_USER')) {
          // Recommended production settings
          ini_set('display_errors', 'Off');
-         if (defined('TU_USER')) {
-            //do not set error_reporting to a low level for unit tests
-            error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
-         }
+         error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
          set_error_handler(['Toolbox', 'userErrorHandlerNormal']);
-      }
-
-      if (defined('TU_USER')) {
-         //user default error handler from tests
-         set_error_handler(null);
       }
    }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,6 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
+ini_set('display_errors', 'On');
 error_reporting(E_ALL);
 
 define('GLPI_CACHE_DIR', __DIR__ . '/files/_cache');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While working on PHP 7.4 compatbility, I found some E_NOTICE errors triggered during CI tests, but with no relation with changes on PHP 7.4.
I figured out that it could came from a difference in `error_reporting` behaviour and in a bad configuration of it on CI environment.

Commit 85b8a18a0bd2d794bd51ee0076920a6512cecb74 seems to be made to have all errors reported on CI test suite, but does the opposite.