### PR TITLE
GLPI docker image nightly build

### DIFF
--- a/.docker/glpi-app/Dockerfile
+++ b/.docker/glpi-app/Dockerfile
@@ -1,0 +1,135 @@
+ARG BASE_APP_IMAGE=php:apache
+
+#####
+# Builder image
+#####
+FROM php:7.4-cli-alpine AS builder
+
+# Copy composer binary from latest composer image.
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Install required system packages.
+RUN \
+  # Install intl PHP extension (required during CSS compilation execution).
+  apk add --update --virtual .build-deps $PHPIZE_DEPS \
+  && apk add --update icu-dev \
+  && docker-php-ext-install intl \
+  && apk del -f .build-deps \
+  \
+  # Install gettext required to compile locales.
+  && apk add --update gettext \
+  # Install nodejs and npm.
+  && apk add --update nodejs npm \
+  \
+  # Install git and zip used by composer when fetching dependencies.
+  && apk add --update git unzip \
+  \
+  # Clean sources list.
+  && rm -rf /var/cache/apk/*
+
+ # Update PHP configuration.
+RUN echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/docker-php-memory.ini
+
+# Copy GLPI source.
+COPY ./ /usr/src/glpi
+
+# Change working dir.
+WORKDIR /usr/src/glpi
+
+# Build GLPI app
+RUN \
+  # Install dev dependencies (required to run Robo.li tasks)
+  composer install --ignore-platform-reqs --no-progress --no-suggest --prefer-dist \
+  \
+  && ./vendor/bin/robo build:app /usr/src/glpi /tmp/glpi --load-from ./tools
+
+
+#####
+# Application image
+#####
+FROM $BASE_APP_IMAGE
+
+RUN apt-get update \
+  \
+  # Install APCU PHP extension.
+  && pecl install apcu \
+  && docker-php-ext-enable apcu \
+  && echo "apc.enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini \
+  \
+  # Install exif extension.
+  && docker-php-ext-install exif \
+  \
+  # Install gd PHP extension.
+  # GD extension configuration parameters changed on PHP 7.4
+  # see https://www.php.net/manual/en/image.installation.php#image.installation
+  && apt-get install --assume-yes --no-install-recommends --quiet libfreetype6-dev libjpeg-dev libpng-dev \
+  && PHP_MAJOR_VERSION="$(echo $PHP_VERSION | cut -d '.' -f 1)" \
+  && PHP_MINOR_VERSION="$(echo $PHP_VERSION | cut -d '.' -f 2)" \
+  && if [ $PHP_MAJOR_VERSION -le "5" ] || ([ $PHP_MAJOR_VERSION -eq "7" ] && [ $PHP_MINOR_VERSION -le "3" ]); then \
+    # For PHP <= 5.x or PHP 7 <= 7.3, use old parameters
+    docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+  ; else \
+    docker-php-ext-configure gd --with-freetype --with-jpeg \
+  ; fi \
+  && docker-php-ext-install gd \
+  \
+  # Install imap PHP extension.
+  && apt-get install --assume-yes --no-install-recommends --quiet libc-client-dev libkrb5-dev \
+  && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
+  && docker-php-ext-install imap \
+  \
+  # Install intl PHP extension.
+  && apt-get install --assume-yes --no-install-recommends --quiet libicu-dev \
+  && docker-php-ext-configure intl \
+  && docker-php-ext-install intl \
+  \
+  # Install ldap PHP extension.
+  && apt-get install --assume-yes --no-install-recommends --quiet libldap2-dev \
+  && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+  && docker-php-ext-install ldap \
+  \
+  # Install mysqli PHP extension.
+  && docker-php-ext-install mysqli \
+  \
+  # Install soap PHP extension (required for some plugins).
+  && apt-get install --assume-yes --no-install-recommends --quiet libxml2-dev \
+  && docker-php-ext-install soap \
+  \
+  # Install xmlrpc PHP extension.
+  && apt-get install --assume-yes --no-install-recommends --quiet libxml2-dev \
+  && docker-php-ext-install xmlrpc \
+  \
+  # Install cron service.
+  && apt-get install --assume-yes --no-install-recommends --quiet cron \
+  \
+  # Install acl to manage acl of writable directories.
+  && apt-get install --assume-yes --no-install-recommends --quiet acl \
+  \
+  # Clean sources list.
+  && rm -rf /var/lib/apt/lists/*
+
+# Copy services configuration files to container.
+COPY .docker/glpi-app/files /
+
+# Install GLPI crontab.
+RUN crontab -u www-data /etc/cron.d/glpi
+
+# Copy GLPI application.
+COPY --from=builder --chown=www-data:www-data /tmp/glpi /var/www/glpi
+
+# Declare a volume for "config" and "files" directory
+RUN mkdir /var/glpi && chown www-data:www-data /var/glpi
+VOLUME /var/glpi
+
+# Define GLPI environment variables
+ENV \
+  GLPI_INSTALL_MODE=DOCKER \
+  GLPI_CONFIG_DIR=/var/glpi/config \
+  GLPI_VAR_DIR=/var/glpi/files
+
+# Make startup script executable and executes it as default command.
+RUN chmod u+x /opt/startup.sh
+CMD /opt/startup.sh
+
+# Define application path as base working dir.
+WORKDIR /var/www/glpi

--- a/.docker/glpi-app/files/etc/apache2/sites-available/000-default.conf
+++ b/.docker/glpi-app/files/etc/apache2/sites-available/000-default.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:80>
+    DocumentRoot /var/www/glpi
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    <Directory /var/www/glpi>
+        DirectoryIndex index.php
+        Options FollowSymLinks
+        Require all granted
+    </Directory>
+</VirtualHost>
+

--- a/.docker/glpi-app/files/etc/cron.d/glpi
+++ b/.docker/glpi-app/files/etc/cron.d/glpi
@@ -1,0 +1,1 @@
+* * * * *    /usr/local/bin/php /var/www/glpi/front/cron.php &>/dev/null

--- a/.docker/glpi-app/files/opt/startup.sh
+++ b/.docker/glpi-app/files/opt/startup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Create config and files volume subdirectories that are missing
+# and set ACL for www-data user
+dirs=(
+    "/var/glpi/config"
+    "/var/glpi/files"
+    "/var/glpi/files/_cache"
+    "/var/glpi/files/_cron"
+    "/var/glpi/files/_dumps"
+    "/var/glpi/files/_graphs"
+    "/var/glpi/files/_lock"
+    "/var/glpi/files/_log"
+    "/var/glpi/files/_pictures"
+    "/var/glpi/files/_plugins"
+    "/var/glpi/files/_rss"
+    "/var/glpi/files/_sessions"
+    "/var/glpi/files/_tmp"
+    "/var/glpi/files/_uploads"
+)
+for dir in "${dirs[@]}"
+do
+    if [ ! -d "$dir" ]
+    then
+        mkdir "$dir"
+    fi
+    setfacl -m user:www-data:rwx,group:www-data:rwx "$dir"
+done
+
+# Run cron service.
+cron
+
+# Run command previously defined in base php-apache Dockerfile.
+apache2-foreground
+

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# ignore all hidden files and dir except:
+# - .docker that contains some files to copy during build;
+# - .htaccess that is used in application image.
+.*
+!.docker
+!.htaccess
+
+# ignore test files files
+/tests
+
+# ignore GLPI user and plugin files
+/config/*
+/files/*/*
+/plugins/*
+
+# ignore all installed dependencies
+/node_modules
+/vendor
+
+# ignore builded assets
+/css_compiled
+/public/build
+/public/lib

--- a/.github/workflows/docker-glpi-app.yml
+++ b/.github/workflows/docker-glpi-app.yml
@@ -1,0 +1,36 @@
+name: "GLPI docker image"
+
+on:
+  # build and push docker images for every tags
+  push:
+    tags:
+    - '*'
+  # build and push docker images for default branch once a day
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+      - name: "Build image"
+        run: |
+          docker build --pull --tag image --file .docker/glpi-app/Dockerfile .
+      - name: "Push image to Docker hub"
+        if: github.repository == 'glpi-project/glpi'
+        run: |
+          echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+          REF_NAME=$(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||' | sed -E 's|/|-|')
+          IMAGE_TAG=glpi/glpi:$REF_NAME
+          docker tag image $IMAGE_TAG
+          docker push $IMAGE_TAG
+      - name: "Push image to Github registry"
+        if: github.repository == 'glpi-project/glpi'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+          REF_NAME=$(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||' | sed -E 's|/|-|')
+          IMAGE_TAG=docker.pkg.github.com/${{ github.repository }}/glpi:$REF_NAME
+          docker tag image $IMAGE_TAG
+          docker push $IMAGE_TAG

--- a/bin/console
+++ b/bin/console
@@ -50,6 +50,10 @@ if (isset($_SERVER['argv']) && ['dependencies', 'install'] === array_slice($_SER
       $composer_command .= ' ' . $options['composer-options'];
    }
 
+   $mode = array_key_exists('mode', $options) && is_string($options['mode'])
+      ? $options['mode']
+      : 'development';
+
    chdir(dirname(__FILE__, 2));
 
    $exit_code = 0;
@@ -66,7 +70,7 @@ if (isset($_SERVER['argv']) && ['dependencies', 'install'] === array_slice($_SER
 
    file_put_contents('.package.hash', sha1_file('package-lock.json'));
 
-   passthru('npm run-script build-dev', $exit_code);
+   passthru('npm run-script build -- --mode=' . $mode, $exit_code);
    exit($exit_code);
 }
 

--- a/composer.json
+++ b/composer.json
@@ -59,12 +59,14 @@
         "natxet/cssmin": "^3.0",
         "patchwork/jsqueeze": "^2.0",
         "php-parallel-lint/php-parallel-lint": "^1.1",
-        "sensiolabs/security-checker": "^6.0"
+        "sensiolabs/security-checker": "^6.0",
+        "symfony/finder": "^4.4"
     },
     "suggest": {
         "ext-ldap": "Used ot provide LDAP authentication and synchronization"
     },
     "config": {
+        "discard-changes": true,
         "optimize-autoloader": true,
         "platform": {
             "php": "7.2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "490267512c4f2496f5057e7400450cf3",
+    "content-hash": "287b81e1420ad689d59449e727f5b74e",
     "packages": [
         {
             "name": "blueimp/jquery-file-upload",
@@ -4626,5 +4626,6 @@
     },
     "platform-overrides": {
         "php": "7.2.0"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
         "unorm": "^1.6.0"
     },
     "scripts": {
-        "build": "webpack --config webpack.config.js --mode=production",
-        "build-dev": "webpack --config webpack.config.js --mode=development"
+        "build": "webpack --config webpack.config.js"
     },
     "devDependencies": {
         "acorn": "^7.0.0",

--- a/tools/RoboFile.php
+++ b/tools/RoboFile.php
@@ -29,16 +29,27 @@
  * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
  * ---------------------------------------------------------------------
  */
