### PR TITLE
Fix markup diplay when term match with html entity

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -936,11 +936,6 @@ var templateResult = function(result) {
       }
 
       var text = result.text;
-      if (text.indexOf('>') !== -1 || text.indexOf('<') !== -1) {
-         // escape text, if it contains chevrons (can already be escaped prior to this point :/)
-         text = jQuery.fn.select2.defaults.defaults.escapeMarkup(text);
-      };
-
       if (!result.id) {
          // If result has no id, then it is used as an optgroup and is not used for matches
          _elt.html(text);

--- a/js/common.js
+++ b/js/common.js
@@ -906,17 +906,17 @@ function markMatch (text, term) {
    }
 
    // Put in whatever text is before the match
-   _result.html(text.substring(0, match));
+   _result.html(escapeMarkupText(text.substring(0, match)));
 
    // Mark the match
    var _match = $('<span class=\'select2-rendered__match\'></span>');
-   _match.html(text.substring(match, match + term.length));
+   _match.html(escapeMarkupText(text.substring(match, match + term.length)));
 
    // Append the matching text
    _result.append(_match);
 
    // Put in whatever is after the match
-   _result.append(text.substring(match + term.length));
+   _result.append(escapeMarkupText(text.substring(match + term.length)));
 
    return _result.html();
 }
@@ -942,7 +942,7 @@ var templateResult = function(result) {
          return _elt;
       }
 
-      var _term = escapeMarkupText(query.term || '');
+      var _term = query.term || '';
       var markup = markMatch(text, _term);
 
       if (result.level) {
@@ -1003,6 +1003,17 @@ var getTextWithoutDiacriticalMarks = function (text) {
    return text.replace(/[\u0300-\u036f]/g, '');
 }
 
+/**
+ * Escape markup in text to prevent XSS.
+ *
+ * @param {string} text
+ *
+ * @return {string}
+ */
 var escapeMarkupText = function (text) {
-   return jQuery.fn.select2.defaults.defaults.escapeMarkup(text);
+   if (text.indexOf('>') !== -1 || text.indexOf('<') !== -1) {
+      // escape text, if it contains chevrons (can already be escaped prior to this point :/)
+      text = jQuery.fn.select2.defaults.defaults.escapeMarkup(text);
+   };
+   return text;
 }

--- a/js/common.js
+++ b/js/common.js
@@ -901,7 +901,7 @@ function markMatch (text, term) {
 
    // If there is no match, move on
    if (match < 0) {
-      _result.append(text);
+      _result.append(escapeMarkupText(text));
       return _result.html();
    }
 
@@ -938,11 +938,11 @@ var templateResult = function(result) {
       var text = result.text;
       if (!result.id) {
          // If result has no id, then it is used as an optgroup and is not used for matches
-         _elt.html(text);
+         _elt.html(escapeMarkupText(text));
          return _elt;
       }
 
-      var _term = jQuery.fn.select2.defaults.defaults.escapeMarkup(query.term || '');
+      var _term = escapeMarkupText(query.term || '');
       var markup = markMatch(text, _term);
 
       if (result.level) {
@@ -1001,4 +1001,8 @@ var getTextWithoutDiacriticalMarks = function (text) {
    // The U+0300 -> U+036F range corresponds to diacritical chars.
    // They are removed to keep only chars without their diacritical mark.
    return text.replace(/[\u0300-\u036f]/g, '');
+}
+
+var escapeMarkupText = function (text) {
+   return jQuery.fn.select2.defaults.defaults.escapeMarkup(text);
 }


### PR DESCRIPTION
With the Select2 search function, when we search term "gt" (to find Wellington for example) and if GLPI is configured to display the completename

Select2 escapes ">" and "<" when occurences is find and display ```&gt;``` on result set because templateResult underline matches on text

![image](https://user-images.githubusercontent.com/7335054/80068287-a8d22680-853f-11ea-8877-c178f651963f.png)

This PR fix this 

![image](https://user-images.githubusercontent.com/7335054/80068693-580efd80-8540-11ea-8749-d69e3222c1d7.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 19509
