### PR TITLE
Count max actions from all actions not actions added by user

### DIFF
--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -1023,9 +1023,8 @@ class Rule extends CommonDBTM {
     * @return the maximum number of actions
    **/
    function maxActionsCount() {
-      return count(array_filter($this->actions, function($action_obj) {
-         $action = $this->getAction($action_obj->fields['field']);
-         return !isset($action['duplicatewith']);
+      return count(array_filter($this->getAllActions(), function($action_obj) {
+         return !isset($action_obj['duplicatewith']);
       }));
    }
 
@@ -2658,6 +2657,7 @@ class Rule extends CommonDBTM {
 
    /**
     * @since 0.84
+    * @return array
    */
    function getAllActions() {
       return self::doHookAndMergeResults("getRuleActions", $this->getActions(), $this->getType());

--- a/tests/functionnal/Rule.php
+++ b/tests/functionnal/Rule.php
@@ -243,7 +243,7 @@ class Rule extends DbTestCase {
       $this->integer($rule->maxActionsCount())->isIdenticalTo(0);
 
       $rule = new \RuleTicket();
-      $this->integer($rule->maxActionsCount())->isIdenticalTo(0);
+      $this->integer($rule->maxActionsCount())->isIdenticalTo(29);
 
       $rule = new \RuleDictionnarySoftware();
       $this->integer($rule->maxActionsCount())->isIdenticalTo(4);


### PR DESCRIPTION
Signed-off-by: Stanislas <skita@teclib.com>

Dear GLPI team,

the problem that prevents adding more than 4 rules on user assignment rules.
and more than 1 rule from rule business ticket.

originally the maxCount function is based on actions already added by the user.

However, this must be based on the available actions


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
