### PR TITLE
Force authentication for CalDAV access server

### DIFF
--- a/inc/caldav/plugin/acl.class.php
+++ b/inc/caldav/plugin/acl.class.php
@@ -56,6 +56,8 @@ class Acl extends Plugin {
       Principal::PREFIX_USERS,
    ];
 
+   public $allowUnauthenticatedAccess = false;
+
    public function getAcl($node) {
       if (is_string($node)) {
          $node = $this->server->tree->getNodeForPath($node);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Some clients request CalDAV server without sending `Authorization` header on some request. It can result in serving unwanted filtered data.
For instance, `REPORT /caldav.php/calendars/users/glpi/calendar/` will send all events from `glpi` users when request contains `Authorization` header, but will send empty data otherwise (as anonymous user is not part of users, groups or profiles that can see `glpi` calendar).
Forcing authentication for all request will prevent this kind of issues, and we do not need unauthenticated requests as we have no "fully public" data to serve.
