### PR TITLE
Fix tickest rules for addme_assign and addme_observer forms

### DIFF
--- a/inc/rulecollection.class.php
+++ b/inc/rulecollection.class.php
@@ -1503,16 +1503,25 @@ class RuleCollection extends CommonDBTM {
    /**
     * Process all the rules collection
     *
-    * @param input            array the input data used to check criterias (need to be clean slashes)
-    * @param output           array the initial ouput array used to be manipulate by actions (need to be clean slashes)
-    * @param params           array parameters for all internal functions (need to be clean slashes)
-    * @param options          array options :
-    *                            - condition : specific condition to limit rule list
-    *                            - only_criteria : only react on specific criteria
+    * @param array $input    The input data used to check criterias (need to be clean slashes)
+    * @param array $output   The initial ouput array used to be manipulate by actions (need to be clean slashes)
+    * @param array $params   Parameters for all internal functions (need to be clean slashes)
+    * @param array $options  Options :
+    *                           - condition : specific condition to limit rule list
+    *                           - only_criteria : only react on specific criteria
+    * @param array $fields   Contains the fields of the object on which we are
+    *                        applying the rules (ONLY USED for addme_assign and
+    *                        addme_observer special forms)
     *
-    * @return the output array updated by actions (addslashes datas)
-   **/
-   function processAllRules($input = [], $output = [], $params = [], $options = []) {
+    * @return array the output array updated by actions (addslashes datas)
+    */
+   function processAllRules(
+      $input = [],
+      $output = [],
+      $params = [],
+      $options = [],
+      $fields = []
+   ) {
 
       $p['condition']     = 0;
       $p['only_criteria'] = null;
@@ -1536,7 +1545,7 @@ class RuleCollection extends CommonDBTM {
 
             if ($rule->fields["is_active"]) {
                $output["_rule_process"] = false;
-               $rule->process($input, $output, $params, $p);
+               $rule->process($input, $output, $params, $p, $fields);
 
                if ($output["_rule_process"] && $this->stop_on_first_match) {
                   unset($output["_rule_process"]);

--- a/inc/rulecollection.class.php
+++ b/inc/rulecollection.class.php
@@ -1545,7 +1545,8 @@ class RuleCollection extends CommonDBTM {
 
             if ($rule->fields["is_active"]) {
                $output["_rule_process"] = false;
-               $rule->process($input, $output, $params, $p, $fields);
+               $rule->set_object_fields($fields);
+               $rule->process($input, $output, $params, $p);
 
                if ($output["_rule_process"] && $this->stop_on_first_match) {
                   unset($output["_rule_process"]);

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1236,12 +1236,23 @@ class Ticket extends CommonITILObject {
             $changes[] = '_groups_id_of_requester';
          }
 
-         $input = $rules->processAllRules($input,
-                                          $input,
-                                          ['recursive'   => true,
-                                                'entities_id' => $entid],
-                                          ['condition'     => RuleTicket::ONUPDATE,
-                                          'only_criteria' => $changes]);
+         $fields = [];
+
+         // Since addme_assign and addme_observer send a simplified form that
+         // only contain the new assigned/observer user, we need to inject the
+         // others fields so that rules can check their conditions against the
+         // reals values of the objets and not the (almost) empty addme_XXX form
+         if (isset($_POST['addme_assign']) || isset($_POST['addme_observer'])) {
+            $fields = $this->fields;
+         }
+
+         $input = $rules->processAllRules(
+            $input,
+            $input,
+            ['recursive' => true, 'entities_id' => $entid],
+            ['condition' => RuleTicket::ONUPDATE, 'only_criteria' => $changes],
+            $fields
+         );
          $input = Toolbox::stripslashes_deep($input);
       }
 


### PR DESCRIPTION
Internal ref: 18539.

The specials addme_assign and addme_observer forms that allow one click assignment do not trigger tickets rules correctly.

This is because the rules use the form input to check the rules condition and our "addme_" forms does not send any data in their forms apart from the new assignment.
Thus any rules not based on assignements will be checked against empty value instead of the real value of our object.

To fix this, I injected the fields of the target object into the rules so they can be used if no matching field is found in the given input form.
This change is limited to addme_assign and addme_observer forms only to avoid any unwanted side effects.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
