### PR TITLE
fix missing closing DIV tag when showing a file upload area for textarea

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -5117,8 +5117,6 @@ class Html {
                  "<div class='uploadbar' style='width: 0%;'></div></div>";
          $display .= "</div>";
 
-         $display .= "</div>"; // .fileupload
-
          $display .= Html::scriptBlock("
          $(function() {
             var fileindex{$p['rand']} = 0;
@@ -5180,6 +5178,7 @@ class Html {
             });
          });");
       }
+      $display .= "</div>"; // .fileupload
 
       if ($p['display']) {
          echo $display;


### PR DESCRIPTION
Hi

I found an inconsistency in HTML if we show a textarea with file upload enabled

![image](https://user-images.githubusercontent.com/14139801/72382366-68316880-3719-11ea-9c30-92dbbecba655.png)

In the else {} part if the alternative, there is a closing DIV for the first DIV of the method; but it is missing in the other part of the alternative.

I think it should be moved out if the alternative.

This issue impacts Formcreator https://github.com/pluginsGLPI/formcreator/issues/1613

