### PR TITLE
Rework massiveactions for add or delete template from notification

### DIFF
--- a/inc/notification_notificationtemplate.class.php
+++ b/inc/notification_notificationtemplate.class.php
@@ -263,6 +263,27 @@ class Notification_NotificationTemplate extends CommonDBRelation {
    }
 
 
+   /**
+    * Form for Notification on Massive action
+   **/
+   static function showFormMassiveAction() {
+
+      echo __('Mode')."<br>";
+      self::dropdownMode(['name' => 'mode', 'multiple' => false]);
+      echo "<br><br>";
+
+      echo NotificationTemplate::getTypeName(1)."<br>";
+      NotificationTemplate::dropdown([
+         'name'       => 'notificationtemplates_id',
+         'value'     => 0,
+         'comment'   => 1,
+      ]);
+      echo "<br><br>";
+
+      echo Html::submit(_x('button', 'Add'), ['name' => 'massiveaction']);
+   }
+
+
    function getName($options = []) {
       return $this->getID();
    }


### PR DESCRIPTION

Add capability to 
- add template to a notification 
- remove all templates defined from notification

![image](https://user-images.githubusercontent.com/7335054/78769920-3af9fc80-798e-11ea-8f4c-81f0092d2bd3.png)


for add : check if template already defined

![image](https://user-images.githubusercontent.com/7335054/78769782-1140d580-798e-11ea-8726-8ba08fa4fd17.png)


for add : check if notification itemtype is equal to selected template itemtype

![image](https://user-images.githubusercontent.com/7335054/78769719-0128f600-798e-11ea-9dbe-99986dd273f1.png)

For add : Add template to notification if it is possible.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 19544
