### PR TITLE
Wrong/default language when using 'Other authentication send in the HTTP request' - fixed #7302

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2010,21 +2010,25 @@ class Config extends CommonDBTM {
 
 
    /**
-    * Get language in GLPI associated with the value coming from LDAP
-    * Value can be, for example : English, en_EN or en
+    * Get language in GLPI associated with the value coming from LDAP/SSO
+    * Value can be, for example : English, en_EN, en-EN or en
     *
-    * @param string $lang the value coming from LDAP
+    * @param string $lang the value coming from LDAP/SSO
     *
     * @return string locale's php page in GLPI or '' is no language associated with the value
    **/
    static function getLanguage($lang) {
       global $CFG_GLPI;
 
+      // Alternative language code: en-EN --> en_EN
+      $altLang = str_replace("-", "_", $lang);
+
       // Search in order : ID or extjs dico or tinymce dico / native lang / english name
       //                   / extjs dico / tinymce dico
       // ID  or extjs dico or tinymce dico
       foreach ($CFG_GLPI["languages"] as $ID => $language) {
          if ((strcasecmp($lang, $ID) == 0)
+             || (strcasecmp($altLang, $ID) == 0)
              || (strcasecmp($lang, $language[2]) == 0)
              || (strcasecmp($lang, $language[3]) == 0)) {
             return $ID;

--- a/tests/functionnal/Config.php
+++ b/tests/functionnal/Config.php
@@ -502,6 +502,8 @@ class Config extends DbTestCase {
                ->isIdenticalTo('fr_FR')
             ->string($this->testedInstance->getLanguage('fr_FR'))
                ->isIdenticalTo('fr_FR')
+            ->string($this->testedInstance->getLanguage('fr-FR'))
+               ->isIdenticalTo('fr_FR')
             ->string($this->testedInstance->getLanguage('Français'))
                ->isIdenticalTo('fr_FR')
             ->string($this->testedInstance->getLanguage('french'))


### PR DESCRIPTION
- Added support for hyphen in language ID;
- Added test for language ID with hyphen;

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | **not tested**
| Fixed tickets | fixed #7302 

I tested the code and it works. I did not run the tests.