### PR TITLE
Fix recurrent tickets having periodicity > 1 day

### DIFF
--- a/inc/ticketrecurrent.class.php
+++ b/inc/ticketrecurrent.class.php
@@ -372,8 +372,36 @@ class TicketRecurrent extends CommonDropdown {
       }
 
       $calendar = new Calendar();
-      if ($calendars_id && $calendar->getFromDB($calendars_id) && $calendar->hasAWorkingDay()) {
-         // Base computation on calendar if calendar is defined
+      $is_calendar_valid = $calendars_id && $calendar->getFromDB($calendars_id) && $calendar->hasAWorkingDay();
+
+      if (!$is_calendar_valid || $periodicity_in_seconds > DAY_TIMESTAMP) {
+         // Compute next occurence without using the calendar if calendar is not valid
+         // or if periodicity is at least one day.
+
+         // First occurence of creation
+         $occurence_time = strtotime($begin_date);
+         $creation_time  = $occurence_time - $create_before;
+
+         // Add steps while creation time is in past
+         while ($creation_time < $now) {
+            $creation_time  = strtotime("+ $periodicity_as_interval", $creation_time);
+            $occurence_time = $creation_time + $create_before;
+
+            // Stop if end date reached
+            if ($has_end_date && $occurence_time > strtotime($end_date)) {
+               return 'NULL';
+            }
+         }
+
+         if ($is_calendar_valid) {
+            // If calendar is valid, set begin date to found occurence date.
+            // Calendar based computation will be done and will jump to next working second if necessary.
+            $begin_date = date('Y-m-d H:i:s', $occurence_time);
+         }
+      }
+
+      if ($is_calendar_valid) {
+         // Base computation on calendar if calendar is valid
 
          $occurence_date = $calendar->computeEndDate(
             $begin_date,
@@ -399,21 +427,6 @@ class TicketRecurrent extends CommonDropdown {
                return 'NULL';
             }
          };
-      } else {
-         // First occurence of creation
-         $occurence_time = strtotime($begin_date);
-         $creation_time  = $occurence_time - $create_before;
-
-         // Add steps while creation time is in past
-         while ($creation_time < $now) {
-            $creation_time  = strtotime("+ $periodicity_as_interval", $creation_time);
-            $occurence_time = $creation_time + $create_before;
-
-            // Stop if end date reached
-            if ($has_end_date && $occurence_time > strtotime($end_date)) {
-               return 'NULL';
-            }
-         }
       }
 
       return date("Y-m-d H:i:s", $creation_time);

--- a/tests/functionnal/TicketRecurrent.php
+++ b/tests/functionnal/TicketRecurrent.php
@@ -274,17 +274,17 @@ class TicketRecurrent extends DbTestCase {
       // Ticket created every 7 days with no anticipation and with calendar.
       // We expect ticket to be created every monday at opening hour.
       $data[] = [
-         'begin_date'     => date('Y-m-d 00:00:00', strtotime('last monday')),
+         'begin_date'     => date('Y-m-d 12:00:00', strtotime('last monday')),
          'end_date'       => $end_of_next_year,
          'periodicity'    => DAY_TIMESTAMP * 7,
          'create_before'  => 0,
          'calendars_id'   => $calendar_id,
          'expected_value' => $this->getNextWorkingDayDate(
             $working_days,
-            (int)date('w') === 1 && (int)date('G') >= 9
-               ? 'next monday' // monday on next week if today is monday and creation time is already passed
-               : 'monday', // else monday on current week
-            'Y-m-d 09:00:00'
+            (int)date('w') === 1
+               ? 'tomorrow' // postpone to tomorrow if we are on monday, as today is a day off
+               : 'monday',
+            'Y-m-d 12:00:00'
          ),
       ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Internal id: 18603

Considering we ask to create a ticket every 7 days, using a calendar that has monday to friday as working days.
Before this PR, ticket will be created every 7 working days, e.g: monday form first week, wednesday from second week, friday from third week, tuesday from fifth week, ...
With this PR, ticket will be created every 7 civil days (postponed to next working day if creation date is on a day off).