### PR TITLE
missing planning list on central

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -456,6 +456,7 @@ $CFG_GLPI['javascript'] = [
    'central'   => [
       'central' => array_merge([
          'fullcalendar',
+         'planning',
          'tinymce',
       ], $dashboard_libs)
    ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Don't know when the `planning` was truncated but without, planning list doesn't load on central
