### PR TITLE
Fix KB item form when not related to an ITIL item; fixes #6568

### DIFF
--- a/inc/knowbaseitem_item.class.php
+++ b/inc/knowbaseitem_item.class.php
@@ -129,9 +129,18 @@ class KnowbaseItem_Item extends CommonDBRelation {
          );
       }
 
-      if ($canedit
-          && !in_array($item->fields['status'], array_merge($item->getClosedStatusArray(),
-                                                            $item->getSolvedStatusArray()))) {
+      $ok_state = true;
+      if ($item instanceof CommonITILObject) {
+         $ok_state = !in_array(
+            $item->fields['status'],
+            array_merge(
+               $item->getClosedStatusArray(),
+               $item->getSolvedStatusArray()
+            )
+         );
+      }
+
+      if ($canedit && $ok_state) {
          echo '<form method="post" action="' . Toolbox::getItemTypeFormURL(__CLASS__) . '">';
          echo "<div class='center'>";
          echo "<table class=\"tab_cadre_fixe\">";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6568 

Cherry-pick of commit 772ce786120be1800ce646df6686f2c7fd5143d2 done on 9.5 branch.

Replaces #6569
