### PR TITLE
Fix handling on spaces in MySQL aliases

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -1043,7 +1043,7 @@ class DBmysql {
          return $name->getValue();
       }
       //handle aliases
-      $names = preg_split('/ AS /i', $name);
+      $names = preg_split('/\s+AS\s+/i', $name);
       if (count($names) > 2) {
          throw new \RuntimeException(
             'Invalid field name ' . $name

--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -114,7 +114,7 @@ class DBmysqlIterator implements Iterator, Countable {
       $is_legacy = false;
 
       if (is_string($table) && strpos($table, " ")) {
-         $names = preg_split('/ AS /i', $table);
+         $names = preg_split('/\s+AS\s+/i', $table);
          if (isset($names[1]) && strpos($names[1], ' ') || !isset($names[1]) || strpos($names[0], ' ')) {
             $is_legacy = true;
          }
@@ -445,7 +445,7 @@ class DBmysqlIterator implements Iterator, Countable {
     * @return string
     */
    private function handleFieldsAlias($t, $f, $suffix = '') {
-      $names = preg_split('/ AS /i', $f);
+      $names = preg_split('/\s+AS\s+/i', $f);
       $expr  = "$t(".$this->handleFields(0, $names[0])."$suffix)";
       if (isset($names[1])) {
           $expr .= " AS " . DBmysql::quoteName($names[1]);

--- a/tests/units/DBmysqlIterator.php
+++ b/tests/units/DBmysqlIterator.php
@@ -792,6 +792,20 @@ class DBmysqlIterator extends DbTestCase {
          ]
       ]);
       $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `bar` AS `b` INNER JOIN `foo` AS `f` ON (`b`.`fid` = `f`.`id`)');
+
+      $it = $this->it->execute([
+         'SELECT' => ['id', 'field  AS  f', 'baz as  Z'],
+         'FROM' => 'bar  AS b',
+         'INNER JOIN'   => [
+            'foo AS  f' => [
+               'FKEY' => [
+                  'b'   => 'fid',
+                  'f'   => 'id'
+               ]
+            ]
+         ]
+      ]);
+      $this->string($it->getSql())->isIdenticalTo('SELECT `id`, `field` AS `f`, `baz` AS `Z` FROM `bar` AS `b` INNER JOIN `foo` AS `f` ON (`b`.`fid` = `f`.`id`)');
    }
 
    public function testExpression() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`AS` keyword used with multiple spaces around it does not work as expected, for instance, https://github.com/glpi-project/glpi/blob/9.5/bugfixes/inc/migration.class.php#L1349 produces

```
  *** MySQL query error:
  SQL: SELECT `table_name ` AS `TABLE_NAME`, `column_name` AS `COLUMN_NAME` FROM `information_schema`.`columns` WHERE `table_schema` = 'glpi.local.9-5' AND `table_name` LIKE 'glpi_%' AND ((`column_name` = 'itemtype') OR (`column_name` LIKE 'itemtype_%')) ORDER BY `TABLE_NAME`
  Error: Unknown column 'table_name ' in 'field list'
```