-class RoboFile extends \Robo\Tasks
-{
+
+use Robo\Result;
+use Robo\ResultData;
+use Robo\Task\Assets\Minify;
+use Robo\Task\Base\Exec;
+use Robo\Task\Composer\Update as ComposerUpdate;
+use Robo\Task\Filesystem\CleanDir;
+use Robo\Task\Filesystem\CopyDir;
+use Robo\Task\Filesystem\DeleteDir;
+use Robo\Task\Filesystem\FilesystemStack;
+use Symfony\Component\Finder\Finder;
+
+class RoboFile extends \Robo\Tasks {
+
    /**
     * Minify all
     *
     * @return void
     */
    public function minify() {
-      $this->minifyCSS()
-         ->minifyJS();
+      return $this->doMinify(realpath(dirname(__DIR__)));
    }
 
    /**
@@ -47,34 +58,7 @@ class RoboFile extends \Robo\Tasks
     * @return void
     */
    public function minifyCSS() {
-      $css_dirs = [
-         __DIR__ . '/../css',
-         __DIR__ . '/../lib',
-         __DIR__ . '/../public/lib',
-      ];
-
-      foreach ($css_dirs as $css_dir) {
-         if (!is_dir($css_dir)) {
-            continue;
-         }
-
-         $it = new RegexIterator(
-            new RecursiveIteratorIterator(
-               new RecursiveDirectoryIterator($css_dir)
-            ),
-            "/\\.css\$/i"
-         );
-
-         foreach ($it as $css_file) {
-            if (!$this->endsWith($css_file->getFilename(), 'min.css')) {
-               $this->taskMinify($css_file->getRealpath())
-                  ->to(preg_replace('/\.css$/', '.min.css', $css_file->getRealpath()))
-                  ->type('css')
-                  ->run();
-            }
-         }
-      }
-      return $this;
+      return $this->doMinify(realpath(dirname(__DIR__)), false, true);
    }
 
    /**
@@ -83,52 +67,272 @@ class RoboFile extends \Robo\Tasks
     * @return void
     */
    public function minifyJS() {
-      $js_dirs = [
-         __DIR__ . '/../js',
-         __DIR__ . '/../lib',
-         __DIR__ . '/../public/lib',
-      ];
+      return $this->doMinify(realpath(dirname(__DIR__)), true, false);
+   }
 
-      foreach ($js_dirs as $js_dir) {
-         if (!is_dir($js_dir)) {
-            continue;
-         }
+   /**
+    * Build GLPI application from source code.
+    *
+    * @param string $src      Source path (absolute or relative to "tools" directory), defaults to parent dir.
+    * @param string $dest     Destination path (absolute or relative to "tools" directory).
+    * @param array  $options  Task options.
+    */
+   public function buildApp($src = null, $dest = '/tmp/glpi', array $options = ['format' => 'string']) {
+      $task_collection = $this->collectionBuilder();
 
-         $it = new RegexIterator(
-            new RecursiveIteratorIterator(
-               new RecursiveDirectoryIterator($js_dir)
-            ),
-            "/\\.js\$/i"
+      $root_dir = realpath($src === null ? dirname(__DIR__) : $src);
+      $work_dir = $task_collection->workDir($dest);
+
+      // Check/prepare output dir
+      if (file_exists($dest) && realpath($dest) === $root_dir) {
+         return new Result(
+            $task_collection,
+            ResultData::EXITCODE_ERROR,
+            'Destination directory must be different from source'
          );
+      } else if (file_exists($dest)) {
+         $task_collection->addTask(new CleanDir($dest));
+      }
 
-         foreach ($it as $js_file) {
-            if (!$this->endsWith($js_file->getFilename(), 'min.js')) {
-               $this->taskMinify($js_file->getRealpath())
-                  ->to(preg_replace('/\.js$/', '.min.js', $js_file->getRealpath()))
-                  ->type('js')
-                  ->run();
+      // Copy source files
+      $copy_task = new CopyDir([$root_dir => $work_dir]);
+      $task_collection->addTask($copy_task);
+
+      // Install dependencies
+      $composer_options = '--ignore-platform-reqs --prefer-dist --no-progress';
+      $deps_install_task = new Exec(
+         sprintf(
+            'php bin/console dependencies install --mode=production --composer-options="%s"',
+            $composer_options
+         )
+      );
+      $deps_install_task->dir($work_dir);
+      $task_collection->addTask($deps_install_task);
+
+      // Minify CSS/JS files
+      // File list can be populated only after execution of previous tasks (dependencies install).
+      // So list of files will be populated by a defered code execution
+      // that will populate a sub task list which will be executed next to it.
+      $min_task_collection = $this->collectionBuilder();
+      $task_collection->addCode(
+         function() use ($work_dir, $min_task_collection) {
+            $files_finder = $this->getMinifiableFilesFinder($work_dir);
+            foreach ($files_finder->getIterator() as $file) {
+               $min_task_collection->addTask(new Minify($file->getRealPath()));
             }
          }
-      }
+      );
+      $task_collection->addTask($min_task_collection);
+
+      // Compile SCSS
+      $scss_compile_task = new Exec('php bin/console build:compile_scss');
+      $scss_compile_task->dir($work_dir);
+      $task_collection->addTask($scss_compile_task);
+
+      // Compile locale files
+      // File list can be populated only after execution of previous tasks (checkout).
+      // So list of files will be populated by a defered code execution
+      // that will populate a sub task list which will be executed next to it.
+      $mo_task_collection = $this->collectionBuilder();
+      $task_collection->addCode(
+         function() use ($work_dir, $mo_task_collection) {
+            $files_finder = new Finder();
+            $files_finder->files()->name('*.po')->in($work_dir . '/locales')->sortByName();
+            foreach ($files_finder->getIterator() as $file) {
+               $mo_task_collection->addTask(
+                  new Exec(
+                     sprintf(
+                        'msgfmt %s -o %s',
+                        $file->getRealPath(),
+                        preg_replace('/.po$/', '.mo', $file->getRealPath())
+                     )
+                  )
+               );
+            }
+         }
+      );
+      $task_collection->addTask($mo_task_collection);
+
+      // Remove PHP dev dependencies
+      $composer_update_task = new ComposerUpdate();
+      $composer_update_task->dir($work_dir)
+         ->option('ignore-platform-reqs')
+         ->option('no-dev')
+         ->arg('nothing');
+      $task_collection->addTask($composer_update_task);
+
+      // Clean useless directories
+      $clean_dir_task_collection = $this->collectionBuilder();
+      $task_collection->addCode(
+         function() use ($work_dir, $clean_dir_task_collection) {
+            $directories_to_clean = [];
+
+            $core_directories_finder = new Finder();
+            $core_directories_finder->directories()
+               ->ignoreDotFiles(false)
+               ->ignoreVCS(false)
+               ->path(
+                  [
+                     '/^\.[^\/]+$/', // all hidden directories
+                     '/^files\/[^\/]+\/[^\/]*$/', // all user subdirectories
+                     '/^node_modules$/',
+                     '/^plugins\/[^\/]*$/', // all plugins
+                     '/^tests$/',
+                     '/^tools$/',
+                     '/^vendor\/bin$/',
+                  ]
+               )
+               ->in($work_dir)
+               ->sortByName();
+            foreach ($core_directories_finder->getIterator() as $dir) {
+               $directories_to_clean[] = $dir->getRealPath();
+            }
+
+            $vendor_directories_finder = new Finder();
+            $vendor_directories_finder->directories()
+               ->path(
+                  [
+                     '/\/docs?$/',
+                     '/\/examples?$/',
+                     '/\/tests?$/',
+                  ]
+               )
+               ->in($work_dir . '/vendor/**')
+               ->sortByName();
+            foreach ($vendor_directories_finder->getIterator() as $dir) {
+               $directories_to_clean[] = $dir->getRealPath();
+            }
+
+            $clean_dir_task_collection->addTask(new DeleteDir($directories_to_clean));
+         }
+      );
+      $task_collection->addTask($clean_dir_task_collection);
+
+      // Clean useless files (do it ater dirs, to fasten cleanup)
+      $clean_files_task_collection = $this->collectionBuilder();
+      $task_collection->addCode(
+         function() use ($work_dir, $clean_files_task_collection) {
+            $files_to_clean = [];
+
+            $core_files_finder = new Finder();
+            $core_files_finder->files()
+               ->ignoreDotFiles(false)
+               ->ignoreVCS(false)
+               ->path(
+                  [
+                     '/^\.[^\/]+$/', // all hidden files (except .htaccess, see notPath())
+                     'CONTRIBUTING.md',
+                     'ISSUE_TEMPLATE.md',
+                     'PULL_REQUEST_TEMPLATE.md',
+                     'SECURITY.md',
+                     'composer.json',
+                     'composer.lock',
+                     'package.json',
+                     'package-lock.json',
+                     'webpack.config.js',
+                     '/^config\/.*/', // all config files
+                     '/^files\/[^\/]+\/.*/', // all user files
+                     '/^pics\/.*\.eps$/i',
+                  ]
+               )
+               ->notPath(
+                  [
+                     '.htaccess',
+                  ]
+               )
+               ->in($work_dir)
+               ->sortByName();
+            foreach ($core_files_finder->getIterator() as $file) {
+               $files_to_clean[] = $file->getRealPath();
+            }
+
+            $vendor_files_finder = new Finder();
+            $vendor_files_finder->files()
+               ->ignoreDotFiles(false)
+               ->ignoreVCS(false)
+               ->path(
+                  [
+                     '.gitignore',
+                     'build.properties',
+                     'build.xml',
+                     '/^changelog\.md$/i',
+                     'composer.json',
+                     'composer.lock',
+                     'phpunit.xml.dist',
+                     '/^readme\.md$/i',
+                  ]
+               )
+               ->in($work_dir . '/vendor/**')
+               ->sortByName();
+            foreach ($vendor_files_finder->getIterator() as $file) {
+               $files_to_clean[] = $file->getRealPath();
+            }
+
+            $fs_remove_task = new FilesystemStack();
+            $fs_remove_task->remove($files_to_clean);
+            $clean_files_task_collection->addTask($fs_remove_task);
+         }
+      );
+      $task_collection->addTask($clean_files_task_collection);
+
+      $task_collection->run();
 
       return $this;
    }
 
    /**
-    * Checks if a string ends with another string
+    * Run minify task on given directory.
     *
-    * @param string $haystack Full string
-    * @param string $needle   Ends string
+    * @param string  $dir
+    * @param boolean $minify_js
+    * @param boolean $minify_css
     *
-    * @return boolean
-    * @see http://stackoverflow.com/a/834355
+    * @return RoboFile
     */
-   private function endsWith($haystack, $needle) {
-      $length = strlen($needle);
-      if ($length == 0) {
-         return true;
+   private function doMinify($dir, $minify_js = true, $minify_css = true) {
+      $root_dir = realpath(dirname(__DIR__));
+
+      $min_task_collection = $this->collectionBuilder();
+      $files_finder = $this->getMinifiableFilesFinder($root_dir, $minify_js, $minify_css);
+      foreach ($files_finder->getIterator() as $file) {
+         $min_task_collection->addTask(new Minify($file->getRealPath()));
       }
 
-      return (substr($haystack, -$length) === $needle);
+      $min_task_collection->run();
+
+      return $this;
+   }
+
+   /**
+    * Returns minifiable files finder.
+    *
+    * @param string  $dir
+    * @param boolean $include_js
+    * @param boolean $include_css
+    *
+    * @return Finder
+    */
+   private function getMinifiableFilesFinder($dir, $include_js = true, $include_css = true) {
+      $names = [];
+      if ($include_js) {
+         $names[] = '*.js';
+      }
+      if ($include_css) {
+         $names[] = '*.css';
+      }
+      $files_finder = new Finder();
+      $files_finder->files()
+         ->name($names)
+         ->notName(['*.min.css', '*.min.js'])
+         ->in(
+            [
+               $dir . '/css',
+               $dir . '/js',
+               $dir . '/lib',
+            ]
+         )
+         ->sortByName();
+
+      return $files_finder;
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Nightly publication of a docker image of bugfixes branches (9.5 only for now).

Example of `docker-compose.yml` file that can be used to run this image.
```yml
version: "3.5"

services:
    glpi:
        container_name: "glpi-9.5-bugfixes"
        image: "glpi/glpi:9.5-bugfixes"
        ports:
            - "8080:80"
        volumes:
            - "./config:/var/glpi/config"
            - "./files:/var/glpi/files"
            - "./plugins:/var/www/glpi/plugins"
    db:
        image: "mysql:5.7"
        restart: "always"
        environment:
            MYSQL_RANDOM_ROOT_PASSWORD: "yes"
            MYSQL_DATABASE: "glpi"
            MYSQL_USER: "glpi"
            MYSQL_PASSWORD: "glpi"
        volumes:
            - "./db:/var/lib/mysql"
```

Remaining tasks to do:
- [x] schedule build
- [x] configure secrets on Github Actions
- [x] clean Robofile, split tasks and make them reusable
- [ ] publish a package description on Docker Hub and Github Packages
- [x] ~logs rotation~ *log rotation has to be configured on host directly*
- [x] set installation mode to "Docker"
