### PR TITLE
Fix default rights for self-service profiles

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -6221,3 +6221,7 @@ with incorrect shading in some cases */
 .enabled {
    color: green !important;
 }
+
+.cursor-not-allowed {
+   cursor: not-allowed;
+}

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -6222,6 +6222,6 @@ with incorrect shading in some cases */
    color: green !important;
 }
 
-.cursor-not-allowed {
+input:disabled + .label-checkbox {
    cursor: not-allowed;
 }

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -2301,11 +2301,9 @@ class Html {
          }
       }
 
-      $label_class = "label-checkbox";
 
       if ($params['readonly']) {
          $out .= " disabled='disabled'";
-         $label_class .= " cursor-not-allowed";
       }
 
       if ($params['checked']) {
@@ -2313,7 +2311,7 @@ class Html {
       }
 
       $out .= ">";
-      $out .= "<label class='$label_class' title=\"".$params['title']."\" for='".$params['id']."'>";
+      $out .= "<label class='label-checkbox' title=\"".$params['title']."\" for='".$params['id']."'>";
       $out .= " <span class='check'></span>";
       $out .= " <span class='box'></span>";
       $out .= "&nbsp;";

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -2301,7 +2301,6 @@ class Html {
          }
       }
 
-
       if ($params['readonly']) {
          $out .= " disabled='disabled'";
       }

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -2301,8 +2301,11 @@ class Html {
          }
       }
 
+      $label_class = "label-checkbox";
+
       if ($params['readonly']) {
          $out .= " disabled='disabled'";
+         $label_class .= " cursor-not-allowed";
       }
 
       if ($params['checked']) {
@@ -2310,7 +2313,7 @@ class Html {
       }
 
       $out .= ">";
-      $out .= "<label class='label-checkbox' title=\"".$params['title']."\" for='".$params['id']."'>";
+      $out .= "<label class='$label_class' title=\"".$params['title']."\" for='".$params['id']."'>";
       $out .= " <span class='check'></span>";
       $out .= " <span class='box'></span>";
       $out .= "&nbsp;";

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -254,10 +254,10 @@ class Profile extends CommonDBTM {
       }
 
       if (isset($input["_cycle_ticket"])) {
-         $tab   = Ticket::getAllStatusArray();
+         $tab   = array_keys(Ticket::getAllStatusArray());
          $cycle = [];
-         foreach ($tab as $from => $label) {
-            foreach ($tab as $dest => $label) {
+         foreach ($tab as $from) {
+            foreach ($tab as $dest) {
                if (($from != $dest)
                    && (!isset($input["_cycle_ticket"][$from][$dest])
                       || ($input["_cycle_ticket"][$from][$dest] == 0))) {
@@ -372,10 +372,10 @@ class Profile extends CommonDBTM {
       // Set default values, only needed for helpdesk
       $interface = isset($input['interface']) ? $input['interface'] : "";
       if (!empty($interface) && $interface == "helpdesk" && !isset($input["_cycle_ticket"])) {
-         $tab   = Ticket::getAllStatusArray();
+         $tab   = array_keys(Ticket::getAllStatusArray());
          $cycle = [];
-         foreach ($tab as $from => $label) {
-            foreach ($tab as $dest => $label) {
+         foreach ($tab as $from) {
+            foreach ($tab as $dest) {
                if ($from != $dest) {
                   $cycle[$from][$dest] = 0;
                }

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -371,7 +371,7 @@ class Profile extends CommonDBTM {
 
       // Set default values, only needed for helpdesk
       $interface = isset($input['interface']) ? $input['interface'] : "";
-      if (!empty($interface) && $interface == "helpdesk" && !isset($input["_cycle_ticket"])) {
+      if ($interface == "helpdesk" && !isset($input["_cycle_ticket"])) {
          $tab   = array_keys(Ticket::getAllStatusArray());
          $cycle = [];
          foreach ($tab as $from) {

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -369,6 +369,21 @@ class Profile extends CommonDBTM {
          }
       }
 
+      // Set default values, only needed for helpdesk
+      $interface = $input['interface'] ?? "";
+      if (!empty($interface) && $interface == "helpdesk" && !isset($input["_cycle_ticket"])) {
+         $tab   = Ticket::getAllStatusArray();
+         $cycle = [];
+         foreach ($tab as $from => $label) {
+            foreach ($tab as $dest => $label) {
+               if ($from != $dest) {
+                  $cycle[$from][$dest] = 0;
+               }
+            }
+         }
+         $input["ticket_status"] = exportArrayToDB($cycle);
+      }
+
       return $input;
    }
 
@@ -1214,7 +1229,7 @@ class Profile extends CommonDBTM {
 
       $allowactions = [Ticket::INCOMING => [],
                             Ticket::SOLVED   => [Ticket::CLOSED],
-                            Ticket::CLOSED   => [Ticket::CLOSED, Ticket::INCOMING]];
+                            Ticket::CLOSED   => [Ticket::INCOMING]];
 
       foreach ($statuses as $index_1 => $status_1) {
          $columns[$index_1] = $status_1;

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -370,7 +370,7 @@ class Profile extends CommonDBTM {
       }
 
       // Set default values, only needed for helpdesk
-      $interface = $input['interface'] ?? "";
+      $interface = isset($input['interface']) ? $input['interface'] : "";
       if (!empty($interface) && $interface == "helpdesk" && !isset($input["_cycle_ticket"])) {
          $tab   = Ticket::getAllStatusArray();
          $cycle = [];


### PR DESCRIPTION
Internal ref: 19652.

#### Fix default rights for self-service profiles

After creating a new helpdesk profile, the life cycle tabs looks like everything is allowed:
![image](https://user-images.githubusercontent.com/42734840/80976527-d8c4d800-8e23-11ea-90f3-158551eb29f6.png)

After any update, the rights reset to the correct "default" state:
![image](https://user-images.githubusercontent.com/42734840/80976637-f7c36a00-8e23-11ea-8dad-eb9512b4e730.png)

To fix this I've added a check in the prepareInputForAdd in order to initialize the life cycle correctly when creating a new helpdesk profile.

No modification needed for central profiles, they already work as expected.

#### Add disabled cursor for readonly checkbox

On the previous screenshot, only 2 out of the 9 checkbox are clickable.
This is very confusing for the users as we give no UI feedback for read-only checkboxes.

After this change any read-only checkbox will display the "not-allowed" cursor when hovered:
![image](https://user-images.githubusercontent.com/42734840/80977317-dd3dc080-8e24-11ea-8b67-5673750ed1d8.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
