### PR TITLE
Run Github CI job on any PR, even from a fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,16 @@
 name: "GLPI CI"
 
-on: ["push"]
+on:
+  # Runs test suite when a new commit is pushed on "master" and "*/bugfixes" branches
+  # and when a new tag is created
+  push:
+    branches:
+      - master
+      - '*/bugfixes'
+    tags:
+       - '*'
+  # Runs test suite when a PR is opened or synchronyzed
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This configuration, once merged, should enable GithubAction CI test suite even for PR created from a fork repository.