### PR TITLE
Fix ability to retrieve ITIL items document on API

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -909,11 +909,11 @@ abstract class API extends CommonGLPI {
          }
       }
 
-      // retrieve item contracts
+      // retrieve item documents
       if (isset($params['with_documents'])
           && $params['with_documents']) {
          $fields['_documents'] = [];
-         if (!$itemtype != 'Ticket'
+         if (!($item instanceof CommonITILObject)
              && $itemtype != 'KnowbaseItem'
              && $itemtype != 'Reminder'
              && !Document::canView()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes ability to retrieve ITIL item documents for a profile using simplified interface.