### PR TITLE
Add error when user tries to update pass using current value

### DIFF
--- a/front/helpdesk.public.php
+++ b/front/helpdesk.public.php
@@ -99,7 +99,7 @@ if (isset($_GET['create_ticket'])) {
 
    $user = new User();
    $user->getFromDB(Session::getLoginUserID());
-   if ($user->shouldChangePassword()) {
+   if ($user->fields['authtype'] == Auth::DB_GLPI && $user->shouldChangePassword()) {
       $expiration_msg = sprintf(
          __('Your password will expire on %s.'),
          Html::convDateTime(date('Y-m-d H:i:s', $user->getPasswordExpirationTime()))

--- a/front/updatepassword.php
+++ b/front/updatepassword.php
@@ -65,7 +65,9 @@ if (array_key_exists('update', $_POST)) {
          'password'         => $_POST['password'],
          'password2'        => $_POST['password2'],
       ];
-      if ($input['password'] !== $input['password2']) {
+      if ($input['password'] === $input['current_password']) {
+         $error_messages = [__('The new password must be different from current password')];
+      } else if ($input['password'] !== $input['password2']) {
          $error_messages = [__('The two passwords do not match')];
       } else {
          try {

--- a/inc/central.class.php
+++ b/inc/central.class.php
@@ -160,7 +160,7 @@ class Central extends CommonGLPI {
 
       $user = new User();
       $user->getFromDB(Session::getLoginUserID());
-      if ($user->shouldChangePassword()) {
+      if ($user->fields['authtype'] == Auth::DB_GLPI && $user->shouldChangePassword()) {
          $expiration_msg = sprintf(
             __('Your password will expire on %s.'),
             Html::convDateTime(date('Y-m-d H:i:s', $user->getPasswordExpirationTime()))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Currently, if user updates its password using current value, nothing is saved on DB and no error is shown to user.