### PR TITLE
Anonymous support agents on helpdesk

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -5477,4 +5477,21 @@ class CommonDBTM extends CommonGLPI {
       }
       return '';
    }
+
+   /**
+    * Retrieve an item from the database
+    *
+    * @param integer $ID ID of the item to get
+    *
+    * @return boolean true if succeed else false
+   */
+   public static function getById(int $id) {
+      $item = new static();
+
+      if (!$item->getFromDB($id)) {
+         return false;
+      }
+
+      return $item;
+   }
 }

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6923,7 +6923,8 @@ abstract class CommonITILObject extends CommonDBTM {
                $userdata = getUserName($item_i['users_id'], 2);
                if (\Entity::getUsedConfig('anonymize_support_agents')
                   && \Session::getCurrentInterface() == 'helpdesk'
-                  && $item_i['timeline_position'] == self::TIMELINE_RIGHT) {
+                  && \ITILFollowup::getById($item_i['id'])->isFromSupportAgent()
+               ) {
                   echo __("Helpdesk");
                } else {
                   echo $user->getLink()."&nbsp;";

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6921,9 +6921,17 @@ abstract class CommonITILObject extends CommonDBTM {
 
                echo "<span class='h_user_name'>";
                $userdata = getUserName($item_i['users_id'], 2);
-               echo $user->getLink()."&nbsp;";
-               echo Html::showToolTip($userdata["comment"],
-                                      ['link' => $userdata['link']]);
+               if (\Entity::getUsedConfig('anonymize_support_agents')
+                  && \Session::getCurrentInterface() == 'helpdesk'
+                  && $item_i['timeline_position'] == self::TIMELINE_RIGHT) {
+                  echo __("Helpdesk");
+               } else {
+                  echo $user->getLink()."&nbsp;";
+                  echo Html::showToolTip(
+                     $userdata["comment"],
+                     ['link' => $userdata['link']]
+                  );
+               }
                echo "</span>";
             } else {
                echo __("Requester");

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6921,9 +6921,9 @@ abstract class CommonITILObject extends CommonDBTM {
 
                echo "<span class='h_user_name'>";
                $userdata = getUserName($item_i['users_id'], 2);
-               if (\Entity::getUsedConfig('anonymize_support_agents')
-                  && \Session::getCurrentInterface() == 'helpdesk'
-                  && \ITILFollowup::getById($item_i['id'])->isFromSupportAgent()
+               if (Entity::getUsedConfig('anonymize_support_agents')
+                  && Session::getCurrentInterface() == 'helpdesk'
+                  && ITILFollowup::getById($item_i['id'])->isFromSupportAgent()
                ) {
                   echo __("Helpdesk");
                } else {

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -63,56 +63,61 @@ class Entity extends CommonTreeDropdown {
 
    // Array of "right required to update" => array of fields allowed
    // Missing field here couldn't be update (no right)
-   private static $field_right = ['entity'
-                                          => [// Address
-                                                   'address', 'country', 'email', 'fax', 'notepad',
-                                                   'longitude','latitude','altitude',
-                                                   'phonenumber', 'postcode', 'state', 'town',
-                                                   'website',
-                                                   // Advanced (could be user_authtype ?)
-                                                   'authldaps_id', 'entity_ldapfilter', 'ldap_dn',
-                                                   'mail_domain', 'tag',
-                                                   // Inventory
-                                                   'entities_id_software', 'level', 'name',
-                                                   'completename', 'entities_id',
-                                                   'ancestors_cache', 'sons_cache', 'comment'],
-                                          // Inventory
-                                          'infocom'
-                                          => ['autofill_buy_date', 'autofill_delivery_date',
-                                                   'autofill_order_date', 'autofill_use_date',
-                                                   'autofill_warranty_date',
-                                                   'autofill_decommission_date'],
-                                          // Notification
-                                          'notification'
-                                          => ['admin_email', 'admin_reply', 'admin_email_name',
-                                                   'admin_reply_name', 'delay_send_emails',
-                                                   'is_notif_enable_default',
-                                                   'default_cartridges_alarm_threshold',
-                                                   'default_consumables_alarm_threshold',
-                                                   'default_contract_alert', 'default_infocom_alert',
-                                                   'mailing_signature', 'cartridges_alert_repeat',
-                                                   'consumables_alert_repeat', 'notclosed_delay',
-                                                   'use_licenses_alert', 'use_certificates_alert',
-                                                   'send_licenses_alert_before_delay',
-                                                   'send_certificates_alert_before_delay',
-                                                   'use_contracts_alert',
-                                                   'send_contracts_alert_before_delay',
-                                                   'use_reservations_alert', 'use_infocoms_alert',
-                                                   'send_infocoms_alert_before_delay',
-                                                   'notification_subject_tag', 'use_domains_alert',
-                                                   'send_domains_alert_close_expiries_delay', 'send_domains_alert_expired_delay'],
-                                          // Helpdesk
-                                          'entity_helpdesk'
-                                          => ['calendars_id', 'tickettype', 'auto_assign_mode',
-                                                   'autoclose_delay', 'inquest_config',
-                                                   'inquest_rate', 'inquest_delay',
-                                                   'inquest_duration','inquest_URL',
-                                                   'max_closedate', 'tickettemplates_id',
-                                                   'changetemplates_id', 'problemtemplates_id',
-                                                   'suppliers_as_private', 'autopurge_delay'],
-                                          // Configuration
-                                          'config'
-                                          => ['enable_custom_css', 'custom_css_code']];
+   private static $field_right = [
+      'entity' => [
+         // Address
+         'address', 'country', 'email', 'fax', 'notepad',
+         'longitude','latitude','altitude',
+         'phonenumber', 'postcode', 'state', 'town',
+         'website',
+         // Advanced (could be user_authtype ?)
+         'authldaps_id', 'entity_ldapfilter', 'ldap_dn',
+         'mail_domain', 'tag',
+         // Inventory
+         'entities_id_software', 'level', 'name',
+         'completename', 'entities_id',
+         'ancestors_cache', 'sons_cache', 'comment'
+      ],
+      // Inventory
+      'infocom' => [
+         'autofill_buy_date', 'autofill_delivery_date',
+         'autofill_order_date', 'autofill_use_date',
+         'autofill_warranty_date',
+         'autofill_decommission_date'
+      ],
+      // Notification
+      'notification' => [
+         'admin_email', 'admin_reply', 'admin_email_name',
+         'admin_reply_name', 'delay_send_emails',
+         'is_notif_enable_default',
+         'default_cartridges_alarm_threshold',
+         'default_consumables_alarm_threshold',
+         'default_contract_alert', 'default_infocom_alert',
+         'mailing_signature', 'cartridges_alert_repeat',
+         'consumables_alert_repeat', 'notclosed_delay',
+         'use_licenses_alert', 'use_certificates_alert',
+         'send_licenses_alert_before_delay',
+         'send_certificates_alert_before_delay',
+         'use_contracts_alert',
+         'send_contracts_alert_before_delay',
+         'use_reservations_alert', 'use_infocoms_alert',
+         'send_infocoms_alert_before_delay',
+         'notification_subject_tag', 'use_domains_alert',
+         'send_domains_alert_close_expiries_delay', 'send_domains_alert_expired_delay'
+      ],
+      // Helpdesk
+      'entity_helpdesk' => [
+         'calendars_id', 'tickettype', 'auto_assign_mode',
+         'autoclose_delay', 'inquest_config',
+         'inquest_rate', 'inquest_delay',
+         'inquest_duration','inquest_URL',
+         'max_closedate', 'tickettemplates_id',
+         'changetemplates_id', 'problemtemplates_id',
+         'suppliers_as_private', 'autopurge_delay', 'anonymize_support_agents'
+      ],
+      // Configuration
+      'config' => ['enable_custom_css', 'custom_css_code']
+   ];
 
 
    function getForbiddenStandardMassiveAction() {
@@ -2586,6 +2591,33 @@ class Entity extends CommonTreeDropdown {
       }
       echo "</td></tr>";
 
+      echo "<tr class='tab_bg_1'><td  colspan='2'>".__('Anonymize support agents')."</td>";
+      echo "<td colspan='2'>";
+      $anonymizeValues = self::getAnonymizeSupportAgentsValues();
+      $currentAnonymizeValue = $entity->fields['anonymize_support_agents'];
+
+      if ($ID == 0) { // Remove parent option for root entity
+         unset($anonymizeValues[self::CONFIG_PARENT]);
+      }
+
+      Dropdown::showFromArray(
+         'anonymize_support_agents',
+         $anonymizeValues,
+         ['value' => $currentAnonymizeValue]
+      );
+
+      // If the entity is using it's parent value, print it
+      if ($currentAnonymizeValue == self::CONFIG_PARENT && $ID != 0) {
+         $parentHelpdeskValue = self::getUsedConfig(
+            'anonymize_support_agents',
+            $entity->fields['entities_id']
+         );
+         echo "<font class='green'>&nbsp;&nbsp;";
+         echo $anonymizeValues[$parentHelpdeskValue];
+         echo "</font>";
+      }
+      echo "</td></tr>";
+
       echo "<tr><th colspan='4'>".__('Automatic closing configuration')."</th></tr>";
 
       echo "<tr class='tab_bg_1'>".
@@ -2776,7 +2808,12 @@ class Entity extends CommonTreeDropdown {
     * @param string  $fieldval       name of the field that we want value (default '')
     * @param mixed   $default_value  value to return (default -2)
    **/
-   static function getUsedConfig($fieldref, $entities_id, $fieldval = '', $default_value = -2) {
+   static function getUsedConfig($fieldref, $entities_id = null, $fieldval = '', $default_value = -2) {
+
+      // Get for current entity
+      if ($entities_id === null) {
+         $entities_id = \Session::getActiveEntity();
+      }
 
       // for calendar
       if (empty($fieldval)) {
@@ -2972,6 +3009,22 @@ class Entity extends CommonTreeDropdown {
          self::CONFIG_PARENT => __('Inheritance of the parent entity'),
          0                   => __('No'),
          1                   => __('Yes'),
+      ];
+   }
+
+   /**
+    * Get values for anonymize_support_agents
+    *
+    * @since 9.5
+    *
+    * @return array
+   **/
+   static function getAnonymizeSupportAgentsValues() {
+
+      return [
+         self::CONFIG_PARENT => __('Inheritance of the parent entity'),
+         0 => __('No'),
+         1 => __('Yes'),
       ];
    }
 

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -2812,7 +2812,7 @@ class Entity extends CommonTreeDropdown {
 
       // Get for current entity
       if ($entities_id === null) {
-         $entities_id = \Session::getActiveEntity();
+         $entities_id = Session::getActiveEntity();
       }
 
       // for calendar

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -6806,13 +6806,9 @@ JAVASCRIPT;
          }
 
          //  Tickets
-         if ((Session::haveRight("ticket", CREATE)
+         if (Session::haveRight("ticket", CREATE)
             || Session::haveRight("ticket", Ticket::READMY)
-            || Session::haveRight("followup", ITILFollowup::SEEPUBLIC))
-            && !(
-               Plugin::isPluginActive('formcreator')
-               && \Session::getCurrentInterface() == "helpdesk"
-            )
+            || Session::haveRight("followup", ITILFollowup::SEEPUBLIC)
          ) {
             $menu['tickets'] = [
                'default'   => '/front/ticket.php',
@@ -6839,6 +6835,8 @@ JAVASCRIPT;
             ];
          }
       }
+
+      $menu = Plugin::doHookFunction("redefine_menus", $menu);
 
       $already_used_shortcut = ['1'];
 

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -6806,9 +6806,14 @@ JAVASCRIPT;
          }
 
          //  Tickets
-         if (Session::haveRight("ticket", CREATE)
+         if ((Session::haveRight("ticket", CREATE)
             || Session::haveRight("ticket", Ticket::READMY)
-            || Session::haveRight("followup", ITILFollowup::SEEPUBLIC)) {
+            || Session::haveRight("followup", ITILFollowup::SEEPUBLIC))
+            && !(
+               Plugin::isPluginActive('formcreator')
+               && \Session::getCurrentInterface() == "helpdesk"
+            )
+         ) {
             $menu['tickets'] = [
                'default'   => '/front/ticket.php',
                'title'     => _n('Ticket', 'Tickets', Session::getPluralNumber()),

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -1206,4 +1206,33 @@ JAVASCRIPT;
    public static function getNameField() {
       return 'id';
    }
+
+   /**
+    * Check if this item author is a support agent
+    *
+    * @return bool
+    */
+   public function isFromSupportAgent() {
+      // Get parent item
+      $commonITILObject = new $this->fields['itemtype']();
+      $commonITILObject->getFromDB($this->fields['items_id']);
+
+      $actors = $commonITILObject->getITILActors();
+      $user_id = $this->fields['users_id'];
+      $roles = $actors[$user_id] ?? [];
+
+      if (in_array(CommonITILActor::ASSIGN, $roles)) {
+         // The author is a requested -> support agent
+         return true;
+      } else if (in_array(CommonITILActor::OBSERVER, $roles)
+         || in_array(CommonITILActor::REQUESTER, $roles)
+      ) {
+         // The author is an observer or a requester -> not a support agent
+         return false;
+      } else {
+         // The author is not an actor of the ticket -> he was most likely a
+         // support agent that is no longer assigned to the ticket
+         return true;
+      }
+   }
 }

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -1222,7 +1222,7 @@ JAVASCRIPT;
       $roles = $actors[$user_id] ?? [];
 
       if (in_array(CommonITILActor::ASSIGN, $roles)) {
-         // The author is a requested -> support agent
+         // The author is assigned -> support agent
          return true;
       } else if (in_array(CommonITILActor::OBSERVER, $roles)
          || in_array(CommonITILActor::REQUESTER, $roles)

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -403,7 +403,7 @@ class Migration {
             $this->change[$table][] = "ADD `$field` $format ".$params['comment'] ." ".
                                       $params['null'].$params['first'].$params['after'];
 
-            if (!empty($params['update'])) {
+            if ($params['update'] !== '') {
                $this->migrationOneTable($table);
                $query = "UPDATE `$table`
                         SET `$field` = ".$params['update']." ".

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1233,7 +1233,16 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
          foreach ($followups as $followup) {
             $tmp                             = [];
             $tmp['##followup.isprivate##']   = Dropdown::getYesNo($followup['is_private']);
-            $tmp['##followup.author##']      = Html::clean(getUserName($followup['users_id']));
+
+            // Check if the author need to be anonymized
+            if (\Entity::getUsedConfig('anonymize_support_agents')
+               && $followup['timeline_position'] = CommonITILObject::TIMELINE_RIGHT
+            ) {
+               $tmp['##followup.author##'] = __("Helpdesk");
+            } else {
+               $tmp['##followup.author##'] = Html::clean(getUserName($followup['users_id']));
+            }
+
             $tmp['##followup.requesttype##'] = Dropdown::getDropdownName('glpi_requesttypes',
                                                                          $followup['requesttypes_id']);
             $tmp['##followup.date##']        = Html::convDateTime($followup['date']);

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1235,8 +1235,8 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
             $tmp['##followup.isprivate##']   = Dropdown::getYesNo($followup['is_private']);
 
             // Check if the author need to be anonymized
-            if (\Entity::getUsedConfig('anonymize_support_agents')
-               && \ITILFollowup::getById($followup['id'])->isFromSupportAgent()
+            if (Entity::getUsedConfig('anonymize_support_agents')
+               && ITILFollowup::getById($followup['id'])->isFromSupportAgent()
             ) {
                $tmp['##followup.author##'] = __("Helpdesk");
             } else {

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1236,7 +1236,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
 
             // Check if the author need to be anonymized
             if (\Entity::getUsedConfig('anonymize_support_agents')
-               && $followup['timeline_position'] = CommonITILObject::TIMELINE_RIGHT
+               && \ITILFollowup::getById($followup['id'])->isFromSupportAgent()
             ) {
                $tmp['##followup.author##'] = __("Helpdesk");
             } else {

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5497,6 +5497,12 @@ JAVASCRIPT;
 
          switch ($table.'.'.$field) {
             case "glpi_users.name" :
+               if ($itemtype == 'Ticket'
+                  &&\Entity::getUsedConfig('anonymize_support_agents')
+                  && \Session::getCurrentInterface() == 'helpdesk') {
+                  return __("Helpdesk");
+               }
+
                // USER search case
                if (($itemtype != 'User')
                    && isset($so["forcegroupby"]) && $so["forcegroupby"]) {
@@ -5538,6 +5544,7 @@ JAVASCRIPT;
                         // Manage alternative_email for tickets_users
                         if (($itemtype == 'Ticket')
                             && isset($data[$ID][$k][2])) {
+
                            $split = explode(self::LONGSEP, $data[$ID][$k][2]);
                            for ($l=0; $l<count($split); $l++) {
                               $split2 = explode(" ", $split[$l]);

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5498,7 +5498,7 @@ JAVASCRIPT;
          switch ($table.'.'.$field) {
             case "glpi_users.name" :
                if ($itemtype == 'Ticket'
-                  &&\Entity::getUsedConfig('anonymize_support_agents')
+                  && \Entity::getUsedConfig('anonymize_support_agents')
                   && \Session::getCurrentInterface() == 'helpdesk') {
                   return __("Helpdesk");
                }

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5498,8 +5498,8 @@ JAVASCRIPT;
          switch ($table.'.'.$field) {
             case "glpi_users.name" :
                if ($itemtype == 'Ticket'
-                  && \Entity::getUsedConfig('anonymize_support_agents')
-                  && \Session::getCurrentInterface() == 'helpdesk') {
+                  && Entity::getUsedConfig('anonymize_support_agents')
+                  && Session::getCurrentInterface() == 'helpdesk') {
                   return __("Helpdesk");
                }
 

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -1396,4 +1396,15 @@ class Session {
    static function mustChangePassword() {
       return array_key_exists('glpi_password_expired', $_SESSION);
    }
+
+   /**
+    * Get active entity id.
+    *
+    * @since 9.5
+    *
+    * @return int
+    */
+   public static function getActiveEntity() {
+      return $_SESSION['glpiactive_entity'];
+   }
 }

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -2064,6 +2064,7 @@ $tables['glpi_entities'] = [
       'autofill_decommission_date'           => 0,
       'suppliers_as_private'                 => 0,
       'enable_custom_css'                    => 0,
+      'anonymize_support_agents'             => 0,
    ],
 ];
 

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -2543,6 +2543,7 @@ CREATE TABLE `glpi_entities` (
   `date_creation` timestamp NULL DEFAULT NULL,
   `autofill_decommission_date` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '-2',
   `suppliers_as_private` int(11) NOT NULL DEFAULT '-2',
+  `anonymize_support_agents` int(11) NOT NULL DEFAULT '-2',
   `enable_custom_css` int(11) NOT NULL DEFAULT '-2',
   `custom_css_code` text COLLATE utf8_unicode_ci,
   `latitude` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -1678,6 +1678,21 @@ HTML
       )
    );
 
+   // Add anonymize_support_agents to entity
+   if (!$DB->fieldExists("glpi_entities", "anonymize_support_agents")) {
+      $migration->addField(
+         "glpi_entities",
+         "anonymize_support_agents",
+         "integer",
+         [
+            'after'     => "suppliers_as_private",
+            'value'     => -2,               // Inherit as default value
+            'update'    => '0',              // Not enabled for root entity
+            'condition' => 'WHERE `id` = 0'
+         ]
+      );
+   }
+
    $migration->executeMigration();
 
    return $updateresult;

--- a/tests/functionnal/ITILFollowup.php
+++ b/tests/functionnal/ITILFollowup.php
@@ -32,7 +32,11 @@
 
 namespace tests\units;
 
+use CommonITILActor;
 use \DbTestCase;
+use ITILFollowup as CoreITILFollowup;
+use Ticket;
+use Ticket_User;
 
 /* Test for inc/itilfollowup.class.php */
 
@@ -275,24 +279,24 @@ class ITILFollowup extends DbTestCase {
          ],
          [
             // Case 2: user is a requester
-            "roles"    => [\CommonITILActor::REQUESTER],
+            "roles"    => [CommonITILActor::REQUESTER],
             "expected" => false,
          ],
          [
             // Case 3: user is an observer
-            "roles"    => [\CommonITILActor::OBSERVER],
+            "roles"    => [CommonITILActor::OBSERVER],
             "expected" => false,
          ],
          [
             // Case 4: user is assigned
-            "roles"    => [\CommonITILActor::ASSIGN],
+            "roles"    => [CommonITILActor::ASSIGN],
             "expected" => true,
          ],
          [
             // Case 5: user is observer and assigned
             "roles"    => [
-               \CommonITILActor::OBSERVER,
-               \CommonITILActor::ASSIGN,
+               CommonITILActor::OBSERVER,
+               CommonITILActor::ASSIGN,
             ],
             "expected" => true,
          ],
@@ -315,7 +319,7 @@ class ITILFollowup extends DbTestCase {
       $this->login();
 
       // Insert a ticket;
-      $ticket = new \Ticket();
+      $ticket = new Ticket();
       $ticket_id = $ticket->add([
          "name"    => "testIsFromSupportAgent",
          "content" => "testIsFromSupportAgent",
@@ -324,7 +328,7 @@ class ITILFollowup extends DbTestCase {
 
       // Insert a followup
       $user1 = getItemByTypeName('User', TU_USER, true);
-      $fup = new \ITILFollowup;
+      $fup = new CoreITILFollowup();
       $fup_id = $fup->add([
          'content'  => "testIsFromSupportAgent",
          'users_id' => $user1,
@@ -335,11 +339,11 @@ class ITILFollowup extends DbTestCase {
       $this->boolean($fup->getFromDB($fup_id))->isTrue();
 
       // Remove any roles that may have been set after insert
-      $DB->delete(\Ticket_User::getTable(), ['tickets_id' => $ticket_id]);
+      $DB->delete(Ticket_User::getTable(), ['tickets_id' => $ticket_id]);
       $this->array($ticket->getITILActors())->hasSize(0);
 
       // Insert roles
-      $tuser = new \Ticket_User();
+      $tuser = new Ticket_User();
       foreach ($roles as $role) {
          $this->integer($tuser->add([
             'tickets_id' => $ticket_id,

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -416,6 +416,16 @@ class Migration extends \GLPITestCase {
             'format'    => 'integer',
             'options'   => ['first' => true],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` INT(11) NOT NULL DEFAULT '0'   FIRST  "
+         ], [
+            'table'     => 'my_table',
+            'field'     => 'my_field',
+            'format'    => 'integer',
+            'options'   => ['value' => '-2', 'update' => '0', 'condition' => 'WHERE `id` = 0'],
+            'sql'       => [
+               "ALTER TABLE `my_table` ADD `my_field` INT(11) NOT NULL DEFAULT '-2'   ",
+               "UPDATE `my_table`
+                        SET `my_field` = 0 WHERE `id` = 0",
+            ]
          ]
       ];
    }
@@ -436,7 +446,11 @@ class Migration extends \GLPITestCase {
          }
       )->isIdenticalTo("Change of the database layout - my_tableTask completed.");
 
-      $this->array($this->queries)->isIdenticalTo([$sql]);
+      if (!is_array($sql)) {
+         $sql = [$sql];
+      }
+
+      $this->array($this->queries)->isIdenticalTo($sql);
    }
 
    public function testFormatBooleanBadDefault() {


### PR DESCRIPTION
Add a new entity setting to enable anonymization of support agents on the helpdesk.

Linked to https://github.com/pluginsGLPI/formcreator/pull/1694.

Internal ref: 16950.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
