### PR TITLE
fix warning with objects in session

### DIFF
--- a/inc/abstractquery.class.php
+++ b/inc/abstractquery.class.php
@@ -65,4 +65,8 @@ abstract class AbstractQuery {
     * @return string
     */
    abstract public function getQuery();
+
+   public function __toString() {
+      return $this->getQuery();
+   }
 }

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3925,7 +3925,7 @@ JAVASCRIPT;
                   }
                } else {
                   if (is_object($val)) {
-                     print_r($val);
+                     echo (string) $val; // It is expected that the object implements __toString()
                   } else {
                      echo htmlentities($val);
                   }

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3925,7 +3925,11 @@ JAVASCRIPT;
                   }
                } else {
                   if (is_object($val)) {
-                     echo (string) $val; // It is expected that the object implements __toString()
+                     if (method_exists($val, '__toString')) {
+                        echo (string) $val;
+                     } else {
+                        echo "(object) " . get_class($val);
+                     }
                   } else {
                      echo htmlentities($val);
                   }

--- a/inc/queryexpression.class.php
+++ b/inc/queryexpression.class.php
@@ -60,4 +60,9 @@ class QueryExpression {
    public function getValue() {
       return $this->expression;
    }
+
+
+   public function __toString() {
+      return $this->getValue();
+   }
 }

--- a/inc/queryparam.class.php
+++ b/inc/queryparam.class.php
@@ -63,4 +63,9 @@ class QueryParam  {
    public function getValue() {
       return $this->value;
    }
+
+
+   public function __toString() {
+      return $this->getValue();
+   }
 }

--- a/inc/querysubquery.class.php
+++ b/inc/querysubquery.class.php
@@ -74,8 +74,4 @@ class QuerySubQuery extends AbstractQuery {
       }
       return $sql;
    }
-
-   public function __toString() {
-      return $this->getQuery();
-   }
 }

--- a/inc/querysubquery.class.php
+++ b/inc/querysubquery.class.php
@@ -74,4 +74,8 @@ class QuerySubQuery extends AbstractQuery {
       }
       return $sql;
    }
+
+   public function __toString() {
+      return $this->getQuery();
+   }
 }


### PR DESCRIPTION
A proposal to fix warnings in debug mode when QuerySubQuery objects are added in $_SESSION['glpicondition']

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6546
