### PR TITLE
Make plugin TOBECLEANED state realtime computed

### DIFF
--- a/tests/functionnal/Plugin.php
+++ b/tests/functionnal/Plugin.php
@@ -315,7 +315,7 @@ class Plugin extends DbTestCase {
 
    /**
     * Test state checking on an invalid directory corresponding to a known plugin.
-    * Should results in changing plugin state to "TOBECLEANED".
+    * Should results in no change in plugin state, as "TOBECLEANED" state is realtime computed.
     */
    public function testCheckPluginStateForInvalidKnownPlugin() {
 
@@ -325,18 +325,13 @@ class Plugin extends DbTestCase {
          'version'   => '1.0',
          'state'     => \Plugin::ACTIVATED,
       ];
-      $expected_data = array_merge(
-         $initial_data,
-         [
-            'state' => \Plugin::TOBECLEANED,
-         ]
-      );
+      $expected_data = $initial_data;
 
       $this->doTestCheckPluginState(
          $initial_data,
          null,
          $expected_data,
-         'Unable to load plugin "' . $this->test_plugin_directory . '" informations. Its state has been changed to "To be cleaned".'
+         'Unable to load plugin "' . $this->test_plugin_directory . '" informations.'
       );
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`TOBECLEANED` state is currently a persistent state. It means that if, for any reason, plugin directory or `setup.php` file is not accessible, this state is stored in DB and the only way to make plugin active again is to clean, reinstall plugin, and activate it.

With this PR, `TOBECLEANED` state is not stored anymore in DB. It means that if directory or `setup.php` file is not accessible, the clean action will be proposed and plugin will not be loaded/activated, but as soon as `setup.php` file becomes accessible again, plugin will get back its previous state.

A side effect is that the warning `Unable to load plugin "%s" informations.` will be trigerred on each usage of `Plugin::init()` (done in `includes.php`) for plugins that have an active state in DB.

This PR includes #6872.