### PR TITLE
Always create a doc_item, use -1 value in timeline to not display images

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -5065,19 +5065,13 @@ class CommonDBTM extends CommonGLPI {
                                                 stripslashes($doc->fields["filename"]));
             $docadded[$docID]['filepath'] = $doc->fields["filepath"];
 
-            // for sub item, attach to document to parent item
-            $item_fordocitem = $this;
-            if (isset($input['_job'])) {
-               $item_fordocitem = $input['_job'];
-            }
-
             // add doc - item link
             $toadd = [
                'documents_id'  => $docID,
                '_do_notif'     => $donotif,
                '_disablenotif' => $disablenotif,
-               'itemtype'      => $item_fordocitem->getType(),
-               'items_id'      => $item_fordocitem->getID()
+               'itemtype'      => $this->getType(),
+               'items_id'      => $this->getID()
             ];
             if (isset($input['users_id'])) {
                $toadd['users_id'] = $input['users_id'];
@@ -5085,6 +5079,7 @@ class CommonDBTM extends CommonGLPI {
             if (isset($input[$options['content_field']])
                 && strpos($input[$options['content_field']], $doc->fields["tag"]) !== false
                 && strpos($doc->fields['mime'], 'image/') !== false) {
+               //do not display inline docs in timeline
                $toadd['timeline_position'] = CommonITILObject::NO_TIMELINE;
             }
 

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -5067,32 +5067,28 @@ class CommonDBTM extends CommonGLPI {
 
             // for sub item, attach to document to parent item
             $item_fordocitem = $this;
-            $skip_docitem = false;
             if (isset($input['_job'])) {
                $item_fordocitem = $input['_job'];
             }
 
-            // if doc is an image and already inserted in content, do not attach in docitem
+            // add doc - item link
+            $toadd = [
+               'documents_id'  => $docID,
+               '_do_notif'     => $donotif,
+               '_disablenotif' => $disablenotif,
+               'itemtype'      => $item_fordocitem->getType(),
+               'items_id'      => $item_fordocitem->getID()
+            ];
+            if (isset($input['users_id'])) {
+               $toadd['users_id'] = $input['users_id'];
+            }
             if (isset($input[$options['content_field']])
                 && strpos($input[$options['content_field']], $doc->fields["tag"]) !== false
                 && strpos($doc->fields['mime'], 'image/') !== false) {
-               $skip_docitem = true;
+               $toadd['timeline_position'] = CommonITILObject::NO_TIMELINE;
             }
 
-            // add doc - item link
-            if (!$skip_docitem) {
-               $toadd = [
-                  'documents_id'  => $docID,
-                  '_do_notif'     => $donotif,
-                  '_disablenotif' => $disablenotif,
-                  'itemtype'      => $item_fordocitem->getType(),
-                  'items_id'      => $item_fordocitem->getID()
-               ];
-               if (isset($input['users_id'])) {
-                  $toadd['users_id'] = $input['users_id'];
-               }
-               $docitem->add($toadd);
-            }
+            $docitem->add($toadd);
          }
          // Only notification for the first New doc
          $donotif = false;

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -77,6 +77,7 @@ abstract class CommonITILObject extends CommonDBTM {
    const TEST          = 11; // test
    const QUALIFICATION = 12; // qualification
 
+   const NO_TIMELINE       = -1;
    const TIMELINE_NOTSET   = 0;
    const TIMELINE_LEFT     = 1;
    const TIMELINE_MIDLEFT  = 2;
@@ -6691,7 +6692,11 @@ abstract class CommonITILObject extends CommonDBTM {
 
       //add documents to timeline
       $document_obj   = new Document();
-      $document_items = $document_item_obj->find(['itemtype' => $objType, 'items_id' => $this->getID()]);
+      $document_items = $document_item_obj->find([
+         'itemtype'           => $objType,
+         'items_id'           => $this->getID(),
+         'timeline_position'  => ['>', self::NO_TIMELINE]
+      ]);
       foreach ($document_items as $document_item) {
          $document_obj->getFromDB($document_item['documents_id']);
 

--- a/inc/define.php
+++ b/inc/define.php
@@ -242,7 +242,8 @@ $CFG_GLPI["document_types"]               = ['Budget', 'CartridgeItem', 'Change'
                                                   'Printer', 'Problem', 'Project', 'ProjectTask',
                                                   'Reminder', 'Software', 'Line',
                                                   'SoftwareLicense', 'Supplier', 'Ticket','User',
-                                                  'Certificate', 'Cluster'];
+                                                  'Certificate', 'Cluster', 'ITILFollowup', 'ITILSolution',
+                                                   'ChangeTask', 'ProblemTask', 'TicketTask'];
 
 $CFG_GLPI["consumables_types"]            = ['Group', 'User'];
 

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -665,21 +665,6 @@ class Document extends CommonDBTM {
       );
 
       $result = $DB->request($criteria)->next();
-      if ($result['cpt'] > 0) {
-         return true;
-      }
-
-      // Inlined images do not have entries in glpi_documents_items table.
-      // Check in Reminder content
-      $criteria = array_merge_recursive(
-         [
-            'COUNT'     => 'cpt',
-            'FROM'      => 'glpi_reminders',
-         ],
-         Reminder::getVisibilityCriteria()
-      );
-
-      $result = $DB->request($criteria)->next();
       return $result['cpt'] > 0;
    }
 
@@ -733,9 +718,7 @@ class Document extends CommonDBTM {
 
       $result = $DB->request($request)->next();
 
-      if ($result['cpt'] > 0) {
-         return true;
-      }
+      return $result['cpt'] > 0;
    }
 
    /**

--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -129,7 +129,7 @@ class Document_Item extends CommonDBRelation{
       }
 
       /** FIXME: should not this be handled on CommonITILObject side? */
-      if (is_subclass_of($input['itemtype'], 'CommonITILObject')) {
+      if (is_subclass_of($input['itemtype'], 'CommonITILObject') && !isset($input['timeline_position'])) {
          $input['timeline_position'] = CommonITILObject::TIMELINE_LEFT;
          if (isset($input["users_id"])) {
             $input['timeline_position'] = $input['itemtype']::getTimelinePosition($input['items_id'], $this->getType(), $input["users_id"]);

--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -172,7 +172,7 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
             foreach ($documents_ids as $document_id) {
                $doc->getFromDB($document_id);
                // Add embeded image if tag present in ticket content
-               if (preg_match_all('/'.Document::getImageTag($doc->fields['tag']).'/',
+               if (preg_match_all('/'.preg_quote($doc->fields['tag']).'/',
                                   $current->fields['body_html'], $matches, PREG_PATTERN_ORDER)) {
                   $image_path = Document::getImage(
                      GLPI_DOC_DIR."/".$doc->fields['filepath'],

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -1316,12 +1316,12 @@ HTML
          ]
       ]);
       while ($data = $result->next()) {
-         //TODO create Document_Item entry, with a timeline_position set to Document_Item::NO_TL
          preg_match('/document\\.send\\.php\\?docid=([0-9]+)/', $data[$field], $matches);
          $docs_input[] = [
-            'documents_id' => $matches[1],
-            'itemtype'     => $itemtype,
-            'items_id'     => $data['id']
+            'documents_id'       => $matches[1],
+            'itemtype'           => $itemtype,
+            'items_id'           => $data['id'],
+            'timeline_position'  => CommonITILObject::NO_TIMELINE
          ];
       }
    }

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -1296,7 +1296,7 @@ HTML
    /** A doc_item to rule them all! */
    $itemtypes = [
       'ITILFollowup' => 'content',
-      'ITILSOlution' => 'content',
+      'ITILSolution' => 'content',
       'Reminder'     => 'text',
       'KnowbaseItem' => 'answer'
    ];

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -1308,8 +1308,9 @@ HTML
    foreach ($itemtypes as $itemtype => $field) {
       // Check ticket and child items (followups, tasks, solutions) contents
       $regexPattern = 'document\\\.send\\\.php\\\?docid=[0-9]+';
+      $user_field = ($itemtype instanceof CommonITILObject) ? 'users_id_recipient' : 'users_id';
       $result = $DB->request([
-         'SELECT' => ['id', $field],
+         'SELECT' => ['id', $field, $user_field],
          'FROM'   => $itemtype::getTable(),
          'WHERE'  => [
             $field => ['REGEXP', $regexPattern]
@@ -1321,7 +1322,8 @@ HTML
             'documents_id'       => $matches[1],
             'itemtype'           => $itemtype,
             'items_id'           => $data['id'],
-            'timeline_position'  => CommonITILObject::NO_TIMELINE
+            'timeline_position'  => CommonITILObject::NO_TIMELINE,
+            'users_id'           => $user_field
          ];
       }
    }

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -1308,7 +1308,7 @@ HTML
    foreach ($itemtypes as $itemtype => $field) {
       // Check ticket and child items (followups, tasks, solutions) contents
       $regexPattern = 'document\\\.send\\\.php\\\?docid=[0-9]+';
-      $user_field = ($itemtype instanceof CommonITILObject) ? 'users_id_recipient' : 'users_id';
+      $user_field = is_a($itemtype, CommonITILObject::class, true) ? 'users_id_recipient' : 'users_id';
       $result = $DB->request([
          'SELECT' => ['id', $field, $user_field],
          'FROM'   => $itemtype::getTable(),
@@ -1323,7 +1323,7 @@ HTML
             'itemtype'           => $itemtype,
             'items_id'           => $data['id'],
             'timeline_position'  => CommonITILObject::NO_TIMELINE,
-            'users_id'           => $user_field
+            'users_id'           => $data[$user_field],
          ];
       }
    }

--- a/tests/functionnal/Document.php
+++ b/tests/functionnal/Document.php
@@ -319,6 +319,14 @@ class Document extends DbTestCase {
          ])
       )->isGreaterThan(0);
 
+      $this->integer(
+         (int)$document_item->add([
+            'documents_id' => $inlinedDocument->getID(),
+            'items_id'     => $glpiReminder->getID(),
+            'itemtype'     => \Reminder::class,
+         ])
+      )->isGreaterThan(0);
+
       $this->boolean($basicDocument->canViewFile())->isFalse();
       $this->boolean($inlinedDocument->canViewFile())->isFalse();
 
@@ -336,6 +344,14 @@ class Document extends DbTestCase {
       $this->integer(
          (int)$document_item->add([
             'documents_id' => $basicDocument->getID(),
+            'items_id'     => $myReminder->getID(),
+            'itemtype'     => \Reminder::class,
+         ])
+      )->isGreaterThan(0);
+
+      $this->integer(
+         (int)$document_item->add([
+            'documents_id' => $inlinedDocument->getID(),
             'items_id'     => $myReminder->getID(),
             'itemtype'     => \Reminder::class,
          ])
@@ -520,6 +536,14 @@ class Document extends DbTestCase {
          ])
       )->isGreaterThan(0);
 
+      $this->integer(
+         (int)$document_item->add([
+            'documents_id' => $inlinedDocument->getID(),
+            'items_id'     => $item->getID(),
+            'itemtype'     => $itemtype,
+         ])
+      )->isGreaterThan(0);
+
       // post-only cannot see documents if not able to view ITIL (ITIL content)
       $this->login('post-only', 'postonly');
       $_SESSION["glpiactiveprofile"][$item::$rightname] = READ; // force READ write for tested ITIL type
@@ -624,6 +648,15 @@ class Document extends DbTestCase {
             'items_id'   => $itil->getID(),
             'itemtype'   => $itil_itemtype,
             'users_id'   => '2', // user "glpi"
+         ])
+      )->isGreaterThan(0);
+
+      $document_item = new \Document_Item();
+      $this->integer(
+         (int)$document_item->add([
+            'documents_id' => $inlinedDocument->getID(),
+            'items_id'     => $itil->getID(),
+            'itemtype'     => $itil_itemtype,
          ])
       )->isGreaterThan(0);
 

--- a/tests/functionnal/Document.php
+++ b/tests/functionnal/Document.php
@@ -361,6 +361,24 @@ class Document extends DbTestCase {
          ])
       )->isGreaterThan(0);
 
+      $inlinedDocument = new \Document();
+      $this->integer(
+         (int)$inlinedDocument->add([
+            'name'     => 'inlined document',
+            'filename' => 'inlined.png',
+            'users_id' => '2', // user "glpi"
+         ])
+      )->isGreaterThan(0);
+
+      $kbItem = new \KnowbaseItem();
+      $this->integer(
+         (int)$kbItem->add([
+            'name'     => 'Generic KB item',
+            'answer'   => '<img src="/front/document.send.php?docid=' . $inlinedDocument->getID() . '" />',
+            'users_id' => '2', // user "glpi"
+         ])
+      )->isGreaterThan(0);
+
       $document_item = new \Document_Item();
       $this->integer(
          (int)$document_item->add([
@@ -370,8 +388,17 @@ class Document extends DbTestCase {
          ])
       )->isGreaterThan(0);
 
+      $this->integer(
+         (int)$document_item->add([
+            'documents_id' => $inlinedDocument->getID(),
+            'items_id'     => $kbItem->getID(),
+            'itemtype'     => \KnowbaseItem::class,
+         ])
+      )->isGreaterThan(0);
+
       // anonymous cannot see documents if not linked to FAQ items
       $this->boolean($basicDocument->canViewFile())->isFalse();
+      $this->boolean($inlinedDocument->canViewFile())->isFalse();
 
       // anonymous cannot see documents linked to FAQ items if public FAQ is not active
       $CFG_GLPI['use_public_faq'] = 0;
@@ -395,11 +422,13 @@ class Document extends DbTestCase {
       $this->integer($ent_kb_id)->isGreaterThan(0);
 
       $this->boolean($basicDocument->canViewFile())->isFalse();
+      $this->boolean($inlinedDocument->canViewFile())->isFalse();
 
       // anonymous can see documents linked to FAQ items when public FAQ is active
       $CFG_GLPI['use_public_faq'] = 1;
 
       $this->boolean($basicDocument->canViewFile())->isTrue();
+      $this->boolean($inlinedDocument->canViewFile())->isTrue();
 
       $CFG_GLPI['use_public_faq'] = 0;
 
@@ -407,6 +436,7 @@ class Document extends DbTestCase {
       $this->login('post-only', 'postonly');
 
       $this->boolean($basicDocument->canViewFile())->isTrue();
+      $this->boolean($inlinedDocument->canViewFile())->isTrue();
 
       // post-only cannot see documents if not linked to FAQ items
       $this->boolean(
@@ -424,6 +454,7 @@ class Document extends DbTestCase {
       )->isTrue();
 
       $this->boolean($basicDocument->canViewFile())->isFalse();
+      $this->boolean($inlinedDocument->canViewFile())->isFalse();
    }
 
    /**

--- a/tests/functionnal/Document.php
+++ b/tests/functionnal/Document.php
@@ -361,24 +361,6 @@ class Document extends DbTestCase {
          ])
       )->isGreaterThan(0);
 
-      $inlinedDocument = new \Document();
-      $this->integer(
-         (int)$inlinedDocument->add([
-            'name'     => 'inlined document',
-            'filename' => 'inlined.png',
-            'users_id' => '2', // user "glpi"
-         ])
-      )->isGreaterThan(0);
-
-      $kbItem = new \KnowbaseItem();
-      $this->integer(
-         (int)$kbItem->add([
-            'name'     => 'Generic KB item',
-            'answer'   => '<img src="/front/document.send.php?docid=' . $inlinedDocument->getID() . '" />',
-            'users_id' => '2', // user "glpi"
-         ])
-      )->isGreaterThan(0);
-
       $document_item = new \Document_Item();
       $this->integer(
          (int)$document_item->add([
@@ -390,7 +372,6 @@ class Document extends DbTestCase {
 
       // anonymous cannot see documents if not linked to FAQ items
       $this->boolean($basicDocument->canViewFile())->isFalse();
-      $this->boolean($inlinedDocument->canViewFile())->isFalse();
 
       // anonymous cannot see documents linked to FAQ items if public FAQ is not active
       $CFG_GLPI['use_public_faq'] = 0;
@@ -414,13 +395,11 @@ class Document extends DbTestCase {
       $this->integer($ent_kb_id)->isGreaterThan(0);
 
       $this->boolean($basicDocument->canViewFile())->isFalse();
-      $this->boolean($inlinedDocument->canViewFile())->isFalse();
 
       // anonymous can see documents linked to FAQ items when public FAQ is active
       $CFG_GLPI['use_public_faq'] = 1;
 
       $this->boolean($basicDocument->canViewFile())->isTrue();
-      $this->boolean($inlinedDocument->canViewFile())->isTrue();
 
       $CFG_GLPI['use_public_faq'] = 0;
 
@@ -428,7 +407,6 @@ class Document extends DbTestCase {
       $this->login('post-only', 'postonly');
 
       $this->boolean($basicDocument->canViewFile())->isTrue();
-      $this->boolean($inlinedDocument->canViewFile())->isTrue();
 
       // post-only cannot see documents if not linked to FAQ items
       $this->boolean(
@@ -446,7 +424,6 @@ class Document extends DbTestCase {
       )->isTrue();
 
       $this->boolean($basicDocument->canViewFile())->isFalse();
-      $this->boolean($inlinedDocument->canViewFile())->isFalse();
    }
 
    /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

When using the new clean orphan docs crontask, all documents without a doc_item entry are clened.