### PR TITLE
Handle @ error control operator in debug error handler

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -681,6 +681,12 @@ class Toolbox {
       // For file record
       $type = self::userErrorHandlerNormal($errno, $errmsg, $filename, $linenum);
 
+      if (0 === error_reporting()) {
+         // Do not display error message if '@' operator is used on errored expression
+         // see https://www.php.net/manual/en/language.operators.errorcontrol.php
+         return;
+      }
+
       // Display
       if (!isCommandLine()) {
          echo '<div style="position:float-left; background-color:red; z-index:10000">'.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When prepending `@` operator to an expression, `error_reporting()` will returns 0 if an error occurs during its evaluation (see https://www.php.net/manual/en/language.operators.errorcontrol.php).

In this case, we should not display the error, even in debug mode, as this `@` was intentionnaly used to suppress error messages.