### PR TITLE
Fix API search for items without entity field

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3338,6 +3338,7 @@ JAVASCRIPT;
 
       // Add entity view :
       if (Session::isMultiEntitiesMode()
+          && $item->isEntityAssign()
           && (isset($CFG_GLPI["union_search_type"][$itemtype])
               || ($item && $item->maybeRecursive())
               || isset($_SESSION['glpiactiveentities']) && (count($_SESSION["glpiactiveentities"]) > 1))) {


### PR DESCRIPTION
This error probably doesn't happen only on the API but this is where I encountered it.

The following request was failling:
```http
GET apirest.php/search/KnowbaseItem
```
```json
[
    "ERROR_SQL",
    "Unexpected SQL Error : Unknown column 'glpi_knowbaseitems.entities_id' in 'on clause'"
]
```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
