### PR TITLE
Prevent useless calls to autocomplete script

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3499,7 +3499,7 @@ class Html {
 
       // Check if field is allowed
       $field_so = $item->getSearchOptionByField('field', $field, $item->getTable());
-      $can_autocomplete = true || array_key_exists('autocomplete', $field_so) && $field_so['autocomplete'];
+      $can_autocomplete = array_key_exists('autocomplete', $field_so) && $field_so['autocomplete'];
 
       $output = '';
       if ($can_autocomplete && $CFG_GLPI["use_ajax_autocompletion"]) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I guess this condition was added for debug purpose.

As this check is also done on `ajax/autocompletion.php`, the only change with this will be to prevent useless calls when user inputs text.