### PR TITLE
Revert "Native sodium extension is broken on circle; disable it."

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ commands:
       - run:
           name: Install dependencies
           command: |
-            sudo rm -f /usr/local/etc/php/conf.d/docker-php-ext-sodium.ini
             composer --version
             echo "node version: $(node --version)"
             echo "npm version: $(npm --version)"


### PR DESCRIPTION
This reverts commit 489cacc1b2231bd4d775938708db441602ef41c4.