### PR TITLE
Prevent ITIL creation link from a templated item creation form

### DIFF
--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -1023,11 +1023,12 @@ class Change extends CommonITILObject {
     *
     * Will also display changes of linked items
     *
-    * @param $item CommonDBTM object
+    * @param CommonDBTM $item
+    * @param boolean    $withtemplate
     *
     * @return boolean|void
    **/
-   static function showListForItem(CommonDBTM $item) {
+   static function showListForItem(CommonDBTM $item, $withtemplate = 0) {
       global $DB;
 
       if (!Session::haveRight(self::$rightname, self::READALL)) {

--- a/inc/change_item.class.php
+++ b/inc/change_item.class.php
@@ -264,7 +264,7 @@ class Change_Item extends CommonDBRelation{
             break;
 
          default :
-            Change::showListForItem($item);
+            Change::showListForItem($item, $withtemplate);
       }
       return true;
 

--- a/inc/item_problem.class.php
+++ b/inc/item_problem.class.php
@@ -267,7 +267,7 @@ class Item_Problem extends CommonDBRelation{
             break;
 
          default :
-            Problem::showListForItem($item);
+            Problem::showListForItem($item, $withtemplate);
       }
       return true;
    }

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -1350,11 +1350,12 @@ class Problem extends CommonITILObject {
     *
     * Will also display problems of linked items
     *
-    * @param $item CommonDBTM object
+    * @param CommonDBTM $item
+    * @param boolean    $withtemplate
     *
     * @return nothing (display a table)
    **/
-   static function showListForItem(CommonDBTM $item) {
+   static function showListForItem(CommonDBTM $item, $withtemplate = 0) {
       global $DB, $CFG_GLPI;
 
       if (!Session::haveRight(self::$rightname, self::READALL)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I am not sure it will fix something, but `showListForItem` methods from `Change` and `Problem` are checking value of the `$withtemplate` var, which is actually undefined.
I just passed the value as it is done for `Ticket` objects.