### PR TITLE
Fix mixed classes case

### DIFF
--- a/ajax/dropdownMassiveActionField.php
+++ b/ajax/dropdownMassiveActionField.php
@@ -39,7 +39,7 @@ if (!isset($_POST["itemtype"]) || !($item = getItemForItemtype($_POST['itemtype'
    exit();
 }
 
-if (InfoCom::canApplyOn($_POST["itemtype"])) {
+if (Infocom::canApplyOn($_POST["itemtype"])) {
    Session::checkSeveralRightsOr([$_POST["itemtype"] => UPDATE,
                                        "infocom"          => UPDATE]);
 } else {

--- a/ajax/ldapdaterestriction.php
+++ b/ajax/ldapdaterestriction.php
@@ -39,4 +39,4 @@ if (strpos($_SERVER['PHP_SELF'], "ldapdaterestriction.php")) {
 }
 
 Session::checkLoginUser();
-AuthLdap::showDateRestrictionForm($_POST);
+AuthLDAP::showDateRestrictionForm($_POST);

--- a/front/authldap.form.php
+++ b/front/authldap.form.php
@@ -48,7 +48,7 @@ if (isset($_POST["update"])) {
    //If no name has been given to this configuration, then go back to the page without adding
    if ($_POST["name"] != "") {
       if ($newID = $config_ldap->add($_POST)) {
-         if (AuthLdap::testLDAPConnection($newID)) {
+         if (AuthLDAP::testLDAPConnection($newID)) {
             Session::addMessageAfterRedirect(__('Test successful'));
          } else {
             Session::addMessageAfterRedirect(__('Test failed'), false, ERROR);
@@ -67,7 +67,7 @@ if (isset($_POST["update"])) {
 } else if (isset($_POST["test_ldap"])) {
    $config_ldap->getFromDB($_POST["id"]);
 
-   if (AuthLdap::testLDAPConnection($_POST["id"])) {
+   if (AuthLDAP::testLDAPConnection($_POST["id"])) {
                                        //TRANS: %s is the description of the test
       $_SESSION["LDAP_TEST_MESSAGE"] = sprintf(__('Test successful: %s'),
                                                //TRANS: %s is the name of the LDAP main server
@@ -85,7 +85,7 @@ if (isset($_POST["update"])) {
    $replicate = new AuthLdapReplicate();
    $replicate->getFromDB($_POST["ldap_replicate_id"]);
 
-   if (AuthLdap::testLDAPConnection($_POST["id"], $_POST["ldap_replicate_id"])) {
+   if (AuthLDAP::testLDAPConnection($_POST["id"], $_POST["ldap_replicate_id"])) {
                                        //TRANS: %s is the description of the test
       $_SESSION["LDAP_TEST_MESSAGE"] = sprintf(__('Test successful: %s'),
                                                //TRANS: %s is the name of the LDAP replica server

--- a/front/crontask.form.php
+++ b/front/crontask.form.php
@@ -78,7 +78,7 @@ if (isset($_POST['execute'])) {
    if (!isset($_GET["id"]) || empty($_GET["id"])) {
       exit();
    }
-   Html::header(Crontask::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'config', 'crontask');
+   Html::header(CronTask::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'config', 'crontask');
    $crontask->display(['id' =>$_GET["id"]]);
    Html::footer();
 }

--- a/front/crontask.php
+++ b/front/crontask.php
@@ -38,7 +38,7 @@ include ('../inc/includes.php');
 
 Session::checkRight("config", UPDATE);
 
-Html::header(Crontask::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'config', 'crontask');
+Html::header(CronTask::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'config', 'crontask');
 
 $crontask = new CronTask();
 if ($crontask->getNeedToRun(CronTask::MODE_INTERNAL)) {

--- a/front/ldap.group.import.php
+++ b/front/ldap.group.import.php
@@ -39,7 +39,7 @@ Session::checkRight('user', User::UPDATEAUTHENT);
 Html::header(__('LDAP directory link'), $_SERVER['PHP_SELF'], "admin", "group", "ldap");
 
 if (isset($_GET['next']) || !isset($_SESSION['ldap_server']) && !isset($_POST['ldap_server'])) {
-   AuthLdap::ldapChooseDirectory($_SERVER['PHP_SELF']);
+   AuthLDAP::ldapChooseDirectory($_SERVER['PHP_SELF']);
 } else {
    if (isset($_POST["change_ldap_filter"])) {
       if (isset($_POST["ldap_filter"])) {
@@ -66,7 +66,7 @@ if (isset($_GET['next']) || !isset($_SESSION['ldap_server']) && !isset($_POST['l
          }
       }
 
-      if (!AuthLdap::testLDAPConnection($_SESSION["ldap_server"])) {
+      if (!AuthLDAP::testLDAPConnection($_SESSION["ldap_server"])) {
          unset($_SESSION["ldap_server"]);
          echo "<div class='center b'>".__('Unable to connect to the LDAP directory')."<br>";
          echo "<a href='".$_SERVER['PHP_SELF']."?next=listservers'>".__('Back')."</a></div>";
@@ -85,9 +85,9 @@ if (isset($_GET['next']) || !isset($_SESSION['ldap_server']) && !isset($_POST['l
             $_SESSION["ldap_sortorder"] = "ASC";
          }
 
-         AuthLdap::displayLdapFilter($_SERVER['PHP_SELF'], false);
+         AuthLDAP::displayLdapFilter($_SERVER['PHP_SELF'], false);
 
-         AuthLdap::showLdapGroups($_SERVER['PHP_SELF'], $_GET['start'], 0,
+         AuthLDAP::showLdapGroups($_SERVER['PHP_SELF'], $_GET['start'], 0,
                                   $_SESSION["ldap_group_filter"], $_SESSION["ldap_group_filter2"],
                                   $_SESSION["glpiactive_entity"], $_SESSION["ldap_sortorder"]);
       }

--- a/front/ldap.import.php
+++ b/front/ldap.import.php
@@ -37,7 +37,7 @@ if (!defined('GLPI_ROOT')) {
 Session::checkRight("user", User::IMPORTEXTAUTHUSERS);
 
 // Need REQUEST to manage initial walues and posted ones
-AuthLdap::manageValuesInSession($_REQUEST);
+AuthLDAP::manageValuesInSession($_REQUEST);
 
 if (isset($_SESSION['ldap_import']['_in_modal']) && $_SESSION['ldap_import']['_in_modal']) {
    $_REQUEST['_in_modal'] = 1;
@@ -56,14 +56,14 @@ if ($_SESSION['ldap_import']['action'] == 'show') {
    $authldap = new AuthLDAP();
    $authldap->getFromDB($_SESSION['ldap_import']['authldaps_id']);
 
-   AuthLdap::showUserImportForm($authldap);
+   AuthLDAP::showUserImportForm($authldap);
 
    if (isset($_SESSION['ldap_import']['authldaps_id'])
        && ($_SESSION['ldap_import']['authldaps_id'] != NOT_AVAILABLE)
        && (isset($_POST['search']) || isset($_GET['start']) || isset($_POST['glpilist_limit']))) {
 
       echo "<br />";
-      AuthLdap::searchUser($authldap);
+      AuthLDAP::searchUser($authldap);
    }
 }
 

--- a/front/ldap.php
+++ b/front/ldap.php
@@ -40,7 +40,7 @@ if (isset($_SESSION["ldap_sortorder"])) {
    unset($_SESSION["ldap_sortorder"]);
 }
 
-AuthLdap::manageValuesInSession([], true);
+AuthLDAP::manageValuesInSession([], true);
 echo "<div class='center'><table class='tab_cadre'>";
 echo "<tr><th>".__('Bulk import users from a LDAP directory')."</th></tr>";
 

--- a/front/user.form.php
+++ b/front/user.form.php
@@ -99,7 +99,7 @@ if (isset($_GET['getvcard'])) {
    Session::checkRight('user', User::UPDATEAUTHENT);
 
    $user->getFromDB($_POST["id"]);
-   AuthLdap::forceOneUserSynchronization($user);
+   AuthLDAP::forceOneUserSynchronization($user);
    Html::back();
 
 } else if (isset($_POST["update"])) {
@@ -183,7 +183,7 @@ if (isset($_GET['getvcard'])) {
       Session::checkRight("user", User::IMPORTEXTAUTHUSERS);
 
       if (isset($_POST['login']) && !empty($_POST['login'])) {
-         AuthLdap::importUserFromServers(['name' => $_POST['login']]);
+         AuthLDAP::importUserFromServers(['name' => $_POST['login']]);
       }
       Html::back();
    } else if (isset($_POST['add_ext_auth_simple'])) {

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -216,7 +216,7 @@ class Auth extends CommonGLPI {
          return false;
       }
 
-      $this->ldap_connection   = AuthLdap::tryToConnectToServer($ldap_method, $login, $password);
+      $this->ldap_connection   = AuthLDAP::tryToConnectToServer($ldap_method, $login, $password);
       $this->user_deleted_ldap = false;
 
       if ($this->ldap_connection) {
@@ -229,7 +229,7 @@ class Auth extends CommonGLPI {
          if (!empty($ldap_method['sync_field'])) {
             $params['fields']['sync_field'] = $ldap_method['sync_field'];
          }
-         $infos = AuthLdap::searchUserDn($this->ldap_connection,
+         $infos = AuthLDAP::searchUserDn($this->ldap_connection,
                                          ['basedn'            => $ldap_method['basedn'],
                                                'login_field'       => $ldap_method['login_field'],
                                                'search_parameters' => $params,
@@ -655,7 +655,7 @@ class Auth extends CommonGLPI {
                //User has already authenticate, at least once : it's ldap server if filled
                if (isset($this->user->fields["auths_id"])
                    && ($this->user->fields["auths_id"] > 0)) {
-                  $authldap = new AuthLdap();
+                  $authldap = new AuthLDAP();
                   //If ldap server is enabled
                   if ($authldap->getFromDB($this->user->fields["auths_id"])
                       && $authldap->fields['is_active']) {
@@ -669,7 +669,7 @@ class Auth extends CommonGLPI {
 
                $ldapservers_status = false;
                foreach ($ldapservers as $ldap_method) {
-                  $ds = AuthLdap::connectToServer($ldap_method["host"],
+                  $ds = AuthLDAP::connectToServer($ldap_method["host"],
                                                   $ldap_method["port"],
                                                   $ldap_method["rootdn"],
                                                   Toolbox::decrypt($ldap_method["rootdn_passwd"],
@@ -680,13 +680,13 @@ class Auth extends CommonGLPI {
                   if ($ds) {
                      $ldapservers_status = true;
                      $params = [
-                        'method' => AuthLdap::IDENTIFIER_LOGIN,
+                        'method' => AuthLDAP::IDENTIFIER_LOGIN,
                         'fields' => [
-                           AuthLdap::IDENTIFIER_LOGIN => $ldap_method["login_field"],
+                           AuthLDAP::IDENTIFIER_LOGIN => $ldap_method["login_field"],
                         ],
                      ];
                      try {
-                        $user_dn = AuthLdap::searchUserDn($ds, [
+                        $user_dn = AuthLDAP::searchUserDn($ds, [
                            'basedn'            => $ldap_method["basedn"],
                            'login_field'       => $ldap_method['login_field'],
                            'search_parameters' => $params,
@@ -761,7 +761,7 @@ class Auth extends CommonGLPI {
                      || $this->user->fields["authtype"] == $this::LDAP) {
 
                   if (Toolbox::canUseLdap()) {
-                     AuthLdap::tryLdapAuth($this, $login_name, $login_password,
+                     AuthLDAP::tryLdapAuth($this, $login_name, $login_password,
                                              $this->user->fields["auths_id"]);
                      if (!$this->auth_succeded && $this->user_deleted_ldap) {
                         $search_params = [
@@ -993,10 +993,10 @@ class Auth extends CommonGLPI {
 
       switch ($authtype) {
          case self::LDAP :
-            $auth = new AuthLdap();
+            $auth = new AuthLDAP();
             if ($auth->getFromDB($auths_id)) {
                //TRANS: %1$s is the auth method type, %2$s the auth method name or link
-               return sprintf(__('%1$s: %2$s'), AuthLdap::getTypeName(1), $auth->getLink());
+               return sprintf(__('%1$s: %2$s'), AuthLDAP::getTypeName(1), $auth->getLink());
             }
             return sprintf(__('%1$s: %2$s'), __('LDAP directory'), $name);
 
@@ -1004,17 +1004,17 @@ class Auth extends CommonGLPI {
             $auth = new AuthMail();
             if ($auth->getFromDB($auths_id)) {
                //TRANS: %1$s is the auth method type, %2$s the auth method name or link
-               return sprintf(__('%1$s: %2$s'), AuthLdap::getTypeName(1), $auth->getLink());
+               return sprintf(__('%1$s: %2$s'), AuthLDAP::getTypeName(1), $auth->getLink());
             }
             return sprintf(__('%1$s: %2$s'), __('Email server'), $name);
 
          case self::CAS :
             if ($auths_id > 0) {
-               $auth = new AuthLdap();
+               $auth = new AuthLDAP();
                if ($auth->getFromDB($auths_id)) {
                   return sprintf(__('%1$s: %2$s'),
                                  sprintf(__('%1$s + %2$s'),
-                                         __('CAS'), AuthLdap::getTypeName(1)),
+                                         __('CAS'), AuthLDAP::getTypeName(1)),
                                  $auth->getLink());
                }
             }
@@ -1022,12 +1022,12 @@ class Auth extends CommonGLPI {
 
          case self::X509 :
             if ($auths_id > 0) {
-               $auth = new AuthLdap();
+               $auth = new AuthLDAP();
                if ($auth->getFromDB($auths_id)) {
                   return sprintf(__('%1$s: %2$s'),
                                  sprintf(__('%1$s + %2$s'),
                                          __('x509 certificate authentication'),
-                                         AuthLdap::getTypeName(1)),
+                                         AuthLDAP::getTypeName(1)),
                                  $auth->getLink());
                }
             }
@@ -1035,11 +1035,11 @@ class Auth extends CommonGLPI {
 
          case self::EXTERNAL :
             if ($auths_id > 0) {
-               $auth = new AuthLdap();
+               $auth = new AuthLDAP();
                if ($auth->getFromDB($auths_id)) {
                   return sprintf(__('%1$s: %2$s'),
                                  sprintf(__('%1$s + %2$s'),
-                                         __('Other'), AuthLdap::getTypeName(1)),
+                                         __('Other'), AuthLDAP::getTypeName(1)),
                                  $auth->getLink());
                }
             }
@@ -1073,7 +1073,7 @@ class Auth extends CommonGLPI {
          case self::EXTERNAL :
          case self::CAS :
          case self::LDAP :
-            $auth = new AuthLdap();
+            $auth = new AuthLDAP();
             if ($auths_id>0 && $auth->getFromDB($auths_id)) {
                return ($auth->fields);
             }
@@ -1099,7 +1099,7 @@ class Auth extends CommonGLPI {
       global $CFG_GLPI;
 
       //Get all the ldap directories
-      if (AuthLdap::useAuthLdap()) {
+      if (AuthLDAP::useAuthLdap()) {
          return true;
       }
 

--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -283,7 +283,7 @@ class AuthLDAP extends CommonDBTM {
                                         'entities_id'  => $entity,
                                         'is_recursive' => $is_recursive,
                                         'type'         => $input['ldap_import_type'][$id]];
-                  if (AuthLdap::ldapImportGroup($group_dn, $options)) {
+                  if (AuthLDAP::ldapImportGroup($group_dn, $options)) {
                      $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
                   } else {
                      $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
@@ -303,7 +303,7 @@ class AuthLDAP extends CommonDBTM {
                return;
             }
             foreach ($ids as $id) {
-               if (AuthLdap::ldapImportUserByServerId(['method' => AuthLDAP::IDENTIFIER_LOGIN,
+               if (AuthLDAP::ldapImportUserByServerId(['method' => AuthLDAP::IDENTIFIER_LOGIN,
                                                        'value'  => $id],
                                                       $_SESSION['ldap_import']['mode'],
                                                       $_SESSION['ldap_import']['authldaps_id'],
@@ -2359,7 +2359,7 @@ class AuthLDAP extends CommonDBTM {
     * @return array|boolean  with state, else false
     */
    static function forceOneUserSynchronization(User $user, $display = true) {
-      $authldap = new AuthLdap();
+      $authldap = new AuthLDAP();
 
       //Get the LDAP server from which the user has been imported
       if ($authldap->getFromDB($user->fields['auths_id'])) {
@@ -2369,7 +2369,7 @@ class AuthLDAP extends CommonDBTM {
             $user_field = 'sync_field';
             $id_field   = $authldap->fields['sync_field'];
          }
-         return AuthLdap::ldapImportUserByServerId(
+         return AuthLDAP::ldapImportUserByServerId(
             [
                'method'             => self::IDENTIFIER_LOGIN,
                'value'              => $user->fields[$user_field],
@@ -3302,11 +3302,11 @@ class AuthLDAP extends CommonDBTM {
    /**
     * Build LDAP filter
     *
-    * @param AuthLdap $authldap AuthLDAP object
+    * @param AuthLDAP $authldap AuthLDAP object
     *
     * @return string
     */
-   static function buildLdapFilter(AuthLdap $authldap) {
+   static function buildLdapFilter(AuthLDAP $authldap) {
       //Build search filter
       $counter = 0;
       $filter  = '';

--- a/inc/budget.class.php
+++ b/inc/budget.class.php
@@ -660,7 +660,7 @@ class Budget extends CommonDropdown{
          return false;
       }
 
-      $types_iterator = InfoCom::getTypes(
+      $types_iterator = Infocom::getTypes(
          [
             'budgets_id' => $budgets_id
          ] + getEntitiesRestrictCriteria('glpi_infocoms', 'entities_id')

--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -1243,7 +1243,7 @@ abstract class CommonDBRelation extends CommonDBConnexity {
                   $peertype::$dropdown_method($options);
                }
             }
-            // Allow any relation to display its own fields (Networkport_Vlan for tagged ...)
+            // Allow any relation to display its own fields (NetworkPort_Vlan for tagged ...)
             static::showRelationMassiveActionsSubForm($ma, $peer_number);
             echo "<br><br>".Html::submit($specificities['button_labels'][$action],
                                          ['name' => 'massiveaction']);

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -1135,7 +1135,7 @@ class CommonDBTM extends CommonGLPI {
 
                // If itemtype is in infocomtype and if states_id field is filled
                // and item is not a template
-               if (InfoCom::canApplyOn($this)
+               if (Infocom::canApplyOn($this)
                    && isset($this->input['states_id'])
                             && (!isset($this->input['is_template'])
                                 || !$this->input['is_template'])) {
@@ -1433,7 +1433,7 @@ class CommonDBTM extends CommonGLPI {
 
                      // If itemtype is in infocomtype and if states_id field is filled
                      // and item not a template
-                     if (InfoCom::canApplyOn($this)
+                     if (Infocom::canApplyOn($this)
                          && in_array('states_id', $this->updates)
                          && ($this->getField('is_template') != NOT_AVAILABLE)) {
                         //Check if we have to automatical fill dates
@@ -1981,7 +1981,7 @@ class CommonDBTM extends CommonGLPI {
       }
 
       // Can purge an object with Infocom only if can purge Infocom
-      if (InfoCom::canApplyOn($this)) {
+      if (Infocom::canApplyOn($this)) {
          $infocom = new Infocom();
 
          if ($infocom->getFromDBforDevice($this->getType(), $this->fields['id'])) {
@@ -3251,7 +3251,7 @@ class CommonDBTM extends CommonGLPI {
                           'value' => nl2br($this->getField('contact_num'))];
       }
 
-      if (InfoCom::canApplyOn($this)) {
+      if (Infocom::canApplyOn($this)) {
          $infocom = new Infocom();
          if ($infocom->getFromDBforDevice($this->getType(), $this->fields['id'])) {
             $toadd[] = ['name'  => __('Warranty expiration date'),
@@ -3699,7 +3699,7 @@ class CommonDBTM extends CommonGLPI {
       ];
 
       if (Infocom::canApplyOn($this)) {
-         $ic = new InfoCom();
+         $ic = new Infocom();
          if ($ic->getFromDBforDevice($this->getType(), $this->fields['id'])) {
             $excluded[] = 'Infocom:activate';
          }

--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -261,7 +261,7 @@ class CommonGLPI {
       if (($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE)
           && (!$this->isNewItem() || $this->showdebug)
           && (method_exists($class, 'showDebug')
-              || InfoCom::canApplyOn($class)
+              || Infocom::canApplyOn($class)
               || in_array($class, $CFG_GLPI["reservation_types"]))) {
 
             $onglets[-2] = __('Debug');
@@ -1195,7 +1195,7 @@ class CommonGLPI {
          $this->showDebug();
       }
 
-      if (InfoCom::canApplyOn($class)) {
+      if (Infocom::canApplyOn($class)) {
          $infocom = new Infocom();
          if ($infocom->getFromDBforDevice($class, $this->fields['id'])) {
             $infocom->showDebug();

--- a/inc/console/ldap/synchronizeuserscommand.class.php
+++ b/inc/console/ldap/synchronizeuserscommand.class.php
@@ -266,7 +266,7 @@ class SynchronizeUsersCommand extends AbstractCommand {
             ];
             $limitexceeded = false;
 
-            $users = AuthLdap::getAllUsers(
+            $users = AuthLDAP::getAllUsers(
                [
                   'authldaps_id' => $server_id,
                   'mode'         => $action,
@@ -346,7 +346,7 @@ class SynchronizeUsersCommand extends AbstractCommand {
                   $user_sync_field
                );
 
-               if ($existing_user instanceof User && $action == AuthLdap::ACTION_IMPORT) {
+               if ($existing_user instanceof User && $action == AuthLDAP::ACTION_IMPORT) {
                   continue; // Do not update existing user if current action is only import
                }
 
@@ -361,7 +361,7 @@ class SynchronizeUsersCommand extends AbstractCommand {
                   $id_field   = $server->fields['sync_field'];
                }
 
-               $result = AuthLdap::ldapImportUserByServerId(
+               $result = AuthLDAP::ldapImportUserByServerId(
                   [
                      'method'           => AuthLDAP::IDENTIFIER_LOGIN,
                      'value'            => $value,

--- a/inc/console/task/unlockcommand.class.php
+++ b/inc/console/task/unlockcommand.class.php
@@ -111,9 +111,9 @@ class UnlockCommand extends AbstractCommand {
                   . ') AS ' . $this->db->quoteName('task')
                )
             ],
-            'FROM'   => Crontask::getTable(),
+            'FROM'   => CronTask::getTable(),
             'WHERE'  => [
-               'state' => Crontask::STATE_RUNNING,
+               'state' => CronTask::STATE_RUNNING,
                new QueryExpression(
                   'UNIX_TIMESTAMP(' .  $this->db->quoteName('lastrun') . ') + ' . $delay
                   . ' <  UNIX_TIMESTAMP(NOW())'

--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -108,7 +108,7 @@ class CronTask extends CommonDBTM{
 
 
    /**
-    * Read a Crontask by its name
+    * Read a CronTask by its name
     *
     * Used by plugins to load its crontasks
     *
@@ -1703,7 +1703,7 @@ class CronTask extends CommonDBTM{
    static function cronWatcher($task) {
       global $DB;
 
-      // Crontasks running for more than 1 hour or 2 frequency
+      // CronTasks running for more than 1 hour or 2 frequency
       $iterator = $DB->request([
          'FROM'   => self::getTable(),
          'WHERE'  => [
@@ -1721,7 +1721,7 @@ class CronTask extends CommonDBTM{
 
       if (count($crontasks)) {
          $task = new self();
-         $task->getFromDBByCrit(['itemtype' => 'Crontask', 'name' => 'watcher']);
+         $task->getFromDBByCrit(['itemtype' => 'CronTask', 'name' => 'watcher']);
          if (NotificationEvent::raiseEvent("alert", $task, ['items' => $crontasks])) {
             $task->addVolume(1);
          }

--- a/inc/dbconnection.class.php
+++ b/inc/dbconnection.class.php
@@ -382,11 +382,11 @@ class DBConnection extends CommonDBTM {
    /**
     * Cron process to check DB replicate state
     *
-    * @param Crontask $task to log and get param
+    * @param CronTask $task to log and get param
     *
     * @return integer
    **/
-   static function cronCheckDBreplicate(Crontask $task) {
+   static function cronCheckDBreplicate(CronTask $task) {
       global $DB;
 
       //Lauch cron only is :

--- a/inc/define.php
+++ b/inc/define.php
@@ -358,7 +358,7 @@ $CFG_GLPI['itemdevicegraphiccard_types']  = ['Computer'];
 $CFG_GLPI['itemdevicemotherboard_types']  = ['Computer'];
 
 $CFG_GLPI["notificationtemplates_types"]  = ['CartridgeItem', 'Change', 'ConsumableItem',
-                                             'Contract', 'Crontask', 'DBConnection',
+                                             'Contract', 'CronTask', 'DBConnection',
                                              'FieldUnicity', 'Infocom', 'MailCollector',
                                              'ObjectLock', 'PlanningRecall', 'Problem',
                                              'Project', 'ProjectTask', 'Reservation',

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -1660,11 +1660,11 @@ class Document extends CommonDBTM {
    /**
     * Cron for clean orphan documents (without Document_Item)
     *
-    * @param Crontask $task Crontask object
+    * @param CronTask $task CronTask object
     *
     * @return integer (0 : nothing done - 1 : done)
    **/
-   static function cronCleanOrphans(Crontask $task) {
+   static function cronCleanOrphans(CronTask $task) {
       global $DB;
 
       $dtable = static::getTable();

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -2258,7 +2258,7 @@ class Entity extends CommonTreeDropdown {
       }
 
       //If there's a directory marked as default
-      if (AuthLdap::getDefault()) {
+      if (AuthLDAP::getDefault()) {
          return true;
       }
       return false;

--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -135,7 +135,7 @@ class Group extends CommonTreeDropdown {
                if ($item->getField('is_usergroup')
                    && Group::canUpdate()
                    && Session::haveRight("user", User::UPDATEAUTHENT)
-                   && AuthLdap::useAuthLdap()) {
+                   && AuthLDAP::useAuthLdap()) {
                   $ong[3] = __('LDAP directory link');
                }
                return $ong;
@@ -307,7 +307,7 @@ class Group extends CommonTreeDropdown {
       $buttons = [];
       if (Group::canUpdate()
           && Session::haveRight("user", User::UPDATEAUTHENT)
-          && AuthLdap::useAuthLdap()) {
+          && AuthLDAP::useAuthLdap()) {
 
          $buttons["ldap.group.php"] = __('LDAP directory link');
          $title                     = "";
@@ -422,7 +422,7 @@ class Group extends CommonTreeDropdown {
    function rawSearchOptions() {
       $tab = parent::rawSearchOptions();
 
-      if (AuthLdap::useAuthLdap()) {
+      if (AuthLDAP::useAuthLdap()) {
          $tab[] = [
             'id'                 => '3',
             'table'              => $this->getTable(),
@@ -564,7 +564,7 @@ class Group extends CommonTreeDropdown {
 
       if (Group::canUpdate()
           && Session::haveRight("user", User::UPDATEAUTHENT)
-          && AuthLdap::useAuthLdap()) {
+          && AuthLDAP::useAuthLdap()) {
          echo "<tr class='tab_bg_1'>";
          echo "<th colspan='2' class='center'>".__('In users')."</th></tr>";
 

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1457,7 +1457,7 @@ JAVASCRIPT;
 
       $menu['config']['title']       = __('Setup');
       $menu['config']['types']       = ['CommonDropdown', 'CommonDevice', 'Notification',
-                                        'SLM', 'Config', 'FieldUnicity', 'Crontask', 'Auth',
+                                        'SLM', 'Config', 'FieldUnicity', 'CronTask', 'Auth',
                                         'MailCollector', 'Link', 'Plugin'];
 
       // Special items

--- a/inc/item_devices.class.php
+++ b/inc/item_devices.class.php
@@ -125,7 +125,7 @@ class Item_Devices extends CommonDBRelation {
       $forbidden = parent::getForbiddenStandardMassiveAction();
 
       if ((count(static::getSpecificities()) == 0)
-          && !InfoCom::canApplyOn($this)) {
+          && !Infocom::canApplyOn($this)) {
          $forbidden[] = 'update';
       }
 

--- a/inc/levelagreementlevel.class.php
+++ b/inc/levelagreementlevel.class.php
@@ -98,9 +98,9 @@ abstract class LevelAgreementLevel extends RuleTicket {
 
       $tab[] = [
          'id'                 => '3',
-         'table'              => Sla::getTable(),
+         'table'              => SLA::getTable(),
          'field'              => 'name',
-         'name'               => Sla::getTypeName(),
+         'name'               => SLA::getTypeName(),
          'datatype'           => 'itemlink',
          'massiveaction'      => false
       ];

--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -537,7 +537,7 @@ class MassiveAction {
       } else {
          if (Session::getCurrentInterface() == 'central'
              && ($canupdate
-                 || (InfoCom::canApplyOn($itemtype)
+                 || (Infocom::canApplyOn($itemtype)
                      && Infocom::canUpdate()))) {
 
             //TRANS: select action 'update' (before doing it)
@@ -682,7 +682,7 @@ class MassiveAction {
                   $show_infocoms               = true;
                   $itemtable                   = getTableForItemType($itemtype);
 
-                  if (InfoCom::canApplyOn($itemtype)
+                  if (Infocom::canApplyOn($itemtype)
                       && (!$itemtype::canUpdate()
                           || !Infocom::canUpdate())) {
                      $show_all      = false;
@@ -855,7 +855,7 @@ class MassiveAction {
                   continue;
                }
 
-               if (InfoCom::canApplyOn($itemtype)) {
+               if (Infocom::canApplyOn($itemtype)) {
                   Session::checkSeveralRightsOr([$itemtype  => UPDATE,
                                                       "infocom"  => UPDATE]);
                } else {

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -576,7 +576,7 @@ class NetworkPort extends CommonDBChild {
          $porttypes = ['NetworkPortAlias', 'NetworkPortAggregate'];
       } else {
          $porttypes = self::getNetworkPortInstantiations();
-         // Manage NetworkportMigration
+         // Manage NetworkPortMigration
          $porttypes[] = '';
       }
       $display_options = self::getDisplayOptions($itemtype);
@@ -750,7 +750,7 @@ class NetworkPort extends CommonDBChild {
                   if (!empty($portType)) {
                      $content .= "<a href=\"" . NetworkPort::getFormURLWithID($netport->fields["id"]) ."\">";
                   } else {
-                     $content .= "<a href=\"" . NetworkportMigration::getFormURLWithID($netport->fields["id"]) ."\">";
+                     $content .= "<a href=\"" . NetworkPortMigration::getFormURLWithID($netport->fields["id"]) ."\">";
                   }
                }
                $content .= $netport->fields["logical_number"];

--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -223,7 +223,7 @@ class Notification extends CommonDBTM {
       } else {
          $rand = Dropdown::showItemTypes('itemtype',
                                          array_diff($CFG_GLPI["notificationtemplates_types"],
-                                                    ['Crontask', 'DBConnection', 'User']),
+                                                    ['CronTask', 'DBConnection', 'User']),
                                          ['value' => $this->fields['itemtype']]);
       }
 
@@ -435,7 +435,7 @@ class Notification extends CommonDBTM {
 
    function canViewItem() {
 
-      if ((($this->fields['itemtype'] == 'Crontask')
+      if ((($this->fields['itemtype'] == 'CronTask')
            || ($this->fields['itemtype'] == 'DBConnection'))
           && !Config::canView()) {
           return false;
@@ -451,7 +451,7 @@ class Notification extends CommonDBTM {
    **/
    function canCreateItem() {
 
-      if ((($this->fields['itemtype'] == 'Crontask')
+      if ((($this->fields['itemtype'] == 'CronTask')
            || ($this->fields['itemtype'] == 'DBConnection'))
           && !Config::canUpdate()) {
           return false;

--- a/inc/notificationtargetcrontask.class.php
+++ b/inc/notificationtargetcrontask.class.php
@@ -51,7 +51,7 @@ class NotificationTargetCrontask extends NotificationTarget {
       $events                             = $this->getAllEvents();
       $this->data['##crontask.action##'] = $events[$event];
 
-      $cron                               = new Crontask();
+      $cron                               = new CronTask();
       foreach ($options['items'] as $id => $crontask) {
          $tmp                      = [];
          $tmp['##crontask.name##'] = '';
@@ -63,7 +63,7 @@ class NotificationTargetCrontask extends NotificationTarget {
          $tmp['##crontask.name##']       .= $crontask['name'];
          $tmp['##crontask.description##'] = $cron->getDescription($id);
          $tmp['##crontask.url##']         = $this->formatURL($options['additionnaloption']['usertype'],
-                                                             "Crontask_".$id);
+                                                             "CronTask_".$id);
          $this->data['crontasks'][] = $tmp;
       }
 

--- a/inc/notificationtemplatetranslation.class.php
+++ b/inc/notificationtemplatetranslation.class.php
@@ -453,7 +453,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
       echo "<table class='tab_cadre_fixe'>";
       echo "<tr><th colspan='2'>".__('Preview')."</th></tr>";
 
-      $oktypes = ['CartridgeItem', 'Change', 'ConsumableItem', 'Contract', 'Crontask',
+      $oktypes = ['CartridgeItem', 'Change', 'ConsumableItem', 'Contract', 'CronTask',
                        'Problem', 'Project', 'Ticket', 'User'];
 
       if (!in_array($itemtype, $oktypes)) {

--- a/inc/planningrecall.class.php
+++ b/inc/planningrecall.class.php
@@ -74,7 +74,7 @@ class PlanningRecall extends CommonDBChild {
 
       $_SESSION['glpiplanningreminder_isavailable'] = 0;
       if ($CFG_GLPI["use_notifications"]) {
-         $task = new Crontask();
+         $task = new CronTask();
          if ($task->getFromDBbyName('PlanningRecall', 'planningrecall')) {
             // Only disabled by config
             if ($task->isDisabled() != 1) {

--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -1293,7 +1293,7 @@ class SavedSearch extends CommonDBTM {
    /**
     * Update all bookmarks execution time
     *
-    * @param Crontask $task Crontask instance
+    * @param CronTask $task CronTask instance
     *
     * @return void
    **/

--- a/inc/savedsearch_alert.class.php
+++ b/inc/savedsearch_alert.class.php
@@ -338,7 +338,7 @@ class SavedSearch_Alert extends CommonDBChild {
    /**
     * Send saved searches alerts
     *
-    * @param Crontask $task Crontask instance
+    * @param CronTask $task CronTask instance
     *
     * @return int : <0 : need to run again, 0:nothing to do, >0:ok
     */

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1587,7 +1587,7 @@ class Search {
          // Form to massive actions
          $isadmin = ($data['item'] && $data['item']->canUpdate());
          if (!$isadmin
-               && InfoCom::canApplyOn($data['itemtype'])) {
+               && Infocom::canApplyOn($data['itemtype'])) {
             $isadmin = (Infocom::canUpdate() || Infocom::canCreate());
          }
          if ($data['itemtype'] != 'AllAssets') {
@@ -3735,7 +3735,7 @@ JAVASCRIPT;
 
          case 'Notification' :
             if (!Config::canView()) {
-               $condition = " `glpi_notifications`.`itemtype` NOT IN ('Crontask', 'DBConnection') ";
+               $condition = " `glpi_notifications`.`itemtype` NOT IN ('CronTask', 'DBConnection') ";
             }
             break;
 
@@ -6582,7 +6582,7 @@ JAVASCRIPT;
       $todel   = [];
 
       if (!Session::haveRight('infocom', $action)
-          && InfoCom::canApplyOn($itemtype)) {
+          && Infocom::canApplyOn($itemtype)) {
          $itemstodel = Infocom::getSearchOptionsToAdd($itemtype);
          $todel      = array_merge($todel, array_keys($itemstodel));
       }
@@ -6830,7 +6830,7 @@ JAVASCRIPT;
             self::$search[$itemtype] += Document::getSearchOptionsToAdd();
          }
 
-         if (InfoCom::canApplyOn($itemtype)
+         if (Infocom::canApplyOn($itemtype)
              || ($itemtype == 'AllAssets')) {
             self::$search[$itemtype] += Infocom::getSearchOptionsToAdd($itemtype);
          }
@@ -6898,7 +6898,7 @@ JAVASCRIPT;
     * @return boolean
    **/
    static function isInfocomOption($itemtype, $searchID) {
-      if (!InfoCom::canApplyOn($itemtype)) {
+      if (!Infocom::canApplyOn($itemtype)) {
          return false;
       }
 

--- a/inc/slm.class.php
+++ b/inc/slm.class.php
@@ -84,8 +84,8 @@ class SLM extends CommonDBTM {
 
       $this->deleteChildrenAndRelationsFromDb(
          [
-            Sla::class,
-            Ola::class,
+            SLA::class,
+            OLA::class,
          ]
       );
    }
@@ -184,7 +184,7 @@ class SLM extends CommonDBTM {
          $menu['page']            = static::getSearchURL(false);
          $menu['links']['search'] = static::getSearchURL(false);
          if (static::canCreate()) {
-            $menu['links']['add'] = Slm::getFormURL(false);
+            $menu['links']['add'] = SLM::getFormURL(false);
          }
 
          $menu['options']['sla']['title']           = SLA::getTypeName(1);

--- a/inc/supplier.class.php
+++ b/inc/supplier.class.php
@@ -466,7 +466,7 @@ class Supplier extends CommonDBTM {
          return false;
       }
 
-      $types_iterator = InfoCom::getTypes(['suppliers_id' => $instID]);
+      $types_iterator = Infocom::getTypes(['suppliers_id' => $instID]);
       $number = count($types_iterator);
 
       echo "<div class='spaced'><table class='tab_cadre_fixe'>";

--- a/inc/telemetry.class.php
+++ b/inc/telemetry.class.php
@@ -268,7 +268,7 @@ class Telemetry extends CommonGLPI {
    /**
     * Send telemetry informations
     *
-    * @param Crontask $task Crontask instance
+    * @param CronTask $task CronTask instance
     *
     * @return void
     */

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -6515,11 +6515,11 @@ class Ticket extends CommonITILObject {
    /**
     * Cron for ticket's automatic purge
     *
-    * @param Crontask $task Crontask object
+    * @param CronTask $task CronTask object
     *
     * @return integer (0 : nothing done - 1 : done)
    **/
-   static function cronPurgeTicket(Crontask $task) {
+   static function cronPurgeTicket(CronTask $task) {
       global $DB;
 
       $ticket = new self();

--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -1079,7 +1079,7 @@ class Transfer extends CommonDBTM {
             $this->transferTickets($itemtype, $ID, $newID);
             // Infocoms : keep / delete
 
-            if (InfoCom::canApplyOn($itemtype)) {
+            if (Infocom::canApplyOn($itemtype)) {
                $this->transferInfocoms($itemtype, $ID, $newID);
             }
 

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -1125,7 +1125,7 @@ class User extends CommonDBTM {
                }
 
                //get picture content in ldap
-               $info = AuthLdap::getUserByDn($ds, $this->fields['user_dn'],
+               $info = AuthLDAP::getUserByDn($ds, $this->fields['user_dn'],
                                              [$picture_field], false);
 
                //getUserByDn returns an array. If the picture is empty,
@@ -1945,7 +1945,7 @@ class User extends CommonDBTM {
       }
       if (Session::haveRight("user", self::IMPORTEXTAUTHUSERS)
          && (static::canCreate() || static::canUpdate())) {
-         if (AuthLdap::useAuthLdap()) {
+         if (AuthLDAP::useAuthLdap()) {
             $buttons["ldap.php"] = __('LDAP directory link');
          }
       }
@@ -2927,7 +2927,7 @@ JAVASCRIPT;
                if ($item->can($id, UPDATE)) {
                   if (($item->fields["authtype"] == Auth::LDAP)
                       || ($item->fields["authtype"] == Auth::EXTERNAL)) {
-                     if (AuthLdap::forceOneUserSynchronization($item, false)) {
+                     if (AuthLDAP::forceOneUserSynchronization($item, false)) {
                         $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
                      } else {
                         $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
@@ -4372,16 +4372,16 @@ JAVASCRIPT;
       } else {
          if ($CFG_GLPI["is_users_auto_add"]) {
             //Get all ldap servers with email field configured
-            $ldaps = AuthLdap::getServersWithImportByEmailActive();
+            $ldaps = AuthLDAP::getServersWithImportByEmailActive();
             //Try to find the user by his email on each ldap server
 
             foreach ($ldaps as $ldap) {
                $params = [
-                  'method' => AuthLdap::IDENTIFIER_EMAIL,
+                  'method' => AuthLDAP::IDENTIFIER_EMAIL,
                   'value'  => $email,
                ];
-               $res = AuthLdap::ldapImportUserByServerId($params,
-                                                         AuthLdap::ACTION_IMPORT,
+               $res = AuthLDAP::ldapImportUserByServerId($params,
+                                                         AuthLDAP::ACTION_IMPORT,
                                                          $ldap);
 
                if (isset($res['id'])) {
@@ -4796,7 +4796,7 @@ JAVASCRIPT;
          }
 
          if ($ds) {
-            $info = AuthLdap::getUserByDn($ds, $this->fields['user_dn'],
+            $info = AuthLDAP::getUserByDn($ds, $this->fields['user_dn'],
                                           ['*', 'createTimeStamp', 'modifyTimestamp']);
             if (is_array($info)) {
                Html::printCleanArray($info);

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -347,7 +347,7 @@ $tables['glpi_crontasks'] = [
       'logs_lifetime' => 30,
    ], [
       'id'            => 6,
-      'itemtype'      => 'InfoCom',
+      'itemtype'      => 'Infocom',
       'name'          => 'infocom',
       'frequency'     => '86400',
       'param'         => null,
@@ -1266,7 +1266,7 @@ $tables['glpi_displaypreferences'] = [
       'num'      => '18',
       'rank'     => '8',
    ], [
-      'itemtype' => 'AuthLdap',
+      'itemtype' => 'AuthLDAP',
       'num'      => '30',
       'rank'     => '3',
    ], [
@@ -2348,7 +2348,7 @@ $tables['glpi_notifications'] = [
       'is_active'    => 1,
    ], [
       'id'           => 28,
-      'name'         => 'Crontask Watcher',
+      'name'         => 'CronTask Watcher',
       'itemtype'     => 'CronTask',
       'event'        => 'alert',
       'is_recursive' => 1,

--- a/install/update_0831_084.php
+++ b/install/update_0831_084.php
@@ -1608,7 +1608,7 @@ function createNetworkNameFromItem($itemtype, $items_id, $main_items_id, $main_i
 
    // Using gethostbyaddr() allows us to define its reald internet name according to its IP.
    //   But each gethostbyaddr() may reach several milliseconds. With very large number of
-   //   Networkports or NetworkeEquipment, the migration may take several minutes or hours ...
+   //   NetworkPorts or NetworkeEquipment, the migration may take several minutes or hours ...
    //$computerName = gethostbyaddr($IP);
    $computerName = $IP;
    if ($computerName != $IP) {

--- a/install/update_0905_91.php
+++ b/install/update_0905_91.php
@@ -304,7 +304,7 @@ function update0905to91() {
    Config::setConfigurationValues('core', ['set_default_requester' => 1]);
    $migration->addField("glpi_users", "set_default_requester", "tinyint(1) NULL DEFAULT NULL");
 
-   // ************ Networkport ethernets **************
+   // ************ NetworkPort ethernets **************
    if (!$DB->tableExists("glpi_networkportfiberchannels")) {
       $query = "CREATE TABLE `glpi_networkportfiberchannels` (
                   `id` int(11) NOT NULL AUTO_INCREMENT,

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -916,6 +916,17 @@ function update94to95() {
    }
    /** /Add glpi_vobjects table for CalDAV server */
 
+   /** Fix mixed classes case in DB */
+   $mixed_case_classes = [
+      'AuthLdap' => 'AuthLDAP',
+      'Crontask' => 'CronTask',
+      'InfoCom'  => 'Infocom',
+   ];
+   foreach ($mixed_case_classes as $bad_case_classname => $classname) {
+      $migration->renameItemtype($bad_case_classname, $classname, false);
+   }
+   /** /Fix mixed classes case in DB */
+
    // ************ Keep it at the end **************
    foreach ($ADDTODISPLAYPREF as $type => $tab) {
       $rank = 1;

--- a/scripts/ldap_mass_sync.php
+++ b/scripts/ldap_mass_sync.php
@@ -150,9 +150,9 @@ function import(array $options) {
    foreach ($actions_to_do as $action_to_do) {
       $options['mode']         = $action_to_do;
       $options['authldaps_id'] = $options['ldapservers_id'];
-      $authldap = new \AuthLdap();
+      $authldap = new \AuthLDAP();
       $authldap->getFromDB($options['authldaps_id']);
-      $users                   = AuthLdap::getAllUsers($options, $results, $limitexceeded);
+      $users                   = AuthLDAP::getAllUsers($options, $results, $limitexceeded);
       $contact_ok              = true;
 
       if (is_array($users)) {
@@ -171,7 +171,7 @@ function import(array $options) {
                $user_sync_field
             );
 
-            if ($dbuser && $action_to_do == AuthLdap::ACTION_IMPORT) {
+            if ($dbuser && $action_to_do == AuthLDAP::ACTION_IMPORT) {
                continue;
             }
 
@@ -184,7 +184,7 @@ function import(array $options) {
                $id_field   = $authldap->fields['sync_field'];
             }
 
-            $result = AuthLdap::ldapImportUserByServerId(
+            $result = AuthLDAP::ldapImportUserByServerId(
                [
                   'method'             => AuthLDAP::IDENTIFIER_LOGIN,
                   'value'              => $value,

--- a/tests/APIBaseClass.php
+++ b/tests/APIBaseClass.php
@@ -1203,7 +1203,7 @@ abstract class APIBaseClass extends \atoum {
       $this->object($computer)->isInstanceOf('\Computer');
       $deviceSimcard = getItemByTypeName('DeviceSimcard', '_test_simcard_1');
       $this->integer((int) $deviceSimcard->getID())->isGreaterThan(0);
-      $this->object($deviceSimcard)->isInstanceOf('\Devicesimcard');
+      $this->object($deviceSimcard)->isInstanceOf('\DeviceSimcard');
       $input = [
             'itemtype'           => 'Computer',
             'items_id'           => $computer->getID(),

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -184,7 +184,7 @@ class AuthLDAP extends DbTestCase {
       $this->array($users)->hasSize(1);
       $this->array($results)->hasSize(0);
 
-      $import = \AuthLdap::ldapImportUserByServerId(
+      $import = \AuthLDAP::ldapImportUserByServerId(
          [
             'method' => \AuthLDAP::IDENTIFIER_LOGIN,
             'value'  => 'ecuador0'
@@ -342,7 +342,7 @@ class AuthLDAP extends DbTestCase {
       $group = new \Group();
       $this->boolean($group->getFromDB($import))->isTrue();
 
-      $import = \AuthLdap::ldapImportUserByServerId(
+      $import = \AuthLDAP::ldapImportUserByServerId(
          [
             'method' => \AuthLDAP::IDENTIFIER_LOGIN,
             'value'  => 'remi'
@@ -377,7 +377,7 @@ class AuthLDAP extends DbTestCase {
       $ldap = $this->ldap;
       $this->boolean($ldap->isSyncFieldEnabled())->isFalse();
 
-      $import = \AuthLdap::ldapImportUserByServerId(
+      $import = \AuthLDAP::ldapImportUserByServerId(
          [
             'method' => \AuthLDAP::IDENTIFIER_LOGIN,
             'value'  => 'ecuador0'
@@ -535,7 +535,7 @@ class AuthLDAP extends DbTestCase {
       $this->boolean($ldap->isSyncFieldEnabled())->isTrue();
 
       //try to import an user from its sync_field
-      $import = \AuthLdap::ldapImportUserByServerId(
+      $import = \AuthLDAP::ldapImportUserByServerId(
          [
             'method' => \AuthLDAP::IDENTIFIER_LOGIN,
             'value'  => '10'
@@ -761,7 +761,7 @@ class AuthLDAP extends DbTestCase {
       )->isTrue();
 
       //import the user
-      $import = \AuthLdap::ldapImportUserByServerId(
+      $import = \AuthLDAP::ldapImportUserByServerId(
          [
             'method' => \AuthLDAP::IDENTIFIER_LOGIN,
             'value'  => 'toremovetest'
@@ -939,7 +939,7 @@ class AuthLDAP extends DbTestCase {
          )
       )->isTrue(ldap_error($ldap_con));
 
-      $import = \AuthLdap::ldapImportUserByServerId(
+      $import = \AuthLDAP::ldapImportUserByServerId(
          [
             'method' => \AuthLDAP::IDENTIFIER_LOGIN,
             'value'  => 'verylongdn'
@@ -1039,7 +1039,7 @@ class AuthLDAP extends DbTestCase {
          )
       )->isTrue(ldap_error($ldap_con));
 
-      $import = \AuthLdap::ldapImportUserByServerId(
+      $import = \AuthLDAP::ldapImportUserByServerId(
          [
             'method' => \AuthLDAP::IDENTIFIER_LOGIN,
             'value'  => 'Тестов Тест Тестович'

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -473,7 +473,7 @@ function loadDataset() {
             'entities_id'  => '_test_root_entity',
             'is_recursive' => 1
          ]
-      ], 'AuthLdap' => [
+      ], 'AuthLDAP' => [
          [
             'name'            => '_local_ldap',
             'host'            => 'openldap',
@@ -494,7 +494,7 @@ function loadDataset() {
             'title_field'     => 'title',
             'category_field'  => 'businesscategory',
             'language_field'  => 'preferredlanguage',
-            'group_search_type'  => \AuthLdap::GROUP_SEARCH_GROUP,
+            'group_search_type'  => \AuthLDAP::GROUP_SEARCH_GROUP,
             'group_condition' => '(objectclass=groupOfNames)',
             'group_member_field' => 'member'
          ]

--- a/tests/functionnal/AuthLdapReplicate.php
+++ b/tests/functionnal/AuthLdapReplicate.php
@@ -36,7 +36,7 @@ use \DbTestCase;
 
 /* Test for inc/authldapreplicate.class.php */
 
-class AuthLDAPReplicate extends DbTestCase {
+class AuthLdapReplicate extends DbTestCase {
 
    public function testCanCreate() {
       $this->login();

--- a/tests/functionnal/Cartridge.php
+++ b/tests/functionnal/Cartridge.php
@@ -47,7 +47,7 @@ class Cartridge extends DbTestCase {
       $this->integer((int)$pid)->isGreaterThan(0);
       $this->boolean($printer->getFromDB($pid))->isTrue();
 
-      $ctype = new \CartridgeItemtype();
+      $ctype = new \CartridgeItemType();
       $tid = $ctype->add([
          'name'         => 'Test cartridge type',
       ]);

--- a/tests/functionnal/DeviceSimcard.php
+++ b/tests/functionnal/DeviceSimcard.php
@@ -34,7 +34,7 @@ namespace tests\units;
 
 use DbTestCase;
 
-class Devicesimcard extends DbTestCase {
+class DeviceSimcard extends DbTestCase {
    private $method;
 
    public function beforeTestMethod($method) {

--- a/tests/functionnal/Dropdown.php
+++ b/tests/functionnal/Dropdown.php
@@ -986,7 +986,7 @@ class Dropdown extends DbTestCase {
                      'text'   => '-----',
                   ],
                   1 => [
-                     'id'     => (int)getItemByTypeName('user', '_test_user', true),
+                     'id'     => (int)getItemByTypeName('User', '_test_user', true),
                      'text'   => '_test_user',
                      'title'  => '_test_user - _test_user',
                   ],

--- a/tests/functionnal/Item_DeviceSimcard.php
+++ b/tests/functionnal/Item_DeviceSimcard.php
@@ -69,8 +69,8 @@ class Item_DeviceSimcard extends DbTestCase {
       // Add
       $computer = getItemByTypeName('Computer', '_test_pc01');
       $this->object($computer)->isInstanceOf('\Computer');
-      $deviceSimcard = getItemForItemtype('Devicesimcard', '_test_simcard_1');
-      $this->object($deviceSimcard)->isInstanceOf('\Devicesimcard');
+      $deviceSimcard = getItemForItemtype('DeviceSimcard', '_test_simcard_1');
+      $this->object($deviceSimcard)->isInstanceOf('\DeviceSimcard');
       $id = $obj->add([
             'itemtype'           => 'Computer',
             'items_id'           => $computer->getID(),
@@ -124,8 +124,8 @@ class Item_DeviceSimcard extends DbTestCase {
       // Add
       $computer = getItemByTypeName('Computer', '_test_pc01');
       $this->object($computer)->isInstanceOf('\Computer');
-      $deviceSimcard = getItemForItemtype('Devicesimcard', '_test_simcard_1');
-      $this->object($deviceSimcard)->isInstanceOf('\Devicesimcard');
+      $deviceSimcard = getItemForItemtype('DeviceSimcard', '_test_simcard_1');
+      $this->object($deviceSimcard)->isInstanceOf('\DeviceSimcard');
       $id = $obj->add([
             'itemtype'           => 'Computer',
             'items_id'           => $computer->getID(),
@@ -165,8 +165,8 @@ class Item_DeviceSimcard extends DbTestCase {
       // Add
       $computer = getItemByTypeName('Computer', '_test_pc01');
       $this->object($computer)->isInstanceOf('\Computer');
-      $deviceSimcard = getItemForItemtype('Devicesimcard', '_test_simcard_1');
-      $this->object($deviceSimcard)->isInstanceOf('\Devicesimcard');
+      $deviceSimcard = getItemForItemtype('DeviceSimcard', '_test_simcard_1');
+      $this->object($deviceSimcard)->isInstanceOf('\DeviceSimcard');
       $id = $obj->add([
             'itemtype'           => 'Computer',
             'items_id'           => $computer->getID(),

--- a/tests/functionnal/NetworkPort.php
+++ b/tests/functionnal/NetworkPort.php
@@ -36,7 +36,7 @@ use \DbTestCase;
 
 /* Test for inc/networkport.class.php */
 
-class Networkport extends DbTestCase {
+class NetworkPort extends DbTestCase {
 
    public function testAddSimpleNetworkPort() {
       $this->login();

--- a/tests/functionnal/SLM.php
+++ b/tests/functionnal/SLM.php
@@ -34,7 +34,7 @@ namespace tests\units;
 
 use DbTestCase;
 
-class Slm extends DbTestCase {
+class SLM extends DbTestCase {
    private $method;
 
    public function beforeTestMethod($method) {
@@ -93,14 +93,14 @@ class Slm extends DbTestCase {
       $sla2_in['name'] = "SLA TTR";
 
       // add two sla (TTO & TTR)
-      $sla    = new \Sla();
+      $sla    = new \SLA();
       $sla1_id = $sla->add($sla1_in);
       $this->checkInput($sla, $sla1_id, $sla1_in);
       $sla2_id = $sla->add($sla2_in);
       $this->checkInput($sla, $sla2_id, $sla2_in);
 
       // add two ola (TTO & TTR), we re-use the same inputs as sla
-      $ola  = new \Ola();
+      $ola  = new \OLA();
       $sla1_in['name'] = str_replace("SLA", "OLA", $sla1_in['name']);
       $sla2_in['name'] = str_replace("SLA", "OLA", $sla2_in['name']);
       $ola1_id = $ola->add($sla1_in);
@@ -306,7 +306,7 @@ class Slm extends DbTestCase {
       );
       $this->integer($slm_id)->isGreaterThan(0);
 
-      $ola = new \Ola();
+      $ola = new \OLA();
       $ola_id = $ola->add(
          [
             'slms_id'         => $slm_id,

--- a/tests/units/Html.php
+++ b/tests/units/Html.php
@@ -397,7 +397,7 @@ class Html extends \GLPITestCase {
          'SLM',
          'Config',
          'FieldUnicity',
-         'Crontask',
+         'CronTask',
          'Auth',
          'MailCollector',
          'Link',

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -721,6 +721,7 @@ class Migration extends \GLPITestCase {
          return [];
       };
 
+      // Test renaming with DB structure update
       $this->output(
          function () {
             $this->migration->renameItemtype('SomeOldType', 'NewName');
@@ -746,6 +747,32 @@ class Migration extends \GLPITestCase {
          "ALTER TABLE `glpi_oneitem_with_fkey` CHANGE `someoldtypes_id` `newnames_id` INT(11) NOT NULL DEFAULT '0'   ",
          "ALTER TABLE `glpi_anotheritem_with_fkey` CHANGE `someoldtypes_id` `newnames_id` INT(11) NOT NULL DEFAULT '0'   ,\n"
          . "CHANGE `someoldtypes_id_tech` `newnames_id_tech` INT(11) NOT NULL DEFAULT '0'   ",
+         "UPDATE `glpi_computers` SET `itemtype` = 'NewName' WHERE `itemtype` = 'SomeOldType'",
+         "UPDATE `glpi_users` SET `itemtype` = 'NewName' WHERE `itemtype` = 'SomeOldType'",
+         "UPDATE `glpi_stuffs` SET `itemtype_source` = 'NewName' WHERE `itemtype_source` = 'SomeOldType'",
+         "UPDATE `glpi_stuffs` SET `itemtype_dest` = 'NewName' WHERE `itemtype_dest` = 'SomeOldType'",
+      ]);
+
+      // Test renaming without DB structure update
+      $this->queries = [];
+
+      $this->output(
+         function () {
+            $this->migration->renameItemtype('SomeOldType', 'NewName', false);
+            $this->migration->executeMigration();
+         }
+      )->isIdenticalTo(
+         implode(
+            '',
+            [
+               '============================ Rename "SomeOldType" itemtype to "NewName" ============================' . "\n",
+               'Rename "SomeOldType" itemtype to "NewName" in all tables',
+               'Task completed.',
+            ]
+         )
+      );
+
+      $this->array($this->queries)->isIdenticalTo([
          "UPDATE `glpi_computers` SET `itemtype` = 'NewName' WHERE `itemtype` = 'SomeOldType'",
          "UPDATE `glpi_users` SET `itemtype` = 'NewName' WHERE `itemtype` = 'SomeOldType'",
          "UPDATE `glpi_stuffs` SET `itemtype_source` = 'NewName' WHERE `itemtype_source` = 'SomeOldType'",

--- a/tools/generate_bigdump.function.php
+++ b/tools/generate_bigdump.function.php
@@ -245,7 +245,7 @@ function addNetworkEthernetPort($itemtype, $items_id, $entities_id, $locations_i
    }
    if ($locations_id && $refportID && $newportID) {
       // link ports
-      $nn = new Networkport_Networkport();
+      $nn = new NetworkPort_NetworkPort();
       $nn->add([
          'networkports_id_1' => $refportID,
          'networkports_id_2' => $newportID,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Some classes are used with wrong case. Not a problem for now but it can be a problem if we plan to migrate to PSR-4 autoloading. Indeed, in PSR-4, files naming is case sensitive regarding to classname.

I added a migration on some classes as they were using in previous migrations with a wrong form.