### PR TITLE
Use an alternative to GLOB_BRACE that may not be available

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1932,7 +1932,11 @@ class Config extends CommonDBTM {
 
       Session::loadLanguage($oldlang);
 
-      $files = glob(GLPI_LOCAL_I18N_DIR."/**/*.{php,mo}", GLOB_BRACE);
+      $files = array_merge(
+         glob(GLPI_LOCAL_I18N_DIR."/**/*.php"),
+         glob(GLPI_LOCAL_I18N_DIR."/**/*.mo")
+      );
+      sort($files);
       if (count($files)) {
          echo "<tr><th>Locales overrides</th></tr>\n";
          echo "<tr class='tab_bg_1'><td>\n";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

GLOB_BRACE is not available on all systems, so it would be preferable to not use it.
For instance, it is not available on Alpine Linux, which is the system we use for Github Actions checks.

see https://www.php.net/manual/fr/function.glob.php#refsect1-function.glob-notes