### PR TITLE
Fix bug introduced in #6850, no reflection for "AllAssets"

### DIFF
--- a/inc/apirest.class.php
+++ b/inc/apirest.class.php
@@ -336,6 +336,11 @@ class APIRest extends API {
                $itemtype                            = $additional_itemtype;
             }
 
+            // AllAssets
+            if ($all_assets && $this->url_elements[$index] == "AllAssets") {
+               return "AllAssets";
+            }
+
             // Get case sensitive itemtype name
             $rc = new \ReflectionClass($itemtype);
             $itemtype = $rc->getName();


### PR DESCRIPTION
Fix a bug introduced by #6850, the special case "AllAssets" is not a real class and can't be instantiated by reflection.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes