### PR TITLE
set execution time only if request succeeds

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1264,15 +1264,15 @@ class Search {
          }
       }
 
-      $data['data']['execution_time'] = $DBread->execution_time;
-      if (isset($data['search']['savedsearches_id'])) {
-         SavedSearch::updateExecutionTime(
-            (int)$data['search']['savedsearches_id'],
-            $DBread->execution_time
-         );
-      }
-
       if ($result) {
+         $data['data']['execution_time'] = $DBread->execution_time;
+         if (isset($data['search']['savedsearches_id'])) {
+            SavedSearch::updateExecutionTime(
+               (int)$data['search']['savedsearches_id'],
+               $DBread->execution_time
+            );
+         }
+
          $data['data']['totalcount'] = 0;
          // if real search or complete export : get numrows from request
          if (!$data['search']['no_search']


### PR DESCRIPTION
If we call the Search endpoint of the API and the search fails due to a SQL error, the max execution time is set. This prevents detection of the failure in the API and returns inconsistent JSON result.

see: https://github.com/glpi-project/glpi/blob/9.4/bugfixes/inc/api.class.php#L1609

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
