### PR TITLE
factorize showFormHeader for itil classes

### DIFF
--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -788,18 +788,7 @@ class Change extends CommonITILObject {
          }
       }
 
-      if (!$options['template_preview']) {
-         $this->showFormHeader($options);
-         if (isset($this->fields['_tasktemplates_id'])) {
-            foreach ($this->fields['_tasktemplates_id'] as $tasktemplates_id) {
-               echo "<input type='hidden' name='_tasktemplates_id[]' value='$tasktemplates_id'>";
-            }
-         }
-      }
-
-      echo "<div class='spaced' id='tabsbody'>";
-
-      echo "<table class='tab_cadre_fixe' id='mainformtable'>";
+      $this->showFormHeader($options);
 
       echo "<tr class='tab_bg_1'>";
       echo "<th class='left' width='$colsize1%'>";
@@ -1178,9 +1167,10 @@ class Change extends CommonITILObject {
          }
 
          $this->showFormButtons($options);
+      } else {
+         echo "</table>";
+         echo "</div>";
       }
-      echo "</table>";
-      echo "</div>";
 
       return true;
 

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7419,6 +7419,65 @@ abstract class CommonITILObject extends CommonDBTM {
       }
    }
 
+
+   function showFormHeader($options = []) {
+      $ID   = $this->fields['id'];
+      $rand = mt_rand();
+
+      if (!$options['template_preview']) {
+         echo "<form method='post' name='form_ticket' enctype='multipart/form-data' action='".
+                Ticket::getFormURL()."'>";
+         if (isset($options['_projecttasks_id'])) {
+            echo "<input type='hidden' name='_projecttasks_id' value='".$options['_projecttasks_id']."'>";
+         }
+         if (isset($this->fields['_tasktemplates_id'])) {
+            foreach ($this->fields['_tasktemplates_id'] as $tasktemplates_id) {
+               echo "<input type='hidden' name='_tasktemplates_id[]' value='$tasktemplates_id'>";
+            }
+         }
+      }
+      echo "<div class='spaced' id='tabsbody'>";
+
+      echo "<table class='tab_cadre_fixe' id='mainformtable'>";
+
+      // Optional line
+      $ismultientities = Session::isMultiEntitiesMode();
+      echo "<tr class='headerRow responsive_hidden'>";
+      echo "<th colspan='4'>";
+
+      if ($ID) {
+         $text = sprintf(__('%1$s - ID %2$d'), $this->getTypeName(1), $ID);
+         if ($ismultientities) {
+            $text = sprintf(__('%1$s (%2$s)'), $text,
+                            Dropdown::getDropdownName('glpi_entities',
+                                                      $this->fields['entities_id']));
+         }
+         echo $text;
+      } else {
+         if ($ismultientities) {
+            printf(
+               __('The %s will be added in the entity %s'),
+               strtolower(static::getTypeName()),
+               Dropdown::getDropdownName("glpi_entities", $this->fields['entities_id'])
+            );
+         } else {
+            echo sprintf(
+               __('New %'),
+               strtolower(static::getTypeName())
+            );
+         }
+      }
+
+      if ($this->maybeRecursive()) {
+         echo "&nbsp;<label for='dropdown_is_recursive$rand'>".__('Child entities')."</label>&nbsp;";
+         Dropdown::showYesNo("is_recursive", $this->fields["is_recursive"], -1, ['rand' => $rand]);
+      }
+      echo "</th>";
+      echo "</tr>";
+
+      Plugin::doHook("pre_item_form", ['item' => $this, 'options' => &$options]);
+   }
+
    /**
     * Summary of getITILActors
     * Get the list of actors for the current Change

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7426,7 +7426,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       if (!$options['template_preview']) {
          echo "<form method='post' name='form_ticket' enctype='multipart/form-data' action='".
-                Ticket::getFormURL()."'>";
+                static::getFormURL()."'>";
          if (isset($options['_projecttasks_id'])) {
             echo "<input type='hidden' name='_projecttasks_id' value='".$options['_projecttasks_id']."'>";
          }

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -1185,18 +1185,7 @@ class Problem extends CommonITILObject {
          }
       }
 
-      if (!$options['template_preview']) {
-         $this->showFormHeader($options);
-         if (isset($this->fields['_tasktemplates_id'])) {
-            foreach ($this->fields['_tasktemplates_id'] as $tasktemplates_id) {
-               echo "<input type='hidden' name='_tasktemplates_id[]' value='$tasktemplates_id'>";
-            }
-         }
-      }
-
-      echo "<div class='spaced' id='tabsbody'>";
-
-      echo "<table class='tab_cadre_fixe' id='mainformtable'>";
+      $this->showFormHeader($options);
 
       echo "<tr class='tab_bg_1'>";
       echo "<th class='left' width='$colsize1%'>";
@@ -1505,9 +1494,10 @@ class Problem extends CommonITILObject {
          }
 
          $this->showFormButtons($options);
+      } else {
+         echo "</table>";
+         echo "</div>";
       }
-      echo "</table>";
-      echo "</div>";
 
       return true;
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -4352,46 +4352,7 @@ class Ticket extends CommonITILObject {
       $colsize3 = '13';
       $colsize4 = '45';
 
-      if (!$options['template_preview']) {
-         echo "<form method='post' name='form_ticket' enctype='multipart/form-data' action='".
-                Ticket::getFormURL()."'>";
-         if (isset($options['_projecttasks_id'])) {
-            echo "<input type='hidden' name='_projecttasks_id' value='".$options['_projecttasks_id']."'>";
-         }
-         if (isset($this->fields['_tasktemplates_id'])) {
-            foreach ($this->fields['_tasktemplates_id'] as $tasktemplates_id) {
-               echo "<input type='hidden' name='_tasktemplates_id[]' value='$tasktemplates_id'>";
-            }
-         }
-      }
-      echo "<div class='spaced' id='tabsbody'>";
-
-      echo "<table class='tab_cadre_fixe' id='mainformtable'>";
-
-      // Optional line
-      $ismultientities = Session::isMultiEntitiesMode();
-      echo "<tr class='headerRow responsive_hidden'>";
-      echo "<th colspan='4'>";
-
-      if ($ID) {
-         $text = sprintf(__('%1$s - ID %2$d'), $this->getTypeName(1), $ID);
-         if ($ismultientities) {
-            $text = sprintf(__('%1$s (%2$s)'), $text,
-                            Dropdown::getDropdownName('glpi_entities',
-                                                      $this->fields['entities_id']));
-         }
-         echo $text;
-      } else {
-         if ($ismultientities) {
-            printf(__('The ticket will be added in the entity %s'),
-                   Dropdown::getDropdownName("glpi_entities", $this->fields['entities_id']));
-         } else {
-            echo __('New ticket');
-         }
-      }
-      echo "</th></tr>";
-
-      Plugin::doHook("pre_item_form", ['item' => $this, 'options' => &$options]);
+      $this->showFormHeader($options);
 
       echo "<tr class='tab_bg_1'>";
       echo "<th width='$colsize1%'>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Internal ref 19703

This prevent change of entity when editing changes/problems.

`$options` passed to `showFormHeader` contains a `entities_id` (set by `getDefaultValues`) key who force the change of entities of change/problem

Ticket doesn't have the issue because it had a custom header and doesn't rely on standard `showFormHeader` (it it was the case, Ticket would have the same issue as the `getDefaultValues` is also present.

I moved (and adapt a little)  the custom header of Ticket into a CommonItilObject::showFormHeader to share the same base code between the 3 itemtypes (and fix the issues)

The else part on the end prevent display hazard in split view (same reason as Ticket don't use `showFormButtons` but less impactant currently).
