### PR TITLE
Fix orphaned ticket items on asset deletion; fixes #6678

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -839,15 +839,9 @@ class CommonDBTM extends CommonGLPI {
 
          while ($data = $iterator->next()) {
             $cnt = countElementsInTable('glpi_items_tickets', ['tickets_id' => $data['tickets_id']]);
-            $job->getFromDB($data['tickets_id']);
-            if ($cnt == 1) {
-               if ($CFG_GLPI["keep_tickets_on_delete"] == 1) {
-                  $itemsticket->delete(["id" => $data["id"]]);
-               } else {
-                  $job->delete(["id" => $data["tickets_id"]]);
-               }
-            } else {
-               $itemsticket->delete(["id" => $data["id"]]);
+            $itemsticket->delete(["id" => $data["id"]]);
+            if ($cnt == 1 && !$CFG_GLPI["keep_tickets_on_delete"]) {
+               $job->delete(["id" => $data["tickets_id"]]);
             }
          }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6678 

When an asset is deleted from DB, corresponding `Item_Ticket` should be deleted too, whenever the Ticket is kept or not.