### PR TITLE
fix links in event list

### DIFF
--- a/inc/consumable.class.php
+++ b/inc/consumable.class.php
@@ -226,7 +226,7 @@ class Consumable extends CommonDBChild {
                      $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                   }
                }
-               Event::log($item->fields['consumableitems_id'], "consumables", 5, "inventory",
+               Event::log($item->fields['consumableitems_id'], "consumableitems", 5, "inventory",
                           //TRANS: %s is the user login
                           sprintf(__('%s gives a consumable'), $_SESSION["glpiname"]));
             } else {

--- a/inc/event.class.php
+++ b/inc/event.class.php
@@ -207,10 +207,10 @@ class Event extends CommonDBTM {
                $type = getSingular($type);
                $url  = '';
                if ($item = getItemForItemtype($type)) {
-                  $url  =  $item->getFormURL();
+                  $url  =  $item->getFormURLWithID($items_id);
                }
                if (!empty($url)) {
-                  echo "<a href=\"".$url."?id=".$items_id."\">".$items_id."</a>";
+                  echo "<a href=\"".$url."\">".$items_id."</a>";
                } else {
                   echo $items_id;
                }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6274 

Fixes link for consumable give events. It also fixes some links where the URL from getFormURL already has a query parameter like devices. For example, a simcard link became "front/device.form.php?itemtype=DeviceSimcard?id=1" and caused a 500 error.