### PR TITLE
Fix CTRL+enter for textareas

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -665,7 +665,7 @@ var submitparentForm = function(input) {
    var form = $(input).closest('form');
 
    // find submit button(s)
-   var submit = form.find('button[type=submit]').filter('[name=add], [name=update]');
+   var submit = form.find('[type=submit]').filter('[name=add], [name=update]');
 
    // trigger if only one submit button
    if (submit.length == 1) {

--- a/js/common.js
+++ b/js/common.js
@@ -665,7 +665,7 @@ var submitparentForm = function(input) {
    var form = $(input).closest('form');
 
    // find submit button(s)
-   var submit = form.find('input[type=submit]').filter('[name=add], [name=update]');
+   var submit = form.find('button[type=submit]').filter('[name=add], [name=update]');
 
    // trigger if only one submit button
    if (submit.length == 1) {


### PR DESCRIPTION
The "submit" input was replaced by a button in 9.5 so we need to update this selector.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
