### PR TITLE
Fix src path for plugins; fixes #6677

### DIFF
--- a/inc/impact.class.php
+++ b/inc/impact.class.php
@@ -931,7 +931,7 @@ class Impact extends CommonGLPI {
             $icon = "pics/impact/default.png";
          }
 
-         echo '<h4><img class="impact-side-icon" src="../' . $icon . '" title="' . $itemtype::getTypeName() . '" data-itemtype="' . $itemtype . '">';
+         echo '<h4><img class="impact-side-icon" src="' . $CFG_GLPI['root_doc'] . '/' . $icon . '" title="' . $itemtype::getTypeName() . '" data-itemtype="' . $itemtype . '">';
          echo "<span>" . $itemtype::getTypeName() . "</span></h4>";
          echo '</div>'; // impact-side-filter-itemtypes-item
       }


### PR DESCRIPTION
Fix icons `src` for plugins, relative paths wont work as the path is different for plugins classes.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6677
