### PR TITLE
Enhance Status Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The present file will list all changes made to the project; according to the
 - the API gives the ID of the user who logs in with initSession
 - Kanban view for projects
 - Network ports on Monitors
+- Add ability to get information from the status endpoint in JSON format using Accept header
+- Add `glpi:system:status` CLI command for getting the GLPI status
 
 ### Changed
 
@@ -51,6 +53,9 @@ The present file will list all changes made to the project; according to the
 - Database datetime fields have been replaced by timestamp fields to handle timezones support.
 - Database integer/float fields values are now returned as number instead of strings from DB read operations.
 - Field `domains_id` of Computer, NetworkEquipment and Printer has been dropped and data has been transfered into `glpi_domains_items` table.
+- Plugin status hook can now be used to provide an array with more information about the plugin's status the status of any child services.
+    - Returned array should contain a 'status' value at least (See status values in Glpi\System\Status\StatusChecker)
+    - Old style returns are still supported
 
 #### Deprecated
 

--- a/inc/console/system/checkstatuscommand.class.php
+++ b/inc/console/system/checkstatuscommand.class.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\System;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use Glpi\Console\AbstractCommand;
+use Glpi\System\Status\StatusChecker;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CheckStatusCommand extends AbstractCommand {
+
+   protected function configure() {
+      parent::configure();
+
+      $this->setName('glpi:system:status');
+      $this->setAliases(['system:status']);
+      $this->setDescription(__('Check system status'));
+      $this->addOption('format', 'f', InputOption::VALUE_OPTIONAL,
+         'Output format [plain or json]', 'plain');
+      $this->addOption('private', 'p', InputOption::VALUE_NONE,
+         'Status information publicity. Private status information may contain potentially sensitive information such as version information.');
+   }
+
+   protected function execute(InputInterface $input, OutputInterface $output) {
+
+      $format = strtolower($input->getOption('format'));
+      $status = StatusChecker::getFullStatus(!$input->getOption('private'), $format === 'json');
+
+      if ($format === 'json') {
+         $output->writeln(json_encode($status, JSON_PRETTY_PRINT));
+      } else {
+         $output->writeln($status);
+      }
+
+      return 0; // Success
+   }
+}

