### PR TITLE
Fix not clickable buttons on installed plugins page

### DIFF
--- a/css/marketplace.scss
+++ b/css/marketplace.scss
@@ -466,7 +466,7 @@ $break_s_screen: 1400px;
             .footer {
                background: none;
                border: none;
-               margin-top: -25px;
+               margin: -25px 36px 0 0;
 
                .misc-left {
                   margin-left: 15px;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

On "installed plugins" marketplace view, some buttons may not be clickable as they are overlapped by card footer.

Before:
![image](https://user-images.githubusercontent.com/33253653/80980485-f7799d80-8e28-11ea-9fa3-125d01e21ae0.png)

After:
![image](https://user-images.githubusercontent.com/33253653/80980600-1d06a700-8e29-11ea-9624-05c51620bc64.png)
