### PR TITLE
Feature/planning toggle only bg events

### DIFF
--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -898,7 +898,7 @@ class Planning extends CommonGLPI {
          if ($filter_key == 'NotPlanned') {
             $title = __('Not planned tasks');
          } else if ($filter_key == 'OnlyBgEvents') {
-            $title = __('Only BG events');
+            $title = __('Only background events');
          } else {
             if (!getItemForItemtype($filter_key)) {
                return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Add a toggle filter to manage background events (they're normally non editable on fullcalendar) instead of managing them into a list.

![glpi_toggle_only_bg_events_2](https://user-images.githubusercontent.com/418844/77651227-c0cc7f80-6f6c-11ea-8411-cbbf2463dc44.gif)