--- a/inc/system/status/statuschecker.class.php
+++ b/inc/system/status/statuschecker.class.php
@@ -1,0 +1,516 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2019 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\System\Status;
+
+use AuthLDAP;
+use CronTask;
+use DBConnection;
+use DBmysql;
+use Plugin;
+use Toolbox;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ * @since 9.5.0
+ */
+final class StatusChecker {
+
+   /**
+    * The plugin or service is working as expected.
+    */
+   public const STATUS_OK = 'OK';
+
+   /**
+    * The plugin or service is reachable but not working as expected.
+    */
+   public const STATUS_PROBLEM = 'PROBLEM';
+
+   /**
+    * Unable to get the status of a plugin or service.
+    * This is likely due to a prerequisite plugin or service being unavailable or the plugin not implementing the status hook.
+    * For example, some checks require the DB to be accessible.
+    */
+   public const STATUS_NO_DATA = 'NO_DATA';
+
+   /**
+    * @param bool $public_only True if only public status information should be given.
+    * @return array
+    */
+   public static function getDBStatus($public_only = true): array {
+      static $status = null;
+
+      if ($status === null) {
+         $status = [
+            'status' => self::STATUS_OK,
+            'master' => [
+               'status' => self::STATUS_OK,
+            ],
+            'slaves' => [
+               'status' => self::STATUS_NO_DATA,
+               'servers' => []
+            ]
+         ];
+         // Check slave server connection
+         if (DBConnection::isDBSlaveActive()) {
+            $DBslave = DBConnection::getDBSlaveConf();
+            if (is_array($DBslave->dbhost)) {
+               $hosts = $DBslave->dbhost;
+            } else {
+               $hosts = [$DBslave->dbhost];
+            }
+
+            if (count($hosts)) {
+               $status['slaves']['status'] = self::STATUS_OK;
+            }
+
+            foreach ($hosts as $num => $name) {
+               $diff = DBConnection::getReplicateDelay($num);
+               if (abs($diff) > 1000000000) {
+                  $status['slaves']['servers'][$num] = [
+                     'status'             => self::STATUS_PROBLEM,
+                     'replication_delay'  => '-1'
+                  ];
+                  $status['slaves']['status'] = self::STATUS_PROBLEM;
+                  $status['status'] = self::STATUS_PROBLEM;
+               } else if (abs($diff) > HOUR_TIMESTAMP) {
+                  $status['slaves']['servers'][$num] = [
+                     'status'             => self::STATUS_PROBLEM,
+                     'replication_delay'  => abs($diff)
+                  ];
+                  $status['slaves']['status'] = self::STATUS_PROBLEM;
+                  $status['status'] = self::STATUS_PROBLEM;
+               } else {
+                  $status['slaves']['servers'][$num] = [
+                     'status'             => self::STATUS_OK,
+                     'replication_delay'  => abs($diff)
+                  ];
+               }
+            }
+         }
+
+         // Check main server connection
+         if (!DBConnection::establishDBConnection(false, true, false)) {
+            $status['master'] = [
+               'status' => self::STATUS_PROBLEM
+            ];
+            $status['status'] = self::STATUS_PROBLEM;
+         }
+      }
+
+      return $status;
+   }
+
+   private static function isDBAvailable(): bool {
+      static $db_ok = null;
+
+      if ($db_ok === null) {
+         $status = self::getDBStatus();
+         $db_ok = ($status['master']['status'] === self::STATUS_OK || $status['slaves']['status'] === self::STATUS_OK);
+      }
+
+      return $db_ok;
+   }
+
+   /**
+    * @param bool $public_only True if only public status information should be given.
+    * @return array
+    */
+   public static function getLDAPStatus($public_only = true): array {
+      static $status = null;
+
+      if ($status === null) {
+         $status = [
+            'status' => self::STATUS_NO_DATA,
+            'servers' => []
+         ];
+         if (self::isDBAvailable()) {
+            // Check LDAP Auth connections
+            $ldap_methods = getAllDataFromTable('glpi_authldaps', ['is_active' => 1]);
+
+            if (count($ldap_methods)) {
+               $status['status'] = self::STATUS_OK;
+               foreach ($ldap_methods as $method) {
+                  try {
+                     if (AuthLDAP::tryToConnectToServer($method, $method['rootdn'],
+                        Toolbox::sodiumDecrypt($method['rootdn_passwd']))) {
+                        $status['servers'][$method['name']] = [
+                           'status' => self::STATUS_OK
+                        ];
+                     } else {
+                        $status['servers'][$method['name']] = [
+                           'status' => self::STATUS_PROBLEM
+                        ];
+                        $status['status'] = self::STATUS_PROBLEM;
+                     }
+                  } catch (\RuntimeException $e) {
+                     // May be missing LDAP extension (Probably test environment)
+                     $status['servers'][$method['name']] = [
+                        'status' => self::STATUS_PROBLEM
+                     ];
+                     $status['status'] = self::STATUS_PROBLEM;
+                  }
+               }
+            }
+         }
+      }
+
+      return $status;
+   }
+
+   /**
+    * @param bool $public_only True if only public status information should be given.
+    * @return array
+    */
+   public static function getIMAPStatus($public_only = true): array {
+      static $status = null;
+
+      if ($status === null) {
+         $status = [
+            'status' => self::STATUS_NO_DATA,
+            'servers' => []
+         ];
+         if (self::isDBAvailable()) {
+            // Check IMAP Auth connections
+            $imap_methods = getAllDataFromTable('glpi_authmails', ['is_active' => 1]);
+
+            if (count($imap_methods)) {
+               $status['status'] = self::STATUS_OK;
+               foreach ($imap_methods as $method) {
+                  $param = Toolbox::parseMailServerConnectString($method['connect_string'], true);
+                  if ($param['ssl'] === true) {
+                     $host = 'ssl://'.$param['address'];
+                  } else if ($param['tls'] === true) {
+                     $host = 'tls://'.$param['address'];
+                  } else {
+                     $host = $param['address'];
+                  }
+                  if ($fp = @fsockopen($host, $param['port'], $errno, $errstr, 1)) {
+                     $status['servers'][$method['name']] = [
+                        'status' => 'OK'
+                     ];
+                  } else {
+                     $status['servers'][$method['name']] = [
+                        'status' => self::STATUS_PROBLEM
+                     ];
+                     $status['status'] = self::STATUS_PROBLEM;
+                  }
+                  if ($fp !== false) {
+                     fclose($fp);
+                  }
+               }
+            }
+         }
+      }
+
+      return $status;
+   }
+
+   /**
+    * @param bool $public_only True if only public status information should be given.
+    * @return array
+    */
+   public static function getCASStatus($public_only = true): array {
+      static $status = null;
+
+      if ($status === null) {
+         $status['status'] = self::STATUS_NO_DATA;
+         if (!empty($CFG_GLPI['cas_host'])) {
+            $url = $CFG_GLPI['cas_host'];
+            if (!empty($CFG_GLPI['cas_port'])) {
+               $url .= ':'. (int)$CFG_GLPI['cas_port'];
+            }
+            $url .= '/'.$CFG_GLPI['cas_uri'];
+            $data = Toolbox::getURLContent($url);
+            if (!empty($data)) {
+               $status['status'] = self::STATUS_OK;
+            } else {
+               $status['status'] = self::STATUS_PROBLEM;
+            }
+         }
+      }
+
+      return $status;
+   }
+
+   /**
+    * @param bool $public_only True if only public status information should be given.
+    * @return array
+    */
+   public static function getMailCollectorStatus($public_only = true): array {
+      static $status = null;
+
+      if ($status === null) {
+         $status = [
+            'status' => self::STATUS_NO_DATA,
+            'servers' => []
+         ];
+         if (self::isDBAvailable()) {
+            $mailcollectors = getAllDataFromTable('glpi_mailcollectors', ['is_active' => 1]);
+            if (count($mailcollectors)) {
+               $status['status'] = self::STATUS_OK;
+               $mailcol = new MailCollector();
+               foreach ($mailcollectors as $mc) {
+                  if ($mailcol->getFromDB($mc['id'])) {
+                     try {
+                        $mailcol->connect();
+                        $status['servers'][$mc['name']] = [
+                           'status' => 'OK'
+                        ];
+                     } catch (\Exception $e) {
+                        $status['servers'][$mc['name']] = [
+                           'status'       => self::STATUS_PROBLEM,
+                           'error_code'   => $e->getCode()
+                        ];
+                        $status['status'] = self::STATUS_PROBLEM;
+                     }
+                  }
+               }
+            }
+         }
+      }
+
+      return $status;
+   }
+
+   /**
+    * @param bool $public_only True if only public status information should be given.
+    * @return array
+    */
+   public static function getCronTaskStatus($public_only = true): array {
+      static $status = null;
+
+      if ($status === null) {
+         $status = [
+            'status' => self::STATUS_NO_DATA,
+            'stuck' => []
+         ];
+         if (self::isDBAvailable()) {
+            $stuck_crontasks = getAllDataFromTable(
+               'glpi_crontasks', [
+                  'state'  => CronTask::STATE_RUNNING,
+                  'OR'     => [
+                     new \QueryExpression(
+                        '(unix_timestamp(' . DBmysql::quoteName('lastrun') . ') + 2 * '.
+                        DBmysql::quoteName('frequency') .' < unix_timestamp(now()))'
+                     ),
+                     new \QueryExpression(
+                        '(unix_timestamp(' . DBmysql::quoteName('lastrun') . ') + 2 * '.
+                        HOUR_TIMESTAMP . ' < unix_timestamp(now()))'
+                     )
+                  ]
+               ]
+            );
+            foreach ($stuck_crontasks as $ct) {
+               $status['stuck'][] = $ct['name'];
+            }
+            $status['status'] = count($status['stuck']) ? self::STATUS_PROBLEM : self::STATUS_OK;
+         }
+      }
+
+      return $status;
+   }
+
+   /**
+    * @param bool $public_only True if only public status information should be given.
+    * @return array
+    */
+   public static function getFilesystemStatus($public_only = true): array {
+      static $status = null;
+
+      if ($status === null) {
+         $status = [
+            'status' => self::STATUS_OK,
+            'session_dir' => [
+               'status' => self::STATUS_OK
+            ]
+         ];
+         // Check session dir (useful when NFS mounted))
+         if (!is_dir(GLPI_SESSION_DIR)) {
+            $status['session_dir'] = [
+               'status' => self::STATUS_PROBLEM,
+               'status_msg'   => 'GLPI_SESSION_DIR variable is not a directory'
+            ];
+            $status['status'] = self::STATUS_PROBLEM;
+         } else if (!is_writable(GLPI_SESSION_DIR)) {
+            $status['session_dir'] = [
+               'status' => self::STATUS_PROBLEM,
+               'status_msg'   => 'GLPI_SESSION_DIR is not writeable'
+            ];
+            $status['status'] = self::STATUS_PROBLEM;
+         }
+      }
+
+      return $status;
+   }
+
+   /**
+    *
+    * @since 9.5.0
+    * @param bool $public_only True if only public status information should be given.
+    * @return array
+    */
+   public static function getPluginsStatus($public_only = true): array {
+      static $status = null;
+
+      if ($status === null) {
+         $plugins = Plugin::getPlugins();
+         $status = [];
+
+         foreach ($plugins as $plugin) {
+            // Old-style plugin status hook which only modified the global OK status.
+            $param = ['ok' => true];
+            $plugin_status = Plugin::doOneHook($plugin, 'status', $param);
+            if ($plugin_status === null) {
+               continue;
+            }
+            if (isset($plugin_status['ok']) && count(array_keys($plugin_status)) === 1) {
+               $status[$plugin] = [
+                  'status'    => $plugin_status['ok'] ? self::STATUS_OK : self::STATUS_PROBLEM,
+                  'version'   => Plugin::getInfo($plugin)['version']
+               ];
+            } else {
+               $status[$plugin] = $plugin_status;
+            }
+         }
+      }
+
+      if (count($status) === 0) {
+         $status['status'] = self::STATUS_NO_DATA;
+      } else {
+         if ($public_only) {
+            // Only show overall plugin status
+            // Giving out plugin names and versions to anonymous users could make it easier to target insecure plugins and versions
+            $statuses = array_column($status, 'status');
+            $all_ok = !in_array(self::STATUS_PROBLEM, $statuses, true);
+            return ['status' => $all_ok ? self::STATUS_OK : self::STATUS_PROBLEM];
+         }
+      }
+
+      return $status;
+   }
+
+   /**
+    * @param bool $public_only True if only public status information should be given.
+    * @param bool $as_array
+    * @return array|string
+    */
+   public static function getFullStatus($public_only = true, $as_array = true) {
+      static $status = null;
+
+      if ($status === null) {
+         $status = [
+            'db'              => self::getDBStatus($public_only),
+            'cas'             => self::getCASStatus($public_only),
+            'ldap'            => self::getLDAPStatus($public_only),
+            'imap'            => self::getIMAPStatus($public_only),
+            'mail_collectors' => self::getMailCollectorStatus($public_only),
+            'crontasks'       => self::getCronTaskStatus($public_only),
+            'filesystem'      => self::getFilesystemStatus($public_only),
+            'glpi'            => [
+               'status'    => self::STATUS_OK,
+            ],
+            'plugins'         => self::getPluginsStatus($public_only)
+         ];
+         // Compute GLPI status from top-level services
+         $statuses = array_column($status, 'status');
+         $all_ok = !in_array(self::STATUS_PROBLEM, $statuses, true);
+         $status['glpi']['status'] = $all_ok ? self::STATUS_OK : self::STATUS_PROBLEM;
+      }
+
+      // Only show overall core status for public
+      // Giving out the version to anonymous users could make it easier to target insecure versions of GLPI
+      if (!$public_only) {
+         $status['glpi']['version'] = GLPI_VERSION;
+      }
+
+      if ($as_array) {
+         return $status;
+      }
+
+      $output = '';
+      // Plain-text output
+      if (count($status['db']['slaves'])) {
+         foreach ($status['db']['slaves']['servers'] as $num => $slave_info) {
+            $output .= "GLPI_DBSLAVE_{$num}_{$slave_info['status']}\n";
+         }
+      } else {
+         $output .= "No slave DB\n";
+      }
+      $output .= "GLPI_DB_{$status['db']['master']['status']}\n";
+      $output .= "GLPI_SESSION_DIR_{$status['filesystem']['session_dir']['status']}\n";
+      if (count($status['ldap']['servers'])) {
+         $output .= 'Check LDAP servers:';
+         foreach ($status['db']['slaves']['servers'] as $name => $ldap_info) {
+            $output .= " {$name}_{$ldap_info['status']}\n";
+         }
+      } else {
+         $output .= "No LDAP server\n";
+      }
+      if (count($status['imap']['servers'])) {
+         $output .= 'Check IMAP servers:';
+         foreach ($status['imap']['servers'] as $name => $imap_info) {
+            $output .= " {$name}_{$imap_info['status']}\n";
+         }
+      } else {
+         $output .= "No IMAP server\n";
+      }
+      if (isset($status['cas']['status']) && $status['cas']['status'] !== self::STATUS_NO_DATA) {
+         $output .= "CAS_SERVER_{$status['cas']['status']}\n";
+      } else {
+         $output .= "No CAS server\n";
+      }
+      if (count($status['mail_collectors']['servers'])) {
+         $output .= 'Check mail collectors:';
+         foreach ($status['mail_collectors']['servers'] as $name => $collector_info) {
+            $output .= " {$name}_{$collector_info['status']}\n";
+         }
+      } else {
+         $output .= "No mail collector\n";
+      }
+      if (count($status['crontasks']['stuck'])) {
+         $output .= 'Check crontasks:';
+         foreach ($status['crontasks']['stuck'] as $name) {
+            $output .= " {$name}_PROBLEM\n";
+         }
+      } else {
+         $output .= "Crontasks_OK\n";
+      }
+
+      // Overall Status
+      $output .= "\nGLPI_{$status['glpi']['status']}\n";
+      return $output;
+   }
+}

