### PR TITLE
permit to add users without rights into group

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -3607,8 +3607,11 @@ JAVASCRIPT;
 
          case "all" :
             $WHERE = [
-               'glpi_users.id' => ['>', 0]
-            ] + getEntitiesRestrictCriteria('glpi_profiles_users', '', $entity_restrict, 1);
+               'glpi_users.id' => ['>', 0],
+               'OR' => [
+                  'glpi_profiles_users.entities_id' => null
+               ] + getEntitiesRestrictCriteria('glpi_profiles_users', '', $entity_restrict, 1)
+            ];
             break;
 
          default :


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Following #6794, we now permits to triggers ruleright on local users, targeting their group for example. Issue is we can't, from group page, add users without rights.