### PR TITLE
Prevent usage of console as root user

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -70,18 +70,34 @@ if (isset($_SERVER['argv']) && ['dependencies', 'install'] === array_slice($_SER
    exit($exit_code);
 }
 
+// Prevent console execution from root user.
+// Main purpose of this limitation is to prevent creation of files (cache, logs, ...)
+// owned by root user to prevent possible file rights errors.
+if (function_exists('posix_getuid') && 0 === posix_getuid()
+    && !(array_key_exists('allow-superuser', $options) && $options['allow-superuser'])) {
+   $user = function_exists('posix_getpwuid') ? posix_getpwuid(0) : ['name' => 'root'];
+   echo(
+      sprintf(
+         'Using bin/console as %s/super user is discouraged. Use --allow-superuser option to bypass this limitation.' . "\n",
+         $user['name']
+      )
+   );
+   exit(1);
+}
+
 // If "config-dir" option is used in command line, defines GLPI_CONFIG_DIR with its value
 if (array_key_exists('config-dir', $options)) {
    $config_dir = $options['config-dir'];
 
    if (false === $config_dir || !@is_dir($config_dir)) {
-      die(
+      echo(
          sprintf(
             '--config-dir "%s" does not exists in "%s".' . "\n",
             $config_dir,
             getcwd()
          )
       );
+      exit(1);
    }
 
    define('GLPI_CONFIG_DIR', realpath($config_dir));

--- a/front/cron.php
+++ b/front/cron.php
@@ -30,6 +30,21 @@
  * ---------------------------------------------------------------------
  */
 
+// Prevent cron execution from root user.
+// Main purpose of this limitation is to prevent creation of files (cache, logs, ...)
+// owned by root user to prevent possible file rights errors.
+if ('cli' === PHP_SAPI && function_exists('posix_getuid') && 0 === posix_getuid()
+    && !(isset($_SERVER['argv']) && array_search('--allow-superuser', $_SERVER['argv']))) {
+   $user = function_exists('posix_getpwuid') ? posix_getpwuid(0) : ['name' => 'root'];
+   echo(
+      sprintf(
+         'Using cron as %s/super user is discouraged to prevent file rights issues. Use --allow-superuser option to bypass this limitation.' . "\n",
+         $user['name']
+      )
+   );
+   exit(1);
+}
+
 // Ensure current directory when run from crontab
 chdir(__DIR__);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It is common for users to have rights issues after using the console and / or cron from the root user. This PR introduces a limitation that blocks execution of them from root (POSIX systems only). This limitation can still be bypassed, using a specific `--allow-superuser` command line option.