### PR TITLE
Do not silent fatal errors and always output exceptions in CLI context

### DIFF
--- a/tests/units/Glpi/Application/ErrorHandler.php
+++ b/tests/units/Glpi/Application/ErrorHandler.php
@@ -305,13 +305,6 @@ class ErrorHandler extends \GLPITestCase {
 
       $this->newTestedInstance($logger);
 
-      // Assert that nothing is logged when using '@' operator
-      $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;
-      @$this->testedInstance->handleException($exception);
-      $_SESSION['glpi_use_mode'] = $previous_use_mode;
-      $this->integer(count($handler->getRecords()))->isEqualTo(0);
-      $this->output->isEmpty();
-
       // Assert that exception handler acts as expected when not using '@' operator
       // Fatal error are not logged by function, but other errors should be
       $_SESSION['glpi_use_mode'] = \Session::DEBUG_MODE;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Errors that cannot be recovered (i.e. Exceptions and Fatal errors) should not be muted.
2. Exceptions message should always be outputed in CLI context.