### PR TITLE
Fix template entity

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -5282,7 +5282,11 @@ class CommonDBTM extends CommonGLPI {
     *
     * @return array
     */
-   public static function checkTemplateEntity(array $data, $parent_field) {
+   public static function checkTemplateEntity(
+      array $data,
+      $parent_field,
+      $parent_itemtype
+   ) {
       // No entity field -> no modification needed
       if (!isset($data['entities_id'])) {
          return $data;
@@ -5291,13 +5295,6 @@ class CommonDBTM extends CommonGLPI {
       // If the entity used in the template in not allowed for our current user,
       // fallback to the parent template entity
       if (!Session::haveAccessToEntity($data['entities_id'])) {
-         if ($parent_field == "items_id") {
-            // Generic "items_id" foreign key
-            $parent_itemtype = $data['itemtype'];
-         } else {
-            $parent_itemtype = getItemtypeForForeignKeyField($parent_field);
-         }
-
          // Load parent
          $parent = new $parent_itemtype();
          $parent_id = $data[$parent_field];

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -5284,7 +5284,7 @@ class CommonDBTM extends CommonGLPI {
     */
    public static function checkTemplateEntity(
       array $data,
-      $parent_field,
+      $parent_id,
       $parent_itemtype
    ) {
       // No entity field -> no modification needed
@@ -5297,7 +5297,6 @@ class CommonDBTM extends CommonGLPI {
       if (!Session::haveAccessToEntity($data['entities_id'])) {
          // Load parent
          $parent = new $parent_itemtype();
-         $parent_id = $data[$parent_field];
 
          if (!$parent->getFromDB($parent_id)) {
             // Can't load parent -> no modification

--- a/inc/contract.class.php
+++ b/inc/contract.class.php
@@ -119,7 +119,7 @@ class Contract extends CommonDBTM {
          $cd = new Contract_Item();
          unset($data['id']);
          $data['items_id'] = $newid;
-         $data = self::checkTemplateEntity($data, 'items_id', $data['itemtype']);
+         $data = self::checkTemplateEntity($data, $data['items_id'], $data['itemtype']);
          $data             = Toolbox::addslashes_deep($data);
 
          $cd->add($data);

--- a/inc/contract.class.php
+++ b/inc/contract.class.php
@@ -119,6 +119,7 @@ class Contract extends CommonDBTM {
          $cd = new Contract_Item();
          unset($data['id']);
          $data['items_id'] = $newid;
+         $data = self::checkTemplateEntity($data, 'items_id');
          $data             = Toolbox::addslashes_deep($data);
 
          $cd->add($data);

--- a/inc/contract.class.php
+++ b/inc/contract.class.php
@@ -119,7 +119,7 @@ class Contract extends CommonDBTM {
          $cd = new Contract_Item();
          unset($data['id']);
          $data['items_id'] = $newid;
-         $data = self::checkTemplateEntity($data, 'items_id');
+         $data = self::checkTemplateEntity($data, 'items_id', $data['itemtype']);
          $data             = Toolbox::addslashes_deep($data);
 
          $cd->add($data);

--- a/inc/projectcost.class.php
+++ b/inc/projectcost.class.php
@@ -210,7 +210,7 @@ class ProjectCost extends CommonDBChild {
          $cd                   = new self();
          unset($data['id']);
          $data['projects_id'] = $newid;
-         $data = self::checkTemplateEntity($data, 'projects_id');
+         $data = self::checkTemplateEntity($data, 'projects_id', Project::class);
          $data                 = Toolbox::addslashes_deep($data);
          $cd->add($data);
       }

--- a/inc/projectcost.class.php
+++ b/inc/projectcost.class.php
@@ -210,6 +210,7 @@ class ProjectCost extends CommonDBChild {
          $cd                   = new self();
          unset($data['id']);
          $data['projects_id'] = $newid;
+         $data = self::checkTemplateEntity($data, 'projects_id');
          $data                 = Toolbox::addslashes_deep($data);
          $cd->add($data);
       }

--- a/inc/projectcost.class.php
+++ b/inc/projectcost.class.php
@@ -210,7 +210,7 @@ class ProjectCost extends CommonDBChild {
          $cd                   = new self();
          unset($data['id']);
          $data['projects_id'] = $newid;
-         $data = self::checkTemplateEntity($data, 'projects_id', Project::class);
+         $data = self::checkTemplateEntity($data, $data['projects_id'], Project::class);
          $data                 = Toolbox::addslashes_deep($data);
          $cd->add($data);
       }

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -163,7 +163,7 @@ class ProjectTask extends CommonDBChild {
          $cd                  = new self();
          unset($data['id']);
          $data['projects_id'] = $newid;
-         $data = self::checkTemplateEntity($data, 'projects_id');
+         $data = self::checkTemplateEntity($data, 'projects_id', Project::class);
          $data                = Toolbox::addslashes_deep($data);
          $cd->add($data);
       }

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -163,6 +163,7 @@ class ProjectTask extends CommonDBChild {
          $cd                  = new self();
          unset($data['id']);
          $data['projects_id'] = $newid;
+         $data = self::checkTemplateEntity($data, 'projects_id');
          $data                = Toolbox::addslashes_deep($data);
          $cd->add($data);
       }

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -163,7 +163,7 @@ class ProjectTask extends CommonDBChild {
          $cd                  = new self();
          unset($data['id']);
          $data['projects_id'] = $newid;
-         $data = self::checkTemplateEntity($data, 'projects_id', Project::class);
+         $data = self::checkTemplateEntity($data, $data['projects_id'], Project::class);
          $data                = Toolbox::addslashes_deep($data);
          $cd->add($data);
       }

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -33,6 +33,7 @@
 namespace tests\units;
 
 use \DbTestCase;
+use SoftwareVersion;
 use TicketTask;
 
 /* Test for inc/commondbtm.class.php */
@@ -971,6 +972,7 @@ class CommonDBTM extends DbTestCase {
             // Case 1: no entites field -> no change
             'data'            => ['test' => "test"],
             'parent_field'    => '',
+            'parent_itemtype' => SoftwareVersion::class,
             'active_entities' => [],
             'expected'        => ['test' => "test"],
          ],
@@ -978,6 +980,7 @@ class CommonDBTM extends DbTestCase {
             // Case 2: entity is allowed -> no change
             'data'            => $sv1->fields,
             'parent_field'    => 'softwares_id',
+            'parent_itemtype' => SoftwareVersion::class,
             'active_entities' => [$sv1->fields['entities_id']],
             'expected'        => $sv1->fields,
          ],
@@ -985,6 +988,7 @@ class CommonDBTM extends DbTestCase {
             // Case 3: entity is not allowed -> change to parent entity
             'data'            => $sv2->fields, // SV with modified entity
             'parent_field'    => 'softwares_id',
+            'parent_itemtype' => SoftwareVersion::class,
             'active_entities' => [],
             'expected'        => $sv1->fields, // SV with correct entity
          ],
@@ -992,6 +996,7 @@ class CommonDBTM extends DbTestCase {
             // Case 4: can't load parent -> no change
             'data'            => $sv3->fields,
             'parent_field'    => 'softwares_id',
+            'parent_itemtype' => SoftwareVersion::class,
             'active_entities' => [],
             'expected'        => $sv3->fields,
          ],
@@ -1004,13 +1009,14 @@ class CommonDBTM extends DbTestCase {
    public function testCheckTemplateEntity(
       array $data,
       $parent_field,
+      $parent_itemtype,
       array $active_entities,
       array $expected
    ) {
       $old_active_entities = $_SESSION['glpiactiveentities'];
       $_SESSION['glpiactiveentities'] = $active_entities;
 
-      $res = \CommonDBTM::checkTemplateEntity($data, $parent_field);
+      $res = \CommonDBTM::checkTemplateEntity($data, $parent_field, $parent_itemtype);
       $this->array($res)->isEqualTo($expected);
 
       // Reset session

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -33,6 +33,7 @@
 namespace tests\units;
 
 use \DbTestCase;
+use TicketTask;
 
 /* Test for inc/commondbtm.class.php */
 
@@ -952,5 +953,67 @@ class CommonDBTM extends DbTestCase {
       $this->boolean($relation_item->getFromDB($relation_item_1_id))->isFalse();
       // Relation with witness object is still present
       $this->boolean($relation_item->getFromDB($relation_item_2_id))->isTrue();
+   }
+
+
+   protected function testCheckTemplateEntityProvider() {
+      $sv1 = getItemByTypeName('SoftwareVersion', '_test_softver_1');
+
+      $sv2 = getItemByTypeName('SoftwareVersion', '_test_softver_1');
+      $sv2->fields['entities_id'] = 99999;
+
+      $sv3 = getItemByTypeName('SoftwareVersion', '_test_softver_1');
+      $sv3->fields['entities_id'] = 99999;
+      $sv3->fields['softwares_id'] = 99999;
+
+      return [
+         [
+            // Case 1: no entites field -> no change
+            'data'            => ['test' => "test"],
+            'parent_field'    => '',
+            'active_entities' => [],
+            'expected'        => ['test' => "test"],
+         ],
+         [
+            // Case 2: entity is allowed -> no change
+            'data'            => $sv1->fields,
+            'parent_field'    => 'softwares_id',
+            'active_entities' => [$sv1->fields['entities_id']],
+            'expected'        => $sv1->fields,
+         ],
+         [
+            // Case 3: entity is not allowed -> change to parent entity
+            'data'            => $sv2->fields, // SV with modified entity
+            'parent_field'    => 'softwares_id',
+            'active_entities' => [],
+            'expected'        => $sv1->fields, // SV with correct entity
+         ],
+         [
+            // Case 4: can't load parent -> no change
+            'data'            => $sv3->fields,
+            'parent_field'    => 'softwares_id',
+            'active_entities' => [],
+            'expected'        => $sv3->fields,
+         ],
+      ];
+   }
+
+   /**
+    * @dataProvider testCheckTemplateEntityProvider
+    */
+   public function testCheckTemplateEntity(
+      array $data,
+      $parent_field,
+      array $active_entities,
+      array $expected
+   ) {
+      $old_active_entities = $_SESSION['glpiactiveentities'];
+      $_SESSION['glpiactiveentities'] = $active_entities;
+
+      $res = \CommonDBTM::checkTemplateEntity($data, $parent_field);
+      $this->array($res)->isEqualTo($expected);
+
+      // Reset session
+      $_SESSION['glpiactiveentities'] = $old_active_entities;
    }
 }

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -965,13 +965,12 @@ class CommonDBTM extends DbTestCase {
 
       $sv3 = getItemByTypeName('SoftwareVersion', '_test_softver_1');
       $sv3->fields['entities_id'] = 99999;
-      $sv3->fields['softwares_id'] = 99999;
 
       return [
          [
             // Case 1: no entites field -> no change
             'data'            => ['test' => "test"],
-            'parent_field'    => '',
+            'parent_id'       => 999,
             'parent_itemtype' => SoftwareVersion::class,
             'active_entities' => [],
             'expected'        => ['test' => "test"],
@@ -979,7 +978,7 @@ class CommonDBTM extends DbTestCase {
          [
             // Case 2: entity is allowed -> no change
             'data'            => $sv1->fields,
-            'parent_field'    => 'softwares_id',
+            'parent_id'       => $sv1->fields['softwares_id'],
             'parent_itemtype' => SoftwareVersion::class,
             'active_entities' => [$sv1->fields['entities_id']],
             'expected'        => $sv1->fields,
@@ -987,7 +986,7 @@ class CommonDBTM extends DbTestCase {
          [
             // Case 3: entity is not allowed -> change to parent entity
             'data'            => $sv2->fields, // SV with modified entity
-            'parent_field'    => 'softwares_id',
+            'parent_id'       => $sv2->fields['softwares_id'],
             'parent_itemtype' => SoftwareVersion::class,
             'active_entities' => [],
             'expected'        => $sv1->fields, // SV with correct entity
@@ -995,7 +994,7 @@ class CommonDBTM extends DbTestCase {
          [
             // Case 4: can't load parent -> no change
             'data'            => $sv3->fields,
-            'parent_field'    => 'softwares_id',
+            'parent_id'       => 99999,
             'parent_itemtype' => SoftwareVersion::class,
             'active_entities' => [],
             'expected'        => $sv3->fields,
@@ -1008,7 +1007,7 @@ class CommonDBTM extends DbTestCase {
     */
    public function testCheckTemplateEntity(
       array $data,
-      $parent_field,
+      $parent_id,
       $parent_itemtype,
       array $active_entities,
       array $expected
@@ -1016,7 +1015,7 @@ class CommonDBTM extends DbTestCase {
       $old_active_entities = $_SESSION['glpiactiveentities'];
       $_SESSION['glpiactiveentities'] = $active_entities;
 
-      $res = \CommonDBTM::checkTemplateEntity($data, $parent_field, $parent_itemtype);
+      $res = \CommonDBTM::checkTemplateEntity($data, $parent_id, $parent_itemtype);
       $this->array($res)->isEqualTo($expected);
 
       // Reset session


### PR DESCRIPTION
Internal ref: 19597.

Situation:
Create a project template with a task in the `Root` entity + subentities.
Switch to a sub entity (`Root > A`).
Create a project using the previous template.
-> the project will be in `Root > A` entity
-> the task will be in `Root` entity

Fixed this by adding a new check in some cloneXXXX methods:
If the entity id of the cloned item is not allowed for the current user -> remplace it by the entity of its parent item.

So in our previous case (task) we can't see `Root` entity so we fall back to the parent (project) entity which is `Root > A`.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
