### PR TITLE
Fix missing inlined images in notifications; fixes #6650

### DIFF
--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -156,7 +156,7 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                foreach ($document_items as $doc_i_data) {
                   $doc->getFromDB($doc_i_data['documents_id']);
                   // Add embeded image if tag present in ticket content
-                  if (preg_match_all('/'.Document::getImageTag($doc->fields['tag']).'/',
+                  if (preg_match_all('/'.preg_quote($doc->fields['tag'], '/').'/',
                                      $current->fields['body_html'], $matches, PREG_PATTERN_ORDER)) {
                      $image_path = Document::getImage(
                         GLPI_DOC_DIR."/".$doc->fields['filepath'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6650 

Prior to #5868, tag of images inside their alt attribute was surrounded by `#` (here https://github.com/glpi-project/glpi/pull/5868/files#diff-298092ebe134c5b9ccbc7042328fb02cR5756), but this is no more the case. Result is that detection of inlined images was broken in notification process.

I reviewed usage of `Document::getImageTag()` is now used only to handle replacement of an `<img>` by the image tag (when display context is not in a rich text), or to do the inverse process. So putting back these `#` around value of images alt attributes seems not necessary (and would be a pain to handle into a migration).
