### PR TITLE
Fix strict comparison in Kanban items display

### DIFF
--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -2302,7 +2302,7 @@ class Project extends CommonDBTM {
             $content .= "</div>";
          }
          $content .= "<div class='flex-break'></div>";
-         if ($itemtype === 'ProjectTask' && $item['projecttasktypes_id'] !== '0') {
+         if ($itemtype === 'ProjectTask' && $item['projecttasktypes_id'] !== 0) {
             $typematches = array_filter($alltypes, function($t) use ($item){
                return $t['id'] === $item['projecttasktypes_id'];
             });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Due to #6495 , Kanban display is not working properly since it has been rebased on current 9.5/bugfixes state.