### PR TITLE
Fix unwanted debug mode after web install

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -527,6 +527,8 @@ function step8() {
       ]
    );
 
+   Session::destroy(); // Remove session data (debug mode for instance) set by web installation
+
    echo "<h2>".__('The installation is finished')."</h2>";
    echo "<p>".__('Default logins / passwords are:')."</p>";
    echo "<p><ul><li> ".__('glpi/glpi for the administrator account')."</li>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Debug mode is forced during first step of installation process. As this debug mode was not unset, login box shown just after installation process was loading CSS using the PHP SCSS compiler instead of using the compiled and minified CSS.