### PR TITLE
Run test suite on MariaDB 10.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           #- "mariadb:10.2"
           #- "mariadb:10.3"
           - "mariadb:10.4"
+          - "mariadb:10.5"
           #- "mysql:5.6"
           #- "mysql:5.7"
           - "mysql:8.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Test suite results: https://github.com/cedric-anne/glpi/runs/663538123?check_suite_focus=true

Image is built using MariaDB 10.5 beta2.

It may be merged later, I just wanted to check compatibility with this new version prior to GLPI 9.5 release.