### PR TITLE
Revert "Fix HAVING in search (#6204)"

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -511,36 +511,6 @@ class Search {
       return $data;
    }
 
-   /**
-    * Search for a "usehaving" field in the searchOption of for each criteria
-    *
-    * @param $criterias List of criterias
-    * @param $searchopt List of searchOptions
-    *
-    * @return bool
-    */
-   private static function hasHaving($criterias, $searchopt) {
-      foreach ($criterias as $criteria) {
-         // Search recursively for groups
-         if (isset($criteria['criteria'])) {
-            $hasHaving = self::hasHaving($criteria['criteria'], $searchopt);
-            if ($hasHaving) {
-               return true;
-            }
-            continue;
-         }
-
-         if (isset($criteria['field'])
-            && isset($searchopt[$criteria['field']]["usehaving"])
-            || (isset($criteria['meta']) && $criteria['meta'] && $criteria['link'] == "AND NOT")
-         ) {
-            return true;
-         }
-      }
-
-      return false;
-   }
-
 
    /**
     * Construct SQL request depending of search parameters
@@ -693,25 +663,6 @@ class Search {
       if (count($data['search']['criteria'])) {
          $WHERE  = self::constructCriteriaSQL($data['search']['criteria'], $data, $searchopt);
          $HAVING = self::constructCriteriaSQL($data['search']['criteria'], $data, $searchopt, true);
-
-         // Check if a criteria was meant to be used as a having field
-         $hasHaving = self::hasHaving($data['search']['criteria'], $searchopt);
-         if ($hasHaving) {
-            $HAVING = $WHERE;
-            $WHERE = "";
-
-            // Each field specified in the HAVING must be in the SELECT aswell
-            $regex = "/`glpi_\w*?`\.`.*?`/";
-            $matches = [];
-            preg_match_all($regex, $HAVING, $matches);
-            if (isset($matches[0])) {
-               foreach ($matches[0] as $havingElement) {
-                  if (strpos($SELECT, $havingElement) === false) {
-                     $SELECT .= " $havingElement, ";
-                  }
-               }
-            }
-         }
 
          // if criteria (with meta flag) need additional join/from sql
          self::constructAdditionalSqlForMetacriteria($data['search']['criteria'], $SELECT, $FROM, $already_link_tables, $data);
@@ -1036,18 +987,15 @@ class Search {
             } else if (isset($searchopt[$criterion['field']]["usehaving"])
                        || ($meta && "AND NOT" === $criterion['link'])) {
                if (!$is_having) {
-                  // Add the having in the where as the whole WHERE will be
-                  // converted into an HAVING later
-                  $new_where = self::addHaving(
-                     $LINK,
-                     $NOT,
-                     $itemtype,
-                     $criterion['field'],
-                     $criterion['searchtype'],
-                     $criterion['value']
-                  );
-                  $sql .= $new_where;
+                  // the having part will be managed in a second pass
                   continue;
+               }
+
+               $new_having = self::addHaving($LINK, $NOT, $itemtype,
+                                             $criterion['field'], $criterion['searchtype'],
+                                             $criterion['value']);
+               if ($new_having !== false) {
+                  $sql .= $new_having;
                }
             } else {
                if ($is_having) {

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -544,14 +544,6 @@ class Search extends DbTestCase {
     * @return void
     */
    public function testSearchOptions() {
-
-      $displaypref = new \DisplayPreference();
-      // save table glpi_displaypreferences
-      $dp = getAllDatasFromTable($displaypref->getTable());
-      foreach ($dp as $line) {
-         $displaypref->delete($line, true);
-      }
-
       $itemtypeslist = $this->getClasses(
          'searchOptions',
          [
@@ -569,7 +561,6 @@ class Search extends DbTestCase {
          ]
       );
       foreach ($itemtypeslist as $itemtype) {
-         $number = 0;
          if (!file_exists('front/'.strtolower($itemtype).'.php')) {
             // it's the case where not have search possible in this itemtype
             continue;
@@ -580,53 +571,41 @@ class Search extends DbTestCase {
          $options = \Search::getCleanedOptions($itemtype);
          //but reload only items one because of mysql join limit
          $options = $item->searchOptions();
-         $compare_options = [];
-         foreach ($options as $key => $value) {
-            if (is_array($value) && count($value) == 1) {
-               $compare_options[$key] = $value['name'];
-            } else {
-               $compare_options[$key] = $value;
-            }
-         }
 
+         $all_criteria = [];
          foreach ($options as $key=>$data) {
-            if (is_int($key)) {
-               $input = [
-                   'itemtype' => $itemtype,
-                   'users_id' => 0,
-                   'num' => $key,
-               ];
-                $displaypref->add($input);
-               $number++;
+            if (!is_int($key) || (array_key_exists('nosearch', $data) && $data['nosearch'])) {
+               continue;
             }
-         }
-         $this->integer(
-            (int)countElementsInTable(
-               $displaypref->getTable(),
-               ['itemtype' => $itemtype, 'users_id' => 0]
-            )
-         )->isIdenticalTo($number);
+            $actions = \Search::getActionsFor($itemtype, $key);
+            $searchtype = array_keys($actions)[0];
 
-         // do a search query
+            $criterion = [
+               'field'      => $key,
+               'searchtype' => $searchtype,
+               'value'      => 0
+            ];
+
+            // do a search query based on current search option
+            $data = $this->doSearch(
+               $itemtype,
+               [
+                  'is_deleted'   => 0,
+                  'start'        => 0,
+                  'criteria'     => [$criterion],
+                  'metacriteria' => []
+               ]
+            );
+
+            $all_criteria[] = $criterion;
+         }
+
+         // do a search query with all criteria at the same time
          $search_params = ['is_deleted'   => 0,
                            'start'        => 0,
-                           'criteria'     => [],
+                           'criteria'     => $all_criteria,
                            'metacriteria' => []];
          $data = $this->doSearch($itemtype, $search_params);
-         // check for sql error (data key missing or empty)
-         $this->array($data)
-            ->hasKey('data')
-               ->array['last_errors']->isIdenticalTo([])
-               ->array['data']->isNotEmpty();
-      }
-      // restore displaypreference table
-      /// TODO: review, this can't work.
-      foreach (getAllDatasFromTable($displaypref->getTable()) as $line) {
-         $displaypref->delete($line, true);
-      }
-      $this->integer((int)countElementsInTable($displaypref->getTable()))->isIdenticalTo(0);
-      foreach ($dp as $input) {
-         $displaypref->add($input);
       }
    }
 

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -515,6 +515,7 @@ class Search extends DbTestCase {
             'SlaLevel',
             'OlaLevel',
             'Reservation',
+            'ReservationItem',
             'Event',
             'Glpi\\Event',
             'KnowbaseItem',

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -310,44 +310,6 @@ class Search extends DbTestCase {
                      ->contains("LEFT JOIN `glpi_entities`  AS `glpi_entities_");
    }
 
-   public function testHaving() {
-      $search_params = [
-         'reset'        => 'reset',
-         'is_deleted'   => 0,
-         'start'        => 0,
-         'search'       => 'Search',
-         'criteria'     => [
-            0 => [
-               'field'      => 1,
-               'searchtype' => 'contains',
-               'value'      => 'vm'
-            ],
-            1 => [
-               'link'       => 'OR',
-               'field'      => 18,
-               'searchtype' => 'contains',
-               'value'      => 4
-            ],
-         ]
-      ];
-
-      $data = $this->doSearch('Computer', $search_params);
-
-      // check for sql error (data key missing or empty)
-      $this->array($data)
-         ->hasKey('data')
-         ->array['last_errors']->isIdenticalTo([])
-         ->array['data']->isNotEmpty();
-
-      // Check having
-      $this->array($data)
-         ->hasKey('sql')
-         ->array['sql']
-         ->hasKey('search')
-         ->string['search']
-         ->contains("HAVING    (`glpi_computers`.`name`  LIKE '%vm%'  )  OR (`ITEM_Computer_18` = 4) ");
-   }
-
    public function testNestedAndMetaComputer() {
       $search_params = [
          'reset'      => 'reset',
@@ -454,7 +416,7 @@ class Search extends DbTestCase {
          ->contains("(`glpi_users`.`id` = '2')")
          ->contains("OR (`glpi_users`.`id` = '3')")
          // match having
-         ->matches("/HAVING.*\(`ITEM_Budget_2`\s+<>\s+5\)\s+AND\s+\(\(`ITEM_Printer_1`\s+NOT LIKE\s+'%HP%'\s+OR\s+`ITEM_Printer_1`\s+IS NULL\)\s*\)/");
+         ->matches("/HAVING\s*\(`ITEM_Budget_2`\s+<>\s+5\)\s+AND\s+\(\(`ITEM_Printer_1`\s+NOT LIKE\s+'%HP%'\s+OR\s+`ITEM_Printer_1`\s+IS NULL\)\s*\)/");
    }
 
    function testViewCriterion() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The idea here is to rework test of search options to add them to search criteria instead of just using them as display preference. It makes queries more complete as adding them in WHERE/HAVING clause will verify that the whole query (SELECT, JOINS and WHERE/HAVING conditions are correctly built).
For each item, a search is made for each search option using it as the only criterion, then all of these criteria are used at the same time on a single search.

Tests are currently failing as some of the column used in HAVING clause are not present in SELECT.
For example, for a search based on notepad content:
 - SELECT contains `` GROUP_CONCAT(DISTINCT CONCAT(IFNULL(`glpi_notepads`.`content`, '__NULL__'), '$#$',`glpi_notepads`.`id`) ORDER BY `glpi_notepads`.`id` SEPARATOR '$$##$$') AS `ITEM_NetworkEquipment_200` ``
 - WHERE contains `` `glpi_notepads`.`content`  LIKE '%0%'  OR `glpi_notepads`.`content` IS NULL ``

This is valid.
But if we use another criteria that requires using HAVING, search condition is used as it on HAVING, which is not valid. Valid HAVING should be using the field alias, like `` `ITEM_NetworkEquipment_200`  LIKE '%0%'  OR `ITEM_NetworkEquipment_200` IS NULL ``.
