### PR TITLE
Add unique for reservation items + drop is_deleted

### DIFF
--- a/inc/reservationitem.class.php
+++ b/inc/reservationitem.class.php
@@ -555,7 +555,6 @@ class ReservationItem extends CommonDBChild {
                    LEFT JOIN `glpi_locations`
                         ON (`$itemtable`.`locations_id` = `glpi_locations`.`id`)
                    WHERE `glpi_reservationitems`.`is_active` = 1
-                         AND `glpi_reservationitems`.`is_deleted` = 0
                          AND `$itemtable`.`is_deleted` = 0
                          $where ".
                          getEntitiesRestrictRequest(" AND", $itemtable, '',

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -7641,13 +7641,12 @@ CREATE TABLE `glpi_reservationitems` (
   `items_id` int(11) NOT NULL DEFAULT '0',
   `comment` text COLLATE utf8_unicode_ci,
   `is_active` tinyint(1) NOT NULL DEFAULT '1',
-  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `is_active` (`is_active`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
-  KEY `is_deleted` (`is_deleted`)
+  UNIQUE KEY `unicity` (`itemtype`,`items_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 

--- a/install/update_946_947.php
+++ b/install/update_946_947.php
@@ -46,6 +46,14 @@ function update946to947() {
 
    $DB->updateOrDie('glpi_events', ['type'   => 'dcrooms'], ['type' => 'serverroms']);
 
+   $migration->dropField(ReservationItem::getTable(), "is_deleted");
+   $migration->addKey(
+      ReservationItem::getTable(),
+      ['itemtype', 'items_id'],
+      'unicity',
+      'UNIQUE'
+   );
+
    // ************ Keep it at the end **************
    $migration->executeMigration();
 


### PR DESCRIPTION
Internal ref: 19770.

Items have 3 states regarding reservation:
- reservable (= there is ONE entry in glpi_reservations_items)
- reservable but not active (= there is ONE entry in glpi_reservations_items with is_active = 0)
- not reservable (= no entry in glpi_reservations_items).

There was no unique constraint in the glpi_reservations_items table.
This meant that if for some reasons one item ended up multiple times in this table then reservations would be broken for this item.

I've also dropped the `is_deleted` field as it seems useless right now (maybe it was used in the past) ? 

Also, regarding the unique key, I guess the migration should also delete any duplicate before trying to add it ?

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
