### PR TITLE
Fix forgotten reference to _names

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1069,7 +1069,7 @@ abstract class API extends CommonGLPI {
       }
 
       if (count($params['add_keys_names']) > 0) {
-         $fields["_names"] = $this->getFriendlyNames(
+         $fields["_keys_names"] = $this->getFriendlyNames(
             $fields,
             $params,
             $itemtype


### PR DESCRIPTION
In #6858 the returned key started as `_names` and was latter renamed to `_keys_names`.
This occurrence was forgotten.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
