### PR TITLE
Remove direct dependency to zend/mime component

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -35,7 +35,6 @@ if (!defined('GLPI_ROOT')) {
 }
 
 use LitEmoji\LitEmoji;
-use Zend\Mime\Mime as Zend_Mime;
 
 /**
  * MailCollector class
@@ -1480,8 +1479,8 @@ class MailCollector  extends CommonDBTM {
                //not an attachment
             return false;
          } else {
-            if (strtok($part->contentDisposition, ';') != Zend_Mime::DISPOSITION_ATTACHMENT
-               && strtok($part->contentDisposition, ';') != Zend_Mime::DISPOSITION_INLINE
+            if (strtok($part->contentDisposition, ';') != 'attachment'
+               && strtok($part->contentDisposition, ';') != 'inline'
             ) {
                //not an attachment
                return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In #6118, a direct usage oz zend/mime component as been introduced. As it is only to use constant which values will probably never change, I propose to remove usage of these constants to not directly use this dependency.

Alternative solution would be to add it in composer.json and config class as it was done for other dependencies in #6777 .