### PR TITLE
Remove error log when a plugin does not provide translations

### DIFF
--- a/front/locale.php
+++ b/front/locale.php
@@ -67,7 +67,8 @@ $default_response = json_encode(
 // Get messages from translator component
 $messages = $TRANSLATE->getAllMessages($_GET['domain']);
 if (!($messages instanceof \Laminas\I18n\Translator\TextDomain)) {
-   Toolbox::logError(sprintf('Unable to get messages from domain "%s".', $_GET['domain']));
+   // No TextDomain found means that there is no translations for given domain.
+   // It is mostly related to plugins that does not provide any translations.
    exit($default_response);
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

