### PR TITLE
Fix search with non-standard foreign keys

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3410,7 +3410,7 @@ JAVASCRIPT;
             && (!isset($CFG_GLPI["union_search_type"][$itemtype])
                 || ($CFG_GLPI["union_search_type"][$itemtype] != $table)))
            || !empty($complexjoin))
-          && ($searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table))) {
+          && getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) != $table) {
          $addtable .= "_".$searchopt[$ID]["linkfield"];
       }
 
@@ -4846,7 +4846,8 @@ JAVASCRIPT;
       }
 
       // Multiple link possibilies case
-      if (!empty($linkfield) && ($linkfield != getForeignKeyFieldForTable($new_table))) {
+      $ref_fk = getForeignKeyFieldForTable($new_table);
+      if (!empty($linkfield) && ($linkfield != $ref_fk) && strpos($linkfield, $ref_fk . '_') !== 0) {
          $nt .= "_".$linkfield;
          $AS  = " AS `$nt`";
       }
@@ -4867,7 +4868,7 @@ JAVASCRIPT;
 
       // Do not take into account standard linkfield
       $tocheck = $nt.".".$linkfield;
-      if ($linkfield == getForeignKeyFieldForTable($new_table)) {
+      if ($linkfield == $ref_fk || strpos($linkfield, $ref_fk . '_') === 0) {
          $tocheck = $nt;
       }
 

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -4868,7 +4868,7 @@ JAVASCRIPT;
 
       // Do not take into account standard linkfield
       $tocheck = $nt.".".$linkfield;
-      if (getTableNameForForeignKeyField($linkfield) !== $new_table) {
+      if ($linkfield == $ref_fk || strpos($linkfield, $ref_fk . '_') === 0) {
          $tocheck = $nt;
       }
 

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -4868,7 +4868,7 @@ JAVASCRIPT;
 
       // Do not take into account standard linkfield
       $tocheck = $nt.".".$linkfield;
-      if ($linkfield == $ref_fk || strpos($linkfield, $ref_fk . '_') === 0) {
+      if (getTableNameForForeignKeyField($linkfield) == $new_table) {
          $tocheck = $nt;
       }
 

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -4868,7 +4868,7 @@ JAVASCRIPT;
 
       // Do not take into account standard linkfield
       $tocheck = $nt.".".$linkfield;
-      if ($linkfield == $ref_fk || strpos($linkfield, $ref_fk . '_') === 0) {
+      if (getTableNameForForeignKeyField($linkfield) !== $new_table) {
          $tocheck = $nt;
       }
 

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -4846,8 +4846,7 @@ JAVASCRIPT;
       }
 
       // Multiple link possibilies case
-      $ref_fk = getForeignKeyFieldForTable($new_table);
-      if (!empty($linkfield) && ($linkfield != $ref_fk) && strpos($linkfield, $ref_fk . '_') !== 0) {
+      if (!empty($linkfield) && getTableNameForForeignKeyField($linkfield) != $new_table) {
          $nt .= "_".$linkfield;
          $AS  = " AS `$nt`";
       }

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -953,6 +953,33 @@ class Search extends DbTestCase {
 
    }
 
+   public function addSelectProvider() {
+      return [
+         'special_fk' => [[
+            'itemtype'  => 'Computer',
+            'ID'        => 24, // users_id_tech
+            'sql'       => '`glpi_users`.`name` AS `ITEM_Computer_24`, `glpi_users`.`realname` AS `ITEM_Computer_24_realname`, 
+                           `glpi_users`.`id` AS `ITEM_Computer_24_id`, `glpi_users`.`firstname` AS `ITEM_Computer_24_firstname`,'
+         ]],
+         'regular_fk' => [[
+            'itemtype'  => 'Computer',
+            'ID'        => 70, // users_id
+            'sql'       => '`glpi_users`.`name` AS `ITEM_Computer_70`, `glpi_users`.`realname` AS `ITEM_Computer_70_realname`, 
+                           `glpi_users`.`id` AS `ITEM_Computer_70_id`, `glpi_users`.`firstname` AS `ITEM_Computer_70_firstname`,'
+         ]],
+      ];
+   }
+
+   /**
+    * @dataProvider addSelectProvider
+    */
+   public function testAddSelect($provider) {
+      $sql_select = \Search::addSelect($provider['itemtype'], $provider['ID']);
+
+      $this->string($this->cleanSQL($sql_select))
+         ->isEqualTo($this->cleanSQL($provider['sql']));
+   }
+
    public function addLeftJoinProvider() {
       return [
          'itemtype_item_revert' => [[
@@ -979,6 +1006,26 @@ class Search extends DbTestCase {
                         ON (`glpi_contacts_id_d36f89b191ea44cf6f7c8414b12e1e50`.`id` = `glpi_projectteams`.`items_id`
                         AND `glpi_projectteams`.`itemtype` = 'Contact'
                          )"
+         ]],
+         'special_fk' => [[
+            'itemtype'           => 'Computer',
+            'table'              => \User::getTable(),
+            'field'              => 'name',
+            'linkfield'          => 'users_id_tech',
+            'meta'               => false,
+            'meta_type'          => null,
+            'joinparams'         => [],
+            'sql' => "LEFT JOIN `glpi_users` ON (`glpi_computers`.`users_id_tech` = `glpi_users`.`id` )"
+         ]],
+         'regular_fk' => [[
+            'itemtype'           => 'Computer',
+            'table'              => \User::getTable(),
+            'field'              => 'name',
+            'linkfield'          => 'users_id',
+            'meta'               => false,
+            'meta_type'          => null,
+            'joinparams'         => [],
+            'sql' => "LEFT JOIN `glpi_users` ON (`glpi_computers`.`users_id` = `glpi_users`.`id` )"
          ]],
       ];
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6375

Some search options use non-standard foreign keys such as "users_id_tech" which is not recognized as a valid link field in the search engine. I added a check to see if the expected key is at the start of the given link field.