### PR TITLE
Fix search to restore a feature removed permit to have only '^' and s…

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -7589,6 +7589,11 @@ JAVASCRIPT;
             ($matches[1] != '^' ? '%' : '') .
             trim($matches[2]) .
             ($matches[3] != '$' ? '%' : '');
+      } else if (isset($matches[1])
+            && strlen(trim($matches[1])) == 1
+            && (!isset($matches[3]) || empty($matches[3]))) {
+         // this case is for search with only ^, so mean the field is not empty / not null
+         $search = '%';
       }
       return $search;
    }

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1241,7 +1241,7 @@ class Search extends DbTestCase {
    protected function makeTextSearchValueProvider() {
       return [
          ['', ''],
-         ['^', ''],
+         ['^', '%'],
          ['$', ''],
          ['^$', ''],
          ['looking for', '%looking for%'],


### PR DESCRIPTION
…o return only filled field (so exclude empty and null fields)

This restore the feature search with only _^_ and return all rows have the fields filled (so not empty / null).

Old code for reference is here: https://github.com/glpi-project/glpi/blob/9.2/bugfixes/inc/search.class.php#L6353-L6371