### PR TITLE
Fix/planning timezones

### DIFF
--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -1343,9 +1343,9 @@ class Planning extends CommonGLPI {
     */
    static function showAddEventSubForm($params = []) {
 
-      $rand            = mt_rand();
-      $params['begin'] = date("Y-m-d H:i:s", strtotime($params['begin']));
-      $params['end']   = date("Y-m-d H:i:s", strtotime($params['end']));
+      $rand   = mt_rand();
+      $params = self::cleanDates($params);
+
       $params['res_itemtype'] = $params['res_itemtype'] ?? '';
       $params['res_items_id'] = $params['res_items_id'] ?? 0;
       if ($item = getItemForItemtype($params['itemtype'])) {
@@ -2030,8 +2030,7 @@ class Planning extends CommonGLPI {
     */
    static function updateEventTimes($params = []) {
       if ($item = getItemForItemtype($params['itemtype'])) {
-         $params['start'] = date("Y-m-d H:i:s", strtotime($params['start']));
-         $params['end']   = date("Y-m-d H:i:s", strtotime($params['end']));
+         $params = self::cleanDates($params);
 
          if ($item->getFromDB($params['items_id'])
           && empty($item->fields['is_deleted'])
@@ -2156,6 +2155,32 @@ class Planning extends CommonGLPI {
             }
          }
       }
+   }
+
+   /**
+    * Clean timezone informations from dates fields,
+    * as fullcalendar doesn't support easily timezones, let's consider it sends raw dates
+    * (remove timezone suffix), we will manage timezone directy on database
+    * see https://fullcalendar.io/docs/timeZone
+    *
+    * @since 9.5
+    *
+    * @param array $params parameters send by fullcalendar
+    *
+    * @return array cleaned $params
+    */
+   static function cleanDates(array $params = []): array {
+      $dates_fields = [
+         'start', 'begin', 'end'
+      ];
+
+      foreach ($params as $key => &$value) {
+         if (in_array($key, $dates_fields)) {
+            $value  = date("Y-m-d H:i:s", strtotime(trim($value, 'Z')));
+         }
+      }
+
+      return $params;
    }
 
 

--- a/inc/planningevent.class.php
+++ b/inc/planningevent.class.php
@@ -547,14 +547,16 @@ trait PlanningEvent {
 
                   $rset = self::getRsetFromRRuleField($event['rrule'], $event['begin']);
 
-                  // rrule object doesn't any duration property,
-                  // so we remove the duration from the begin part of the range
-                  // (minus 1second to avoid mathing precise end date)
-                  // to check if event started before begin and could be still valid
-                  $begin_datetime = new DateTime($options['begin']);
+                  // - rrule object doesn't any duration property,
+                  //   so we remove the duration from the begin part of the range
+                  //   (minus 1second to avoid mathing precise end date)
+                  //   to check if event started before begin and could be still valid
+                  // - also set begin and end dates like it was as UTC
+                  //   (Rrule lib will always compare with UTC)
+                  $begin_datetime = new DateTime($options['begin'], new DateTimeZone('UTC'));
                   $begin_datetime->sub(New DateInterval("PT".($duration - 1)."S"));
-
-                  $occurences = $rset->getOccurrencesBetween($begin_datetime, $options['end']);
+                  $end_datetime   = new DateTime($options['end'], new DateTimeZone('UTC'));
+                  $occurences = $rset->getOccurrencesBetween($begin_datetime, $end_datetime);
 
                   // add the found occurences to the final tab after replacing their dates
                   foreach ($occurences as $currentDate) {

--- a/js/planning.js
+++ b/js/planning.js
@@ -48,6 +48,7 @@ var GLPIPlanning  = {
       this.calendar = new FullCalendar.Calendar(document.getElementById(GLPIPlanning.dom_id), {
          plugins:     options.plugins,
          height:      options.height,
+         timeZone:    'UTC',
          theme:       true,
          weekNumbers: options.full_view ? true : false,
          defaultView: options.default_view,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Fix some timezone issues.
CF : https://fullcalendar.io/docs/timeZone#UTC-coercion

Browser (javascript) support is not done well everywhere, so fullcalendar always send dates as utc.
Let's consider the date will be shifted by user preference when inserting data in DB, we can manipulate raw dates (without timezones) when echanging with javascript.

Same for Rrule lib, they compare date with UTC.
