### PR TITLE
Fix optionnal state of check_prerequisites plugins function

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -2039,8 +2039,8 @@ class Plugin extends CommonDBTM {
 
                case self::NOTACTIVATED :
                   ob_start();
-                  $process = $plugin->checkVersions($plug['directory']);
-                  if (!$process) {
+                  $do_activate = $plugin->checkVersions($plug['directory']);
+                  if (!$do_activate) {
                      $output .= "<span class='error'>" . ob_get_contents() . "</span>";
                   }
                   ob_end_clean();
@@ -2048,7 +2048,7 @@ class Plugin extends CommonDBTM {
                   if (!isset($PLUGIN_HOOKS['csrf_compliant'][$plug['directory']])
                       || !$PLUGIN_HOOKS['csrf_compliant'][$plug['directory']]) {
                      $output .= __('Not CSRF compliant');
-                  } else if (function_exists($function) && $process) {
+                  } else if (function_exists($function) && $do_activate) {
                      ob_start();
                      $do_activate = $function();
                      $msg = '';
@@ -2056,18 +2056,19 @@ class Plugin extends CommonDBTM {
                         $msg = '<span class="error">' . ob_get_contents() . '</span>';
                      }
                      ob_end_clean();
-                     if (!$do_activate) {
-                        $output .= $msg;
-                     } else {
-                        $output .= Html::getSimpleForm(
-                           static::getFormURL(),
-                           ['action' => 'activate'],
-                           _x('button', 'Enable'),
-                           ['id' => $ID],
-                           'fa-fw fa-toggle-off fa-2x disabled'
-                        ) . '&nbsp;';
-                     }
                   }
+                  if ($do_activate) {
+                     $output .= Html::getSimpleForm(
+                        static::getFormURL(),
+                        ['action' => 'activate'],
+                        _x('button', 'Enable'),
+                        ['id' => $ID],
+                        'fa-fw fa-toggle-off fa-2x disabled'
+                     ) . '&nbsp;';
+                  } else {
+                     $output .= $msg;
+                  }
+
                   // Else : reason displayed by the plugin
                   if (function_exists("plugin_".$plug['directory']."_uninstall")) {
                      $output .= Html::getSimpleForm(

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -2051,9 +2051,8 @@ class Plugin extends CommonDBTM {
                   } else if (function_exists($function) && $do_activate) {
                      ob_start();
                      $do_activate = $function();
-                     $msg = '';
                      if (!$do_activate) {
-                        $msg = '<span class="error">' . ob_get_contents() . '</span>';
+                        $output .= '<span class="error">' . ob_get_contents() . '</span>';
                      }
                      ob_end_clean();
                   }
@@ -2065,8 +2064,6 @@ class Plugin extends CommonDBTM {
                         ['id' => $ID],
                         'fa-fw fa-toggle-off fa-2x disabled'
                      ) . '&nbsp;';
-                  } else {
-                     $output .= $msg;
                   }
 
                   // Else : reason displayed by the plugin


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

According to developper documentation, `check_prerequisites` function of a plugin is optionnal (see https://glpi-developer-documentation.readthedocs.io/en/master/plugins/requirements.html#setup-php ), but if this function is not existing, it is actually impossible to activate the plugin and nothing tell the user why he cannot do it.