### PR TITLE
Fix missing history for TicketTask

### DIFF
--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -331,7 +331,7 @@ abstract class CommonITILTask  extends CommonDBTM {
             // change ticket status (from splitted button)
             $itemtype = $this->getItilObjectItemType();
             $this->input['_job'] = new $itemtype();
-            if (!$this->input['_job']->getFromDB($this->input[$this->input['_job']->getForeignKeyField()])) {
+            if (!$this->input['_job']->getFromDB($this->fields[$this->input['_job']->getForeignKeyField()])) {
                return false;
             }
             if (isset($this->input['_status'])


### PR DESCRIPTION
Internal ref: 19464.

If you update a TicketTask through the API, the Ticket history will not be updated because the post_updateItem method check for a "tickets_id" field in the input (which will be missing as your API call will only contains the field you update).

This does not affect the standard interface because any update will send the entire form (and thus the tickets_id field).

Fixed it by using the item fields in the check instead of the input.
This is consistent with what is done in ITILFollowup:

```php
if (!$job->getFromDB($this->fields['items_id'])) {
   return;
}
```
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
