### PR TITLE
Fix handling of ITIL documents

### DIFF
--- a/front/change.form.php
+++ b/front/change.form.php
@@ -105,13 +105,13 @@ if (isset($_POST["add"])) {
               sprintf(__('%s adds an actor'), $_SESSION["glpiname"]));
    Html::redirect(Change::getFormURLWithID($_POST['changes_id']));
 } else if (isset($_REQUEST['delete_document'])) {
+   $change->getFromDB((int)$_REQUEST['changes_id']);
    $doc = new Document();
    $doc->getFromDB(intval($_REQUEST['documents_id']));
    if ($doc->can($doc->getID(), UPDATE)) {
       $document_item = new Document_Item;
       $found_document_items = $document_item->find([
-         'itemtype'     => 'Change',
-         'items_id'     => (int)$_REQUEST['changes_id'],
+         $change->getAssociatedDocumentsCriteria(),
          'documents_id' => $doc->getID()
       ]);
       foreach ($found_document_items  as $item) {

--- a/front/problem.form.php
+++ b/front/problem.form.php
@@ -108,13 +108,13 @@ if (isset($_POST["add"])) {
               sprintf(__('%s adds an actor'), $_SESSION["glpiname"]));
    Html::redirect($problem->getFormURLWithID($_POST['problems_id']));
 } else if (isset($_REQUEST['delete_document'])) {
+   $problem->getFromDB((int)$_REQUEST['problems_id']);
    $doc = new Document();
    $doc->getFromDB(intval($_REQUEST['documents_id']));
    if ($doc->can($doc->getID(), UPDATE)) {
       $document_item = new Document_Item;
       $found_document_items = $document_item->find([
-         'itemtype'     => 'Problem',
-         'items_id'     => (int)$_REQUEST['problems_id'],
+         $problem->getAssociatedDocumentsCriteria(),
          'documents_id' => $doc->getID()
       ]);
       foreach ($found_document_items  as $item) {

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -185,13 +185,13 @@ if (isset($_POST["add"])) {
               sprintf(__('%s adds an actor'), $_SESSION["glpiname"]));
    Html::redirect(Ticket::getFormURLWithID($_POST['tickets_id']));
 } else if (isset($_REQUEST['delete_document'])) {
+   $track->getFromDB((int)$_REQUEST['tickets_id']);
    $doc = new Document();
    $doc->getFromDB(intval($_REQUEST['documents_id']));
    if ($doc->can($doc->getID(), UPDATE)) {
       $document_item = new Document_Item;
       $found_document_items = $document_item->find([
-         'itemtype'     => 'Ticket',
-         'items_id'     => (int)$_REQUEST['tickets_id'],
+         $track->getAssociatedDocumentsCriteria(),
          'documents_id' => $doc->getID()
       ]);
       foreach ($found_document_items  as $item) {

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -937,7 +937,7 @@ abstract class API extends CommonGLPI {
                $doc_criteria = [
                   $item->getAssociatedDocumentsCriteria(),
                   'timeline_position' => ['>', CommonITILObject::NO_TIMELINE], // skip inlined images
-               ]
+               ];
             }
             $doc_iterator = $DB->request([
                'SELECT'    => [

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -929,6 +929,16 @@ abstract class API extends CommonGLPI {
              && !Document::canView()) {
             $fields['_documents'] = self::arrayRightError();
          } else {
+            $doc_criteria = [
+               'glpi_documents_items.items_id'  => $id,
+               'glpi_documents_items.itemtype'  => $itemtype
+            ];
+            if ($item instanceof CommonITILObject) {
+               $doc_criteria = [
+                  $item->getAssociatedDocumentsCriteria(),
+                  'timeline_position' => ['>', CommonITILObject::NO_TIMELINE], // skip inlined images
+               ]
+            }
             $doc_iterator = $DB->request([
                'SELECT'    => [
                   'glpi_documents_items.id AS assocID',
@@ -959,10 +969,7 @@ abstract class API extends CommonGLPI {
                      ]
                   ]
                ],
-               'WHERE'     => [
-                  'glpi_documents_items.items_id'  => $id,
-                  'glpi_documents_items.itemtype'  => $itemtype
-               ]
+               'WHERE'     => $doc_criteria,
             ]);
             while ($data = $doc_iterator->next()) {
                $fields['_documents'][] = $data;

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7885,8 +7885,7 @@ abstract class CommonITILObject extends CommonDBTM {
     *
     * @return array
     */
-   public function getAssociatedDocumentsCriteria(): array
-   {
+   public function getAssociatedDocumentsCriteria(): array {
       $task_class = $this->getType() . 'Task';
 
       return [

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7912,6 +7912,19 @@ abstract class CommonITILObject extends CommonDBTM {
                ),
             ],
             [
+               Document_Item::getTableField('itemtype') => ITILSolution::getType(),
+               Document_Item::getTableField('items_id') => new QuerySubQuery(
+                  [
+                     'SELECT' => 'id',
+                     'FROM'   => ITILSolution::getTable(),
+                     'WHERE'  => [
+                        ITILSolution::getTableField('itemtype') => $this->getType(),
+                        ITILSolution::getTableField('items_id') => $this->getID(),
+                     ],
+                  ]
+               ),
+            ],
+            [
                'glpi_documents_items.itemtype' => $task_class::getType(),
                'glpi_documents_items.items_id' => new QuerySubQuery(
                   [

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6686,6 +6686,7 @@ abstract class CommonITILObject extends CommonDBTM {
       $taskClass             = $objType."Task";
       $task_obj              = new $taskClass;
       $document_item_obj     = new Document_Item();
+      $doc_items_or_crit = [];
       if ($supportsValidation) {
          $validation_class    = $objType."Validation";
          $valitation_obj     = new $validation_class;
@@ -6723,6 +6724,10 @@ abstract class CommonITILObject extends CommonDBTM {
             $timeline[$followup['date']."_followup_".$followups_id] = ['type' => $fupClass,
                                                                             'item' => $followup,
                                                                             'itiltype' => 'Followup'];
+            $doc_items_or_crit[] = [
+               'itemtype' => $followup_obj->getType(),
+               'items_id' => $followups_id,
+            ];
          }
       }
 
@@ -6735,14 +6740,21 @@ abstract class CommonITILObject extends CommonDBTM {
             $timeline[$task['date']."_task_".$tasks_id] = ['type' => $taskClass,
                                                                 'item' => $task,
                                                                 'itiltype' => 'Task'];
+            $doc_items_or_crit[] = [
+               'itemtype' => $task_obj->getType(),
+               'items_id' => $tasks_id,
+            ];
          }
       }
 
       //add documents to timeline
       $document_obj   = new Document();
+      $doc_items_or_crit[] = [
+         'itemtype' => $objType,
+         'items_id' => $this->getID(),
+      ];
       $document_items = $document_item_obj->find([
-         'itemtype'           => $objType,
-         'items_id'           => $this->getID(),
+         'OR' => $doc_items_or_crit,
          'timeline_position'  => ['>', self::NO_TIMELINE]
       ]);
       foreach ($document_items as $document_item) {

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7885,7 +7885,7 @@ abstract class CommonITILObject extends CommonDBTM {
     *
     * @return array
     */
-   public function getAssociatedDocumentsCriteria(): array {
+   public function getAssociatedDocumentsCriteria($force_privates = false): array {
       $task_class = $this->getType() . 'Task';
 
       return [
@@ -7903,7 +7903,7 @@ abstract class CommonITILObject extends CommonDBTM {
                      'WHERE'  => [
                         ITILFollowup::getTableField('itemtype') => $this->getType(),
                         ITILFollowup::getTableField('items_id') => $this->getID(),
-                        'OR' => !Session::haveRight('followup', ITILFollowup::SEEPRIVATE)
+                        'OR' => !$force_privates && !Session::haveRight('followup', ITILFollowup::SEEPRIVATE)
                            ? ['is_private' => 0, 'users_id' => Session::getLoginUserID()]
                            : ['1'],
                      ],
@@ -7931,7 +7931,7 @@ abstract class CommonITILObject extends CommonDBTM {
                      'FROM'   => $task_class::getTable(),
                      'WHERE'  => [
                         $this->getForeignKeyField() => $this->getID(),
-                        'OR' => !Session::haveRight('task', CommonITILTask::SEEPRIVATE)
+                        'OR' => !$force_privates && !Session::haveRight('task', CommonITILTask::SEEPRIVATE)
                            ? ['is_private' => 0, 'users_id' => Session::getLoginUserID()]
                            : ['1'],
                      ],

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7892,19 +7892,19 @@ abstract class CommonITILObject extends CommonDBTM {
       return [
          'OR' => [
             [
-               'itemtype' => $this->getType(),
-               'items_id' => $this->getID(),
+               Document_Item::getTableField('itemtype') => $this->getType(),
+               Document_Item::getTableField('items_id') => $this->getID(),
             ],
             [
-               'itemtype' => ITILFollowup::getType(),
-               'items_id' => new QuerySubQuery(
+               Document_Item::getTableField('itemtype') => ITILFollowup::getType(),
+               Document_Item::getTableField('items_id') => new QuerySubQuery(
                   [
                      'SELECT' => 'id',
                      'FROM'   => ITILFollowup::getTable(),
                      'WHERE'  => [
-                        'itemtype' => $this->getType(),
-                        'items_id' => $this->getID(),
-                        'OR'       => !Session::haveRight('followup', ITILFollowup::SEEPRIVATE)
+                        ITILFollowup::getTableField('itemtype') => $this->getType(),
+                        ITILFollowup::getTableField('items_id') => $this->getID(),
+                        'OR' => !Session::haveRight('followup', ITILFollowup::SEEPRIVATE)
                            ? ['is_private' => 0, 'users_id' => Session::getLoginUserID()]
                            : ['1'],
                      ],
@@ -7912,8 +7912,8 @@ abstract class CommonITILObject extends CommonDBTM {
                ),
             ],
             [
-               'itemtype' => $task_class::getType(),
-               'items_id' => new QuerySubQuery(
+               'glpi_documents_items.itemtype' => $task_class::getType(),
+               'glpi_documents_items.items_id' => new QuerySubQuery(
                   [
                      'SELECT' => 'id',
                      'FROM'   => $task_class::getTable(),

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7886,10 +7886,6 @@ abstract class CommonITILObject extends CommonDBTM {
     * @return array
     */
    public function getAssociatedDocumentsCriteria($bypass_rights = false): array {
-      if (!Document::canView()) {
-         return ['0'];
-      }
-
       $task_class = $this->getType() . 'Task';
 
       $or_crits = [

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -772,52 +772,14 @@ class Document extends CommonDBTM {
          return false;
       }
 
+      $itil->getFromDB($items_id);
+
       $result = $DB->request([
          'FROM'  => Document_Item::getTable(),
          'COUNT' => 'cpt',
          'WHERE' => [
-            'items_id'     => $items_id,
-            'itemtype'     => $itemtype,
+            $itil->getAssociatedDocumentsCriteria(),
             'documents_id' => $this->fields['id']
-         ]
-      ])->next();
-
-      if ($result['cpt'] > 0) {
-         return true;
-      }
-
-      // Check ticket and child items (followups, tasks, solutions) contents
-      $itil_table = $itil->getTable();
-      $itil_key   = $itil->getForeignKeyField();
-      $task_table = getTableForItemType($itil->getType() . 'Task');
-
-      $result = $DB->request([
-         'FROM'      => $itil_table,
-         'COUNT'     => 'cpt',
-         'LEFT JOIN' => [
-            'glpi_itilfollowups' => [
-               'FKEY' => [
-                  $itil_table          => 'id',
-                  'glpi_itilfollowups' => 'items_id',
-                  ['AND' => ['glpi_itilfollowups.itemtype' => $itemtype]]
-               ]
-            ],
-            $task_table          => [
-               'FKEY' => [
-                  $itil_table => 'id',
-                  $task_table => $itil_key
-               ]
-            ],
-            'glpi_itilsolutions' => [
-               'FKEY' => [
-                  $itil_table          => 'id',
-                  'glpi_itilsolutions' => 'items_id',
-                  ['AND' => ['glpi_itilsolutions.itemtype' => $itemtype]]
-               ]
-            ],
-         ],
-         'WHERE'     => [
-            $itil_table . '.id' => $items_id,
          ]
       ])->next();
 

--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -144,14 +144,28 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
          if ($is_html || $CFG_GLPI['attach_ticket_documents_to_mail']) {
             // Retieve document list if mail is in HTML format (for inline images)
             // or if documents are attached to mail.
+            $item = getItemForItemtype($current->fields['itemtype']);
+            $doc_crit = [
+               'items_id' => $current->fields['items_id'],
+               'itemtype' => $current->fields['itemtype'],
+            ];
+            if ($item instanceof CommonITILObject) {
+               $item->getFromDB($current->fields['items_id']);
+               $doc_crit = $item->getAssociatedDocumentsCriteria();
+               if ($is_html) {
+                  // Remove documents having "NO_TIMELINE" position if mail is HTML, as
+                  // these documents corresponds to inlined images.
+                  // If ntification is in plain text, they should be kepts as they cannot be rendered in text.
+                  $doc_crit[] = [
+                     'timeline_position'  => ['>', CommonITILObject::NO_TIMELINE]
+                  ];
+               }
+            }
             $doc_items_iterator = $DB->request(
                [
                   'SELECT' => ['documents_id'],
                   'FROM'   => Document_Item::getTable(),
-                  'WHERE'  => [
-                     'items_id' => $current->fields['items_id'],
-                     'itemtype' => $current->fields['itemtype'],
-                  ]
+                  'WHERE'  => $doc_crit,
                ]
             );
             foreach ($doc_items_iterator as $doc_item) {

--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -155,7 +155,7 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                if ($is_html) {
                   // Remove documents having "NO_TIMELINE" position if mail is HTML, as
                   // these documents corresponds to inlined images.
-                  // If ntification is in plain text, they should be kepts as they cannot be rendered in text.
+                  // If notification is in plain text, they should be kepts as they cannot be rendered in text.
                   $doc_crit[] = [
                      'timeline_position'  => ['>', CommonITILObject::NO_TIMELINE]
                   ];

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1296,8 +1296,8 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
                ]
             ],
             'WHERE'     => [
-               'glpi_documents_items.itemtype'  => $item->getType(),
-               'glpi_documents_items.items_id'  => $item->fields['id']
+               $item->getAssociatedDocumentsCriteria(),
+               'timeline_position' => ['>', CommonITILObject::NO_TIMELINE], // skip inlined images
             ]
          ]);
 

--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -1105,6 +1105,23 @@ class Transfer extends CommonDBTM {
             // Document : keep / delete + clean unused / keep unused
             if (Document::canApplyOn($itemtype)) {
                $this->transferDocuments($itemtype, $ID, $newID);
+
+               if (is_a($itemtype, CommonITILObject::class, true)) {
+                  // Transfer ITIL childs documents too
+                  $itil_item = getItemForItemtype($itemtype);
+                  $itil_item->getFromDB($ID);
+                  $document_item_obj = new Document_Item();
+                  $document_items = $document_item_obj->find(
+                     $itil_item->getAssociatedDocumentsCriteria(true)
+                  );
+                  foreach ($document_items as $document_item) {
+                     $this->transferDocuments(
+                        $document_item['itemtype'],
+                        $document_item['items_id'],
+                        $document_item['items_id']
+                     );
+                  }
+               }
             }
 
             // Transfer compatible printers

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -2937,7 +2937,7 @@ class Ticket extends DbTestCase {
             'bypass_rights'  => false,
             'expected_where' => sprintf(
                "(`glpi_documents_items`.`itemtype` = 'Ticket' AND `glpi_documents_items`.`items_id` = '%1\$s')",
-               $ticket_id,
+               $ticket_id
             ),
          ],
          [

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -2912,4 +2912,142 @@ class Ticket extends DbTestCase {
       // Target ticket should have all suppliers not marked as duplicates above
       $this->integer((int)$supplier_count)->isEqualTo(3);
    }
+
+   /**
+    * @see self::testGetAssociatedDocumentsCriteria()
+    */
+   protected function getAssociatedDocumentsCriteriaProvider() {
+      $ticket = new \Ticket();
+      $ticket_id = $ticket->add([
+         'name'            => "test",
+         'content'         => "test",
+      ]);
+      $this->integer((int)$ticket_id)->isGreaterThan(0);
+
+      return [
+         [
+            'rights'   => [
+               \Document::$rightname => 0,
+            ],
+            'ticket_id'      => $ticket_id,
+            'bypass_rights'  => false,
+            'expected_where' => '0',
+         ],
+         [
+            'rights'   => [
+               \Document::$rightname     => \READ,
+               \Change::$rightname       => 0,
+               \Problem::$rightname      => 0,
+               \Ticket::$rightname       => 0,
+               \ITILFollowup::$rightname => 0,
+               \TicketTask::$rightname   => 0,
+            ],
+            'ticket_id'      => $ticket_id,
+            'bypass_rights'  => false,
+            'expected_where' => sprintf(
+               "(`glpi_documents_items`.`itemtype` = 'Ticket' AND `glpi_documents_items`.`items_id` = '%1\$s')",
+               $ticket_id,
+            ),
+         ],
+         [
+            'rights'   => [
+               \Document::$rightname     => \READ,
+               \Change::$rightname       => 0,
+               \Problem::$rightname      => 0,
+               \Ticket::$rightname       => \READ,
+               \ITILFollowup::$rightname => 0,
+               \TicketTask::$rightname   => 0,
+            ],
+            'ticket_id'      => $ticket_id,
+            'bypass_rights'  => false,
+            'expected_where' => sprintf(
+               "(`glpi_documents_items`.`itemtype` = 'Ticket' AND `glpi_documents_items`.`items_id` = '%1\$s')"
+               . " OR (`glpi_documents_items`.`itemtype` = 'ITILFollowup' AND `glpi_documents_items`.`items_id` IN (SELECT `id` FROM `glpi_itilfollowups` WHERE `glpi_itilfollowups`.`itemtype` = 'Ticket' AND `glpi_itilfollowups`.`items_id` = '%1\$s' AND ((`is_private` = '0' OR `users_id` = '%2\$s'))))"
+               . " OR (`glpi_documents_items`.`itemtype` = 'ITILSolution' AND `glpi_documents_items`.`items_id` IN (SELECT `id` FROM `glpi_itilsolutions` WHERE `glpi_itilsolutions`.`itemtype` = 'Ticket' AND `glpi_itilsolutions`.`items_id` = '%1\$s'))",
+               $ticket_id,
+               getItemByTypeName('User', TU_USER, true)
+            ),
+         ],
+         [
+            'rights'   => [
+               \Document::$rightname     => \READ,
+               \Change::$rightname       => 0,
+               \Problem::$rightname      => 0,
+               \Ticket::$rightname       => \READ,
+               \ITILFollowup::$rightname => \ITILFollowup::SEEPUBLIC,
+               \TicketTask::$rightname   => \TicketTask::SEEPUBLIC,
+            ],
+            'ticket_id'      => $ticket_id,
+            'bypass_rights'  => false,
+            'expected_where' => sprintf(
+               "(`glpi_documents_items`.`itemtype` = 'Ticket' AND `glpi_documents_items`.`items_id` = '%1\$s')"
+               . " OR (`glpi_documents_items`.`itemtype` = 'ITILFollowup' AND `glpi_documents_items`.`items_id` IN (SELECT `id` FROM `glpi_itilfollowups` WHERE `glpi_itilfollowups`.`itemtype` = 'Ticket' AND `glpi_itilfollowups`.`items_id` = '%1\$s' AND ((`is_private` = '0' OR `users_id` = '%2\$s'))))"
+               . " OR (`glpi_documents_items`.`itemtype` = 'ITILSolution' AND `glpi_documents_items`.`items_id` IN (SELECT `id` FROM `glpi_itilsolutions` WHERE `glpi_itilsolutions`.`itemtype` = 'Ticket' AND `glpi_itilsolutions`.`items_id` = '%1\$s'))"
+               . " OR (`glpi_documents_items`.`itemtype` = 'TicketTask' AND `glpi_documents_items`.`items_id` IN (SELECT `id` FROM `glpi_tickettasks` WHERE `tickets_id` = '%1\$s' AND ((`is_private` = '0' OR `users_id` = '%2\$s'))))",
+               $ticket_id,
+               getItemByTypeName('User', TU_USER, true)
+            ),
+         ],
+         [
+            'rights'   => [
+               \Document::$rightname     => \READ,
+               \Change::$rightname       => 0,
+               \Problem::$rightname      => 0,
+               \Ticket::$rightname       => \READ,
+               \ITILFollowup::$rightname => \ITILFollowup::SEEPRIVATE,
+               \TicketTask::$rightname   => 0,
+            ],
+            'ticket_id'      => $ticket_id,
+            'bypass_rights'  => false,
+            'expected_where' => sprintf(
+               "(`glpi_documents_items`.`itemtype` = 'Ticket' AND `glpi_documents_items`.`items_id` = '%1\$s')"
+               . " OR (`glpi_documents_items`.`itemtype` = 'ITILFollowup' AND `glpi_documents_items`.`items_id` IN (SELECT `id` FROM `glpi_itilfollowups` WHERE `glpi_itilfollowups`.`itemtype` = 'Ticket' AND `glpi_itilfollowups`.`items_id` = '%1\$s'))"
+               . " OR (`glpi_documents_items`.`itemtype` = 'ITILSolution' AND `glpi_documents_items`.`items_id` IN (SELECT `id` FROM `glpi_itilsolutions` WHERE `glpi_itilsolutions`.`itemtype` = 'Ticket' AND `glpi_itilsolutions`.`items_id` = '%1\$s'))",
+               $ticket_id,
+               getItemByTypeName('User', TU_USER, true)
+            ),
+         ],
+         [
+            'rights'   => [
+               \Document::$rightname     => \READ,
+               \Change::$rightname       => 0,
+               \Problem::$rightname      => 0,
+               \Ticket::$rightname       => \READ,
+               \ITILFollowup::$rightname => \ITILFollowup::SEEPUBLIC,
+               \TicketTask::$rightname   => \TicketTask::SEEPRIVATE,
+            ],
+            'ticket_id'      => $ticket_id,
+            'bypass_rights'  => false,
+            'expected_where' => sprintf(
+               "(`glpi_documents_items`.`itemtype` = 'Ticket' AND `glpi_documents_items`.`items_id` = '%1\$s')"
+               . " OR (`glpi_documents_items`.`itemtype` = 'ITILFollowup' AND `glpi_documents_items`.`items_id` IN (SELECT `id` FROM `glpi_itilfollowups` WHERE `glpi_itilfollowups`.`itemtype` = 'Ticket' AND `glpi_itilfollowups`.`items_id` = '%1\$s' AND ((`is_private` = '0' OR `users_id` = '%2\$s'))))"
+               . " OR (`glpi_documents_items`.`itemtype` = 'ITILSolution' AND `glpi_documents_items`.`items_id` IN (SELECT `id` FROM `glpi_itilsolutions` WHERE `glpi_itilsolutions`.`itemtype` = 'Ticket' AND `glpi_itilsolutions`.`items_id` = '%1\$s'))"
+               . " OR (`glpi_documents_items`.`itemtype` = 'TicketTask' AND `glpi_documents_items`.`items_id` IN (SELECT `id` FROM `glpi_tickettasks` WHERE `tickets_id` = '%1\$s'))",
+               $ticket_id,
+               getItemByTypeName('User', TU_USER, true)
+            ),
+         ],
+      ];
+   }
+
+   /**
+    * @dataProvider getAssociatedDocumentsCriteriaProvider
+    */
+   public function testGetAssociatedDocumentsCriteria($rights, $ticket_id, $bypass_rights, $expected_where) {
+      $this->login();
+
+      $ticket = new \Ticket();
+      $this->boolean($ticket->getFromDB($ticket_id))->isTrue();
+
+      $session_backup = $_SESSION['glpiactiveprofile'];
+      foreach ($rights as $rightname => $rightvalue) {
+         $_SESSION['glpiactiveprofile'][$rightname] = $rightvalue;
+      }
+      $crit = $ticket->getAssociatedDocumentsCriteria($bypass_rights);
+      $_SESSION['glpiactiveprofile'] = $session_backup;
+
+      $it = new \DBmysqlIterator(null);
+      $it->execute('glpi_tickets', $crit);
+      $this->string($it->getSql())->isIdenticalTo('SELECT * FROM `glpi_tickets` WHERE (' . $expected_where . ')');
+   }
 }

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -2927,15 +2927,6 @@ class Ticket extends DbTestCase {
       return [
          [
             'rights'   => [
-               \Document::$rightname => 0,
-            ],
-            'ticket_id'      => $ticket_id,
-            'bypass_rights'  => false,
-            'expected_where' => '0',
-         ],
-         [
-            'rights'   => [
-               \Document::$rightname     => \READ,
                \Change::$rightname       => 0,
                \Problem::$rightname      => 0,
                \Ticket::$rightname       => 0,
@@ -2951,7 +2942,6 @@ class Ticket extends DbTestCase {
          ],
          [
             'rights'   => [
-               \Document::$rightname     => \READ,
                \Change::$rightname       => 0,
                \Problem::$rightname      => 0,
                \Ticket::$rightname       => \READ,
@@ -2970,7 +2960,6 @@ class Ticket extends DbTestCase {
          ],
          [
             'rights'   => [
-               \Document::$rightname     => \READ,
                \Change::$rightname       => 0,
                \Problem::$rightname      => 0,
                \Ticket::$rightname       => \READ,
@@ -2990,7 +2979,6 @@ class Ticket extends DbTestCase {
          ],
          [
             'rights'   => [
-               \Document::$rightname     => \READ,
                \Change::$rightname       => 0,
                \Problem::$rightname      => 0,
                \Ticket::$rightname       => \READ,
@@ -3009,7 +2997,6 @@ class Ticket extends DbTestCase {
          ],
          [
             'rights'   => [
-               \Document::$rightname     => \READ,
                \Change::$rightname       => 0,
                \Problem::$rightname      => 0,
                \Ticket::$rightname       => \READ,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7059

Due to #6598, document items of followup and tasks are not directly attached to parent ITIL item directly anymore.
Maybe some other features have to be fixed, for instance notifications related to ITIL items, list of items related to a document, ....