### PR TITLE
fix(html): fix wrong colspan

### DIFF
--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -710,7 +710,7 @@ class Reminder extends CommonDBVisible {
 
       $this->showFormHeader($options);
 
-      echo "<tr class='tab_bg_2'><td colspan='2'>".__('Title')."</td>";
+      echo "<tr class='tab_bg_2'><td>".__('Title')."</td>";
       echo "<td colspan='2'>";
       if (!$ID) {
          echo "<input type='hidden' name='users_id' value='".$this->fields['users_id']."'>\n";
@@ -732,7 +732,7 @@ class Reminder extends CommonDBVisible {
 
       if (!isset($options['from_planning_ajax'])) {
          echo "<tr class='tab_bg_2'>";
-         echo "<td colspan='2'>".__('Visibility')."</td>";
+         echo "<td>".__('Visibility')."</td>";
          echo "<td colspan='2'>";
          echo '<table><tr><td>';
          echo __('Begin').'</td><td>';
@@ -753,7 +753,7 @@ class Reminder extends CommonDBVisible {
       }
 
       echo "<tr class='tab_bg_2'>";
-      echo "<td colspan='2'>".__('Status')."</td>";
+      echo "<td>".__('Status')."</td>";
       echo "<td colspan='2'>";
       if ($canedit) {
          Planning::dropdownState("state", $this->fields["state"]);
@@ -763,7 +763,7 @@ class Reminder extends CommonDBVisible {
       echo "</td>\n";
       echo "</tr>\n";
 
-      echo "<tr class='tab_bg_2'><td  colspan='2'>".__('Calendar')."</td>";
+      echo "<tr class='tab_bg_2'><td>".__('Calendar')."</td>";
       $active_recall = ($ID && $this->fields["is_planned"] && PlanningRecall::isAvailable());
 
       echo "<td";


### PR DESCRIPTION
When adding new fields with plugin fields on reminder object, 

the HTML display is bad

![image](https://user-images.githubusercontent.com/7335054/76527106-f5214580-646e-11ea-960e-125868650875.png)

this PR fix this

after : 

![image](https://user-images.githubusercontent.com/7335054/76527139-01a59e00-646f-11ea-937c-e30ebda1867e.png)

See 

https://github.com/pluginsGLPI/fields/issues/370

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
