### PR TITLE
Check canViewItem before showing KBI in new task form

### DIFF
--- a/inc/commondropdown.class.php
+++ b/inc/commondropdown.class.php
@@ -941,7 +941,7 @@ abstract class CommonDropdown extends CommonDBTM {
          $rand = mt_rand();
          $kbitem = new KnowbaseItem;
          $found_kbitem = $kbitem->find([
-            'knowbaseitemcategories_id' => $this->fields['knowbaseitemcategories_id']
+            'id' => KnowbaseItem::getForCategory($this->fields['knowbaseitemcategories_id'])
          ]);
 
          $kbitem->getFromDB(reset($found_kbitem)['id']);
@@ -976,7 +976,7 @@ abstract class CommonDropdown extends CommonDBTM {
                   'display'   => false,
                   'rand'      => $rand,
                   'condition' => [
-                     'knowbaseitemcategories_id' => $this->fields['knowbaseitemcategories_id']
+                     'id' => KnowbaseItem::getForCategory($this->fields['knowbaseitemcategories_id'])
                   ],
                   'on_change' => "getKnowbaseItemAnswer$rand()"
                ]);

--- a/inc/commondropdown.class.php
+++ b/inc/commondropdown.class.php
@@ -941,7 +941,7 @@ abstract class CommonDropdown extends CommonDBTM {
          $rand = mt_rand();
          $kbitem = new KnowbaseItem;
          $found_kbitem = $kbitem->find([
-            'id' => KnowbaseItem::getForCategory($this->fields['knowbaseitemcategories_id'])
+            KnowbaseItem::getTable() . '.id'  => KnowbaseItem::getForCategory($this->fields['knowbaseitemcategories_id'])
          ]);
 
          $kbitem->getFromDB(reset($found_kbitem)['id']);
@@ -976,7 +976,7 @@ abstract class CommonDropdown extends CommonDBTM {
                   'display'   => false,
                   'rand'      => $rand,
                   'condition' => [
-                     'id' => KnowbaseItem::getForCategory($this->fields['knowbaseitemcategories_id'])
+                     KnowbaseItem::getTable() . '.id' => KnowbaseItem::getForCategory($this->fields['knowbaseitemcategories_id'])
                   ],
                   'on_change' => "getKnowbaseItemAnswer$rand()"
                ]);

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -1928,13 +1928,18 @@ class KnowbaseItem extends CommonDBVisible {
    /**
     * Get ids of KBI in given category
     *
-    * @param $category_id
-    * @return array Array of ids
+    * @param int           $category_id   id of the parent category
+    * @param KnowbaseItem  $kbi           used only for unit tests
+    *
+    * @return array        Array of ids
     */
-   public static function getForCategory($category_id) {
+   public static function getForCategory($category_id, $kbi = null) {
       global $DB;
 
-      $kbi = new self();
+      if ($kbi === null) {
+         $kbi = new self();
+      }
+
       $ids = $DB->request([
          'SELECT' => 'id',
          'FROM'   => self::getTable(),

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -1924,4 +1924,39 @@ class KnowbaseItem extends CommonDBVisible {
          return false;
       }
    }
+
+   /**
+    * Get ids of KBI in given category
+    *
+    * @param $category_id
+    * @return array Array of ids
+    */
+   public static function getForCategory($category_id) {
+      global $DB;
+
+      $kbi = new self();
+      $ids = $DB->request([
+         'SELECT' => 'id',
+         'FROM'   => self::getTable(),
+         'WHERE'  => ['knowbaseitemcategories_id' => $category_id],
+      ]);
+
+      // Get array of ids
+      $ids = array_map(function($row){
+         return $row['id'];
+      }, iterator_to_array($ids, false));
+
+      // Filter on canViewItem
+      $ids = array_filter($ids, function($id) use ($kbi) {
+         $kbi->getFromDB($id);
+         return $kbi->canViewItem();
+      });
+
+      // Avoid empty IN
+      if (count($ids) === 0) {
+         $ids[] = -1;
+      }
+
+      return $ids;
+   }
 }

--- a/tests/units/KnowbaseItem.php
+++ b/tests/units/KnowbaseItem.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+*/
+
+namespace tests\units;
+
+class KnowbaseItem extends \GLPITestCase {
+
+   public function testGetForCategory() {
+      global $DB;
+
+      // Prepare mocks
+      $m_db = new \mock\DB();
+      $m_kbi = new \mock\KnowbaseItem();
+
+      // Mocked db request result
+      $it = new \ArrayIterator([
+         ['id' => '1'],
+         ['id' => '2'],
+         ['id' => '3'],
+      ]);
+      $this->calling($m_db)->request = $it;
+
+      // Ignore get fromDB
+      $this->calling($m_kbi)->getFromDB = true;
+
+      // True for call 1 & 3, false for call 2
+      $this->calling($m_kbi)->canViewItem = true;
+      $this->calling($m_kbi)->canViewItem[0] = true;
+      $this->calling($m_kbi)->canViewItem[1] = true;
+      $this->calling($m_kbi)->canViewItem[2] = false;
+      $this->calling($m_kbi)->canViewItem[3] = true;
+
+      // Replace global DB with mocked DB
+      $DB = $m_db;
+
+      // Expected : [1, 3]
+      $this->array(\KnowbaseItem::getForCategory(1, $m_kbi))
+         ->hasSize(2)
+         ->containsValues([1, 3]);
+   }
+}

--- a/tests/units/KnowbaseItem.php
+++ b/tests/units/KnowbaseItem.php
@@ -52,9 +52,8 @@ class KnowbaseItem extends \GLPITestCase {
       // Ignore get fromDB
       $this->calling($m_kbi)->getFromDB = true;
 
-      // True for call 1 & 3, false for call 2
-      $this->calling($m_kbi)->canViewItem = true;
-      $this->calling($m_kbi)->canViewItem[0] = true;
+      // True for call 1 & 3, false for call 2 and every following calls
+      $this->calling($m_kbi)->canViewItem[0] = false;
       $this->calling($m_kbi)->canViewItem[1] = true;
       $this->calling($m_kbi)->canViewItem[2] = false;
       $this->calling($m_kbi)->canViewItem[3] = true;
@@ -66,5 +65,10 @@ class KnowbaseItem extends \GLPITestCase {
       $this->array(\KnowbaseItem::getForCategory(1, $m_kbi))
          ->hasSize(2)
          ->containsValues([1, 3]);
+
+      // Expected : [-1]
+      $this->array(\KnowbaseItem::getForCategory(1, $m_kbi))
+         ->hasSize(1)
+         ->contains(-1);
    }
 }


### PR DESCRIPTION
Internal ref: 18414.

KBI that are not visible by the user are still shown and can be selected in the following dropdown :
![image](https://user-images.githubusercontent.com/42734840/68849278-1137f480-06d2-11ea-82db-0de5603096db.png)


This changes removes theses KBI from the dropdown if the user is not allowed to see them.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes