### PR TITLE
Fix display for single right

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -5446,9 +5446,7 @@ class Html {
                                              > ($nb_cb_per_row['total'] / 2));
             echo "\t\t<td class='center'>".Html::getCheckbox($cb_options)."</td>\n";
          }
-         if ($nb_cb_per_row['total'] == 1) {
-            echo "\t\t<td class='center'></td>\n";
-         }
+
          echo "\t</tr>\n";
       }
 


### PR DESCRIPTION
Right matrix display is broken if you have only one right:
![image](https://user-images.githubusercontent.com/42734840/68933554-2e81c700-0795-11ea-9e13-91176b053bfd.png)


After fix: 
![image](https://user-images.githubusercontent.com/42734840/68933568-393c5c00-0795-11ea-8884-b1dc58acdd7a.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
