### PR TITLE
ItemTicket: add missing 'tickets_id' searchOption

### DIFF
--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -1199,6 +1199,14 @@ class Item_Ticket extends CommonDBRelation{
       $tab = [];
 
       $tab[] = [
+         'id'                 => '3',
+         'table'              => $this->getTable(),
+         'field'              => 'tickets_id',
+         'name'               => __('Ticket'),
+         'datatype'           => 'dropdown',
+      ];
+
+      $tab[] = [
          'id'                 => '13',
          'table'              => $this->getTable(),
          'field'              => 'items_id',


### PR DESCRIPTION
This search option is needed to interact with Item_Tickets through the API (e.g. to find a ticket created by formcreator).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
