### PR TITLE
Allow Rule creation and suppresion through API

### DIFF
--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -3164,5 +3164,11 @@ class Rule extends CommonDBTM {
       echo "</div>";
    }
 
+   public static function canCreate() {
+      return static::canUpdate();
+   }
 
+   public static function canPurge() {
+      return static::canUpdate();
+   }
 }


### PR DESCRIPTION
It's currently impossible to create or delete `Rule` object through the API as it use the `config` right name which only support `READ` and `UPDATE` rights :
![image](https://user-images.githubusercontent.com/42734840/81072631-b5af2c80-8ee6-11ea-909f-65fbb7ab755a.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
