### PR TITLE
Make release process compatible with GPLI 9.5

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -66,7 +66,7 @@ if (isset($_SERVER['argv']) && ['dependencies', 'install'] === array_slice($_SER
 
    file_put_contents('.package.hash', sha1_file('package-lock.json'));
 
-   passthru('npm run-script build-dev', $exit_code);
+   passthru('npm run-script build', $exit_code);
    exit($exit_code);
 }
 

--- a/bin/console
+++ b/bin/console
@@ -43,7 +43,7 @@ if (isset($_SERVER['argv'])) {
 
 // Handle specific dependencies update command that cannot be made upon symfony console
 if (isset($_SERVER['argv']) && ['dependencies', 'install'] === array_slice($_SERVER['argv'], 1, 2)) {
-   $composer_command = 'composer install --no-interaction --no-suggest';
+   $composer_command = 'composer install --ansi --no-interaction --no-suggest';
    $npm_command = 'npm install';
 
    if (array_key_exists('composer-options', $options) && is_string($options['composer-options'])) {

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
         "unorm": "^1.6.0"
     },
     "scripts": {
-        "build": "webpack --config webpack.config.js --mode=production",
-        "build-dev": "webpack --config webpack.config.js --mode=development"
+        "build": "webpack --config webpack.config.js"
     },
     "devDependencies": {
         "acorn": "^7.0.0",

--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# /**
+#  * ---------------------------------------------------------------------
+#  * GLPI - Gestionnaire Libre de Parc Informatique
+#  * Copyright (C) 2015-2018 Teclib' and contributors.
+#  *
+#  * http://glpi-project.org
+#  *
+#  * based on GLPI - Gestionnaire Libre de Parc Informatique
+#  * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+#  *
+#  * ---------------------------------------------------------------------
+#  *
+#  * LICENSE
+#  *
+#  * This file is part of GLPI.
+#  *
+#  * GLPI is free software; you can redistribute it and/or modify
+#  * it under the terms of the GNU General Public License as published by
+#  * the Free Software Foundation; either version 2 of the License, or
+#  * (at your option) any later version.
+#  *
+#  * GLPI is distributed in the hope that it will be useful,
+#  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  * GNU General Public License for more details.
+#  *
+#  * You should have received a copy of the GNU General Public License
+#  * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+#  * ---------------------------------------------------------------------
+#  */
+
+SCRIPT_DIR=$(dirname $0)
+WORKING_DIR=$(readlink --canonicalize "$SCRIPT_DIR/..")
+
+if [ -e "$WORKING_DIR/.git" ]
+then
+    # Prevent script to corrupt user local Git repository
+    echo "$WORKING_DIR/.git directory found!"
+    echo "This script alters targetted directory and must not be run on a Git repository."
+    exit 1
+fi
+
+echo "Install dependencies"
+# PHP dev dependencies are usefull at this point as they are used by some build operations
+$WORKING_DIR/bin/console dependencies install --composer-options="--ignore-platform-reqs --prefer-dist --no-progress"
+
+echo "Minify stylesheets and javascripts"
+php -d memory_limit=2G $WORKING_DIR/vendor/bin/robo minify --load-from $WORKING_DIR/tools
+
+echo "Compile SCSS"
+$WORKING_DIR/bin/console build:compile_scss
+
+echo "Compile locale files"
+$WORKING_DIR/tools/locale/update_mo.pl
+
+echo "Remove dev files and directories"
+# Remove PHP dev dependencies that are not anymore used
+composer update nothing --ignore-platform-reqs --no-dev --working-dir=$WORKING_DIR
+
+# Remove hidden files and directory, except .htaccess files
+find $WORKING_DIR -depth \( -iname ".*" ! -iname ".htaccess" \) -exec rm -rf {} \;
+
+# Remove useless dev files and directories
+dev_nodes=(
+    "composer.json"
+    "composer.lock"
+    "ISSUE_TEMPLATE.md"
+    "node_modules"
+    "package.json"
+    "package-lock.json"
+    "PULL_REQUEST_TEMPLATE.md"
+    "tests"
+    "tools"
+    "vendor/bin"
+)
+for node in "${dev_nodes[@]}"
+do
+    rm -rf $WORKING_DIR/$node
+done
+exit;
+find $WORKING_DIR/pics/ -depth -type f -iname "*.eps" -exec rm -rf {} \;
+
+# Remove useless files and directories in vendor subdirs
+vendor_dirs=( "doc*" "example*" "test*" )
+for directory in "${vendor_dirs[@]}"
+do
+    find $WORKING_DIR/vendor -depth -type d -iname $directory -exec rm -rf {} \;
+done
+vendor_filenames=( "build.xml" "changelog.md" "composer.json" "phpunit.xml.dist" "readme.md" )
+for filename in "${vendor_filenames[@]}"
+do
+    find $WORKING_DIR/vendor -depth -type f -iname $filename -exec rm -rf {} \;
+done
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -204,10 +204,13 @@ for (let packageName in libs) {
     }
 }
 
-module.exports = (env, argv) => {
+module.exports = function() {
     var configs = [glpiConfig, libsConfig];
 
     for (let config of configs) {
+        config.mode = 'none'; // Force 'none' mode, as optimizations will be done on release process
+        config.devtool = 'source-map'; // Add sourcemap to files
+
         // Limit verbosity to only usefull informations
         config.stats = {
             all: false,
@@ -218,10 +221,6 @@ module.exports = (env, argv) => {
             entrypoints: true,
             timings: true,
         };
-
-        if (argv.mode === 'development') {
-            config.devtool = 'source-map';
-        }
     }
 
     return configs;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

There are also some improvements:
 - dependencies install now outputs colors of composer output
 - building script has been moved apart so it can be used directly on an extracted tarball retrieved from Github (will be usefull for nightly builds and internal archive build)