### PR TITLE
Unsaved form changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The present file will list all changes made to the project; according to the
 - the API gives the ID of the user who logs in with initSession
 - Kanban view for projects
 - Network ports on Monitors
+- Add warning when there are unsaved changes in forms
 - Add ability to get information from the status endpoint in JSON format using Accept header
 - Add `glpi:system:status` CLI command for getting the GLPI status
 

--- a/front/appliance.form.php
+++ b/front/appliance.form.php
@@ -115,6 +115,6 @@ if (isset($_POST["add"])) {
 } else {
    $appliance->checkGlobal(READ);
    Html::header(Appliance::getTypeName(1), $_SERVER['PHP_SELF'], "management", "appliance");
-   $appliance->display($_GET);
+   $appliance->display($_GET + ['formoptions' => "data-track-changes=true"]);
    Html::footer();
 }

--- a/front/budget.form.php
+++ b/front/budget.form.php
@@ -104,8 +104,11 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Budget::getTypeName(1), $_SERVER['PHP_SELF'], "management", "budget");
-   $budget->display(['id'           => $_GET["id"],
-                          'withtemplate' => $_GET["withtemplate"]]);
+   $budget->display([
+      'id'           => $_GET["id"],
+      'withtemplate' => $_GET["withtemplate"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
 
    Html::footer();
 }

--- a/front/cartridgeitem.form.php
+++ b/front/cartridgeitem.form.php
@@ -96,6 +96,7 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Cartridge::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "cartridgeitem");
-   $cartype->display(['id' => $_GET["id"]]);
+   $cartype->display(['id' => $_GET["id"],
+      'formoptions'  => "data-track-changes=true"]);
    Html::footer();
 }

