### PR TITLE
Fix infocom values search options

### DIFF
--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -1522,7 +1522,6 @@ class Infocom extends CommonDBChild {
          'field'              => 'value',
          'name'               => _x('price', 'Value'),
          'datatype'           => 'decimal',
-         'width'              => '100',
          'forcegroupby'       => true,
          'joinparams'         => $joinparams
       ];
@@ -1533,7 +1532,6 @@ class Infocom extends CommonDBChild {
          'field'              => 'warranty_value',
          'name'               => __('Warranty extension value'),
          'datatype'           => 'decimal',
-         'width'              => '100',
          'forcegroupby'       => true,
          'joinparams'         => $joinparams
       ];

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -4548,6 +4548,8 @@ JAVASCRIPT;
                   return $link." ($tocompute ".$regs[1]." ".$regs[3].") ";
                }
                if (is_numeric($val)) {
+                  $numeric_val = floatval($val);
+
                   if (isset($searchopt[$ID]["width"])) {
                      $ADD = "";
                      if ($nott
@@ -4555,18 +4557,18 @@ JAVASCRIPT;
                         $ADD = " OR $tocompute IS NULL";
                      }
                      if ($nott) {
-                        return $link." ($tocompute < ".(intval($val) - $searchopt[$ID]["width"])."
-                                        OR $tocompute > ".(intval($val) + $searchopt[$ID]["width"])."
+                        return $link." ($tocompute < ".($numeric_val - $searchopt[$ID]["width"])."
+                                        OR $tocompute > ".($numeric_val + $searchopt[$ID]["width"])."
                                         $ADD) ";
                      }
-                     return $link." (($tocompute >= ".(intval($val) - $searchopt[$ID]["width"])."
-                                      AND $tocompute <= ".(intval($val) + $searchopt[$ID]["width"]).")
+                     return $link." (($tocompute >= ".($numeric_val - $searchopt[$ID]["width"])."
+                                      AND $tocompute <= ".($numeric_val + $searchopt[$ID]["width"]).")
                                      $ADD) ";
                   }
                   if (!$nott) {
-                     return " $link ($tocompute = ".(intval($val)).") ";
+                     return " $link ($tocompute = $numeric_val) ";
                   }
-                  return " $link ($tocompute <> ".(intval($val)).") ";
+                  return " $link ($tocompute <> $numeric_val) ";
                }
                break;
          }


### PR DESCRIPTION
Internal ref: 19110

#### Issue 1:

Search on `value` or `warranty_value` returns incorrect results because of the width set in the search option: 
![image](https://user-images.githubusercontent.com/42734840/74142543-6c0db900-4bf9-11ea-9c7a-aa43685a9d97.png)

Because of the width, the generated condition is
```sql
`glpi_infocoms`.`warranty_value` >= -95 AND `glpi_infocoms`.`warranty_value` <= 105)`
```

I've removed the width param in 096563c to fix this.


#### Issue 2:

Searches using float as value are getting truncated:
![image](https://user-images.githubusercontent.com/42734840/74142912-1ede1700-4bfa-11ea-9468-7df5db532906.png)

This was fixed in 073b438 by using floatval instead of intval (which does not change behavior for integers as they are also valid floats).


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | pending