### PR TITLE
Do not compute takeintoaccount_delay_stat if ticket is new

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7101,4 +7101,21 @@ abstract class CommonITILObject extends CommonDBTM {
       return array_key_exists('_do_not_compute_status', $input)
          && $input['_do_not_compute_status'];
    }
+
+   /**
+    * Check if this item is new
+    *
+    * @return bool|null null if we can't check the status
+    */
+   protected function isNew() {
+      if (isset($this->input['status'])) {
+         $status = $this->input['status'];
+      } else if (isset($this->fields['status'])) {
+         $status = $this->fields['status'];
+      } else {
+         return null;
+      }
+
+      return $status == CommonITILObject::INCOMING;
+   }
 }

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7105,7 +7105,7 @@ abstract class CommonITILObject extends CommonDBTM {
    /**
     * Check if this item is new
     *
-    * @return bool|null null if we can't check the status
+    * @return bool
     */
    protected function isNew() {
       if (isset($this->input['status'])) {
@@ -7113,7 +7113,7 @@ abstract class CommonITILObject extends CommonDBTM {
       } else if (isset($this->fields['status'])) {
          $status = $this->fields['status'];
       } else {
-         return null;
+         throw new LogicException("Can't get status value: no object loaded");
       }
 
       return $status == CommonITILObject::INCOMING;

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1506,7 +1506,10 @@ class Ticket extends CommonITILObject {
    function pre_updateInDB() {
 
       if (!$this->isTakeIntoAccountComputationBlocked($this->input)
-          && !$this->isAlreadyTakenIntoAccount() && $this->canTakeIntoAccount()) {
+         && !$this->isAlreadyTakenIntoAccount()
+         && $this->canTakeIntoAccount()
+         && !$this->isNew()
+      ) {
          $this->updates[]                            = "takeintoaccount_delay_stat";
          $this->fields['takeintoaccount_delay_stat'] = $this->computeTakeIntoAccountDelayStat();
       }

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -32,6 +32,7 @@
 
 namespace tests\units;
 
+use CommonITILObject;
 use \DbTestCase;
 
 /* Test for inc/ticket.class.php */
@@ -2033,6 +2034,7 @@ class Ticket extends DbTestCase {
          $input + [
             'name'    => '',
             'content' => 'A ticket to check canTakeIntoAccount() results',
+            'status'  => CommonITILObject::ASSIGNED
          ]
       );
       $this->integer((int)$ticketId)->isGreaterThan(0);


### PR DESCRIPTION
Internal ref: 19613.

Prevent `takeintoaccount_delay_stat` from being computed on update if the ticket status is still `INCOMING`.

Currently, any update by a support agent on a ticket will trigger the `takeintoaccount_delay_stat` computation.
This can result in a ticket still in `INCOMING` status but already taken into account (the TTO will be displayed as still running but no progression bar is shown).


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
