### PR TITLE
Display SQL error trace in debug mode

### DIFF
--- a/inc/application/errorhandler.class.php
+++ b/inc/application/errorhandler.class.php
@@ -201,6 +201,26 @@ class ErrorHandler {
    }
 
    /**
+    * SQL error handler.
+    *
+    * This handler is manually by application when a SQL error occured.
+    *
+    * @param integer $error_code
+    * @param string  $error_message
+    * @param string  $query
+    *
+    * @return void
+    */
+   public function handleSqlError($error_code, $error_message, $query) {
+      $this->outputDebugMessage(
+         sprintf('SQL Error "%s"', $error_code),
+         sprintf('%s in query "%s"', $error_message, $query),
+         self::ERROR_LEVEL_MAP[E_USER_ERROR],
+         isCommandLine()
+      );
+   }
+
+   /**
     * Exception handler.
     *
     * This handler is called by PHP prior to exiting, when an Exception is not catched.

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -34,6 +34,8 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use Glpi\Application\ErrorHandler;
+
 /**
  *  Database class for Mysql
 **/
@@ -281,7 +283,7 @@ class DBmysql {
     * @throws GlpitestSQLError
     */
    function query($query) {
-      global $CFG_GLPI, $DEBUG_SQL, $SQL_TOTAL_REQUEST;
+      global $CFG_GLPI, $DEBUG_SQL, $GLPI, $SQL_TOTAL_REQUEST;
 
       $is_debug = isset($_SESSION['glpi_use_mode']) && ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE);
       if ($is_debug && $CFG_GLPI["debug_sql"]) {
@@ -301,6 +303,11 @@ class DBmysql {
          $error .= Toolbox::backtrace(false, 'DBmysql->query()', ['Toolbox::backtrace()']);
 
          Toolbox::logSqlError($error);
+
+         $error_handler = $GLPI->getErrorHandler();
+         if ($error_handler instanceof ErrorHandler) {
+            $error_handler->handleSqlError($this->dbh->errno, $this->dbh->error, $query);
+         }
 
          if (($is_debug || isAPI()) && $CFG_GLPI["debug_sql"]) {
             $DEBUG_SQL["errors"][$SQL_TOTAL_REQUEST] = $this->error();

--- a/inc/glpi.class.php
+++ b/inc/glpi.class.php
@@ -109,4 +109,13 @@ class GLPI {
 
       return $this->error_handler;
    }
+
+   /**
+    * Get registered error handler.
+    *
+    * @return null|ErrorHandler
+    */
+   public function getErrorHandler() {
+      return $this->error_handler;
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | part of #6731 

With this PR, a trace of SQL errors appears when user is on debug mode.

![image](https://user-images.githubusercontent.com/33253653/73540418-29e1bc00-4430-11ea-938a-3ccd518287fe.png)