### PR TITLE
Fix CLI and API detection when using php-cgi; fixes #6780

### DIFF
--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -43,7 +43,7 @@ define ('NS_PLUG', 'GlpiPlugin\\');
  * @return boolean
  */
 function isCommandLine() {
-   return (PHP_SAPI == 'cli');
+   return PHP_SAPI == 'cli' || (PHP_SAPI == 'cgi-fcgi' && defined('STDIN'));
 }
 
 /**
@@ -52,10 +52,11 @@ function isCommandLine() {
  * @return boolean
  */
 function isAPI() {
-   if (strpos($_SERVER["SCRIPT_FILENAME"], 'apirest.php') !== false) {
+   $script = isset($_SERVER['SCRIPT_FILENAME']) ? $_SERVER['SCRIPT_FILENAME'] : '';
+   if (strpos($script, 'apirest.php') !== false) {
       return true;
    }
-   if (strpos($_SERVER["SCRIPT_FILENAME"], 'apixmlrpc.php') !== false) {
+   if (strpos($script, 'apixmlrpc.php') !== false) {
       return true;
    }
    return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6780 

As `php-cgi` set `PHP_SAPI` to `cgi-fcgi` even on CLI context, `isCommandLine()` function is not returning expected value when GLPI cron is called on a system that uses `php-cgi`.

According to documentation, `STDIN` constant is only defined on CLI context by PHP, so we should be able to detect CLI context based on its presence.
We could theorically simplify condition to `return PHP_SAPI == 'cli' || defined('STDIN');`, but as it is hard to test, I prefer to check `STDIN` only on `php-cgi` context.