### PR TITLE
Nightly build GLPI using Github Actions

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,0 +1,48 @@
+name: "GLPI nightly build"
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  build:
+    name: "Build ${{ matrix.branch }}"
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # build on lower supported version to ensure building tools are compatible with this version
+          - {branch: "9.4/bugfixes", php-version: "5.6"}
+          - {branch: "9.5/bugfixes", php-version: "7.2"}
+    services:
+      app:
+        image: "glpi/githubactions-php:${{ matrix.php-version }}"
+        options: >-
+          --volume /glpi:/var/glpi
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+        with:
+          ref: ${{ matrix.branch }}
+      - name: "Deploy source into app container"
+        run: |
+          sudo cp --no-target-directory --preserve --recursive `pwd` /glpi
+          sudo chown -R 1000:1000 /glpi
+      - name: "Install dependencies"
+        run: |
+          docker exec ${{ job.services.app.id }} composer install --optimize-autoloader --prefer-dist --no-interaction --no-progress --no-suggest
+      - name: "Define release name"
+        run: |
+          REF_NAME=$(echo ${{ matrix.branch }} | sed -E 's|/|-|')
+          SHA=$(git rev-parse --short HEAD)
+          echo "::set-env name=release_name::$REF_NAME.$SHA"
+      - name: "Build"
+        run: |
+          echo "Y" | docker exec --interactive ${{ job.services.app.id }} tools/make_release.sh . ${{ env.release_name }}
+          docker cp ${{ job.services.app.id }}:/tmp/glpi-${{ env.release_name }}.tgz ${{ github.workspace }}/${{ env.release_name }}.tar.gz
+      - name: "Store archive"
+        uses: actions/upload-artifact@v2
+        with:
+            name: ${{ env.release_name }}.tar.gz
+            path: ${{ github.workspace }}/${{ env.release_name }}.tar.gz


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Build GLPI nightly directly from Github Actions, and using CI docker images which provides an environment compatible with GLPI (required at least to be able to install dependencies using composer, as we need some of them during the build process).

TODO:

- [x] install bash package on CI docker images (mandatory to be able to run some scripts, like `tools/make_release.sh`)
- [x] remove push event trigger
- [x] ~upload archive on a server capable of providing stable URLs (Github Action artifacts URL changed on each run)~
