### PR TITLE
Force purge when delete reservationitem with transfer

### DIFF
--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -3073,7 +3073,7 @@ class Transfer extends CommonDBTM {
             case 0 :
                // Same item -> delete
                if ($ID == $newID) {
-                  $ri->delete(['id' => $ri->fields['id']]);
+                  $ri->delete(['id' => $ri->fields['id']], true);
                }
                // Copy : nothing to do
                break;


### PR DESCRIPTION
Signed-off-by: Stanislas <skita@teclib.com>

When we want to delete permanently reservation attached to a computer with transfer mode, glpi only delete it but reservation is still possible and active

this PR fix this

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
