### PR TITLE
Add forcename option to API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ The present file will list all changes made to the project; according to the
 - `Plugin::setUnloaded()`
 - `Plugin::setUnloadedByName()`
 - Usage of `$LOADED_PLUGINS` global variable
-- `CommonDBTM::getRawName()`
+- `CommonDBTM::getRawName()` replaced by `CommonDBTM::getFriendlyName()`
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The present file will list all changes made to the project; according to the
 - `Plugin::setUnloaded()`
 - `Plugin::setUnloadedByName()`
 - Usage of `$LOADED_PLUGINS` global variable
+- `CommonDBTM::getRawName()`
 
 #### Removed
 

--- a/apirest.md
+++ b/apirest.md
@@ -508,7 +508,7 @@ $ curl -X GET \
   * *with_changes*: Retrieve associated ITIL changes. Optional.
   * *with_notes*: Retrieve Notes. Optional.
   * *with_logs*: Retrieve historical. Optional.
-  * *forcename*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
+  * *add_keys_names*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
 * **Returns**:
   * 200 (OK) with item data (Last-Modified header should contain the date of last modification of the item).
   * 401 (UNAUTHORIZED).
@@ -599,7 +599,7 @@ Note: To download a document see [Download a document file](#download-a-document
   * *order* (default ASC): ASC - Ascending sort / DESC Descending sort. Optional.
   * *searchText* (default NULL): array of filters to pass on the query (with key = field and value the text to search)
   * *is_deleted* (default: false): Return deleted element. Optional.
-  * *forcename*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
+  * *add_keys_names*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
 * **Returns**:
   * 200 (OK) with items data.
   * 206 (PARTIAL CONTENT) with items data defined by range.
@@ -705,7 +705,7 @@ $ curl -X GET \
   * *range* (default: 0-50): a string with a couple of number for start and end of pagination separated by a '-' char. Ex: 150-200. Optional.
   * *sort* (default 1): id of the "searchoption" to sort by. Optional.
   * *order* (default ASC): ASC - Ascending sort / DESC Descending sort. Optional.
-  * *forcename*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
+  * *add_keys_names*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
 * **Returns**:
   * 200 (OK) with the items data.
   * 401 (UNAUTHORIZED).
@@ -784,7 +784,7 @@ $ curl -X GET \
   * *with_changes*: Retrieve associated ITIL changes. Optional.
   * *with_notes*: Retrieve Notes. Optional.
   * *with_logs*: Retrieve historical. Optional.
-  * *forcename*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
+  * *add_keys_names*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
 * **Returns**:
   * 200 (OK) with item data (Last-Modified header should contain the date of last modification of the item).
   * 401 (UNAUTHORIZED).

--- a/apirest.md
+++ b/apirest.md
@@ -508,6 +508,7 @@ $ curl -X GET \
   * *with_changes*: Retrieve associated ITIL changes. Optional.
   * *with_notes*: Retrieve Notes. Optional.
   * *with_logs*: Retrieve historical. Optional.
+  * *forcename*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
 * **Returns**:
   * 200 (OK) with item data (Last-Modified header should contain the date of last modification of the item).
   * 401 (UNAUTHORIZED).
@@ -598,6 +599,7 @@ Note: To download a document see [Download a document file](#download-a-document
   * *order* (default ASC): ASC - Ascending sort / DESC Descending sort. Optional.
   * *searchText* (default NULL): array of filters to pass on the query (with key = field and value the text to search)
   * *is_deleted* (default: false): Return deleted element. Optional.
+  * *forcename*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
 * **Returns**:
   * 200 (OK) with items data.
   * 206 (PARTIAL CONTENT) with items data defined by range.
@@ -703,6 +705,7 @@ $ curl -X GET \
   * *range* (default: 0-50): a string with a couple of number for start and end of pagination separated by a '-' char. Ex: 150-200. Optional.
   * *sort* (default 1): id of the "searchoption" to sort by. Optional.
   * *order* (default ASC): ASC - Ascending sort / DESC Descending sort. Optional.
+  * *forcename*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
 * **Returns**:
   * 200 (OK) with the items data.
   * 401 (UNAUTHORIZED).
@@ -781,6 +784,7 @@ $ curl -X GET \
   * *with_changes*: Retrieve associated ITIL changes. Optional.
   * *with_notes*: Retrieve Notes. Optional.
   * *with_logs*: Retrieve historical. Optional.
+  * *forcename*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
 * **Returns**:
   * 200 (OK) with item data (Last-Modified header should contain the date of last modification of the item).
   * 401 (UNAUTHORIZED).

--- a/apirest.md
+++ b/apirest.md
@@ -508,7 +508,7 @@ $ curl -X GET \
   * *with_changes*: Retrieve associated ITIL changes. Optional.
   * *with_notes*: Retrieve Notes. Optional.
   * *with_logs*: Retrieve historical. Optional.
-  * *add_keys_names*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
+  * *add_keys_names*: Retrieve friendly names. Array containing fkey(s) and/or "id". Optional.
 * **Returns**:
   * 200 (OK) with item data (Last-Modified header should contain the date of last modification of the item).
   * 401 (UNAUTHORIZED).
@@ -599,7 +599,7 @@ Note: To download a document see [Download a document file](#download-a-document
   * *order* (default ASC): ASC - Ascending sort / DESC Descending sort. Optional.
   * *searchText* (default NULL): array of filters to pass on the query (with key = field and value the text to search)
   * *is_deleted* (default: false): Return deleted element. Optional.
-  * *add_keys_names*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
+  * *add_keys_names*: Retrieve friendly names. Array containing fkey(s) and/or "id". Optional.
 * **Returns**:
   * 200 (OK) with items data.
   * 206 (PARTIAL CONTENT) with items data defined by range.
@@ -705,7 +705,7 @@ $ curl -X GET \
   * *range* (default: 0-50): a string with a couple of number for start and end of pagination separated by a '-' char. Ex: 150-200. Optional.
   * *sort* (default 1): id of the "searchoption" to sort by. Optional.
   * *order* (default ASC): ASC - Ascending sort / DESC Descending sort. Optional.
-  * *add_keys_names*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
+  * *add_keys_names*: Retrieve friendly names. Array containing fkey(s) and/or "id". Optional.
 * **Returns**:
   * 200 (OK) with the items data.
   * 401 (UNAUTHORIZED).
@@ -784,7 +784,7 @@ $ curl -X GET \
   * *with_changes*: Retrieve associated ITIL changes. Optional.
   * *with_notes*: Retrieve Notes. Optional.
   * *with_logs*: Retrieve historical. Optional.
-  * *add_keys_names*: Retrieve friendly names. Array containing fkey(s) and/or "self". Optional.
+  * *add_keys_names*: Retrieve friendly names. Array containing fkey(s) and/or "id". Optional.
 * **Returns**:
   * 200 (OK) with item data (Last-Modified header should contain the date of last modification of the item).
   * 401 (UNAUTHORIZED).

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -2372,7 +2372,7 @@ abstract class API extends CommonGLPI {
                $itemtype = getItemTypeForTable($tablename);
 
                // get hateoas
-               if ($params['get_hateoas']) {
+               if ($params['get_hateoas'] && is_integer($value)) {
                   $fields['links'][] = ['rel'  => $itemtype,
                                              'href' => self::$api_url."/$itemtype/".$value];
                }

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -50,8 +50,6 @@ abstract class API extends CommonGLPI {
    protected $app_tokens    = [];
    protected $apiclients_id = 0;
 
-   const PARAM_FORCENAME = "forcename";
-
    /**
     * First function used on api call
     * Parse sended query/parameters and call the corresponding API::method
@@ -536,7 +534,7 @@ abstract class API extends CommonGLPI {
                        'with_changes'      => false,
                        'with_notes'        => false,
                        'with_logs'         => false,
-                       self::PARAM_FORCENAME => [],
+                       'forcename'         => [],
       ];
       $params = array_merge($default, $params);
 
@@ -1070,7 +1068,7 @@ abstract class API extends CommonGLPI {
                                              | JSON_NUMERIC_CHECK));
       }
 
-      if (count($params[self::PARAM_FORCENAME]) > 0) {
+      if (count($params['forcename']) > 0) {
          $fields["_names"] = $this->getFriendlyNames(
             $fields,
             $params,
@@ -1132,7 +1130,7 @@ abstract class API extends CommonGLPI {
                        'order'            => "ASC",
                        'searchText'       => null,
                        'is_deleted'       => false,
-                       self::PARAM_FORCENAME => [],
+                       'forcename'        => [],
       ];
       $params = array_merge($default, $params);
 
@@ -1266,7 +1264,7 @@ abstract class API extends CommonGLPI {
       }
 
       // Check if we need to add raw names later on
-      $forcename = count($params[SELF::PARAM_FORCENAME]) > 0;
+      $forcename = count($params['forcename']) > 0;
 
       // build query
       $query = "SELECT SQL_CALC_FOUND_ROWS DISTINCT ".$DB->quoteName("$table.id").",  ".$DB->quoteName("$table.*")."
@@ -2652,7 +2650,7 @@ abstract class API extends CommonGLPI {
    ) {
       $_names = [];
 
-      foreach ($params[self::PARAM_FORCENAME] as $fn_fkey) {
+      foreach ($params['forcename'] as $fn_fkey) {
          if ($fn_fkey == "self") {
             // Get friendlyname for current item
             $fn_itemtype = $self_itemtype;

--- a/inc/caldav/backend/calendar.class.php
+++ b/inc/caldav/backend/calendar.class.php
@@ -86,7 +86,7 @@ class Calendar extends AbstractBackend {
             'uri'          => self::BASE_CALENDAR_URI,
             'principaluri' => $principalPath,
             'name'         => $principal_item->getName(),
-            'desc'         => sprintf(__('Calendar of %s'), $principal_item->getRawName()),
+            'desc'         => sprintf(__('Calendar of %s'), $principal_item->getFriendlyName()),
             'color'        => null,
          ]
       ];
@@ -124,7 +124,7 @@ class Calendar extends AbstractBackend {
                   : $key,
                'principaluri' => $this->getPrincipalUri($calendar_principal),
                'name'         => $calendar_principal->getName(),
-               'desc'         => sprintf(__('Calendar of %s'), $calendar_principal->getRawName()),
+               'desc'         => sprintf(__('Calendar of %s'), $calendar_principal->getFriendlyName()),
                'color'        => $calendar_params['color'],
             ];
          }

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -558,13 +558,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
 
    // SPECIFIC FUNCTIONS
-
-   /**
-    * @see CommonDBTM::getRawName()
-    *
-    * @since 0.85
-   **/
-   function getRawName() {
+   public function computeFriendlyName() {
 
       if (isset($this->fields['taskcategories_id'])) {
          if ($this->fields['taskcategories_id']) {

--- a/inc/contact.class.php
+++ b/inc/contact.class.php
@@ -260,7 +260,7 @@ class Contact extends CommonDBTM{
    }
 
 
-   function getRawName() {
+   public function computeFriendlyName() {
 
       if (isset($this->fields["id"]) && ($this->fields["id"] > 0)) {
          return formatUserName('',

--- a/inc/item_devices.class.php
+++ b/inc/item_devices.class.php
@@ -80,7 +80,7 @@ class Item_Devices extends CommonDBRelation {
       return true;
    }
 
-   function getRawName() {
+   public function computeFriendlyName() {
       $itemtype = static::$itemtype_2;
       if (!empty($this->fields[static::$itemtype_1])) {
          $item = new $this->fields[static::$itemtype_1];

--- a/inc/item_operatingsystem.class.php
+++ b/inc/item_operatingsystem.class.php
@@ -342,7 +342,7 @@ class Item_OperatingSystem extends CommonDBRelation {
       $this->showFormButtons($options);
    }
 
-   function getRawName() {
+   public function computeFriendlyName() {
       $item = getItemForItemtype($this->fields['itemtype']);
       $item->getFromDB($this->fields['items_id']);
       $name = $item->getTypeName(1) . ' ' . $item->getName();

--- a/inc/item_rack.class.php
+++ b/inc/item_rack.class.php
@@ -1075,7 +1075,7 @@ JAVASCRIPT;
       return $input;
    }
 
-   function getRawName() {
+   public function computeFriendlyName() {
       $rack = new Rack();
       $rack->getFromDB($this->fields['racks_id']);
       $name = sprintf(

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -470,7 +470,7 @@ class ITILFollowup  extends CommonDBChild {
    }
 
 
-   function getRawName() {
+   public function computeFriendlyName() {
 
       if (isset($this->fields['requesttypes_id'])) {
          if ($this->fields['requesttypes_id']) {

--- a/inc/itiltemplatefield.class.php
+++ b/inc/itiltemplatefield.class.php
@@ -75,7 +75,7 @@ abstract class ITILTemplateField extends CommonDBChild {
    }
 
 
-   function getRawName() {
+   function computeFriendlyName() {
       $tt_class = static::$itemtype;
       $tt     = new $tt_class;
       $fields = $tt->getAllowedFieldsNames(true);

--- a/inc/itiltemplatepredefinedfield.class.php
+++ b/inc/itiltemplatepredefinedfield.class.php
@@ -49,7 +49,7 @@ class ITILTemplatePredefinedField extends ITILTemplateField {
    }
 
 
-   function getRawName() {
+   function computeFriendlyName() {
 
       $tt_class = static::$itemtype;
       $tt     = new $tt_class;

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -226,15 +226,7 @@ class NotificationTarget extends CommonDBChild {
       return _n('Recipient', 'Recipients', $nb);
    }
 
-
-   /**
-    * Get a notificationtarget class by giving the object which raises the event
-    *
-    * @see CommonDBTM::getRawName
-    *
-    * @return string
-   **/
-   function getRawName() {
+   public function computeFriendlyName() {
 
       if (isset($this->notification_targets_labels[$this->getField("type")]
                                                   [$this->getField("items_id")])) {
@@ -244,7 +236,6 @@ class NotificationTarget extends CommonDBChild {
       }
       return '';
    }
-
 
    /**
     * Get a notificationtarget class by giving the object which raises the event

--- a/inc/notificationtemplatetranslation.class.php
+++ b/inc/notificationtemplatetranslation.class.php
@@ -62,10 +62,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
    }
 
 
-   /**
-    * @see CommonDBTM::getRawName()
-   **/
-   function getRawName() {
+   public function computeFriendlyName() {
       global $CFG_GLPI;
 
       if ($this->getField('language') != '') {

--- a/inc/operatingsystemkernelversion.class.php
+++ b/inc/operatingsystemkernelversion.class.php
@@ -62,16 +62,9 @@ class OperatingSystemKernelVersion extends CommonDropdown {
       }
    }
 
-   function getRawName() {
-      $kernel = new OperatingSystemKernel();
-      $kname = $kernel->getRawName();
-      $kvname = parent::getRawName();
+   public function computeFriendlyName() {
+      $kvname = parent::computeFriendlyName();
 
-      $name = str_replace(
-         ['%kernel', '%version'],
-         [$kname, $kvname],
-         '%kernel %version'
-      );
-      return trim($name);
+      return trim($kvname);
    }
 }

--- a/inc/planningcsv.class.php
+++ b/inc/planningcsv.class.php
@@ -113,7 +113,7 @@ class PlanningCsv extends CommonGLPI {
 
             //(acteur;titre item;id item;date-heure début,date-heure fin;catégorie)
             $this->lines[] = [
-               'actor'     => $user->getRawName(),
+               'actor'     => $user->getFriendlyName(),
                'title'     => $val['name'],
                'itemtype'  => $itemtype->getTypeName(1),
                'items_id'  => $val[$itemtype->getForeignKeyField()],

--- a/inc/profile_user.class.php
+++ b/inc/profile_user.class.php
@@ -957,11 +957,7 @@ class Profile_User extends CommonDBRelation {
       return _n('Profile', 'Profiles', $nb);
    }
 
-
-   /**
-    * @see CommonDBTM::getRawName()
-   **/
-   function getRawName() {
+   public function computeFriendlyName() {
 
       $name = sprintf(__('%1$s, %2$s'),
                       Dropdown::getDropdownName('glpi_profiles', $this->fields['profiles_id']),
@@ -979,7 +975,6 @@ class Profile_User extends CommonDBRelation {
       }
       return $name;
    }
-
 
    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
       global $DB;

--- a/inc/ruleaction.class.php
+++ b/inc/ruleaction.class.php
@@ -89,18 +89,13 @@ class RuleAction extends CommonDBChild {
       return _n('Action', 'Actions', $nb);
    }
 
-
-   /**
-    * @see CommonDBTM::getRawName()
-   **/
-   function getRawName() {
+   public function computeFriendlyName() {
 
       if ($rule = getItemForItemtype(static::$itemtype)) {
          return Html::clean($rule->getMinimalActionText($this->fields));
       }
       return '';
    }
-
 
    /**
     * @since 0.84

--- a/inc/rulecriteria.class.php
+++ b/inc/rulecriteria.class.php
@@ -92,18 +92,13 @@ class RuleCriteria extends CommonDBChild {
       return _n('Criterion', 'Criteria', $nb);
    }
 
-
-   /**
-    * @see CommonDBTM::getRawName()
-   **/
-   function getRawName() {
+   public function computeFriendlyName() {
 
       if ($rule = getItemForItemtype(static::$itemtype)) {
          return Html::clean($rule->getMinimalCriteriaText($this->fields));
       }
       return '';
    }
-
 
    /**
     * @since 0.84

--- a/inc/tickettemplatehiddenfield.class.php
+++ b/inc/tickettemplatehiddenfield.class.php
@@ -42,5 +42,4 @@ class TicketTemplateHiddenField extends ITILTemplateHiddenField {
    static public $itemtype  = 'TicketTemplate';
    static public $items_id  = 'tickettemplates_id';
    static public $itiltype = 'Ticket';
-
 }

--- a/inc/tickettemplatemandatoryfield.class.php
+++ b/inc/tickettemplatemandatoryfield.class.php
@@ -42,5 +42,4 @@ class TicketTemplateMandatoryField extends ITILTemplateMandatoryField {
    static public $itemtype  = 'TicketTemplate';
    static public $items_id  = 'tickettemplates_id';
    static public $itiltype = 'Ticket';
-
 }

--- a/inc/tickettemplatepredefinedfield.class.php
+++ b/inc/tickettemplatepredefinedfield.class.php
@@ -48,5 +48,4 @@ class TicketTemplatePredefinedField extends ITILTemplatePredefinedField {
    static public $itemtype  = 'TicketTemplate';
    static public $items_id  = 'tickettemplates_id';
    static public $itiltype  = 'Ticket';
-
 }

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -1340,11 +1340,11 @@ class User extends CommonDBTM {
       }
    }
 
-   function getRawName() {
+   function computeFriendlyName() {
       global $CFG_GLPI;
 
       if (isset($this->fields["id"]) && ($this->fields["id"] > 0)) {
-         //getRawName should not add ID
+         //computeFriendlyName should not add ID
          $bkp_conf = $CFG_GLPI['is_ids_visible'];
          $CFG_GLPI['is_ids_visible'] = 0;
          $bkp_sessconf = (isset($_SESSION['glpiis_ids_visible']) ? $_SESSION["glpiis_ids_visible"] : 0);

--- a/tests/functionnal/Glpi/CalDAV/Server.php
+++ b/tests/functionnal/Glpi/CalDAV/Server.php
@@ -431,11 +431,11 @@ class Server extends DbTestCase {
       $calendars = [
          [
             'path' => 'calendars/users/' . $user->fields['name'] . '/calendar/',
-            'name' => $user->getRawName(),
+            'name' => $user->getFriendlyName(),
          ],
          [
             'path' => 'calendars/groups/' . $group_id . '/calendar/',
-            'name' => $group->getRawName(),
+            'name' => $group->getFriendlyName(),
          ],
       ];
 

--- a/tests/functionnal/PlanningCsv.php
+++ b/tests/functionnal/PlanningCsv.php
@@ -130,7 +130,7 @@ class PlanningCsv extends \DbTestCase {
 
       $expected = [
          [
-            'actor'     => $user->getRawName(),
+            'actor'     => $user->getFriendlyName(),
             'title'     => 'This is a "test"',
             'itemtype'  => 'Reminder',
             'items_id'  => (string)$rid,
@@ -141,7 +141,7 @@ class PlanningCsv extends \DbTestCase {
 
       foreach ($tasks as $input) {
          $expected[] = [
-            'actor'     => $user->getRawName(),
+            'actor'     => $user->getFriendlyName(),
             'title'     => 'ticket title',
             'itemtype'  => 'Ticket task',
             'items_id'  => (string)$input['id'],
@@ -153,9 +153,9 @@ class PlanningCsv extends \DbTestCase {
       $this->array($csv->getLines())->isEqualTo($expected);
 
       $sexpected = "\"Actor\";\"Title\";\"Item type\";\"Item id\";\"Begin date\";\"End date\"".$csv->eol;
-      $sexpected .= "\"".$user->getRawName()."\";\"This is a \"\"test\"\"\";\"Reminder\";\"$rid\";\"$fbegin\";\"$fend\"{$csv->eol}";
+      $sexpected .= "\"".$user->getFriendlyName()."\";\"This is a \"\"test\"\"\";\"Reminder\";\"$rid\";\"$fbegin\";\"$fend\"{$csv->eol}";
       foreach ($tasks as $input) {
-         $sexpected .= "\"".$user->getRawName()."\";\"ticket title\";\"Ticket task\";\"{$input['id']}\";\"{$input['begin']}\";\"{$input['end']}\"{$csv->eol}";
+         $sexpected .= "\"".$user->getFriendlyName()."\";\"ticket title\";\"Ticket task\";\"{$input['id']}\";\"{$input['begin']}\";\"{$input['end']}\"{$csv->eol}";
       }
       $this->output(
          function () use ($csv) {

--- a/tests/functionnal/RuleCriteria.php
+++ b/tests/functionnal/RuleCriteria.php
@@ -100,7 +100,7 @@ class RuleCriteria extends DbTestCase {
       $this->integer((int)$criteria_id)->isGreaterThan(0);
 
       $this->boolean($criteria->getFromDB($criteria_id))->isTrue();
-      $this->string($criteria->getRawName())->isIdenticalTo('SoftwareisMozilla Firefox 52');
+      $this->string($criteria->computeFriendlyName())->isIdenticalTo('SoftwareisMozilla Firefox 52');
    }
 
    public function testPost_addItem() {

--- a/tests/functionnal/User.php
+++ b/tests/functionnal/User.php
@@ -585,10 +585,10 @@ class User extends \DbTestCase {
    /**
     * @dataProvider rawNameProvider
     */
-   public function testGetRawName($input, $rawname) {
+   public function testGetFriendlyName($input, $rawname) {
       $user = $this->newTestedInstance;
 
-      $this->string($user->getRawName())->isIdenticalTo('');
+      $this->string($user->getFriendlyName())->isIdenticalTo('');
 
       $this
          ->given($this->newTestedInstance)
@@ -596,7 +596,7 @@ class User extends \DbTestCase {
                ->integer($uid = (int)$this->testedInstance->add($input))
                   ->isGreaterThan(0)
                ->boolean($this->testedInstance->getFromDB($uid))->isTrue()
-               ->string($this->testedInstance->getRawName())->isIdenticalTo($rawname);
+               ->string($this->testedInstance->getFriendlyName())->isIdenticalTo($rawname);
    }
 
    public function testBlankPassword() {

--- a/tools/glpiuser.php
+++ b/tools/glpiuser.php
@@ -59,7 +59,7 @@ if (isset($_GET['help']) || !isset($_GET['user'])) {
 
 function displayUser(User $user) {
    printf("\nLogin:    %s\n", $user->getField('name'));
-   printf("Name:     %s\n", $user->getRawName());
+   printf("Name:     %s\n", $user->getFriendlyName());
    printf("Password: %s\n", $user->getField('password'));// ? 'set' : 'sot set');
    printf("Authent:  %s\n", Auth::getMethodName($user->getField('authtype'), $user->getField('auths_id')));
    printf("Active:   %s\n\n", $user->getField('is_active') ? 'yes' : 'no');


### PR DESCRIPTION
Some API requests returns ids (e.g. users_id) that a self-service user can't work with (as he is not allowed to query /User/{id}) and thus can't get the name matching this id (e.g. the name of the author of an ITILFollowup).

This proposal add a "forcename" option that allow to access the rawname of the items.  

Example request: 
```http
GET apirest.php/ITILFollowup?id=22
&forcename[0]=users_id
&forcename[1]=users_id_editor
```

Response:
```json
{
        "id": 22,
        "itemtype": "Ticket",
        "items_id": 5,
        "date": "2019-02-25 16:27:05",
        "users_id": 2,
        "users_id_editor": 2,
        "content": "&lt;p&gt;aaaqdzdqdqzdqzdqzdqz&lt;/p&gt;&lt;p&gt;&lt;a href=\"http://72.glpi-fusion-94.local/front/document.send.php?docid=4&amp;tickets_id=5\" target=\"_blank\" rel=\"noopener\"&gt;&lt;img src=\"http://72.glpi-fusion-94.local/front/document.send.php?docid=4&amp;tickets_id=5\" alt=\"3577bb62-c6a01f19-5c740943affc40.83487561\" width=\"185\" /&gt;&lt;/a&gt;&lt;/p&gt;",
        "is_private": 0,
        "requesttypes_id": 1,
        "date_mod": "2020-01-28 10:06:09",
        "date_creation": "2019-02-25 16:27:05",
        "timeline_position": 1,
        "sourceitems_id": 0,
        "sourceof_items_id": 0,
 |      "_names": {
 |          "users_id": "glpi",
 |          "users_id_editor": "glpi",
 |          "links": [
 |              {
 |                  "rel": "User",
 |                  "href": "http://glpi-fusion-94.local/api/User/glpi"
 |              },
 |              {
 |                  "rel": "User",
 |                  "href": "http://glpi-fusion-94.local/api/User/glpi"
 |              }
 |          ]
 |      }
}
```


Performance impact:

Benchmark request (80 followups, two names requested):
```http
GET apirest.php/ITILFollowup?range=0-80
&forcename[0]=users_id
&forcename[1]=users_id_editor
```

Without cache:
```
PHP message: Additional time: 76.05 ms
PHP message: Average time per name fetched:  0.93 ms
```

With cache:
```
PHP message: Additional time: 30.44 ms
PHP message: Average time per name fetched:  0.37 ms
```

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
