### PR TITLE
Add ID search option on Rule; closes #6641

### DIFF
--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -701,6 +701,15 @@ class Rule extends CommonDBTM {
       ];
 
       $tab[] = [
+         'id'                 => '2',
+         'table'              => $this->getTable(),
+         'field'              => 'id',
+         'name'               => __('ID'),
+         'massiveaction'      => false,
+         'datatype'           => 'number'
+      ];
+
+      $tab[] = [
          'id'                 => '3',
          'table'              => $this->getTable(),
          'field'              => 'ranking',

--- a/tests/functionnal/Rule.php
+++ b/tests/functionnal/Rule.php
@@ -182,7 +182,7 @@ class Rule extends DbTestCase {
 
    public function testGetSearchOptionsNew() {
       $rule = new \Rule();
-      $this->array($rule->rawSearchOptions())->hasSize(10);
+      $this->array($rule->rawSearchOptions())->hasSize(11);
    }
 
    public function testGetRuleWithCriteriasAndActions() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6641 

This search option is mandatory to be able to get ID of rules in API.