--- a/inc/system/status/statuschecker.class.php
+++ b/inc/system/status/statuschecker.class.php
@@ -36,6 +36,7 @@ use AuthLDAP;
 use CronTask;
 use DBConnection;
 use DBmysql;
+use MailCollector;
 use Plugin;
 use Toolbox;
 
@@ -243,6 +244,8 @@ final class StatusChecker {
     * @return array
     */
    public static function getCASStatus($public_only = true): array {
+      global $CFG_GLPI;
+
       static $status = null;
 
       if ($status === null) {

--- a/status.php
+++ b/status.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\System\Status\StatusChecker;
+
 define('DO_NOT_CHECK_HTTP_REFERER', 1);
 include ('./inc/includes.php');
 
@@ -39,197 +41,16 @@ $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
 // Need to be used using :
 // check_http -H servername -u /glpi/status.php -s GLPI_OK
 
+$valid_response_types = ['text/plain', 'application/json'];
+$fallback_response_type = 'text/plain';
 
-// Plain text content
-header('Content-type: text/plain');
-
-$ok_master = true;
-$ok_slave  = true;
-$ok        = true;
-
-// Check slave server connection
-if (DBConnection::isDBSlaveActive()) {
-   $DBslave = DBConnection::getDBSlaveConf();
-   if (is_array($DBslave->dbhost)) {
-      $hosts = $DBslave->dbhost;
-   } else {
-      $hosts = [$DBslave->dbhost];
-   }
-
-   foreach ($hosts as $num => $name) {
-      $diff = DBConnection::getReplicateDelay($num);
-      if (abs($diff) > 1000000000) {
-         echo "GLPI_DBSLAVE_${num}_OFFLINE\n";
-         $ok_slave = false;
-      } else if (abs($diff)> HOUR_TIMESTAMP) {
-         echo "GLPI_DBSLAVE_${num}_PROBLEM\n";
-         $ok_slave = false;
-      } else {
-         echo "GLPI_DBSLAVE_${num}_OK\n";
-      }
-   }
-} else {
-   echo "No slave DB\n";
+if (!isset($_SERVER['HTTP_ACCEPT']) || !in_array($_SERVER['HTTP_ACCEPT'], $valid_response_types, true)) {
+   $_SERVER['HTTP_ACCEPT'] = $fallback_response_type;
 }
+header('Content-type: ' . $_SERVER['HTTP_ACCEPT']);
 
-// Check main server connection
-if (DBConnection::establishDBConnection(false, true, false)) {
-   echo "GLPI_DB_OK\n";
+if ($_SERVER['HTTP_ACCEPT'] === 'application/json') {
+   echo json_encode(StatusChecker::getFullStatus(true, true));
 } else {
-   echo "GLPI_DB_PROBLEM\n";
-   $ok_master = false;
-}
-
-// Slave and master ok;
-$ok = $ok_slave && $ok_master;
-
-// Check session dir (useful when NFS mounted))
-if (is_dir(GLPI_SESSION_DIR) && is_writable(GLPI_SESSION_DIR)) {
-   echo "GLPI_SESSION_DIR_OK\n";
-} else {
-   echo "GLPI_SESSION_DIR_PROBLEM\n";
-   $ok = false;
-}
-
-// Reestablished DB connection
-if (($ok_master || $ok_slave )
-    && DBConnection::establishDBConnection(false, false, false)) {
-
-   // Check LDAP Auth connections
-   $ldap_methods = getAllDataFromTable('glpi_authldaps', ['is_active' => 1]);
-
-   if (count($ldap_methods)) {
-      echo "Check LDAP servers:";
-
-      foreach ($ldap_methods as $method) {
-         echo " ".$method['name'];
-         if (AuthLDAP::tryToConnectToServer($method, $method["rootdn"],
-                                            Toolbox::sodiumDecrypt($method["rootdn_passwd"]))) {
-            echo "_OK";
-         } else {
-            echo "_PROBLEM";
-            $ok = false;
-         }
-         echo "\n";
-      }
-
-   } else {
-      echo "No LDAP server\n";
-   }
-
-   // Check IMAP Auth connections
-   $imap_methods = getAllDataFromTable('glpi_authmails', ['is_active' => 1]);
-
-   if (count($imap_methods)) {
-      echo "Check IMAP servers:";
-
-      foreach ($imap_methods as $method) {
-         echo " ".$method['name'];
-         $param = Toolbox::parseMailServerConnectString($method['connect_string'], true);
-         if ($param['ssl'] === true) {
-            $host = 'ssl://'.$host;
-         } else {
-            if ($param['tls'] === true) {
-               $host = 'tls://'.$host;
-            }
-         }
-         if ($fp = @fsockopen($host, $param['port'],
-                            $errno, $errstr, 1)) {
-            echo "_OK";
-         } else {
-            echo "_PROBLEM";
-            $ok = false;
-         }
-         fclose($fp);
-         echo "\n";
-      }
-
-   } else {
-      echo "No IMAP server\n";
-   }
-
-   // Check CAS
-   if (!empty($CFG_GLPI["cas_host"])) {
-      echo "CAS_SERVER";
-
-      $url = $CFG_GLPI["cas_host"];
-      if (!empty($CFG_GLPI["cas_port"])) {
-         $url .= ':'.intval($CFG_GLPI["cas_port"]);
-      }
-      $url .= '/'.$CFG_GLPI["cas_uri"];
-      $data = Toolbox::getURLContent($url);
-      if (!empty($data)) {
-         echo "_OK";
-      } else {
-         echo "_PROBLEM";
-         $ok = false;
-      }
-      echo "\n";
-   } else {
-      echo "No CAS server\n";
-   }
-
-   /// Check mailcollectors
-   $mailcollectors = getAllDataFromTable('glpi_mailcollectors', ['is_active' => 1]);
-   if (count($mailcollectors)) {
-      echo "Check mail collectors:";
-      $mailcol = new MailCollector();
-      foreach ($mailcollectors as $mc) {
-         echo " ".$mc['name'];
-         if ($mailcol->getFromDB($mc['id'])) {
-            try {
-               $mailcol->connect();
-               echo "_OK";
-            } catch (\Exception $e) {
-               echo "_PROBLEM";
-               $ok = false;
-            }
-            echo "\n";
-         }
-      }
-
-   } else {
-      echo "No mail collector\n";
-   }
-
-   // Check crontask
-   $crontasks = getAllDataFromTable(
-      'glpi_crontasks', [
-         'state'  => CronTask::STATE_RUNNING,
-         'OR'     => [
-            new \QueryExpression(
-               '(unix_timestamp(' . DBmysql::quoteName('lastrun') . ') + 2 * '.
-               DBmysql::quoteName('frequency') .' < unix_timestamp(now()))'
-            ),
-            new \QueryExpression(
-               '(unix_timestamp(' . DBmysql::quoteName('lastrun') . ') + 2 * '.
-               HOUR_TIMESTAMP . ' < unix_timestamp(now()))'
-            )
-         ]
-      ]
-   );
-   if (count($crontasks)) {
-      echo "Check crontasks:";
-      foreach ($crontasks as $ct) {
-         echo " ".$ct['name']."_PROBLEM\n";
-         $ok = false;
-      }
-   } else {
-      echo "Crontasks_OK\n";
-   }
-
-   // hook for plugin
-   $param = ['ok' => $ok];
-   Plugin::doHook("status", $param);
-   if (isset($param['ok'])) {
-      $ok = $param['ok'];
-   }
-}
-
-echo "\n";
-
-if ($ok) {
-   echo "GLPI_OK\n";
-} else {
-   echo "GLPI_PROBLEM\n";
+   echo StatusChecker::getFullStatus(true, false);
 }

--- a/tests/functionnal/Glpi/System/Status/StatusChecker.php
+++ b/tests/functionnal/Glpi/System/Status/StatusChecker.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\System\Status;
+
+use AuthLDAP;
+use AuthMail;
+use CronTask;
+use DbTestCase;
+use \Glpi\System\Status\StatusChecker as GlpiStatusChecker;
+
+class StatusChecker extends DbTestCase {
+
+   public function testStatusFormats() {
+      $status = GlpiStatusChecker::getFullStatus(true);
+      $this->boolean(is_array($status))->isTrue();
+
+      $status = GlpiStatusChecker::getFullStatus(true, false);
+      $this->boolean(is_string($status))->isTrue();
+   }
+
+   public function testDefaultStatus() {
+      $status = GlpiStatusChecker::getFullStatus(true);
+
+      $known_services = ['db', 'cas', 'ldap', 'imap', 'mail_collectors', 'crontasks', 'filesystem', 'glpi', 'plugins'];
+      // Check we are getting all of the expected services
+      $this->array($status)->hasKeys($known_services);
+
+      // Check each service has a status value
+      foreach ($known_services as $service) {
+         $this->boolean(is_array($status[$service]))->isTrue();
+         $this->array($status[$service])->hasKey('status');
+         $this->boolean(is_string($status[$service]['status']))->isTrue();
+      }
+
+      // Test overall status is OK
+      $this->string($status['glpi']['status'])->isEqualTo(GlpiStatusChecker::STATUS_OK);
+
+      // Test the overall status matches the combined status of the top-level services
+      // NO_DATA should not count against the overall status.
+      // If an administrator expects something to have data, that should be a separate service check in their monitoring system.
+      $statuses = array_column($status, 'status');
+      $all_ok = !in_array(GlpiStatusChecker::STATUS_PROBLEM, $statuses, true);
+      $this->boolean($all_ok)->isTrue();
+
+      // We have no plugins. Verify the status is NO_DATA
+      $this->string($status['plugins']['status'])->isEqualTo(GlpiStatusChecker::STATUS_NO_DATA);
+      // We should have a master DB for tests. Verify status is OK.
+      $this->string($status['db']['master']['status'])->isEqualTo(GlpiStatusChecker::STATUS_OK);
+      // We have no DB slaves. Verify the status is NO_DATA
+      $this->string($status['db']['slaves']['status'])->isEqualTo(GlpiStatusChecker::STATUS_NO_DATA);
+      // We have no CAS. Verify the status is NO_DATA
+      $this->string($status['cas']['status'])->isEqualTo(GlpiStatusChecker::STATUS_NO_DATA);
+      // We have no LDAP servers. Verify the status is NO_DATA
+      $this->string($status['ldap']['status'])->isEqualTo(GlpiStatusChecker::STATUS_NO_DATA);
+      // We have no IMAP servers. Verify the status is NO_DATA
+      $this->string($status['imap']['status'])->isEqualTo(GlpiStatusChecker::STATUS_NO_DATA);
+      // We have no mail collectors. Verify the status is NO_DATA
+      $this->string($status['mail_collectors']['status'])->isEqualTo(GlpiStatusChecker::STATUS_NO_DATA);
+
+      // Make sure no stuck cron tasks are reported
+      $this->string($status['crontasks']['status'])->isEqualTo(GlpiStatusChecker::STATUS_OK);
+      $this->array($status['crontasks']['stuck'])->size->isEqualTo(0);
+
+      // Check filesystem and session_dir are OK
+      $this->string($status['filesystem']['status'])->isEqualTo(GlpiStatusChecker::STATUS_OK);
+      $this->string($status['filesystem']['session_dir']['status'])->isEqualTo(GlpiStatusChecker::STATUS_OK);
+   }
+
+   public function testBadStatus() {
+      global $DB;
+
+      // Run a DB check first so the status checker knows the DB is available.
+      // Future checks won't re-run that check then, so the DB changes aren't lost.
+      GlpiStatusChecker::getDBStatus();
+
+      // Manually start a transaction since this is a new connection
+      $DB->beginTransaction();
+
+      // Add a bunch of bad service items
+      $auth_mail = new AuthMail();
+      $authmail_id = $auth_mail->add([
+         'name'            => 'testmail',
+         'connect_string'  => '{smtp.localhost/imap/ssl/validate-cert/tls/secure}',
+         'host'            => 'localhost',
+         'is_active'       => 1
+      ]);
+      $this->integer($authmail_id)->isGreaterThan(0);
+
+      $auth_ldap = new AuthLDAP();
+      $authlap_id = $auth_ldap->add([
+         'name'            => 'testldap',
+         'host'            => 'localhost',
+         'is_active'       => 1,
+         'rootdn'          => 'cn=Manager,dc=glpi,dc=org',
+         'rootdn_passwd'   => md5(mt_rand())
+      ]);
+      $this->integer($authlap_id)->isGreaterThan(0);
+
+      $crontask = new CronTask();
+      // A definitely stuck crontask running for over an hour.
+      $crontask->add([
+         'itemtype'     => 'Ticket',
+         'name'         => 'stucktest1',
+         'frequency'    => 60,
+         'lastrun'      => date('Y-m-d 00:00:00', strtotime('-61 minute')),
+         'state'        => \CronTask::STATE_RUNNING,
+      ]);
+      // A probably stuck crontask running for longer than the run interval.
+      $crontask->add([
+         'itemtype'     => 'Ticket',
+         'name'         => 'stucktest2',
+         'frequency'    => 60,
+         'lastrun'      => date('Y-m-d 00:00:00', strtotime('-5 minute')),
+         'state'        => \CronTask::STATE_RUNNING,
+      ]);
+
+      $status = GlpiStatusChecker::getFullStatus(true);
+
+      // Test overall status is PROBLEM
+      $this->string($status['glpi']['status'])->isEqualTo(GlpiStatusChecker::STATUS_PROBLEM);
+
+      // Test there is at least one service with a problem
+      $statuses = array_column($status, 'status');
+      $all_ok = !in_array(GlpiStatusChecker::STATUS_PROBLEM, $statuses, true);
+      $this->boolean($all_ok)->isFalse();
+
+      // We have a non-existent LDAP server. Verify the status is PROBLEM.
+      $this->string($status['ldap']['status'])->isEqualTo(GlpiStatusChecker::STATUS_PROBLEM);
+      // We have a non-existent IMAP server. Verify the status is PROBLEM.
+      $this->string($status['imap']['status'])->isEqualTo(GlpiStatusChecker::STATUS_PROBLEM);
+
+      // Make sure there are two stuck tasks
+      $this->string($status['crontasks']['status'])->isEqualTo(GlpiStatusChecker::STATUS_PROBLEM);
+      $this->array($status['crontasks']['stuck'])->size->isEqualTo(2);
+
+      // afterTestMethod will rollback the DB changes for us
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5922

Added ability to get JSON format for status endpoint in addition to the "legacy" plain-text format. Allows for providing more information to monitoring systems/scripts (I added the DB replication delay as an example).
To provide BC, the plain-text format is the default and is output in the same way it was before. Extra information like the replication delay is not shown.

Fixed #5922 while I was at it (I don't have an IMAP server anymore for dev. Someone will have to test this to be sure. Wasn't sure if it mattered if I used the host from the DB or connection string.).

I think eventually this endpoint should be added to the API instead of a public file in the root.

Need to think about how plugins report their status. Currently it looks like they just change the flag for GLPI_OK/GLPI_PROBLEM. With a the new format, they could report their own status and the status of their dependencies.