### PR TITLE
Fix web tests

### DIFF
--- a/tests/APIBaseClass.php
+++ b/tests/APIBaseClass.php
@@ -88,8 +88,8 @@ abstract class APIBaseClass extends \atoum {
          (int)$apiclient->add([
             'name'             => 'test app token',
             'is_active'        => 1,
-            'ipv4_range_start' => 2130706433,
-            'ipv4_range_end'   => 2130706433,
+            'ipv4_range_start' => '127.0.0.1',
+            'ipv4_range_end'   => '127.0.0.1',
             '_reset_app_token' => true,
          ])
       )->isGreaterThan(0);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Fix missing ips range in test database (use '127.0.0.1' instead of numeric value as it will be handled by ip2long).

