### PR TITLE
API: fix search requests on ITILFollowup

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3626,14 +3626,18 @@ JAVASCRIPT;
          case "glpi_itilfollowups.content":
          case "glpi_tickettasks.content":
          case "glpi_changetasks.content":
+            if (is_subclass_of($itemtype, "CommonITILObject")) {
                // force ordering by date desc
-               return " GROUP_CONCAT(DISTINCT CONCAT(IFNULL($tocompute, '".self::NULLVALUE."'),
-                                               '".self::SHORTSEP."',$tocomputeid)
-                                     ORDER BY `$table$addtable`.`date` DESC
-                                     SEPARATOR '".self::LONGSEP."')
-                                    AS `".$NAME."`,
-
-                       $ADDITONALFIELDS";
+               return " GROUP_CONCAT(
+                  DISTINCT CONCAT(
+                     IFNULL($tocompute, '".self::NULLVALUE."'),
+                     '".self::SHORTSEP."',
+                     $tocomputeid
+                  )
+                  ORDER BY `$table$addtable`.`date` DESC
+                  SEPARATOR '".self::LONGSEP."'
+               ) AS `".$NAME."`, $ADDITONALFIELDS";
+            }
             break;
 
          default:


### PR DESCRIPTION
Executing a search request on ITILFollowups gives 40+ warnings and incorrect results because of a group_concat on the content fields (each results are empty except the first which contains ALL the data in his content fields).

![image](https://user-images.githubusercontent.com/42734840/76532011-4ed93e00-6476-11ea-889c-41a849cba592.png)

I've fixed it by adding a check on the itemtype so the group_concat clause is only added when the source of the search is a `CommonITILObject` and also improved the SQL readability.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
