### PR TITLE
Do not display plugin config link if not active/configurable

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -2227,7 +2227,7 @@ class Plugin extends CommonDBTM {
             $state = $values['state'];
             $directory = $values['directory'];
             self::load($directory); // Load plugin to give it ability to define its config_page hook
-            if (in_array($state, [self::ACTIVATED, self::TOBECONFIGURED, self::NOTACTIVATED])
+            if (in_array($state, [self::ACTIVATED, self::TOBECONFIGURED])
                && isset($PLUGIN_HOOKS['config_page'][$directory])
             ) {
                return "<a href='".$CFG_GLPI["root_doc"]."/plugins/".$directory."/".


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Link to config page should only be displayed for ACTIVATED/TOBECONFIGURED plugins.
Prior to #6872, this link was added only for ACTIVATED plugins as other were not loaded at this point (and so hook was not defined). See https://github.com/glpi-project/glpi/pull/6872/files#diff-914d92bd95159c81411f15f65416774bR2227 .
