### PR TITLE
Fix sodium decrypt for blank values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 phpunit.xml
 /tests/code-coverage/
 /tests/files/
+/tests/glpicrypt.key
 /config/based_config.php
 /config/config.php
 /config/define.php

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -275,6 +275,10 @@ class Toolbox {
    }
 
    public static function sodiumDecrypt($content, $key = null) {
+      if (empty($content)) {
+         // Avoid sodium exception for blank content. Just return the null/empty value.
+         return $content;
+      }
       if ($key === null) {
          $key = self::getGlpiSecKey();
       }

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -364,6 +364,16 @@ class Toolbox extends \GLPITestCase {
       $this->string(\Toolbox::sodiumDecrypt($crypted))->isIdenticalTo($string);
    }
 
+   /**
+    * Test blank or null content. If not handled correctly, a sodium exception would be raised and fail the test.
+    * This could be a blank password that was never encrypted, so it is a blank value in the DB still.
+    * @since 9.5.0
+    */
+   public function testSodiumDecryptBlank() {
+      $this->variable(\Toolbox::sodiumDecrypt(null))->isNull();
+      $this->string(\Toolbox::sodiumDecrypt(''))->isEmpty();
+   }
+
    protected function cleanProvider() {
       return [
          ['mystring', 'mystring', null, 15, 0.56, false],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Some passwords like the LDAP bind password are allowed to be blank and may not be encrypted in that case so the DB values are still null or empty. When trying to decrypt them, a sodium exception is raised. The null or empty string value can just be returned instead.