### PR TITLE
Add SSO Logout URL

### DIFF
--- a/front/logout.php
+++ b/front/logout.php
@@ -38,6 +38,13 @@ include ('../inc/includes.php');
 
 //@session_start();
 
+
+if (!empty($CFG_GLPI["ssovariables_id"])
+    && !empty($CFG_GLPI['ssologout_url'])) {
+
+   Html::redirect($CFG_GLPI["ssologout_url"]);
+}
+
 if (!isset($_SESSION["noAUTO"])
     && isset($_SESSION["glpiauthtype"])
     && $_SESSION["glpiauthtype"] == Auth::CAS

--- a/front/logout.php
+++ b/front/logout.php
@@ -38,10 +38,8 @@ include ('../inc/includes.php');
 
 //@session_start();
 
-
-if (!empty($CFG_GLPI["ssovariables_id"])
-    && !empty($CFG_GLPI['ssologout_url'])) {
-
+if ($CFG_GLPI["ssovariables_id"] > 0
+    && strlen($CFG_GLPI['ssologout_url']) > 0) {
    Html::redirect($CFG_GLPI["ssologout_url"]);
 }
 

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -1455,6 +1455,12 @@ class Auth extends CommonGLPI {
       echo "</tr>\n";
 
       echo "<tr class='tab_bg_2'>";
+      echo "<td class='center'>" . __('SSO logout url') . "</td>";
+      echo "<td><input type='text' name='ssologout_url' value='".
+                 $CFG_GLPI['ssologout_url']."'></td>";
+      echo "</tr>\n";
+
+      echo "<tr class='tab_bg_2'>";
       echo "<td class='center'>" . __('Remove the domain of logins like login@domain')."</td><td>";
       Dropdown::showYesNo('existing_auth_server_field_clean_domain',
                           $CFG_GLPI['existing_auth_server_field_clean_domain']);

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -231,6 +231,7 @@ $default_prefs = [
    'entity_ssofield'                         => '',
    'registration_number_ssofield'            => '',
    'ssovariables_id'                         => '0',
+   'ssologout_url'                           => '',
    'translate_kb'                            => '0',
    'translate_dropdowns'                     => '0',
    'pdffont'                                 => 'helvetica',

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -1153,6 +1153,11 @@ function update94to95() {
    }
    /** /Domain records */
 
+
+   /** SSO logout URL */
+   $migration->addField("glpi_configs", "ssologout_url", "string");
+   /** SSO logout URL */
+
    // ************ Keep it at the end **************
    foreach ($ADDTODISPLAYPREF as $type => $tab) {
       $rank = 1;

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -1190,7 +1190,7 @@ function update94to95() {
       $migration->addKey("glpi_impactitems", "impactcontexts_id", "impactcontexts_id");
    }
    /** /Impact context */
-  
+
    /** SSO logout URL */
    $migration->addConfig(['ssologout_url' => '']);
    /** SSO logout URL */

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -1153,9 +1153,8 @@ function update94to95() {
    }
    /** /Domain records */
 
-
    /** SSO logout URL */
-   $migration->addField("glpi_configs", "ssologout_url", "string");
+   $migration->addConfig(['ssologout_url' => '']);
    /** SSO logout URL */
 
    // ************ Keep it at the end **************


### PR DESCRIPTION
Hi,

I use external authentication with :
* Apache
* zmartzone/mod_auth_openidc
* Keycloak

The actual logout process does not redirect to my SSO login page.  
In the ```mod_auth_openidc documentation```, I found : https://github.com/zmartzone/mod_auth_openidc/wiki#9-how-do-i-logout-users

I add a new config param to set a "SSO Logout URL"

In my case, I set the value to ```/redirect_uri?logout=http%3A%2F%2Fglpi%2F```

When I click on "Logout", my browser do a ```GET https://glpi/front/logout.php?noAUTO=1```.
The server response is a 302 with ```location: /redirect_uri?logout=http%3A%2F%2Fglpi%2F``` 
The server response is a 302 with ```location: location: https://keycloak/auth/realms/myrealm/protocol/openid-connect/logout?id_token_hint=...&post_logout_redirect_uri=http%3A%2F%2Fglpi%2F``` 
The Keycloak login page is displayed.


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |  
