### PR TITLE
Revert "Use Github docker repository for Github actions"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: "ubuntu-latest"
     services:
       app:
-        image: "docker.pkg.github.com/glpi-project/docker-images/githubactions-php:5.6"
+        image: "glpi/githubactions-php:5.6"
         options: >-
           --volume /glpi:/var/glpi
     steps:
@@ -57,17 +57,17 @@ jobs:
           - "7.4"
     services:
       app:
-        image: "docker.pkg.github.com/glpi-project/docker-images/githubactions-php:${{ matrix.php-version }}"
+        image: "glpi/githubactions-php:${{ matrix.php-version }}"
         options: >-
           --volume /glpi:/var/glpi
       db:
-        image: "docker.pkg.github.com/glpi-project/docker-images/githubactions-${{ matrix.db-image }}"
+        image: "glpi/githubactions-${{ matrix.db-image }}"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
         options: >-
           --shm-size=1g
       openldap:
-        image: "docker.pkg.github.com/glpi-project/docker-images/githubactions-openldap"
+        image: "glpi/githubactions-openldap"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"


### PR DESCRIPTION
This reverts commit 493d05772a82563b14b9b3e3127ce466c6ca7a8f.

It is not possible for now to use this repository, as it requires credentials.