### PR TITLE
Fix display of documents associated items

### DIFF
--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -414,8 +414,16 @@ class Document_Item extends CommonDBRelation{
             }
 
             while ($data = $iterator->next()) {
-               if ($itemtype == 'Ticket') {
-                  $data["name"] = sprintf(__('%1$s: %2$s'), __('Ticket'), $data["id"]);
+               if ($item instanceof ITILFollowup || $item instanceof CommonITILTask) {
+                  $itemtype = $data['itemtype'];
+                  $item = new $itemtype();
+                  $item->getFromDB($data['items_id']);
+                  $data['id'] = $item->fields['id'];
+                  $data['entity'] = $item->fields['entities_id'];
+               }
+
+               if ($item instanceof CommonITILObject) {
+                  $data["name"] = sprintf(__('%1$s: %2$s'), $item->getTypeName(1), $data["id"]);
                }
 
                if ($itemtype == 'SoftwareLicense') {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In `Associated items` tab of a document, documents related to Change, Problems, Followup and Tasks were not correctly displayed.

Also, this error was trigerred:
```
PHP Notice (8): Undefined index: name in /var/www/glpi/inc/document_item.class.php at line 431
```