### PR TITLE
Fix additionnal buttons value

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -2518,7 +2518,7 @@ class CommonDBTM extends CommonGLPI {
          echo "<tr class='tab_bg_2'>";
          echo "<td class='right' colspan='".($params['colspan']*2)."'>";
          foreach ($params['addbuttons'] as $key => $val) {
-            echo "<button type='submit' class='vsubmit' name='$key'>
+            echo "<button type='submit' class='vsubmit' name='$key' value='1'>
                   $val
                </button>&nbsp;";
          }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Due to commit 0c89b8a962b84ddef0ea4e011225391a2dee3905, additionnal buttons have no more value.
This breaks some of them, for instance the "Send a test email to the administrator" button.