### PR TITLE
Fix rounding in dropdown values

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -4509,7 +4509,7 @@ class Html {
          }
       }
 
-      $values = [$value => $valuename];
+      $values = ["$value" => $valuename];
       $output = self::select($name, $values, $options);
 
       $js = "


### PR DESCRIPTION
The current value of a number dropdown is truncated if it's a float.

Example, the value of the field is "4.5" but when you reload the page it's actually "4" that is selected :
![image](https://user-images.githubusercontent.com/42734840/77336527-ef0d4d80-6d27-11ea-9585-e122ec31b66d.png)

This is because float are always truncated when used as array keys unless you force the key to be a string.

Internal ref: 19444.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
