### PR TITLE
planning: move now indicator to the correct datetime

### DIFF
--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -617,7 +617,8 @@ class Planning extends CommonGLPI {
             'full_view'    => true,
             'default_view' => $_SESSION['glpi_plannings']['lastview'] ?? 'timeGridWeek',
             'license_key'  => $scheduler_key,
-            'resources'    => self::getTimelineResources()
+            'resources'    => self::getTimelineResources(),
+            'now'          => date("Y-m-d H:i:s"),
          ];
       } else {
          // short view (on Central page)
@@ -628,6 +629,7 @@ class Planning extends CommonGLPI {
             'header'       => false,
             'height'       => 'auto',
             'rand'         => $rand,
+            'now'          => date("Y-m-d H:i:s"),
          ];
       }
 

--- a/js/planning.js
+++ b/js/planning.js
@@ -19,6 +19,7 @@ var GLPIPlanning  = {
          plugins: ['dayGrid', 'interaction', 'list', 'timeGrid', 'resourceTimeline', 'rrule'],
          license_key: "",
          resources: [],
+         now: null,
          rand: '',
          header: {
             left:   'prev,next,today',
@@ -61,6 +62,7 @@ var GLPIPlanning  = {
          editable: true, // we can drag / resize items
          droppable: false, // we cant drop external items by default
          nowIndicator: true,
+         now: options.now,// as we set the calendar as UTC, we need to reprecise the current datetime
          listDayAltFormat: false,
          agendaEventMinHeight: 13,
          header: options.header,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

![image](https://user-images.githubusercontent.com/418844/75534784-49f7a180-5a15-11ea-823d-6dd23588fd96.png)

Regarding the placement of the red line (now indicator), since i moved previously all dates to utc (to prevent shifting dates when moving them), it's currently missplaced (set to utc), i now force the current datetime to the server one.
