### PR TITLE
Add new hook to give ability to handle more mail protocols

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -184,14 +184,19 @@ class Auth extends CommonGLPI {
             $ssl = 'TLS';
          }
 
-         $imap = new \Laminas\Mail\Protocol\Imap();
-         $imap->connect(
+         $protocol_class = Toolbox::getMailServerProtocolClassname($config['type']);
+         if ($protocol_class === null) {
+            throw new \RuntimeException(sprintf(__('Unsupported mail server type:%s.'), $config['type']));
+         }
+         $mail = new $protocol_class();
+
+         $mail->connect(
             $config['address'],
             $config['port'],
             $ssl
          );
 
-         return $imap->login($login, $pass);
+         return $mail->login($login, $pass);
       } catch (\Exception $e) {
          $this->addToError($e->getMessage());
          return false;

--- a/inc/mail/protocol/protocolinterface.class.php
+++ b/inc/mail/protocol/protocolinterface.class.php
@@ -30,14 +30,30 @@
  * ---------------------------------------------------------------------
  */
 
-define('GLPI_CONFIG_DIR', __DIR__);
-define('GLPI_PICTURE_DIR', __DIR__ . '/files/_pictures');
+namespace Glpi\Mail\Protocol;
 
-define(
-   'PLUGINS_DIRECTORIES',
-   [
-      __DIR__ . '/fixtures/plugins',
-   ]
-);
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
 
-return false;
+interface ProtocolInterface {
+
+   /**
+    * Open connection to server.
+    *
+    * @param  string      $host  hostname or IP address of POP3 server
+    * @param  int|null    $port  server port, null value with fallback to default port
+    * @param  string|bool $ssl   use 'SSL', 'TLS' or false
+    */
+   public function connect($host, $port = null, $ssl = false);
+
+   /**
+    * Login to server.
+    *
+    * @param  string $user      username
+    * @param  string $password  password
+    *
+    * @return bool
+    */
+   public function login($user, $password);
+}

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -1262,8 +1262,10 @@ class MailCollector  extends CommonDBTM {
       }
 
       try {
-         $class = '\Laminas\Mail\Storage\\';
-         $class .= ($config['type']== 'pop' ? 'Pop3' : 'Imap');
+         $class = Toolbox::getMailServerStorageClassname($config['type']);
+         if ($class === null) {
+            throw new \Exception(sprintf(__('Unsupported mail server type:%s.'), $config['type']));
+         }
          $this->storage = new $class($params);
          if ($this->fields['errors'] > 0) {
             $this->update([

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,6 +38,14 @@ define('GLPI_CONFIG_DIR', __DIR__);
 define('GLPI_VAR_DIR', __DIR__ . '/files');
 define('GLPI_URI', (getenv('GLPI_URI') ?: 'http://localhost:8088'));
 
+define(
+   'PLUGINS_DIRECTORIES',
+   [
+      GLPI_ROOT . '/plugins',
+      GLPI_ROOT . '/tests/fixtures/plugins',
+   ]
+);
+
 define('TU_USER', '_test_user');
 define('TU_PASS', 'PhpUnit_4');
 
@@ -561,6 +569,13 @@ function loadDataset() {
             'dashboards_dashboards_id' => 'Test_Dashboard',
             'itemtype'                 => 'Profile',
             'items_id'                 => 3,
+         ]
+      ], 'Plugin' => [
+         [
+            'directory'    => 'tester',
+            'name'         => 'tester',
+            'version'      => '1.0.0',
+            'state'        => 1,
          ]
       ],
    ];

--- a/tests/fixtures/plugins/tester/setup.php
+++ b/tests/fixtures/plugins/tester/setup.php
@@ -30,14 +30,16 @@
  * ---------------------------------------------------------------------
  */
 
-define('GLPI_CONFIG_DIR', __DIR__);
-define('GLPI_PICTURE_DIR', __DIR__ . '/files/_pictures');
-
-define(
-   'PLUGINS_DIRECTORIES',
-   [
-      __DIR__ . '/fixtures/plugins',
-   ]
-);
-
-return false;
+function plugin_version_tester() {
+   return [
+      'name'           => 'tester',
+      'version'        => '1.0.0',
+      'author'         => 'GLPI Test suite',
+      'license'        => 'GPL v2+',
+      'requirements'   => [
+         'glpi' => [
+            'min' => '9.5.0',
+         ]
+      ]
+   ];
+}

--- a/tests/functionnal/Telemetry.php
+++ b/tests/functionnal/Telemetry.php
@@ -65,14 +65,17 @@ class Telemetry extends DbTestCase {
       $this->string($result['uuid'])
          ->hasLength(40);
       $expected['uuid'] = $result['uuid'];
-      $this->array($result['plugins'])
-         ->hasSize(count(glob(GLPI_ROOT . "/plugins/*", GLOB_ONLYDIR)));
+      $plugins_count = 0;
+      foreach (PLUGINS_DIRECTORIES as $plugin_base_dir) {
+         $plugins_count += count(glob("$plugin_base_dir/*", GLOB_ONLYDIR));
+      }
+      $this->array($result['plugins'])->hasSize($plugins_count);
       $expected['plugins'] = $result['plugins'];
       $this->array($result)->isIdenticalTo($expected);
 
       $plugins = new \Plugin();
       $this->integer((int)$plugins->add(['directory' => 'testplugin',
-                                         'name'      => 'test plugin',
+                                         'name'      => 'testplugin',
                                          'version'   => '0.x.z']))
          ->isGreaterThan(0);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6895

Imap Oauth implementation requires a secret/token exchange between GLPI and tier providers and this part may be specific for each of them.
I propose to add a new hook that will give ability to plugins to specify a new "protocol" (e.g. "Google IMAP XOauth2") and corresponding classes to use.

Remaining work to do:
- [x] use corresponding classes;
- [x] try to see if specifying an interface is possible.