### PR TITLE
Remove link to old Problem documents tab; closes #6823

### DIFF
--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -1239,18 +1239,6 @@ class Problem extends CommonITILObject {
              Html::clean(Html::entity_decode_deep($this->fields["content"]))."</textarea>";
       echo "</td></tr>";
 
-      if ($ID) {
-         echo "<tr class='tab_bg_1'>";
-         echo "<th colspan='2'  width='".($colsize1+$colsize2)."%'>";
-         $docnb = Document_Item::countForItem($this);
-         echo "<a href=\"".$this->getLinkURL()."&amp;forcetab=Document_Item$1\">";
-         //TRANS: %d is the document number
-         echo sprintf(_n('%d associated document', '%d associated documents', $docnb), $docnb);
-         echo "</a></th>";
-         echo "<td colspan='2'></td>";
-         echo "</tr>";
-      }
-
       $options['colspan'] = 2;
       $this->showFormButtons($options);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6823 

Even if document count is correct, links points to old tab that has been removed in 9.4.0.
