### PR TITLE
Warn if there are unsaved form changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The present file will list all changes made to the project; according to the
 - Add lightbox with PhotoSwipe to timeline images
 - Ability to copy tasks while merging tickets
 - the API gives the ID of the user who logs in with initSession
+- Add warning when there are unsaved changes in forms
 
 ### Changed
 

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3657,6 +3657,11 @@ class Html {
                editor.on('SaveContent', function (contentEvent) {
                   contentEvent.content = contentEvent.content.replace(/\\r?\\n/g, '');
                });
+               editor.on('Change', function (e) {
+                  // Nothing fancy here. Since this is only used for tracking unsaved changes,
+                  // we want to keep the logic in common.js with the other form input events.
+                  onTinyMCEChange(e);
+               });
 
                // ctrl + enter submit the parent form
                editor.addShortcut('ctrl+13', 'submit', function() {

--- a/js/common.js
+++ b/js/common.js
@@ -1021,3 +1021,18 @@ var getTextWithoutDiacriticalMarks = function (text) {
    // They are removed to keep only chars without their diacritical mark.
    return text.replace(/[\u0300-\u036f]/g, '');
 };
+
+/** Track input changes and warn the user of unsaved changes if they try to navigate away */
+window.glpiUnsavedFormChanges = false;
+$(document).ready(function() {
+   // Try to limit tracking to item forms by binding to inputs under glpi_tabs only.
+   $('#page .glpi_tabs form').on('change', 'input, textarea, select', function() {
+      window.glpiUnsavedFormChanges = true;
+   });
+   $(window).on('beforeunload', function() {
+      if (window.glpiUnsavedFormChanges) {
+         // Only used for older browsers. Newer ones will display a localized message that is unique to the browser.
+         return "Do you want to leave this site? Changes you made may not be saved.";
+      }
+   });
+});

--- a/js/common.js
+++ b/js/common.js
@@ -1026,7 +1026,14 @@ var getTextWithoutDiacriticalMarks = function (text) {
 window.glpiUnsavedFormChanges = false;
 $(document).ready(function() {
    // Try to limit tracking to item forms by binding to inputs under glpi_tabs only.
-   $('#page .glpi_tabs form').on('change', 'input, textarea, select', function() {
+   var glpiTabs = $('#page .glpi_tabs');
+   glpiTabs.on('input', 'form input, form textarea', function() {
+      window.glpiUnsavedFormChanges = true;
+   });
+   glpiTabs.on('change', 'form select', function() {
+      window.glpiUnsavedFormChanges = true;
+   });
+   glpiTabs.on('select2:select', 'form select', function() {
       window.glpiUnsavedFormChanges = true;
    });
    $(window).on('beforeunload', function() {
@@ -1036,3 +1043,7 @@ $(document).ready(function() {
       }
    });
 });
+
+function onTinyMCEChange() {
+   window.glpiUnsavedFormChanges = true;
+}

--- a/js/common.js
+++ b/js/common.js
@@ -1042,6 +1042,10 @@ $(document).ready(function() {
          return "Do you want to leave this site? Changes you made may not be saved.";
       }
    });
+
+   glpiTabs.on('submit', 'form', function() {
+      window.glpiUnsavedFormChanges = false;
+   });
 });
 
 function onTinyMCEChange() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Warn the user when navigating away from a page if there are unsaved changes to prevent data loss.

Related:
https://glpi.userecho.com/communities/1/topics/1073-display-a-warning-when-closing-an-unsaved-followup-or-task
