### PR TITLE
Fixed : object types cannot contain numbers

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1365,7 +1365,7 @@ class Search {
 
             // Parse datas
             foreach ($newrow['raw'] as $key => $val) {
-               if (preg_match('/ITEM(_(\w[^\d]+))?_(\d+)(_(.+))?/', $key, $matches)) {
+               if (preg_match('/ITEM(_(\w+))?_(\d+)(_(.+))?/', $key, $matches)) {
                   $j = $matches[3];
                   if (isset($matches[2]) && !empty($matches[2])) {
                      $j = $matches[2] . '_' . $matches[3];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

I suggest this modification because some plugins add asset types and this line prevented them from working when the type contained a number
