### PR TITLE
API support for deprecated itemtypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ phpunit.xml
 .package.hash
 /public/build/
 /public/lib/
+/tests/web/error.log

--- a/apirest.php
+++ b/apirest.php
@@ -44,5 +44,5 @@ include_once (GLPI_ROOT . "/inc/based_config.php");
 //init cache
 $GLPI_CACHE = Config::getCache('cache_db');
 
-$api = new APIRest;
+$api = new Glpi\Api\APIRest;
 $api->call();

--- a/apixmlrpc.php
+++ b/apixmlrpc.php
@@ -43,5 +43,5 @@ include_once (GLPI_ROOT . "/inc/based_config.php");
 //init cache
 $GLPI_CACHE = Config::getCache('cache_db');
 
-$api = new APIXmlrpc;
+$api = new Glpi\Api\APIXmlrpc;
 $api->call();

--- a/inc/api/api.class.php
+++ b/inc/api/api.class.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * ---------------------------------------------------------------------
  * GLPI - Gestionnaire Libre de Parc Informatique
@@ -34,8 +35,36 @@
  * @since 9.1
  */
 
+namespace Glpi\Api;
+
+use APIClient;
+use Auth;
+use Change;
+use CommonDevice;
+use CommonGLPI;
+use Config;
+use Contract;
+use Document;
+use Dropdown;
 use Glpi\Exception\ForgetPasswordException;
 use Glpi\Exception\PasswordTooWeakException;
