### PR TITLE
Refactor cache keys

### DIFF
--- a/inc/commontreedropdown.class.php
+++ b/inc/commontreedropdown.class.php
@@ -187,7 +187,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
          if ($input[$this->getForeignKeyField()] != $this->fields[$this->getForeignKeyField()]) {
             $input["ancestors_cache"] = '';
             if (Toolbox::useCache()) {
-               $ckey = 'ancestors_cache_' . md5($this->getTable() . $this->getID());
+               $ckey = 'ancestors_cache_' . $this->getTable() . '_' . $this->getID();
                $GLPI_CACHE->delete($ckey);
             }
             return $this->adaptTreeFieldsFromUpdateOrAdd($input);
@@ -212,7 +212,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
       //drop from sons cache when needed
       if ($changeParent && Toolbox::useCache()) {
-         $ckey = 'ancestors_cache_' . md5($this->getTable() . $ID);
+         $ckey = 'ancestors_cache_' . $this->getTable() . '_' . $ID;
          $GLPI_CACHE->delete($ckey);
       }
 
@@ -305,7 +305,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       //drop from sons cache when needed
       if ($cache && Toolbox::useCache()) {
          foreach ($ancestors as $ancestor) {
-            $ckey = 'sons_cache_' . md5($this->getTable() . $ancestor);
+            $ckey = 'sons_cache_' . $this->getTable() . '_' . $ancestor;
             if ($GLPI_CACHE->has($ckey)) {
                $sons = $GLPI_CACHE->get($ckey);
                if (isset($sons[$this->getID()])) {
@@ -335,7 +335,7 @@ abstract class CommonTreeDropdown extends CommonDropdown {
       if (Toolbox::useCache()) {
          $ancestors = getAncestorsOf($this->getTable(), $this->getID());
          foreach ($ancestors as $ancestor) {
-            $ckey = 'sons_cache_' . md5($this->getTable() . $ancestor);
+            $ckey = 'sons_cache_' . $this->getTable() . '_' . $ancestor;
             if ($GLPI_CACHE->has($ckey)) {
                $sons = $GLPI_CACHE->get($ckey);
                if (!isset($sons[$this->getID()])) {

--- a/inc/dashboard/dashboard.class.php
+++ b/inc/dashboard/dashboard.class.php
@@ -208,7 +208,7 @@ class Dashboard extends \CommonDBTM {
       }
 
       // invalidate dashboard cache
-      $cache_key = "dashboard_card_".sha1($this->key);
+      $cache_key = "dashboard_card_".$this->key;
       $GLPI_CACHE->delete($cache_key);
    }
 

--- a/inc/dashboard/grid.class.php
+++ b/inc/dashboard/grid.class.php
@@ -935,7 +935,7 @@ HTML;
       $use_cache =
          !($card_options['args']['force'] ?? $card_options['force'] ?? false)
          && $_SESSION['glpi_use_mode'] != \Session::DEBUG_MODE;
-      $cache_key    = "dashboard_card_".sha1($dashboard);
+      $cache_key    = "dashboard_card_".$dashboard;
       $cache_age    = 40;
       if ($use_cache) {
          // browser cache

--- a/inc/dbutils.class.php
+++ b/inc/dbutils.class.php
@@ -679,7 +679,7 @@ final class DbUtils {
    public function getSonsOf($table, $IDf) {
       global $DB, $GLPI_CACHE;
 
-      $ckey = 'sons_cache_' . md5($table . $IDf);
+      $ckey = 'sons_cache_' . $table . '_' . $IDf;
       $sons = false;
 
       if (Toolbox::useCache()) {
@@ -788,9 +788,9 @@ final class DbUtils {
 
       $ckey = 'ancestors_cache_';
       if (is_array($items_id)) {
-         $ckey .= md5($table . implode('|', $items_id));
+         $ckey .= $table . '_' . md5(implode('|', $items_id));
       } else {
-         $ckey .= md5($table . $items_id);
+         $ckey .= $table . '_' . $items_id;
       }
       $ancestors = [];
 

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -139,7 +139,7 @@ class Entity extends CommonTreeDropdown {
       //Cleaning sons calls getAncestorsOf and thus... Re-create cache. Call it before clean.
       $this->cleanParentsSons();
       if (Toolbox::useCache()) {
-         $ckey = 'ancestors_cache_' . md5($this->getTable() . $this->getID());
+         $ckey = 'ancestors_cache_' . $this->getTable() . '_' . $this->getID();
          $GLPI_CACHE->delete($ckey);
       }
       return true;

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -30,7 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
-use Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator;
+use Glpi\Cache\SimpleCache;
 
 // Main GLPI test case. All tests should extends this class.
 
@@ -63,7 +63,7 @@ class GLPITestCase extends atoum {
                'namespace' => $this->nscache
             ]
          ]);
-         $GLPI_CACHE = new SimpleCacheDecorator($storage);
+         $GLPI_CACHE = new SimpleCache($storage, GLPI_CACHE_DIR, false);
       }
    }
 

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -631,10 +631,9 @@ class DbUtils extends DbTestCase {
       //- if $cache === 1; we expect cache to be empty before call, and populated after
       //- if $hit   === 1; we expect cache to be populated
 
-      $ckey_prefix = $this->nscache . ':ancestors_cache_';
-      $ckey_ent0   = $ckey_prefix . md5('glpi_entities' . $ent0);
-      $ckey_ent1   = $ckey_prefix . md5('glpi_entities' . $ent1);
-      $ckey_ent2   = $ckey_prefix . md5('glpi_entities' . $ent2);
+      $ckey_ent0 = $this->nscache . ':' .sha1('ancestors_cache_glpi_entities_' . $ent0);
+      $ckey_ent1 = $this->nscache . ':' .sha1('ancestors_cache_glpi_entities_' . $ent1);
+      $ckey_ent2 = $this->nscache . ':' .sha1('ancestors_cache_glpi_entities_' . $ent2);
 
       //test on ent0
       $expected = [0 => 0];
@@ -693,7 +692,7 @@ class DbUtils extends DbTestCase {
          ]);
          $this->integer($new_id)->isGreaterThan(0);
       }
-      $ckey_new_id = $ckey_prefix . md5('glpi_entities' . $new_id);
+      $ckey_new_id = $this->nscache . ':' .sha1('ancestors_cache_glpi_entities_' . $new_id);
 
       $expected = [0 => 0, $ent0 => $ent0, $ent1 => $ent1];
       if ($cache === true) {
@@ -717,7 +716,7 @@ class DbUtils extends DbTestCase {
          ]);
          $this->integer($new_id2)->isGreaterThan(0);
       }
-      $ckey_new_id2 = $ckey_prefix . md5('glpi_entities' . $new_id2);
+      $ckey_new_id2 = $this->nscache . ':' .sha1('ancestors_cache_glpi_entities_' . $new_id2);
 
       $expected = [0 => 0, $ent0 => $ent0, $ent2 => $ent2];
       if ($cache === true) {
@@ -733,7 +732,7 @@ class DbUtils extends DbTestCase {
 
       //test on multiple entities
       $expected = [0 => 0, $ent0 => $ent0, $ent1 => $ent1, $ent2 => $ent2];
-      $ckey_new_all = $ckey_prefix . md5('glpi_entities' . $new_id . '|' . $new_id2);
+      $ckey_new_all = $this->nscache . ':' .sha1('ancestors_cache_glpi_entities_' . md5($new_id . '|' . $new_id2));
       if ($cache === true && $hit === false) {
          $this->boolean(apcu_exists($ckey_new_all))->isFalse();
       } else if ($cache === true && $hit === true) {
@@ -795,10 +794,9 @@ class DbUtils extends DbTestCase {
       //- if $cache === 1; we expect cache to be empty before call, and populated after
       //- if $hit   === 1; we expect cache to be populated
 
-      $ckey_prefix = $this->nscache . ':sons_cache_';
-      $ckey_ent0 = $ckey_prefix . md5('glpi_entities' . $ent0);
-      $ckey_ent1 = $ckey_prefix . md5('glpi_entities' . $ent1);
-      $ckey_ent2 = $ckey_prefix . md5('glpi_entities' . $ent2);
+      $ckey_ent0 = $this->nscache . ':' .sha1('sons_cache_glpi_entities_' . $ent0);
+      $ckey_ent1 = $this->nscache . ':' .sha1('sons_cache_glpi_entities_' . $ent1);
+      $ckey_ent2 = $this->nscache . ':' .sha1('sons_cache_glpi_entities_' . $ent2);
 
       //test on ent0
       $expected = [$ent0 => $ent0, $ent1 => $ent1, $ent2 => $ent2];

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -121,10 +121,8 @@ class Entity extends DbTestCase {
       $ent1 = getItemByTypeName('Entity', '_test_child_1', true);
       $ent2 = getItemByTypeName('Entity', '_test_child_2', true);
 
-      $ackey_prefix = $this->nscache . ':ancestors_cache_';
-      $sckey_prefix = $this->nscache . ':sons_cache_';
-      $sckey_ent1   = $sckey_prefix . md5('glpi_entities' . $ent1);
-      $sckey_ent2   = $sckey_prefix . md5('glpi_entities' . $ent2);
+      $sckey_ent1 = $this->nscache . ':' .sha1('sons_cache_glpi_entities_' . $ent1);
+      $sckey_ent2 = $this->nscache . ':' .sha1('sons_cache_glpi_entities_' . $ent2);
 
       $entity = new \Entity();
       $new_id = (int)$entity->add([
@@ -132,7 +130,7 @@ class Entity extends DbTestCase {
          'entities_id'  => $ent1
       ]);
       $this->integer($new_id)->isGreaterThan(0);
-      $ackey_new_id = $ackey_prefix . md5('glpi_entities' . $new_id);
+      $ackey_new_id = $this->nscache . ':' .sha1('ancestors_cache_glpi_entities_' . $new_id);
 
       $expected = [0 => 0, $ent0 => $ent0, $ent1 => $ent1];
       if ($cache === true) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Alternative to #6968 in order to globally fix this problem.

- Use hashless keys in code
- Display hashless keys in debug panel
- Convert cche keys into hash in GLPI cache decorator (prevent issues with too long cache key)
