### PR TITLE
[Impact] Add rightchecks

### DIFF
--- a/ajax/impact.php
+++ b/ajax/impact.php
@@ -65,7 +65,7 @@ switch ($_SERVER['REQUEST_METHOD']) {
       $item->getFromDB($items_id);
       $graph = Impact::makeDataForCytoscape(Impact::buildGraph($item));
       $params = Impact::prepareParams($item);
-      $readonly = !Session::haveRight(get_class($item)::$rightname, UPDATE);
+      $readonly = $item->can($items_id, UPDATE);
 
       // Output graph
       header('Content-Type: application/json');
@@ -99,7 +99,8 @@ switch ($_SERVER['REQUEST_METHOD']) {
             $stored_impact_item = new ImpactItem();
             $stored_impact_item->getFromDB($id);
             $itemtype = $stored_impact_item->fields['itemtype'];
-            $readonly = !Session::haveRight($itemtype::$rightname, UPDATE);
+            $item = new $itemtype();
+            $readonly = !$item->can($stored_impact_item->fields['items_id'], UPDATE);
             break;
          }
       }

--- a/inc/impact.class.php
+++ b/inc/impact.class.php
@@ -585,7 +585,7 @@ class Impact extends CommonGLPI {
       // Build the graph
       $graph = self::makeDataForCytoscape(Impact::buildGraph($item));
       $params = self::prepareParams($item);
-      $readonly = !Session::haveRight(get_class($item)::$rightname, UPDATE);
+      $readonly = !$item->can($item->fields['id'], UPDATE);
 
       echo Html::scriptBlock("
          $(function() {

--- a/inc/impact.class.php
+++ b/inc/impact.class.php
@@ -197,7 +197,8 @@ class Impact extends CommonGLPI {
                   success: function(data, textStatus, jqXHR) {
                      GLPIImpact.buildNetwork(
                         JSON.parse(data.graph),
-                        JSON.parse(data.params)
+                        JSON.parse(data.params),
+                        data.readonly
                      );
                   }
                });
@@ -230,13 +231,13 @@ class Impact extends CommonGLPI {
       echo '<div class="impact_toolbar">';
       echo '<span id="help_text"></span>';
       echo '<div id="impact_tools">';
-      echo '<span id="save_impact">' . __("Save") . '&nbsp;<i></i></span>';
-      echo '<span id="add_node"><i class="fas fa-plus"></i></span>';
-      echo '<span id="add_edge"><i class="fas fa-marker"></i></span>';
-      echo '<span id="add_compound"><i class="far fa-square"></i></span>';
-      echo '<span id="delete_element"><i class="fas fa-trash"></i></span>';
+      echo '<span id="save_impact" style="display: none">' . __("Save") . '&nbsp;<i></i></span>';
+      echo '<span id="add_node" style="display: none"><i class="fas fa-plus"></i></span>';
+      echo '<span id="add_edge" style="display: none"><i class="fas fa-marker"></i></span>';
+      echo '<span id="add_compound" style="display: none"><i class="far fa-square"></i></span>';
+      echo '<span id="delete_element" style="display: none"><i class="fas fa-trash"></i></span>';
       echo '<span id="export_graph"><i class="fas fa-download"></i></span>';
-      echo '<span id="expand_toolbar"><i class="fas fa-ellipsis-v "></i></span>';
+      echo '<span id="expand_toolbar" style="display: none"><i class="fas fa-ellipsis-v "></i></span>';
       echo '</div>';
       self::printDropdownMenu();
       echo '</div>';
@@ -584,10 +585,11 @@ class Impact extends CommonGLPI {
       // Build the graph
       $graph = self::makeDataForCytoscape(Impact::buildGraph($item));
       $params = self::prepareParams($item);
+      $readonly = !Session::haveRight(get_class($item)::$rightname, UPDATE);
 
       echo Html::scriptBlock("
          $(function() {
-            GLPIImpact.buildNetwork($graph, $params);
+            GLPIImpact.buildNetwork($graph, $params, $readonly);
          });
       ");
    }

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3206,8 +3206,8 @@ class Toolbox {
       return $CFG_GLPI["root_doc"] . '/front/document.send.php?file=_pictures/' . $path;
    }
 
-   public static function throwBadRequest($message) {
-      http_response_code(400);
+   public static function throwError($code, $message) {
+      http_response_code($code);
       Toolbox::logWarning($message);
       die(json_encode(["message" => $message]));
    }

--- a/js/impact.js
+++ b/js/impact.js
@@ -994,7 +994,7 @@ var GLPIImpact = {
    /**
     * Set readonly and show toolbar
     */
-   enableGraphEdition() {
+   enableGraphEdition: function() {
       // Show toolbar
       $(this.toolbar.save).show();
       $(this.toolbar.addNode).show();


### PR DESCRIPTION
Rights management:
* Add rights check for each impact actions : the user is allowed to update the graph if he can update the starting asset of the graph.
* Add readonly mode for graph.

I still think a new "global" right on READ and UPDATE would be better as users can easily bypass restriction if they are allowed to update at least one asset type (since impact data is global and not per graph).


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
