### PR TITLE
Add solution type to prevent error with behaviors

### DIFF
--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -224,6 +224,7 @@ class RuleTicket extends Rule {
                         $solution = new ITILSolution();
                         $solution->add([
                            "itemtype" => "Ticket",
+                           "solutiontypes_id" => $template->getField("solutiontypes_id"),
                            "content" => Toolbox::addslashes_deep($template->getField('content')),
                            "status" => CommonITILValidation::WAITING,
                            "items_id" => $output['id']]);


### PR DESCRIPTION
Signed-off-by: Stanislas <skita@teclib.com>

To prevent error when behaviors is activated, 
rule action must add solution type from template to ITILSolution



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
