### PR TITLE
Do not cache dashboard cards debug info

### DIFF
--- a/inc/dashboard/grid.class.php
+++ b/inc/dashboard/grid.class.php
@@ -978,19 +978,19 @@ HTML;
 
       $execution_time = round(microtime(true) - $start, 3);
 
+      // store server cache
+      if (strlen($dashboard)) {
+         $dashboard_cards = $GLPI_CACHE->get($cache_key) ?? [];
+         $dashboard_cards[$gridstack_id] = $html;
+         $GLPI_CACHE->set($cache_key, $dashboard_cards, new \DateInterval("PT".$cache_age."S"));
+      }
+
       if ($_SESSION['glpi_use_mode'] == \Session::DEBUG_MODE) {
          $html.= <<<HTML
          <span class='debug-card'>
             {$execution_time}s
          </span>
 HTML;
-      }
-
-      // store server cache
-      if (strlen($dashboard)) {
-         $dashboard_cards = $GLPI_CACHE->get($cache_key) ?? [];
-         $dashboard_cards[$gridstack_id] = $html;
-         $GLPI_CACHE->set($cache_key, $dashboard_cards, new \DateInterval("PT".$cache_age."S"));
       }
 
       return $html;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Debug information of dashboard cards were stored in cache, and so were served to all users, even thoose having not debug mode enabled.