### PR TITLE
Drop dead code causing SQL error

### DIFF
--- a/inc/notificationtargetprojecttask.class.php
+++ b/inc/notificationtargetprojecttask.class.php
@@ -438,9 +438,6 @@ class NotificationTargetProjectTask extends NotificationTarget {
       $this->data["##projecttask.numberofdocuments##"]
                      = count($this->data['documents']);
 
-      // Items infos
-      $items    = getAllDatasFromTable('glpi_items_projects', $restrict);
-
       $this->getTags();
       foreach ($this->tag_descriptions[NotificationTarget::TAG_LANGUAGE] as $tag => $values) {
          if (!isset($this->data[$tag])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6317

Remove dead/unneeded code which caused a SQL error. It may have been copied from notificationtargetproject.class.php when it was first created.