### PR TITLE
Impact visibility restrictions

### DIFF
--- a/inc/extravisibilitycriteria.class.php
+++ b/inc/extravisibilitycriteria.class.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+interface ExtraVisibilityCriteria
+{
+   /**
+    * Return visibility joins to add to DBIterator parameters
+    *
+    * @since 9.5
+    *
+    * @param boolean $forceall force all joins (false by default)
+    *
+    * @return array
+    */
+   public static function getVisibilityCriteria(bool $forceall = false): array;
+}

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -39,7 +39,7 @@ if (!defined('GLPI_ROOT')) {
 /**
  * KnowbaseItem Class
 **/
-class KnowbaseItem extends CommonDBVisible {
+class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
 
 
    // From CommonDBTM
@@ -495,7 +495,7 @@ class KnowbaseItem extends CommonDBVisible {
     *
     * @return array
     */
-   static public function getVisibilityCriteria($forceall = false) {
+   static public function getVisibilityCriteria(bool $forceall = false): array {
       global $CFG_GLPI;
 
       $is_public_faq_context = !Session::getLoginUserID() && $CFG_GLPI["use_public_faq"];

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -39,7 +39,7 @@ if (!defined('GLPI_ROOT')) {
  *
  * @since 0.85
 **/
-class Project extends CommonDBTM {
+class Project extends CommonDBTM implements ExtraVisibilityCriteria {
    use Kanban;
 
    // From CommonDBTM
@@ -383,7 +383,7 @@ class Project extends CommonDBTM {
     *
     * @return array
     */
-   static public function getVisibilityCriteria($forceall = false) {
+   static public function getVisibilityCriteria(bool $forceall = false): array {
       if (Session::haveRight('project', self::READALL)) {
          return [
             'LEFT JOIN' => [],

--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -43,7 +43,10 @@ use Sabre\VObject\Component\VTodo;
 /**
  * Reminder Class
 **/
-class Reminder extends CommonDBVisible implements CalDAVCompatibleItemInterface {
+class Reminder extends CommonDBVisible implements
+   CalDAVCompatibleItemInterface,
+   ExtraVisibilityCriteria
+{
    use PlanningEvent {
       post_getEmpty as trait_post_getEmpty;
    }
@@ -239,7 +242,7 @@ class Reminder extends CommonDBVisible implements CalDAVCompatibleItemInterface 
     *
     * @return array
     */
-   static public function getVisibilityCriteria($forceall = false) {
+   static public function getVisibilityCriteria(bool $forceall = false): array {
       if (!Session::haveRight(self::$rightname, READ)) {
          return [
             'WHERE' => ['glpi_reminders.users_id' => Session::getLoginUserID()],

--- a/inc/rssfeed.class.php
+++ b/inc/rssfeed.class.php
@@ -59,7 +59,7 @@ if (!defined('GLPI_ROOT')) {
  *
  * @since 0.84
 **/
-class RSSFeed extends CommonDBVisible {
+class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria {
 
    // From CommonDBTM
    public $dohistory                   = true;
@@ -248,7 +248,7 @@ class RSSFeed extends CommonDBVisible {
     *
     * @return array
     */
-   static public function getVisibilityCriteria($forceall = false) {
+   static public function getVisibilityCriteria(bool $forceall = false): array {
       $where = [self::getTable() . '.users_id' => Session::getLoginUserID()];
       $join = [];
 

--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -39,7 +39,7 @@ if (!defined('GLPI_ROOT')) {
  *
  * @since 9.2
 **/
-class SavedSearch extends CommonDBTM {
+class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria {
 
    static $rightname               = 'bookmark_public';
 
@@ -1463,7 +1463,7 @@ class SavedSearch extends CommonDBTM {
     *
     * @return array
     */
-   static public function getVisibilityCriteria($forceall = false) {
+   static public function getVisibilityCriteria(bool $forceall = false): array {
       $criteria = ['WHERE' => []];
       if (Session::haveRight('config', UPDATE)) {
          return $criteria;

--- a/js/impact.js
+++ b/js/impact.js
@@ -1308,7 +1308,7 @@ var GLPIImpact = {
             id             : 'goTo',
             content        : '<i class="fas fa-link"></i>' + __("Go to"),
             tooltipText    : __("Open this element in a new tab"),
-            selector       : 'node[!color]',
+            selector       : 'node[link]',
             onClickFunction: this.menuOnGoTo
          },
          {


### PR DESCRIPTION
New visibility restrictions:

Graph context menu (right click on node)
* Do not display "go to" contextual menu action for an item that the user is not allowed to read

Add assets panel
* Do not display itemtypes that the user is not allowed to read
* If an itemtype have a `getVisibilityCriteria` method, use it to only show items that match the defined criterias



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
