### PR TITLE
Display uninstall button for NOTUPDATED plugins

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -2181,7 +2181,8 @@ class Plugin extends CommonDBTM {
                   $output .= sprintf(__('%1$s: %2$s'), __('Non-existent function'),
                          $missing);
                }
-            } else if (in_array($state, [self::ACTIVATED, self::NOTUPDATED, self::TOBECONFIGURED, self::NOTACTIVATED], true)) {
+            }
+            if (in_array($state, [self::ACTIVATED, self::NOTUPDATED, self::TOBECONFIGURED, self::NOTACTIVATED], true)) {
                // Uninstall button for installed plugins
                if (function_exists("plugin_".$directory."_uninstall")) {
                   $output .= Html::getSimpleForm(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Due to #6872, uninstall button was not shown anymore for plugins which had a NOTUPDATED state.