### PR TITLE
Fix collecting emails without some headers

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -2009,10 +2009,15 @@ class MailCollector  extends CommonDBTM {
             // returned verbatim
             break;
          default:
-            throw new \UnexpectedValueException("$encoding is not known");
+            break;
+            //throw new \UnexpectedValueException("$encoding is not known");
       }
 
-      $contentType = $part->getHeader('contentType');
+      try {
+         $contentType = $part->getHeader('contentType');
+      } catch (Exception $e) {
+         $contentType = 'text/html; charset="utf-8"';
+      }
       if ($contentType instanceof \Laminas\Mail\Header\ContentType
           && preg_match('/^text\//', $contentType->getType())
           && mb_detect_encoding($contents) != 'UTF-8') {


### PR DESCRIPTION
This commit fixes importing emails, when someone sends an email without content type header or encoding.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
