### PR TITLE
Fix/planning step 4

### DIFF
--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -1705,9 +1705,15 @@ class Planning extends CommonGLPI {
       //handle not planned events
       $raw_events = array_merge($raw_events, $not_planned);
 
+      // get external calendars events (ical)
+      // and on list view, only get future events
+      $begin_ical = $param['begin'];
+      if ($param['view_name'] == "listFull") {
+         $begin_ical = date('Y-m-d 00:00:00');
+      }
       $raw_events = array_merge(
          $raw_events,
-         self::getExternalCalendarRawEvents($param['begin'], $param['end'])
+         self::getExternalCalendarRawEvents($begin_ical, $param['end'])
       );
 
       // construct events (in fullcalendar format)

--- a/inc/planningevent.class.php
+++ b/inc/planningevent.class.php
@@ -63,7 +63,8 @@ trait PlanningEvent {
          'content_field' => 'text']
       );
 
-      if (isset($this->fields["users_id"])
+      if (!isset($this->input['_no_check_plan'])
+          && isset($this->fields["users_id"])
           && isset($this->fields["begin"])
           && !empty($this->fields["begin"])) {
          Planning::checkAlreadyPlanned(
@@ -214,7 +215,8 @@ trait PlanningEvent {
 
 
    function post_updateItem($history = 1) {
-      if (isset($this->fields["users_id"])
+      if (!isset($this->input['_no_check_plan'])
+          && isset($this->fields["users_id"])
           && isset($this->fields["begin"])
           && !empty($this->fields["begin"])) {
          Planning::checkAlreadyPlanned(
@@ -274,8 +276,9 @@ trait PlanningEvent {
          ]
       ]);
       return $this->update([
-         'id'    => $id,
-         'rrule' => $rrule
+         'id'             => $id,
+         'rrule'          => $rrule,
+         '_no_check_plan' => true,
       ]);
    }
 
@@ -297,6 +300,8 @@ trait PlanningEvent {
          'begin' => $fields['begin'],
          'end'   => $fields['end'],
       ];
+      // avoid checking avaibility, will be done after when updating new dates
+      $fields['_no_check_plan'] = true;
 
       $instance = new self;
       $new_id = $instance->add($fields);

--- a/inc/planningevent.class.php
+++ b/inc/planningevent.class.php
@@ -301,7 +301,7 @@ trait PlanningEvent {
          'begin' => $fields['begin'],
          'end'   => $fields['end'],
       ];
-      // avoid checking avaibility, will be done after when updating new dates
+      // avoid checking availability, will be done after when updating new dates
       $fields['_no_check_plan'] = true;
 
       $instance = new self;

--- a/inc/planningevent.class.php
+++ b/inc/planningevent.class.php
@@ -392,7 +392,7 @@ trait PlanningEvent {
          // guests accounts
          if ($DB->fieldExists($table, 'users_id_guests')) {
             $nreadpriv = ['OR' => [
-               ["$table.users_id" => $who],
+               "$table.users_id" => $who,
                "$table.users_id_guests" => ['LIKE', '%"'.$who.'"%'],
             ]];
          }

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -3923,7 +3923,7 @@ JAVASCRIPT;
 
       // check default value (in case of multiple observers)
       if (is_array($p['value'])) {
-         $p['value'] = $p['value'][$p['_user_index']];
+         $p['value'] = $p['value'][$p['_user_index']] ?? 0;
       }
 
       // Check default value for dropdown : need to be a numeric

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -7703,6 +7703,7 @@ CREATE TABLE `glpi_planningexternalevents` (
   `is_recursive` TINYINT(1) NOT NULL DEFAULT '1',
   `date` timestamp NULL DEFAULT NULL,
   `users_id` int(11) NOT NULL DEFAULT '0',
+  `users_id_guests` text COLLATE utf8_unicode_ci,
   `groups_id` int(11) NOT NULL DEFAULT '0',
   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `text` text COLLATE utf8_unicode_ci,

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -512,7 +512,7 @@ function update94to95() {
       ]);
       $migration->addKey('glpi_planningexternalevents', 'is_recursive');
    }
-   if (!$DB->fieldExists('glpi_planningexternalevents', 'is_recursive')) {
+   if (!$DB->fieldExists('glpi_planningexternalevents', 'users_id_guests')) {
       $migration->addField('glpi_planningexternalevents', 'users_id_guests', 'text', [
          'after' => 'users_id',
       ]);

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -464,6 +464,7 @@ function update94to95() {
          `is_recursive` TINYINT(1) NOT NULL DEFAULT '1',
          `date` timestamp NULL DEFAULT NULL,
          `users_id` int(11) NOT NULL DEFAULT '0',
+         `users_id_guests` text COLLATE utf8_unicode_ci,
          `groups_id` int(11) NOT NULL DEFAULT '0',
          `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
          `text` text COLLATE utf8_unicode_ci,
@@ -510,6 +511,11 @@ function update94to95() {
          'value' => 1
       ]);
       $migration->addKey('glpi_planningexternalevents', 'is_recursive');
+   }
+   if (!$DB->fieldExists('glpi_planningexternalevents', 'is_recursive')) {
+      $migration->addField('glpi_planningexternalevents', 'users_id_guests', 'text', [
+         'after' => 'users_id',
+      ]);
    }
 
    if (!$DB->tableExists('glpi_planningeventcategories')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

After customer review of planning last changes, here is a batch of fixes/enhancements:

- FEAT: removed clone of events on creation, replaced by guests invitation (field `users_id_guests`)
- FIX: adding exceptions to events may occurs bad availability checking 
- FIX: limit displayed events from external ical calendars on list view: take only future events to limit performance impact