### PR TITLE
Fix reservations namefield

### DIFF
--- a/inc/item_devicesimcard.class.php
+++ b/inc/item_devicesimcard.class.php
@@ -115,6 +115,6 @@ class Item_DeviceSimcard extends Item_Devices {
    }
 
    static function getNameField() {
-      return 'seriale';
+      return 'serial';
    }
 }

--- a/inc/item_devicesimcard.class.php
+++ b/inc/item_devicesimcard.class.php
@@ -113,4 +113,8 @@ class Item_DeviceSimcard extends Item_Devices {
                                   'autocomplete' => true,],
       ];
    }
+
+   static function getNameField() {
+      return 'seriale';
+   }
 }

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -897,6 +897,8 @@ class Search {
                                           $replace, $tmpquery);
                   $tmpquery = str_replace($CFG_GLPI["union_search_type"][$data['itemtype']],
                                           $ctable, $tmpquery);
+                  $name_field = $ctype::getNameField();
+                  $tmpquery = str_replace("`$ctable`.`name`", "`$ctable`.`$name_field`", $tmpquery);
                }
                $tmpquery = str_replace("ENTITYRESTRICT",
                                        getEntitiesRestrictRequest('', $ctable, '', '',


### PR DESCRIPTION
SQL request for reservation fail in 9.5:
![image](https://user-images.githubusercontent.com/42734840/82214655-776a3200-9916-11ea-9992-b611ecf7d319.png)

It seems that a base request with a .name is used to make multiple union queries with str_replace without checking if the new table have a name field.
Using getNameField + adding a name field to item_simcards seems to fix it.

Maybe we should have a global unit test that check the validity of each getNameField ?


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
