### PR TITLE
Add support of OAuth authentication for Imap mailcollectors; fixes #6895

### DIFF
--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -3836,6 +3836,7 @@ CREATE TABLE `glpi_mailcollectors` (
   `accepted` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `refused` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `use_kerberos` tinyint(1) NOT NULL DEFAULT '0',
+  `use_imap_oauth2` tinyint(1) NOT NULL DEFAULT '0',
   `errors` int(11) NOT NULL DEFAULT '0',
   `use_mail_date` tinyint(1) NOT NULL DEFAULT '0',
   `date_creation` timestamp NULL DEFAULT NULL,

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -1585,6 +1585,18 @@ HTML
    }
    /** /Update default right assignement rule */
 
+   /** Support of OAuth2 authentication form IMAP mailcollectors */
+   $migration->addField(
+      'glpi_mailcollectors',
+      'use_imap_oauth2',
+      'bool',
+      [
+         'after' => 'use_kerberos',
+         'value' => 0,
+      ]
+   );
+   /** /Support of OAuth2 authentication form IMAP mailcollectors */
+
    $migration->executeMigration();
 
    return $updateresult;

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -61,6 +61,7 @@ class MailCollector extends DbTestCase {
                   'accepted'             => '',
                   'refused'              => '',
                   'use_kerberos'         => '',
+                  'use_imap_oauth2'      => '',
                   'errors'               => '',
                   'use_mail_date'        => '',
                   'date_creation'        => '',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6895 

Add support of OAuth2 authentication for Imap mail collectors.

I quickly made this POC to validate that we are able to authenticate using OAuth2 with Laminas/Mail component. I made a test using my personnal Gmail account and it is working, but this feature requires still a lot of work. Indeed, it is currently based on a bearer token that has an expiration date. We need to implement something that will automatically refresh the token when needed.

To get a token on for a Gmail account: https://medium.com/@osanda.deshan/getting-google-oauth-access-token-using-google-apis-18b2ba11a11a