### PR TITLE
Fix ID check for user searchoption

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5544,7 +5544,7 @@ JAVASCRIPT;
 
             case "glpi_profiles.name" :
                if (($itemtype == 'User')
-                   && ($ID == 20)) {
+                   && ($ID == "User_20")) {
                   $out           = "";
 
                   $count_display = 0;

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5544,7 +5544,7 @@ JAVASCRIPT;
 
             case "glpi_profiles.name" :
                if (($itemtype == 'User')
-                   && ($ID == "User_20")) {
+                   && ($orig_id == 20)) {
                   $out           = "";
 
                   $count_display = 0;


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->

On users list, if you add "Profiles (Entity)" column, Entity (Profiles) and emails
If users have several mails or entities depending on it's profile
Profiles (Entity) values are are multiply 

![image](https://user-images.githubusercontent.com/7335054/72149148-ccaf9900-33a2-11ea-8e30-2d87fef96da5.png)

Actually GLPI have code to clean data, but the check is on old ID system not the newly

This PR fix this

Result after 

![image](https://user-images.githubusercontent.com/7335054/72149244-fe286480-33a2-11ea-93af-743be67184df.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
