### PR TITLE
Fix mailcollector check on status.php

### DIFF
--- a/status.php
+++ b/status.php
@@ -178,10 +178,10 @@ if (($ok_master || $ok_slave )
       foreach ($mailcollectors as $mc) {
          echo " ".$mc['name'];
          if ($mailcol->getFromDB($mc['id'])) {
-            $mailcol->connect();
-            if ($mailcol->storage) {
+            try {
+               $mailcol->connect();
                echo "_OK";
-            } else {
+            } catch (\Exception $e) {
                echo "_PROBLEM";
                $ok = false;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

```
Fatal error:  Uncaught Error: Cannot access private property MailCollector::$storage in /var/www/glpi/status.php:182
Stack trace:
#0 {main}
  thrown in /var/www/glpi/status.php on line 182
```