### PR TITLE
Set lastrun field to current php date 

### DIFF
--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -211,7 +211,7 @@ class CronTask extends CommonDBTM{
       $result = $DB->update(
          $this->getTable(), [
             'state'  => self::STATE_RUNNING,
-            'lastrun'   => new \QueryExpression('DATE_FORMAT(NOW(),\'%Y-%m-%d %H:%i:00\')')
+            'lastrun'   =>  date("Y-m-d H:i:00")
          ], [
             'id'  => $this->fields['id'],
             'NOT' => ['state' => self::STATE_RUNNING]


### PR DESCRIPTION
The user can modify the time zone in the php.ini of the site on which glpi is installed, in this case the datetime of the site is always different to the server datetime
and if the user does not change the time_zone of mysql in this case DATE_FORMAT(NOW ()) returns the datetime of the server and not the date configured according to the time zone of php.ini file
There are some cases where the cron is useless as long as the time of mysql is different to the time configured on php.ini
So I suggest  to updating the lastrun field with the date returned by php instead of mysql
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | --
