### PR TITLE
Override getNameField for ITILFollowup

### DIFF
--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -1200,4 +1200,8 @@ JAVASCRIPT;
          }
       }
    }
+
+   public static function getNameField() {
+      return 'id';
+   }
 }


### PR DESCRIPTION
Fix sql error on `front/document.form.php`:

``` sql
SELECT COUNT(*) AS cpt
FROM `glpi_itilfollowups`
LEFT JOIN `glpi_documents_items` ON (`glpi_documents_items`.`items_id` = `glpi_itilfollowups`.`id`) 
WHERE (`glpi_documents_items`.`documents_id` = '2' OR (`glpi_documents_items`.`itemtype` = 'Document' AND `glpi_documents_items`.`items_id` = '2')) AND `glpi_documents_items`.`itemtype` = 'ITILFollowup'
ORDER BY `glpi_itilfollowups`.`name`

Error: Unknown column 'glpi_itilfollowups.name' in 'order clause'

Backtrace :
inc/dbmysqliterator.class.php:95                   
inc/dbmysql.class.php:862                          DBmysqlIterator->execute()
inc/commondbrelation.class.php:1823                DBmysql->request()
inc/document_item.class.php:240                    CommonDBRelation::countForMainItem()
inc/commonglpi.class.php:293                       Document_Item->getTabNameForItem()
inc/document.class.php:183                         CommonGLPI->addStandardTab()
inc/commonglpi.class.php:248                       Document->defineTabs()
inc/commonglpi.class.php:813                       CommonGLPI->defineAllTabs()
inc/commonglpi.class.php:1184                      CommonGLPI->showTabsContent()
front/document.form.php:117                        CommonGLPI->display()
```

This happen because `CommonDBRealation::getTypeItemsQueryParams()` use the result of `CommonDBTM::getNameField()` in the order clause.
`ITILFollowup` doesn't override `getNameField()` and thus use the default "name" field which  doesn't exist in `glpi_itilfollowups`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
