### PR TITLE
Fix impersonate on user form submit; fixes #6391

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -2009,10 +2009,24 @@ class User extends CommonDBTM {
       }
 
       if (Session::canImpersonate($ID)) {
-         $formtitle .= '<button type="submit" class="pointer btn-linkstyled btn-impersonate" name="impersonate" value="1">'
+         $formtitle .= '<button type="button" class="pointer btn-linkstyled btn-impersonate" name="impersonate" value="1">'
             . '<i class="fas fa-user-secret fa-lg" title="' . __s('Impersonate') . '"></i> '
             . '<span class="sr-only">' . __s('Impersonate') . '</span>'
             . '</button>';
+
+         // "impersonate" button type is set to "button" on form display to prevent it to be used
+         // by default (as it is the first found in current form) when pressing "enter" key.
+         // When clicking it, switch to "submit" type to make it submit current user form.
+         $impersonate_js = <<<JAVASCRIPT
+            (function($) {
+               $('button[type="button"][name="impersonate"]').click(
+                  function () {
+                     $(this).attr('type', 'submit');
+                  }
+               );
+            })(jQuery);
+JAVASCRIPT;
+         $formtitle .= Html::scriptBlock($impersonate_js);
       }
 
       $options['formtitle']   = $formtitle;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6391

Browser uses first submit button of a form when pressing enter. There is no clean way to prevent this, so I had to use a hack.