### PR TITLE
Fix CommonDBChild forms

### DIFF
--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -984,13 +984,22 @@ class CommonGLPI {
          }
          echo "</span>";
 
-         $ma = new MassiveAction([
-               'item' => [
-                  $this->getType() => [
-                     $this->fields['id'] => 1
-                  ]
+         $ma_post = [
+            'item' => [
+               $this->getType() => [
+                  $this->fields['id'] => 1
                ]
-            ],
+            ]
+         ];
+         if (is_subclass_of($this, 'CommonDBChild')) {
+            if (strpos(static::$itemtype, 'itemtype') === 0) {
+               $ma_post['check_itemtype'] = $this->fields[static::$itemtype];
+            } else {
+               $ma_post['check_itemtype'] = static::$itemtype;
+            }
+            $ma_post['check_items_id'] = $this->fields[static::$items_id];
+         }
+         $ma = new MassiveAction($ma_post,
             $_GET,
             'initial',
             $this->fields['id']

--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -1008,7 +1008,11 @@ class CommonGLPI {
          $input   = $ma->getInput();
 
          if ($this->isEntityAssign()) {
-            $input['entity_restrict'] = $this->fields['entities_id'];
+            if (is_subclass_of($this, 'CommonDBChild')) {
+               $input['entity_restrict'] = $this->getItem()->fields['entities_id'];
+            } else {
+               $input['entity_restrict'] = $this->fields['entities_id'];
+            }
          }
 
          if (count($actions)) {

--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -1008,11 +1008,7 @@ class CommonGLPI {
          $input   = $ma->getInput();
 
          if ($this->isEntityAssign()) {
-            if (is_subclass_of($this, 'CommonDBChild')) {
-               $input['entity_restrict'] = $this->getItem()->fields['entities_id'];
-            } else {
-               $input['entity_restrict'] = $this->fields['entities_id'];
-            }
+            $input['entity_restrict'] = $this->getEntityID();
          }
 
          if (count($actions)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Adds checkitem when trying to display massive actions in header for CommonDBChild items. Previously, an exception occurred while trying to show the header for networkports and no form was displayed.
2. Fix entity restrict for CommonDBChild items. Noticed with ComputerAntivirus