### PR TITLE
Remove fetch-depth option for GH actions lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v1"
-        with:
-          fetch-depth: 1
       - name: "Deploy source into app container"
         run: |
           sudo cp --no-target-directory --preserve --recursive `pwd` /glpi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Remove `fetch-depth` option from lint job in GithubActions as it does not enhances performances (do not really know why), but can result in a bug if a new commit has been pushed before job starts.