### PR TITLE
Fix undefined index for menu entries with no icon

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -7010,7 +7010,7 @@ JAVASCRIPT;
                   "<a href='".$CFG_GLPI["root_doc"].$menu[$sector]['content'][$item]['page']."' ".
                         ($with_option?"":"class='here'")." title=\"".
                         $menu[$sector]['content'][$item]['title']."\" >".
-                        "<i class='".$menu[$sector]['content'][$item]['icon']."'></i>&nbsp;".
+                        "<i class='".($menu[$sector]['content'][$item]['icon'] ?? "")."'></i>&nbsp;".
                         $menu[$sector]['content'][$item]['title'].
                   "</a>".
                   "</li>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Plugin menu entries may have no icon. In this case, following notice was trigerred.
```
Undefined index: icon in /var/www/glpi/inc/html.class.php at line 7013
```

Fix is similar to code already existing on line 7026.