### PR TITLE
Fix unwanted resizing of images smaller than context

### DIFF
--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -1617,7 +1617,7 @@ class Document extends CommonDBTM {
 
       //let's see if original image needs resize
       $img_infos  = getimagesize($path);
-      if (!$img_infos[0] > $mwidth && !$img_infos[1] > $mheight) {
+      if (!($img_infos[0] > $mwidth) && !($img_infos[1] > $mheight)) {
          //no resize needed
          return $path;
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Even if image is smaller than expected max width and max height, it is resized due to missing parenthesis.