### PR TITLE
API: add current user friendlyname in initSession response

### DIFF
--- a/apirest.md
+++ b/apirest.md
@@ -116,7 +116,7 @@ App(lication) token
         * "Authorization: user_token q56hqkniwot8wntb3z1qarka5atf365taaa2uyjrn"
 
 * **Returns**:
-  * 200 (OK) with the *session_token* string and the *ID of the logged in user*.
+  * 200 (OK) with the *session_token* string, the *ID of the logged in user* and the *friendly name of the logged in user*.
   * 400 (Bad Request) with a message indicating an error in input parameter.
   * 401 (UNAUTHORIZED)
 
@@ -132,7 +132,8 @@ $ curl -X GET \
 < 200 OK
 < {
    "session_token": "83af7e620c83a50a18d3eac2f6ed05a3ca0bea62",
-   "users_id": "42"
+   "users_id": "42",
+   "user_friendlyname": "John Doe"
 }
 
 $ curl -X GET \
@@ -144,7 +145,8 @@ $ curl -X GET \
 < 200 OK
 < {
    "session_token": "83af7e620c83a50a18d3eac2f6ed05a3ca0bea62",
-   "users_id": "42"
+   "users_id": "42",
+   "user_friendlyname": "John Doe",
 }
 ```
 

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -249,8 +249,9 @@ abstract class API extends CommonGLPI {
       // stop session and return session key
       session_write_close();
       return [
-         'session_token' => $_SESSION['valid_id'],
-         'users_id'      => Session::getLoginUserID(),
+         'session_token'     => $_SESSION['valid_id'],
+         'users_id'          => Session::getLoginUserID(),
+         'user_friendlyname' => Session::getUserFriendlyName(),
       ];
    }
 

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -1396,4 +1396,25 @@ class Session {
    static function mustChangePassword() {
       return array_key_exists('glpi_password_expired', $_SESSION);
    }
+
+   /**
+    * Get friendly name of the current user
+    *
+    * @since 9.5
+    *
+    * @return string|null
+    */
+   public static function getUserFriendlyName() {
+      if (!isset($_SESSION["glpiID"])) {
+         return null;
+      };
+
+      $user = new \User();
+
+      if (!$user->getFromDB($_SESSION["glpiID"])) {
+         return null;
+      };
+
+      return $user->getFriendlyName();
+   }
 }


### PR DESCRIPTION
<!-- There is currently no reliable way to get the current user friendlyname from the API if he doesn't have the read rights on the user table.

Adding the friendlyname to the initSession response seems to be an easy and lightweight way to fix this.-->

WIP

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
