### PR TITLE
FIX: prevent loading 10 year or reccurence when passing to the listVi…

### DIFF
--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -2215,18 +2215,10 @@ class Planning extends CommonGLPI {
     * @return string
    **/
    static function displayPlanningItem(array $val, $who, $type = "", $complete = 0) {
-      global $GLPI_CACHE;
-
-      $cache_key = "planning_display_item_".sha1(json_encode(func_get_args()));
-      if ($GLPI_CACHE->has($cache_key)) {
-         return $GLPI_CACHE->get($cache_key);
-      }
-
       $html = "";
       // Plugins case
       if (isset($val['itemtype']) && !empty($val['itemtype']) && $val['itemtype'] != 'NotPlanned') {
          $html.= $val['itemtype']::displayPlanningItem($val, $who, $type, $complete);
-         $GLPI_CACHE->set($cache_key, $html);
       }
 
       return $html;

--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -1666,6 +1666,7 @@ class Planning extends CommonGLPI {
     *  - end: mandatory, planning end.
     *       (should be an ISO_8601 date, but could be anything wo can be parsed by strtotime)
     *  - display_done_events: default true, show also events tagged as done
+    *  - force_all_events: even if the range is big, don't reduce the returned set
     * @return array $events : array with events in fullcalendar.io format
     */
    static function constructEventsArray($options = []) {
@@ -1675,6 +1676,7 @@ class Planning extends CommonGLPI {
       $param['end']                 = '';
       $param['view_name']           = '';
       $param['display_done_events'] = true;
+      $param['force_all_events']    = false;
 
       if (is_array($options) && count($options)) {
          foreach ($options as $key => $val) {
@@ -1688,7 +1690,8 @@ class Planning extends CommonGLPI {
       // if the dates range is greater than a certain amount, and we're not on a list view
       // we certainly are on this view (as our biggest view apart list is month one).
       // we must avoid at all cost to calculate rrules events on a big range
-      if ($param['view_name'] != "listFull"
+      if (!$param['force_all_events']
+          && $param['view_name'] != "listFull"
           && ($time_end - $time_begin) > (2 * MONTH_TIMESTAMP)) {
          $param['view_name'] = "listFull";
          return [];

--- a/inc/planningevent.class.php
+++ b/inc/planningevent.class.php
@@ -432,7 +432,7 @@ trait PlanningEvent {
       $WHERE = [
          'begin' => ['<', $end],
          'end'   => ['>', $begin]
-      ] + $NASSIGN;
+      ] + [$NASSIGN]; // "encapsulate" nassign to prevent OR overriding
 
       if ($DB->fieldExists($table, 'is_planned')) {
          $WHERE["$table.is_planned"] = 1;
@@ -443,11 +443,13 @@ trait PlanningEvent {
       }
 
       if (!$options['display_done_events']) {
-         $WHERE['OR'] = [
-            'state'  => Planning::TODO,
-            'AND'    => [
-               'state'  => Planning::INFO,
-               'end'    => ['>', new \QueryExpression('NOW()')]
+         $WHERE[] = [
+            'OR' => [
+               'state'  => Planning::TODO,
+               'AND'    => [
+                  'state'  => Planning::INFO,
+                  'end'    => ['>', new \QueryExpression('NOW()')]
+               ]
             ]
          ];
       }

--- a/js/planning.js
+++ b/js/planning.js
@@ -253,11 +253,6 @@ var GLPIPlanning  = {
          viewSkeletonRender: function(info) {
             var view_type = info.view.type;
 
-            // forece refetch events when view changed (avoid to do it on initial render)
-            if (GLPIPlanning.last_view !== null) {
-               GLPIPlanning.refresh();
-            }
-
             GLPIPlanning.last_view = view_type;
             // inform backend we changed view (to store it in session)
             $.ajax({

--- a/tests/functionnal/Planning.php
+++ b/tests/functionnal/Planning.php
@@ -136,8 +136,9 @@ class Planning extends \DbTestCase {
       // Fetch all events
       $all_events = \Planning::constructEventsArray(
          [
-            'start' => '2000-01-01 00:00:00',
-            'end'   => '2050-12-31 23:59:59',
+            'start'     => '2000-01-01 00:00:00',
+            'end'       => '2050-12-31 23:59:59',
+            'view_name' => 'listFull',
          ]
       );
       // Fetch events only for a given month

--- a/tests/functionnal/Planning.php
+++ b/tests/functionnal/Planning.php
@@ -136,9 +136,9 @@ class Planning extends \DbTestCase {
       // Fetch all events
       $all_events = \Planning::constructEventsArray(
          [
-            'start'     => '2000-01-01 00:00:00',
-            'end'       => '2050-12-31 23:59:59',
-            'view_name' => 'listFull',
+            'start'            => '2000-01-01 00:00:00',
+            'end'              => '2050-12-31 23:59:59',
+            'force_all_events' => true
          ]
       );
       // Fetch events only for a given month


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

On planning, we have different views to switch on the top right.

![image](https://user-images.githubusercontent.com/418844/77046018-89852e00-69c2-11ea-9c45-a6c508030f34.png)

"My planning" is a special view listing all non-done events in the past and the future.
To prevent infinite load, we limit to -/+5years and reccurent event, are displayed only for their next occurence.

Issue is when, we switch from a normal view (like month one) to list View, [fullcalendar do an ajax query to check if previous view is valid](https://fullcalendar.io/docs/visibleRange#when-it-gets-called) and so we call a 10 years range of calculation with reccuring events on.

consequence, very high load (from 1.5s  to 45s in my case).


I added some modifications to inc/planningevent.class.php as i realized some iterator parts are erased by others (OR cases)



