### PR TITLE
Fix SCSS compile command checks

### DIFF
--- a/tools/compilescsscommand.class.php
+++ b/tools/compilescsscommand.class.php
@@ -114,7 +114,7 @@ class CompileScssCommand extends Command {
             ]
          );
 
-         if (@file_put_contents($compiled_path, $css)) {
+         if (strlen($css) === @file_put_contents($compiled_path, $css)) {
             $message = sprintf('"%s" compiled successfully in "%s".', $file, $compiled_path);
             $output->writeln(
                '<info>' . $message . '</info>',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`file_put_contents` returns size of written file. File writting was wrongly considered as failed when generated CSS was empty.
This is uncommon but [happens here](https://circleci.com/gh/orthagh/glpi/2390).