### PR TITLE
Fix notices on Item_Rack::prepareInput()

### DIFF
--- a/inc/item_rack.class.php
+++ b/inc/item_rack.class.php
@@ -942,48 +942,25 @@ JAVASCRIPT;
    private function prepareInput($input) {
       $error_detected = [];
 
-      $itemtype = $this->fields['itemtype'];
-      $items_id = $this->fields['items_id'];
-      $racks_id = $this->fields['racks_id'];
-      $position = $this->fields['position'];
-      $hpos = $this->fields['hpos'];
-      $orientation = $this->fields['orientation'];
+      $itemtype    = $input['itemtype']    ?? $this->fields['itemtype']    ?? null;
+      $items_id    = $input['items_id']    ?? $this->fields['items_id']    ?? null;
+      $racks_id    = $input['racks_id']    ?? $this->fields['racks_id']    ?? null;
+      $position    = $input['position']    ?? $this->fields['position']    ?? null;
+      $hpos        = $input['hpos']        ?? $this->fields['hpos']        ?? Rack::POS_NONE;
+      $orientation = $input['orientation'] ?? $this->fields['orientation'] ?? Rack::FRONT;
 
       //check for requirements
-      if (($this->isNewItem() && (!isset($input['itemtype']) || empty($input['itemtype'])))
-          || (isset($input['itemtype']) && empty($input['itemtype']))) {
+      if (empty($itemtype)) {
          $error_detected[] = __('An item type is required');
       }
-      if (($this->isNewItem() && (!isset($input['items_id']) || empty($input['items_id'])))
-          || (isset($input['items_id']) && empty($input['items_id']))) {
+      if (empty($items_id)) {
          $error_detected[] = __('An item is required');
       }
-      if (($this->isNewItem() && (!isset($input['racks_id']) || empty($input['racks_id'])))
-          || (isset($input['racks_id']) && empty($input['racks_id']))) {
+      if (empty($racks_id)) {
          $error_detected[] = __('A rack is required');
       }
-      if (($this->isNewItem() && (!isset($input['position']) || empty($input['position'])))
-          || (isset($input['position']) && empty($input['position']))) {
+      if (empty($position)) {
          $error_detected[] = __('A position is required');
-      }
-
-      if (isset($input['itemtype'])) {
-         $itemtype = $input['itemtype'];
-      }
-      if (isset($input['items_id'])) {
-         $items_id = $input['items_id'];
-      }
-      if (isset($input['racks_id'])) {
-         $racks_id = $input['racks_id'];
-      }
-      if (isset($input['position'])) {
-         $position = $input['position'];
-      }
-      if (isset($input['hpos'])) {
-         $hpos = $input['hpos'];
-      }
-      if (isset($input['orientation'])) {
-         $orientation = $input['orientation'];
       }
 
       if (!count($error_detected)) {

--- a/tests/functionnal/Item_Rack.php
+++ b/tests/functionnal/Item_Rack.php
@@ -207,7 +207,7 @@ class Item_Rack extends DbTestCase {
       )->isIdenticalTo(0);
 
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Item is out of rack bounds']]
+         [ERROR => [__('Item is out of rack bounds')]]
       );
       $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
 
@@ -235,7 +235,7 @@ class Item_Rack extends DbTestCase {
       )->isIdenticalTo(0);
 
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Item is out of rack bounds']]
+         [ERROR => [__('Item is out of rack bounds')]]
       );
       $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
 
@@ -251,7 +251,7 @@ class Item_Rack extends DbTestCase {
       )->isIdenticalTo(0);
 
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Item is out of rack bounds']]
+         [ERROR => [__('Item is out of rack bounds')]]
       );
       $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
 
@@ -282,7 +282,7 @@ class Item_Rack extends DbTestCase {
       )->isIdenticalTo(0);
 
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['You must define an horizontal position for this item']]
+         [ERROR => [__('You must define an horizontal position for this item')]]
       );
       $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
 
@@ -299,7 +299,7 @@ class Item_Rack extends DbTestCase {
       )->isIdenticalTo(0);
 
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
+         [ERROR => [__('Not enough space available to place item')]]
       );
       $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
 
@@ -328,7 +328,7 @@ class Item_Rack extends DbTestCase {
       )->isIdenticalTo(0);
 
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
+         [ERROR => [__('Not enough space available to place item')]]
       );
       $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
 
@@ -357,7 +357,7 @@ class Item_Rack extends DbTestCase {
       )->isIdenticalTo(0);
 
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
+         [ERROR => [__('Not enough space available to place item')]]
       );
       $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
 
@@ -377,7 +377,7 @@ class Item_Rack extends DbTestCase {
       )->isIdenticalTo(0);
 
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['You must define an orientation for this item']]
+         [ERROR => [__('You must define an orientation for this item')]]
       );
       $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
 
@@ -394,7 +394,7 @@ class Item_Rack extends DbTestCase {
       )->isIdenticalTo(0);
 
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
+         [ERROR => [__('Not enough space available to place item')]]
       );
       $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
 
@@ -411,7 +411,7 @@ class Item_Rack extends DbTestCase {
       )->isIdenticalTo(0);
 
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
+         [ERROR => [__('Not enough space available to place item')]]
       );
       $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
 
@@ -441,7 +441,7 @@ class Item_Rack extends DbTestCase {
       )->isIdenticalTo(0);
 
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
+         [ERROR => [__('Not enough space available to place item')]]
       );
       $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
 
@@ -477,7 +477,7 @@ class Item_Rack extends DbTestCase {
       )->isIdenticalTo(0);
 
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
+         [ERROR => [__('Not enough space available to place item')]]
       );
       $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
 
@@ -506,7 +506,7 @@ class Item_Rack extends DbTestCase {
       )->isIdenticalTo(0);
 
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
+         [ERROR => [__('Not enough space available to place item')]]
       );
       $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I had these notices when trying to do some tests:
```
==> Error E_NOTICE in /var/www/glpi/tests/functionnal/CommonDBTM.php on line 934, generated by file /var/www/glpi/inc/item_rack.class.php on line 945:
Undefined index: itemtype
==> Error E_NOTICE in /var/www/glpi/tests/functionnal/CommonDBTM.php on line 934, generated by file /var/www/glpi/inc/item_rack.class.php on line 946:
Undefined index: items_id
==> Error E_NOTICE in /var/www/glpi/tests/functionnal/CommonDBTM.php on line 934, generated by file /var/www/glpi/inc/item_rack.class.php on line 947:
Undefined index: racks_id
==> Error E_NOTICE in /var/www/glpi/tests/functionnal/CommonDBTM.php on line 934, generated by file /var/www/glpi/inc/item_rack.class.php on line 948:
Undefined index: position
==> Error E_NOTICE in /var/www/glpi/tests/functionnal/CommonDBTM.php on line 934, generated by file /var/www/glpi/inc/item_rack.class.php on line 949:
Undefined index: hpos
==> Error E_NOTICE in /var/www/glpi/tests/functionnal/CommonDBTM.php on line 934, generated by file /var/www/glpi/inc/item_rack.class.php on line 950:
Undefined index: orientation
```