### PR TITLE
Impact analysis bugfixes / improvements

### DIFF
--- a/css/impact.scss
+++ b/css/impact.scss
@@ -558,6 +558,10 @@ i.fa-impact-manipulation {
 .impact-res-disabled {
    opacity: 0.5;
    cursor: not-allowed !important;
+
+   i {
+      cursor: not-allowed !important;
+   }
 }
 
 /*

--- a/js/impact.js
+++ b/js/impact.js
@@ -263,6 +263,7 @@ var GLPIImpact = {
          case this.ACTION_ADD_EDGE:
             this.cy.remove("edge" + this.makeIDSelector(data.id));
             this.updateFlags();
+            this.refreshVisiblity();
             break;
 
          // Delete compound
@@ -274,6 +275,7 @@ var GLPIImpact = {
             });
             this.cy.remove("node" + this.makeIDSelector(data.data.id));
             this.updateFlags();
+            this.refreshVisiblity();
             break;
 
          // Remove the newly added graph
@@ -301,6 +303,8 @@ var GLPIImpact = {
             });
 
             this.updateFlags();
+            this.refreshVisiblity();
+
             break;
 
          // Revert edit
@@ -370,6 +374,8 @@ var GLPIImpact = {
             });
 
             this.updateFlags();
+            this.refreshVisiblity();
+
             break;
 
          // Toggle impact visibility
@@ -492,6 +498,8 @@ var GLPIImpact = {
                data: data,
             });
             this.updateFlags();
+            this.refreshVisiblity();
+
             break;
 
          // Add compound and update its children
@@ -506,6 +514,8 @@ var GLPIImpact = {
                   .move({parent: data.data.id});
             });
             this.updateFlags();
+            this.refreshVisiblity();
+
             break;
 
          // Insert again the graph
@@ -543,6 +553,8 @@ var GLPIImpact = {
             });
 
             this.updateFlags();
+            this.refreshVisiblity();
+
             break;
 
          // Reapply edit
@@ -599,6 +611,8 @@ var GLPIImpact = {
             });
 
             this.updateFlags();
+            this.refreshVisiblity();
+
             break;
 
          // Toggle impact visibility
@@ -1327,6 +1341,8 @@ var GLPIImpact = {
                   y: position.y
                });
                GLPIImpact.updateFlags();
+               GLPIImpact.refreshVisiblity();
+
             }
          ).fail(
             function () {
@@ -1554,6 +1570,7 @@ var GLPIImpact = {
             $(GLPIImpact.selectors.toggleDepends).prop("checked", false);
          }
          this.updateFlags();
+         this.refreshVisiblity();
 
          // Set viewport
          if (params.zoom != '0') {
@@ -1756,7 +1773,13 @@ var GLPIImpact = {
    toggleVisibility: function(toToggle) {
       // Update visibility setting
       GLPIImpact.directionVisibility[toToggle] = !GLPIImpact.directionVisibility[toToggle];
+      GLPIImpact.refreshVisiblity();
+   },
 
+   /**
+    * Recalculate the visibilit of every node and edges in the graph
+    */
+   refreshVisiblity: function() {
       // Compute direction
       var direction;
       var forward = GLPIImpact.directionVisibility[GLPIImpact.FORWARD];
@@ -1772,12 +1795,14 @@ var GLPIImpact = {
          direction = 0;
       }
 
-      // Hide all nodes
-      GLPIImpact.cy.filter("node").data('hidden', 1);
+      // Hide all nodes, expect if they have no link with the current asset
+      GLPIImpact.cy.nodes().filter(function(node) {
+         return node.neighborhood().length !== 0;
+      }).data('hidden', 1);
 
       // Show/Hide edges according to the direction
       GLPIImpact.cy.filter("edge").forEach(function(edge) {
-         if (edge.data('flag') & direction) {
+         if (edge.data('flag') & direction || edge.data('flag') == 0) {
             edge.data('hidden', 0);
 
             // If the edge is visible, show the nodes they are connected to it
@@ -2588,6 +2613,7 @@ var GLPIImpact = {
 
       // Update flags
       GLPIImpact.updateFlags();
+      GLPIImpact.refreshVisiblity();
 
       // Multiple deletion, set the data in eventData buffer so it can be added
       // as a simple undo/redo entry later
@@ -3115,6 +3141,7 @@ var GLPIImpact = {
 
             // Update dependencies flags according to the new link
             GLPIImpact.updateFlags();
+            GLPIImpact.refreshVisiblity();
             break;
 
          case GLPIImpact.EDITION_DELETE:

--- a/js/impact.js
+++ b/js/impact.js
@@ -767,13 +767,13 @@ var GLPIImpact = {
          {
             selector: '[hidden=1], [depth > ' + this.maxDepth + ']',
             style: {
-               'opacity': '0',
+               'display': 'none',
             }
          },
          {
             selector: '[id="tmp_node"]',
             style: {
-               'opacity': '0',
+               'display': 'none',
             }
          },
          {

--- a/js/impact.js
+++ b/js/impact.js
@@ -3905,7 +3905,9 @@ var GLPIImpact = {
       // Handle drag & drop on add node search result
       $(document).on('mousedown', GLPIImpact.selectors.sideSearchResults + ' p', function(e) {
          // Only on left click and not for disabled item
-         if (e.which !== 1 || $(e.target).hasClass('impact-res-disabled')) {
+         if (e.which !== 1
+            || $(e.target).hasClass('impact-res-disabled')
+            || $(e.target).parent().hasClass('impact-res-disabled')) {
             return;
          }
 

--- a/js/impact.js
+++ b/js/impact.js
@@ -1797,7 +1797,7 @@ var GLPIImpact = {
 
       // Hide all nodes, expect if they have no link with the current asset
       GLPIImpact.cy.nodes().filter(function(node) {
-         return node.neighborhood().length !== 0;
+         return !(node.neighborhood().length == 0 && !node.isParent());
       }).data('hidden', 1);
 
       // Show/Hide edges according to the direction
@@ -1811,12 +1811,15 @@ var GLPIImpact = {
             GLPIImpact.cy.filter(sourceFilter + ", " + targetFilter)
                .data("hidden", 0);
 
-            // Make the parents of theses node visibles too
-            GLPIImpact.cy.filter(sourceFilter + ", " + targetFilter)
-               .parent()
-               .data("hidden", 0);
          } else {
             edge.data('hidden', 1);
+         }
+      });
+
+      // Show parent if one of their children is visible
+      GLPIImpact.cy.$("node[hidden=0]").forEach(function(node) {
+         if (!node.isOrphan()) {
+            node.parent().data("hidden", 0);
          }
       });
 


### PR DESCRIPTION
A few bugfixes and improvements following a report from @cedric-anne  :)

- The graph visibility (= show/hide impact/depends) is now re-calculated on each edition of the graph (previously, it was only calculated when the relevant settings were edited).

- Nodes with no relations are always shown.

- Groups dimensions are now recalculated when one of it's children become hidden

- Fix inconsistent style / behavior in add node menu.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
