### PR TITLE
User synchro: remove double escaping for manager field

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -1593,7 +1593,7 @@ class User extends CommonDBTM {
                      break;
 
                   case 'users_id_supervisor':
-                     $this->fields[$k] = self::getIdByField('user_dn', $val);
+                     $this->fields[$k] = self::getIdByField('user_dn', $val, false);
                      break;
 
                   default :
@@ -4403,13 +4403,17 @@ class User extends CommonDBTM {
     *
     * @return integer
     */
-   static function getIdByField($field, $value) {
+   static function getIdByField($field, $value, $escape = true) {
       global $DB;
+
+      if ($escape) {
+         $value = addslashes($value);
+      }
 
       $iterator = $DB->request([
          'SELECT' => 'id',
          'FROM'   => self::getTable(),
-         'WHERE'  => [$field => addslashes($value)]
+         'WHERE'  => [$field => $value]
       ]);
 
       if (count($iterator) == 1) {


### PR DESCRIPTION
Internal ref: 19550.

When synchronizing an user, the value used to search for his manager was escaped twice.
If the manager DN contained any escaped chars like `\` it would then never be found.

First escaping in `User::getFromLDAP()`  
```php
$val = Toolbox::addslashes_deep($val);
```
Second escaping in `User::getIdByField()`
```php
$iterator = $DB->request([
         'SELECT' => 'id',
         'FROM'   => self::getTable(),
         'WHERE'  => [$field => addslashes($value)]
]);
```

I've removed the second escaping for this specific case and kept it as a default parameter for the function since it is used in others places that may need the escaping.

----

Concrete example:

Manager DN to search for: `cn=Clairembault\2C Adrien,cn=abcd,dc=nodomain`
-> `\2C` is an encoded coma here, the displayed CN in the LDAP is `Clairembault, Adrien`

With double escaping, we end up doing this request which will never find anything:
```sql
SELECT `id`
FROM `glpi_users`
WHERE `user_dn` = 'cn=Clairembault\\\\2C Adrien,cn=abcd,dc=nodomain'
```

---


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
