### PR TITLE
planning: redo clone events ux with a context menu

### DIFF
--- a/ajax/planning.php
+++ b/ajax/planning.php
@@ -60,7 +60,7 @@ if ($_REQUEST["action"] == "clone_event") {
 }
 
 if ($_REQUEST["action"] == "delete_event") {
-   echo Planning::DeleteEvent($_REQUEST['event']);
+   echo Planning::deleteEvent($_REQUEST['event']);
    exit;
 }
 
@@ -135,4 +135,3 @@ if ($_REQUEST["action"] == "delete_filter") {
 }
 
 Html::ajaxFooter();
-

--- a/ajax/planning.php
+++ b/ajax/planning.php
@@ -54,8 +54,13 @@ if ($_REQUEST["action"] == "view_changed") {
    exit;
 }
 
-if ($_REQUEST["action"] == "post_cloned_event") {
-   echo Planning::postClonedEvent($_REQUEST['event']);
+if ($_REQUEST["action"] == "clone_event") {
+   echo Planning::cloneEvent($_REQUEST['event']);
+   exit;
+}
+
+if ($_REQUEST["action"] == "delete_event") {
+   echo Planning::DeleteEvent($_REQUEST['event']);
    exit;
 }
 

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -2629,6 +2629,28 @@ a.icon_nav_move {
    background-image: linear-gradient(left, green 50%, red 0%);
 }
 
+.planning-context-menu {
+   position:fixed;
+   z-index:20000;
+   background-color: #FFF;
+   box-shadow: 0 10px 20px rgba(0,0,0,0.19),
+               0 6px 6px rgba(0,0,0,0.23);
+
+   li {
+      padding: 8px 10px;
+      cursor: pointer;
+
+      i.fas, i.far {
+         margin-right: 5px;
+         color: #555
+      }
+
+      &:hover {
+         background-color: #CCC;
+      }
+   }
+}
+
 /* ################--------------- Menu navigation  ---------------#################### */
 
 #menu_navigate {

--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -1508,7 +1508,7 @@ class Planning extends CommonGLPI {
     *
     * @return mixed the id (integer) or false if it failed
     */
-   static function postClonedEvent(array $event = []) {
+   static function cloneEvent(array $event = []) {
       $item = new $event['old_itemtype'];
       $item->getFromDB((int) $event['old_items_id']);
 
@@ -1562,6 +1562,22 @@ class Planning extends CommonGLPI {
       }
 
       return $new_items_id;
+   }
+
+   /**
+    * Delete an event
+    *
+    * @since 9.5
+    *
+    * @param array $event the event to clone (with itemtype and items_id keys)
+    *
+    * @return bool
+    */
+   static function deleteEvent(array $event = []):bool {
+      $item = new $event['itemtype'];
+      return $item->delete([
+         'id' => (int) $event['items_id']
+      ]);
    }
 
 

--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -1575,9 +1575,17 @@ class Planning extends CommonGLPI {
     */
    static function deleteEvent(array $event = []):bool {
       $item = new $event['itemtype'];
-      return $item->delete([
-         'id' => (int) $event['items_id']
-      ]);
+
+      if (isset($event['day'])
+          && isset($event['instance'])
+          && $event['instance']
+          && method_exists($item, "deleteInstance")) {
+         return $item->deleteInstance((int) $event['items_id'], $event['day']);
+      } else {
+         return $item->delete([
+            'id' => (int) $event['items_id']
+         ]);
+      }
    }
 
 

--- a/js/planning.js
+++ b/js/planning.js
@@ -301,11 +301,6 @@ var GLPIPlanning  = {
                });
             });
 
-            // remove all context menus on document click
-            $(document).click(function() {
-                $('.planning-context-menu').remove();
-            })
-
          },
          datesRender: function(info) {
             var view = info.view;
@@ -585,6 +580,11 @@ var GLPIPlanning  = {
 
       // force focus on the current window
       $(window).focus();
+
+      // remove all context menus on document click
+      $(document).click(function() {
+         $('.planning-context-menu').remove();
+      })
    },
 
    refresh: function() {

--- a/js/planning.js
+++ b/js/planning.js
@@ -287,7 +287,7 @@ var GLPIPlanning  = {
                // 2- delete event (manage serie/instance specific events)
                $('.planning-context-menu .delete-event').click(function() {
                   var ajaxDeleteEvent = function(instance) {
-                     instance = instance || false
+                     instance = instance || false;
                      $.ajax({
                         url:  CFG_GLPI.root_doc+"/ajax/planning.php",
                         type: 'POST',
@@ -621,7 +621,7 @@ var GLPIPlanning  = {
       // remove all context menus on document click
       $(document).click(function() {
          $('.planning-context-menu').remove();
-      })
+      });
    },
 
    refresh: function() {

--- a/tests/functionnal/Planning.php
+++ b/tests/functionnal/Planning.php
@@ -36,7 +36,7 @@ namespace tests\units;
 
 class Planning extends \DbTestCase {
 
-   public function testpostClonedEvent() {
+   public function testCloneEvent() {
       $this->login();
 
       $input = [
@@ -55,7 +55,7 @@ class Planning extends \DbTestCase {
       $new_start = date('Y-m-d H:i:s', $timestamp);
       $new_end   = date('Y-m-d H:i:s', $timestamp + 2 * HOUR_TIMESTAMP);
 
-      $this->integer($clone_events_id = \Planning::postClonedEvent([
+      $this->integer($clone_events_id = \Planning::cloneEvent([
          'old_itemtype' => 'PlanningExternalEvent',
          'old_items_id' => $event_id,
          'start'        => $new_start,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

internal ref 19826

Current UX for cloning event (maintain [Shift] key while draggin' event) is bugged and doesn't work all the time.
So i re-did with a simple context menu. It's also more discoverable.
All planning views i know (zimbra, google calendar) use context menu for "fast actions".

![planning_context_menu gif](https://user-images.githubusercontent.com/418844/82821692-d135a380-9ea4-11ea-87f9-672369ab325a.gif)

