### PR TITLE
API/initSession: add get_full_session option

### DIFF
--- a/apirest.md
+++ b/apirest.md
@@ -114,9 +114,10 @@ App(lication) token
      You should pass this parameter in 'Authorization' HTTP header.
      A valid Authorization header is:
         * "Authorization: user_token q56hqkniwot8wntb3z1qarka5atf365taaa2uyjrn"
-
+* **Parameters**: (query string)
+  * *get_full_session* (default: false): Get the full session, useful if you want to login and access session data in one request.
 * **Returns**:
-  * 200 (OK) with the *session_token* string and the *ID of the logged in user*.
+  * 200 (OK) with the *session_token* string.
   * 400 (Bad Request) with a message indicating an error in input parameter.
   * 401 (UNAUTHORIZED)
 
@@ -131,20 +132,24 @@ $ curl -X GET \
 
 < 200 OK
 < {
-   "session_token": "83af7e620c83a50a18d3eac2f6ed05a3ca0bea62",
-   "users_id": "42"
+   "session_token": "83af7e620c83a50a18d3eac2f6ed05a3ca0bea62"
 }
 
 $ curl -X GET \
 -H 'Content-Type: application/json' \
 -H "Authorization: user_token q56hqkniwot8wntb3z1qarka5atf365taaa2uyjrn" \
 -H "App-Token: f7g3csp8mgatg5ebc5elnazakw20i9fyev1qopya7" \
-'http://path/to/glpi/apirest.php/initSession'
+'http://path/to/glpi/apirest.php/initSession?get_full_session=true'
 
 < 200 OK
 < {
    "session_token": "83af7e620c83a50a18d3eac2f6ed05a3ca0bea62",
-   "users_id": "42"
+   "session": {
+      'glpi_plugins': ...,
+      'glpicookietest': ...,
+      'glpicsrftokens': ...,
+      ...
+   }
 }
 ```
 

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -248,10 +248,15 @@ abstract class API extends CommonGLPI {
 
       // stop session and return session key
       session_write_close();
-      return [
-         'session_token' => $_SESSION['valid_id'],
-         'users_id'      => Session::getLoginUserID(),
-      ];
+      $data = ['session_token' => $_SESSION['valid_id']];
+
+      // Insert session data if requested
+      $get_full_session = $params['get_full_session'] ?? false;
+      if ($get_full_session) {
+         $data['session'] = $_SESSION;
+      }
+
+      return $data;
    }
 
 

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -103,6 +103,7 @@ class Session {
                     && (($auth->user->fields['end_date'] > $_SESSION["glpi_currenttime"])
                         || is_null($auth->user->fields['end_date'])))) {
                $_SESSION["glpiID"]              = $auth->user->fields['id'];
+               $_SESSION["glpifriendlyname"]    = $auth->user->getFriendlyName();
                $_SESSION["glpiname"]            = $auth->user->fields['name'];
                $_SESSION["glpirealname"]        = $auth->user->fields['realname'];
                $_SESSION["glpifirstname"]       = $auth->user->fields['firstname'];

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -216,7 +216,7 @@ class APIRest extends APIBaseClass {
          $token = $user->getAuthToken('api_token');
       }
 
-      $res = $this->doHttpRequest('GET', 'initSession/',
+      $res = $this->doHttpRequest('GET', 'initSession?get_full_session=true',
                                          ['headers' => [
                                              'Authorization' => "user_token $token"
                                          ]]);
@@ -228,8 +228,8 @@ class APIRest extends APIBaseClass {
       $data = json_decode($body, true);
       $this->variable($data)->isNotFalse();
       $this->array($data)->hasKey('session_token');
-      $this->array($data)->hasKey('users_id');
-      $this->integer((int) $data['users_id'])->isEqualTo($uid);
+      $this->array($data)->hasKey('session');
+      $this->integer((int) $data['session']['glpiID'])->isEqualTo($uid);
    }
 
    /**

--- a/tests/web/APIXmlrpc.php
+++ b/tests/web/APIXmlrpc.php
@@ -115,8 +115,6 @@ class APIXmlrpc extends APIBaseClass {
       $this->variable($data)->isNotFalse();
       $this->array($data)->hasKey('session_token');
       $this->session_token = $data['session_token'];
-      $this->array($data)->hasKey('users_id');
-      $this->integer((int) $data['users_id'])->isEqualTo($uid);
    }
 
    /**


### PR DESCRIPTION
* Add friendlyname in `$_SESSION`.
* Remove `users_id` from `initSession` response
* Add new `get_full_session` parameter to `initSession` to retrieve the full session data alongside the session token.


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes