### PR TITLE
Network ports on Monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The present file will list all changes made to the project; according to the
 - Ability to copy tasks while merging tickets
 - the API gives the ID of the user who logs in with initSession
 - Kanban view for projects
+- Network ports on Monitors
 
 ### Changed
 

--- a/inc/define.php
+++ b/inc/define.php
@@ -271,7 +271,7 @@ $CFG_GLPI["dictionnary_types"]            = ['ComputerModel', 'ComputerType', 'M
 
 $CFG_GLPI["helpdesk_visible_types"]       = ['Software', 'Appliance', 'Item_DeviceSimcard'];
 
-$CFG_GLPI["networkport_types"]            = ['Computer', 'NetworkEquipment', 'Peripheral',
+$CFG_GLPI["networkport_types"]            = ['Computer', 'Monitor', 'NetworkEquipment', 'Peripheral',
                                                   'Phone', 'Printer', 'Enclosure', 'PDU', 'Cluster'];
 
 // Warning : the order is used for displaying different NetworkPort types ! Keep it !

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -42,7 +42,7 @@ class Monitor extends CommonDBTM {
 
    // From CommonDBTM
    public $dohistory                   = true;
-   static protected $forward_entity_to = ['Infocom', 'ReservationItem', 'Item_OperatingSystem'];
+   static protected $forward_entity_to = ['Infocom', 'ReservationItem', 'Item_OperatingSystem', 'NetworkPort'];
 
    static $rightname                   = 'monitor';
    protected $usenotepad               = true;
@@ -79,6 +79,7 @@ class Monitor extends CommonDBTM {
       $this->addStandardTab('Item_OperatingSystem', $ong, $options);
       $this->addStandardTab('Item_Devices', $ong, $options);
       $this->addStandardTab('Computer_Item', $ong, $options);
+      $this->addStandardTab('NetworkPort', $ong, $options);
       $this->addStandardTab('Infocom', $ong, $options);
       $this->addStandardTab('Contract_Item', $ong, $options);
       $this->addStandardTab('Document_Item', $ong, $options);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Some people use Monitors for any display device such as TVs and I have found a few monitors for digital signage purposes that can have a network port (Seems to be for email alerts, chaining, etc).

https://glpi.userecho.com/communities/1/topics/1816-network-ports-on-monitors