### PR TITLE
Fix logger exception on cache init error

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -41,6 +41,14 @@ include_once (GLPI_ROOT."/inc/based_config.php");
 include_once (GLPI_ROOT."/inc/define.php");
 include_once (GLPI_ROOT."/inc/dbconnection.class.php");
 
+// Default Use mode
+if (!isset($_SESSION['glpi_use_mode'])) {
+   $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
+}
+
+$GLPI = new GLPI();
+$GLPI->initLogger();
+
 //init cache
 $GLPI_CACHE = Config::getCache('cache_db');
 
@@ -71,14 +79,6 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
 
 } else {
    include_once(GLPI_CONFIG_DIR . "/config_db.php");
-
-   // Default Use mode
-   if (!isset($_SESSION['glpi_use_mode'])) {
-      $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
-   }
-
-   $GLPI = new GLPI();
-   $GLPI->initLogger();
 
    //Database connection
    DBConnection::establishDBConnection((isset($USEDBREPLICATE) ? $USEDBREPLICATE : 0),

--- a/inc/config.php
+++ b/inc/config.php
@@ -41,6 +41,9 @@ include_once (GLPI_ROOT."/inc/based_config.php");
 include_once (GLPI_ROOT."/inc/define.php");
 include_once (GLPI_ROOT."/inc/dbconnection.class.php");
 
+Session::setPath();
+Session::start();
+
 // Default Use mode
 if (!isset($_SESSION['glpi_use_mode'])) {
    $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
@@ -51,9 +54,6 @@ $GLPI->initLogger();
 
 //init cache
 $GLPI_CACHE = Config::getCache('cache_db');
-
-Session::setPath();
-Session::start();
 
 Config::detectRootDoc();
 

--- a/install/install.php
+++ b/install/install.php
@@ -35,10 +35,10 @@ define('GLPI_ROOT', realpath('..'));
 include_once (GLPI_ROOT . "/inc/based_config.php");
 include_once (GLPI_ROOT . "/inc/db.function.php");
 
-Config::detectRootDoc();
-
 $GLPI = new GLPI();
 $GLPI->initLogger();
+
+Config::detectRootDoc();
 
 //Print a correct  Html header for application
 function header_html($etape) {

--- a/install/update.php
+++ b/install/update.php
@@ -38,6 +38,9 @@ include_once (GLPI_ROOT . "/inc/based_config.php");
 include_once (GLPI_ROOT . "/inc/db.function.php");
 include_once (GLPI_CONFIG_DIR . "/config_db.php");
 
+$GLPI = new GLPI();
+$GLPI->initLogger();
+
 $GLPI_CACHE = Config::getCache('cache_db');
 $GLPI_CACHE->clear(); // Force cache cleaning to prevent usage of outdated cache data
 
@@ -45,9 +48,6 @@ $translation_cache = Config::getCache('cache_trans');
 $translation_cache->clear(); // Force cache cleaning to prevent usage of outdated cache data
 
 Config::detectRootDoc();
-
-$GLPI = new GLPI();
-$GLPI->initLogger();
 
 $DB = new DB();
 $DB->disableTableCaching(); //prevents issues on fieldExists upgrading from old versions


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

On cron execution, when there is something wrong during cache initialization, a fatal error is trigerred as logger is not yet instanciated.
```
$ php front/cron.php
Fatal error: Uncaught Error: Call to a member function addRecord() on null in /var/www/glpi/inc/toolbox.class.php:434
Stack trace:
#0 /var/www/glpi/inc/toolbox.class.php(472): Toolbox::log(NULL, 400, Array)
#1 /var/www/glpi/inc/config.class.php(3189): Toolbox::logError('Cache directory...')
#2 /var/www/glpi/inc/config.php(45): Config::getCache('cache_db')
#3 /var/www/glpi/inc/includes.php(48): include_once('/var/www/glpi/i...')
#4 /var/www/glpi/front/cron.php(38): include('/var/www/glpi/i...')
#5 {main}
  thrown in /var/www/glpi/inc/toolbox.class.php on line 434
```

To prevent this kind of issues, I moved logger init just after main includes and prior to everything else.

Now there is a clear ouput:
```
$ php front/cron.php
Config::getCache() in /var/www/glpi/inc/config.class.php line 3189
Cache directory '/var/www/glpi/files/_cache/cache_db' not writable 
```