### PR TITLE
Fix warning during 9.5 update

### DIFF
--- a/inc/impact.class.php
+++ b/inc/impact.class.php
@@ -1756,6 +1756,11 @@ class Impact extends CommonGLPI {
    public static function getEnabledItemtypes(): array {
       // Get configured values
       $conf = Config::getConfigurationValues('core');
+
+      if (!isset($conf[self::CONF_ENABLED])) {
+         return [];
+      }
+
       $enabled = importArrayFromDB($conf[self::CONF_ENABLED]);
 
       // Remove any forbidden values


### PR DESCRIPTION
Fix a (harmless) warning when running 9.5 update for the first time and the new impact conf does not exist yet. 

![image](https://user-images.githubusercontent.com/42734840/82996711-add63a00-a005-11ea-8447-9b97ff6eddc8.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
