### PR TITLE
Fix cache automatic namespace when using multiple DB hosts

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2984,7 +2984,9 @@ class Config extends CommonDBTM {
       if (!isset($opt['options']['namespace'])) {
          $namespace = "glpi_${optname}_" . GLPI_VERSION;
          if ($DB) {
-            $namespace .= md5($DB->dbhost . $DB->dbdefault);
+            $namespace .= md5(
+               (is_array($DB->dbhost) ? implode(' ', $DB->dbhost) : $DB->dbhost) . $DB->dbdefault
+            );
          }
          $opt['options']['namespace'] = $namespace;
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes following error.

```
glpiphplog.ERROR: Toolbox::userErrorHandlerNormal() in inc/toolbox.class.php line 658
  *** PHP Warning(2): Cannot use a scalar value as an array
  Backtrace :
  inc/config.class.php:2989                          
  inc/config.php:253                                 Config::getCache()
  inc/includes.php:48                                include_once()
  front/entity.form.php:33                           include()
```
