### PR TITLE
Improve install script

### DIFF
--- a/tests/units/DB.php
+++ b/tests/units/DB.php
@@ -317,4 +317,50 @@ class DB extends \GLPITestCase {
             ->string($this->testedInstance->escape("First\rSecond"))->isIdenticalTo("First\\rSecond")
             ->string($this->testedInstance->escape('Hi, "you"'))->isIdenticalTo('Hi, \\"you\\"');
    }
+
+   protected function commentsProvider() {
+      return [
+         [
+            'sql' => "SQL EXPRESSION;
+/* Here begins a
+   multiline comment */
+OTHER EXPRESSION;
+",
+            'expected'  => "SQL EXPRESSION;
+OTHER EXPRESSION;"
+         ]
+      ];
+   }
+
+   /**
+    * @dataProvider commentsProvider
+    */
+   public function testRemoveSqlComments($sql, $expected) {
+      $this
+         ->if($this->newTestedInstance)
+         ->then
+            ->string($this->testedInstance->removeSqlComments($sql))->isIdenticalTo($expected);
+   }
+
+   /**
+    * Sql expressions provider
+    */
+   protected function sqlProvider () {
+      return array_merge([
+         [
+            'sql'       => "SQL;\n-- comment;\n\nSQL2;",
+            'expected'  => "SQL;\n\nSQL2;"
+         ]
+      ], $this->commentsProvider());
+   }
+
+   /**
+    * @dataProvider sqlProvider
+    */
+   public function testRemoveSqlRemarks($sql, $expected) {
+      $this
+         ->if($this->newTestedInstance)
+         ->then
+            ->string($this->testedInstance->removeSqlRemarks($sql))->isIdenticalTo($expected);
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

I have at least two issues with current sql parsing:
- when an error occurs, it outputs the whole SQL file, this is **huge**
- when the last line of the file (engine etc part of the last table), the script does not fail. Install is OK, but the lat table is not created.