### PR TITLE
Fix search when using options based on composite keys

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3162,8 +3162,10 @@ JAVASCRIPT;
 
       $addtable = '';
 
-      if (($table != getTableForItemType($itemtype))
-          && (getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) != $table)) {
+      $is_fkey_composite_on_self = getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) == $table
+         && $searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table);
+      if (($is_fkey_composite_on_self || $table != getTableForItemType($itemtype))
+          && ($searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table))) {
          $addtable .= "_".$searchopt[$ID]["linkfield"];
       }
 
@@ -3364,11 +3366,13 @@ JAVASCRIPT;
          $complexjoin = self::computeComplexJoinID($searchopt[$ID]['joinparams']);
       }
 
-      if (((($table != getTableForItemType($itemtype))
+      $is_fkey_composite_on_self = getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) == $table
+         && $searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table);
+      if (((($is_fkey_composite_on_self || $table != getTableForItemType($itemtype))
             && (!isset($CFG_GLPI["union_search_type"][$itemtype])
                 || ($CFG_GLPI["union_search_type"][$itemtype] != $table)))
            || !empty($complexjoin))
-          && getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) != $table) {
+          && ($searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table))) {
          $addtable .= "_".$searchopt[$ID]["linkfield"];
       }
 
@@ -4011,9 +4015,11 @@ JAVASCRIPT;
 
       $inittable = $table;
       $addtable  = '';
+      $is_fkey_composite_on_self = getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) == $table
+         && $searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table);
       if (($table != 'asset_types')
-         && ($table != getTableForItemType($itemtype))
-         && (getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) != $table)) {
+          && ($is_fkey_composite_on_self || $table != getTableForItemType($itemtype))
+          && ($searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table))) {
          $addtable = "_".$searchopt[$ID]["linkfield"];
          $table   .= $addtable;
       }
@@ -4814,7 +4820,7 @@ JAVASCRIPT;
       }
 
       // Multiple link possibilies case
-      if (!empty($linkfield) && getTableNameForForeignKeyField($linkfield) != $new_table) {
+      if (!empty($linkfield) && ($linkfield != getForeignKeyFieldForTable($new_table))) {
          $nt .= "_".$linkfield;
          $AS  = " AS `$nt`";
       }
@@ -4835,7 +4841,7 @@ JAVASCRIPT;
 
       // Do not take into account standard linkfield
       $tocheck = $nt.".".$linkfield;
-      if (getTableNameForForeignKeyField($linkfield) == $new_table) {
+      if ($linkfield == getForeignKeyFieldForTable($new_table)) {
          $tocheck = $nt;
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Internal support id: 18695

 #6388 and #6452 introduced a bug when doing a search using two search options using 2 different foreign keys from a same table A to a same table B (this is a limited case).
For example, when searching/displaying both `Last edit by` and `Requester - Writer` fields on Ticket list, as no alias was set anymore in JOIN, only one JOIN was made and values of these 2 fields were mixed up.

This PR fixes this by putting back usage of aliases by reverting these pieces of code:
```diff
       if (($table != getTableForItemType($itemtype))
-          && ($searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table))) {
+          && (getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) != $table)) {
          $addtable .= "_".$searchopt[$ID]["linkfield"];
       }
```

A new case was introduced in to force alias usage when the search option points on current table BUT uses a composite foreign key. This case correspond, for example, to a search on User using `Responsible` field.