### PR TITLE
Add log and debug display for exception and fatal errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The present file will list all changes made to the project; according to the
 
 ### Changed
 
+- PHP error_reporting and display_errors configuration directives are no longer overrided by GLPI, unless in debug mode (which forces reporting and display of all errors).
 - `scripts/migrations/racks_plugin.php` has been replaced by `glpi:migration:racks_plugin_to_core` command available using `bin/console`
 
 ### API changes
@@ -70,6 +71,8 @@ The present file will list all changes made to the project; according to the
 - `Config::checkWriteAccessToDirs()`
 - `Config::displayCheckExtensions()`
 - `Toolbox::checkSELinux()`
+- `Toolbox::userErrorHandlerDebug()`
+- `Toolbox::userErrorHandlerNormal()`
 
 #### Removed
 

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -109,7 +109,6 @@ abstract class API extends CommonGLPI {
       self::$api_url = trim($CFG_GLPI['url_base_api'], "/");
 
       // Don't display error in result
-      set_error_handler(['Toolbox', 'userErrorHandlerNormal']);
       ini_set('display_errors', 'Off');
 
       // Avoid keeping messages between api calls

--- a/inc/application/errorhandler.class.php
+++ b/inc/application/errorhandler.class.php
@@ -1,0 +1,340 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Application;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+class ErrorHandler {
+
+   /**
+    * Map between error codes and log levels.
+    *
+    * @var array
+    */
+   const ERROR_LEVEL_MAP = [
+      E_ERROR             => LogLevel::CRITICAL,
+      E_WARNING           => LogLevel::WARNING,
+      E_PARSE             => LogLevel::ALERT,
+      E_NOTICE            => LogLevel::NOTICE,
+      E_CORE_ERROR        => LogLevel::CRITICAL,
+      E_CORE_WARNING      => LogLevel::WARNING,
+      E_COMPILE_ERROR     => LogLevel::ALERT,
+      E_COMPILE_WARNING   => LogLevel::WARNING,
+      E_USER_ERROR        => LogLevel::ERROR,
+      E_USER_WARNING      => LogLevel::WARNING,
+      E_USER_NOTICE       => LogLevel::NOTICE,
+      E_STRICT            => LogLevel::NOTICE,
+      E_RECOVERABLE_ERROR => LogLevel::ERROR,
+      E_DEPRECATED        => LogLevel::NOTICE,
+      E_USER_DEPRECATED   => LogLevel::NOTICE,
+   ];
+
+   /**
+    * Fatal errors list.
+    *
+    * @var array
+    */
+   const FATAL_ERRORS = [
+      E_ERROR,
+      E_PARSE,
+      E_CORE_ERROR,
+      E_COMPILE_ERROR,
+      E_USER_ERROR
+   ];
+
+   /**
+    * Logger instance.
+    *
+    * @var LoggerInterface
+    */
+   private $logger;
+
+   /**
+    * Last fatal error trace.
+    *
+    * @var array
+    */
+   private $last_fatal_trace;
+
+   /**
+    * Reserved memory that will be used in case of an "out of memory" error.
+    *
+    * @var string
+    */
+   private $reserved_memory;
+
+   /**
+    * @param LoggerInterface $logger
+    */
+   public function __construct(LoggerInterface $logger) {
+      $this->logger = $logger;
+   }
+
+   /**
+    * Register error handler callbacks.
+    *
+    * @return void
+    */
+   public function register() {
+      set_error_handler([$this, 'handleError']);
+      set_exception_handler([$this, 'handleException']);
+      register_shutdown_function([$this, 'handleFatalError']);
+      $this->reserved_memory = str_repeat('x', 50 * 1024); // reserve 50 kB of memory space
+   }
+
+   /**
+    * Error handler.
+    *
+    * @param integer $error_code
+    * @param string  $error_message
+    * @param string  $filename
+    * @param integer $line_number
+    *
+    * @return void
+    */
+   public function handleError($error_code, $error_message, $filename, $line_number) {
+
+      $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+      array_shift($trace);  // Remove current method from trace
+      $error_trace = $this->getTraceAsString($trace);
+
+      if (in_array($error_code, self::FATAL_ERRORS)) {
+         // Fatal errors are handled by shutdown function
+         // (as some are not recoverable and cannot be handled here).
+         // Store backtrace to be able to use it there.
+         $this->last_fatal_trace = $trace;
+         return false; // Forward to PHP internal error handler
+      }
+
+      $error_type = sprintf(
+         'PHP %s (%s)',
+         $this->codeToString($error_code),
+         $error_code
+      );
+      $error_description = sprintf(
+         '%s in %s at line %s',
+         $error_message,
+         $filename,
+         $line_number
+      );
+
+      $this->logErrorMessage(
+         $error_type,
+         $error_description,
+         $error_trace,
+         self::ERROR_LEVEL_MAP[$error_code]
+      );
+
+      $this->outputDebugMessage($error_type, $error_description);
+
+      return false; // Forward to PHP internal error handler
+   }
+
+   /**
+    * Exception handler.
+    * Logs exception and exits with a error code.
+    *
+    * @param \Throwable $exception
+    *
+    * @return void
+    */
+   public function handleException(\Throwable $exception) {
+      $error_type = sprintf(
+         'Uncaught Exception %s',
+         get_class($exception)
+      );
+      $error_description = sprintf(
+         '%s in %s at line %s',
+         $exception->getMessage(),
+         $exception->getFile(),
+         $exception->getLine()
+      );
+      $error_trace = $this->getTraceAsString($exception->getTrace());
+
+      $this->logErrorMessage(
+         $error_type,
+         $error_description,
+         $error_trace,
+         self::ERROR_LEVEL_MAP[E_ERROR]
+      );
+
+      $this->outputDebugMessage($error_type, $error_description);
+
+      exit(255); // Exit with an error code
+   }
+
+   /**
+    * Handle fatal errors.
+    *
+    * @retun void
+    */
+   public function handleFatalError() {
+      // Free reserved memory to be able to handle "out of memory" errors
+      $this->reserved_memory = null;
+
+      $error = error_get_last();
+      if ($error && in_array($error['type'], self::FATAL_ERRORS)) {
+         $error_type = sprintf(
+            'PHP Fatal Error (%s)',
+            $error['type']
+         );
+         $error_description = $error['message'];
+
+         // debug_backtrace is not available in shutdown function
+         // so get stored trace if any exists
+         $trace = $this->last_fatal_trace ?? [];
+         $error_trace = $this->getTraceAsString($trace);
+
+         $this->logErrorMessage(
+            $error_type,
+            $error_description,
+            $error_trace,
+            self::ERROR_LEVEL_MAP[$error['type']]
+         );
+
+         $this->outputDebugMessage($error_type, $error_description);
+      }
+   }
+
+   /**
+    * Log message related to error.
+    *
+    * @param string $type
+    * @param string $description
+    * @param string $trace
+    * @param string $log_level
+    *
+    * @return void
+    */
+   private function logErrorMessage(string $type, string $description, string $trace, string $log_level) {
+      if (!($this->logger instanceof LoggerInterface)) {
+         return;
+      }
+
+      $this->logger->log(
+         $log_level,
+         '  *** ' . $type . ': ' . $description . "\n" . $trace
+      );
+   }
+
+   /**
+    * Output debug message related to error.
+    *
+    * @param string $error_type
+    * @param string $message
+    *
+    * @return void
+    */
+   private function outputDebugMessage(string $error_type, string $message) {
+
+      if (!isset($_SESSION['glpi_use_mode']) || $_SESSION['glpi_use_mode'] != \Session::DEBUG_MODE) {
+         return;
+      }
+
+      if (!isCommandLine()) {
+         echo '<div style="position:float-left; background-color:red; z-index:10000">'
+            . '<span class="b">' . $error_type . ': </span>' . $message . '</div>';
+      } else {
+         echo $error_type . ': ' . $message . "\n";
+      }
+   }
+
+   /**
+    * Get error type as string from error code.
+    *
+    * @param int $error_code
+    *
+    * @return string
+    */
+   private function codeToString(int $error_code): string {
+      $map = [
+         E_ERROR             => 'Error',
+         E_WARNING           => 'Warning',
+         E_PARSE             => 'Parsing Error',
+         E_NOTICE            => 'Notice',
+         E_CORE_ERROR        => 'Core Error',
+         E_CORE_WARNING      => 'Core Warning',
+         E_COMPILE_ERROR     => 'Compile Error',
+         E_COMPILE_WARNING   => 'Compile Warning',
+         E_USER_ERROR        => 'User Error',
+         E_USER_WARNING      => 'User Warning',
+         E_USER_NOTICE       => 'User Notice',
+         E_STRICT            => 'Runtime Notice',
+         E_RECOVERABLE_ERROR => 'Catchable Fatal Error',
+         E_DEPRECATED        => 'Deprecated function',
+         E_USER_DEPRECATED   => 'User deprecated function',
+      ];
+
+      return $map[$error_code] ?? 'Unknown error';
+   }
+
+   /**
+    * Get trace as string.
+    *
+    * @param array $trace
+    *
+    * @return string
+    */
+   private function getTraceAsString(array $trace): string {
+      if (empty($trace)) {
+         return '';
+      }
+
+      $message = "  Backtrace :\n";
+
+      foreach ($trace as $item) {
+         $script = ($item['file'] ?? '') . ':' . ($item['line'] ?? '');
+         if (strpos($script, GLPI_ROOT) === 0) {
+            $script = substr($script, strlen(GLPI_ROOT) + 1);
+         }
+         if (strlen($script) > 50) {
+            $script = '...' . substr($script, -47);
+         } else {
+            $script = str_pad($script, 50);
+         }
+
+         $call = ($item['class'] ?? '') . ($item['type'] ?? '') . ($item['function'] ?? '');
+         if (!empty($call)) {
+            $call .= '()';
+         }
+         $message .= "  $script $call\n";
+      }
+
+      return $message;
+   }
+}

--- a/inc/config.php
+++ b/inc/config.php
@@ -51,6 +51,7 @@ if (!isset($_SESSION['glpi_use_mode'])) {
 
 $GLPI = new GLPI();
 $GLPI->initLogger();
+$GLPI->initErrorHandler();
 
 //init cache
 $GLPI_CACHE = Config::getCache('cache_db');

--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -252,6 +252,7 @@ class Application extends BaseApplication {
       global $GLPI;
       $GLPI = new GLPI();
       $GLPI->initLogger();
+      $GLPI->initErrorHandler();
 
       Config::detectRootDoc();
    }

--- a/inc/glpi.class.php
+++ b/inc/glpi.class.php
@@ -30,6 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\ErrorHandler;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\TestHandler;
@@ -44,6 +45,7 @@ if (!defined('GLPI_ROOT')) {
 **/
 class GLPI {
 
+   private $error_handler;
    private $loggers;
    private $log_level;
 
@@ -92,5 +94,17 @@ class GLPI {
     */
    public function getLogLevel() {
       return $this->log_level;
+   }
+
+   /**
+    * Init and register error handler.
+    *
+    * @return void
+    */
+   public function initErrorHandler() {
+      global $PHPLOGGER;
+
+      $this->error_handler = new ErrorHandler($PHPLOGGER);
+      $this->error_handler->register();
    }
 }

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -612,8 +612,12 @@ class Toolbox {
     * @param integer $linenum   line number the error was raised at.
     *
     * @return string  Error type
+    *
+    * @deprecated 9.5.0
    **/
    static function userErrorHandlerNormal($errno, $errmsg, $filename, $linenum) {
+
+      Toolbox::deprecated();
 
       $errortype = [E_ERROR             => 'Error',
                          E_WARNING           => 'Warning',
@@ -676,8 +680,12 @@ class Toolbox {
     * @param integer $linenum   line number the error was raised at.
     *
     * @return void
+    *
+    * @deprecated 9.5.0
    **/
    static function userErrorHandlerDebug($errno, $errmsg, $filename, $linenum) {
+
+      Toolbox::deprecated();
 
       // For file record
       $type = self::userErrorHandlerNormal($errno, $errmsg, $filename, $linenum);
@@ -729,15 +737,10 @@ class Toolbox {
 
       // If debug mode activated : display some information
       if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
-         // Recommended development settings
-         ini_set('display_errors', 'On');
+         // Force reporting of all errors
          error_reporting(E_ALL);
-         set_error_handler(['Toolbox','userErrorHandlerDebug']);
-      } else if (!defined('TU_USER')) {
-         // Recommended production settings
+         // Disable native error displaying as it will be done by custom handler
          ini_set('display_errors', 'Off');
-         error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
-         set_error_handler(['Toolbox', 'userErrorHandlerNormal']);
       }
    }
 

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -423,6 +423,10 @@ class Toolbox {
          }
       }
 
+      if (defined('TU_USER') && $level >= Logger::NOTICE) {
+         throw new \RuntimeException($msg);
+      }
+
       $tps = microtime(true);
 
       if ($logger === null) {
@@ -437,9 +441,7 @@ class Toolbox {
          error_log($e);
       }
 
-      if (defined('TU_USER') && $level >= Logger::NOTICE) {
-         throw new \RuntimeException($msg);
-      } else if (isCommandLine() && $level >= Logger::WARNING) {
+      if (isCommandLine() && $level >= Logger::WARNING) {
          echo $msg;
       }
    }

--- a/install/install.php
+++ b/install/install.php
@@ -37,6 +37,7 @@ include_once (GLPI_ROOT . "/inc/db.function.php");
 
 $GLPI = new GLPI();
 $GLPI->initLogger();
+$GLPI->initErrorHandler();
 
 Config::detectRootDoc();
 

--- a/install/update.php
+++ b/install/update.php
@@ -40,6 +40,7 @@ include_once (GLPI_CONFIG_DIR . "/config_db.php");
 
 $GLPI = new GLPI();
 $GLPI->initLogger();
+$GLPI->initErrorHandler();
 
 $GLPI_CACHE = Config::getCache('cache_db');
 $GLPI_CACHE->clear(); // Force cache cleaning to prevent usage of outdated cache data

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -75,6 +75,23 @@ class GLPITestCase extends atoum {
          }
          $GLPI_CACHE = false;
       }
+
+      global $PHPLOGGER;
+      $handlers = $PHPLOGGER->getHandlers();
+      foreach ($handlers as $handler) {
+         $records  = $handler->getRecords();
+         $messages = array_column($records, 'message');
+         $this->integer(count($records))
+            ->isEqualTo(
+               0,
+               sprintf(
+                  'Unexpected logs records found in %s::%s() test: %s',
+                  static::class,
+                  $method,
+                  "\n" . implode("\n", $messages)
+               )
+            );
+      }
    }
 
    /**

--- a/tests/units/Glpi/Application/ErrorHandler.php
+++ b/tests/units/Glpi/Application/ErrorHandler.php
@@ -32,8 +32,6 @@
 
 namespace tests\units\Glpi\Application;
 
-use Monolog\Logger;
-use Monolog\Handler\TestHandler;
 use Psr\Log\LogLevel;
 
 class ErrorHandler extends \GLPITestCase {

--- a/tests/units/Glpi/Application/ErrorHandler.php
+++ b/tests/units/Glpi/Application/ErrorHandler.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+*/
+
+namespace tests\units\Glpi\Application;
+
+use Psr\Log\LogLevel;
+
+class ErrorHandler extends \GLPITestCase {
+
+   public function afterTestMethod($method) {
+      switch ($method) {
+         case 'testRegisteredHandleError':
+            // Restore previous handlers
+            restore_error_handler();
+            restore_exception_handler();
+            break;
+      }
+      parent::afterTestMethod($method);
+   }
+
+   /**
+    * @return array
+    */
+   protected function errorProvider(): array {
+
+      $log_prefix = '/';
+      $log_suffix = '.*' . preg_quote(' in ' . __FILE__ . ' at line ', '/') . '\d+' . '/';
+
+      return [
+         [
+            'error_call'           => function () { file_get_contents('this-file-does-not-exists'); },
+            'expected_log_level'   => LogLevel::WARNING,
+            'expected_msg_pattern' => $log_prefix
+               . preg_quote('PHP Warning (' . E_WARNING . '): file_get_contents(this-file-does-not-exists): failed to open stream: No such file or directory', '/')
+               . $log_suffix,
+         ],
+         [
+            'error_call'           => function () { $a = $b; },
+            'expected_log_level'   => LogLevel::NOTICE,
+            'expected_msg_pattern' => $log_prefix
+               . preg_quote('PHP Notice (' . E_NOTICE . '): Undefined variable: b', '/')
+               . $log_suffix,
+         ],
+         [
+            'error_call'           => function () { $inst = new class { function nonstatic() {} }; $inst::nonstatic(); },
+            'expected_log_level'   => LogLevel::NOTICE,
+            'expected_msg_pattern' => $log_prefix
+               . preg_quote('PHP Deprecated function (' . E_DEPRECATED . '): Non-static method class@anonymous::nonstatic() should not be called statically', '/')
+               . $log_suffix,
+         ],
+         [
+            'error_call'           => function () { trigger_error('this is a warning', E_USER_WARNING); },
+            'expected_log_level'   => LogLevel::WARNING,
+            'expected_msg_pattern' => $log_prefix
+               . preg_quote('PHP User Warning (' . E_USER_WARNING . '): this is a warning', '/')
+               . $log_suffix,
+         ],
+         [
+            'error_call'           => function () { trigger_error('some notice', E_USER_NOTICE); },
+            'expected_log_level'   => LogLevel::NOTICE,
+            'expected_msg_pattern' => $log_prefix
+               . preg_quote('PHP User Notice (' . E_USER_NOTICE . '): some notice', '/')
+               . $log_suffix,
+         ],
+         [
+            'error_call'           => function () { trigger_error('this method is deprecated', E_USER_DEPRECATED); },
+            'expected_log_level'   => LogLevel::NOTICE,
+            'expected_msg_pattern' => $log_prefix
+               . preg_quote('PHP User deprecated function (' . E_USER_DEPRECATED . '): this method is deprecated', '/')
+               . $log_suffix,
+         ]
+      ];
+   }
+
+   /**
+    * Test that errors trigerred are correctly processed by registered error handler.
+    *
+    * Nota: Fatal errors cannot be tested that way, as they will result in exiting current execution.
+    * Related constants are E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR.
+    *
+    * @dataProvider errorProvider
+    */
+   public function testRegisteredErrorHandler(
+      callable $error_call,
+      string $expected_log_level,
+      string $expected_msg_pattern
+   ) {
+      $logger = $this->newMockInstance('Psr\\Log\\NullLogger');
+      $logged_level = null;
+      $logged_message = null;
+      $this->calling($logger)->log = function($level, $message) use(&$logged_level, &$logged_message) {
+         $logged_level   = $level;
+         $logged_message = $message;
+      };
+
+      // Force session in debug mode (to get debug output)
+      $previous_use_mode         = $_SESSION['glpi_use_mode'];
+      $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
+
+      $this->newTestedInstance($logger);
+      $this->testedInstance->setForwardToInternalHandler(false);
+      $this->testedInstance->register();
+
+      // Assert that nothing is logged when using '@' operator
+      $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
+      @$error_call();
+      $_SESSION['glpi_use_mode'] = $previous_use_mode;
+      $this->mock($logger)->call('log')->never();
+      $this->output->isEmpty();
+
+      // Assert that error handler acts as expected when not using '@' operator
+      $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
+      $error_call();
+      $_SESSION['glpi_use_mode'] = $previous_use_mode;
+      $this->mock($logger)->call('log')->once();
+
+      $this->string($logged_level)->isEqualTo($expected_log_level);
+      $this->string($logged_message)->matches($expected_msg_pattern);
+
+      $this->output->matches($expected_msg_pattern);
+   }
+
+   /**
+    * @return array
+    */
+   protected function handleErrorProvider(): array {
+
+      $log_prefix = '/';
+      $log_suffix = ' \(\d+\): .*' . preg_quote(' in ' . __FILE__ . ' at line ', '/') . '\d+' . '/';
+
+      return [
+         [
+            'error_code'           => E_ERROR,
+            'expected_log_level'   => LogLevel::CRITICAL,
+            'expected_msg_pattern' => $log_prefix . 'PHP Error' . $log_suffix,
+            'is_fatal_error'       => true,
+         ],
+         [
+            'error_code'           => E_WARNING,
+            'expected_log_level'   => LogLevel::WARNING,
+            'expected_msg_pattern' => $log_prefix . 'PHP Warning' . $log_suffix,
+         ],
+         [
+            'error_code'           => E_PARSE,
+            'expected_log_level'   => LogLevel::ALERT,
+            'expected_msg_pattern' => $log_prefix . 'PHP Parsing Error' . $log_suffix,
+            'is_fatal_error'       => true,
+         ],
+         [
+            'error_code'           => E_NOTICE,
+            'expected_log_level'   => LogLevel::NOTICE,
+            'expected_msg_pattern' => $log_prefix . 'PHP Notice' . $log_suffix,
+         ],
+         [
+            'error_code'           => E_CORE_ERROR,
+            'expected_log_level'   => LogLevel::CRITICAL,
+            'expected_msg_pattern' => $log_prefix . 'PHP Core Error' . $log_suffix,
+            'is_fatal_error'       => true,
+         ],
+         [
+            'error_code'           => E_CORE_WARNING,
+            'expected_log_level'   => LogLevel::WARNING,
+            'expected_msg_pattern' => $log_prefix . 'PHP Core Warning' . $log_suffix,
+         ],
+         [
+            'error_code'           => E_COMPILE_ERROR,
+            'expected_log_level'   => LogLevel::ALERT,
+            'expected_msg_pattern' => $log_prefix . 'PHP Compile Error' . $log_suffix,
+            'is_fatal_error'       => true,
+         ],
+         [
+            'error_code'           => E_COMPILE_WARNING,
+            'expected_log_level'   => LogLevel::WARNING,
+            'expected_msg_pattern' => $log_prefix . 'PHP Compile Warning' . $log_suffix,
+         ],
+         [
+            'error_code'           => E_USER_ERROR,
+            'expected_log_level'   => LogLevel::ERROR,
+            'expected_msg_pattern' => $log_prefix . 'PHP User Error' . $log_suffix,
+            'is_fatal_error'       => true,
+         ],
+         [
+            'error_code'           => E_USER_WARNING,
+            'expected_log_level'   => LogLevel::WARNING,
+            'expected_msg_pattern' => $log_prefix . 'PHP User Warning' . $log_suffix,
+         ],
+         [
+            'error_code'           => E_USER_NOTICE,
+            'expected_log_level'   => LogLevel::NOTICE,
+            'expected_msg_pattern' => $log_prefix . 'PHP User Notice' . $log_suffix,
+         ],
+         [
+            'error_code'           => E_RECOVERABLE_ERROR,
+            'expected_log_level'   => LogLevel::ERROR,
+            'expected_msg_pattern' => $log_prefix . 'PHP Catchable Fatal Error' . $log_suffix,
+         ],
+         [
+            'error_code'           => E_DEPRECATED,
+            'expected_log_level'   => LogLevel::NOTICE,
+            'expected_msg_pattern' => $log_prefix . 'PHP Deprecated function' . $log_suffix,
+         ],
+         [
+            'error_code'           => E_USER_DEPRECATED,
+            'expected_log_level'   => LogLevel::NOTICE,
+            'expected_msg_pattern' => $log_prefix . 'PHP User deprecated function' . $log_suffix,
+         ],
+      ];
+   }
+
+   /**
+    * Test error handler and fatal error handler methods.
+    *
+    * @dataProvider handleErrorProvider
+    */
+   public function testHandleErrorAndHandleFatalError(
+      int $error_code,
+      string $expected_log_level,
+      string $expected_msg_pattern,
+      bool $is_fatal_error = false
+   ) {
+      $logger = $this->newMockInstance('Psr\\Log\\NullLogger');
+      $logged_level = null;
+      $logged_message = null;
+      $this->calling($logger)->log = function($level, $message) use(&$logged_level, &$logged_message) {
+         $logged_level   = $level;
+         $logged_message = $message;
+      };
+
+      // Force session in debug mode (to get debug output)
+      $previous_use_mode         = $_SESSION['glpi_use_mode'];
+      $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
+
+      $this->newTestedInstance($logger);
+      $this->testedInstance->setForwardToInternalHandler(false);
+
+      // Assert that nothing is logged when using '@' operator
+      $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
+      @$this->testedInstance->handleError($error_code, 'err_msg', __FILE__, __LINE__);
+      $_SESSION['glpi_use_mode'] = $previous_use_mode;
+      $this->mock($logger)->call('log')->never();
+      $this->output->isEmpty();
+
+      // Assert that error handler acts as expected when not using '@' operator
+      // Fatal error are not logged by function, but other errors should be
+      $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
+      $this->testedInstance->handleError($error_code, 'err_msg', __FILE__, __LINE__);
+      $_SESSION['glpi_use_mode'] = $previous_use_mode;
+      $this->mock($logger)->call('log')->exactly($is_fatal_error ? 0 : 1);
+
+      if ($is_fatal_error) {
+         // If error is a Fatal error, message logging should be delegated to
+         // the 'handleFatalError' method which will be used as shutdown function.
+         $this->variable($logged_level)->isNull();
+         $this->variable($logged_message)->isNull();
+
+         $this->function->error_get_last = [
+            'type'    => $error_code,
+            'message' => 'err_msg',
+            'file'    => __FILE__,
+            'line'    => __LINE__,
+         ];
+         $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
+         $this->testedInstance->handleFatalError();
+         $_SESSION['glpi_use_mode'] = $previous_use_mode;
+         $this->mock($logger)->call('log')->once();
+      }
+
+      $this->string($logged_level)->isEqualTo($expected_log_level);
+      $this->string($logged_message)->matches($expected_msg_pattern);
+
+      $this->output->matches($expected_msg_pattern);
+   }
+
+   /**
+    * Test exception handler.
+    */
+   public function testHandleException() {
+      $logger = $this->newMockInstance('Psr\\Log\\NullLogger');
+      $logged_level = null;
+      $logged_message = null;
+      $this->calling($logger)->log = function($level, $message) use(&$logged_level, &$logged_message) {
+         $logged_level   = $level;
+         $logged_message = $message;
+      };
+
+      $exception = new \RuntimeException('Something went wrong');
+      $expected_msg_pattern = '/'
+         . preg_quote('Uncaught Exception RuntimeException: Something went wrong in ' . __FILE__ . ' at line ', '/')
+         . '\d+'
+         . '/';
+
+      // Force session in debug mode (to get debug output)
+      $previous_use_mode         = $_SESSION['glpi_use_mode'];
+      $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
+
+      $this->newTestedInstance($logger);
+
+      // Assert that nothing is logged when using '@' operator
+      $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
+      @$this->testedInstance->handleException($exception);
+      $_SESSION['glpi_use_mode'] = $previous_use_mode;
+      $this->mock($logger)->call('log')->never();
+      $this->output->isEmpty();
+
+      // Assert that exception handler acts as expected when not using '@' operator
+      // Fatal error are not logged by function, but other errors should be
+      $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
+      $this->testedInstance->handleException($exception);
+      $_SESSION['glpi_use_mode'] = $previous_use_mode;
+      $this->mock($logger)->call('log')->once();
+
+      $this->string($logged_level)->isEqualTo(LogLevel::CRITICAL);
+      $this->string($logged_message)->matches($expected_msg_pattern);
+
+      $this->output->matches($expected_msg_pattern);
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | part of #6731 

Add exception handler and shutdown function to be able to:
 - display a message for exceptions and fatal errors when user uses debug mode;
 - log exception and fatal erros in `php-errors.log`.

Inspired by `Monolog\ErrorHandler`, but rewritten to fits current GLPI log format.

Other changes:
 - error handler now forward error to native PHP error handler, to give ability to sysadmin to also write PHP errors into system log;
 - error_reporting level and display error flags are not longer set when user does not use debug mode, to give ability to sysadmin to set custom values for these configurations.


## Case 1: PHP Fatal Error (preceded by a notice)
Code sample:
```diff
diff --git a/inc/central.class.php b/inc/central.class.php
index 3b4dd52ec8..bccfb0303c 100644
--- a/inc/central.class.php
+++ b/inc/central.class.php
@@ -116,6 +116,9 @@ class Central extends CommonGLPI {
       } else {
          Ticket::showCentralCount(true);
       }
+
+      $bad_variable->doSomething();
+
       if ($showproblem) {
          Problem::showCentralCount();
       }

```

Result in interface:
![image](https://user-images.githubusercontent.com/33253653/70941758-770af980-204d-11ea-8d84-56e5231d5c21.png)

Result in logs:
```
[2019-12-16 20:45:23] glpiphplog.NOTICE:   *** PHP Notice (8): Undefined variable: bad_variable in /var/www/glpi/inc/central.class.php at line 120
  Backtrace :
  inc/central.class.php:90                           Central::showGlobalView()
  inc/commonglpi.class.php:587                       Central::displayTabContentForItem()
  ajax/common.tabs.php:92                            CommonGLPI::displayStandardTab()
  
[2019-12-16 20:45:23] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Call to a member function doSomething() on null in /var/www/glpi/inc/central.class.php at line 120
  Backtrace :
  inc/central.class.php:90                           Central::showGlobalView()
  inc/commonglpi.class.php:587                       Central::displayTabContentForItem()
  ajax/common.tabs.php:92                            CommonGLPI::displayStandardTab()
  
```

## Case 2: "Out of memory"
Code sample:
```diff
diff --git a/front/problem.php b/front/problem.php
index 4b0cb2c6d4..cbfb9f2fa6 100644
--- a/front/problem.php
+++ b/front/problem.php
@@ -32,6 +32,8 @@
 
 include ('../inc/includes.php');
 
+ini_set('memory_limit', '5M');
+
 Session::checkRightsOr('problem', [Problem::READALL, Problem::READMY]);
 
 Html::header(Problem::getTypeName(Session::getPluralNumber()), '', "helpdesk", "problem");
```

Result in interface:
![image](https://user-images.githubusercontent.com/33253653/70942250-89d1fe00-204e-11ea-9a16-bfb42de8d6f1.png)

Result in logs:
```
[2019-12-16 20:52:16] glpiphplog.CRITICAL:   *** PHP Fatal Error (1): Allowed memory size of 5242880 bytes exhausted (tried to allocate 1310720 bytes)
```

## Case 3: Exception

Code sample:
```diff
diff --git a/inc/search.class.php b/inc/search.class.php
index db0f0bbb7d..26f2bc6a7a 100755
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1734,6 +1734,8 @@ class Search {
                Session::initNavigateListItems($data['itemtype']);
             }
 
+            throw new \RuntimeException('Some error message');
+
             // Num of the row (1=header_line)
             $row_num = 1;
 ```

Result in interface:
![image](https://user-images.githubusercontent.com/33253653/70942499-14b2f880-204f-11ea-9e4f-661284d16579.png)

Result in logs:
```
[2019-12-16 20:56:17] glpiphplog.CRITICAL:   *** Uncaught Exception RuntimeException: Some error message in /var/www/glpi/inc/search.class.php at line 1737
  Backtrace :
  inc/search.class.php:99                            Search::displayData()
  inc/search.class.php:80                            Search::showList()
  front/ticket.php:45                                Search::show()

```
