### PR TITLE
Fix location pager

### DIFF
--- a/inc/location.class.php
+++ b/inc/location.class.php
@@ -423,10 +423,15 @@ class Location extends CommonTreeDropdown {
       $criteria['LIMIT'] = $_SESSION['glpilist_limit'];
 
       $iterator = $DB->request($criteria);
-      $number = count($iterator);;
-      if ($start >= $number) {
-         $start = 0;
-      }
+
+      // Execute a second request to get the total number of rows
+      unset($criteria['SELECT']);
+      unset($criteria['START']);
+      unset($criteria['LIMIT']);
+
+      $criteria['COUNT'] = 'total';
+      $number = $DB->request($criteria)->next()['total'];
+
       // Mini Search engine
       echo "<table class='tab_cadre_fixe'>";
       echo "<tr class='tab_bg_1'><th colspan='2'>".__('Type')."</th></tr>";


### PR DESCRIPTION
Internal ref: 19508

Fix ajax pager in Location > Elements.
The total count was using the size of the iterator results
-> total was always equals to the number of results returned 
-> only one page displayed with no pagination

I've fixed it by adding a second DB request that count the real total.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