+use Html;
+use Infocom;
+use Item_Devices;
+use Log;
+use Michelf\MarkdownExtra;
+use NetworkEquipment;
+use NetworkPort;
+use Notepad;
+use Problem;
+use QueryExpression;
+use SavedSearch;
+use Search;
+use Session;
+use Software;
+use Ticket;
+use Toolbox;
+use User;
 
 abstract class API extends CommonGLPI {
 
@@ -49,6 +78,7 @@ abstract class API extends CommonGLPI {
    protected $ipnum         = "";
    protected $app_tokens    = [];
    protected $apiclients_id = 0;
+   protected $deprecated_item = null;
 
    /**
     * First function used on api call
@@ -490,7 +520,6 @@ abstract class API extends CommonGLPI {
    }
 
 
-
    /**
     * Return the instance fields of itemtype identified by id
     *
@@ -521,6 +550,7 @@ abstract class API extends CommonGLPI {
       global $CFG_GLPI, $DB;
 
       $this->initEndpoint();
+      $itemtype = $this->handleDepreciation($itemtype);
 
       // default params
       $default = ['expand_dropdowns'  => false,
@@ -1088,6 +1118,14 @@ abstract class API extends CommonGLPI {
          );
       }
 
+      // Convert fields to the format expected by the deprecated type
+      if ($this->isDeprecated()) {
+         $fields = $this->deprecated_item->mapCurrentToDeprecatedFields($fields);
+         $fields["links"] = $this->deprecated_item->mapCurrentToDeprecatedHateoas(
+            $fields["links"] ?? []
+         );
+      }
+
       return $fields;
    }
 
@@ -1132,6 +1170,7 @@ abstract class API extends CommonGLPI {
       global $DB;
 
       $this->initEndpoint();
+      $itemtype = $this->handleDepreciation($itemtype);
 
       // default params
       $default = ['expand_dropdowns' => false,
@@ -1194,8 +1233,9 @@ abstract class API extends CommonGLPI {
           && isset($this->parameters['parent_id'])) {
 
          // check parent itemtype
-         if (!class_exists($this->parameters['parent_itemtype'])
-             || !is_subclass_of($this->parameters['parent_itemtype'], 'CommonDBTM')) {
+         if (!Toolbox::isCommonDBTM($this->parameters['parent_itemtype'])
+            && !Toolbox::isAPIDeprecated($this->parameters['parent_itemtype'])
+         ) {
             $this->returnError(__("parent itemtype not found or not an instance of CommonDBTM"),
                                400,
                                "ERROR_ITEMTYPE_NOT_FOUND_NOR_COMMONDBTM");
@@ -1331,6 +1371,15 @@ abstract class API extends CommonGLPI {
             }
          }
       }
+      // Break reference
+      unset($fields);
+
+      // Map values for deprecated itemtypes
+      if ($this->isDeprecated()) {
+         $found = array_map(function($fields) {
+            return $this->deprecated_item->mapCurrentToDeprecatedFields($fields);
+         }, $found);
+      }
 
       return array_values($found);
    }
@@ -1389,14 +1438,25 @@ abstract class API extends CommonGLPI {
    /**
     * List the searchoptions of provided itemtype. To use with searchItems function
     *
-    * @param string $itemtype itemtype (class) of object
-    * @param array  $params   parameters
+    * @param string $itemtype             itemtype (class) of object
+    * @param array  $params               parameters
+    * @param bool   $check_depreciation   disable depreciation check, useful
+    *                                     if depreciation have already been
+    *                                     handled by a parent call (e.g. search)
     *
     * @return array all searchoptions of specified itemtype
     */
-   protected function listSearchOptions($itemtype, $params = []) {
-
+   protected function listSearchOptions(
+      $itemtype,
+      $params = [],
+      bool $check_depreciation = true
+   ) {
       $this->initEndpoint();
+
+      if ($check_depreciation) {
+         $itemtype = $this->handleDepreciation($itemtype);
+      }
+
       $soptions = Search::getOptions($itemtype);
 
       if (isset($params['raw'])) {
@@ -1428,6 +1488,10 @@ abstract class API extends CommonGLPI {
          } else {
             $cleaned_soptions[$sID] = $option;
          }
+      }
+
+      if ($check_depreciation && $this->isDeprecated()) {
+         $cleaned_soptions = $this->deprecated_item->mapCurrentToDeprecatedSearchOptions($cleaned_soptions);
       }
 
       return $cleaned_soptions;
@@ -1541,6 +1605,7 @@ abstract class API extends CommonGLPI {
       global $DEBUG_SQL;
 
       $this->initEndpoint();
+      $itemtype = $this->handleDepreciation($itemtype);
 
       // check rights
       if ($itemtype != 'AllAssets'
@@ -1549,14 +1614,23 @@ abstract class API extends CommonGLPI {
       }
 
       // retrieve searchoptions
-      $soptions = $this->listSearchOptions($itemtype);
+      $soptions = $this->listSearchOptions($itemtype, [], false);
+
+      if ($this->isDeprecated()) {
+         $criteria = $this->deprecated_item->mapDeprecatedToCurrentCriteria(
+            $params['criteria'] ?? []
+         );
+
+         if (count($criteria)) {
+            $params['criteria'] = $criteria;
+         }
+      }
 
       // Check the criterias are valid
       if (isset($params['criteria']) && is_array($params['criteria'])) {
 
          // use a recursive closure to check each nested criteria
-         $check_message = "";
-         $check_criteria = function($criteria) use (&$check_criteria, $soptions, $check_message) {
+         $check_criteria = function($criteria) use (&$check_criteria, $soptions) {
             foreach ($criteria as $criterion) {
                // recursive call
                if (isset($criterion['criteria'])) {
@@ -1565,21 +1639,18 @@ abstract class API extends CommonGLPI {
 
                if (!isset($criterion['field']) || !isset($criterion['searchtype'])
                    || !isset($criterion['value'])) {
-                  $check_message = __("Malformed search criteria");
-                  return false;
+                  return __("Malformed search criteria");
                }
 
                if (!ctype_digit((string) $criterion['field'])
                    || !array_key_exists($criterion['field'], $soptions)) {
-                  $check_message = __("Bad field ID in search criteria");
-                  return false;
+                  return __("Bad field ID in search criteria");
                }
 
                if (isset($soptions[$criterion['field']])
                    && isset($soptions[$criterion['field']]['nosearch'])
                    && $soptions[$criterion['field']]['nosearch']) {
-                  $check_message = __("Forbidden field ID in search criteria");
-                  return false;
+                  return __("Forbidden field ID in search criteria");
                }
             }
 
@@ -1587,8 +1658,9 @@ abstract class API extends CommonGLPI {
          };
 
          // call the closure
-         if (!$check_criteria($params['criteria'])) {
-            return $this->returnError($check_message);
+         $check_criteria_result = $check_criteria($params['criteria']);
+         if ($check_criteria_result !== true) {
+            return $this->returnError($check_criteria_result);
          }
       }
 
@@ -1758,6 +1830,8 @@ abstract class API extends CommonGLPI {
     */
    protected function createItems($itemtype, $params = []) {
       $this->initEndpoint();
+      $itemtype = $this->handleDepreciation($itemtype);
+
       $input    = isset($params['input']) ? $params["input"] : null;
       $item     = new $itemtype;
 
@@ -1766,6 +1840,12 @@ abstract class API extends CommonGLPI {
          $isMultiple = false;
       } else {
          $isMultiple = true;
+      }
+
+      if ($this->isDeprecated()) {
+         $input = array_map(function($item) {
+            return $this->deprecated_item->mapDeprecatedToCurrentFields($item);
+         }, $input);
       }
 
       if (is_array($input)) {
@@ -1868,8 +1948,9 @@ abstract class API extends CommonGLPI {
     * @return   array of boolean
     */
    protected function updateItems($itemtype, $params = []) {
-
       $this->initEndpoint();
+      $itemtype = $this->handleDepreciation($itemtype);
+
       $input    = isset($params['input']) ? $params["input"] : null;
       $item     = new $itemtype;
 
@@ -1878,6 +1959,12 @@ abstract class API extends CommonGLPI {
          $isMultiple = false;
       } else {
          $isMultiple = true;
+      }
+
+      if ($this->isDeprecated()) {
+         $input = array_map(function($item) {
+            return $this->deprecated_item->mapDeprecatedToCurrentFields($item);
+         }, $input);
       }
 
       if (is_array($input)) {
@@ -1972,6 +2059,8 @@ abstract class API extends CommonGLPI {
    protected function deleteItems($itemtype, $params = []) {
 
       $this->initEndpoint();
+      $itemtype = $this->handleDepreciation($itemtype);
+
       $default  = ['force_purge' => false,
                         'history'     => true];
       $params   = array_merge($default, $params);
@@ -1983,6 +2072,12 @@ abstract class API extends CommonGLPI {
          $isMultiple = false;
       } else {
          $isMultiple = true;
+      }
+
+      if ($this->isDeprecated()) {
+         $input = array_map(function($item) {
+            return $this->deprecated_item->mapDeprecatedToCurrentFields($item);
+         }, $input);
       }
 
       if (is_array($input)) {
@@ -2324,7 +2419,7 @@ abstract class API extends CommonGLPI {
 
       echo "<div class='documentation'>";
       $documentation = file_get_contents(GLPI_ROOT.'/'.$file);
-      $md = new Michelf\MarkdownExtra();
+      $md = new MarkdownExtra();
       $md->code_class_prefix = "language-";
       $md->header_id_func = function($headerName) {
          $headerName = str_replace(['(', ')'], '', $headerName);
@@ -2670,7 +2765,7 @@ abstract class API extends CommonGLPI {
          } else {
 
             if (!isset($data[$kn_fkey])) {
-               \Toolbox::logWarning(
+               Toolbox::logWarning(
                   "Invalid value: \"$kn_fkey\" doesn't exist.
                ");
                continue;
@@ -2684,7 +2779,7 @@ abstract class API extends CommonGLPI {
          // Check itemtype is valid
          $kn_item = getItemForItemtype($kn_itemtype);
          if (!$kn_item) {
-            \Toolbox::logWarning(
+            Toolbox::logWarning(
                "Invalid itemtype \"$kn_itemtype\" for fkey  \"$kn_fkey\""
             );
             continue;
@@ -2708,7 +2803,7 @@ abstract class API extends CommonGLPI {
       $this->initEndpoint();
 
       // Try to load target user
-      $user = new \User();
+      $user = new User();
       if (!$user->getFromDB($user_id)) {
          $this->returnError("Bad request: user with id '$user_id' not found");
       }
@@ -2722,5 +2817,37 @@ abstract class API extends CommonGLPI {
          http_response_code(204);
       }
       die;
+   }
+
+   /**
+    * If the given itemtype is deprecated, replace it by it's current
+    * equivalent and keep a reference to the deprecation logic so we can convert
+    * the API input and/or output to the exêcted format.
+    *
+    * @param string  $itemtype
+    * @return string The corrected itemtype.
+    */
+   public function handleDepreciation(string $itemtype): string {
+      $deprecated = Toolbox::isAPIDeprecated($itemtype);
+
+      if ($deprecated) {
+         // Keep a reference to deprecated item
+         $class = "Glpi\Api\Deprecated\\$itemtype";
+         $this->deprecated_item = new $class();
+
+         // Get correct itemtype
+         $itemtype = $this->deprecated_item->getType();
+      }
+
+      return $itemtype;
+   }
+
+   /**
+    * Check if the current call is using a deprecated item
+    *
+    * @return bool
+    */
+   public function isDeprecated(): bool {
+      return $this->deprecated_item !== null;
    }
 }

--- a/inc/api/apixmlrpc.class.php
+++ b/inc/api/apixmlrpc.class.php
@@ -30,6 +30,10 @@
  * ---------------------------------------------------------------------
  */
 
+namespace Glpi\Api;
+
+use Toolbox;
+
 class APIXmlrpc extends API {
    protected $request_uri;
    protected $url_elements;
@@ -225,7 +229,7 @@ class APIXmlrpc extends API {
          } else if ($resource === "deleteItems") { // delete one or many CommonDBTM items
             if (isset($this->parameters['id'])) {
                //override input
-               $this->parameters['input'] = new stdClass();;
+               $this->parameters['input'] = new \stdClass();
                $this->parameters['input']->id = $this->parameters['id'];
             }
             return $this->returnResponse($this->deleteItems($this->parameters['itemtype'],

--- a/inc/api/deprecated/commondeprecatedtrait.class.php
+++ b/inc/api/deprecated/commondeprecatedtrait.class.php
@@ -1,0 +1,242 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\Deprecated;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ * @since 9.5
+ */
+
+trait CommonDeprecatedTrait
+{
+   abstract public function getType(): string;
+
+   /**
+    * Get the class short name for the deprecated itemtpe
+    *
+    * @return string
+    */
+   private function getDeprecatedClass(): string {
+      return (new \ReflectionClass(static::class))->getShortName();
+   }
+
+   /**
+    * For each hateoas, update the href ref to match the deprecated type
+    *
+    * @param array $hateoas Current hateoas
+    * @return array Updated hateoas
+    */
+   public function replaceCurrentHateoasRefByDeprecated(array $hateoas): array {
+      foreach ($hateoas as $key => $value) {
+         if (isset($value["href"])) {
+            $hateoas[$key]["href"] = str_replace(
+               $this->getType(),
+               $this->getDeprecatedClass(),
+               $value["href"]
+            );
+         }
+      }
+
+      return $hateoas;
+   }
+
+   /**
+    * For each searchoption, update the UID ref to match the deprecated type
+    *
+    * @param array $soptions
+    * @return CommonDeprecatedTrait Return self to allow method chaining
+    */
+   public function updateSearchOptionsUids(array &$soptions) {
+      $soptions = array_map(function($soption) {
+         if (isset($soption['uid'])) {
+            $new_uid = str_replace(
+               $this->getType(),
+               $this->getDeprecatedClass(),
+               $soption['uid']
+            );
+            $soption['uid'] = $new_uid;
+         }
+
+         return $soption;
+      }, $soptions);
+
+      return $this;
+   }
+
+   /**
+    * For each searchoption, update the table ref to match the deprecated type
+    *
+    * @param array $soptions
+    * @return CommonDeprecatedTrait Return self to allow method chaining
+    */
+   public function updateSearchOptionsTables(array &$soptions) {
+      $soptions = array_map(function($soption) {
+         if (isset($soption['table'])) {
+            $new_table = str_replace(
+               getTableForItemType($this->getType()),
+               getTableForItemType($this->getDeprecatedClass()),
+               $soption['table']
+            );
+            $soption['table'] = $new_table;
+         }
+
+         return $soption;
+      }, $soptions);
+
+      return $this;
+   }
+
+   /**
+    * Add a field in an array or an object
+    *
+    * @param array|object $fields
+    * @param string $name
+    * @param string $value
+    * @return CommonDeprecatedTrait Return self to allow method chaining
+    */
+   public function addField(&$fields, string $name, string $value) {
+      if (is_object($fields)) {
+         if (!isset($fields->$name)) {
+            $fields->$name = $value;
+         }
+      } else if (is_array($fields)) {
+         if (!isset($fields[$name])) {
+            $fields[$name] = $value;
+         }
+      }
+
+      return $this;
+   }
+
+   /**
+    * Rename a field in an array or an object
+    *
+    * @param array|object $fields
+    * @param string $old
+    * @param string $new
+    * @return CommonDeprecatedTrait Return self to allow method chaining
+    */
+   public function renameField(&$fields, string $old, string $new) {
+      if (is_object($fields)) {
+         if (isset($fields->$old)) {
+            $fields->$new = $fields->$old;
+            unset($fields->$old);
+         }
+      } else if (is_array($fields)) {
+         if (isset($fields[$old])) {
+            $fields[$new] = $fields[$old];
+            unset($fields[$old]);
+         }
+      }
+
+      return $this;
+   }
+
+   /**
+    * Delete a field in an array or an object
+    *
+    * @param array|object $fields
+    * @param string $name
+    * @return CommonDeprecatedTrait Return self to allow method chaining
+    */
+   public function deleteField(&$fields, string $name) {
+      if (is_object($fields)) {
+         if (isset($fields->$name)) {
+            unset($fields->$name);
+         }
+      } else if (is_array($fields)) {
+         if (isset($fields[$name])) {
+            unset($fields[$name]);
+         }
+      }
+
+      return $this;
+   }
+
+   /**
+    * Add a searchoption
+    *
+    * @param array $fields
+    * @param string $key
+    * @param array $values
+    * @return CommonDeprecatedTrait Return self to allow method chaining
+    */
+   public function addSearchOption(
+      array &$soptions,
+      string $key,
+      array $values
+   ) {
+      $soptions[$key] = $values;
+
+      return $this;
+   }
+
+   /**
+    * Edit an existing searchoption
+    *
+    * @param array $fields
+    * @param string $key
+    * @param array $values
+    * @return CommonDeprecatedTrait Return self to allow method chaining
+    */
+   public function alterSearchOption(
+      array &$soptions,
+      string $key,
+      array $values
+   ) {
+      foreach ($values as $v_key => $v_value) {
+         $soptions[$key][$v_key] = $v_value;
+      }
+
+      return $this;
+   }
+
+   /**
+    * Delete an existing searchoption
+    *
+    * @param array $fields
+    * @param string $key
+    * @param array $values
+    * @return CommonDeprecatedTrait Return self to allow method chaining
+    */
+   public function deleteSearchOption(array &$soptions, string $key) {
+      if (isset($soptions[$key])) {
+         unset($soptions[$key]);
+      }
+      return $this;
+   }
+}

--- a/inc/api/deprecated/computer_softwarelicense.class.php
+++ b/inc/api/deprecated/computer_softwarelicense.class.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\Deprecated;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ * @since 9.5
+ */
+class Computer_SoftwareLicense implements DeprecatedInterface
+{
+   use CommonDeprecatedTrait;
+
+   public function getType(): string {
+      return "Item_SoftwareLicense";
+   }
+
+   public function mapCurrentToDeprecatedHateoas(array $hateoas): array {
+      $hateoas = $this->replaceCurrentHateoasRefByDeprecated($hateoas);
+      return $hateoas;
+   }
+
+   public function mapDeprecatedToCurrentFields(object $fields): object {
+      $this
+         ->renameField($fields, "computers_id", "items_id")
+         ->addField($fields, "itemtype", "Computer");
+
+      return $fields;
+   }
+
+   public function mapCurrentToDeprecatedFields(array $fields): array {
+      $this
+         ->renameField($fields, "items_id", "computers_id")
+         ->deleteField($fields, "itemtype");
+
+      return $fields;
+   }
+
+   public function mapDeprecatedToCurrentCriteria(array $criteria): array {
+      $criteria[] = [
+         "link"       => 'AND',
+         "field"      => "6",
+         "searchtype" => 'equals',
+         "value"      => "Computer"
+      ];
+
+      return $criteria;
+   }
+
+   public function mapCurrentToDeprecatedSearchOptions(array $soptions): array {
+      $this
+         ->updateSearchOptionsUids($soptions)
+         ->updateSearchOptionsTables($soptions)
+         ->alterSearchOption($soptions, "5", [
+            'name'                  => "Computer",
+            'table'                 => "glpi_computers",
+            'field'                 => "name",
+            'datatype'              => "dropdown",
+            'uid'                   => "Computer_SoftwareLicense.Computer.name",
+            'available_searchtypes' => [
+               "contains",
+               "notcontains",
+               "equals",
+               "notequals"
+            ],
+         ])
+         ->deleteSearchOption($soptions, "6");
+
+      return $soptions;
+   }
+}

--- a/inc/api/deprecated/computer_softwareversion.class.php
+++ b/inc/api/deprecated/computer_softwareversion.class.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\Deprecated;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ * @since 9.5
+ */
+class Computer_SoftwareVersion implements DeprecatedInterface
+{
+   use CommonDeprecatedTrait;
+
+   public function getType(): string {
+      return "Item_SoftwareVersion";
+   }
+
+   public function mapCurrentToDeprecatedHateoas(array $hateoas): array {
+      $hateoas = $this->replaceCurrentHateoasRefByDeprecated($hateoas);
+      return $hateoas;
+   }
+
+   public function mapDeprecatedToCurrentFields(object $fields): object {
+      $this
+         ->renameField($fields, "computers_id", "items_id")
+         ->addField($fields, "itemtype", "Computer")
+         ->renameField($fields, "is_template_computer", "is_template_item")
+         ->renameField($fields, "is_deleted_computer", "is_deleted_item");
+
+      return $fields;
+   }
+
+   public function mapCurrentToDeprecatedFields(array $fields): array {
+      $this
+         ->renameField($fields, "items_id", "computers_id")
+         ->deleteField($fields, "itemtype")
+         ->renameField($fields, "is_template_item", "is_template_computer")
+         ->renameField($fields, "is_deleted_item", "is_deleted_computer");
+
+      return $fields;
+   }
+
+   public function mapDeprecatedToCurrentCriteria(array $criteria): array {
+      $criteria[] = [
+         "link"       => 'AND',
+         "field"      => "5",
+         "searchtype" => 'equals',
+         "value"      => "Computer"
+      ];
+
+      return $criteria;
+   }
+
+   public function mapCurrentToDeprecatedSearchOptions(array $soptions): array {
+      $this
+         ->updateSearchOptionsUids($soptions)
+         ->updateSearchOptionsTables($soptions)
+         ->alterSearchOption($soptions, "3", [
+            'name'                  => "Computer",
+            'table'                 => "glpi_computers",
+            'field'                 => "name",
+            'datatype'              => "dropdown",
+            'uid'                   => "Computer_SoftwareVersion.Computer.name",
+            'available_searchtypes' => [
+               "contains",
+               "notcontains",
+               "equals",
+               "notequals"
+            ],
+         ])
+         ->deleteSearchOption($soptions, "5");
+
+      return $soptions;
+   }
+}

--- a/inc/api/deprecated/deprecatedinterface.class.php
+++ b/inc/api/deprecated/deprecatedinterface.class.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\Deprecated;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ * @since 9.5
+ */
+
+interface DeprecatedInterface
+{
+   /**
+    * Get the deprecated itemtype
+    *
+    * @return string
+    */
+   public function getType(): string;
+
+   /**
+    * Convert current hateoas to deprecated hateoas
+    *
+    * @param array $hateoas
+    * @return array
+    */
+   public function mapCurrentToDeprecatedHateoas(array $hateoas): array;
+
+   /**
+    * Convert current fields to deprecated fields
+    *
+    * @param array $fields
+    * @return array
+    */
+   public function mapCurrentToDeprecatedFields(array $fields): array;
+
+   /**
+    * Convert current searchoptions to deprecated searchoptions
+    *
+    * @param array $soptions
+    * @return array
+    */
+   public function mapCurrentToDeprecatedSearchOptions(array $soptions): array;
+
+   /**
+    * Convert deprecated fields to current fields
+    *
+    * @param object $fields
+    * @return object
+    */
+   public function mapDeprecatedToCurrentFields(object $fields): object;
+
+   /**
+    * Convert deprecated search criteria to current search criteria
+    *
+    * @param array $criteria
+    * @return array
+    */
+   public function mapDeprecatedToCurrentCriteria(array $criteria): array;
+}

--- a/inc/api/deprecated/ticketfollowup.class.php
+++ b/inc/api/deprecated/ticketfollowup.class.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\Deprecated;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ * @since 9.4.0
+ */
+class TicketFollowup implements DeprecatedInterface
+{
+   use CommonDeprecatedTrait;
+
+   public function getType(): string {
+      return "ITILFollowup";
+   }
+
+   public function mapCurrentToDeprecatedHateoas(array $hateoas): array {
+      $hateoas = $this->replaceCurrentHateoasRefByDeprecated($hateoas);
+      return $hateoas;
+   }
+
+   public function mapDeprecatedToCurrentFields(object $fields): object {
+      $this
+         ->renameField($fields, "tickets_id", "items_id")
+         ->addField($fields, "itemtype", "Ticket");
+
+      return $fields;
+   }
+
+   public function mapCurrentToDeprecatedFields(array $fields): array {
+      $this
+         ->renameField($fields, "items_id", "tickets_id")
+         ->deleteField($fields, "itemtype")
+         ->deleteField($fields, "sourceitems_id")
+         ->deleteField($fields, "sourceof_items_id");
+
+      return $fields;
+   }
+
+   public function mapDeprecatedToCurrentCriteria(array $criteria): array {
+      // Add itemtype condition
+      $criteria[] = [
+         "link"       => 'AND',
+         "field"      => "6",
+         "searchtype" => 'equals',
+         "value"      => "Ticket"
+      ];
+
+      return $criteria;
+   }
+
+   public function mapCurrentToDeprecatedSearchOptions(array $soptions): array {
+      $this
+         ->updateSearchOptionsUids($soptions)
+         ->updateSearchOptionsTables($soptions)
+         ->alterSearchOption($soptions, "1", [
+            "available_searchtypes" => ["contains"]
+         ])
+         ->alterSearchOption($soptions, "2", [
+            "available_searchtypes" => [
+               "contains",
+               "equals",
+               "notequals"
+            ]
+         ])
+         ->alterSearchOption($soptions, "3", [
+            "available_searchtypes" => [
+               "equals",
+               "notequals",
+               "lessthan",
+               "morethan",
+               "contains"
+            ]
+         ])
+         ->alterSearchOption($soptions, "4", [
+            "available_searchtypes" => [
+               "equals",
+               "notequals",
+               "contains"
+            ]
+         ])
+         ->alterSearchOption($soptions, "5", [
+            "available_searchtypes" => [
+               "contains",
+               "equals",
+               "notequals"
+            ]
+         ])
+         ->deleteSearchOption($soptions, "6")
+         ->deleteSearchOption($soptions, "119")
+         ->deleteSearchOption($soptions, "document");
+
+      return $soptions;
+   }
+}

--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -259,7 +259,6 @@ function glpi_autoload($classname) {
    global $DEBUG_AUTOLOAD;
    static $notfound = ['xStates'    => true,
                             'xAllAssets' => true, ];
-
    // empty classname or non concerted plugin or classname containing dot (leaving GLPI main treee)
    if (empty($classname) || is_numeric($classname) || (strpos($classname, '.') !== false)) {
       trigger_error(
@@ -303,6 +302,27 @@ function glpi_autoload($classname) {
             break;
          }
       }
+   } else if (strpos($classname, 'Glpi\Tests\Web\Deprecated') !== false) {
+      // Special case to autoload files in the tests dir that have a namespace
+      // and are not an atoum test case
+      $dir = GLPI_ROOT . "/tests/";
+
+      // Convert classname to array
+      $path = explode('\\', $classname);
+
+      // Remove first two items (Glpi\Tests)
+      array_splice($path, 0, 2);
+
+      // Extract file name
+      $item = array_pop($path);
+
+      // Convert all remaining path to lowercase
+      $path = array_map(function($folder) {
+         return strtolower($folder);
+      }, $path);
+
+      // Revert to string and add to dir path
+      $dir .= implode('/', $path) . '/';
    } else {
       $item = strtolower($classname);
       if (substr($classname, 0, \strlen(NS_GLPI)) === NS_GLPI) {

--- a/inc/item_softwarelicense.class.php
+++ b/inc/item_softwarelicense.class.php
@@ -101,6 +101,14 @@ class Item_SoftwareLicense extends CommonDBRelation {
          'additionalfields'   => ['itemtype']
       ];
 
+      $tab[] = [
+         'id'                 => '6',
+         'table'              => $this->getTable(),
+         'field'              => 'itemtype',
+         'name'               => __('Request source'),
+         'datatype'           => 'dropdown'
+      ];
+
       return $tab;
    }
 

--- a/inc/item_softwareversion.class.php
+++ b/inc/item_softwareversion.class.php
@@ -91,6 +91,14 @@ class Item_SoftwareVersion extends CommonDBRelation {
          'massiveaction'      => false
       ];
 
+      $tab[] = [
+         'id'                 => '5',
+         'table'              => $this->getTable(),
+         'field'              => 'itemtype',
+         'name'               => __('Request source'),
+         'datatype'           => 'dropdown'
+      ];
+
       return $tab;
    }
 

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -554,6 +554,14 @@ class ITILFollowup  extends CommonDBChild {
          'right'              => 'all'
       ];
 
+      $tab[] = [
+         'id'                 => '6',
+         'table'              => $this->getTable(),
+         'field'              => 'itemtype',
+         'name'               => __('Request source'),
+         'datatype'           => 'dropdown'
+      ];
+
       return $tab;
    }
 

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -456,7 +456,7 @@ class Search {
       }
 
       if (count($p['criteria']) > 0) {
-         // use a recursive clojure to push searchoption when using nested criteria
+         // use a recursive closure to push searchoption when using nested criteria
          $parse_criteria = function($criteria) use (&$parse_criteria, &$data) {
             foreach ($criteria as $criterion) {
                // recursive call
@@ -486,7 +486,7 @@ class Search {
             }
          };
 
-         // call the clojure
+         // call the closure
          $parse_criteria($p['criteria']);
       }
 
@@ -3325,8 +3325,11 @@ JAVASCRIPT;
 
       $toview = [];
       $item   = null;
+      $entity_check = true;
+
       if ($itemtype != 'AllAssets') {
          $item = getItemForItemtype($itemtype);
+         $entity_check = $item->isEntityAssign();
       }
       // Add first element (name)
       array_push($toview, 1);
@@ -3338,7 +3341,7 @@ JAVASCRIPT;
 
       // Add entity view :
       if (Session::isMultiEntitiesMode()
-          && $item->isEntityAssign()
+          && $entity_check
           && (isset($CFG_GLPI["union_search_type"][$itemtype])
               || ($item && $item->maybeRecursive())
               || isset($_SESSION['glpiactiveentities']) && (count($_SESSION["glpiactiveentities"]) > 1))) {

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3414,4 +3414,31 @@ HTML;
 
       return $_SERVER[$name] ?? null;
    }
+
+   /**
+    * Check if the given class exist and extends CommonDBTM
+    *
+    * @param string $class
+    * @return bool
+    */
+   public static function isCommonDBTM(string $class): bool {
+      return class_exists($class) && is_subclass_of($class, 'CommonDBTM');
+   }
+
+   /**
+    * Check if the given class exist and implement DeprecatedInterface
+    *
+    * @param string $class
+    * @return bool
+    */
+   public static function isAPIDeprecated(string $class): bool {
+      $deprecated = "Glpi\Api\Deprecated\DeprecatedInterface";
+
+      // Insert namespace if missing
+      if (strpos($class, "Glpi\Api\Deprecated") === false) {
+         $class = "Glpi\Api\Deprecated\\$class";
+      }
+
+      return class_exists($class) && is_a($class, $deprecated, true);
+   }
 }

--- a/tests/APIBaseClass.php
+++ b/tests/APIBaseClass.php
@@ -38,7 +38,7 @@ abstract class APIBaseClass extends \atoum {
 
    abstract protected function query($resource = "",
                                      $params = [],
-                                     $expected_code = 200);
+                                     $expected_codes = 200);
 
    public function beforeTestMethod($method) {
       parent::beforeTestMethod($method);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -584,6 +584,7 @@ function loadDataset() {
    $_SESSION['glpishowallentities'] = 1;
    $_SESSION['glpicronuserrunning'] = "cron_phpunit";
    $_SESSION['glpi_use_mode']       = Session::NORMAL_MODE;
+   $_SESSION['glpiactive_entity']   = 0;
    $_SESSION['glpiactiveentities']  = [0];
    $_SESSION['glpiactiveentities_string'] = "'0'";
    $CFG_GLPI['root_doc']            = '/glpi';

--- a/tests/deprecated-searchoptions/Computer_SoftwareLicense.json
+++ b/tests/deprecated-searchoptions/Computer_SoftwareLicense.json
@@ -1,0 +1,50 @@
+{
+    "common": {
+        "name": "Characteristics"
+    },
+    "2": {
+        "name": "ID",
+        "table": "glpi_computers_softwarelicenses",
+        "field": "id",
+        "datatype": "number",
+        "nosearch": false,
+        "nodisplay": false,
+        "available_searchtypes": [
+            "contains",
+            "notcontains"
+        ],
+        "uid": "Computer_SoftwareLicense.id"
+    },
+    "4": {
+        "name": "License",
+        "table": "glpi_softwarelicenses",
+        "field": "name",
+        "datatype": "dropdown",
+        "nosearch": false,
+        "nodisplay": false,
+        "available_searchtypes": [
+            "contains",
+            "notcontains",
+            "equals",
+            "notequals",
+            "under",
+            "notunder"
+        ],
+        "uid": "Computer_SoftwareLicense.SoftwareLicense.name"
+    },
+    "5": {
+        "name": "Computer",
+        "table": "glpi_computers",
+        "field": "name",
+        "datatype": "dropdown",
+        "nosearch": false,
+        "nodisplay": false,
+        "available_searchtypes": [
+            "contains",
+            "notcontains",
+            "equals",
+            "notequals"
+        ],
+        "uid": "Computer_SoftwareLicense.Computer.name"
+    }
+}

--- a/tests/deprecated-searchoptions/Computer_SoftwareVersion.json
+++ b/tests/deprecated-searchoptions/Computer_SoftwareVersion.json
@@ -1,0 +1,48 @@
+{
+    "common": {
+        "name": "Characteristics"
+    },
+    "2": {
+        "name": "ID",
+        "table": "glpi_computers_softwareversions",
+        "field": "id",
+        "datatype": "number",
+        "nosearch": false,
+        "nodisplay": false,
+        "available_searchtypes": [
+            "contains",
+            "notcontains"
+        ],
+        "uid": "Computer_SoftwareVersion.id"
+    },
+    "3": {
+        "name": "Computer",
+        "table": "glpi_computers",
+        "field": "name",
+        "datatype": "dropdown",
+        "nosearch": false,
+        "nodisplay": false,
+        "available_searchtypes": [
+            "contains",
+            "notcontains",
+            "equals",
+            "notequals"
+        ],
+        "uid": "Computer_SoftwareVersion.Computer.name"
+    },
+    "4": {
+        "name": "Version",
+        "table": "glpi_softwareversions",
+        "field": "name",
+        "datatype": "dropdown",
+        "nosearch": false,
+        "nodisplay": false,
+        "available_searchtypes": [
+            "contains",
+            "notcontains",
+            "equals",
+            "notequals"
+        ],
+        "uid": "Computer_SoftwareVersion.SoftwareVersion.name"
+    }
+}

--- a/tests/deprecated-searchoptions/TicketFollowup.json
+++ b/tests/deprecated-searchoptions/TicketFollowup.json
@@ -1,0 +1,75 @@
+{
+    "common": {
+        "name": "Characteristics"
+    },
+    "1": {
+        "name": "Description",
+        "table": "glpi_ticketfollowups",
+        "field": "content",
+        "datatype": "text",
+        "nosearch": false,
+        "nodisplay": false,
+        "available_searchtypes": [
+            "contains"
+        ],
+        "uid": "TicketFollowup.content"
+    },
+    "2": {
+        "name": "Request source",
+        "table": "glpi_requesttypes",
+        "field": "name",
+        "datatype": "dropdown",
+        "nosearch": false,
+        "nodisplay": false,
+        "available_searchtypes": [
+            "contains",
+            "equals",
+            "notequals"
+        ],
+        "uid": "TicketFollowup.RequestType.name"
+    },
+    "3": {
+        "name": "Date",
+        "table": "glpi_ticketfollowups",
+        "field": "date",
+        "datatype": "datetime",
+        "nosearch": false,
+        "nodisplay": false,
+        "available_searchtypes": [
+            "equals",
+            "notequals",
+            "lessthan",
+            "morethan",
+            "contains"
+        ],
+        "uid": "TicketFollowup.date"
+    },
+    "4": {
+        "name": "Private",
+        "table": "glpi_ticketfollowups",
+        "field": "is_private",
+        "datatype": "bool",
+        "nosearch": false,
+        "nodisplay": false,
+        "available_searchtypes": [
+            "equals",
+            "notequals",
+            "contains"
+        ],
+        "uid": "TicketFollowup.is_private"
+    },
+    "5": {
+        "name": "User",
+        "table": "glpi_users",
+        "field": "name",
+        "datatype": "dropdown",
+        "nosearch": false,
+        "nodisplay": false,
+        "available_searchtypes": [
+            "contains",
+            "equals",
+            "notequals"
+        ],
+        "uid": "TicketFollowup.User.name"
+    }
+}

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -179,7 +179,7 @@ class CommonDBTM extends DbTestCase {
 
       $this->boolean($comp->getEmpty())->isTrue();
       $this->array($comp->fields)
-         ->string['entities_id']->isIdenticalTo('');
+         ->integer['entities_id']->isIdenticalTo($_SESSION["glpiactive_entity"]);
 
       $_SESSION["glpiactive_entity"] = 12;
       $this->boolean($comp->getEmpty())->isTrue();

--- a/tests/functionnal/Item_SoftwareLicense.php
+++ b/tests/functionnal/Item_SoftwareLicense.php
@@ -240,6 +240,6 @@ class Item_SoftwareLicense extends DbTestCase {
 
       $cSoftwareLicense = new \Item_SoftwareLicense();
       $this->array($cSoftwareLicense->rawSearchOptions())
-         ->hasSize(4);
+         ->hasSize(5);
    }
 }

--- a/tests/router.php
+++ b/tests/router.php
@@ -40,4 +40,13 @@ define(
    ]
 );
 
+// Avoid warnings because of missing globals
+$DEBUG_SQL = [
+    'queries' => [],
+    'errors'  => [],
+    'times'   => [],
+];
+
+ini_set("error_log", "tests/web/error.log");
+
 return false;

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -32,6 +32,10 @@
 
 namespace tests\units;
 
+use Glpi\Api\Deprecated\TicketFollowup;
+use ITILFollowup;
+use Ticket;
+
 /* Test for inc/toolbox.class.php */
 
 class Toolbox extends \GLPITestCase {
@@ -830,4 +834,61 @@ class Toolbox extends \GLPITestCase {
       $this->string(\Toolbox::getFgColor($bg_color, $offset))
          ->isEqualTo($fg_color);
    }
+
+   protected function testIsCommonDBTMProvider() {
+      return [
+         [
+            'class'         => TicketFollowup::class,
+            'is_commondbtm' => false,
+         ],
+         [
+            'class'         => Ticket::class,
+            'is_commondbtm' => true,
+         ],
+         [
+            'class'         => ITILFollowup::class,
+            'is_commondbtm' => true,
+         ],
+         [
+            'class'         => "Not a real class",
+            'is_commondbtm' => false,
+         ],
+      ];
+   }
+
+   /**
+    * @dataProvider testIsCommonDBTMProvider
+    */
+   public function testIsCommonDBTM(string $class, bool $is_commondbtm) {
+      $this->boolean(\Toolbox::isCommonDBTM($class))->isEqualTo($is_commondbtm);
+   }
+
+   protected function testIsAPIDeprecatedProvider() {
+      return [
+         [
+            'class'         => TicketFollowup::class,
+            'is_deprecated' => true,
+         ],
+         [
+            'class'         => Ticket::class,
+            'is_deprecated' => false,
+         ],
+         [
+            'class'         => ITILFollowup::class,
+            'is_deprecated' => false,
+         ],
+         [
+            'class'         => "Not a real class",
+            'is_deprecated' => false,
+         ],
+      ];
+   }
+
+   /**
+    * @dataProvider testIsAPIDeprecatedProvider
+    */
+   public function testIsAPIDeprecated(string $class, bool $is_deprecated) {
+      $this->boolean(\Toolbox::isAPIDeprecated($class))->isEqualTo($is_deprecated);
+   }
+
 }

--- a/tests/web/APIXmlrpc.php
+++ b/tests/web/APIXmlrpc.php
@@ -30,13 +30,13 @@
  * ---------------------------------------------------------------------
  */
 
-namespace tests\units;
+namespace tests\units\Glpi\Api;
 
 use \GuzzleHttp\Exception\ClientException;
 use \GuzzleHttp;
 use \APIBaseClass;
 
-/* Test for inc/apixmlrpc.class.php */
+/* Test for inc/api/apixmlrpc.class.php */
 
 /**
  * @engine isolate
@@ -64,7 +64,7 @@ class APIXmlrpc extends APIBaseClass {
                                                        'headers' => $headers]);
    }
 
-   protected function query($resource = "", $params = [], $expected_code = 200, $expected_symbol = '') {
+   protected function query($resource = "", $params = [], $expected_codes = 200, $expected_symbol = '') {
       //reconstruct params for xmlrpc (base params done for rest)
       $flat_params = array_merge($params,
                                  isset($params['query'])   ? $params['query']   : [],
@@ -81,7 +81,7 @@ class APIXmlrpc extends APIBaseClass {
          $res = $this->doHttpRequest($resource, $flat_params);
       } catch (\Exception $e) {
          $response = $e->getResponse();
-         $this->variable($response->getStatusCode())->isEqualTo($expected_code);
+         $this->variable($response->getStatusCode())->isEqualTo($expected_codes);
          $body = xmlrpc_decode($response->getBody());
          $this->array($body)
             ->hasKey('0')
@@ -92,7 +92,7 @@ class APIXmlrpc extends APIBaseClass {
       if (isset($this->last_error)) {
          $this->variable($res)->isNotNull();
       }
-      $this->variable($res->getStatusCode())->isEqualTo($expected_code);
+      $this->variable($res->getStatusCode())->isEqualTo($expected_codes);
       // retrieve data
       $data = xmlrpc_decode($res->getBody());
       if (is_array($data)) {

--- a/tests/web/deprecated/Computer_SoftwareLicense.class.php
+++ b/tests/web/deprecated/Computer_SoftwareLicense.class.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Tests\Web\Deprecated;
+
+/**
+ * @ignore
+ */
+class Computer_SoftwareLicense implements DeprecatedInterface {
+
+   public static function getDeprecatedType(): string {
+      return "Computer_SoftwareLicense";
+   }
+
+   public static function getCurrentType(): string {
+      return "Item_SoftwareLicense";
+   }
+
+   public static function getDeprecatedFields(): array {
+      return [
+        "id", "computers_id", "softwarelicenses_id", "is_deleted", "is_dynamic",
+        "links"
+      ];
+   }
+
+   public static function getCurrentAddInput(): array {
+      return [
+         "itemtype" => "Computer",
+         "items_id" => getItemByTypeName(
+            'Computer',
+            '_test_pc01',
+            true
+         ),
+         "softwarelicenses_id" => getItemByTypeName(
+            'SoftwareLicense',
+            '_test_softlic_1',
+            true
+         ),
+      ];
+   }
+
+   public static function getDeprecatedAddInput(): array {
+      return [
+         "computers_id" => getItemByTypeName(
+            'Computer',
+            '_test_pc01',
+            true
+         ),
+         "softwarelicenses_id" => getItemByTypeName(
+            'SoftwareLicense',
+            '_test_softlic_1',
+            true
+         ),
+      ];
+   }
+
+   public static function getDeprecatedUpdateInput(): array {
+      return [
+         'computers_id' => getItemByTypeName('Computer', '_test_pc02', true),
+      ];
+   }
+
+   public static function getExpectedAfterInsert(): array {
+      return [
+         "itemtype" => "Computer",
+         "items_id" => getItemByTypeName('Computer', '_test_pc01', true),
+      ];
+   }
+
+   public static function getExpectedAfterUpdate(): array {
+      return [
+         "itemtype" => "Computer",
+         "items_id" => getItemByTypeName('Computer', '_test_pc02', true),
+      ];
+   }
+
+   public static function getDeprecatedSearchQuery(): string {
+      return "forcedisplay[0]=2&rawdata=1";
+   }
+
+   public static function getCurrentSearchQuery(): string {
+      return "forcedisplay[0]=2&criteria[0][field]=6&criteria[0][searchtype]=equals&criteria[0][value]=Computer&rawdata=1";
+   }
+}

--- a/tests/web/deprecated/Computer_SoftwareVersion.class.php
+++ b/tests/web/deprecated/Computer_SoftwareVersion.class.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Tests\Web\Deprecated;
+
+/**
+ * @ignore
+ */
+class Computer_SoftwareVersion implements DeprecatedInterface {
+
+   public static function getDeprecatedType(): string {
+      return "Computer_SoftwareVersion";
+   }
+
+   public static function getCurrentType(): string {
+      return "Item_SoftwareVersion";
+   }
+
+   public static function getDeprecatedFields(): array {
+      return [
+        "id", "computers_id", "softwareversions_id", "is_deleted_computer",
+        "is_template_computer", "entities_id", "is_deleted", "is_dynamic",
+        "date_install", "links"
+      ];
+   }
+
+   public static function getCurrentAddInput(): array {
+      return [
+         "users_id" => TU_USER,
+         "itemtype" => "Computer",
+         "items_id" => getItemByTypeName(
+            'Computer',
+            '_test_pc01',
+            true
+         ),
+         "softwareversions_id" => getItemByTypeName(
+            'SoftwareVersion',
+            '_test_softver_1',
+            true
+         ),
+         "entities_id" => getItemByTypeName(
+            'Entity',
+            '_test_root_entity',
+            true
+         ),
+      ];
+   }
+
+   public static function getDeprecatedAddInput(): array {
+      return [
+         "users_id" => TU_USER,
+         "computers_id" => getItemByTypeName(
+            'Computer',
+            '_test_pc01',
+            true
+         ),
+         "softwareversions_id" => getItemByTypeName(
+            'SoftwareVersion',
+            '_test_softver_1',
+            true
+         ),
+         "entities_id" => getItemByTypeName(
+            'Entity',
+            '_test_root_entity',
+            true
+         ),
+      ];
+   }
+
+   public static function getDeprecatedUpdateInput(): array {
+      return [
+         'computers_id' => getItemByTypeName('Computer', '_test_pc02', true),
+      ];
+   }
+
+   public static function getExpectedAfterInsert(): array {
+      return [
+         "itemtype" => "Computer",
+         "items_id" => getItemByTypeName('Computer', '_test_pc01', true),
+      ];
+   }
+
+   public static function getExpectedAfterUpdate(): array {
+      return [
+         "itemtype" => "Computer",
+         "items_id" => getItemByTypeName('Computer', '_test_pc02', true),
+      ];
+   }
+
+   public static function getDeprecatedSearchQuery(): string {
+      return "forcedisplay[0]=2&rawdata=1";
+   }
+
+   public static function getCurrentSearchQuery(): string {
+      return "forcedisplay[0]=2&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=Computer&rawdata=1";
+   }
+}

--- a/tests/web/deprecated/DeprecatedInterface.class.php
+++ b/tests/web/deprecated/DeprecatedInterface.class.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Tests\Web\Deprecated;
+
+/**
+ * @ignore
+ */
+interface DeprecatedInterface {
+
+   /**
+    * Get deprecated type
+    * @return string
+    */
+   public static function getDeprecatedType(): string;
+
+   /**
+    * Get current type
+    * @return string
+    */
+   public static function getCurrentType(): string;
+
+   /**
+    * Get deprecated expected fields
+    * @return array
+    */
+   public static function getDeprecatedFields(): array;
+
+   /**
+    * Get current add input
+    * @return array
+    */
+   public static function getCurrentAddInput(): array;
+
+   /**
+    * Get deprecated add input
+    * @return array
+    */
+   public static function getDeprecatedAddInput(): array;
+
+   /**
+    * Get deprecated update input
+    * @return array
+    */
+   public static function getDeprecatedUpdateInput(): array;
+
+   /**
+    * Get expected data after insert
+    * @return array
+    */
+   public static function getExpectedAfterInsert(): array;
+
+   /**
+    * Get expected data after update
+    * @return array
+    */
+   public static function getExpectedAfterUpdate(): array;
+
+   /**
+    * Get deprecated search query
+    * @return string
+    */
+   public static function getDeprecatedSearchQuery(): string;
+
+   /**
+    * Get current search query
+    * @return string
+    */
+   public static function getCurrentSearchQuery(): string;
+}

--- a/tests/web/deprecated/TicketFollowup.class.php
+++ b/tests/web/deprecated/TicketFollowup.class.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Tests\Web\Deprecated;
+
+/**
+ * @ignore
+ */
+class TicketFollowup implements DeprecatedInterface {
+
+   public static function getDeprecatedType(): string {
+      return "TicketFollowup";
+   }
+
+   public static function getCurrentType(): string {
+      return "ITILFollowup";
+   }
+
+   public static function getDeprecatedFields(): array {
+      return [
+         "id", "tickets_id", "date", "users_id", "users_id_editor", "content",
+         "is_private", "requesttypes_id", "date_mod", "date_creation",
+         "timeline_position", "links"
+      ];
+   }
+
+   public static function getCurrentAddInput(): array {
+      return [
+         "users_id" => TU_USER,
+         "itemtype" => "Ticket",
+         "items_id" => getItemByTypeName('Ticket', '_ticket01', true),
+         "content"  => "New followup"
+      ];
+   }
+
+   public static function getDeprecatedAddInput(): array {
+      return [
+         'tickets_id' => getItemByTypeName('Ticket', '_ticket01', true),
+         'users_id'   => TU_USER,
+         'content'    => "Test insert deprecated",
+      ];
+   }
+
+   public static function getDeprecatedUpdateInput(): array {
+      return [
+         'tickets_id' => getItemByTypeName('Ticket', '_ticket02', true),
+      ];
+   }
+
+   public static function getExpectedAfterInsert(): array {
+      return [
+         "itemtype" => "Ticket",
+         "items_id" => getItemByTypeName('Ticket', '_ticket01', true),
+      ];
+   }
+
+   public static function getExpectedAfterUpdate(): array {
+      return [
+         "itemtype" => "Ticket",
+         "items_id" => getItemByTypeName('Ticket', '_ticket02', true),
+      ];
+   }
+
+   public static function getDeprecatedSearchQuery(): string {
+      return "forcedisplay[0]=2&rawdata=1";
+   }
+
+   public static function getCurrentSearchQuery(): string {
+      return "forcedisplay[0]=2&criteria[0][field]=6&criteria[0][searchtype]=equals&criteria[0][value]=Ticket&rawdata=1";
+   }
+}


### PR DESCRIPTION
Keep support of deprecated itemtypes in the API.

Each API calls that may concern a deprecated item (getItem, getItems, createItems, updateItems, deleteItems, listSearchOptions and search) will check the itemtype at the beginning of their execution.

If the itemtype is deprecated, it will be corrected (e.g. TicketFollowup -> ITILFollowup) and the API will remember that there is an ongoing depreciation.

Later during the call, some data will retrofitted before output to the deprecated specs and / or upgraded to the current spec before being used.

API stuff was moved to an API folder and a `Glpi\Api` namespace.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
