### PR TITLE
Remove usage of unexisting gzopen64

### DIFF
--- a/front/backup.php
+++ b/front/backup.php
@@ -319,11 +319,7 @@ function backupMySql($DB, $dumpFile, $duree, $rowlimit) {
    // $dumpFile, fichier source
    // $duree=timeout pour changement de page (-1 = aucun)
 
-   if (function_exists('gzopen')) {
-      $fileHandle = gzopen($dumpFile, "a");
-   } else {
-      $fileHandle = gzopen64($dumpFile, "a");
-   }
+   $fileHandle = gzopen($dumpFile, "a");
 
    if (!$fileHandle) {
       //TRANS: %s is the name of the file


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This code was due to a PHP bug that was fixed in PHP 5.5.20
see https://bugs.php.net/bug.php?id=53829