### PR TITLE
updating ticket_tco. fixes #7128

### DIFF
--- a/front/ticketcost.form.php
+++ b/front/ticketcost.form.php
@@ -48,6 +48,8 @@ if (isset($_POST["add"])) {
       Event::log($_POST['tickets_id'], "tickets", 4, "tracking",
                  //TRANS: %s is the user login
                  sprintf(__('%s adds a cost'), $_SESSION["glpiname"]));
+      //update ticket_tco on linked items
+      TicketCost::updateLinkedItemsTCO(filter_input(INPUT_POST, 'tickets_id', FILTER_VALIDATE_INT));
    }
    Html::back();
 
@@ -57,6 +59,8 @@ if (isset($_POST["add"])) {
       Event::log($cost->fields['tickets_id'], "tickets", 4, "tracking",
                  //TRANS: %s is the user login
                  sprintf(__('%s purges a cost'), $_SESSION["glpiname"]));
+      //update ticket_tco on linked items
+      TicketCost::updateLinkedItemsTCO(filter_input(INPUT_POST, 'tickets_id', FILTER_VALIDATE_INT));
    }
    Html::redirect(Toolbox::getItemTypeFormURL('Ticket').'?id='.$cost->fields['tickets_id']);
 
@@ -67,6 +71,8 @@ if (isset($_POST["add"])) {
       Event::log($cost->fields['tickets_id'], "tickets", 4, "tracking",
                  //TRANS: %s is the user login
                  sprintf(__('%s updates a cost'), $_SESSION["glpiname"]));
+      //update ticket_tco on linked items
+      TicketCost::updateLinkedItemsTCO(filter_input(INPUT_POST, 'tickets_id', FILTER_VALIDATE_INT));
    }
    Html::back();
 

--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -99,7 +99,7 @@ class Item_Ticket extends CommonDBRelation{
       }
 
       $ticket->update($input);
-      
+
       //update ticket_tco of item when added to ticket.
       TicketCost::updateLinkedItemsTCO($this->fields['tickets_id']);
       parent::post_addItem();

--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -99,6 +99,9 @@ class Item_Ticket extends CommonDBRelation{
       }
 
       $ticket->update($input);
+      
+      //update ticket_tco of item when added to ticket.
+      TicketCost::updateLinkedItemsTCO($this->fields['tickets_id']);
       parent::post_addItem();
    }
 
@@ -115,6 +118,8 @@ class Item_Ticket extends CommonDBRelation{
       }
       $ticket->update($input);
 
+      //update ticket_tco when item removed from ticket.
+      TicketCost::updateItemsTCO($this->fields['items_id'], $this->fields['itemtype']);
       parent::post_purgeItem();
    }
 

--- a/inc/ticketcost.class.php
+++ b/inc/ticketcost.class.php
@@ -46,7 +46,7 @@ class TicketCost extends CommonITILCost {
    static public $items_id  = 'tickets_id';
 
    static $rightname        = 'ticketcost';
-   
+
    /**
    * Given a tickets_id, updates the ticket_tco field of linked items with
    * the computed TCO (glpi_ticketcosts).
@@ -57,10 +57,10 @@ class TicketCost extends CommonITILCost {
    **/
    static function updateLinkedItemsTCO($tickets_id) {
       $returnValue = false;
-      if(is_numeric($tickets_id) && $tickets_id > 0) {
+      if (is_numeric($tickets_id) && $tickets_id > 0) {
          $item_ticket = new Item_Ticket();
          $ticketLinkedItems = $item_ticket->find(['tickets_id' => $tickets_id]);
-         foreach($ticketLinkedItems as $linkedItem) {
+         foreach ($ticketLinkedItems as $linkedItem) {
             if ($linkedItem && ($item = getItemForItemtype($linkedItem['itemtype']))) {
                if ($item->getFromDB($linkedItem['items_id'])) {
                   $newinput               = [];
@@ -86,8 +86,8 @@ class TicketCost extends CommonITILCost {
    **/
    static function updateItemsTCO($items_id, $itemtype) {
       $returnValue = false;
-      if(is_numeric($items_id) && $itemtype) {
-         if($item = getItemForItemtype($itemtype)) {
+      if (is_numeric($items_id) && $itemtype) {
+         if ($item = getItemForItemtype($itemtype)) {
             if ($item->getFromDB($items_id)) {
                $newinput               = [];
                $newinput['id']         = $items_id;

--- a/inc/ticketcost.class.php
+++ b/inc/ticketcost.class.php
@@ -99,5 +99,4 @@ class TicketCost extends CommonITILCost {
       }
       return $returnValue;
    }
-
 }


### PR DESCRIPTION
Functionality to update the "ticket_tco" on ticket items when ticket costs are added, edited, purged.
Field also updated when ticket items are added or purged.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7128
