### PR TITLE
Add missing $itemtype for RuleCriteria

### DIFF
--- a/inc/rulecriteria.class.php
+++ b/inc/rulecriteria.class.php
@@ -38,6 +38,7 @@ if (!defined('GLPI_ROOT')) {
 class RuleCriteria extends CommonDBChild {
 
    // From CommonDBChild
+   static public $itemtype        = 'Rule';
    static public $items_id        = 'rules_id';
    public $dohistory              = true;
    public $auto_message_on_action = false;


### PR DESCRIPTION
Internal ref: 18498.

Fix the following error when trying to get `RuleCriteria` items through GLPI's API :

```
PHP message: PHP Fatal error:  Uncaught Error: Class name must be a valid object or a string in glpi/inc/commondbconnexity.class.php:314
Stack trace:
#0 glpi/inc/commondbchild.class.php(230): CommonDBConnexity::canConnexity('canView', 3, NULL, 'rules_id')
#1 glpi/inc/commondbchild.class.php(153): CommonDBChild::canChild('canView')
#2 glpi/inc/api.class.php(1134): CommonDBChild::canView()
#3 glpi/inc/apirest.class.php(237): API->getItems('RuleCriteria', Array, 0)
#4 glpi/apirest.php(48): APIRest->call()
#5 {main}
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
