### PR TITLE
No reply configuration for email notifications

### DIFF
--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -209,6 +209,11 @@ class Notification extends CommonDBTM {
       Dropdown::showYesNo('is_active', $this->fields['is_active']);
       echo "</td></tr>";
 
+      echo "<tr class='tab_bg_1'><td>" . __('Allow response') . "</td>";
+      echo "<td>";
+      Dropdown::showYesNo('allow_response', $this->allowResponse());
+      echo "</td></tr>";
+
       echo "<tr class='tab_bg_1'><td>" . __('Type') . "</td>";
       echo "<td>";
       if (!Session::haveRight(static::$rightname, UPDATE)) {
@@ -685,5 +690,9 @@ class Notification extends CommonDBTM {
 
    static function getIcon() {
       return "fas fa-bell";
+   }
+
+   public function allowResponse() {
+      return $this->fields['allow_response'];
    }
 }

--- a/inc/notificationevent.class.php
+++ b/inc/notificationevent.class.php
@@ -130,6 +130,7 @@ class NotificationEvent extends CommonDBTM {
          foreach ($notifications as $data) {
             $notificationtarget->clearAddressesList();
             $notificationtarget->setMode($data['mode']);
+            $notificationtarget->setAllowResponse($data['allow_response']);
 
             //Get template's information
             $template = new NotificationTemplate();

--- a/inc/notificationmailingsetting.class.php
+++ b/inc/notificationmailingsetting.class.php
@@ -116,6 +116,23 @@ class NotificationMailingSetting extends NotificationSetting {
          $out .= " </td></tr>";
 
          $out .= "<tr class='tab_bg_2'>";
+         $out .= "<td><label for='admin_email_noreply'>" . __('No-Reply address') . " <i class='pointer fa fa-info' title='" .
+            __s('Optionnal No-Reply address.') . "\n" . __s('If set, it will be used for notifications that doesn\'t expect a reply.') . "'></i></label></td>";
+         $out .= "<td><input type='text' name='admin_email_noreply' id='admin_email_noreply' size='40' value='" .
+                    $CFG_GLPI["admin_email_noreply"] . "'>";
+         if (!empty($CFG_GLPI['admin_email_noreply'])
+             && !NotificationMailing::isUserAddressValid($CFG_GLPI["admin_email_noreply"])) {
+            $out .= "<br/><span class='red'>&nbsp;".__('Invalid email address')."</span>";
+         }
+         $out .= " </td>";
+         $out .= "<td><label for='admin_email_noreply_name'>" . __('No-Reply name') . " <i class='pointer fa fa-info' title='" .
+            __s('Optionnal No-Reply name.') . "\n" . __s('If not set, main administrator name will be used.'). "'></i></label></td>";
+            $out .= "<td><input type='text' name='admin_email_noreply_name' id='admin_email_noreply_name' size='40' value='" .
+                    $CFG_GLPI["admin_email_noreply_name"] . "'>";
+         $out .= " </td></tr>";
+         $out .= "</tr>";
+
+         $out .= "<tr class='tab_bg_2'>";
 
          $attachrand = mt_rand();
          $out .= "<td><label for='dropdown_attach_ticket_documents_to_mail$attachrand'>" . __('Add documents into ticket notifications') . "</label></td><td>";

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -78,6 +78,7 @@ class NotificationTarget extends CommonDBChild {
    public $options                     = [];
    public $raiseevent                  = '';
 
+   private $allow_response             = true;
    private $mode                       = null;
    private $event                      = null;
 
@@ -1022,6 +1023,21 @@ class NotificationTarget extends CommonDBChild {
          }
       }
 
+      if (!$this->allowResponse()
+         && isset($CFG_GLPI['admin_email_noreply'])
+         && !empty($CFG_GLPI['admin_email_noreply'])
+      ) {
+         // Override with no reply email if defined
+         $sender['email'] = $CFG_GLPI['admin_email_noreply'];
+
+         if (isset($CFG_GLPI['admin_email_noreply_name'])
+            && !empty($CFG_GLPI['admin_email_noreply_name'])
+         ) {
+            // Override name with no replay name if defined
+            $sender['name']  = $CFG_GLPI['admin_email_noreply_name'];
+         }
+      }
+
       return $sender;
    }
 
@@ -1458,6 +1474,25 @@ class NotificationTarget extends CommonDBChild {
     */
    public function setEvent($event) {
       $this->event = $event;
+      return $this;
+   }
+
+
+   /**
+    * Get the value of allow_response
+    */
+   public function allowResponse() {
+      return $this->allow_response;
+   }
+
+   /**
+    * Set the value of allow_response
+    *
+    * @return self
+    */
+   public function setAllowResponse($allow_response) {
+      $this->allow_response = $allow_response;
+
       return $this;
    }
 }

--- a/inc/notificationtargetticket.class.php
+++ b/inc/notificationtargetticket.class.php
@@ -68,7 +68,6 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject {
       return parent::getSubjectPrefix();
    }
 
-
    /**
    * Get header to add to content
    **/
@@ -76,6 +75,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject {
 
       if ($this->getMode() == \Notification_NotificationTemplate::MODE_MAIL
          && MailCollector::countActiveCollectors()
+         && $this->allowResponse()
       ) {
          return self::HEADERTAG.' '.__('To answer by email, write above this line').' '.
                 self::HEADERTAG;
@@ -92,6 +92,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject {
 
       if ($this->getMode() == \Notification_NotificationTemplate::MODE_MAIL
          && MailCollector::countActiveCollectors()
+         && $this->allowResponse()
       ) {
          return self::FOOTERTAG.' '.__('To answer by email, write under this line').' '.
                 self::FOOTERTAG;

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -302,6 +302,8 @@ $default_prefs = [
    'default_dashboard_assets'                => 'assets',
    'default_dashboard_helpdesk'              => 'helpdesk',
    'default_dashboard_mini_ticket'           => 'mini_ticket',
+   'admin_email_noreply'                     => '',
+   'admin_email_noreply_name'                => '',
 ];
 
 $tables['glpi_configs'] = [];

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -4426,6 +4426,7 @@ CREATE TABLE `glpi_notifications` (
   `is_active` tinyint(1) NOT NULL DEFAULT '0',
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
+  `allow_response` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `itemtype` (`itemtype`),

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -1826,12 +1826,10 @@ HTML
       ]);
    }
 
-   if (!isset(Config::getConfigurationValues('core')['admin_email_noreply'])) {
-      $migration->addConfig([
-         'admin_email_noreply'      => "",
-         'admin_email_noreply_name' => "",
-      ]);
-   }
+   $migration->addConfig([
+      'admin_email_noreply'      => "",
+      'admin_email_noreply_name' => "",
+   ]);
    // /No-reply notifications
 
    $migration->executeMigration();

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -1819,6 +1819,21 @@ HTML
       $migration->addKey('glpi_contracts', 'states_id');
    }
 
+   // No-reply notifications
+   if (!$DB->fieldExists(Notification::getTable(), 'allow_response')) {
+      $migration->addField(Notification::getTable(), 'allow_response', 'bool', [
+         'value' => 1
+      ]);
+   }
+
+   if (!isset(Config::getConfigurationValues('core')['admin_email_noreply'])) {
+      $migration->addConfig([
+         'admin_email_noreply'      => "",
+         'admin_email_noreply_name' => "",
+      ]);
+   }
+   // /No-reply notifications
+
    $migration->executeMigration();
 
    return $updateresult;


### PR DESCRIPTION
Internal ref: 17298.

* Add a new configuration option for notification to indicate whether or not they should allow a response ('allow_response' param).
* If a notification doesn't expect a response, the `"To answer by email, write above this line"` headers and footers won't be printed in the email
* Add a new general configuration for notifications (no reply address)
* If a notification doesn't expect a response AND a no reply address is configured, use it as the sender address for the notification.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
