### PR TITLE
Fix scss compilation notice

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -474,7 +474,7 @@ input {
 }
 
 input:required:valid {
-   border: 1px solid RGB(211, 211, 211) !important;
+   border: 1px solid rgb(211, 211, 211) !important;
 }
 
 span.required {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

SCSS compiler is case sensitive for "CSS function", so it does not recognize `RGB()` function.

```
PHP Notice: Trying to access array offset on value of type null in /var/www/glpi/vendor/scssphp/scssphp/src/Compiler.php at line 4658
PHP Notice: Trying to access array offset on value of type null in /var/www/glpi/vendor/scssphp/scssphp/src/Compiler.php at line 4658
PHP Notice: Trying to access array offset on value of type null in /var/www/glpi/vendor/scssphp/scssphp/src/Compiler.php at line 4658
PHP Warning: Cannot modify header information - headers already sent by (output started at /var/www/glpi/inc/toolbox.class.php:688) in /var/www/glpi/front/css.php at line 47
```