### PR TITLE
Fix inline images handling on item update

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -658,13 +658,6 @@ abstract class CommonITILObject extends CommonDBTM {
 
       // Add document if needed
       $this->getFromDB($input["id"]); // entities_id field required
-      if (!isset($input['_donotadddocs']) || !$input['_donotadddocs']) {
-         $options = [];
-         if (isset($input['solution'])) {
-            $options['content_field'] = 'solution';
-         }
-         $input = $this->addFiles($input, $options);
-      }
 
       if (isset($input["document"]) && ($input["document"] > 0)) {
          $doc = new Document();
@@ -937,6 +930,16 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       return $input;
+   }
+
+   function post_updateItem($history = 1) {
+      if (!isset($this->input['_donotadddocs']) || !$this->input['_donotadddocs']) {
+         $options = ['force_update' => true];
+         if (isset($this->input['solution'])) {
+            $options['content_field'] = 'solution';
+         }
+         $this->input = $this->addFiles($this->input, $options);
+      }
    }
 
 

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -284,14 +284,14 @@ abstract class CommonITILTask  extends CommonDBTM {
          }
       }
 
-      $input = $this->addFiles($input);
-
       return $input;
    }
 
 
    function post_updateItem($history = 1) {
       global $CFG_GLPI;
+
+      $this->input = $this->addFiles($this->input, ['force_update' => true]);
 
       if (in_array("begin", $this->updates)) {
          PlanningRecall::managePlanningUpdates($this->getType(), $this->getID(),

--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -360,16 +360,21 @@ class ITILSolution extends CommonDBChild {
       parent::post_addItem();
    }
 
-
-   /**
-    * @see CommonDBTM::prepareInputForUpdate()
-   **/
    function prepareInputForUpdate($input) {
 
-      // Replace inline pictures
-      $input = $this->addFiles($input);
+      if (!isset($this->fields['itemtype'])) {
+         return false;
+      }
+      $input["_job"] = new $this->fields['itemtype']();
+      if (!$input["_job"]->getFromDB($this->fields["items_id"])) {
+         return false;
+      }
 
       return $input;
+   }
+
+   function post_updateItem($history = 1) {
+      $this->input = $this->addFiles($this->input, ['force_update' => true]);
    }
 
 

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -646,22 +646,22 @@ class KnowbaseItem extends CommonDBVisible {
    }
 
 
-   /**
-    * @see CommonDBTM::prepareInputForUpdate()
-   **/
    function prepareInputForUpdate($input) {
-
-      // add documents (and replace inline pictures)
-      $input = $this->addFiles(
-         $input,
-         ['content_field' => 'answer']
-      );
-
       // set title for question if empty
       if (isset($input["name"]) && empty($input["name"])) {
          $input["name"] = __('New item');
       }
       return $input;
+   }
+
+   function post_updateItem($history = 1) {
+      $this->input = $this->addFiles(
+         $this->input,
+         [
+            'force_update'  => true,
+            'content_field' => 'answer',
+         ]
+      );
    }
 
 

--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -353,6 +353,14 @@ class Reminder extends CommonDBVisible {
    **/
    function post_updateItem($history = 1) {
 
+      $this->input = $this->addFiles(
+         $this->input,
+         [
+            'force_update'  => true,
+            'content_field' => 'text',
+         ]
+      );
+
       if (isset($this->fields["begin"]) && !empty($this->fields["begin"])) {
          Planning::checkAlreadyPlanned($this->fields["users_id"], $this->fields["begin"],
                                        $this->fields["end"],
@@ -654,8 +662,6 @@ class Reminder extends CommonDBVisible {
                                              false, ERROR);
          }
       }
-
-      $input = $this->addFiles($input, ['content_field' => 'text']);
 
       return $input;
    }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1541,6 +1541,8 @@ class Ticket extends CommonITILObject {
    function post_updateItem($history = 1) {
       global $CFG_GLPI;
 
+      parent::post_updateItem($history);
+
       //Action for send_validation rule : do validation before clean
       $this->manageValidationAdd($this->input);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Internal support id: 19224

2 problems fixed by this PR:
1. On ITIL followup/task/solution update, link that was generated to display inlined images in rich text content were not containing reference to ITIL item (due to https://github.com/glpi-project/glpi/blob/9.4/bugfixes/inc/toolbox.class.php#L2680 which is looking into $item->input['_job'] was not defined at this point).
2. Files were handling prior to content saving into DB, so if, for any reason, saving was blocked or errored, documents were still created for inlined images from unsaved content.

Solution: as for item creation, use the `CommonDBTM::addFiles()` after item saving into DB, on `post_UpdateItem` method.