### PR TITLE
Fix for see AnalysisImpact without loaded plugin

### DIFF
--- a/inc/impact.class.php
+++ b/inc/impact.class.php
@@ -1126,10 +1126,9 @@ class Impact extends CommonGLPI {
       // Iterate on each relations found
       foreach ($relations as $related_item) {
          // Add the related node
-         if (!($item = getItemForItemtype($related_item['itemtype_' . $source]))) {
+         if (!($related_node = getItemForItemtype($related_item['itemtype_' . $source]))) {
             continue;
          }
-         $related_node = new $related_item['itemtype_' . $source];
          $related_node->getFromDB($related_item['items_id_' . $source]);
          self::addNode($nodes, $related_node);
 

--- a/inc/impact.class.php
+++ b/inc/impact.class.php
@@ -1123,11 +1123,11 @@ class Impact extends CommonGLPI {
       if (count($relations)) {
          self::addNode($nodes, $node);
       }
-      $dbu = new DbUtils();
+
       // Iterate on each relations found
       foreach ($relations as $related_item) {
          // Add the related node
-         if (!($item = $dbu->getItemForItemtype($source))) {
+         if (!($item = getItemForItemtype($related_item['itemtype_' . $source]))) {
             continue;
          }
          $related_node = new $related_item['itemtype_' . $source];

--- a/inc/impact.class.php
+++ b/inc/impact.class.php
@@ -1123,10 +1123,13 @@ class Impact extends CommonGLPI {
       if (count($relations)) {
          self::addNode($nodes, $node);
       }
-
+      $dbu = new DbUtils();
       // Iterate on each relations found
       foreach ($relations as $related_item) {
          // Add the related node
+         if (!($item = $dbu->getItemForItemtype($source))) {
+            continue;
+         }
          $related_node = new $related_item['itemtype_' . $source];
          $related_node->getFromDB($related_item['items_id_' . $source]);
          self::addNode($nodes, $related_node);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

If a plugin is used into Analysis Impact & is not activated : 

![image](https://user-images.githubusercontent.com/13178158/82021181-bd12ca80-968a-11ea-81f7-6c0e6186a932.png)

```
[2020-05-15 06:53:36] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Class 'PluginWebapplicationsWebapplication' not found in C:\wamp64\www\glpi95\inc\impact.class.php at line 1130
  Backtrace :
  inc\impact.class.php:1147                          Impact::buildGraphFromNode()
  inc\impact.class.php:1052                          Impact::buildGraphFromNode()
  inc\impact.class.php:154                           Impact::buildGraph()
  inc\commonglpi.class.php:622                       Impact::displayTabContentForItem()
  ajax\common.tabs.php:92                            CommonGLPI::displayStandardTab()
```
