### PR TITLE
Fix ITILFollowup and TicketTask case in addDefaultWhere

### DIFF
--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -1099,10 +1099,10 @@ class ITILFollowup  extends CommonDBChild {
          );
       }
 
-      $lc_itemtype = strtolower($itemtype);
+      $rightname = $itemtype::$rightname;
       // Can see all items, no need to go further
-      if (Session::haveRight($lc_itemtype, $itemtype::READALL)) {
-         return "(LOWER(`itemtype`) = '$lc_itemtype') ";
+      if (Session::haveRight($rightname, $itemtype::READALL)) {
+         return "(`itemtype` = '$itemtype') ";
       }
 
       $user   = Session::getLoginUserID();
@@ -1119,10 +1119,10 @@ class ITILFollowup  extends CommonDBChild {
       // We need to do some specific checks for tickets
       if ($itemtype == "Ticket") {
          // Default condition
-         $condition = "(LOWER(`itemtype`) = '$lc_itemtype' AND (0 = 1 ";
+         $condition = "(`itemtype` = '$itemtype' AND (0 = 1 ";
          return $condition . Ticket::buildCanViewCondition("items_id") . ")) ";
       } else {
-         if (Session::haveRight($lc_itemtype, $itemtype::READMY)) {
+         if (Session::haveRight($rightname, $itemtype::READMY)) {
             // Subquery for affected/assigned/observer user
             $user_query = "SELECT `$target`
                FROM `$user_table`
@@ -1139,7 +1139,7 @@ class ITILFollowup  extends CommonDBChild {
                WHERE `users_id_recipient` = '$user'";
 
             return "(
-               LOWER(`itemtype`) = '$lc_itemtype' AND (
+               `itemtype` = '$itemtype' AND (
                   `items_id` IN ($user_query) OR
                   `items_id` IN ($group_query) OR
                   `items_id` IN ($recipient_query)
@@ -1147,7 +1147,7 @@ class ITILFollowup  extends CommonDBChild {
             ) ";
          } else {
             // Can't see any items
-            return "(LOWER(`itemtype`) = '$lc_itemtype' AND 0 = 1) ";
+            return "(`itemtype` = '$itemtype' AND 0 = 1) ";
          }
       }
    }

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -1099,9 +1099,10 @@ class ITILFollowup  extends CommonDBChild {
          );
       }
 
+      $lc_itemtype = strtolower($itemtype);
       // Can see all items, no need to go further
-      if (Session::haveRight($itemtype, $itemtype::READALL)) {
-         return "(`itemtype` = '$itemtype') ";
+      if (Session::haveRight($lc_itemtype, $itemtype::READALL)) {
+         return "(LOWER(`itemtype`) = '$lc_itemtype') ";
       }
 
       $user   = Session::getLoginUserID();
@@ -1118,10 +1119,10 @@ class ITILFollowup  extends CommonDBChild {
       // We need to do some specific checks for tickets
       if ($itemtype == "Ticket") {
          // Default condition
-         $condition = "(`itemtype` = '$itemtype' AND (0 = 1 ";
+         $condition = "(LOWER(`itemtype`) = '$lc_itemtype' AND (0 = 1 ";
          return $condition . Ticket::buildCanViewCondition("items_id") . ")) ";
       } else {
-         if (Session::haveRight($itemtype, $itemtype::READMY)) {
+         if (Session::haveRight($lc_itemtype, $itemtype::READMY)) {
             // Subquery for affected/assigned/observer user
             $user_query = "SELECT `$target`
                FROM `$user_table`
@@ -1138,7 +1139,7 @@ class ITILFollowup  extends CommonDBChild {
                WHERE `users_id_recipient` = '$user'";
 
             return "(
-               `itemtype` = '$itemtype' AND (
+               LOWER(`itemtype`) = '$lc_itemtype' AND (
                   `items_id` IN ($user_query) OR
                   `items_id` IN ($group_query) OR
                   `items_id` IN ($recipient_query)
@@ -1146,7 +1147,7 @@ class ITILFollowup  extends CommonDBChild {
             ) ";
          } else {
             // Can't see any items
-            return "(`itemtype` = '$itemtype' AND 0 = 1) ";
+            return "(LOWER(`itemtype`) = '$lc_itemtype' AND 0 = 1) ";
          }
       }
    }

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3959,12 +3959,12 @@ JAVASCRIPT;
             $condition .= "AND (";
 
             // Filter for "ticket" parents
-            $condition .= ITILFollowup::buildParentCondition("Ticket");
+            $condition .= ITILFollowup::buildParentCondition(\Ticket::getType());
             $condition .= "OR ";
 
             // Filter for "change" parents
             $condition .= ITILFollowup::buildParentCondition(
-               "Change",
+               \Change::getType(),
                'changes_id',
                "glpi_changes_users",
                "glpi_changes_groups"
@@ -3973,7 +3973,7 @@ JAVASCRIPT;
 
             // Fitler for "problem" parents
             $condition .= ITILFollowup::buildParentCondition(
-               "Problem",
+               \Problem::getType(),
                'problems_id',
                "glpi_problems_users",
                "glpi_groups_problems"

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3926,8 +3926,14 @@ JAVASCRIPT;
             $condition .= "OR `users_id` = " . Session::getLoginUserID() . " ";
             $condition .= "OR `users_id_tech` = " . Session::getLoginUserID() . " ";
 
-            // Check for parent item visibility
-            $condition .= "AND " . TicketTask::buildParentCondition() . ")";
+            // Check for parent item visibility unless the user can see all the
+            // possible parents
+            if (!Session::haveRight('ticket', Ticket::READALL)) {
+               $condition .= "AND " . TicketTask::buildParentCondition();
+            }
+
+            $condition .= ")";
+
             break;
 
          case 'ITILFollowup':


### PR DESCRIPTION
ITILFollowup:
Fix some conditions that were never true because of an incorrect case on the right name (e.g. 'Ticket' instead of 'ticket').

The conditions were also improved by making some comparisons case insensitive.


----
TicketTask:
Add missing check on Ticket::READALL (no need to check the visibility of the parent of the task in this case: the user can see every possible parents).


Internal ref: 18939.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
