### PR TITLE
fix canupdate detection in change|problem form

### DIFF
--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -678,7 +678,7 @@ class Change extends CommonITILObject {
          $this->check(-1, CREATE, $options);
       }
 
-      $canupdate = !$ID && $this->canUpdateItem();
+      $canupdate = !$ID || $this->canUpdateItem();
       $showuserlink = 0;
       if (User::canView()) {
          $showuserlink = 1;

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -1076,7 +1076,7 @@ class Problem extends CommonITILObject {
 
       $this->initForm($ID, $options);
 
-      $canupdate = !$ID && $this->canUpdateItem();
+      $canupdate = !$ID || $this->canUpdateItem();
       $showuserlink = 0;
       if (User::canView()) {
          $showuserlink = 1;


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

internal ref : 19694

Change and problem forms are not editable anymore due to bad logical operator usage
