### PR TITLE
Fix followup and task search on limited profiles

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3615,7 +3615,7 @@ JAVASCRIPT;
                // force ordering by date desc
                return " GROUP_CONCAT(DISTINCT CONCAT(IFNULL($tocompute, '".self::NULLVALUE."'),
                                                '".self::SHORTSEP."',$tocomputeid)
-                                     ORDER BY `$table`.`date` DESC
+                                     ORDER BY `$table$addtable`.`date` DESC
                                      SEPARATOR '".self::LONGSEP."')
                                     AS `".$NAME."`,
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6390

Only seems to affect lower-privileged profiles. The wrong table name was used in order.
May be related to #6288 as well
