### PR TITLE
Fix getLoginUserID strict comparision

### DIFF
--- a/front/preference.php
+++ b/front/preference.php
@@ -53,7 +53,7 @@ if (isset($_GET['lostpassword'])) {
 Session::checkLoginUser();
 
 if (isset($_POST["update"])
-    && ($_POST["id"] === Session::getLoginUserID())) {
+    && ($_POST["id"] == Session::getLoginUserID())) {
    $user->update($_POST);
    Event::log($_POST["id"], "users", 5, "setup",
               //TRANS: %s is the user login

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -48,7 +48,7 @@ if (isset($_POST["update"])) {
    list($begin_year,$begin_month) = explode("-", $_POST['resa']["begin"]);
    Toolbox::manageBeginAndEndPlanDates($_POST['resa']);
    if (Session::haveRight("reservation", UPDATE)
-       || (Session::getLoginUserID() === $_POST["users_id"])) {
+       || (Session::getLoginUserID() == $_POST["users_id"])) {
       $_POST['_target'] = $_SERVER['PHP_SELF'];
       $_POST['_item']   = key($_POST["items"]);
       $_POST['begin']   = $_POST['resa']["begin"];
@@ -110,7 +110,7 @@ if (isset($_POST["update"])) {
          foreach ($dates_to_add as $begin => $end) {
             $input['begin']    = $begin;
             $input['end']      = $end;
-            $input['users_id'] = $_POST['users_id'];
+            $input['users_id'] = (int)$_POST['users_id'];
 
             if (Session::haveRight("reservation", UPDATE)
                 || (Session::getLoginUserID() === $input["users_id"])) {

--- a/inc/planningevent.class.php
+++ b/inc/planningevent.class.php
@@ -279,7 +279,7 @@ trait PlanningEvent {
 
       // See public event ?
       if (!$options['genical']
-         && $who === Session::getLoginUserID()
+         && (Session::getLoginUserID() !== false && $who == Session::getLoginUserID())
          && self::canView()
          && isset($visibility_criteria['WHERE'])) {
          $nreadpub = $visibility_criteria['WHERE'];

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -793,7 +793,7 @@ class User extends CommonDBTM {
       }
 
       if (isset($input["entities_id"])
-          && (Session::getLoginUserID() === $input['id'])) {
+          && (Session::getLoginUserID() == $input['id'])) {
          $_SESSION["glpidefault_entity"] = $input["entities_id"];
       }
 
@@ -830,7 +830,7 @@ class User extends CommonDBTM {
       }
 
       // Manage preferences fields
-      if (Session::getLoginUserID() === $input['id']) {
+      if (Session::getLoginUserID() == $input['id']) {
          if (isset($input['use_mode'])
              && ($_SESSION['glpi_use_mode'] !=  $input['use_mode'])) {
             $_SESSION['glpi_use_mode'] = $input['use_mode'];
@@ -841,7 +841,7 @@ class User extends CommonDBTM {
 
       foreach ($CFG_GLPI['user_pref_field'] as $f) {
          if (isset($input[$f])) {
-            if (Session::getLoginUserID() === $input['id']) {
+            if (Session::getLoginUserID() == $input['id']) {
                if ($_SESSION["glpi$f"] != $input[$f]) {
                   $_SESSION["glpi$f"] = $input[$f];
                   // reinit translations
@@ -2832,7 +2832,7 @@ JAVASCRIPT;
       // should not be able to update its own fields
       // (for example, fields concerned by ldap synchronisation)
       // except on login action (which triggers synchronisation).
-      if (Session::getLoginUserID() === $this->input['id']
+      if (Session::getLoginUserID() === (int)$this->input['id']
           && !Session::haveRight("user", UPDATE)
           && !strpos($_SERVER['PHP_SELF'], "/front/login.php")
           && isset($this->fields["authtype"])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6575

Some existing strict comparisons will fail now that DB data is not always a string. The noted issue was when comparing an ID from a form input (string) to the current user's id in the session (integer now).