### PR TITLE
Fix web installation and friendly filenames caching

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -1452,11 +1452,12 @@ class CommonDBTM extends CommonGLPI {
             }
 
             // Update raw names cache (for API)
-            $GLPI_CACHE->delete(self::getCacheKeyForFriendlyName(
-               $this->getType(),
-               $this->fields['id']
-            ));
-            $this->getFriendlyName();
+            if (Toolbox::useCache()) {
+               $GLPI_CACHE->delete(self::getCacheKeyForFriendlyName(
+                  $this->getType(),
+                  $this->fields['id']
+               ));
+            }
 
             return true;
          }
@@ -5337,15 +5338,16 @@ class CommonDBTM extends CommonGLPI {
    public static function getFriendlyNameById($id) {
       global $GLPI_CACHE;
 
-      $cache_key = self::getCacheKeyForFriendlyName(self::getType(), $id);
-
-      if ($GLPI_CACHE->has($cache_key)) {
-         return $GLPI_CACHE->get($cache_key);
-      } else {
-         $item = new static();
-         $item->getFromDB($id);
-         return $item->getFriendlyName();
+      if (Toolbox::useCache()) {
+         $cache_key = self::getCacheKeyForFriendlyName(self::getType(), $id);
+         if (($name = $GLPI_CACHE->get($cache_key)) !== null) {
+            return $name;
+         }
       }
+
+      $item = new static();
+      $item->getFromDB($id);
+      return $item->getFriendlyName();
    }
 
    /**
@@ -5363,12 +5365,15 @@ class CommonDBTM extends CommonGLPI {
          $this->getID()
       );
 
-      if ($GLPI_CACHE->has($cache_key)) {
-         // Get from cache
-         $name = $GLPI_CACHE->get($cache_key);
-      } else {
-         // Compute the name then set the cache
-         $name = $this->computeFriendlyName();
+      if (Toolbox::useCache()) {
+         if (($name = $GLPI_CACHE->get($cache_key)) !== null) {
+            return $name;
+         }
+      }
+
+      $name = $this->computeFriendlyName();
+
+      if (Toolbox::useCache()) {
          $GLPI_CACHE->set($cache_key, $name);
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes following error:
```
glpiphplog.CRITICAL:   *** Uncaught Exception Error: Call to a member function delete() on null in /var/www/glpi/inc/commondbtm.class.php at line 1455
  Backtrace :
  inc/config.class.php:2981                          CommonDBTM->update()
  inc/toolbox.class.php:2382                         Config::setConfigurationValues()
  install/install.php:430                            Toolbox::createSchema()
  install/install.php:656                            step4()
```

I also removed the call to `$this->getFriendlyName()` on every item updates as it pollutes cache by generating friendly names for all item types (even CommonDbRelation items, Config, ...). As cache usage on this is specific to a small set of classes, and as "mass reading" of this information is a really specific use case, it should not be a problem to set cache only on first read.