### PR TITLE
give the ID of the user after init session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The present file will list all changes made to the project; according to the
 - Add and answer approvals from timeline
 - Add lightbox with PhotoSwipe to timeline images
 - Ability to copy tasks while merging tickets
+- the API gives the ID of the user who logs in with initSession
 
 ### Changed
 

--- a/apirest.md
+++ b/apirest.md
@@ -116,7 +116,7 @@ App(lication) token
         * "Authorization: user_token q56hqkniwot8wntb3z1qarka5atf365taaa2uyjrn"
 
 * **Returns**:
-  * 200 (OK) with the *session_token* string.
+  * 200 (OK) with the *session_token* string and the *ID of the logged in user*.
   * 400 (Bad Request) with a message indicating an error in input parameter.
   * 401 (UNAUTHORIZED)
 
@@ -131,7 +131,8 @@ $ curl -X GET \
 
 < 200 OK
 < {
-   "session_token": "83af7e620c83a50a18d3eac2f6ed05a3ca0bea62"
+   "session_token": "83af7e620c83a50a18d3eac2f6ed05a3ca0bea62",
+   "users_id": "42"
 }
 
 $ curl -X GET \
@@ -142,7 +143,8 @@ $ curl -X GET \
 
 < 200 OK
 < {
-   "session_token": "83af7e620c83a50a18d3eac2f6ed05a3ca0bea62"
+   "session_token": "83af7e620c83a50a18d3eac2f6ed05a3ca0bea62",
+   "users_id": "42"
 }
 ```
 

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -249,7 +249,10 @@ abstract class API extends CommonGLPI {
 
       // stop session and return session key
       session_write_close();
-      return ['session_token' => $_SESSION['valid_id']];
+      return [
+         'session_token' => $_SESSION['valid_id'],
+         'users_id'      => Session::getLoginUserID(),
+      ];
    }
 
 

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -215,6 +215,8 @@ class APIRest extends APIBaseClass {
       $data = json_decode($body, true);
       $this->variable($data)->isNotFalse();
       $this->array($data)->hasKey('session_token');
+      $this->array($data)->hasKey('users_id');
+      $this->integer((int) $data['users_id'])->isEqualTo($uid);
    }
 
    /**

--- a/tests/web/APIXmlrpc.php
+++ b/tests/web/APIXmlrpc.php
@@ -106,6 +106,7 @@ class APIXmlrpc extends APIBaseClass {
     * @covers API::initSession
     */
    public function initSessionCredentials() {
+      $uid = getItemByTypeName('User', TU_USER, true);
       $data = $this->query('initSession',
             ['query' => [
                   'login'    => TU_USER,
@@ -114,6 +115,8 @@ class APIXmlrpc extends APIBaseClass {
       $this->variable($data)->isNotFalse();
       $this->array($data)->hasKey('session_token');
       $this->session_token = $data['session_token'];
+      $this->array($data)->hasKey('users_id');
+      $this->integer((int) $data['users_id'])->isEqualTo($uid);
    }
 
    /**


### PR DESCRIPTION
Give the ID of the user in the repsonse of Init Session.

Helps to avoid calls to getFullSession when need to know our own ID.


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
