### PR TITLE
fix(core): never display GLPI version on helpdesk footer

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1834,7 +1834,7 @@ class Html {
       echo "</div>"; // fin de la div id ='page' initi??e dans la fonction header
 
       echo "<div id='footer'>";
-      echo "<table width='100%'><tr><td class='right'>" . self::getCopyrightMessage();
+      echo "<table width='100%'><tr><td class='right'>" . self::getCopyrightMessage(false);
       echo "</td></tr></table></div>";
 
       self::displayDebugInfos();
@@ -1898,7 +1898,7 @@ class Html {
       if (!isCommandLine()) {
          echo "</div></div>";
 
-         echo "<div id='footer-login'>" . self::getCopyrightMessage() . "</div>";
+         echo "<div id='footer-login'>" . self::getCopyrightMessage(false) . "</div>";
          self::loadJavascript();
          echo "</body></html>";
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

For security reason, I propose to not display GLPI version outside the standard interface, and therefore to remove it from all "helpdesk" footers (simplified interface, public faq, nullfooter, etc.).
