### PR TITLE
Add password expiration strategy

### DIFF
--- a/front/helpdesk.public.php
+++ b/front/helpdesk.public.php
@@ -95,7 +95,34 @@ if (isset($_GET['create_ticket'])) {
 
 } else {
    Html::helpHeader(__('Home'), $_SERVER['PHP_SELF'], $_SESSION["glpiname"]);
-   echo "<table class='tab_cadre_postonly'><tr class='noHover'>";
+   echo "<table class='tab_cadre_postonly'>";
+
+   $user = new User();
+   $user->getFromDB(Session::getLoginUserID());
+   if ($user->shouldChangePassword()) {
+      $expiration_msg = sprintf(
+         __('Your password will expire on %s.'),
+         Html::convDateTime(date('Y-m-d H:i:s', $user->getPasswordExpirationTime()))
+      );
+      echo '<tr>';
+      echo '<th colspan="2">';
+      echo '<div class="warning">';
+      echo '<i class="fa fa-exclamation-triangle fa-5x"></i>';
+      echo '<ul>';
+      echo '<li>';
+      echo $expiration_msg . ' ';
+      echo '<a href="' . $CFG_GLPI['root_doc'] . '/front/updatepassword.php">';
+      echo __('Update my password');
+      echo '</a>';
+      echo '</li>';
+      echo '</ul>';
+      echo '<div class="sep"></div>';
+      echo '</div>';
+      echo '</th>';
+      echo '</tr>';
+   }
+
+   echo "<tr class='noHover'>";
    echo "<td class='top' width='50%'><br>";
    echo "<table class='central'>";
    Plugin::doHook('display_central');

--- a/front/updatepassword.php
+++ b/front/updatepassword.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+include ('../inc/includes.php');
+
+use Glpi\Exception\PasswordTooWeakException;
+
+Session::checkLoginUser();
+
+switch (Session::getCurrentInterface()) {
+   case 'central':
+      Html::header(__('Update password'), $_SERVER['PHP_SELF']);
+      break;
+   case 'helpdesk':
+      Html::helpHeader(__('Update password'), $_SERVER['PHP_SELF']);
+      break;
+   default:
+      Html::simpleHeader(__('Update password'));
+      break;
+}
+
+$user = new User();
+$user->getFromDB(Session::getLoginUserID());
+
+$success  = false;
+$error_messages = [];
+
+if (array_key_exists('update', $_POST)) {
+   $current_password = $_POST['current_password'];
+   if (!Auth::checkPassword($current_password, $user->fields['password'])) {
+      $error_messages = [__('Incorrect password')];
+   } else {
+      $input = [
+         'id'               => $user->fields['id'],
+         'current_password' => $_POST['current_password'],
+         'password'         => $_POST['password'],
+         'password2'        => $_POST['password2'],
+      ];
+      if ($input['password'] !== $input['password2']) {
+         $error_messages = [__('The two passwords do not match')];
+      } else {
+         try {
+            Config::validatePassword($input['password'], false);
+            if ($user->update($input)) {
+               $success = true;
+            } else {
+               $error_messages = [__('An error occured during password update')];
+            }
+         } catch (PasswordTooWeakException $exception) {
+            $error_messages = $exception->getMessages();
+         }
+      }
+   }
+}
+
+if ($success) {
+   echo '<table class="tab_cadre">';
+   echo '<tr><th colspan="2">' . __('Password update') . '</th></tr>';
+   echo '<tr>';
+   echo '<td>';
+   echo __('Your password has been successfully updated.');
+   echo '<br />';
+   echo '<a href="' . $CFG_GLPI['root_doc'] . '/front/logout.php?noAUTO=1">' . __('Log in') . '</a>';
+   echo '</td>';
+   echo '</tr>';
+   echo '</table>';
+} else {
+   $user->showPasswordUpdateForm($error_messages);
+}
+
+
+switch (Session::getCurrentInterface()) {
+   case 'central':
+      Html::footer();
+      break;
+   case 'helpdesk':
+      Html::helpFooter();
+      break;
+   default:
+      Html::nullFooter();
+      break;
+}

--- a/inc/central.class.php
+++ b/inc/central.class.php
@@ -145,7 +145,7 @@ class Central extends CommonGLPI {
     * Show the central personal view
    **/
    static function showMyView() {
-      global $DB;
+      global $CFG_GLPI, $DB;
 
       $showticket  = Session::haveRightsOr("ticket",
                                            [Ticket::READMY, Ticket::READALL, Ticket::READASSIGN]);
@@ -157,6 +157,21 @@ class Central extends CommonGLPI {
       Plugin::doHook('display_central');
 
       $warnings = [];
+
+      $user = new User();
+      $user->getFromDB(Session::getLoginUserID());
+      if ($user->shouldChangePassword()) {
+         $expiration_msg = sprintf(
+            __('Your password will expire on %s.'),
+            Html::convDateTime(date('Y-m-d H:i:s', $user->getPasswordExpirationTime()))
+         );
+         $warnings[] = $expiration_msg
+            . ' '
+            . '<a href="' . $CFG_GLPI['root_doc'] . '/front/updatepassword.php">'
+            . __('Update my password')
+            . '</a>';
+      }
+
       if (Session::haveRight("config", UPDATE)) {
          $logins = User::checkDefaultPasswords();
          $user   = new User();

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1751,46 +1751,6 @@ class Config extends CommonDBTM {
       echo "</td></tr>";
 
       echo "<tr class='tab_bg_1'>";
-      echo "<td colspan='4' class='center b'>".__('Password security policy');
-      echo "</td></tr>";
-
-      echo "<tr class='tab_bg_2'>";
-      echo "<td><label for='dropdown_use_password_security$rand'>" . __('Password security policy validation') . "</label></td>";
-      echo "<td>";
-      Dropdown::showYesNo("use_password_security", $CFG_GLPI["use_password_security"], -1, ['rand' => $rand]);
-      echo "</td>";
-      echo "<td><label for='dropdown_password_min_length$rand'>" . __('Password minimum length') . "</label></td>";
-      echo "<td>";
-      Dropdown::showNumber('password_min_length', ['value' => $CFG_GLPI["password_min_length"],
-                                                   'min'   => 4,
-                                                   'max'   => 30,
-                                                   'rand'  => $rand]);
-      echo "</td>";
-      echo "</tr>";
-
-      echo "<tr class='tab_bg_2'>";
-      echo "<td><label for='dropdown_password_need_number$rand'>" . __('Password need digit') . "</label></td>";
-      echo "<td>";
-      Dropdown::showYesNo("password_need_number", $CFG_GLPI["password_need_number"], -1, ['rand' => $rand]);
-      echo "</td>";
-      echo "<td><label for='dropdown_password_need_letter$rand'>" . __('Password need lowercase character') . "</label></td>";
-      echo "<td>";
-      Dropdown::showYesNo("password_need_letter", $CFG_GLPI["password_need_letter"], -1, ['rand' => $rand]);
-      echo "</td>";
-      echo "</tr>";
-
-      echo "<tr class='tab_bg_2'>";
-      echo "<td><label for='dropdown_password_need_caps$rand'>" . __('Password need uppercase character') . "</label></td>";
-      echo "<td>";
-      Dropdown::showYesNo("password_need_caps", $CFG_GLPI["password_need_caps"], -1, ['rand' => $rand]);
-      echo "</td>";
-      echo "<td><label for='dropdown_password_need_symbol$rand'>" . __('Password need symbol') . "</label></td>";
-      echo "<td>";
-      Dropdown::showYesNo("password_need_symbol", $CFG_GLPI["password_need_symbol"], -1, ['rand' => $rand]);
-      echo "</td>";
-      echo "</tr>";
-
-      echo "<tr class='tab_bg_1'>";
       echo "<td colspan='4' class='center b'>".__('Maintenance mode');
       echo "</td></tr>";
 
@@ -2219,10 +2179,11 @@ class Config extends CommonDBTM {
                4 => __('Assistance'),
             ];
             if (Config::canUpdate()) {
-               $tabs[9] = __('Logs purge');
-               $tabs[5] = __('System');
-               $tabs[7] = __('Performance');
-               $tabs[8] = __('API');
+               $tabs[9]  = __('Logs purge');
+               $tabs[5]  = __('System');
+               $tabs[10] = __('Security');
+               $tabs[7]  = __('Performance');
+               $tabs[8]  = __('API');
             }
 
             if (DBConnection::isDBSlaveActive()
@@ -2287,6 +2248,10 @@ class Config extends CommonDBTM {
 
             case 9:
                $item->showFormLogs();
+               break;
+
+            case 10:
+               $item->showFormSecurity();
                break;
 
          }
@@ -3475,6 +3440,206 @@ class Config extends CommonDBTM {
       echo $out;
    }
 
+   /**
+    * Security policy form
+    *
+    * @since 9.5.0
+    *
+    * @return void
+    */
+   function showFormSecurity() {
+      global $CFG_GLPI;
+
+      if (!Config::canUpdate()) {
+         return false;
+      }
+
+      $rand = mt_rand();
+
+      echo '<div class="center" id="tabsbody">';
+      echo '<form name="form" action="' . Toolbox::getItemTypeFormURL(__CLASS__) . '" method="post">';
+      echo '<table class="tab_cadre_fixe">';
+      echo '<tr><th colspan="4">' . __('Security setup') . '</th></tr>';
+
+      echo '<tr class="tab_bg_1">';
+      echo '<td colspan="4" class="center b">' . __('Password security policy') . '</td>';
+      echo '</tr>';
+
+      echo '<tr class="tab_bg_2">';
+      echo '<td>';
+      echo '<label for="dropdown_use_password_security' . $rand . '">';
+      echo __('Password security policy validation');
+      echo '</label>';
+      echo '</td>';
+      echo '<td>';
+      Dropdown::showYesNo(
+         'use_password_security',
+         $CFG_GLPI['use_password_security'],
+         -1,
+         [
+            'rand' => $rand,
+         ]
+      );
+      echo '</td>';
+      echo '<td>';
+      echo '<label for="dropdown_password_min_length' . $rand . '">';
+      echo __('Password minimum length');
+      echo '</label>';
+      echo '</td>';
+      echo '<td>';
+      Dropdown::showNumber(
+         'password_min_length',
+         [
+            'value' => $CFG_GLPI['password_min_length'],
+            'min'   => 4,
+            'max'   => 30,
+            'rand'  => $rand
+         ]
+      );
+      echo '</td>';
+      echo '</tr>';
+
+      echo '<tr class="tab_bg_2">';
+      echo '<td>';
+      echo '<label for="dropdown_password_need_number' . $rand . '">';
+      echo __('Password need digit');
+      echo '</label>';
+      echo '</td>';
+      echo '<td>';
+      Dropdown::showYesNo(
+         'password_need_number',
+         $CFG_GLPI['password_need_number'],
+         -1,
+         [
+            'rand' => $rand,
+         ]
+      );
+      echo '</td>';
+      echo '<td>';
+      echo '<label for="dropdown_password_need_letter' . $rand . '">';
+      echo __('Password need lowercase character');
+      echo '</label>';
+      echo '</td>';
+      echo '<td>';
+      Dropdown::showYesNo(
+         'password_need_letter',
+         $CFG_GLPI['password_need_letter'],
+         -1,
+         [
+            'rand' => $rand,
+         ]
+      );
+      echo '</td>';
+      echo '</tr>';
+
+      echo '<tr class="tab_bg_2">';
+      echo '<td>';
+      echo '<label for="dropdown_password_need_caps' . $rand . '">';
+      echo __('Password need uppercase character');
+      echo '</label>';
+      echo '</td>';
+      echo '<td>';
+      Dropdown::showYesNo(
+         'password_need_caps',
+         $CFG_GLPI['password_need_caps'],
+         -1,
+         [
+            'rand' => $rand,
+         ]
+      );
+      echo '</td>';
+      echo '<td>';
+      echo '<label for="dropdown_password_need_symbol' . $rand . '">';
+      echo __('Password need symbol');
+      echo '</label>';
+      echo '</td>';
+      echo '<td>';
+      Dropdown::showYesNo(
+         'password_need_symbol',
+         $CFG_GLPI['password_need_symbol'],
+         -1,
+         [
+            'rand' => $rand,
+         ]
+      );
+      echo '</td>';
+      echo '</tr>';
+
+      echo '<tr class="tab_bg_1">';
+      echo '<td colspan="4" class="center b">' . __('Password expiration policy') . '</td>';
+      echo '</tr>';
+
+      echo '<tr class="tab_bg_2">';
+      echo '<td>';
+      echo '<label for="dropdown_password_expiration_delay' . $rand . '">';
+      echo __('Password expiration delay (in days)');
+      echo '</label>';
+      echo '</td>';
+      echo '<td>';
+      Dropdown::showNumber(
+         'password_expiration_delay',
+         [
+            'value' => $CFG_GLPI['password_expiration_delay'],
+            'min'   => 30,
+            'max'   => 365,
+            'step'  => 15,
+            'toadd' => [-1 => __('Never')],
+            'rand'  => $rand
+         ]
+      );
+      echo '</td>';
+      echo '<td>';
+      echo '<label for="dropdown_password_expiration_notice' . $rand . '">';
+      echo __('Password expiration notice time (in days)');
+      echo '</label>';
+      echo '</td>';
+      echo '<td>';
+      Dropdown::showNumber(
+         'password_expiration_notice',
+         [
+            'value' => $CFG_GLPI['password_expiration_notice'],
+            'min'   => 0,
+            'max'   => 30,
+            'step'  => 1,
+            'toadd' => [-1 => __('Notification disabled')],
+            'rand'  => $rand
+         ]
+      );
+      echo '</td>';
+      echo '</tr>';
+
+      echo '<tr class="tab_bg_2">';
+      echo '<td>';
+      echo '<label for="dropdown_password_expiration_lock_delay' . $rand . '">';
+      echo __('Delay before account deactivation (in days)');
+      echo '</label>';
+      echo '</td>';
+      echo '<td>';
+      Dropdown::showNumber(
+         'password_expiration_lock_delay',
+         [
+            'value' => $CFG_GLPI['password_expiration_lock_delay'],
+            'min'   => 0,
+            'max'   => 30,
+            'step'  => 1,
+            'toadd' => [-1 => __('Do not deactivate')],
+            'rand'  => $rand
+         ]
+      );
+      echo '</td>';
+      echo '<td colspan="2"></td>';
+      echo '</tr>';
+
+      echo '<tr class="tab_bg_2">';
+      echo '<td colspan="4" class="center">';
+      echo '<input type="submit" name="update" class="submit" value="' . _sx('button', 'Save') . '">';
+      echo '</td>';
+      echo '</tr>';
+
+      echo '</table>';
+      Html::closeForm();
+   }
+
    public function rawSearchOptions() {
       $tab = [];
 
@@ -3499,6 +3664,29 @@ class Config extends CommonDBTM {
    }
 
    public function post_updateItem($history = 1) {
+      global $DB;
+
+      // Check if password expiration mechanism has been activated
+      if ($this->fields['name'] == 'password_expiration_delay'
+          && array_key_exists('value', $this->oldvalues)
+          && (int)$this->oldvalues['value'] === -1) {
+
+         // As passwords will now expire, consider that "now" is the reference date of expiration delay
+         $DB->update(
+            User::getTable(),
+            ['password_last_update' => $_SESSION['glpi_currenttime']],
+            ['authtype' => Auth::DB_GLPI]
+         );
+
+         // Activate passwordexpiration automated task
+         $DB->update(
+            CronTask::getTable(),
+            ['state' => 1,],
+            ['name' => 'passwordexpiration']
+         );
+      }
+
+      // Keep it at the end as it alter $this->oldvalues
       if (count($this->oldvalues)) {
          foreach ($this->oldvalues as &$value) {
             $value = $this->fields['name'] . ' ' . $value;

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1788,6 +1788,19 @@ JAVASCRIPT;
 
       // Preferences + logout link
       echo "<div id='c_preference'>";
+      if (Session::getLoginUserID()) {
+         $logout_url = $CFG_GLPI['root_doc']
+            . '/front/logout.php'
+            . (isset($_SESSION['glpiextauth']) && $_SESSION['glpiextauth'] ? '?noAUTO=1' : '' );
+         echo '<ul>';
+         echo '<li id="deconnexion">';
+         echo '<a href="' . $logout_url . '" title="' . __s('Logout') . '" class="fa fa-sign-out-alt">';
+         echo '<span class="sr-only">' . __s('Logout') . '</span>';
+         echo '</a>';
+         echo '</li>';
+         echo '</ul>';
+      }
+
       echo "<div class='sep'></div>";
       echo "</div>";
 

--- a/inc/notificationtargetuser.class.php
+++ b/inc/notificationtargetuser.class.php
@@ -39,7 +39,10 @@ class NotificationTargetUser extends NotificationTarget {
 
 
    function getEvents() {
-      return ['passwordforget' => __('Forgotten password?')];
+      return [
+         'passwordexpires' => __('Password expires'),
+         'passwordforget'  => __('Forgotten password?'),
+      ];
    }
 
 
@@ -48,6 +51,10 @@ class NotificationTargetUser extends NotificationTarget {
    **/
    function addNotificationTargets($entity) {
       $this->addTarget(Notification::USER, __('User'));
+
+      if ($this->raiseevent == 'passwordexpires') {
+         parent::addNotificationTargets($entity);
+      }
    }
 
 
@@ -85,13 +92,43 @@ class NotificationTargetUser extends NotificationTarget {
       $this->data['##user.name##']      = $this->obj->getField("name");
       $this->data['##user.realname##']  = $this->obj->getField("realname");
       $this->data['##user.firstname##'] = $this->obj->getField("firstname");
-      $this->data['##user.token##']     = $this->obj->getField("password_forget_token");
-
       $this->data['##user.action##']    = $events[$event];
-      $this->data['##user.passwordforgeturl##']
-                                         = urldecode($CFG_GLPI["url_base"].
-                                                     "/front/lostpassword.php?password_forget_token=".
-                                                     $this->obj->getField("password_forget_token"));
+
+      switch ($event) {
+         case 'passwordexpires':
+            $expiration_time = $this->obj->getPasswordExpirationTime();
+            $this->data['##user.password.expiration.date##'] = Html::convDateTime(
+               date('Y-m-d H:i:s', $expiration_time)
+            );
+
+            $this->data['##user.account.lock.date##']  = null;
+            $lock_delay = (int)$CFG_GLPI['password_expiration_lock_delay'];
+            if (-1 !== $lock_delay) {
+               $this->data['##user.account.lock.date##'] = Html::convDateTime(
+                  date(
+                     'Y-m-d H:i:s',
+                     strtotime(
+                         sprintf(
+                            '+ %s days',
+                            $lock_delay
+                         ),
+                         $expiration_time
+                      )
+                  )
+               );
+            }
+            $this->data['##user.password.has_expired##'] = $this->obj->hasPasswordExpired() ? '1' : '0';
+            $this->data['##user.password.update.url##'] = urldecode(
+               $CFG_GLPI["url_base"] . "/front/updatepassword.php"
+            );
+            break;
+         case 'passwordforget':
+            $this->data['##user.token##']             = $this->obj->getField("password_forget_token");
+            $this->data['##user.passwordforgeturl##'] = urldecode($CFG_GLPI["url_base"]
+               . "/front/lostpassword.php?password_forget_token="
+               . $this->obj->getField("password_forget_token"));
+            break;
+      }
 
       $this->getTags();
       foreach ($this->tag_descriptions[NotificationTarget::TAG_LANGUAGE] as $tag => $values) {
@@ -104,34 +141,91 @@ class NotificationTargetUser extends NotificationTarget {
 
    function getTags() {
 
-      $tags = ['user.name'              => __('Login'),
-                    'user.realname'          => __('Name'),
-                    'user.firstname'         => __('First name'),
-                    'user.token'             => __('Token'),
-                    'user.passwordforgeturl' => __('URL'),
-                    'user.action'            => _n('Event', 'Events', 1)];
+      // Common value tags
+      $tags = [
+         'user.name'      => __('Login'),
+         'user.realname'  => __('Name'),
+         'user.firstname' => __('First name'),
+         'user.action'    => _n('Event', 'Events', 1),
+      ];
 
       foreach ($tags as $tag => $label) {
-         $this->addTagToList(['tag'   => $tag,
-                                   'label' => $label,
-                                   'value' => true]);
+         $this->addTagToList(
+            [
+               'tag'    => $tag,
+               'label'  => $label,
+               'value'  => true,
+            ]
+         );
       }
 
-      // Only lang
-      $lang = ['passwordforget.information'
-                        => __('You have been made a request to reset your account password.'),
-                    'passwordforget.link'
-                        => __('Just follow this link (you have one day):')];
-
-      foreach ($lang as $tag => $label) {
-         $this->addTagToList(['tag'   => $tag,
-                                   'label' => $label,
-                                   'value' => false,
-                                   'lang'  => true]);
+      foreach ($this->getEvents() as $event => $name) {
+         $this->addTagsForEvent($event);
       }
 
       asort($this->tag_descriptions);
       return $this->tag_descriptions;
    }
 
+   /**
+    * Add tags for given event.
+    *
+    * @param string $event
+    *
+    * @return void
+    */
+   private function addTagsForEvent($event) {
+      $lang_tags = [];
+      $values_tags = [];
+
+      switch ($event) {
+         case 'passwordexpires':
+            $values_tags = [
+               'user.account.lock.date'        => __('Account lock date if password is not changed'),
+               'user.password.expiration.date' => __('Password expiration date'),
+               'user.password.has_expired'     => __('Password has expired'),
+               'user.password.update.url'      => __('URL'),
+            ];
+            $lang_tags = [
+               'password.expires_soon.information' => __('We inform you that your password will expire soon.'),
+               'password.has_expired.information'  => __('We inform you that your password has expired.'),
+               'password.update.link'              => __('To update your password, please follow this link:'),
+            ];
+            break;
+         case 'passwordforget':
+            $values_tags = [
+               'user.token'             => __('Token'),
+               'user.passwordforgeturl' => __('URL'),
+            ];
+
+            $lang_tags = [
+               'passwordforget.information' => __('You have been made a request to reset your account password.'),
+               'passwordforget.link'        => __('Just follow this link (you have one day):'),
+            ];
+            break;
+      }
+
+      foreach ($values_tags as $tag => $label) {
+         $this->addTagToList(
+            [
+               'tag'    => $tag,
+               'label'  => $label,
+               'value'  => true,
+               'events' => [$event],
+            ]
+         );
+      }
+
+      foreach ($lang_tags as $tag => $label) {
+         $this->addTagToList(
+            [
+               'tag'    => $tag,
+               'label'  => $label,
+               'value'  => false,
+               'lang'   => true,
+               'events' => [$event],
+            ]
+         );
+      }
+   }
 }

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -141,6 +141,12 @@ class Session {
 
                self::loadLanguage();
 
+               if ($auth->password_expired) {
+                  $_SESSION['glpi_password_expired'] = 1;
+                  // Do not init profiles, as user has to update its password to be able to use GLPI
+                  return;
+               }
+
                // glpiprofiles -> other available profile with link to the associated entities
                Plugin::doHook("init_session");
 
@@ -1380,5 +1386,14 @@ class Session {
    static function getImpersonatorId() {
 
       return self::isImpersonateActive() ? $_SESSION['impersonator_id'] : null;
+   }
+
+   /**
+    * Check if current connected user password has expired.
+    *
+    * @return boolean
+    */
+   static function mustChangePassword() {
+      return array_key_exists('glpi_password_expired', $_SESSION);
    }
 }

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -295,6 +295,9 @@ $default_prefs = [
    'purge_plugins'                           => '0',
    'display_login_source'                    => '1',
    'devices_in_menu'                         => '["Item_DeviceSimcard"]',
+   'password_expiration_delay'               => '-1',
+   'password_expiration_notice'              => '-1',
+   'password_expiration_lock_delay'          => '-1',
 ];
 
 $tables['glpi_configs'] = [];
@@ -634,6 +637,16 @@ $tables['glpi_crontasks'] = [
       'param'         => null,
       'state'         => 0,
       'mode'          => 1,
+      'lastrun'       => null,
+      'logs_lifetime' => 30,
+   ], [
+      'id'            => 36,
+      'itemtype'      => 'User',
+      'name'          => 'passwordexpiration',
+      'frequency'     => 86400,
+      'param'         => 100,
+      'state'         => 0,
+      'mode'          => 2,
       'lastrun'       => null,
       'logs_lifetime' => 30,
    ],
@@ -2656,6 +2669,13 @@ $tables['glpi_notifications'] = [
       'event'        => 'DomainsWhichExpire',
       'is_recursive' => 1,
       'is_active'    => 1,
+   ], [
+      'id'           => 70,
+      'name'         => 'Password expires alert',
+      'itemtype'     => 'User',
+      'event'        => 'passwordexpires',
+      'is_recursive' => 1,
+      'is_active'    => 1,
    ],
 ];
 
@@ -3005,6 +3025,11 @@ $tables['glpi_notifications_notificationtemplates'] = [
       'notifications_id'         =>  '69',
       'mode'                     =>  'mailing',
       'notificationtemplates_id' =>  26,
+   ], [
+      'id'                       => 70,
+      'notifications_id'         =>  '70',
+      'mode'                     =>  'mailing',
+      'notificationtemplates_id' =>  27,
    ],
 ];
 
@@ -3684,6 +3709,11 @@ $tables['glpi_notificationtargets'] = [
       'items_id'         => '23',
       'type'             => '1',
       'notifications_id' => '69',
+   ], [
+      'id'               => '138',
+      'items_id'         => '19',
+      'type'             => '1',
+      'notifications_id' => '70',
    ],
 ];
 
@@ -3792,6 +3822,10 @@ $tables['glpi_notificationtemplates'] = [
       'id'       => '26',
       'name'     => 'Alert domains',
       'itemtype' => 'Domain',
+   ], [
+      'id'       => '27',
+      'name'     => 'Password expires alert',
+      'itemtype' => 'User',
    ],
 ];
 
@@ -4606,6 +4640,40 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
                         ##FOREACHdomains##&lt;br /&gt;
                         ##lang.domain.name##  : ##domain.name## - ##lang.domain.dateexpiration## :  ##domain.dateexpiration##&lt;br /&gt;
                         ##ENDFOREACHdomains##&lt;/p&gt;',
+
+   ], [
+      'id'                       => '27',
+      'notificationtemplates_id' => '27',
+      'language'                 => '',
+      'subject'                  => '##user.action##',
+      'content_text'             => '##user.realname## ##user.firstname##,
+
+##IFuser.password.has_expired=1##
+##lang.password.has_expired.information##
+##ENDIFuser.password.has_expired##
+##ELSEuser.password.has_expired##
+##lang.password.expires_soon.information##
+##ENDELSEuser.password.has_expired##
+##lang.user.password.expiration.date##: ##user.password.expiration.date##
+##IFuser.account.lock.date##
+##lang.user.account.lock.date##: ##user.account.lock.date##
+##ENDIFuser.account.lock.date##
+
+##password.update.link## ##user.password.update.url##',
+      'content_html'             => '&lt;p&gt;&lt;strong&gt;##user.realname## ##user.firstname##&lt;/strong&gt;&lt;/p&gt;
+
+##IFuser.password.has_expired=1##
+&lt;p&gt;##lang.password.has_expired.information##&lt;/p&gt;
+##ENDIFuser.password.has_expired##
+##ELSEuser.password.has_expired##
+&lt;p&gt;##lang.password.expires_soon.information##&lt;/p&gt;
+##ENDELSEuser.password.has_expired##
+&lt;p&gt;##lang.user.password.expiration.date##: ##user.password.expiration.date##&lt;/p&gt;
+##IFuser.account.lock.date##
+&lt;p&gt;##lang.user.account.lock.date##: ##user.account.lock.date##&lt;/p&gt;
+##ENDIFuser.account.lock.date##
+
+&lt;p&gt;##lang.password.update.link## &lt;a href="##user.password.update.url##"&gt;##user.password.update.url##&lt;/a&gt;&lt;/p&gt;',
 
    ],
 ];

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -6840,6 +6840,7 @@ CREATE TABLE `glpi_users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `password` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `password_last_update` timestamp NULL DEFAULT NULL,
   `phone` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `phone2` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `mobile` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -291,8 +291,8 @@ class DbUtils extends DbTestCase {
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'id'))->isGreaterThan(0)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'context'))->isGreaterThan(0)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_tickets', 'entities_id'))->isIdenticalTo(2)
-            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'itemtype', ['frequency' => '86400']))->isIdenticalTo(12)
-            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'id', ['frequency' => '86400']))->isIdenticalTo(15)
+            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'itemtype', ['frequency' => '86400']))->isIdenticalTo(13)
+            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'id', ['frequency' => '86400']))->isIdenticalTo(16)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'context', ['name' => 'version']))->isIdenticalTo(1)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'id', ['context' => 'fakecontext']))->isIdenticalTo(0);
 

--- a/tests/functionnal/NotificationTargetUser.php
+++ b/tests/functionnal/NotificationTargetUser.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use \DbTestCase;
+
+/* Test for inc/notificationtargetuser.class.php */
+
+class NotificationTargetUser extends DbTestCase {
+
+
+   protected function addDataForPasswordExpiresTemplateProvider() {
+      global $CFG_GLPI;
+
+      $time_in_past   = strtotime('-10 days');
+      $time_in_future = strtotime('+10 days');
+      $update_url     = $CFG_GLPI['url_base'] . '/front/updatepassword.php';
+
+      return [
+         // case 1: password already expired but account will not be locked
+         [
+            'expiration_time'                => $time_in_past,
+            'password_expiration_lock_delay' => -1,
+            'expected'                       => [
+               '##user.password.expiration.date##' => date('Y-m-d H:i', $time_in_past),
+               '##user.account.lock.date##'        => null,
+               '##user.password.has_expired##'     => '1',
+               '##user.password.update.url##'      => $update_url,
+            ],
+         ],
+         // case 2: password already expired and account will be locked
+         [
+            'expiration_time'                => $time_in_past,
+            'password_expiration_lock_delay' => 15,
+            'expected'                       => [
+               '##user.password.expiration.date##' => date('Y-m-d H:i', $time_in_past),
+               '##user.account.lock.date##'        => date('Y-m-d H:i', strtotime('+15 days', $time_in_past)),
+               '##user.password.has_expired##'     => '1',
+               '##user.password.update.url##'      => $update_url,
+            ],
+         ],
+         // case 3: password not yet expired but account will not be locked
+         [
+            'expiration_time'                => $time_in_future,
+            'password_expiration_lock_delay' => -1,
+            'expected'                       => [
+               '##user.password.expiration.date##' => date('Y-m-d H:i', $time_in_future),
+               '##user.account.lock.date##'        => null,
+               '##user.password.has_expired##'     => '0',
+               '##user.password.update.url##'      => $update_url,
+            ],
+         ],
+         // case 2: password not yet expired and account will be locked
+         [
+            'expiration_time'                => $time_in_future,
+            'password_expiration_lock_delay' => 15,
+            'expected'                       => [
+               '##user.password.expiration.date##' => date('Y-m-d H:i', $time_in_future),
+               '##user.account.lock.date##'        => date('Y-m-d H:i', strtotime('+15 days', $time_in_future)),
+               '##user.password.has_expired##'     => '0',
+               '##user.password.update.url##'      => $update_url,
+            ],
+         ],
+      ];
+   }
+
+   /**
+    * @dataProvider addDataForPasswordExpiresTemplateProvider
+    */
+   public function testAddDataForPasswordExpiresTemplate(int $expiration_time, int $lock_delay, array $expected) {
+      global $CFG_GLPI;
+
+      $user = new \mock\User();
+      $this->calling($user)->getPasswordExpirationTime = $expiration_time;
+
+      $cfg_backup = $CFG_GLPI;
+      $CFG_GLPI['password_expiration_lock_delay'] = $lock_delay;$target = new \NotificationTargetUser(
+         getItemByTypeName('Entity', '_test_root_entity', true), 'passwordexpires', $user
+      );
+      $target->addDataForTemplate('passwordexpires');
+      $CFG_GLPI = $cfg_backup;
+
+      $this->checkTemplateData($target->data, $expected);
+   }
+
+   private function checkTemplateData(array $data, array $expected) {
+      $this->array($data)->hasKeys(array_keys($expected));
+      foreach ($expected as $key => $value) {
+         $this->variable($data[$key])->isIdenticalTo($value);
+      }
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add a password expiration mechanism. It can be configured on a new `Security` tab of global configuration. Existing password security policy configuration has been moved in this tab.

![image](https://user-images.githubusercontent.com/33253653/72064026-49774000-32db-11ea-8593-897fe25f5165.png)
