### PR TITLE
Change PHPMailer default email validation mode

### DIFF
--- a/inc/glpimailer.class.php
+++ b/inc/glpimailer.class.php
@@ -97,7 +97,7 @@ class GLPIMailer extends PHPMailer {
       }
    }
 
-   public static function validateAddress($address, $patternselect = null) {
+   public static function validateAddress($address, $patternselect = "pcre8") {
       $isValid = parent::validateAddress($address, $patternselect);
       if (!$isValid && Toolbox::endsWith($address, '@localhost')) {
          //since phpmailer6, @localhost address are no longer valid...

--- a/tests/units/GLPIMailer.php
+++ b/tests/units/GLPIMailer.php
@@ -38,12 +38,41 @@ use \DbTestCase;
 
 class GLPIMailer extends DbTestCase {
 
-   public function testValidateAddress() {
+   protected function valideAddressProvider() {
+      return [
+         // Test local part
+         ["!#$%&+-=?^_`.{|}~@localhost.dot", true],
+         ["test.test@localhost.dot", true],
+         ["test..test@localhost.dot", false],
+         [".test.test@localhost.dot", false],
+         ["test.test.@localhost.dot", false],
+         ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@localhost.dot", true],
+         ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@localhost.dot", false],
+
+         // Test domain part
+         ["user", false],
+         ["user@localhost", true],
+         ["user@localhost.dot", true],
+         ["user@localhost.1", true],
+         ["user@127.0.0.1", true],
+         ["user@[127.0.0.1]", true],
+         ["user@[IPv6:2001:db8:1ff::a0b:dbd0]", true],
+         ["user@local-host", true],
+         ["user@local-host-", false],
+         ["user@-local-host", false],
+         ["test@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.dot", true],
+         ["test@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.dot", false],
+         ["test@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true],
+      ];
+   }
+
+   /**
+    * @dataProvider valideAddressProvider
+    */
+   public function testValidateAddress($address, $is_valid) {
       $mailer = new \GLPIMailer;
 
-      $this->boolean($mailer->validateAddress('user'))->isFalse();
-      $this->boolean($mailer->validateAddress('user@localhost'))->isTrue();
-      $this->boolean($mailer->validateAddress('user@localhost.dot'))->isTrue();
+      $this->boolean($mailer->validateAddress($address))->isEqualTo($is_valid);
    }
 
    public function testPhpMailerLang() {


### PR DESCRIPTION
_Internal ref : 18245_

Currently we use the default mode of PHPMailer which is "php" and do the following :

```php
case 'php':
default:
    return (bool) filter_var($address, FILTER_VALIDATE_EMAIL);
```

This modification make us switch to the [pcre8](https://github.com/PHPMailer/PHPMailer/blob/master/src/PHPMailer.php#L1307) mode which is a little bit more permissive.
This allow us to accept addresses like `testemail@127.0.0.1` which seems to be [valid](http://isemail.info/testemail%40127.0.0.1) but are currently refused by GLPI.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
