### PR TITLE
Remove additional backslashes.

### DIFF
--- a/ajax/mailcollector.php
+++ b/ajax/mailcollector.php
@@ -52,6 +52,7 @@ if (isset($_REQUEST['action'])) {
 
          // Update fields with input values
          $input = $_REQUEST;
+         $input['login'] = stripslashes($input['login']);
 
          if (isset($input["passwd"])) {
             if (empty($input["passwd"])) {


### PR DESCRIPTION
Remove additional backslashes when getting folder list from Office365 shared mailboxes.

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7136
