### PR TITLE
Prevent useless caching of names that does not require any computation

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -5450,6 +5450,10 @@ class CommonDBTM extends CommonGLPI {
    final public function getFriendlyName() {
       global $GLPI_CACHE;
 
+      if (!method_exists($this, 'computeFriendlyName')) {
+         return $this->fields[static::getNameField()] ?? '';
+      }
+
       $cache_key = self::getCacheKeyForFriendlyName(
          self::getType(),
          $this->getID()
@@ -5468,20 +5472,6 @@ class CommonDBTM extends CommonGLPI {
       }
 
       return $name;
-   }
-
-   /**
-    * Compute the friendly name of the object
-    *
-    * @since 9.5
-    *
-    * @return string
-    */
-   protected function computeFriendlyName() {
-      if (isset($this->fields[static::getNameField()])) {
-         return $this->fields[static::getNameField()];
-      }
-      return '';
    }
 
    /**

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -558,7 +558,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
 
    // SPECIFIC FUNCTIONS
-   public function computeFriendlyName() {
+   protected function computeFriendlyName() {
 
       if (isset($this->fields['taskcategories_id'])) {
          if ($this->fields['taskcategories_id']) {

--- a/inc/contact.class.php
+++ b/inc/contact.class.php
@@ -260,7 +260,7 @@ class Contact extends CommonDBTM{
    }
 
 
-   public function computeFriendlyName() {
+   protected function computeFriendlyName() {
 
       if (isset($this->fields["id"]) && ($this->fields["id"] > 0)) {
          return formatUserName('',

--- a/inc/item_devices.class.php
+++ b/inc/item_devices.class.php
@@ -80,7 +80,7 @@ class Item_Devices extends CommonDBRelation {
       return true;
    }
 
-   public function computeFriendlyName() {
+   protected function computeFriendlyName() {
       $itemtype = static::$itemtype_2;
       if (!empty($this->fields[static::$itemtype_1])) {
          $item = new $this->fields[static::$itemtype_1];

--- a/inc/item_operatingsystem.class.php
+++ b/inc/item_operatingsystem.class.php
@@ -342,7 +342,7 @@ class Item_OperatingSystem extends CommonDBRelation {
       $this->showFormButtons($options);
    }
 
-   public function computeFriendlyName() {
+   protected function computeFriendlyName() {
       $item = getItemForItemtype($this->fields['itemtype']);
       $item->getFromDB($this->fields['items_id']);
       $name = $item->getTypeName(1) . ' ' . $item->getName();

--- a/inc/item_rack.class.php
+++ b/inc/item_rack.class.php
@@ -1075,7 +1075,7 @@ JAVASCRIPT;
       return $input;
    }
 
-   public function computeFriendlyName() {
+   protected function computeFriendlyName() {
       $rack = new Rack();
       $rack->getFromDB($this->fields['racks_id']);
       $name = sprintf(

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -472,7 +472,7 @@ class ITILFollowup  extends CommonDBChild {
    }
 
 
-   public function computeFriendlyName() {
+   protected function computeFriendlyName() {
 
       if (isset($this->fields['requesttypes_id'])) {
          if ($this->fields['requesttypes_id']) {

--- a/inc/itiltemplatefield.class.php
+++ b/inc/itiltemplatefield.class.php
@@ -75,7 +75,7 @@ abstract class ITILTemplateField extends CommonDBChild {
    }
 
 
-   function computeFriendlyName() {
+   protected function computeFriendlyName() {
       $tt_class = static::$itemtype;
       $tt     = new $tt_class;
       $fields = $tt->getAllowedFieldsNames(true);

--- a/inc/itiltemplatepredefinedfield.class.php
+++ b/inc/itiltemplatepredefinedfield.class.php
@@ -49,7 +49,7 @@ class ITILTemplatePredefinedField extends ITILTemplateField {
    }
 
 
-   function computeFriendlyName() {
+   protected function computeFriendlyName() {
 
       $tt_class = static::$itemtype;
       $tt     = new $tt_class;

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -226,7 +226,7 @@ class NotificationTarget extends CommonDBChild {
       return _n('Recipient', 'Recipients', $nb);
    }
 
-   public function computeFriendlyName() {
+   protected function computeFriendlyName() {
 
       if (isset($this->notification_targets_labels[$this->getField("type")]
                                                   [$this->getField("items_id")])) {

--- a/inc/notificationtemplatetranslation.class.php
+++ b/inc/notificationtemplatetranslation.class.php
@@ -62,7 +62,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
    }
 
 
-   public function computeFriendlyName() {
+   protected function computeFriendlyName() {
       global $CFG_GLPI;
 
       if ($this->getField('language') != '') {

--- a/inc/operatingsystemkernelversion.class.php
+++ b/inc/operatingsystemkernelversion.class.php
@@ -62,7 +62,7 @@ class OperatingSystemKernelVersion extends CommonDropdown {
       }
    }
 
-   public function computeFriendlyName() {
+   protected function computeFriendlyName() {
       $kvname = parent::computeFriendlyName();
 
       return trim($kvname);

--- a/inc/operatingsystemkernelversion.class.php
+++ b/inc/operatingsystemkernelversion.class.php
@@ -61,10 +61,4 @@ class OperatingSystemKernelVersion extends CommonDropdown {
             break;
       }
    }
-
-   protected function computeFriendlyName() {
-      $kvname = parent::computeFriendlyName();
-
-      return trim($kvname);
-   }
 }

--- a/inc/profile_user.class.php
+++ b/inc/profile_user.class.php
@@ -957,7 +957,7 @@ class Profile_User extends CommonDBRelation {
       return _n('Profile', 'Profiles', $nb);
    }
 
-   public function computeFriendlyName() {
+   protected function computeFriendlyName() {
 
       $name = sprintf(__('%1$s, %2$s'),
                       Dropdown::getDropdownName('glpi_profiles', $this->fields['profiles_id']),

--- a/inc/ruleaction.class.php
+++ b/inc/ruleaction.class.php
@@ -89,7 +89,7 @@ class RuleAction extends CommonDBChild {
       return _n('Action', 'Actions', $nb);
    }
 
-   public function computeFriendlyName() {
+   protected function computeFriendlyName() {
 
       if ($rule = getItemForItemtype(static::$itemtype)) {
          return Html::clean($rule->getMinimalActionText($this->fields));

--- a/inc/rulecriteria.class.php
+++ b/inc/rulecriteria.class.php
@@ -92,7 +92,7 @@ class RuleCriteria extends CommonDBChild {
       return _n('Criterion', 'Criteria', $nb);
    }
 
-   public function computeFriendlyName() {
+   protected function computeFriendlyName() {
 
       if ($rule = getItemForItemtype(static::$itemtype)) {
          return Html::clean($rule->getMinimalCriteriaText($this->fields));

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -1353,7 +1353,7 @@ class User extends CommonDBTM {
       }
    }
 
-   function computeFriendlyName() {
+   protected function computeFriendlyName() {
       global $CFG_GLPI;
 
       if (isset($this->fields["id"]) && ($this->fields["id"] > 0)) {

--- a/tests/functionnal/RuleCriteria.php
+++ b/tests/functionnal/RuleCriteria.php
@@ -100,7 +100,7 @@ class RuleCriteria extends DbTestCase {
       $this->integer((int)$criteria_id)->isGreaterThan(0);
 
       $this->boolean($criteria->getFromDB($criteria_id))->isTrue();
-      $this->string($criteria->computeFriendlyName())->isIdenticalTo('SoftwareisMozilla Firefox 52');
+      $this->string($criteria->getFriendlyName())->isIdenticalTo('SoftwareisMozilla Firefox 52');
    }
 
    public function testPost_addItem() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Most of items does not base their friendly name on any computation. Caching them will produce cache overhead for no gain. It can happens when using `CommonDBTM::getName()` method, wich is commonly used in core.