### PR TITLE
Fix recursive project task visibility

### DIFF
--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -83,8 +83,7 @@ class ProjectTask extends CommonDBChild {
     * @return boolean
    **/
    function canViewItem() {
-
-      if (!Session::haveAccessToEntity($this->getEntityID())) {
+      if (!Session::haveAccessToEntity($this->getEntityID(), $this->isRecursive())) {
          return false;
       }
       $project = new Project();


### PR DESCRIPTION
Internal ref: 19597

Recursive project tasks are not visible from sub-entities.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
