### PR TITLE
Fix #6919 allow installation on UDS

### DIFF
--- a/inc/console/database/installcommand.class.php
+++ b/inc/console/database/installcommand.class.php
@@ -235,7 +235,11 @@ class InstallCommand extends Command implements ForceNoPluginsOptionCommandInter
       }
 
       $mysqli = new \mysqli();
-      @$mysqli->connect($db_host, $db_user, $db_pass, null, $db_port);
+      if (intval($db_port) > 0) { // Network port
+          @$mysqli->connect($db_host, $db_user, $db_pass, null, $db_port);
+      } else { // Unix Domain Socket
+          @$mysqli->connect($db_host, $db_user, $db_pass, null, 0, $db_port);
+      }
 
       if (0 !== $mysqli->connect_errno) {
          $message = sprintf(


### PR DESCRIPTION
Test build 
https://kojipkgs.fedoraproject.org//work/tasks/5903/41445903/build.log

Mandatory for MariaDB 10.4
See https://mariadb.com/kb/en/authentication-from-mariadb-104/
And https://bugzilla.redhat.com/show_bug.cgi?id=1796106