### PR TITLE
Check method_exists using $this instead of itemtype; closes #6728

### DIFF
--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -1014,11 +1014,11 @@ class CommonGLPI {
    function showDebugInfo() {
       global $CFG_GLPI;
 
-      $class = $this->getType();
-
-      if (method_exists($class, 'showDebug')) {
+      if (method_exists($this, 'showDebug')) {
          $this->showDebug();
       }
+
+      $class = $this->getType();
 
       if (InfoCom::canApplyOn($class)) {
          $infocom = new Infocom();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6728 
