### PR TITLE
Fix DropdownNumber for step < 1

### DIFF
--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -3501,7 +3501,7 @@ class Dropdown {
       for ($i=$post['min']; $i<=$post['max']; $i+=$post['step']) {
          if (!empty($post['searchText']) && strstr($i, $post['searchText']) || empty($post['searchText'])) {
             if (!in_array($i, $used)) {
-               $values[$i] = $i;
+               $values["$i"] = $i;
             }
          }
       }


### PR DESCRIPTION
```php
Dropdown::showNumber(..., [
    'min'     => 0,
    'step'    => 0.5,
]);
```

Will give the following values: 
```php
[
    0 => 0.5,
    1 => 1.5,
    2 => 2.5,
    3 => 3.5,
    4 => 4.5,
    ...
]
```

This is because the value is also used as the key: 
```php
$values[$i] = $i;
```

Since values are integer, they will be truncated ([PHP: Arrays - Floats are also cast to integers, which means that the fractional part will be truncated. E.g. the key 8.7 will actually be stored under 8.](https://www.php.net/manual/en/language.types.array.php)) and override existing keys.

This change cast the keys to string to avoid any override.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
