### PR TITLE
Impact UX tweaks

### DIFF
--- a/css/impact.scss
+++ b/css/impact.scss
@@ -386,7 +386,7 @@ i.fa-impact-manipulation {
       }
 
       &.impact-separator {
-         border-top: 2px solid #eeeeee;
+         border-top: 2px solid #dfdfdf;
       }
    }
 

--- a/js/impact.js
+++ b/js/impact.js
@@ -773,7 +773,9 @@ var GLPIImpact = {
          {
             selector: '[id="tmp_node"]',
             style: {
-               'display': 'none',
+               // Use opacity instead of display none here as this will make
+               // the edges connected to this node still visible
+               'opacity': 0,
             }
          },
          {
@@ -789,6 +791,17 @@ var GLPIImpact = {
                'target-endpoint'          : 'outside-to-node-or-label',
                'source-distance-from-node': '2px',
                'target-distance-from-node': '2px',
+            }
+         },
+         {
+            selector: 'edge[target="tmp_node"]',
+            style: {
+               // We want the arrow to go exactly where the cursor of the user
+               // is on the graph, no padding.
+               'source-endpoint'          : 'inside-to-node',
+               'target-endpoint'          : 'inside-to-node',
+               'source-distance-from-node': '0px',
+               'target-distance-from-node': '0px',
             }
          },
          {


### PR DESCRIPTION
Edge "preview" when adding a new edge was not shown anymore because of the change to `opacity: 0` -> `display: none` (edges for non displayed node are hidden automatically).

Fixed by using opacity again in this unique case + added a new rule to avoid padding for this case too, as we want the "preview" edge to match the cursor position.

Before removing padding:
![image](https://user-images.githubusercontent.com/42734840/77044747-432ecf80-69c0-11ea-9591-f6ba74a8b709.png)


After removing padding:
![image](https://user-images.githubusercontent.com/42734840/77044541-e9c6a080-69bf-11ea-915f-2e0bf45802c7.png)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
