### PR TITLE
Impact: fix overlap between edges endpoint and labels

### DIFF
--- a/js/impact.js
+++ b/js/impact.js
@@ -266,7 +266,9 @@ var GLPIImpact = {
                'target-arrow-color': this.edgeColors[0],
                'target-arrow-shape': 'triangle',
                'arrow-scale'       : 0.7,
-               'curve-style'       : 'bezier'
+               'curve-style'       : 'bezier',
+               'source-endpoint'   : 'outside-to-node-or-label',
+               'target-endpoint'   : 'outside-to-node-or-label',
             }
          },
          {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1261,9 +1261,9 @@
             "dev": true
         },
         "cytoscape": {
-            "version": "3.12.1",
-            "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.12.1.tgz",
-            "integrity": "sha512-/TIrNXcWZdjTgB2BK2oJfroO8IAM6XSu9lCGEe3boJ68KHqH0fbSrc0tIOfibkzkMfUhFLNed9tcaoYdjxOnTQ==",
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.13.0.tgz",
+            "integrity": "sha512-1pKd6DUyprUmz/ADPI3aKFbZceqeKoVwYBr3zBplzHOaffF311z6Zo5qWqXK12t4JRdTOvFA4kwt8T/QVIrU1Q==",
             "requires": {
                 "heap": "^0.2.6",
                 "lodash.debounce": "^4.0.8"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "chartist-plugin-legend": "^0.6.2",
         "chartist-plugin-tooltips": "^0.0.17",
         "codemirror": "^5.49.2",
-        "cytoscape": "^3.12.1",
+        "cytoscape": "^3.13.0",
         "cytoscape-context-menus": "^3.0.7",
         "cytoscape-dagre": "^2.2.1",
         "cytoscape-grid-guide": "^2.3.0",


### PR DESCRIPTION
Update to cytoscape.js latest version so we can use this fix: https://github.com/cytoscape/cytoscape.js/commit/9efdaf20e0125ab0c349440031d707e96278c48d.

This allow us to use the `outside-to-node-or-label` option for edges and thus avoid labels overlap.

Before: 
![image](https://user-images.githubusercontent.com/42734840/72264913-d4c63d80-361b-11ea-9470-1e0849e31767.png)


After: 
![image](https://user-images.githubusercontent.com/42734840/72264673-671a1180-361b-11ea-900b-1ea36bd27b38.png)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
