### PR TITLE
send a fetch query instead xhr for unlocking object

### DIFF
--- a/inc/objectlock.class.php
+++ b/inc/objectlock.class.php
@@ -310,15 +310,14 @@ class ObjectLock extends CommonDBTM {
                                           'users_id' => Session::getLoginUserID()])) {
          // add a script to unlock the Object
          echo Html::scriptBlock( "$(function() {
-                  $(window).on('beforeunload', function() {
-                     //debugger;
-                      $.ajax({
-                          url: '".$CFG_GLPI['root_doc']."/ajax/unlockobject.php',
-                          cache: false,
-                          data: 'unlock=1&id=$id'
-                          });
-                      });
-                  });" );
+            $(window).on('unload', function() {
+               fetch('".$CFG_GLPI['root_doc']."/ajax/unlockobject.php?unlock=1&id=$id', {
+                  method: 'POST',
+                  keepalive: true,
+                  cache: 'no-cache'
+               });
+            });
+         })" );
          $ret = true;
       } else { // can't add a lock as another one is already existing
          if (!$gotIt) {

--- a/inc/objectlock.class.php
+++ b/inc/objectlock.class.php
@@ -311,11 +311,21 @@ class ObjectLock extends CommonDBTM {
          // add a script to unlock the Object
          echo Html::scriptBlock( "$(function() {
             $(window).on('unload', function() {
-               fetch('".$CFG_GLPI['root_doc']."/ajax/unlockobject.php?unlock=1&id=$id', {
-                  method: 'POST',
-                  keepalive: true,
-                  cache: 'no-cache'
-               });
+               if (window.fetch !== 'undefined') {
+                  fetch('".$CFG_GLPI['root_doc']."/ajax/unlockobject.php?unlock=1&id=$id', {
+                     method: 'POST',
+                     keepalive: true,
+                     cache: 'no-cache'
+                  });
+               } else {
+                  //fallback for browsers with fetch support
+                  $.ajax({
+                     url: '".$CFG_GLPI['root_doc']."/ajax/unlockobject.php',
+                     cache: false,
+                     data: 'unlock=1&id=$id'
+                  });
+                 });
+               }
             });
          })" );
          $ret = true;

--- a/inc/objectlock.class.php
+++ b/inc/objectlock.class.php
@@ -313,7 +313,6 @@ class ObjectLock extends CommonDBTM {
             $(window).on('unload', function() {
                if (typeof window.fetch !== 'undefined') {
                   fetch('".$CFG_GLPI['root_doc']."/ajax/unlockobject.php?unlock=1&id=$id', {
-                     method: 'POST',
                      keepalive: true,
                      cache: 'no-cache'
                   });

--- a/inc/objectlock.class.php
+++ b/inc/objectlock.class.php
@@ -311,7 +311,7 @@ class ObjectLock extends CommonDBTM {
          // add a script to unlock the Object
          echo Html::scriptBlock( "$(function() {
             $(window).on('unload', function() {
-               if (window.fetch !== 'undefined') {
+               if (typeof window.fetch !== 'undefined') {
                   fetch('".$CFG_GLPI['root_doc']."/ajax/unlockobject.php?unlock=1&id=$id', {
                      method: 'POST',
                      keepalive: true,
@@ -324,7 +324,6 @@ class ObjectLock extends CommonDBTM {
                      cache: false,
                      data: 'unlock=1&id=$id'
                   });
-                 });
                }
             });
          })" );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5799

Fetch api seems to work on my side like explained in #5799, tested with chrome 78 and firefox 70
Added fallback for IE<=14 (Edge supports fetch api)
I need confirmation for this fallback (@tomolimo if you have internet explorer in production)