### PR TITLE
Fix invalid nothing return type in PHPDoc

### DIFF
--- a/inc/displaypreference.class.php
+++ b/inc/displaypreference.class.php
@@ -268,7 +268,7 @@ class DisplayPreference extends CommonDBTM {
     * @param $target    form target
     * @param $itemtype  item type
     *
-    * @return nothing
+    * @return void
    **/
    function showFormPerso($target, $itemtype) {
       global $CFG_GLPI, $DB;
@@ -440,7 +440,7 @@ class DisplayPreference extends CommonDBTM {
     * @param $target    form target
     * @param $itemtype  item type
     *
-    * @return nothing
+    * @return void
    **/
    function showFormGlobal($target, $itemtype) {
       global $CFG_GLPI, $DB;

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -354,7 +354,7 @@ class Document extends CommonDBTM {
     *     - target filename : where to go when done.
     *     - withtemplate boolean : template or basic item
     *
-    * @return Nothing (display)
+    * @return void
    **/
    function showForm($ID, $options = []) {
       $this->initForm($ID, $options);
@@ -1312,7 +1312,7 @@ class Document extends CommonDBTM {
     * @param $dir       dir to search a free path for the file
     * @param $sha1sum   SHA1 of the file
     *
-    * @return nothing
+    * @return string
    **/
    static function getUploadFileValidLocationName($dir, $sha1sum) {
       if (empty($dir)) {
@@ -1437,7 +1437,9 @@ class Document extends CommonDBTM {
     *
     * @param $options array of possible options
     *
-    * @return nothing (print out an HTML select box)
+    * @return integer|string
+    *    integer if option display=true (random part of elements id)
+    *    string if option display=false (HTML code)
    **/
    static function dropdown($options = []) {
       global $DB, $CFG_GLPI;

--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -328,7 +328,7 @@ class Document_Item extends CommonDBRelation{
     *
     * @param $doc Document object
     *
-    * @return nothing (HTML display)
+    * @return void
    **/
    static function showForDocument(Document $doc) {
       $instID = $doc->fields['id'];

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -543,7 +543,9 @@ class Dropdown {
     *    - emptylabel          : empty label if empty displayed (default self::EMPTY_VALUE)
     *    - display_emptychoice : display empty choice (default false)
     *
-    * @return nothing (print out an HTML select box)
+    * @return integer|string
+    *    integer if option display=true (random part of elements id)
+    *    string if option display=false (HTML code)
    **/
    static function showItemTypes($name, $types = [], $options = []) {
       global $CFG_GLPI;
@@ -584,7 +586,9 @@ class Dropdown {
     * @param $options       array    of possible options:
     *        - may be value (default value) / field (used field to search itemtype)
     *
-    * @return nothing (print out an HTML select box)
+    * @return integer|string
+    *    integer if option display=true (random part of elements id)
+    *    string if option display=false (HTML code)
    **/
    static function dropdownUsedItemTypes($name, $itemtype_ref, $options = []) {
       global $DB;
@@ -620,7 +624,10 @@ class Dropdown {
     * @param $store_path            path where icons are stored
     * @param $display      boolean  display of get string ? (true by default)
     *
-    * @return nothing (print out an HTML select box)
+    *
+    * @return void|string
+    *    void if param display=true
+    *    string if param display=false (HTML code)
    **/
    static function dropdownIcons($myname, $value, $store_path, $display = true) {
 
@@ -1250,7 +1257,10 @@ class Dropdown {
     *     - step               step time (defaut config GLPI)
     *
     * @since 0.85 update prototype
-    *@return Nothing (display)
+    *
+    * @return integer|string
+    *    integer if option display=true (random part of elements id)
+    *    string if option display=false (HTML code)
     **/
    static function showHours($name, $options = []) {
       global $CFG_GLPI;
@@ -1798,6 +1808,10 @@ class Dropdown {
     *                                'key2' => 'val2'),
     *       'optgroupname2' => array('key3' => 'val3',
     *                                'key4' => 'val4'))
+    *
+    * @return integer|string
+    *    integer if option display=true (random part of elements id)
+    *    string if option display=false (HTML code)
    **/
    static function showFromArray($name, array $elements, $options = []) {
 

--- a/inc/dropdowntranslation.class.php
+++ b/inc/dropdowntranslation.class.php
@@ -239,7 +239,7 @@ class DropdownTranslation extends CommonDBChild {
     * @param $input array    of user values
     * @param $add   boolean  true if translation is added, false if update (tgrue by default)
     *
-    * @return nothing
+    * @return void
    **/
    function generateCompletename($input, $add = true) {
       global $DB;

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -394,7 +394,7 @@ class Entity extends CommonTreeDropdown {
    /**
     * Print a good title for entity pages
     *
-    *@return nothing (display)
+    *@return void
     **/
    function title() {
       // Empty title for entities

--- a/inc/fieldblacklist.class.php
+++ b/inc/fieldblacklist.class.php
@@ -238,7 +238,7 @@ class Fieldblacklist extends CommonDropdown {
    /**
     * Display a dropdown which contains all the available itemtypes
     *
-    * @return nothing
+    * @return void
    **/
    function showItemtype() {
       global $CFG_GLPI;

--- a/inc/fieldunicity.class.php
+++ b/inc/fieldunicity.class.php
@@ -152,7 +152,7 @@ class FieldUnicity extends CommonDropdown {
     * @param ID      the field unicity item id
     * @param value   the selected value (default 0)
     *
-    * @return nothing
+    * @return void
    **/
    function showItemtype($ID, $value = 0) {
       global $CFG_GLPI;
@@ -234,7 +234,7 @@ class FieldUnicity extends CommonDropdown {
     *
     * @param $unicity an instance of CommonDBTM class
     *
-    * @return nothing
+    * @return void
    **/
    static function selectCriterias(CommonDBTM $unicity) {
       global $DB;
@@ -509,7 +509,7 @@ class FieldUnicity extends CommonDropdown {
     *
     * @param itemtype
     *
-    * @return nothing
+    * @return void
    **/
    static function deleteForItemtype($itemtype) {
       global $DB;

--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -206,7 +206,7 @@ class Group extends CommonTreeDropdown {
    *     - target filename : where to go when done.
    *     - withtemplate boolean : template or basic item
    *
-   * @return Nothing (display)
+   * @return void
    **/
    function showForm($ID, $options = []) {
 
@@ -299,7 +299,7 @@ class Group extends CommonTreeDropdown {
    /**
     * Print a good title for group pages
     *
-    *@return nothing (display)
+    *@return void
     **/
    function title() {
       global $CFG_GLPI;

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -471,7 +471,7 @@ class Html {
    /**
     * Redirection to $_SERVER['HTTP_REFERER'] page
     *
-    * @return nothing
+    * @return void
    **/
    static function back() {
       self::redirect(self::getBackUrl());
@@ -484,7 +484,7 @@ class Html {
     * @param $dest string: Redirection destination
     * @param $http_response_code string: Forces the HTTP response code to the specified value
     *
-    * @return nothing
+    * @return void
    **/
    static function redirect($dest, $http_response_code = 302) {
 
@@ -519,7 +519,7 @@ class Html {
     * @param $params       param to add to URL (default '')
     * @since 0.85
     *
-    * @return nothing
+    * @return void
    **/
    static function redirectToLogin($params = '') {
       global $CFG_GLPI;
@@ -543,7 +543,7 @@ class Html {
    /**
     * Display common message for item not found
     *
-    * @return Nothing
+    * @return void
    **/
    static function displayNotFoundError() {
       global $CFG_GLPI, $HEADER_LOADED;
@@ -570,7 +570,7 @@ class Html {
    /**
     * Display common message for privileges errors
     *
-    * @return Nothing (die)
+    * @return void
    **/
    static function displayRightError() {
       self::displayErrorAndDie(__("You don't have permission to perform this action."));
@@ -701,7 +701,7 @@ class Html {
     * @param $ref_title       Title to display (default '')
     * @param $ref_btts        Extra items to display array(link=>text...) (default '')
     *
-    * @return nothing
+    * @return void
    **/
    static function displayTitle($ref_pic_link = "", $ref_pic_text = "", $ref_title = "", $ref_btts = "") {
 
@@ -923,7 +923,7 @@ class Html {
     * @param $message   string   displayed before dying
     * @param $minimal            set to true do not display app menu (false by default)
     *
-    * @return nothing as function kill script
+    * @return void
    **/
    static function displayErrorAndDie ($message, $minimal = false) {
       global $CFG_GLPI, $HEADER_LOADED;
@@ -954,7 +954,7 @@ class Html {
     * @param $additionalactions  string   additional actions to do on success confirmation
     *                                     (default '')
     *
-    * @return nothing
+    * @return string
    **/
    static function addConfirmationOnAction($string, $additionalactions = '') {
 
@@ -971,7 +971,7 @@ class Html {
     * @param $additionalactions  string   additional actions to do on success confirmation
     *                                     (default '')
     *
-    * @return confirmation script
+    * @return string confirmation script
    **/
    static function getConfirmationOnActionScript($string, $additionalactions = '') {
 
@@ -1017,7 +1017,7 @@ class Html {
     *                    - percent   current level
     *
     *
-    * @return nothing (display)
+    * @return void
     **/
    static function progressBar($id, array $options = []) {
 
@@ -1063,7 +1063,7 @@ class Html {
     *
     * @param $msg initial message (under the bar) (default '&nbsp;')
     *
-    * @return nothing
+    * @return void
     **/
    static function createProgressBar($msg = "&nbsp;") {
 
@@ -1080,7 +1080,7 @@ class Html {
     *
     * @param $msg message under the bar (default '&nbsp;')
     *
-    * @return nothing
+    * @return void
    **/
    static function changeProgressBarMessage($msg = "&nbsp;") {
 
@@ -1096,7 +1096,7 @@ class Html {
     * @param $tot   Maximum Value
     * @param $msg   message inside the bar (default is %) (default '')
     *
-    * @return nothing
+    * @return void
    **/
    static function changeProgressBarPosition($crt, $tot, $msg = "") {
 
@@ -1129,7 +1129,7 @@ class Html {
     *            - simple : display a simple progress bar (no title / only percent)
     *            - forcepadding : boolean force str_pad to force refresh (default true)
     *
-    * @return nothing
+    * @return void
    **/
    static function displayProgressBar($width, $percent, $options = []) {
       global $CFG_GLPI;
@@ -1182,7 +1182,7 @@ class Html {
     * @param $item      item corresponding to the page displayed (default 'none')
     * @param $option    option corresponding to the page displayed (default '')
     *
-    * @return nothing
+    * @return void
    **/
    static function includeHeader($title = '', $sector = 'none', $item = 'none', $option = '') {
       global $CFG_GLPI, $PLUGIN_HOOKS;
@@ -2351,7 +2351,7 @@ class Html {
     *
     * @param $options   array
     *
-    * @return nothing (display only)
+    * @return void
    **/
    static function showCheckbox(array $options = []) {
       echo self::getCheckbox($options);
@@ -2405,7 +2405,7 @@ class Html {
     *
     * @param $name given name/id to the form   (default '')
     *
-    * @return nothing / display item
+    * @return void
    **/
    static function openMassiveActionsForm($name = '') {
       echo Html::getOpenMassiveActionsForm($name);
@@ -3316,7 +3316,7 @@ class Html {
     *
     * @param $target target of the form
     *
-    * @return nothing
+    * @return void
    **/
    static function showProfileSelecter($target) {
       global $CFG_GLPI;
@@ -3368,7 +3368,9 @@ class Html {
     *   - display : boolean / display the item : false return the datas
     *   - autoclose : boolean / autoclose the item : default true (false permit to scroll)
     *
-    * @return nothing (print out an HTML div)
+    * @return void|string
+    *    void if option display=true
+    *    string if option display=false (HTML code)
    **/
    static function showToolTip($content, $options = []) {
       global $CFG_GLPI;
@@ -3580,7 +3582,10 @@ class Html {
     * @param $display    boolean display or get js script (true by default)
     * @param $readonly   boolean editor will be readonly or not
     *
-    * @return nothing
+    *
+    * @return void|string
+    *    integer if param display=true
+    *    string if param display=false (HTML code)
    **/
    static function initEditorSystem($name, $rand = '', $display = true, $readonly = false) {
       global $CFG_GLPI;
@@ -3842,7 +3847,7 @@ class Html {
     * @param $pad          Pad used (default 0)
     * @param $jsexpand     Expand using JS ? (default  false)
     *
-    * @return nothing
+    * @return void
    **/
    static function printCleanArray($tab, $pad = 0, $jsexpand = false) {
 
@@ -3907,7 +3912,7 @@ class Html {
     * @param $item_type_output_param      item type parameter for export (default 0)
     * @param $additional_info             Additional information to display (default '')
     *
-    * @return nothing (print a pager)
+    * @return void
     *
    **/
    static function printPager($start, $numrows, $target, $parameters, $item_type_output = 0,
@@ -6245,7 +6250,7 @@ JAVASCRIPT;
     *
     * @param string $action action to switch (should be actually 'getHtml' or 'getList')
     *
-    * @return nothing (display)
+    * @return string
     */
    static function fuzzySearch($action = '') {
       global $CFG_GLPI;

--- a/inc/htmltablegroup.class.php
+++ b/inc/htmltablegroup.class.php
@@ -182,7 +182,7 @@ class HTMLTableGroup extends HTMLTableBase {
     *     'display_header_for_each_group'          display the header of each group
     *     'display_header_on_foot_for_each_group'  repeat group header on foot of group
     *
-    * @return nothing (display only)
+    * @return void
    **/
    function displayGroup($totalNumberOfColumn, array $params) {
 

--- a/inc/htmltableheader.class.php
+++ b/inc/htmltableheader.class.php
@@ -61,7 +61,7 @@ abstract class HTMLTableHeader extends HTMLTableEntity {
     * @param $header_name [out]     string   header name
     * @param $subheader_name [out]  string   sub header name ( = '' in case of super header)
     *
-    * @return nothing
+    * @return void
    **/
    abstract function getHeaderAndSubHeaderName(&$header_name, &$subheader_name);
 

--- a/inc/htmltablemain.class.php
+++ b/inc/htmltablemain.class.php
@@ -78,7 +78,7 @@ class HTMLTableMain extends HTMLTableBase {
     *
     * @param $name the name to print inside the header
     *
-    * @return nothing
+    * @return void
    **/
    function setTitle($name) {
       $this->title = $name;
@@ -101,7 +101,7 @@ class HTMLTableMain extends HTMLTableBase {
     *
     * TODO : study to be sure that the order is the one we have defined ...
     *
-    * @return nothing
+    * @return boolean|HTMLTableGroup
    **/
    function createGroup($name, $content) {
 
@@ -128,7 +128,7 @@ class HTMLTableMain extends HTMLTableBase {
     *
     * @param $group_name (string) the group name
     *
-    * @return nothing
+    * @return boolean|HTMLTableGroup
    **/
    function getGroup($group_name) {
 
@@ -184,7 +184,7 @@ class HTMLTableMain extends HTMLTableBase {
     *    'display_super_for_each_group'           display the super header befor each group
     *    'display_title_for_each_group'           display the title of each group
     *
-    * @return nothing (display only)
+    * @return void
    **/
    function display(array $params) {
 

--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -270,7 +270,7 @@ class Infocom extends CommonDBChild {
     * @param item          CommonDBTM object: the item whose status have changed
     * @param action_add    true if object is added, false if updated (true by default)
     *
-    * @return nothing
+    * @return void
    **/
    static function manageDateOnStatusChange(CommonDBTM $item, $action_add = true) {
       global $CFG_GLPI;
@@ -319,7 +319,7 @@ class Infocom extends CommonDBChild {
     * @param action           the action to peform (copy from another date) (default 0)
     * @param params     array of additional parameters needed to perform the task
     *
-    * @return nothing
+    * @return void
    **/
    static function autofillDates(&$infocoms = [], $field = '', $action = 0, $params = []) {
 

--- a/inc/ipaddress.class.php
+++ b/inc/ipaddress.class.php
@@ -535,7 +535,7 @@ class IPAddress extends CommonDBChild {
    /**
     * Replace textual representation by its canonical form.
     *
-    * @return nothing (internal class update)
+    * @return void
    **/
    function canonicalizeTextual() {
       $this->setAddressFromBinary($this->getBinary());

--- a/inc/ipnetwork.class.php
+++ b/inc/ipnetwork.class.php
@@ -878,7 +878,7 @@ class IPNetwork extends CommonImplicitTreeDropdown {
     * First, reset the tree, then, update each network by its own field, letting
     * CommonImplicitTreeDropdown working such as it would in case of standard update
     *
-    * @return nothing
+    * @return void
    **/
    static function recreateTree() {
       global $DB;

--- a/inc/item_disk.class.php
+++ b/inc/item_disk.class.php
@@ -262,7 +262,7 @@ class Item_Disk extends CommonDBChild {
     * @param $item                  Item object
     * @param $withtemplate boolean  Template or basic item (default 0)
     *
-    * @return Nothing (call to classes members)
+    * @return void
    **/
    static function showForItem(CommonDBTM $item, $withtemplate = 0) {
       global $DB;

--- a/inc/item_operatingsystem.class.php
+++ b/inc/item_operatingsystem.class.php
@@ -72,7 +72,7 @@ class Item_OperatingSystem extends CommonDBRelation {
     *
     * @since 9.2
     *
-    * @return Nothing (call to classes members)
+    * @return void
    **/
    static function showForItem(CommonDBTM $item, $withtemplate = 0) {
       global $DB, $CFG_GLPI;

--- a/inc/item_problem.class.php
+++ b/inc/item_problem.class.php
@@ -83,7 +83,7 @@ class Item_Problem extends CommonDBRelation{
     *
     * @param $problem Problem object
     *
-    * @return Nothing (display)
+    * @return void
    **/
    static function showForProblem(Problem $problem) {
       global $DB, $CFG_GLPI;

--- a/inc/item_project.class.php
+++ b/inc/item_project.class.php
@@ -83,7 +83,7 @@ class Item_Project extends CommonDBRelation{
     *
     * @param $project Project object
     *
-    * @return Nothing (display)
+    * @return void
    **/
    static function showForProject(Project $project) {
       global $DB, $CFG_GLPI;

--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -170,7 +170,7 @@ class Item_Ticket extends CommonDBRelation{
     *    - _users_id_requester : ID of the requester user
     *    - items_id            : array of elements (itemtype => array(id1, id2, id3, ...))
     *
-    * @return Nothing (display)
+    * @return void
    **/
    static function itemAddForm(Ticket $ticket, $options = []) {
       global $CFG_GLPI;
@@ -370,7 +370,7 @@ class Item_Ticket extends CommonDBRelation{
     *
     * @param $ticket Ticket object
     *
-    * @return Nothing (display)
+    * @return void
    **/
    static function showForTicket(Ticket $ticket) {
       global $DB, $CFG_GLPI;
@@ -561,7 +561,7 @@ class Item_Ticket extends CommonDBRelation{
     *    - multiple   : allow multiple choice
     *    - rand       : random number
     *
-    * @return nothing (print out an HTML select box)
+    * @return integer random part of elements id
    **/
    static function dropdownAllDevices($myname, $itemtype, $items_id = 0, $admin = 0, $users_id = 0,
                                       $entity_restrict = -1, $options = []) {
@@ -656,7 +656,7 @@ class Item_Ticket extends CommonDBRelation{
     *    - used     : ID of the requester user
     *    - multiple : allow multiple choice
     *
-    * @return nothing (print out an HTML select box)
+    * @return void
    **/
    static function dropdownMyDevices($userID = 0, $entity_restrict = -1, $itemtype = 0, $items_id = 0, $options = []) {
       global $DB, $CFG_GLPI;

--- a/inc/itiltemplate.class.php
+++ b/inc/itiltemplate.class.php
@@ -551,7 +551,7 @@ abstract class ITILTemplate extends CommonDropdown {
     *
     * @param $tt ITILTemplate object
     *
-    * @return Nothing (call to classes members)
+    * @return void
    **/
    static function showCentralPreview(ITILTemplate $tt) {
 

--- a/inc/itiltemplatehiddenfield.class.php
+++ b/inc/itiltemplatehiddenfield.class.php
@@ -149,7 +149,7 @@ abstract class ITILTemplateHiddenField extends ITILTemplateField {
     * @param $tt                       ITIL Template
     * @param $withtemplate    boolean  Template or basic item (default 0)
     *
-    * @return Nothing (call to classes members)
+    * @return void
    **/
    static function showForITILTemplate(ITILTemplate $tt, $withtemplate = 0) {
       global $DB;

--- a/inc/itiltemplatemandatoryfield.class.php
+++ b/inc/itiltemplatemandatoryfield.class.php
@@ -148,7 +148,7 @@ abstract class ITILTemplateMandatoryField extends ITILTemplateField {
     * @param ITILTemplate $tt           ITIL Template
     * @param boolean      $withtemplate Template or basic item (default 0)
     *
-    * @return Nothing (call to classes members)
+    * @return void
    **/
    static function showForITILTemplate(ITILTemplate $tt, $withtemplate = 0) {
       global $DB;

--- a/inc/itiltemplatepredefinedfield.class.php
+++ b/inc/itiltemplatepredefinedfield.class.php
@@ -223,7 +223,7 @@ class ITILTemplatePredefinedField extends ITILTemplateField {
     * @param $tt                       ITIL Template
     * @param $withtemplate    boolean  Template or basic item (default 0)
     *
-    * @return Nothing (call to classes members)
+    * @return void
    **/
    static function showForITILTemplate(ITILTemplate $tt, $withtemplate = 0) {
       global $DB, $CFG_GLPI;

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -230,7 +230,7 @@ class KnowbaseItem extends CommonDBVisible {
    /**
     * Actions done at the end of the getEmpty function
     *
-    *@return nothing
+    *@return void
    **/
    function post_getEmpty() {
 
@@ -647,7 +647,7 @@ class KnowbaseItem extends CommonDBVisible {
     * @param $options array
     *     - target for the Form
     *
-    * @return nothing (display the form)
+    * @return void
    **/
    function showForm($ID, $options = []) {
       global $CFG_GLPI;
@@ -832,7 +832,7 @@ class KnowbaseItem extends CommonDBVisible {
    /**
     * Add kb item to the public FAQ
     *
-    * @return nothing
+    * @return void
    **/
    function addToFaq() {
       global $DB;
@@ -870,7 +870,9 @@ class KnowbaseItem extends CommonDBVisible {
     *
     * @param $options      array of options
     *
-    * @return nothing (display item : question and answer)
+    * @return void|string
+    *    void if option display=true
+    *    string if option display=false (HTML code)
    **/
    function showFull($options = []) {
       global $DB, $CFG_GLPI;
@@ -977,7 +979,7 @@ class KnowbaseItem extends CommonDBVisible {
     *
     * @param $options   $_GET
     *
-    * @return nothing (display the form)
+    * @return void
    **/
    function searchForm($options) {
       global $CFG_GLPI;
@@ -1024,7 +1026,7 @@ class KnowbaseItem extends CommonDBVisible {
     *
     * @param $options   $_GET
     *
-    * @return nothing (display the form)
+    * @return void
    **/
    function showBrowseForm($options) {
       global $CFG_GLPI;
@@ -1073,7 +1075,7 @@ class KnowbaseItem extends CommonDBVisible {
     *
     * @param $options   $_GET
     *
-    * @return nothing (display the form)
+    * @return void
    **/
    function showManageForm($options) {
       global $CFG_GLPI;
@@ -1606,7 +1608,7 @@ class KnowbaseItem extends CommonDBVisible {
     *
     * @param $type      type : recent / popular / not published
     *
-    * @return nothing (display table)
+    * @return void
    **/
    static function showRecentPopular($type) {
       global $DB, $CFG_GLPI;

--- a/inc/knowbaseitemtranslation.class.php
+++ b/inc/knowbaseitemtranslation.class.php
@@ -138,7 +138,7 @@ class KnowbaseItemTranslation extends CommonDBChild {
     *
     * @param $options      array of options
     *
-    * @return nothing (display item : question and answer)
+    * @return void
    **/
    function showFull($options = []) {
       global $DB, $CFG_GLPI;

--- a/inc/levelagreementlevel.class.php
+++ b/inc/levelagreementlevel.class.php
@@ -298,7 +298,9 @@ abstract class LevelAgreementLevel extends RuleTicket {
     *       - max_time : max time to use
     *       - used : already used values
     *
-    * @return nothing
+    * @return integer|string
+    *    integer if option display=true (random part of elements id)
+    *    string if option display=false (HTML code)
    **/
    static function dropdownExecutionTime($name, $options = []) {
       $p['value']    = '';

--- a/inc/line.class.php
+++ b/inc/line.class.php
@@ -85,7 +85,7 @@ class Line extends CommonDropdown {
     *     - target for the Form
     *     - withtemplate : template or basic item
     *
-    * @return Nothing (display)
+    * @return void
     **/
    function showForm($ID, $options = []) {
 

--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -131,7 +131,7 @@ class Link extends CommonDBTM {
    * @param $options array
    *     - target filename : where to go when done.
    *
-   * @return Nothing (display)
+   * @return void
    **/
    function showForm($ID, $options = []) {
 

--- a/inc/link_itemtype.class.php
+++ b/inc/link_itemtype.class.php
@@ -56,7 +56,7 @@ class Link_Itemtype extends CommonDBChild {
     *
     * @param $link : Link
     *
-    * @return Nothing (display)
+    * @return void
    **/
    static function showForLink($link) {
       global $DB,$CFG_GLPI;

--- a/inc/location.class.php
+++ b/inc/location.class.php
@@ -411,7 +411,7 @@ class Location extends CommonTreeDropdown {
     *
     * @since 0.85
     *
-    * @return Nothing (display)
+    * @return void
    **/
    function showItems() {
       global $DB, $CFG_GLPI;

--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -64,8 +64,6 @@ class MassiveAction {
     * @param $GET   something like $_GET
     * @param $stage the current stage
     * @param boolean $single Get actions for a single item
-    *
-    * @return nothing (it is a constructor).
    **/
    function __construct (array $POST, array $GET, $stage, $single = false) {
       global $CFG_GLPI;
@@ -405,7 +403,7 @@ class MassiveAction {
    /**
     * Add hidden fields containing all the checked items to the current form
     *
-    * @return nothing (display)
+    * @return void
    **/
    function addHiddenFields() {
 
@@ -643,7 +641,7 @@ class MassiveAction {
    /**
     * Main entry of the modal window for massive actions
     *
-    * @return nothing: display
+    * @return void
    **/
    function showSubForm() {
       $processor = $this->processor;
@@ -659,7 +657,7 @@ class MassiveAction {
     /**
     * Class-specific method used to show the fields to specify the massive action
     *
-    * @return nothing (display only)
+    * @return void
    **/
    function showDefaultSubForm() {
       echo Html::submit(_x('button', 'Post'), ['name' => 'massiveaction']);
@@ -947,7 +945,7 @@ class MassiveAction {
     *
     * Display and update the progress bar. If the delay is more than 1 second, then activate it
     *
-    * @return nothing (display only)
+    * @return void
    **/
    function updateProgressBars() {
 
@@ -1268,7 +1266,7 @@ class MassiveAction {
     *
     * @param $redirect link to the page
     *
-    * @return nothing
+    * @return void
    **/
    function setRedirect($redirect) {
       $this->redirect = $redirect;
@@ -1280,7 +1278,7 @@ class MassiveAction {
     *
     * @param $message the message to add
     *
-    * @return nothing
+    * @return void
    **/
    function addMessage($message) {
       $this->results['messages'][] = $message;

--- a/inc/netpoint.class.php
+++ b/inc/netpoint.class.php
@@ -106,7 +106,7 @@ class Netpoint extends CommonDropdown {
     * @param $entity_restrict    Restrict to a defined entity(default -1)
     * @param $devtype            (default '')
     *
-    * @return nothing (display the select box)
+    * @return integer random part of elements id
    **/
    static function dropdownNetpoint($myname, $value = 0, $locations_id = -1, $display_comment = 1,
                                     $entity_restrict = -1, $devtype = '') {
@@ -245,7 +245,7 @@ class Netpoint extends CommonDropdown {
     *
     * @param $item Location
     *
-    * @return Nothing (display)
+    * @return void
    **/
    static function showForLocation($item) {
       global $DB, $CFG_GLPI;

--- a/inc/networkalias.class.php
+++ b/inc/networkalias.class.php
@@ -91,7 +91,7 @@ class NetworkAlias extends FQDNLabel {
     *     - target for the Form
     *     - withtemplate template or basic computer
     *
-    * @return Nothing (display)
+    * @return void
    **/
    function showForm ($ID, $options = []) {
 

--- a/inc/networkname.class.php
+++ b/inc/networkname.class.php
@@ -87,7 +87,7 @@ class NetworkName extends FQDNLabel {
     *     - target for the Form
     *     - withtemplate template or basic computer
     *
-    *@return Nothing (display)
+    *@return void
    **/
    function showForm($ID, $options = []) {
       global $CFG_GLPI;

--- a/inc/networkportinstantiation.class.php
+++ b/inc/networkportinstantiation.class.php
@@ -840,7 +840,7 @@ class NetworkPortInstantiation extends CommonDBChild {
     *    - entity_sons : boolean / if entity restrict specified auto select its sons
     *                   only available if entity is a single value not an array (default false)
     *
-    * @return nothing (print out an HTML select box)
+    * @return integer random part of elements id
    **/
    static function dropdownConnect($ID, $options = []) {
       global $CFG_GLPI;

--- a/inc/notification_notificationtemplate.class.php
+++ b/inc/notification_notificationtemplate.class.php
@@ -109,7 +109,7 @@ class Notification_NotificationTemplate extends CommonDBRelation {
     * @param Notification $notif        Notification object
     * @param boolean      $withtemplate Template or basic item (default '')
     *
-    * @return Nothing (call to classes members)
+    * @return void
    **/
    static function showForNotification(Notification $notif, $withtemplate = 0) {
       global $DB;

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -1339,7 +1339,7 @@ class NotificationTarget extends CommonDBChild {
     *
     * @param $group Group object
     *
-    * @return nothing
+    * @return void
    **/
    static function showForGroup(Group $group) {
       global $DB;

--- a/inc/olalevel.class.php
+++ b/inc/olalevel.class.php
@@ -215,7 +215,7 @@ class OlaLevel extends LevelAgreementLevel {
     * @param $ID              ID of the rule
     * @param $options   array of possible options
     *
-    * @return nothing
+    * @return void
    **/
    function showForm($ID, $options = []) {
 

--- a/inc/olalevel_ticket.class.php
+++ b/inc/olalevel_ticket.class.php
@@ -98,7 +98,7 @@ class OlaLevel_Ticket extends CommonDBTM {
     *
     * @since 9.1 2 parameters mandatory
     *
-    * @return nothing
+    * @return void
    **/
    function deleteForTicket($tickets_id, $olaType) {
       global $DB;
@@ -204,7 +204,7 @@ class OlaLevel_Ticket extends CommonDBTM {
     *
     * @since 9.1   2 parameters mandatory
     *
-    * @return nothing
+    * @return void
    **/
    static function doLevelForTicket(array $data, $olaType) {
 

--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -263,7 +263,7 @@ class Planning extends CommonGLPI {
     *    optional :
     *          - limitto : limit display to a specific user
     *
-    * @return Nothing (display function)
+    * @return void
    **/
    static function checkAvailability($params = []) {
       global $CFG_GLPI, $DB;
@@ -524,7 +524,7 @@ class Planning extends CommonGLPI {
     * Function name change since version 0.84 show() => showPlanning
     * Function prototype changes in 9.1 (no more parameters)
     *
-    * @return Nothing (display function)
+    * @return void
    **/
    static function showPlanning($fullview = true) {
       if (!static::canView()) {
@@ -608,7 +608,7 @@ class Planning extends CommonGLPI {
     *
     * Also manage color index in $_SESSION['glpi_plannings_color_index']
     *
-    * @return Nothing (display function)
+    * @return void
     */
    static function initSessionForCurrentUser() {
       global $CFG_GLPI;
@@ -655,7 +655,7 @@ class Planning extends CommonGLPI {
     * and color choosing.
     * Call self::showSingleLinePlanningFilter for each filters and plannings
     *
-    * @return Nothing (display function)
+    * @return void
     */
    static function showPlanningFilter() {
       global $CFG_GLPI;
@@ -839,7 +839,7 @@ JAVASCRIPT;
     *   * 'filter_color_index' (integer): index of the color to use in self::$palette_bg
     * @param $options
     *
-    * @return Nothing (display function)
+    * @return void
     */
    static function showSingleLinePlanningFilter($filter_key, $filter_data, $options = []) {
       global $CFG_GLPI;
@@ -965,7 +965,7 @@ JAVASCRIPT;
    /**
     * Display ajax form to add actor on planning
     *
-    * @return Nothing (display function)
+    * @return void
     */
    static function showAddPlanningForm() {
       global $CFG_GLPI;
@@ -1003,7 +1003,7 @@ JAVASCRIPT;
     * Display 'User' part of self::showAddPlanningForm spcified by planning type dropdown.
     * Actually called by ajax/planning.php
     *
-    * @return Nothing (display function)
+    * @return void
     */
    static function showAddUserForm() {
       global $CFG_GLPI;
@@ -1059,7 +1059,7 @@ JAVASCRIPT;
     * Display 'All users of a group' part of self::showAddPlanningForm spcified by planning type dropdown.
     * Actually called by ajax/planning.php
     *
-    * @return Nothing (display function)
+    * @return void
     */
    static function showAddGroupUsersForm() {
       echo __("Group")." : <br>";
@@ -1158,7 +1158,7 @@ JAVASCRIPT;
     *
     * @since 9.1
     *
-    * @return Nothing (display function)
+    * @return void
     */
    static function showAddGroupForm($params = []) {
 
@@ -1244,7 +1244,7 @@ JAVASCRIPT;
     *  - end : end of selection range.
     *       (should be an ISO_8601 date, but could be anything wo can be parsed by strtotime)
     *
-    * @return Nothing (display function)
+    * @return void
     */
    static function showAddEventSubForm($params = []) {
 
@@ -1376,7 +1376,7 @@ JAVASCRIPT;
     *  - parent : in case of type=users_group, must contains the id of the group
     *  - name : contains a string with type and id concatened with a '_' char (ex user_41).
     *  - display : boolean value to set to his line
-    * @return nothing
+    * @return void
     */
    static function toggleFilter($options = []) {
 
@@ -1407,7 +1407,7 @@ JAVASCRIPT;
     *  - parent : in case of type=users_group, must contains the id of the group
     *  - name : contains a string with type and id concatened with a '_' char (ex user_41).
     *  - color : rgb color (preceded by '#'' char)
-    * @return nothing
+    * @return void
     */
    static function colorFilter($options = []) {
       $key = 'filters';
@@ -1433,7 +1433,7 @@ JAVASCRIPT;
     * @param  array $options: should contains :
     *  - type : event type, can be event_filter, user, group or group_users
     *  - filter : contains a string with type and id concatened with a '_' char (ex user_41).
-    * @return nothing
+    * @return void
     */
    static function deleteFilter($options = []) {
 
@@ -1569,7 +1569,7 @@ JAVASCRIPT;
     *  - color: string with #rgb color for event's foreground color.
     *  - event_type_color : string with #rgb color for event's foreground color.
     * @param  array  $raw_events: (passed by reference) the events array in construction
-    * @return nothing
+    * @return void
     */
    static function constructEventsArraySingleLine($actor, $params = [], &$raw_events = []) {
 
@@ -1685,7 +1685,7 @@ JAVASCRIPT;
     *                         (default '')
     * @param $complete        complete display (more details) (default 0)
     *
-    * @return Nothing (display function)
+    * @return string
    **/
    static function displayPlanningItem(array $val, $who, $type = "", $complete = 0) {
       global $CFG_GLPI;
@@ -1740,7 +1740,7 @@ JAVASCRIPT;
     *
     * @param $who ID of the user
     *
-    * @return Nothing (display function)
+    * @return void
    **/
    static function showCentral($who) {
       global $CFG_GLPI;

--- a/inc/planningrecall.class.php
+++ b/inc/planningrecall.class.php
@@ -229,7 +229,7 @@ class PlanningRecall extends CommonDBChild {
     *    - value    : integer preselected value for before_time
     *    - field    : string  field used as time mark (default begin)
     *
-    * @return nothing (print out an HTML select box) / return false if mandatory fields are not ok
+    * @return void|boolean print out an HTML select box or return false if mandatory fields are not ok
    **/
    static function dropdown($options = []) {
       global $DB, $CFG_GLPI;
@@ -302,7 +302,7 @@ class PlanningRecall extends CommonDBChild {
     *    - value    : integer preselected value for before_time
     *    - field    : string  field used as time mark (default begin)
     *
-    * @return nothing (print out an HTML select box) / return false if mandatory fields are not ok
+    * @return void|boolean print out an HTML select box or return false if mandatory fields are not ok
    **/
    static function specificForm($options = []) {
       global $CFG_GLPI;

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -140,7 +140,7 @@ class Plugin extends CommonDBTM {
     * @param $name             Name of hook to use
     * @param $withhook boolean to load hook functions (false by default)
     *
-    * @return nothing
+    * @return void
    **/
    static function load($name, $withhook = false) {
       global $LOADED_PLUGINS;
@@ -170,7 +170,7 @@ class Plugin extends CommonDBTM {
     * @param $forcelang       force a specific lang (default '')
     * @param $coretrytoload lang trying to be load from core (default '')
     *
-    * @return nothing
+    * @return void
    **/
    static function loadLang($name, $forcelang = '', $coretrytoload = '') {
       // $LANG needed : used when include lang file
@@ -817,7 +817,7 @@ class Plugin extends CommonDBTM {
     * @param $glpitables   array of GLPI table name used by the plugin
     * @param $plugtables   array of Plugin table name which have an itemtype
     *
-    * @return nothing
+    * @return void
    **/
    static function migrateItemType($types = [], $glpitables = [], $plugtables = []) {
       global $DB;

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -1567,7 +1567,7 @@ class Problem extends CommonITILObject {
     *
     * @param $item CommonDBTM object
     *
-    * @return nothing (display a table)
+    * @return void
    **/
    static function showListForItem(CommonDBTM $item) {
       global $DB, $CFG_GLPI;

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -1121,7 +1121,7 @@ class Profile extends CommonDBTM {
     * @param $statuses       all available statuses for the given cycle (obj::getAllStatusArray())
     * @param $canedit        can we edit the elements ?
     *
-    * @return nothing
+    * @return void
    **/
    function displayLifeCycleMatrix($title, $html_field, $db_field, $statuses, $canedit) {
 
@@ -1203,7 +1203,7 @@ class Profile extends CommonDBTM {
     * @param $db_field       field inside the DB (to get current state)
     * @param $canedit        can we edit the elements ?
     *
-    * @return nothing
+    * @return void
    **/
    function displayLifeCycleMatrixTicketHelpdesk($title, $html_field, $db_field, $canedit) {
 
@@ -2589,7 +2589,9 @@ class Profile extends CommonDBTM {
     *       - display : display or get string (default true)
     *       - rand    : specific rand (default is generated one)
     *
-    * @return nothing (print out an HTML select box)
+    * @return integer|string
+    *    integer if option display=true (random part of elements id)
+    *    string if option display=false (HTML code)
    **/
    static function dropdownRight($name, $options = []) {
 

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -1354,7 +1354,7 @@ class Project extends CommonDBTM {
    /**
     * Print the HTML array children of a TreeDropdown
     *
-    * @return Nothing (display)
+    * @return void
     **/
    function showChildren() {
       global $DB, $CFG_GLPI;
@@ -1416,7 +1416,7 @@ class Project extends CommonDBTM {
     *     - target for the Form
     *     - withtemplate template or basic computer
     *
-    *@return Nothing (display)
+    *@return void
    **/
    function showForm($ID, $options = []) {
       global $CFG_GLPI, $DB;

--- a/inc/projectcost.class.php
+++ b/inc/projectcost.class.php
@@ -327,7 +327,7 @@ class ProjectCost extends CommonDBChild {
     * @param $project               Project object
     * @param $withtemplate  boolean  Template or basic item (default 0)
     *
-    * @return Nothing (call to classes members)
+    * @return void
    **/
    static function showForProject(Project $project, $withtemplate = 0) {
       global $DB, $CFG_GLPI;

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -1071,7 +1071,7 @@ class ProjectTask extends CommonDBChild {
     *
     * @param $item Project or ProjectTask object
     *
-    * @return nothing
+    * @return void
    **/
    static function showFor($item) {
       global $DB, $CFG_GLPI;
@@ -1699,7 +1699,7 @@ class ProjectTask extends CommonDBChild {
     *                         (default '')
     * @param $complete        complete display (more details) (default 0)
     *
-    * @return Nothing (display function)
+    * @return string
     **/
    static function displayPlanningItem(array $val, $who, $type = "", $complete = 0) {
       global $CFG_GLPI;

--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -1038,7 +1038,7 @@ class Reminder extends CommonDBVisible {
     *                         (default '')
     * @param $complete        complete display (more details) (default 0)
     *
-    * @return Nothing (display function)
+    * @return string
    **/
    static function displayPlanningItem(array $val, $who, $type = "", $complete = 0) {
       global $CFG_GLPI;
@@ -1089,7 +1089,7 @@ class Reminder extends CommonDBVisible {
     *
     * @param $personal boolean : display reminders created by me ? (true by default)
     *
-    * @return Nothing (display function)
+    * @return void
     **/
    static function showListForCentral($personal = true) {
       global $DB, $CFG_GLPI;

--- a/inc/reservation.class.php
+++ b/inc/reservation.class.php
@@ -275,7 +275,7 @@ class Reservation extends CommonDBChild {
     * @param $type   error type : date / is_res / other
     * @param $ID     ID of the item
     *
-    * @return nothing
+    * @return void
    **/
    function displayError($type, $ID) {
 

--- a/inc/rssfeed.class.php
+++ b/inc/rssfeed.class.php
@@ -905,7 +905,7 @@ class RSSFeed extends CommonDBVisible {
     *
     * @param $personal boolean   display rssfeeds created by me ? (true by default)
     *
-    * @return Nothing (display function)
+    * @return void
     **/
    static function showListForCentral($personal = true) {
       global $DB, $CFG_GLPI;

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -847,7 +847,7 @@ class Rule extends CommonDBTM {
     *     - target filename : where to go when done.
     *     - withtemplate boolean : template or basic item
     *
-    * @return nothing
+    * @return void
    **/
    function showForm($ID, $options = []) {
       global $CFG_GLPI;

--- a/inc/rulecollection.class.php
+++ b/inc/rulecollection.class.php
@@ -404,7 +404,7 @@ class RuleCollection extends CommonDBTM {
     * @param $target
     * @param $options   array
     *
-    * @return nothing
+    * @return void
    **/
    function showListRules($target, $options = []) {
       global $CFG_GLPI;
@@ -584,7 +584,7 @@ class RuleCollection extends CommonDBTM {
     *
     * @param $target
     *
-    * @return nothing
+    * @return void
    **/
    function showAdditionalInformationsInForm($target) {
    }
@@ -810,7 +810,7 @@ class RuleCollection extends CommonDBTM {
     *
     * @since 0.85
     *
-    * @return nothing (display)
+    * @return void
    **/
    static function titleBackup() {
       global $CFG_GLPI;
@@ -900,7 +900,7 @@ class RuleCollection extends CommonDBTM {
     *
     * @since 0.85
     *
-    * @return nothing, send attachment to browser
+    * @return void send attachment to browser
    **/
    static function exportRulesToXML($items = []) {
 
@@ -1003,7 +1003,7 @@ class RuleCollection extends CommonDBTM {
     *
     * @since 0.85
     *
-    * @return nothing (display)
+    * @return void
    **/
    static function displayImportRulesForm() {
 
@@ -1837,7 +1837,7 @@ class RuleCollection extends CommonDBTM {
    /**
     * Print a title if needed which will be displayed above list of rules
     *
-    * @return nothing (display)
+    * @return void
    **/
    function title() {
    }

--- a/inc/ruledictionnaryprintercollection.class.php
+++ b/inc/ruledictionnaryprintercollection.class.php
@@ -324,7 +324,7 @@ class RuleDictionnaryPrinterCollection extends RuleCollection {
     * @param $ID                 the old printer's id
     * @param $new_printers_id    the new printer's id
     *
-    * @return nothing
+    * @return void
    **/
    function moveDirectConnections($ID, $new_printers_id) {
       global $DB;

--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -552,7 +552,7 @@ class SavedSearch extends CommonDBTM {
     *
     * @param integer $ID ID of the saved search
     *
-    * @return nothing
+    * @return void
    **/
    function load($ID) {
       global $CFG_GLPI;

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -89,7 +89,7 @@ class Search {
     * @param $itemtype item type to manage
     * @param $params search params passed to prepareDatasForSearch function
     *
-    * @return nothing
+    * @return void
    **/
    static function showList($itemtype, $params) {
 
@@ -555,7 +555,7 @@ class Search {
     *
     * @param $data    array of search datas prepared to generate SQL
     *
-    * @return nothing
+    * @return void
    **/
    static function constructSQL(array &$data) {
       global $CFG_GLPI, $DB;
@@ -1219,7 +1219,7 @@ class Search {
     * @param array   $data      array of search data prepared to get data
     * @param boolean $onlycount If we just want to count results
     *
-    * @return nothing
+    * @return void
    **/
    static function constructData(array &$data, $onlycount = false) {
       if (!isset($data['sql']) || !isset($data['sql']['search'])) {
@@ -1512,7 +1512,7 @@ class Search {
     *
     * @param $data array of search datas prepared to get datas
     *
-    * @return nothing
+    * @return void
    **/
    static function displayData(array &$data) {
       global $CFG_GLPI;
@@ -2273,7 +2273,7 @@ class Search {
     * @param $itemtype        type to display the form
     * @param $params    array of parameters may include sort, is_deleted, criteria, metacriteria
     *
-    * @return nothing (displays)
+    * @return void
    **/
    static function showGenericSearch($itemtype, array $params) {
       global $CFG_GLPI;
@@ -6452,7 +6452,7 @@ JAVASCRIPT;
    /**
     * Reset save searches
     *
-    * @return nothing
+    * @return void
    **/
    static function resetSaveSearch() {
 

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -304,7 +304,7 @@ class Session {
     *                                    (default 'all')
     * @param boolean       $is_recursive Also display sub entities of the active entity? (false by default)
     *
-    * @return Nothing
+    * @return boolean true on success, false on failure
    **/
    static function changeActiveEntities($ID = "all", $is_recursive = false) {
 

--- a/inc/slalevel.class.php
+++ b/inc/slalevel.class.php
@@ -215,7 +215,7 @@ class SlaLevel extends LevelAgreementLevel {
     * @param $ID              ID of the rule
     * @param $options   array of possible options
     *
-    * @return nothing
+    * @return void
    **/
    function showForm($ID, $options = []) {
 

--- a/inc/slalevel_ticket.class.php
+++ b/inc/slalevel_ticket.class.php
@@ -94,7 +94,7 @@ class SlaLevel_Ticket extends CommonDBTM {
     *
     * @since 9.1 2 parameters mandatory
     *
-    * @return nothing
+    * @return void
    **/
    function deleteForTicket($tickets_id, $slaType) {
       global $DB;
@@ -200,7 +200,7 @@ class SlaLevel_Ticket extends CommonDBTM {
     *
     * @since 9.1   2 parameters mandatory
     *
-    * @return nothing
+    * @return void
    **/
    static function doLevelForTicket(array $data, $slaType) {
 

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -199,7 +199,7 @@ class Software extends CommonDBTM {
     *
     * @since 0.85
     *
-    * @return nothing
+    * @return void
    **/
    static function updateValidityIndicator($ID) {
 
@@ -701,7 +701,7 @@ class Software extends CommonDBTM {
     * @param $myname          select name
     * @param $entity_restrict restrict to a defined entity
     *
-    * @return nothing (print out an HTML select box)
+    * @return integer random part of elements id
    **/
    static function dropdownSoftwareToInstall($myname, $entity_restrict) {
       global $CFG_GLPI;
@@ -731,7 +731,7 @@ class Software extends CommonDBTM {
     * @param $myname          select name
     * @param $entity_restrict restrict to a defined entity
     *
-    * @return nothing (print out an HTML select box)
+    * @return integer random part of elements id
    **/
    static function dropdownLicenseToInstall($myname, $entity_restrict) {
       global $CFG_GLPI, $DB;
@@ -931,7 +931,7 @@ class Software extends CommonDBTM {
    /**
     * Show softwares candidates to be merged with the current
     *
-    * @return nothing
+    * @return void
    **/
    function showMergeCandidates() {
       global $DB, $CFG_GLPI;

--- a/inc/softwarelicense.class.php
+++ b/inc/softwarelicense.class.php
@@ -138,7 +138,7 @@ class SoftwareLicense extends CommonTreeDropdown {
     *
     * @since 0.85
     *
-    * @return nothing
+    * @return void
    **/
    static function updateValidityIndicator($ID) {
 
@@ -1003,7 +1003,7 @@ class SoftwareLicense extends CommonTreeDropdown {
     *
     * @param $software Software object
     *
-    * @return nothing
+    * @return void
    **/
    static function showForSoftware(Software $software) {
       global $DB, $CFG_GLPI;

--- a/inc/softwareversion.class.php
+++ b/inc/softwareversion.class.php
@@ -216,7 +216,9 @@ class SoftwareVersion extends CommonDBChild {
     *    - value         : integer / value of the selected version
     *    - used          : array / already used items
     *
-    * @return nothing (print out an HTML select box)
+    * @return integer|string
+    *    integer if option display=true (random part of elements id)
+    *    string if option display=false (HTML code)
    **/
    static function dropdownForOneSoftware($options = []) {
       global $CFG_GLPI, $DB;
@@ -273,7 +275,7 @@ class SoftwareVersion extends CommonDBChild {
     *
     * @param $soft Software object
     *
-    * @return nothing
+    * @return void
    **/
    static function showForSoftware(Software $soft) {
       global $DB, $CFG_GLPI;

--- a/inc/supplier.class.php
+++ b/inc/supplier.class.php
@@ -104,7 +104,7 @@ class Supplier extends CommonDBTM {
     *     - target form target
     *     - withtemplate boolean : template or basic item
     *
-    *@return Nothing (display)
+    *@return void
    **/
    function showForm($ID, $options = []) {
 
@@ -453,7 +453,7 @@ class Supplier extends CommonDBTM {
    /**
     * Print the HTML array for infocoms linked
     *
-    *@return Nothing (display)
+    *@return void
     *
    **/
    function showInfocoms() {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -851,7 +851,7 @@ class Ticket extends CommonITILObject {
    /**
     * Retrieve data of the hardware linked to the ticket if exists
     *
-    * @return nothing : set computerfound to 1 if founded
+    * @return void
    **/
    function getAdditionalDatas() {
 
@@ -1943,7 +1943,7 @@ class Ticket extends CommonITILObject {
     *
     * @param $input array : input array
     *
-    * @return nothing
+    * @return boolean
    **/
    function manageValidationAdd($input) {
 
@@ -3418,7 +3418,7 @@ class Ticket extends CommonITILObject {
     * @param $ticket_template boolean  ticket template for preview : false if not used for preview
     *                                  (false by default)
     *
-    * @return nothing (print the helpdesk)
+    * @return void
    **/
    function showFormHelpdesk($ID, $ticket_template = false) {
       global $CFG_GLPI;

--- a/inc/ticket_ticket.class.php
+++ b/inc/ticket_ticket.class.php
@@ -166,7 +166,7 @@ class Ticket_Ticket extends CommonDBRelation {
     *
     * @param $ID ID of the ticket id
     *
-    * @return nothing display
+    * @return void
    **/
    static function displayLinkedTicketsTo ($ID) {
       global $DB, $CFG_GLPI;

--- a/inc/ticketrecurrent.class.php
+++ b/inc/ticketrecurrent.class.php
@@ -292,7 +292,7 @@ class TicketRecurrent extends CommonDropdown {
    /**
     * Show next creation date
     *
-    * @return nothing only display
+    * @return void
    **/
    function showInfos() {
 

--- a/inc/tickettemplate.class.php
+++ b/inc/tickettemplate.class.php
@@ -125,7 +125,7 @@ class TicketTemplate extends ITILTemplate {
     *
     * @param $tt ITILTemplate object
     *
-    * @return Nothing (call to classes members)
+    * @return void
    **/
    static function showHelpdeskPreview(ITILTemplate $tt) {
 

--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -1043,7 +1043,7 @@ class Transfer extends CommonDBTM {
     *
     * Transfer item to a new Item if $ID==$newID : only update entities_id field :
     *                                $ID!=$new ID -> copy datas (like template system)
-    * @return nothing (diplays)
+    * @return void
    **/
    function transferItem($itemtype, $ID, $newID) {
       global $CFG_GLPI, $DB;

--- a/inc/useremail.class.php
+++ b/inc/useremail.class.php
@@ -192,7 +192,7 @@ class UserEmail  extends CommonDBChild {
     *
     * @param $user User object
     *
-    * @return nothing
+    * @return void
    **/
    static function showForUser(User $user) {
 

--- a/install/update.php
+++ b/install/update.php
@@ -128,7 +128,7 @@ function update_importDropdown ($table, $name) {
 /**
  * Display the form of content update (addslashes compatibility (V0.4))
  *
- * @return nothing (displays)
+ * @return void
  */
 function showContentUpdateForm() {
    $_SESSION['do_content_update'] = true;

--- a/install/update_042_05.php
+++ b/install/update_042_05.php
@@ -1379,7 +1379,7 @@ function dropMaintenanceField() {
  * @param $compDpdName string the name of the dropdown foreign key on glpi_computers (eg : hdtype, processor)
  * @param $specif string the name of the dropdown value entry on glpi_computer (eg : hdspace, processor_speed) optionnal argument.
  *
- * @return nothing if everything is good, else display mysql query and error.
+ * @return void
  */
 function compDpd2Device($devtype, $devname, $dpdname, $compDpdName, $specif = '') {
    global $DB;

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -81,7 +81,7 @@ class DbTestCase extends \GLPITestCase {
     * @param  int    $id     The id of added object
     * @param  array  $input  the input used for add object (optionnal)
     *
-    * @return nothing (do tests)
+    * @return void
     */
    protected function checkInput(CommonDBTM $object, $id = 0, $input = []) {
       $this->integer((int)$id)->isGreaterThan(0);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This PR contains only PHPDoc update to fix invalid `@return nothing` that generates errors on some IDE / code analysis tools.

For `show*` methods, I documented that methods returns `void` even when sometimes they return a boolean, as this boolean is not used by callers and is rather made to exit method execution than to return result state.