### PR TITLE
Fix resize of GIF/PNG with transparency; fixes #6797

### DIFF
--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -1623,12 +1623,14 @@ class Document extends CommonDBTM {
       }
 
       $infos = pathinfo($path);
+      // output images with possible transparency to png, other to jpg
+      $extension = in_array(strtolower($infos['extension']), ['png', 'gif']) ? 'png' : 'jpg';
       $context_path = sprintf(
          '%1$s_%2$s-%3$s.%4$s',
          $infos['dirname'] . '/' . $infos['filename'],
          $mwidth,
          $mheight,
-         'jpg' //resizePicture always produces JPG files
+         $extension
       );
 
       //let's check if file already exists

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -1351,12 +1351,31 @@ class Toolbox {
       //create new img resource for store thumbnail
       $source_dest = imagecreatetruecolor($new_width, $new_height);
 
+      // set transparent background for PNG/GIF
+      if ($img_type === IMAGETYPE_GIF || $img_type === IMAGETYPE_PNG) {
+         imagecolortransparent($source_dest, imagecolorallocatealpha($source_dest, 0, 0, 0, 127));
+         imagealphablending($source_dest, false);
+         imagesavealpha($source_dest, true);
+      }
+
       //resize image
       imagecopyresampled($source_dest, $source_res, 0, 0, $img_x, $img_y,
                          $new_width, $new_height, $img_width, $img_height);
 
       //output img
-      return imagejpeg($source_dest, $dest_path, 90);
+      $result = null;
+      switch ($img_type) {
+         case IMAGETYPE_GIF :
+         case IMAGETYPE_PNG :
+            $result = imagepng($source_dest, $dest_path);
+            break;
+
+         case IMAGETYPE_JPEG :
+         default :
+            $result = imagejpeg($source_dest, $dest_path, 90);
+            break;
+      }
+      return $result;
    }
 
 

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -711,8 +711,13 @@ class User extends CommonDBTM {
                // Move uploaded file
                $filename     = uniqid($this->fields['id'].'_');
                $sub          = substr($filename, -2); /* 2 hex digit */
-               $tmp          = explode(".", $input["_picture"]);
-               $extension    = Toolbox::strtolower(array_pop($tmp));
+
+               // output images with possible transparency to png, other to jpg
+               $extension = strtolower(pathinfo($fullpath, PATHINFO_EXTENSION));
+               $extension = in_array($extension, ['png', 'gif'])
+                  ? 'png'
+                  : 'jpg';
+
                @mkdir(GLPI_PICTURE_DIR . "/$sub");
                $picture_path = GLPI_PICTURE_DIR  . "/$sub/${filename}.$extension";
                self::dropPictureFiles("$sub/${filename}.$extension");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6797 

Even if it can result in images with bigger filesize, forcing gif/png to be saved as PNG when resizing will prevent loosing transparency if they have one.
As resize is mostly used for timeline and mail, which produces small images, filesize increase should not be a problem.
