### PR TITLE
Fix plugins check_config usability and make it optionnal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@ The present file will list all changes made to the project; according to the
 - `Toolbox::userErrorHandlerNormal()`
 - `Html::jsDisable()`
 - `Html::jsEnable()`
+- `Plugin::setLoaded()`
+- `Plugin::setUnloaded()`
+- `Plugin::setUnloadedByName()`
+- Usage of `$LOADED_PLUGINS` global variable
 
 #### Removed
 

--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -288,9 +288,8 @@ function glpi_autoload($classname) {
       $plugname = strtolower($plug['plugin']);
       $dir      = GLPI_ROOT . "/plugins/$plugname/inc/";
       $item     = str_replace('\\', '/', strtolower($plug['class']));
-      // Is the plugin active?
       if (!Plugin::isPluginLoaded($plugname)) {
-         // Plugin not activated
+         // Do not load plugin class if plugin is not loaded
          return false;
       }
    } else {

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -4941,7 +4941,7 @@ abstract class CommonITILObject extends CommonDBTM {
       //Types of the plugins (keep the plugin hook for right check)
       if (isset($PLUGIN_HOOKS['assign_to_ticket'])) {
          foreach (array_keys($PLUGIN_HOOKS['assign_to_ticket']) as $plugin) {
-            if (!Plugin::isPluginLoaded($plugin)) {
+            if (!Plugin::isPluginActive($plugin)) {
                continue;
             }
             $ptypes = Plugin::doOneHook($plugin, 'AssignToTicket', $ptypes);

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -94,7 +94,7 @@ class Config extends CommonDBTM {
    function canViewItem() {
       if (isset($this->fields['context']) &&
          ($this->fields['context'] == 'core' ||
-         Plugin::isPluginLoaded($this->fields['context']))) {
+         Plugin::isPluginActive($this->fields['context']))) {
          return true;
       }
       return false;

--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -408,16 +408,7 @@ class Application extends BaseApplication {
       }
 
       $plugin = new Plugin();
-      $plugin->init();
-
-      $plugins_list = $plugin->getPlugins();
-      if (count($plugins_list) > 0) {
-         foreach ($plugins_list as $name) {
-            Plugin::load($name);
-         }
-         // For plugins which require action after all plugin init
-         Plugin::doHook("post_init");
-      }
+      $plugin->init(true);
    }
 
    /**

--- a/inc/console/plugin/installcommand.class.php
+++ b/inc/console/plugin/installcommand.class.php
@@ -295,20 +295,18 @@ class InstallCommand extends AbstractPluginCommand {
       Plugin::load($directory, true);
 
       // Check that required functions exists
-      foreach (['install', 'check_config'] as $fct_suffix) {
-         $function = 'plugin_' . $directory . '_' . $fct_suffix;
-         if (!function_exists($function)) {
-            $message = sprintf(
-               __('Plugin "%s" function "%s" is missing.'),
-               $directory,
-               $function
-            );
-            $this->output->writeln(
-               '<error>' . $message . '</error>',
-               OutputInterface::VERBOSITY_QUIET
-            );
-            return false;
-         }
+      $function = 'plugin_' . $directory . '_install';
+      if (!function_exists($function)) {
+         $message = sprintf(
+            __('Plugin "%s" function "%s" is missing.'),
+            $directory,
+            $function
+         );
+         $this->output->writeln(
+            '<error>' . $message . '</error>',
+            OutputInterface::VERBOSITY_QUIET
+         );
+         return false;
       }
 
       // Check prerequisites

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1335,7 +1335,7 @@ class Html {
       if (isset($PLUGIN_HOOKS['add_css']) && count($PLUGIN_HOOKS['add_css'])) {
 
          foreach ($PLUGIN_HOOKS["add_css"] as $plugin => $files) {
-            if (!Plugin::isPluginLoaded($plugin)) {
+            if (!Plugin::isPluginActive($plugin)) {
                continue;
             }
 
@@ -1495,7 +1495,7 @@ JAVASCRIPT;
          if (isset($PLUGIN_HOOKS["menu_toadd"]) && count($PLUGIN_HOOKS["menu_toadd"])) {
 
             foreach ($PLUGIN_HOOKS["menu_toadd"] as $plugin => $items) {
-               if (!Plugin::isPluginLoaded($plugin)) {
+               if (!Plugin::isPluginActive($plugin)) {
                   continue;
                }
                if (count($items)) {
@@ -6416,7 +6416,7 @@ JAVASCRIPT;
       if (isset($PLUGIN_HOOKS['add_javascript']) && count($PLUGIN_HOOKS['add_javascript'])) {
 
          foreach ($PLUGIN_HOOKS["add_javascript"] as $plugin => $files) {
-            if (!Plugin::isPluginLoaded($plugin)) {
+            if (!Plugin::isPluginActive($plugin)) {
                continue;
             }
             $version = Plugin::getInfo($plugin, 'version');
@@ -6845,7 +6845,7 @@ JAVASCRIPT;
             && count($PLUGIN_HOOKS["helpdesk_menu_entry"])) {
 
             foreach ($PLUGIN_HOOKS["helpdesk_menu_entry"] as $plugin => $active) {
-               if (!Plugin::isPluginLoaded($plugin)) {
+               if (!Plugin::isPluginActive($plugin)) {
                   continue;
                }
                if ($active) {

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -98,16 +98,7 @@ if (!isset($PLUGINS_INCLUDED)) {
    $PLUGINS_INCLUDED = 1;
    $LOADED_PLUGINS   = [];
    $plugin           = new Plugin();
-   $plugin->init();
-
-   $plugins_list = $plugin->getPlugins();
-   if (count($plugins_list)) {
-      foreach ($plugins_list as $name) {
-         Plugin::load($name);
-      }
-      // For plugins which require action after all plugin init
-      Plugin::doHook("post_init");
-   }
+   $plugin->init(true);
 }
 
 

--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -576,7 +576,7 @@ class MassiveAction {
          // Plugin Specific actions
          if (isset($PLUGIN_HOOKS['use_massive_action'])) {
             foreach (array_keys($PLUGIN_HOOKS['use_massive_action']) as $plugin) {
-               if (!Plugin::isPluginLoaded($plugin)) {
+               if (!Plugin::isPluginActive($plugin)) {
                   continue;
                }
                $plug_actions = Plugin::doOneHook($plugin, 'MassiveActions', $itemtype);

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -2113,7 +2113,8 @@ class Plugin extends CommonDBTM {
                $function = 'plugin_' . $directory . '_check_prerequisites';
                if (!isset($PLUGIN_HOOKS['csrf_compliant'][$directory])
                    || !$PLUGIN_HOOKS['csrf_compliant'][$directory]) {
-                  $output .= __('Not CSRF compliant');
+                  $output .= "<span class='error'>" . __('Not CSRF compliant') . "</span>";
+                  $do_activate = false;
                } else if (function_exists($function) && $do_activate) {
                   ob_start();
                   $do_activate = $function();

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -162,7 +162,8 @@ class Plugin extends CommonDBTM {
 
       if (file_exists(GLPI_ROOT . "/plugins/$directory/setup.php")) {
          include_once(GLPI_ROOT . "/plugins/$directory/setup.php");
-         if (!isset($LOADED_PLUGINS[$directory])) {
+         if (!in_array($directory, self::$loaded_plugins)) {
+            self::$loaded_plugins[] = $directory;
             self::loadLang($directory);
             $function = "plugin_init_$directory";
             if (function_exists($function)) {
@@ -175,7 +176,6 @@ class Plugin extends CommonDBTM {
           && file_exists(GLPI_ROOT . "/plugins/$directory/hook.php")) {
          include_once(GLPI_ROOT . "/plugins/$directory/hook.php");
       }
-      self::$loaded_plugins[] = $directory;
    }
 
    /**
@@ -2078,9 +2078,9 @@ class Plugin extends CommonDBTM {
 
             $output = '';
 
-            if (in_array($state, [self::ACTIVATED, self::TOBECONFIGURED, self::NOTACTIVATED], true)
+            if (in_array($state, [self::ACTIVATED, self::TOBECONFIGURED], true)
                 && isset($PLUGIN_HOOKS['config_page'][$directory])) {
-               // Configuration button for installed and up to date plugins
+               // Configuration button for activated or configurable plugins
                $config_url = $CFG_GLPI['root_doc']
                   . '/plugins/'
                   . $directory

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -2177,7 +2177,7 @@ class Plugin extends CommonDBTM {
                      $missing .= "plugin_".$directory."_install";
                   }
                   //TRANS: %s is the list of missing functions
-                  $output = sprintf(__('%1$s: %2$s'), __('Non-existent function'),
+                  $output .= sprintf(__('%1$s: %2$s'), __('Non-existent function'),
                          $missing);
                }
             } else if (in_array($state, [self::ACTIVATED, self::NOTUPDATED, self::TOBECONFIGURED, self::NOTACTIVATED], true)) {

--- a/inc/report.class.php
+++ b/inc/report.class.php
@@ -124,7 +124,7 @@ class Report extends CommonGLPI{
       $optgroup = [];
       if (isset($PLUGIN_HOOKS["reports"]) && is_array($PLUGIN_HOOKS["reports"])) {
          foreach ($PLUGIN_HOOKS["reports"] as $plug => $pages) {
-            if (!Plugin::isPluginLoaded($plug)) {
+            if (!Plugin::isPluginActive($plug)) {
                continue;
             }
             if (is_array($pages) && count($pages)) {

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -1712,7 +1712,7 @@ class Rule extends CommonDBTM {
       $input = $this->prepareInputDataForProcess($input, $params);
       if (isset($PLUGIN_HOOKS['use_rules'])) {
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
-            if (!Plugin::isPluginLoaded($plugin)) {
+            if (!Plugin::isPluginActive($plugin)) {
                continue;
             }
             if (is_array($val) && in_array($this->getType(), $val)) {
@@ -1751,7 +1751,7 @@ class Rule extends CommonDBTM {
          $params['criterias_results'] = $this->criterias_results;
          $params['rule_itemtype']     = $this->getType();
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
-            if (!Plugin::isPluginLoaded($plugin)) {
+            if (!Plugin::isPluginActive($plugin)) {
                continue;
             }
             if (is_array($val) && in_array($this->getType(), $val)) {
@@ -2585,7 +2585,7 @@ class Rule extends CommonDBTM {
          $params['criterias_results'] = $this->criterias_results;
          $params['rule_itemtype']     = $this->getType();
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
-            if (!Plugin::isPluginLoaded($plugin)) {
+            if (!Plugin::isPluginActive($plugin)) {
                continue;
             }
             if (is_array($val) && in_array($this->getType(), $val)) {
@@ -2690,7 +2690,7 @@ class Rule extends CommonDBTM {
       $toreturn = $params;
       if (isset($PLUGIN_HOOKS['use_rules'])) {
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
-            if (!Plugin::isPluginLoaded($plugin)) {
+            if (!Plugin::isPluginActive($plugin)) {
                continue;
             }
             if (is_array($val) && in_array($itemtype, $val)) {

--- a/inc/rulecollection.class.php
+++ b/inc/rulecollection.class.php
@@ -1662,7 +1662,7 @@ class RuleCollection extends CommonDBTM {
       $input = $this->prepareInputDataForProcess($input, $params);
       if (isset($PLUGIN_HOOKS['use_rules'])) {
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
-            if (!Plugin::isPluginLoaded($plugin)) {
+            if (!Plugin::isPluginActive($plugin)) {
                continue;
             }
             if (is_array($val) && in_array($this->getRuleClassName(), $val)) {
@@ -1845,7 +1845,7 @@ class RuleCollection extends CommonDBTM {
       if (isset($PLUGIN_HOOKS['use_rules'])) {
          $params['rule_itemtype'] = $this->getType();
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
-            if (!Plugin::isPluginLoaded($plugin)) {
+            if (!Plugin::isPluginActive($plugin)) {
                continue;
             }
             if (is_array($val) && in_array($this->getType(), $val)) {

--- a/inc/ruleimportcomputer.class.php
+++ b/inc/ruleimportcomputer.class.php
@@ -254,7 +254,7 @@ class RuleImportComputer extends Rule {
       //Add plugin global criteria
       if (isset($PLUGIN_HOOKS['use_rules'])) {
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
-            if (!Plugin::isPluginLoaded($plugin)) {
+            if (!Plugin::isPluginActive($plugin)) {
                continue;
             }
             if (is_array($val) && in_array($this->getType(), $val)) {
@@ -354,7 +354,7 @@ class RuleImportComputer extends Rule {
 
       if (isset($PLUGIN_HOOKS['use_rules'])) {
          foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
-            if (!Plugin::isPluginLoaded($plugin)) {
+            if (!Plugin::isPluginActive($plugin)) {
                continue;
             }
             if (is_array($val) && in_array($this->getType(), $val)) {

--- a/inc/ruleimportentity.class.php
+++ b/inc/ruleimportentity.class.php
@@ -121,7 +121,7 @@ class RuleImportEntity extends Rule {
       if ($criteria['field'] == '_source') {
          $tab = [];
          foreach ($PLUGIN_HOOKS['import_item'] as $plug => $types) {
-            if (!Plugin::isPluginLoaded($plug)) {
+            if (!Plugin::isPluginActive($plug)) {
                continue;
             }
             $tab[$plug] = Plugin::getInfo($plug, 'name');

--- a/inc/stat.class.php
+++ b/inc/stat.class.php
@@ -1515,7 +1515,7 @@ class Stat extends CommonGLPI {
       $optgroup = [];
       if (isset($PLUGIN_HOOKS["stats"]) && is_array($PLUGIN_HOOKS["stats"])) {
          foreach ($PLUGIN_HOOKS["stats"] as $plug => $pages) {
-            if (!Plugin::isPluginLoaded($plug)) {
+            if (!Plugin::isPluginActive($plug)) {
                continue;
             }
             if (is_array($pages) && count($pages)) {

--- a/tests/functionnal/Plugin.php
+++ b/tests/functionnal/Plugin.php
@@ -574,6 +574,40 @@ class Plugin extends DbTestCase {
 
    /**
     * Test state checking on a valid directory corresponding to a known inactive plugin with no modifications
+    * but not validating config.
+    * Should results in changing plugin state to "TOBECONFIGURED".
+    */
+   public function testCheckPluginStateForInactiveAndNotUpdatedPluginNotValidatingConfig() {
+
+      $initial_data = [
+         'directory' => $this->test_plugin_directory,
+         'name'      => 'Test plugin',
+         'version'   => '1.0',
+         'state'     => \Plugin::NOTACTIVATED,
+      ];
+      $setup_informations = [
+         'name'    => 'Test plugin',
+         'version' => '1.0',
+      ];
+      $expected_data = array_merge(
+         $initial_data,
+         [
+            'state' => \Plugin::TOBECONFIGURED,
+         ]
+      );
+
+      $this->function->plugin_test_check_config = false;
+
+      $this->doTestCheckPluginState(
+         $initial_data,
+         $setup_informations,
+         $expected_data,
+         'Plugin "' . $this->test_plugin_directory . '" must be configured.'
+      );
+   }
+
+   /**
+    * Test state checking on a valid directory corresponding to a known active plugin with no modifications
     * but not matching versions.
     * Should results in changing plugin state to "NOTACTIVATED".
     */
@@ -610,7 +644,7 @@ class Plugin extends DbTestCase {
    }
 
    /**
-    * Test state checking on a valid directory corresponding to a known inactive plugin with no modifications
+    * Test state checking on a valid directory corresponding to a known active plugin with no modifications
     * but not matching prerequisites.
     * Should results in changing plugin state to "NOTACTIVATED".
     */
@@ -644,11 +678,11 @@ class Plugin extends DbTestCase {
    }
 
    /**
-    * Test state checking on a valid directory corresponding to a known inactive plugin with no modifications
+    * Test state checking on a valid directory corresponding to a known active plugin with no modifications
     * but not validating config.
-    * Should results in changing plugin state to "NOTACTIVATED".
+    * Should results in changing plugin state to "TOBECONFIGURED".
     */
-   public function testCheckPluginStateForActiveAndNotUpdatedPluginNotValidationConfig() {
+   public function testCheckPluginStateForActiveAndNotUpdatedPluginNotValidatingConfig() {
 
       $initial_data = [
          'directory' => $this->test_plugin_directory,
@@ -663,7 +697,7 @@ class Plugin extends DbTestCase {
       $expected_data = array_merge(
          $initial_data,
          [
-            'state' => \Plugin::NOTACTIVATED,
+            'state' => \Plugin::TOBECONFIGURED,
          ]
       );
 
@@ -673,12 +707,12 @@ class Plugin extends DbTestCase {
          $initial_data,
          $setup_informations,
          $expected_data,
-         'Plugin "' . $this->test_plugin_directory . '" prerequisites are not matched. It has been deactivated.'
+         'Plugin "' . $this->test_plugin_directory . '" must be configured.'
       );
    }
 
    /**
-    * Test state checking on a valid directory corresponding to a known inactive plugin with no modifications,
+    * Test state checking on a valid directory corresponding to a known active plugin with no modifications,
     * matching prerequisites and validating config.
     * Should results in no changes.
     */
@@ -698,6 +732,32 @@ class Plugin extends DbTestCase {
 
       $this->function->plugin_test_check_prerequisites = true;
       $this->function->plugin_test_check_config = true;
+
+      $this->doTestCheckPluginState(
+         $initial_data,
+         $setup_informations,
+         $expected_data
+      );
+   }
+
+   /**
+    * Test state checking on a valid directory corresponding to a known active plugin with no modifications
+    * having nor check_prerequisites nor check_config function.
+    * Should results in no changes.
+    */
+   public function testCheckPluginStateForActiveAndNotUpdatedPluginHavingNoCheckFunctions() {
+
+      $initial_data = [
+         'directory' => $this->test_plugin_directory,
+         'name'      => 'Test plugin',
+         'version'   => '1.0',
+         'state'     => \Plugin::ACTIVATED,
+      ];
+      $setup_informations = [
+         'name'    => 'Test plugin',
+         'version' => '1.0',
+      ];
+      $expected_data = $initial_data;
 
       $this->doTestCheckPluginState(
          $initial_data,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`check_config` function of plugins was not really usage. Indeed, when it was returning `false`, plugin state was put on `NOTACTIVATED` state instead of `TOBECONFIGURED`, and plugin was not loaded at all, so configuration was not really possible.

Changes in this PR:
- check_config is now optionnal;
- a TOBECONFIGURED plugin will now be loaded (for autoload purpose), in order to be configurable;
- hooks will now be called only for activated plugins, instead of loaded plugins;
- `Plugin::getSpecificValueToDisplay()` has been refactored to reduce code duplication;
- a new config action is shown for active plugins when `config_page` hook is defined.

![image](https://user-images.githubusercontent.com/33253653/73544607-d3797b00-4439-11ea-896f-24211b1c9771.png)
