### PR TITLE
add date_mod criterion in RuleTicket

### DIFF
--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -393,6 +393,11 @@ class RuleTicket extends Rule {
       $criterias['content']['name']                         = __('Description');
       $criterias['content']['linkfield']                    = 'content';
 
+      $criterias['date_mod']['table']                       = 'glpi_tickets';
+      $criterias['date_mod']['field']                       = 'date_mod';
+      $criterias['date_mod']['name']                        = __('Last update');
+      $criterias['date_mod']['linkfield']                   = 'date_mod';
+
       $criterias['itilcategories_id']['table']              = 'glpi_itilcategories';
       $criterias['itilcategories_id']['field']              = 'name';
       $criterias['itilcategories_id']['name']               = __('Category')." - ".__('Name');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Follow #5932, it may help to disable more actions like linking items to ticket or adding documents.
Adding assignee still trigger compute of take into account delay stat.

![image](https://user-images.githubusercontent.com/418844/79725285-47187f00-82e9-11ea-87c2-95ae4c5186ec.png)

