### PR TITLE
Fix case insensitive class names in API

### DIFF
--- a/inc/apirest.class.php
+++ b/inc/apirest.class.php
@@ -335,7 +335,10 @@ class APIRest extends API {
                $this->parameters['parent_itemtype'] = $itemtype;
                $itemtype                            = $additional_itemtype;
             }
-            $itemtype = ucfirst($itemtype);
+
+            // Get case sensitive itemtype name
+            $rc = new \ReflectionClass($itemtype);
+            $itemtype = $rc->getName();
             return $itemtype;
          }
          $this->returnError(__("resource not found or not an instance of CommonDBTM"),


### PR DESCRIPTION
The two following API requests give different results:
```http
GET apirest.php/search/itilfollowup
GET apirest.php/search/ITILFollowup
```

This is because search::addDefaultWhere($itemtype) use a switch based on the itemtype name:
```php
switch ($itemtype) {
         ...
         case 'ITILFollowup' :
         ...
}
```

GLPI does not check if the itemtype match the real name of the class, he will only put it throught `ucfirst` which does fix the most common cases like "ticket" but fails for anything else ("TICKET", TiCKeT", ...).


For the first request, "itilfollowup" is converted to "Itilfollowup" and thus doesn't match anything so the switch fall back to the "default" case and generate the wrong SQL request.

---

This proposal get the "correctly cased" class name using reflection.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
