### PR TITLE
Impact context

### DIFF
--- a/css/impact.scss
+++ b/css/impact.scss
@@ -370,8 +370,9 @@ i.fa-impact-manipulation {
       }
 
       &.active {
-         color: rgb(14, 14, 14) !important;
-         background-color: #f1f1f1 !important;
+         color: #444 !important;
+         background-color: #d5d5d5 !important;
+         border-radius: 2px;
       }
    }
 
@@ -534,6 +535,15 @@ i.fa-impact-manipulation {
 .impact-side-settings-item {
    margin-bottom: 10px;
    white-space: nowrap;
+}
+
+.impact-res-hidden {
+   float: right;
+}
+
+.impact-res-disabled {
+   opacity: 0.5;
+   cursor: not-allowed !important;
 }
 
 /*

--- a/front/impactcsv.php
+++ b/front/impactcsv.php
@@ -51,15 +51,19 @@ $item->getFromDB($items_id);
 // Load graph and impactitem
 $graph = Impact::buildGraph($item);
 $impact_item = ImpactItem::findForItem($item);
-if (!$impact_item) {
-   throw new \InvalidArgumentException("No ImpactItem found for $itemtype $items_id");
+$impact_context = ImpactContext::findForImpactItem($impact_item);
+
+if (!$impact_context) {
+   $max_depth = \Impact::DEFAULT_DEPTH;
+} else {
+   $max_deph = $impact_context->fields["max_depth"];
 }
 
 // Load list data
 $data = [];
 $directions = [Impact::DIRECTION_FORWARD, Impact::DIRECTION_BACKWARD];
 foreach ($directions as $direction) {
-   $data[$direction] = Impact::buildListData($graph, $direction, $item, $impact_item);
+   $data[$direction] = Impact::buildListData($graph, $direction, $item, $max_deph);
 }
 
 // Output csv data

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -1647,7 +1647,7 @@ class CommonDBTM extends CommonGLPI {
                $this->addMessageOnPurgeAction();
                $this->post_purgeItem();
                Plugin::doHook("item_purge", $this);
-
+               Impact::clean($this);
             } else {
                $this->addMessageOnDeleteAction();
 
@@ -1673,6 +1673,7 @@ class CommonDBTM extends CommonGLPI {
             if ($this->notificationqueueonaction) {
                QueuedNotification::forceSendFor($this->getType(), $this->fields['id']);
             }
+
             return true;
          }
 

--- a/inc/impactcontext.class.php
+++ b/inc/impactcontext.class.php
@@ -1,0 +1,24 @@
+<?php
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ * @since 9.5.0.
+ */
+class ImpactContext extends CommonDBTM {
+
+   /**
+    * Get ImpactContext for the given ImpactItem
+    *
+    * @param ImpactItem $item
+    * @return ImpactContext|false
+    */
+   public static function findForImpactItem(\ImpactItem $item) {
+      $impactContext = new self();
+      $exist = $impactContext->getFromDB($item->fields['impactcontexts_id']);
+
+      return $exist ? $impactContext : false;
+   }
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -1210,7 +1210,7 @@ CREATE TABLE `glpi_impactcompounds` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 
-### Dump table glpi_impacts_parent
+### Dump table glpi_impactitems
 
 DROP TABLE IF EXISTS `glpi_impactitems`;
 CREATE TABLE `glpi_impactitems` (
@@ -1218,24 +1218,34 @@ CREATE TABLE `glpi_impactitems` (
 	`itemtype` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
 	`items_id` INT(11) NOT NULL DEFAULT '0',
 	`parent_id` INT(11) NOT NULL DEFAULT '0',
-	`zoom` FLOAT NOT NULL DEFAULT '0',
-	`pan_x` FLOAT NOT NULL DEFAULT '0',
-	`pan_y` FLOAT NOT NULL DEFAULT '0',
-	`impact_color` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
-	`depends_color` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
-	`impact_and_depends_color` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
-	`position_x` FLOAT NOT NULL DEFAULT '0',
-	`position_y` FLOAT NOT NULL DEFAULT '0',
-	`show_depends` TINYINT NOT NULL DEFAULT '1',
-	`show_impact` TINYINT NOT NULL DEFAULT '1',
-	`max_depth` INT(11) NOT NULL DEFAULT '5',
+	`impactcontexts_id` INT(11) NOT NULL DEFAULT '0',
+	`is_slave` TINYINT(1) NOT NULL DEFAULT '1',
 	PRIMARY KEY (`id`),
 	UNIQUE KEY `unicity` (
     `itemtype`,
     `items_id`
   ),
 	KEY `source` (`itemtype`, `items_id`),
-	KEY `parent_id` (`parent_id`)
+	KEY `parent_id` (`parent_id`),
+	KEY `impactcontexts_id` (`impactcontexts_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+### Dump table glpi_impactcontexts
+
+DROP TABLE IF EXISTS `glpi_impactcontexts`;
+CREATE TABLE `glpi_impactcontexts` (
+	`id` INT(11) NOT NULL AUTO_INCREMENT,
+	`positions` TEXT NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
+	`zoom` FLOAT NOT NULL DEFAULT '0',
+	`pan_x` FLOAT NOT NULL DEFAULT '0',
+	`pan_y` FLOAT NOT NULL DEFAULT '0',
+	`impact_color` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
+	`depends_color` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
+	`impact_and_depends_color` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
+	`show_depends` TINYINT(1) NOT NULL DEFAULT '1',
+	`show_impact` TINYINT(1) NOT NULL DEFAULT '1',
+	`max_depth` INT(11) NOT NULL DEFAULT '5',
+	PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 ### Dump table glpi_consumableitems

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -1153,6 +1153,44 @@ function update94to95() {
    }
    /** /Domain records */
 
+   /** Impact context */
+
+   // Create new impact_context table
+   if (!$DB->tableExists('glpi_impactcontexts')) {
+      $query = "CREATE TABLE `glpi_impactcontexts` (
+            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `positions` TEXT NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
+            `zoom` FLOAT NOT NULL DEFAULT '0',
+            `pan_x` FLOAT NOT NULL DEFAULT '0',
+            `pan_y` FLOAT NOT NULL DEFAULT '0',
+            `impact_color` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
+            `depends_color` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
+            `impact_and_depends_color` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
+            `show_depends` TINYINT(1) NOT NULL DEFAULT '1',
+            `show_impact` TINYINT(1) NOT NULL DEFAULT '1',
+            `max_depth` INT(11) NOT NULL DEFAULT '5',
+            PRIMARY KEY (`id`)
+         ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
+      $DB->queryOrDie($query, "add table glpi_impactcontexts");
+
+      // Update glpi_impactitems
+      $migration->dropField("glpi_impactitems", "zoom");
+      $migration->dropField("glpi_impactitems", "pan_x");
+      $migration->dropField("glpi_impactitems", "pan_y");
+      $migration->dropField("glpi_impactitems", "impact_color");
+      $migration->dropField("glpi_impactitems", "depends_color");
+      $migration->dropField("glpi_impactitems", "impact_and_depends_color");
+      $migration->dropField("glpi_impactitems", "position_x");
+      $migration->dropField("glpi_impactitems", "position_y");
+      $migration->dropField("glpi_impactitems", "show_depends");
+      $migration->dropField("glpi_impactitems", "show_impact");
+      $migration->dropField("glpi_impactitems", "max_depth");
+      $migration->addField("glpi_impactitems", "impactcontexts_id", "integer");
+      $migration->addField("glpi_impactitems", "is_slave", "bool", ['value' => 1]);
+      $migration->addKey("glpi_impactitems", "impactcontexts_id", "impactcontexts_id");
+   }
+   /** /Impact context */
+
    // ************ Keep it at the end **************
    foreach ($ADDTODISPLAYPREF as $type => $tab) {
       $rank = 1;

--- a/js/impact.js
+++ b/js/impact.js
@@ -234,7 +234,7 @@ var GLPIImpact = {
             }
          },
          {
-            selector: 'node[highlight]',
+            selector: 'node[highlight=1]',
             style: {
                'font-weight': 'bold',
             }
@@ -987,6 +987,7 @@ var GLPIImpact = {
       // Highlight starting node
       this.cy.filter("node[start]").data({
          highlight: 1,
+         start_node: 1,
       });
 
       // Enable context menu
@@ -1576,6 +1577,8 @@ var GLPIImpact = {
             eles : GLPIImpact.cy.filter(""),
          },
       });
+
+      this.cy.getElementById(startNode.id).data("highlight", 1);
    },
 
    /**
@@ -2076,6 +2079,9 @@ var GLPIImpact = {
     */
    onChange: function() {
       GLPIImpact.showDirtyWorkspaceStatus();
+
+      // Remove hightligh for recently inserted graph
+      GLPIImpact.cy.$("[highlight][!start_node]").data("highlight", 0);
    },
 
    /**

--- a/js/impact.js
+++ b/js/impact.js
@@ -236,8 +236,7 @@ var GLPIImpact = {
          {
             selector: 'node[highlight]',
             style: {
-               'overlay-opacity': 0.18,
-               'overlay-color'  : "gold",
+               'font-weight': 'bold',
             }
          },
          {

--- a/tests/functionnal/Impact.class.php
+++ b/tests/functionnal/Impact.class.php
@@ -280,4 +280,151 @@ class Impact extends \DbTestCase {
       });
       $this->array($both)->hasSize(2);
    }
+
+   public function testClean() {
+      global $DB;
+
+      $impactRelationManager = new \ImpactRelation();
+      $impactItemManager = new \ImpactItem();
+      $impactCompoundManager = new \ImpactCompound();
+
+      $computer1 = getItemByTypeName('Computer', '_test_pc01');
+      $computer2 = getItemByTypeName('Computer', '_test_pc02');
+      $computer3 = getItemByTypeName('Computer', '_test_pc03');
+      $computer4 = getItemByTypeName('Computer', '_test_pc11');
+      $computer5 = getItemByTypeName('Computer', '_test_pc12');
+      $computer6 = getItemByTypeName('Computer', '_test_pc13');
+
+      // Set compounds
+      $compound01Id = $impactCompoundManager->add([
+         'name'  => "_test_compound01",
+         'color' => "#000011",
+      ]);
+      $compound02Id = $impactCompoundManager->add([
+         'name'  => "_test_compound02",
+         'color' => "#110000",
+      ]);
+
+      // Set impact items
+      $impactItemManager->add([
+         'itemtype'  => "Computer",
+         'items_id'  => $computer1->fields['id'],
+         'parent_id' => 0,
+      ]);
+      $impactItemManager->add([
+         'itemtype'  => "Computer",
+         'items_id'  => $computer2->fields['id'],
+         'parent_id' => $compound01Id,
+      ]);
+      $impactItemManager->add([
+         'itemtype'  => "Computer",
+         'items_id'  => $computer3->fields['id'],
+         'parent_id' => $compound01Id,
+      ]);
+      $impactItemManager->add([
+         'itemtype'  => "Computer",
+         'items_id'  => $computer4->fields['id'],
+         'parent_id' => $compound02Id,
+      ]);
+      $impactItemManager->add([
+         'itemtype'  => "Computer",
+         'items_id'  => $computer5->fields['id'],
+         'parent_id' => $compound02Id,
+      ]);
+      $impactItemManager->add([
+         'itemtype'  => "Computer",
+         'items_id'  => $computer6->fields['id'],
+         'parent_id' => $compound02Id,
+      ]);
+
+      // Set relations
+      $impactRelationManager->add([
+         'itemtype_source'   => "Computer",
+         'items_id_source'   => $computer1->fields['id'],
+         'itemtype_impacted' => "Computer",
+         'items_id_impacted' => $computer2->fields['id'],
+      ]);
+      $impactRelationManager->add([
+         'itemtype_source'   => "Computer",
+         'items_id_source'   => $computer2->fields['id'],
+         'itemtype_impacted' => "Computer",
+         'items_id_impacted' => $computer3->fields['id'],
+         ]);
+      $impactRelationManager->add([
+         'itemtype_source'   => "Computer",
+         'items_id_source'   => $computer3->fields['id'],
+         'itemtype_impacted' => "Computer",
+         'items_id_impacted' => $computer4->fields['id'],
+      ]);
+      $impactRelationManager->add([
+         'itemtype_source'   => "Computer",
+         'items_id_source'   => $computer4->fields['id'],
+         'itemtype_impacted' => "Computer",
+         'items_id_impacted' => $computer5->fields['id'],
+      ]);
+      $impactRelationManager->add([
+         'itemtype_source'   => "Computer",
+         'items_id_source'   => $computer2->fields['id'],
+         'itemtype_impacted' => "Computer",
+         'items_id_impacted' => $computer6->fields['id'],
+      ]);
+      $impactRelationManager->add([
+         'itemtype_source'   => "Computer",
+         'items_id_source'   => $computer6->fields['id'],
+         'itemtype_impacted' => "Computer",
+         'items_id_impacted' => $computer2->fields['id'],
+      ]);
+
+      $relations_to_computer2_query = [
+         'FROM'   => \ImpactRelation::getTable(),
+         'WHERE' => [
+            'OR' => [
+               [
+                  'itemtype_source' => get_class($computer2),
+                  'items_id_source' => $computer2->fields['id']
+               ],
+               [
+                  'itemtype_impacted' => get_class($computer2),
+                  'items_id_impacted' => $computer2->fields['id']
+               ],
+            ]
+         ]
+      ];
+
+      $impact_item_computer2_query = [
+         'FROM'   => \ImpactItem::getTable(),
+         'WHERE'  => [
+            'itemtype' => get_class($computer2),
+            'items_id' => $computer2->fields['id'],
+         ]
+      ];
+
+      $compound01_members_query = [
+         'FROM' => \ImpactItem::getTable(),
+         'WHERE' => ["parent_id" => $compound01Id]
+      ];
+
+      // Before deletion
+      $this->integer(count($DB->request($relations_to_computer2_query)))
+         ->isEqualTo(4);
+      $this->integer(count($DB->request($impact_item_computer2_query)))
+         ->isEqualTo(1);
+      $this->integer(count($DB->request($compound01_members_query)))
+         ->isEqualTo(2);
+      $this->boolean($impactCompoundManager->getFromDB($compound01Id))
+         ->isEqualTo(true);
+
+      // Delete pc02
+      $computer2->delete($computer2->fields, true);
+
+      // After deletion
+      $this->integer(count($DB->request($relations_to_computer2_query)))
+         ->isEqualTo(0);
+      $this->integer(count($DB->request($impact_item_computer2_query)))
+         ->isEqualTo(0);
+      $this->integer(count($DB->request($compound01_members_query)))
+         ->isEqualTo(0);
+      $this->boolean($impactCompoundManager->getFromDB($compound01Id))
+         ->isEqualTo(false);
+   }
 }

--- a/tests/functionnal/Impact.class.php
+++ b/tests/functionnal/Impact.class.php
@@ -304,76 +304,78 @@ class Impact extends \DbTestCase {
          'name'  => "_test_compound02",
          'color' => "#110000",
       ]);
+      $this->integer($compound01Id);
+      $this->integer($compound02Id);
 
       // Set impact items
-      $impactItemManager->add([
+      $this->integer($impactItemManager->add([
          'itemtype'  => "Computer",
          'items_id'  => $computer1->fields['id'],
          'parent_id' => 0,
-      ]);
-      $impactItemManager->add([
+      ]));
+      $this->integer($impactItemManager->add([
          'itemtype'  => "Computer",
          'items_id'  => $computer2->fields['id'],
          'parent_id' => $compound01Id,
-      ]);
-      $impactItemManager->add([
+      ]));
+      $this->integer($impactItemManager->add([
          'itemtype'  => "Computer",
          'items_id'  => $computer3->fields['id'],
          'parent_id' => $compound01Id,
-      ]);
-      $impactItemManager->add([
+      ]));
+      $this->integer($impactItemManager->add([
          'itemtype'  => "Computer",
          'items_id'  => $computer4->fields['id'],
          'parent_id' => $compound02Id,
-      ]);
-      $impactItemManager->add([
+      ]));
+      $this->integer($impactItemManager->add([
          'itemtype'  => "Computer",
          'items_id'  => $computer5->fields['id'],
          'parent_id' => $compound02Id,
-      ]);
-      $impactItemManager->add([
+      ]));
+      $this->integer($impactItemManager->add([
          'itemtype'  => "Computer",
          'items_id'  => $computer6->fields['id'],
          'parent_id' => $compound02Id,
-      ]);
+      ]));
 
       // Set relations
-      $impactRelationManager->add([
+      $this->integer($impactRelationManager->add([
          'itemtype_source'   => "Computer",
          'items_id_source'   => $computer1->fields['id'],
          'itemtype_impacted' => "Computer",
          'items_id_impacted' => $computer2->fields['id'],
-      ]);
-      $impactRelationManager->add([
+      ]));
+      $this->integer($impactRelationManager->add([
          'itemtype_source'   => "Computer",
          'items_id_source'   => $computer2->fields['id'],
          'itemtype_impacted' => "Computer",
          'items_id_impacted' => $computer3->fields['id'],
-         ]);
-      $impactRelationManager->add([
+      ]));
+      $this->integer($impactRelationManager->add([
          'itemtype_source'   => "Computer",
          'items_id_source'   => $computer3->fields['id'],
          'itemtype_impacted' => "Computer",
          'items_id_impacted' => $computer4->fields['id'],
-      ]);
-      $impactRelationManager->add([
+      ]));
+      $this->integer($impactRelationManager->add([
          'itemtype_source'   => "Computer",
          'items_id_source'   => $computer4->fields['id'],
          'itemtype_impacted' => "Computer",
          'items_id_impacted' => $computer5->fields['id'],
-      ]);
-      $impactRelationManager->add([
+      ]));
+      $this->integer($impactRelationManager->add([
          'itemtype_source'   => "Computer",
          'items_id_source'   => $computer2->fields['id'],
          'itemtype_impacted' => "Computer",
          'items_id_impacted' => $computer6->fields['id'],
-      ]);
-      $impactRelationManager->add([
+      ]));
+      $this->integer($impactRelationManager->add([
          'itemtype_source'   => "Computer",
          'items_id_source'   => $computer6->fields['id'],
          'itemtype_impacted' => "Computer",
          'items_id_impacted' => $computer2->fields['id'],
-      ]);
+      ]));
 
       $relations_to_computer2_query = [
          'FROM'   => \ImpactRelation::getTable(),

--- a/tests/functionnal/ImpactItem.class.php
+++ b/tests/functionnal/ImpactItem.class.php
@@ -37,7 +37,7 @@ class ImpactItem extends \DbTestCase {
    public function testFindForItem_inexistent() {
       $computer = getItemByTypeName('Computer', '_test_pc02');
 
-      $this->boolean(\ImpactItem::findForItem($computer))->isFalse();
+      $this->boolean(\ImpactItem::findForItem($computer, false))->isFalse();
    }
 
    public function testFindForItem_exist() {


### PR DESCRIPTION
### Main change
Add "context" to graph.
Before this change, node positions were shared between each graph -> modifying any graph would impact every graph using one of it's nodes.

Now, context is delegated to a "context" object which contains node positions, camera position, zoom level, visibility settings (impact, depends and depth) and edge color settings.

Any graph have one of the following:
- No context
- His own context (master)
- The context of another item (slave)

Rules for updating or creating context objets:
- If the item has a context (master), update it with the new data.
- If the item has no context or is a slave, store the data in a new context (master). Any linked node that also doesn't have a context or is a slave take this context as their own (slaves).

Rules for setting node positions:
- If the item has no context, generate graph position using the directed acyclic graph algorithm
- If the item has a context, use the saved position. If positions are missing for some nodes, they will be generated using a simple algorithm (try to put the node at a set distance and angle, change angle and increase distance until success).

### Minor changes
Make selected toolbar items more distinct:
Before![image](https://user-images.githubusercontent.com/42734840/70064299-98013280-15e9-11ea-8893-51eb92e4dc67.png)   After      ![image](https://user-images.githubusercontent.com/42734840/70064306-9a638c80-15e9-11ea-8456-44ef1a752c61.png)

Delete/update impact objects when an asset is purged from GLPI.

Take entities restrictions into account when selecting assets to add in the graph.

Highlight starting node of the graph:
![image](https://user-images.githubusercontent.com/42734840/70064799-66d53200-15ea-11ea-86ed-6ff4060cc61d.png)

A few bugfixes.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
