### PR TITLE
Remove useless confirmation on missing optional requirement

### DIFF
--- a/inc/console/abstractcommand.class.php
+++ b/inc/console/abstractcommand.class.php
@@ -202,15 +202,6 @@ abstract class AbstractCommand extends Command {
             '<comment>' . $message . '</comment>',
             OutputInterface::VERBOSITY_NORMAL
          );
-         if (!$input->getOption('no-interaction')) {
-            /** @var Symfony\Component\Console\Helper\QuestionHelper $question_helper */
-            $question_helper = $this->getHelper('question');
-            return $question_helper->ask(
-               $input,
-               $output,
-               new ConfirmationQuestion(__('Do you want to continue ?') . ' [Yes/no]', true)
-            );
-         }
       }
 
       return true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

As commands that uses this check already ask for confirmation (prior to install or update db), this first confirmation is useless.
