### PR TITLE
Revert "Warn if there are unsaved form changes (#6433)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ The present file will list all changes made to the project; according to the
 - Add lightbox with PhotoSwipe to timeline images
 - Ability to copy tasks while merging tickets
 - the API gives the ID of the user who logs in with initSession
-- Add warning when there are unsaved changes in forms
 - Kanban view for projects
 
 ### Changed

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3924,11 +3924,6 @@ JAVASCRIPT;
                editor.on('SaveContent', function (contentEvent) {
                   contentEvent.content = contentEvent.content.replace(/\\r?\\n/g, '');
                });
-               editor.on('Change', function (e) {
-                  // Nothing fancy here. Since this is only used for tracking unsaved changes,
-                  // we want to keep the logic in common.js with the other form input events.
-                  onTinyMCEChange(e);
-               });
 
                // ctrl + enter submit the parent form
                editor.addShortcut('ctrl+13', 'submit', function() {

--- a/js/common.js
+++ b/js/common.js
@@ -1019,36 +1019,6 @@ var getTextWithoutDiacriticalMarks = function (text) {
    return text.replace(/[\u0300-\u036f]/g, '');
 };
 
-/** Track input changes and warn the user of unsaved changes if they try to navigate away */
-window.glpiUnsavedFormChanges = false;
-$(document).ready(function() {
-   // Try to limit tracking to item forms by binding to inputs under glpi_tabs only.
-   var glpiTabs = $('#page .glpi_tabs');
-   glpiTabs.on('input', 'form:not(.no-track) input, form:not(.no-track) textarea', function() {
-      window.glpiUnsavedFormChanges = true;
-   });
-   glpiTabs.on('change', 'form:not(.no-track) select', function() {
-      window.glpiUnsavedFormChanges = true;
-   });
-   glpiTabs.on('select2:select', 'form:not(.no-track) select', function() {
-      window.glpiUnsavedFormChanges = true;
-   });
-   $(window).on('beforeunload', function() {
-      if (window.glpiUnsavedFormChanges) {
-         // Only used for older browsers. Newer ones will display a localized message that is unique to the browser.
-         return "Do you want to leave this site? Changes you made may not be saved.";
-      }
-   });
-
-   glpiTabs.on('submit', 'form:not(.no-track)', function() {
-      window.glpiUnsavedFormChanges = false;
-   });
-});
-
-function onTinyMCEChange() {
-   window.glpiUnsavedFormChanges = true;
-}
-
 /**
  * Updates an accessible progress bar title and foreground width.
  * @since 9.5.0

--- a/js/impact.js
+++ b/js/impact.js
@@ -2418,7 +2418,6 @@ var GLPIImpact = {
     * Enable the save button
     */
    showCleanWorkspaceStatus: function() {
-      window.glpiUnsavedFormChanges = false;
       $(GLPIImpact.selectors.save).removeClass('dirty');
       $(GLPIImpact.selectors.save).removeClass('clean'); // Needed for animations if the workspace is not dirty
       $(GLPIImpact.selectors.save).addClass('clean');
@@ -2430,7 +2429,6 @@ var GLPIImpact = {
     * Enable the save button
     */
    showDirtyWorkspaceStatus: function() {
-      window.glpiUnsavedFormChanges = true;
       $(GLPIImpact.selectors.save).removeClass('clean');
       $(GLPIImpact.selectors.save).addClass('dirty');
       $(GLPIImpact.selectors.save).find('i').removeClass("fas fa-check");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This reverts commit c19c367a4f911606ff057f536e20376a3a3e2ae7.

Although this feature may be interesting, there is some use cases that are not correctly handled and that need to be fixed.

For instance, warning message is displayed when using massive actions inside tab of an item.
To reproduce:
 - create a ticket and attach a computer,
 - go into "Items" tab,
 - select the item, click on "Actions" button, chose an action, and submit the form.

I have no other case in mind right now.