--- a/front/certificate.form.php
+++ b/front/certificate.form.php
@@ -98,8 +98,10 @@ if (isset($_POST["add"])) {
 } else {
    Html::header(Certificate::getTypeName(Session::getPluralNumber()),
                 $_SERVER['PHP_SELF'], 'management', 'certificate');
-   $certificate->display(['id'           => $_GET["id"],
-                          'withtemplate' => $_GET["withtemplate"]
-                         ]);
+   $certificate->display([
+      'id'           => $_GET["id"],
+      'withtemplate' => $_GET["withtemplate"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/cluster.form.php
+++ b/front/cluster.form.php
@@ -95,14 +95,17 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Cluster::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "cluster");
-   $options = ['id' => $_GET['id']];
+   $options = [
+      'id'           => $_GET['id'],
+      'withtemplate' => $_GET['withtemplate'],
+      'formoptions'  => "data-track-changes=true"
+   ];
    if (isset($_GET['position'])) {
       $options['position'] = $_GET['position'];
    }
    if (isset($_GET['room'])) {
       $options['room'] = $_GET['room'];
    }
-   $options['withtemplate'] = $_GET['withtemplate'];
    $cluster->display($options);
    Html::footer();
 }

--- a/front/computer.form.php
+++ b/front/computer.form.php
@@ -100,7 +100,10 @@ if (isset($_POST["add"])) {
 } else {//print computer information
    Html::header(Computer::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "computer");
    //show computer form to add
-   $computer->display(['id'           => $_GET["id"],
-                            'withtemplate' => $_GET["withtemplate"]]);
+   $computer->display([
+      'id'           => $_GET["id"],
+      'withtemplate' => $_GET["withtemplate"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/config.form.php
+++ b/front/config.form.php
@@ -67,5 +67,8 @@ if (!empty($_GET['reset_cache'])) {
 }
 
 Html::header(Config::getTypeName(1), $_SERVER['PHP_SELF'], "config", "config");
-$config->display(['id' => 1]);
+$config->display([
+   'id'           => 1,
+   'formoptions'  => "data-track-changes=true"
+]);
 Html::footer();

--- a/front/consumableitem.form.php
+++ b/front/consumableitem.form.php
@@ -96,6 +96,7 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(_n('Consumable', 'Consumables', 2), $_SERVER['PHP_SELF'], "assets", "consumableitem");
-   $constype->display(['id' =>$_GET["id"]]);
+   $constype->display(['id' =>$_GET["id"],
+      'formoptions'  => "data-track-changes=true"]);
    Html::footer();
 }

--- a/front/contact.form.php
+++ b/front/contact.form.php
@@ -103,6 +103,9 @@ if (isset($_GET['getvcard'])) {
 
 } else {
    Html::header(Contact::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "contact");
-   $contact->display(['id' => $_GET["id"]]);
+   $contact->display([
+      'id'           => $_GET["id"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/contract.form.php
+++ b/front/contract.form.php
@@ -101,7 +101,10 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Contract::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "contract");
-   $contract->display(['id'           => $_GET["id"],
-                            'withtemplate' => $_GET["withtemplate"]]);
+   $contract->display([
+      'id'           => $_GET["id"],
+      'withtemplate' => $_GET["withtemplate"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/datacenter.form.php
+++ b/front/datacenter.form.php
@@ -95,6 +95,9 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Datacenter::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "datacenter");
-   $datacenter->display(['id' => $_GET["id"]]);
+   $datacenter->display([
+      'id'           => $_GET["id"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/document.form.php
+++ b/front/document.form.php
@@ -114,6 +114,9 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Document::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "document");
-   $doc->display(['id' =>$_GET["id"]]);
+   $doc->display([
+      'id'           => $_GET["id"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/domain.form.php
+++ b/front/domain.form.php
@@ -107,7 +107,8 @@ if (isset($_POST["add"])) {
    Html::header(Domain::getTypeName(1), $_SERVER['PHP_SELF'], "management", "domain");
    $domain->display([
       'id'           => $_GET["id"],
-      'withtemplate' => $_GET["withtemplate"]
+      'withtemplate' => $_GET["withtemplate"],
+      'formoptions'  => "data-track-changes=true"
    ]);
 
    Html::footer();

--- a/front/dropdown.common.form.php
+++ b/front/dropdown.common.form.php
@@ -137,7 +137,9 @@ if (isset($_POST["add"])) {
    if (!isset($options)) {
       $options = [];
    }
-   $options['id'] = $_GET["id"];
+   $options['id'] = $_GET['id'];
+   $options['formoptions'] = ($options['formoptions'] ?? '') . ' data-track-changes=true';
+
    $dropdown->display($options);
    Html::footer();
 }

--- a/front/enclosure.form.php
+++ b/front/enclosure.form.php
@@ -95,14 +95,17 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Enclosure::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "enclosure");
-   $options = ['id' => $_GET['id']];
+   $options = [
+      'id'           => $_GET['id'],
+      'withtemplate' => $_GET['withtemplate'],
+      'formoptions'  => "data-track-changes=true"
+   ];
    if (isset($_GET['position'])) {
       $options['position'] = $_GET['position'];
    }
    if (isset($_GET['room'])) {
       $options['room'] = $_GET['room'];
    }
-   $options['withtemplate'] = $_GET['withtemplate'];
    $enclosure->display($options);
    Html::footer();
 }

--- a/front/group.form.php
+++ b/front/group.form.php
@@ -94,7 +94,10 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Group::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "group");
-   $group->display(['id' =>$_GET["id"]]);
+   $group->display([
+      'id'           => $_GET["id"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }
 

--- a/front/line.form.php
+++ b/front/line.form.php
@@ -95,6 +95,9 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Line::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "line");
-   $line->display(['id'           => $_GET["id"]]);
+   $line->display([
+      'id'           => $_GET["id"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/monitor.form.php
+++ b/front/monitor.form.php
@@ -105,7 +105,10 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Monitor::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "monitor");
-   $monitor->display(['id'           => $_GET["id"],
-                           'withtemplate' => $_GET["withtemplate"]]);
+   $monitor->display([
+      'id'           => $_GET["id"],
+      'withtemplate' => $_GET["withtemplate"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/networkequipment.form.php
+++ b/front/networkequipment.form.php
@@ -95,7 +95,10 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(NetworkEquipment::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "networkequipment");
-   $netdevice->display(['id'           => $_GET["id"],
-                             'withtemplate' => $_GET["withtemplate"]]);
+   $netdevice->display([
+      'id'           => $_GET["id"],
+      'withtemplate' => $_GET["withtemplate"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/passivedcequipment.form.php
+++ b/front/passivedcequipment.form.php
@@ -100,14 +100,17 @@ if (isset($_POST["add"])) {
       "assets",
       "passivedcequipment"
    );
-   $options = ['id' => $_GET['id']];
+   $options = [
+      'id' => $_GET['id'],
+      'withtemplate' => $_GET['withtemplate'],
+      'formoptions'  => "data-track-changes=true"
+   ];
    if (isset($_GET['position'])) {
       $options['position'] = $_GET['position'];
    }
    if (isset($_GET['room'])) {
       $options['room'] = $_GET['room'];
    }
-   $options['withtemplate'] = $_GET['withtemplate'];
    $passive_equip->display($options);
    Html::footer();
 }

--- a/front/pdu.form.php
+++ b/front/pdu.form.php
@@ -95,6 +95,10 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(PDU::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "pdu");
-   $pdu->display(['id' => $_GET["id"], 'withtemplate' => $_GET["withtemplate"]]);
+   $pdu->display([
+      'id'           => $_GET["id"],
+      'withtemplate' => $_GET["withtemplate"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/peripheral.form.php
+++ b/front/peripheral.form.php
@@ -105,7 +105,10 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Peripheral::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "peripheral");
-   $peripheral->display(['id'           => $_GET["id"],
-                              'withtemplate' => $_GET["withtemplate"]]);
+   $peripheral->display([
+      'id'           => $_GET["id"],
+      'withtemplate' => $_GET["withtemplate"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/phone.form.php
+++ b/front/phone.form.php
@@ -105,7 +105,10 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Phone::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'assets', 'phone');
-   $phone->display(['id'           => $_GET["id"],
-                         'withtemplate' => $_GET["withtemplate"]]);
+   $phone->display([
+      'id'           => $_GET["id"],
+      'withtemplate' => $_GET["withtemplate"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/printer.form.php
+++ b/front/printer.form.php
@@ -103,7 +103,10 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Printer::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "printer");
-   $print->display(['id'           => $_GET["id"],
-                         'withtemplate' => $_GET["withtemplate"]]);
+   $print->display([
+      'id'           => $_GET["id"],
+      'withtemplate' => $_GET["withtemplate"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/profile.form.php
+++ b/front/profile.form.php
@@ -65,6 +65,9 @@ if (isset($_POST["add"])) {
 
 Html::header(Profile::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "profile");
 
-$prof->display(['id' => $_GET["id"]]);
+$prof->display([
+   'id'           => $_GET["id"],
+   'formoptions'  => " data-track-changes='true'"
+]);
 
 Html::footer();

--- a/front/project.form.php
+++ b/front/project.form.php
@@ -111,8 +111,11 @@ if (isset($_POST["add"])) {
    } else if (isset($_GET['showglobalkanban']) && $_GET['showglobalkanban']) {
       $project->showKanban(0);
    } else {
-      $project->display(['id'           => $_GET["id"],
-                         'withtemplate' => $_GET["withtemplate"]]);
+      $project->display([
+         'id'           => $_GET["id"],
+         'withtemplate' => $_GET["withtemplate"],
+         'formoptions'  => "data-track-changes=true"
+      ]);
    }
    Html::footer();
 }

--- a/front/rack.form.php
+++ b/front/rack.form.php
@@ -100,7 +100,8 @@ if (isset($_POST["add"])) {
    }
    $options = [
       'id'           => $_GET['id'],
-      'withtemplate' => $_GET['withtemplate']
+      'withtemplate' => $_GET['withtemplate'],
+      'formoptions'  => "data-track-changes=true"
    ];
    if (isset($_GET['position'])) {
       $options['position'] = $_GET['position'];

--- a/front/rule.common.form.php
+++ b/front/rule.common.form.php
@@ -86,5 +86,8 @@ if (isset($_POST["add_action"])) {
 Html::header(Rule::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'admin',
              $rulecollection->menu_type, $rulecollection->menu_option);
 
-$rule->display(['id' => $_GET["id"]]);
+$rule->display([
+   'id'           => $_GET["id"],
+   'formoptions'  => " data-track-changes='true'"
+]);
 Html::footer();

--- a/front/software.form.php
+++ b/front/software.form.php
@@ -95,7 +95,10 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Software::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "software");
-   $soft->display(['id'           => $_GET["id"],
-                        'withtemplate' => $_GET["withtemplate"]]);
+   $soft->display([
+      'id'           => $_GET["id"],
+      'withtemplate' => $_GET["withtemplate"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/softwarelicense.form.php
+++ b/front/softwarelicense.form.php
@@ -96,6 +96,6 @@ if (isset($_POST["add"])) {
 } else {
    Html::header(SoftwareLicense::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'],
                 "management", "softwarelicense");
-   $license->display($_REQUEST);
+   $license->display($_REQUEST + ['formoptions' => "data-track-changes=true"]);
    Html::footer();
 }

--- a/front/supplier.form.php
+++ b/front/supplier.form.php
@@ -91,6 +91,9 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Supplier::getTypeName(Session::getPluralNumber()), '', "management", "supplier");
-   $ent->display(['id' => $_GET["id"]]);
+   $ent->display([
+      'id'           => $_GET["id"],
+      'formoptions'  => "data-track-changes=true"
+   ]);
    Html::footer();
 }

--- a/front/user.form.php
+++ b/front/user.form.php
@@ -206,7 +206,10 @@ if (isset($_GET['getvcard'])) {
    } else {
       Session::checkRight("user", READ);
       Html::header(User::getTypeName(Session::getPluralNumber()), '', "admin", "user");
-      $user->display(['id' => $_GET["id"]]);
+      $user->display([
+         'id'           => $_GET["id"],
+         'formoptions'  => "data-track-changes=true"
+      ]);
       Html::footer();
 
    }

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7441,7 +7441,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       if (!$options['template_preview']) {
          echo "<form method='post' name='form_ticket' enctype='multipart/form-data' action='".
-                static::getFormURL()."'>";
+                static::getFormURL()."' data-track-changes='true'>";
          if (isset($options['_projecttasks_id'])) {
             echo "<input type='hidden' name='_projecttasks_id' value='".$options['_projecttasks_id']."'>";
          }

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1433,6 +1433,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
       if (isset($options['parent']) && !empty($options['parent'])) {
          $item = $options['parent'];
       }
+      $options['formoptions'] = ($options['formoptions'] ?? '') . ' data-track-changes=true';
 
       $fkfield = $item->getForeignKeyField();
 

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -290,7 +290,7 @@ class Config extends CommonDBTM {
       $canedit = Session::haveRight(self::$rightname, UPDATE);
 
       if ($canedit) {
-         echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL(__CLASS__)."\" method='post'>";
+         echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL(__CLASS__)."\" method='post' data-track-changes='true'>";
       }
       echo "<div class='center' id='tabsbody'>";
       echo "<table class='tab_cadre_fixe'>";
@@ -489,7 +489,7 @@ class Config extends CommonDBTM {
       $rand = mt_rand();
       $canedit = Config::canUpdate();
       if ($canedit) {
-         echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL(__CLASS__)."\" method='post'>";
+         echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL(__CLASS__)."\" method='post' data-track-changes='true'>";
       }
       echo "<div class='center' id='tabsbody'>";
       echo "<table class='tab_cadre_fixe'>";
@@ -666,7 +666,7 @@ class Config extends CommonDBTM {
          return;
       }
 
-      echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL(__CLASS__)."\" method='post'>";
+      echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL(__CLASS__)."\" method='post' data-track-changes='true'>";
       echo "<div class='center' id='tabsbody'>";
       echo "<table class='tab_cadre_fixe'>";
       echo "<tr><th colspan='4'>" . __('Authentication') . "</th></tr>";
@@ -710,7 +710,7 @@ class Config extends CommonDBTM {
          return;
       }
 
-      echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL(__CLASS__)."\" method='post'>";
+      echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL(__CLASS__)."\" method='post' data-track-changes='true'>";
       echo "<div class='center' id='tabsbody'>";
       echo "<input type='hidden' name='_dbslave_status' value='1'>";
       echo "<table class='tab_cadre_fixe'>";
@@ -784,7 +784,7 @@ class Config extends CommonDBTM {
       $rand = mt_rand();
       $canedit = Config::canUpdate();
       if ($canedit) {
-         echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL(__CLASS__)."\" method='post'>";
+         echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL(__CLASS__)."\" method='post' data-track-changes='true'>";
       }
       echo "<table class='tab_cadre_fixe'>";
 
@@ -865,7 +865,7 @@ class Config extends CommonDBTM {
       $rand = mt_rand();
       $canedit = Config::canUpdate();
       if ($canedit) {
-         echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL(__CLASS__)."\" method='post'>";
+         echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL(__CLASS__)."\" method='post' data-track-changes='true'>";
       }
       echo "<div class='center spaced' id='tabsbody'>";
       echo "<table class='tab_cadre_fixe'>";
@@ -1035,7 +1035,7 @@ class Config extends CommonDBTM {
       }
 
       if ((!$userpref && $canedit) || ($userpref && $canedituser)) {
-         echo "<form name='form' action='$url' method='post'>";
+         echo "<form name='form' action='$url' method='post' data-track-changes='true'>";
       }
 
       // Only set id for user prefs
@@ -1756,7 +1756,7 @@ class Config extends CommonDBTM {
       $rand = mt_rand();
 
       echo "<div class='center' id='tabsbody'>";
-      echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL(__CLASS__)."\" method='post'>";
+      echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL(__CLASS__)."\" method='post' data-track-changes='true'>";
       echo "<table class='tab_cadre_fixe'>";
       echo "<tr><th colspan='4'>" . __('General setup') . "</th></tr>";
 
@@ -3319,7 +3319,7 @@ class Config extends CommonDBTM {
          return false;
       }
 
-      echo "<form name='form' id='purgelogs_form' method='post' action='".$this->getFormURL()."'>";
+      echo "<form name='form' id='purgelogs_form' method='post' action='".$this->getFormURL()."' data-track-changes='true'>";
       echo "<div class='center'>";
       echo "<table class='tab_cadre_fixe'>";
       echo "<tr class='tab_bg_1'><th colspan='4'>".__("Logs purge configuration").
@@ -3528,7 +3528,7 @@ class Config extends CommonDBTM {
       $rand = mt_rand();
 
       echo '<div class="center" id="tabsbody">';
-      echo '<form name="form" action="' . Toolbox::getItemTypeFormURL(__CLASS__) . '" method="post">';
+      echo '<form name="form" action="' . Toolbox::getItemTypeFormURL(__CLASS__) . '" method="post" data-track-changes="true">';
       echo '<table class="tab_cadre_fixe">';
       echo '<tr><th colspan="4">' . __('Security setup') . '</th></tr>';
 

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -1396,7 +1396,7 @@ class Entity extends CommonTreeDropdown {
 
       echo "<div class='spaced'>";
       if ($canedit) {
-         echo "<form method='post' name=form action='".Toolbox::getItemTypeFormURL(__CLASS__)."'>";
+         echo "<form method='post' name=form action='".Toolbox::getItemTypeFormURL(__CLASS__)."' data-track-changes='true'>";
       }
 
       echo "<table class='tab_cadre_fixe'>";
@@ -1512,7 +1512,7 @@ class Entity extends CommonTreeDropdown {
       $canedit = $entity->can($ID, UPDATE);
 
       if ($canedit) {
-         echo "<form method='post' name=form action='".Toolbox::getItemTypeFormURL(__CLASS__)."'>";
+         echo "<form method='post' name=form action='".Toolbox::getItemTypeFormURL(__CLASS__)."' data-track-changes='true'>";
       }
 
       echo "<table class='tab_cadre_fixe'>";
@@ -1599,7 +1599,7 @@ class Entity extends CommonTreeDropdown {
 
       echo "<div class='spaced'>";
       if ($canedit) {
-         echo "<form method='post' name=form action='".Toolbox::getItemTypeFormURL(__CLASS__)."'>";
+         echo "<form method='post' name=form action='".Toolbox::getItemTypeFormURL(__CLASS__)."' data-track-changes='true'>";
       }
 
       echo "<table class='tab_cadre_fixe'>";
@@ -1760,7 +1760,7 @@ class Entity extends CommonTreeDropdown {
 
       echo "<div class='spaced'>";
       if ($canedit) {
-         echo "<form method='post' name=form action='".Toolbox::getItemTypeFormURL(__CLASS__)."'>";
+         echo "<form method='post' name=form action='".Toolbox::getItemTypeFormURL(__CLASS__)."' data-track-changes='true'>";
       }
 
       echo "<table class='tab_cadre_fixe'>";
@@ -2200,7 +2200,7 @@ class Entity extends CommonTreeDropdown {
 
       echo "<div class='spaced'>";
       if ($canedit) {
-         echo "<form method='post' name=form action='".Toolbox::getItemTypeFormURL(__CLASS__)."'>";
+         echo "<form method='post' name=form action='".Toolbox::getItemTypeFormURL(__CLASS__)."' data-track-changes='true'>";
       }
 
       echo "<table class='tab_cadre_fixe custom_css_configuration'>";
@@ -2405,7 +2405,7 @@ class Entity extends CommonTreeDropdown {
 
       echo "<div class='spaced'>";
       if ($canedit) {
-         echo "<form method='post' name=form action='".Toolbox::getItemTypeFormURL(__CLASS__)."'>";
+         echo "<form method='post' name=form action='".Toolbox::getItemTypeFormURL(__CLASS__)."' data-track-changes='true'>";
       }
 
       echo "<table class='tab_cadre_fixe'>";

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3854,6 +3854,11 @@ JS;
                editor.on('SaveContent', function (contentEvent) {
                   contentEvent.content = contentEvent.content.replace(/\\r?\\n/g, '');
                });
+               editor.on('Change', function (e) {
+                  // Nothing fancy here. Since this is only used for tracking unsaved changes,
+                  // we want to keep the logic in common.js with the other form input events.
+                  onTinyMCEChange(e);
+               });
 
                // ctrl + enter submit the parent form
                editor.addShortcut('ctrl+13', 'submit', function() {

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -747,6 +747,7 @@ class ITILFollowup  extends CommonDBChild {
          //when we came from aja/viewsubitem.php
          $options['item'] = $options['parent'];
       }
+      $options['formoptions'] = ($options['formoptions'] ?? '') . ' data-track-changes=true';
 
       $item = $options['item'];
       $this->item = $item;

--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -125,6 +125,7 @@ class ITILSolution extends CommonDBChild {
          //when we came from aja/viewsubitem.php
          $options['item'] = $options['parent'];
       }
+      $options['formoptions'] = ($options['formoptions'] ?? '') . ' data-track-changes=true';
 
       $item = $options['item'];
       $this->item = $item;

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -728,6 +728,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
       $rand = mt_rand();
 
       $this->initForm($ID, $options);
+      $options['formoptions'] = "data-track-changes=true";
       $this->showFormHeader($options);
       echo "<tr class='tab_bg_1'>";
       echo "<td>".__('Category name')."</td>";

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -680,7 +680,7 @@ class Profile extends CommonDBTM {
 
       echo "<div class='spaced'>";
       if ($canedit = Session::haveRightsOr(self::$rightname, [CREATE, UPDATE, PURGE])) {
-         echo "<form method='post' action='".$this->getFormURL()."'>";
+         echo "<form method='post' action='".$this->getFormURL()."' data-track-changes='true'>";
       }
 
       $matrix_options = ['canedit'       => $canedit,
@@ -802,7 +802,7 @@ class Profile extends CommonDBTM {
 
       echo "<div class='spaced'>";
       if ($canedit = Session::haveRightsOr(self::$rightname, [CREATE, UPDATE, PURGE])) {
-         echo "<form method='post' action='".$this->getFormURL()."'>";
+         echo "<form method='post' action='".$this->getFormURL()."' data-track-changes='true'>";
       }
 
       $matrix_options = ['canedit'       => $canedit,
@@ -854,7 +854,7 @@ class Profile extends CommonDBTM {
       echo "<div class='spaced'>";
       if (($canedit = Session::haveRightsOr(self::$rightname, [UPDATE, CREATE, PURGE]))
           && $openform) {
-         echo "<form method='post' action='".$this->getFormURL()."'>";
+         echo "<form method='post' action='".$this->getFormURL()."' data-track-changes='true'>";
       }
 
       $rights = [['itemtype'  => 'Computer',
@@ -928,7 +928,7 @@ class Profile extends CommonDBTM {
 
       if (($canedit = Session::haveRightsOr(self::$rightname, [UPDATE, CREATE, PURGE]))
           && $openform) {
-         echo "<form method='post' action='".$this->getFormURL()."'>";
+         echo "<form method='post' action='".$this->getFormURL()."' data-track-changes='true'>";
       }
 
       $matrix_options = ['canedit'       => $canedit,
@@ -1024,7 +1024,7 @@ class Profile extends CommonDBTM {
 
       if (($canedit = Session::haveRightsOr(self::$rightname, [UPDATE, CREATE, PURGE]))
           && $openform) {
-         echo "<form method='post' action='".$this->getFormURL()."'>";
+         echo "<form method='post' action='".$this->getFormURL()."' data-track-changes='true'>";
       }
 
       $matrix_options = ['canedit'       => $canedit,
@@ -1086,7 +1086,7 @@ class Profile extends CommonDBTM {
       echo "<div class='spaced'>";
       if (($canedit = Session::haveRightsOr(self::$rightname, [CREATE, UPDATE, PURGE]))
           && $openform) {
-         echo "<form method='post' action='".$this->getFormURL()."'>";
+         echo "<form method='post' action='".$this->getFormURL()."' data-track-changes='true'>";
       }
 
       echo "<table class='tab_cadre_fixe'>";
@@ -1301,7 +1301,7 @@ class Profile extends CommonDBTM {
 
       if (($canedit = Session::haveRightsOr(self::$rightname, [CREATE, UPDATE, PURGE]))
           && $openform) {
-         echo "<form method='post' action='".$this->getFormURL()."'>";
+         echo "<form method='post' action='".$this->getFormURL()."' data-track-changes='true'>";
       }
 
       $this->displayLifeCycleMatrix(__('Life cycle of tickets'), '_cycle_ticket', 'ticket_status',
@@ -1402,7 +1402,7 @@ class Profile extends CommonDBTM {
 
       if (($canedit = Session::haveRightsOr(self::$rightname, [CREATE, UPDATE, PURGE]))
           && $openform) {
-         echo "<form method='post' action='".$this->getFormURL()."'>";
+         echo "<form method='post' action='".$this->getFormURL()."' data-track-changes='true'>";
       }
 
       $this->displayLifeCycleMatrixTicketHelpdesk(__('Life cycle of tickets'), '_cycle_ticket',
@@ -1435,7 +1435,7 @@ class Profile extends CommonDBTM {
 
       if (($canedit = Session::haveRightsOr(self::$rightname, [CREATE, UPDATE, PURGE]))
           && $openform) {
-         echo "<form method='post' action='".$this->getFormURL()."'>";
+         echo "<form method='post' action='".$this->getFormURL()."' data-track-changes='true'>";
       }
 
       $matrix_options = ['canedit'       => $canedit,
@@ -1529,7 +1529,7 @@ class Profile extends CommonDBTM {
       echo "<div class='spaced'>";
       if (($canedit = Session::haveRightsOr(self::$rightname, [CREATE, UPDATE, PURGE]))
           && $openform) {
-         echo "<form method='post' action='".$this->getFormURL()."'>";
+         echo "<form method='post' action='".$this->getFormURL()."' data-track-changes='true'>";
       }
 
       $dropdown_rights = CommonDBTM::getRights();
@@ -1676,7 +1676,7 @@ class Profile extends CommonDBTM {
       echo "<div class='spaced'>";
       if (($canedit = Session::haveRightsOr(self::$rightname, [CREATE, UPDATE, PURGE]))
           && $openform) {
-         echo "<form method='post' action='".$this->getFormURL()."'>";
+         echo "<form method='post' action='".$this->getFormURL()."' data-track-changes='true'>";
       }
 
       $rights = [['rights'  => [

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -2083,7 +2083,7 @@ JAVASCRIPT;
       }
 
       $options['formtitle']   = $formtitle;
-      $options['formoptions'] = " enctype='multipart/form-data'";
+      $options['formoptions'] = ($options['formoptions'] ?? '') . " enctype='multipart/form-data'";
       $this->showFormHeader($options);
       $rand = mt_rand();
 

--- a/js/common.js
+++ b/js/common.js
@@ -1135,3 +1135,42 @@ function getUuidV4() {
       return v.toString(16);
    });
 }
+
+/** Track input changes and warn the user of unsaved changes if they try to navigate away */
+window.glpiUnsavedFormChanges = false;
+$(document).ready(function() {
+   // Try to limit tracking to item forms by binding to inputs under glpi_tabs only.
+   // Forms must have the data-track-changes attribute set to true.
+   // Form fields may have their data-track-changes attribute set to false to override the tracking on that input.
+   var glpiTabs = $('#page .glpi_tabs');
+   glpiTabs.on('input', 'form[data-track-changes="true"] input:not([data-track-changes="false"]),' +
+      'form[data-track-changes="true"] textarea:not([data-track-changes="false"])', function() {
+      window.glpiUnsavedFormChanges = true;
+   });
+   glpiTabs.on('change', 'form[data-track-changes="true"] select:not([data-track-changes="false"])', function() {
+      window.glpiUnsavedFormChanges = true;
+   });
+   glpiTabs.on('select2:select', 'form[data-track-changes="true"] select:not([data-track-changes="false"])', function() {
+      window.glpiUnsavedFormChanges = true;
+   });
+   $(window).on('beforeunload', function(e) {
+      if (window.glpiUnsavedFormChanges) {
+         e.preventDefault();
+         // All supported browsers will show a localized message
+         return '';
+      }
+   });
+
+   glpiTabs.on('submit', 'form', function() {
+      window.glpiUnsavedFormChanges = false;
+   });
+});
+
+function onTinyMCEChange(e) {
+   var editor = $(e.target)[0];
+   if ($(editor.targetElm).data('trackChanges') !== false) {
+      if ($(editor.formElement).data('trackChanges') === true) {
+         window.glpiUnsavedFormChanges = true;
+      }
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Rework of #6433 that requires each form to be specifically marked trackable rather than marking forms that should not be tracked.
Forms can be made trackable by adding `data-track-changes="true"`.
Inputs inside a tracked form can be ignore by adding `data-track-changes="false"`. I couldn't find any instance where that is needed yet, but the functionality is there for the future or for plugins.

List of forms made trackable:
- Tickets - Main form
- Changes - Main form
- Problems - Main form
- Projects - Main form
- Computers - Main form
- Monitors - Main form
- Software - Main form
- Network Devices - Main form
- Devices - Main form
- Printers - Main form
- Cartridges - Main form
- Consumables - Main form
- Phones - Main form
- Racks - Main form
- Enclosures - Main form
- PDUs - Main form
- Passive devices - Main form
- Licenses - Main form
- Budgets - Main form
- Suppliers - Main form
- Contacts - Main form
- Contract - Main form
- Documents - Main form
- Lines - Main form
- Certificates - Main form
- Data centers - Main form
- Clusters - Main form
- Domains - Main form
- Appliances - Main form
- Knowledgebase Article - Edit form
- Users - Main form
- Groups - Main form
- Dropdowns - Main form
- Entities - Main form and settings forms
- Rules - Main form
- Profiles - Main form and rights forms
- Settings/Config - Main form and settings forms and user preferences