### PR TITLE
maybeRecursive can return true for CommonDBChild objects

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3307,6 +3307,7 @@ JAVASCRIPT;
     * @return select string
    **/
    static function addDefaultSelect($itemtype) {
+      global $DB;
 
       $itemtable = getTableForItemType($itemtype);
       $item      = null;
@@ -3334,7 +3335,12 @@ JAVASCRIPT;
       if ($itemtable == 'glpi_entities') {
          $ret .= "`$itemtable`.`id` AS entities_id, '1' AS is_recursive, ";
       } else if ($mayberecursive) {
-         $ret .= "`$itemtable`.`entities_id`, `$itemtable`.`is_recursive`, ";
+         $ret .= $DB->quoteName("$itemtable.entities_id").", ";
+         //do not include field if not present in table
+         $item->getEmpty();
+         if (isset($item->fields['is_recursive'])) {
+            $ret .= $DB->quoteName("$itemtable.is_recursive").", ";
+         }
       }
       return $ret;
    }


### PR DESCRIPTION
maybeRecursive can return true for CommonDBChild objects because of their parents; but is_recursive field maybe missing in the table.
Seen this working on future features, it does not seems to be throwed currently from core; but I'm not 100% sure, and plugins may certainly be impacted.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes