### PR TITLE
Fix display of a document associated to an ITIL task

### DIFF
--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -1749,7 +1749,7 @@ abstract class CommonDBRelation extends CommonDBConnexity {
                'glpi_entities'   => 'id'
             ]
          ];
-         $params['WHERE'] += getEntitiesRestrictCriteria($item->getTable(), '', '', true);
+         $params['WHERE'] += getEntitiesRestrictCriteria($item->getTable(), '', '', 'auto');
          $params['ORDER'] = ['glpi_entities.completename', $params['ORDER']];
       }
 

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -59,6 +59,10 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
       return str_replace('Task', '', $this->getType());
    }
 
+   public static function getNameField() {
+      return 'id';
+   }
+
 
    function canViewPrivates() {
       return false;

--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -414,10 +414,16 @@ class Document_Item extends CommonDBRelation{
             }
 
             while ($data = $iterator->next()) {
-               if ($item instanceof ITILFollowup || $item instanceof CommonITILTask) {
+               if ($item instanceof ITILFollowup) {
                   $itemtype = $data['itemtype'];
                   $item = new $itemtype();
                   $item->getFromDB($data['items_id']);
+                  $data['id'] = $item->fields['id'];
+                  $data['entity'] = $item->fields['entities_id'];
+               } else if ($item instanceof CommonITILTask) {
+                  $itemtype = $item->getItilObjectItemType();
+                  $item = new $itemtype();
+                  $item->getFromDB($data[$item->getForeignKeyField()]);
                   $data['id'] = $item->fields['id'];
                   $data['entity'] = $item->fields['entities_id'];
                }

--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -414,7 +414,7 @@ class Document_Item extends CommonDBRelation{
             }
 
             while ($data = $iterator->next()) {
-               if ($item instanceof ITILFollowup) {
+               if ($item instanceof ITILFollowup || $item instanceof ITILSolution) {
                   $itemtype = $data['itemtype'];
                   $item = new $itemtype();
                   $item->getFromDB($data['items_id']);

--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -47,6 +47,10 @@ class ITILSolution extends CommonDBChild {
    static public $itemtype = 'itemtype'; // Class name or field name (start with itemtype) for link to Parent
    static public $items_id = 'items_id'; // Field name
 
+   public static function getNameField() {
+      return 'id';
+   }
+
    static function getTypeName($nb = 0) {
       return _n('Solution', 'Solutions', $nb);
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix following errors.

```
SQL Error "1054": Unknown column 'glpi_tickettasks.name' in 'order clause' in query "SELECT COUNT(*) AS cpt FROM `glpi_tickettasks` LEFT JOIN `glpi_documents_items` ON (`glpi_documents_items`.`items_id` = `glpi_tickettasks`.`id`) WHERE (`glpi_documents_items`.`documents_id` = '88' OR (`glpi_documents_items`.`itemtype` = 'Document' AND `glpi_documents_items`.`items_id` = '88')) AND `glpi_documents_items`.`itemtype` = 'TicketTask' ORDER BY `glpi_tickettasks`.`name`"

PHP Notice (8): Undefined index: itemtype in /var/www/glpi/inc/document_item.class.php at line 418
Uncaught Exception Error: Class name must be a valid object or a string in /var/www/glpi/inc/document_item.class.php at line 419
```