### PR TITLE
fix(core): fix gettable from entity class

### DIFF
--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -269,7 +269,7 @@ class Entity extends CommonTreeDropdown {
          'SELECT' => new \QueryExpression(
             'MAX('.$DB->quoteName('id').')+1 AS newID'
          ),
-         'FROM'   => self::getTable()
+         'FROM'   => $this::getTable()
       ])->next();
       $input['id'] = $result['newID'];
 

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -269,7 +269,7 @@ class Entity extends CommonTreeDropdown {
          'SELECT' => new \QueryExpression(
             'MAX('.$DB->quoteName('id').')+1 AS newID'
          ),
-         'FROM'   => $this::getTable()
+         'FROM'   => $this->getTable()
       ])->next();
       $input['id'] = $result['newID'];
 


### PR DESCRIPTION

about this https://github.com/pluginsGLPI/datainjection/issues/172 and https://github.com/pluginsGLPI/datainjection/issues/149

prepareinputforadd method use ```self::getTable``` to generate table name for entity class to get max ID

But when datainjection try to create entity from import process, 
```getTable``` return  ```glpi_plugin_datainjection_entityinjections```

this PR fix this by use ```Èntity::getTable()``` rather than ```self::getTable()```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
