### PR TITLE
Refactor tree ancestors/sons caching

### DIFF
--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -126,7 +126,6 @@ class Entity extends CommonTreeDropdown {
     * @since 0.84
    **/
    function pre_deleteItem() {
-      global $GLPI_CACHE;
 
       // Security do not delete root entity
       if ($this->input['id'] == 0) {
@@ -136,8 +135,8 @@ class Entity extends CommonTreeDropdown {
       //Cleaning sons calls getAncestorsOf and thus... Re-create cache. Call it before clean.
       $this->cleanParentsSons();
       if (Toolbox::useCache()) {
-         $ckey = 'ancestors_cache_' . md5($this->getTable() . $this->getID());
-         $GLPI_CACHE->delete($ckey);
+         $dbu = new DbUtils();
+         $dbu->unsetAncestorsOfCache($this->getTable(), $this->getID());
       }
       return true;
    }

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -38,7 +38,6 @@ class GLPITestCase extends atoum {
    private $int;
    private $str;
    protected $cached_methods = [];
-   protected $nscache;
 
    public function setUp() {
       // By default, no session, not connected
@@ -51,19 +50,9 @@ class GLPITestCase extends atoum {
 
    public function beforeTestMethod($method) {
       if (in_array($method, $this->cached_methods)) {
-         $this->nscache = 'glpitestcache' . GLPI_VERSION;
          global $GLPI_CACHE;
          //run with cache
          define('CACHED_TESTS', true);
-         //ZendCache does not works with PHP5 acpu...
-         $adapter = (version_compare(PHP_VERSION, '7.0.0') >= 0) ? 'apcu' : 'apc';
-         $storage = \Zend\Cache\StorageFactory::factory([
-            'adapter'   => $adapter,
-            'options'   => [
-               'namespace' => $this->nscache
-            ]
-         ]);
-         $GLPI_CACHE = new SimpleCacheDecorator($storage);
       }
    }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -99,7 +99,13 @@ function loadDataset() {
          ], [
             'name'        => '_test_child_2',
             'entities_id' => '_test_root_entity',
-         ]
+         ], [
+            'name'        => '_test_child_of_child_1',
+            'entities_id' => '_test_child_1',
+         ], [
+            'name'        => '_test_child_of_child_2',
+            'entities_id' => '_test_child_2',
+         ],
       ], 'Computer' => [
          [
             'name'        => '_test_pc01',

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -623,13 +623,16 @@ class DbUtils extends DbTestCase {
     */
    private function validateParentsCachedData($relation, $entities_id, $expected_cached_value) {
       global $GLPI_CACHE;
+      $cache = $GLPI_CACHE->get($relation . '_of_cache', []);
 
-      $cache_entity_key = $relation . '_cache_' . md5('glpi_entities' . $entities_id);
+      $cache_entity_key = 'glpi_entities_' . $entities_id;
 
       if (false === $expected_cached_value) {
-         $this->boolean($GLPI_CACHE->has($cache_entity_key))->isFalse();
+         $this->array($cache)->notHasKey($cache_entity_key);
       } else {
-         $this->array($GLPI_CACHE->get($cache_entity_key))->isIdenticalTo($expected_cached_value);
+         $this->array($cache)
+            ->hasKey($cache_entity_key)
+            ->array[$cache_entity_key]->isIdenticalTo($expected_cached_value);
       }
    }
 
@@ -701,19 +704,24 @@ class DbUtils extends DbTestCase {
       }
 
       // test on multiple items
-      $expected = [0 => 0, $ent0 => $ent0, $ent1 => $ent1, $ent2 => $ent2];
+      $sub_ent1_expected = [0 => 0, $ent0 => $ent0, $ent1 => $ent1];
+      $sub_ent2_expected = [0 => 0, $ent0 => $ent0, $ent2 => $ent2];
+      $combination_expected = [0 => 0, $ent0 => $ent0, $ent1 => $ent1, $ent2 => $ent2];
 
       if ($cache === true && $hit === false) {
-         $this->validateParentsCachedData('ancestors', $sub_ent1 . '|' . $sub_ent2, false);
+         $this->validateParentsCachedData('ancestors', $sub_ent1, false);
+         $this->validateParentsCachedData('ancestors', $sub_ent2, false);
       } else if ($cache === true && $hit === true) {
-         $this->validateParentsCachedData('ancestors', $sub_ent1 . '|' . $sub_ent2, $expected);
+         $this->validateParentsCachedData('ancestors', $sub_ent1, $sub_ent1_expected);
+         $this->validateParentsCachedData('ancestors', $sub_ent2, $sub_ent2_expected);
       }
 
       $ancestors = $this->testedInstance->getAncestorsOf('glpi_entities', [$sub_ent1, $sub_ent2]);
-      $this->array($ancestors)->isIdenticalTo($expected);
+      $this->array($ancestors)->isIdenticalTo($combination_expected);
 
       if ($cache === true) {
-         $this->validateParentsCachedData('ancestors', $sub_ent1 . '|' . $sub_ent2, $expected);
+         $this->validateParentsCachedData('ancestors', $sub_ent1, $sub_ent1_expected);
+         $this->validateParentsCachedData('ancestors', $sub_ent2, $sub_ent2_expected);
       }
    }
 
@@ -781,13 +789,16 @@ class DbUtils extends DbTestCase {
       }
 
       // test on multiple items
-      $expected = [0 => 0, $ent0 => $ent0, $ent1 => $ent1, $ent2 => $ent2];
+      $sub_ent1_expected = [0 => 0, $ent0 => $ent0, $ent1 => $ent1];
+      $sub_ent2_expected = [0 => 0, $ent0 => $ent0, $ent2 => $ent2];
+      $combination_expected = [0 => 0, $ent0 => $ent0, $ent1 => $ent1, $ent2 => $ent2];
 
       $ancestors = $this->testedInstance->getAncestorsOf('glpi_entities', [$sub_ent1, $sub_ent2]);
-      $this->array($ancestors)->isIdenticalTo($expected);
+      $this->array($ancestors)->isIdenticalTo($combination_expected);
 
       if ($cache === true) {
-         $this->validateParentsCachedData('ancestors', $sub_ent1 . '|' . $sub_ent2, $expected);
+         $this->validateParentsCachedData('ancestors', $sub_ent1, $sub_ent1_expected);
+         $this->validateParentsCachedData('ancestors', $sub_ent2, $sub_ent2_expected);
       }
 
       // Move an entity and validates that getAncestorsOf returns fresh data
@@ -803,13 +814,15 @@ class DbUtils extends DbTestCase {
       $entity = new \Entity();
       $this->boolean($entity->update(['id' => $sub_ent2, 'entities_id' => $ent3]))->isTrue();
 
-      $expected = [0 => 0, $ent0 => $ent0, $ent1 => $ent1, $ent3 => $ent3];
+      $sub_ent2_expected = [0 => 0, $ent0 => $ent0, $ent3 => $ent3];
+      $combination_expected = [0 => 0, $ent0 => $ent0, $ent1 => $ent1, $ent3 => $ent3];
 
       $ancestors = $this->testedInstance->getAncestorsOf('glpi_entities', [$sub_ent1, $sub_ent2]);
-      $this->array($ancestors)->isIdenticalTo($expected);
+      $this->array($ancestors)->isIdenticalTo($combination_expected);
 
       if ($cache === true) {
-         $this->validateParentsCachedData('ancestors', $sub_ent1 . '|' . $sub_ent2, $expected);
+         $this->validateParentsCachedData('ancestors', $sub_ent1, $sub_ent1_expected);
+         $this->validateParentsCachedData('ancestors', $sub_ent2, $sub_ent2_expected);
       }
    }
 

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -211,13 +211,16 @@ class Entity extends DbTestCase {
     */
    private function validateParentsCachedData($relation, $entities_id, $expected_cached_value) {
       global $GLPI_CACHE;
+      $cache = $GLPI_CACHE->get($relation . '_of_cache', []);
 
-      $cache_entity_key = $relation . '_cache_' . md5('glpi_entities' . $entities_id);
+      $cache_entity_key = 'glpi_entities_' . $entities_id;
 
       if (false === $expected_cached_value) {
-         $this->boolean($GLPI_CACHE->has($cache_entity_key))->isFalse();
+         $this->array($cache)->notHasKey($cache_entity_key);
       } else {
-         $this->array($GLPI_CACHE->get($cache_entity_key))->isIdenticalTo($expected_cached_value);
+         $this->array($cache)
+            ->hasKey($cache_entity_key)
+            ->array[$cache_entity_key]->isIdenticalTo($expected_cached_value);
       }
    }
 

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -444,7 +444,7 @@ class Search extends DbTestCase {
          // match where parts
          ->contains("`glpi_computers`.`is_deleted` = 0")
          ->contains("AND `glpi_computers`.`is_template` = 0")
-         ->contains("`glpi_computers`.`entities_id` IN ('1', '2', '3')")
+         ->contains("`glpi_computers`.`entities_id` IN ('1', '2', '3', '4', '5')")
          ->contains("OR (`glpi_computers`.`is_recursive`='1'".
                     " AND `glpi_computers`.`entities_id` IN (0))")
          ->contains("`glpi_computers`.`name`  LIKE '%test%'")
@@ -488,7 +488,7 @@ class Search extends DbTestCase {
       $this->string($data['sql']['search'])
          ->contains("`glpi_computers`.`is_deleted` = 0")
          ->contains("AND `glpi_computers`.`is_template` = 0")
-         ->contains("`glpi_computers`.`entities_id` IN ('1', '2', '3')")
+         ->contains("`glpi_computers`.`entities_id` IN ('1', '2', '3', '4', '5')")
          ->contains("OR (`glpi_computers`.`is_recursive`='1'".
                     " AND `glpi_computers`.`entities_id` IN (0))")
          ->matches("/`glpi_computers`\.`name`  LIKE '%test%'/")


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Ancestors cache is not completely refreshed when an item is updated. Indeed, only "single" items cache is refreshed, but cache that was generated by a call on `getAncestorsOf` with multiple `$items_id` is not refreshed.

1st commit: Small refactor on tests to include this case. Tests should fail.

2nd commit: Refactor of ancestors/sons caching system:
 - No more caching of "combinations" of items (to make invalidation/refresh easier);
 - All ancestors/sons are cached inside the same item on cache storage (to prevent having to read/write too many cache storage items (i.e files) when requesting `ancestorsOf` multiple items);
 - A private static variable has also been introduced to store cached items to prevent useless files reading on same request when cached data has already been read.

I also make tests agnostic to cache adapter.