### PR TITLE
Fix 'notification_to_myself' setting for mailgate

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -699,6 +699,10 @@ class MailCollector  extends CommonDBTM {
                $is_supplier_anonymous = !(isset($tkt['_supplier_email'])
                                           && $tkt['_supplier_email']);
 
+               // Keep track of the mail author so we can check his
+               // notifications preferences later (glpinotification_to_myself)
+               $_SESSION['mailcollector_user'] = $tkt['users_id'];
+
                if (isset($tkt['_blacklisted']) && $tkt['_blacklisted']) {
                   $this->deleteMails($uid, self::REFUSED_FOLDER);
                   $blacklisted++;
@@ -779,6 +783,9 @@ class MailCollector  extends CommonDBTM {
                   $this->deleteMails($uid, self::REFUSED_FOLDER);
                }
                $this->fetch_emails++;
+
+               // Clean mail author used for notification settings
+               unset($_SESSION['mailcollector_user']);
             }
             imap_expunge($this->marubox);
             $this->close_mailbox();   //Close Mail Box

--- a/inc/notificationevent.class.php
+++ b/inc/notificationevent.class.php
@@ -137,9 +137,23 @@ class NotificationEvent extends CommonDBTM {
             $template->resetComputedTemplates();
 
             $notify_me = false;
+            $emitter = null;
+
             if (Session::isCron()) {
                // Cron notify me
                $notify_me = true;
+
+               // If mailcollector_user is set, use the given user preferences
+               if (isset($_SESSION['mailcollector_user'])) {
+                  $user = new User();
+                  $res = $user->getFromDB($_SESSION['mailcollector_user']);
+
+                  if ($res) {
+                     $user->computePreferences();
+                     $notify_me = $user->fields['notification_to_myself'];
+                     $emitter = $_SESSION['mailcollector_user'];
+                  }
+               }
             } else {
                // Not cron see my pref
                $notify_me = $_SESSION['glpinotification_to_myself'];
@@ -160,7 +174,8 @@ class NotificationEvent extends CommonDBTM {
                   $data,
                   $notificationtarget->setEvent($eventclass),
                   $template,
-                  $notify_me
+                  $notify_me,
+                  $emitter
                );
             } else {
                Toolbox::logWarning('Missing event class for mode ' . $data['mode'] . ' (' . $eventclass . ')');

--- a/inc/notificationeventabstract.class.php
+++ b/inc/notificationeventabstract.class.php
@@ -57,7 +57,8 @@ abstract class NotificationEventAbstract {
       array $data,
       NotificationTarget $notificationtarget,
       NotificationTemplate $template,
-      $notify_me
+      $notify_me,
+      $emitter = null
    ) {
       global $CFG_GLPI;
       if ($CFG_GLPI['notifications_' . $options['mode']]) {
@@ -93,7 +94,7 @@ abstract class NotificationEventAbstract {
             foreach ($notificationtarget->getTargets() as $users_infos) {
                $key = $users_infos[static::getTargetFieldName()];
                if ($label
-                     || $notificationtarget->validateSendTo($event, $users_infos, $notify_me)) {
+                     || $notificationtarget->validateSendTo($event, $users_infos, $notify_me, $emitter)) {
                   //If the user have not yet been notified
                   if (!isset($processed[$users_infos['language']][$key])) {
                      //If ther user's language is the same as the template's one

--- a/inc/notificationeventinterface.class.php
+++ b/inc/notificationeventinterface.class.php
@@ -58,7 +58,8 @@ interface NotificationEventInterface {
       array $data,
       NotificationTarget $notificationtarget,
       NotificationTemplate $template,
-      $notify_me
+      $notify_me,
+      $emitter = null
    );
 
 

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -167,15 +167,24 @@ class NotificationTarget extends CommonDBChild {
     * @param boolean $notify_me notify me on my action ?
     *                           ($infos contains users_id to check if the target is me)
     *                           (false by default)
+    * @param int|null $emitter  if this action is executed by the cron, we can
+    *                           supply the id of the user who triggered the event
+    *                           so it can be used instead of getLoginUserID
     *
     * @return boolean
    **/
-   function validateSendTo($event, array $infos, $notify_me = false) {
+   function validateSendTo($event, array $infos, $notify_me = false, $emitter = null) {
+      $users_id = Session::getLoginUserID(false);
+
+      // Override session ID with emitter ID if supplied
+      if (!is_null($emitter)) {
+         $users_id = $emitter;
+      }
 
       if (!$notify_me) {
          if (isset($infos['users_id'])
             // Check login user and not event launch by crontask
-             && ($infos['users_id'] === Session::getLoginUserID(false))) {
+             && ($infos['users_id'] === $users_id)) {
             return false;
          }
       }

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -69,10 +69,10 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
    }
 
 
-   function validateSendTo($event, array $infos, $notify_me = false) {
+   function validateSendTo($event, array $infos, $notify_me = false, $emitter = null) {
 
       // Check global ones for notification to myself
-      if (!parent::validateSendTo($event, $infos, $notify_me)) {
+      if (!parent::validateSendTo($event, $infos, $notify_me, $emitter)) {
          return false;
       }
 

--- a/inc/notificationtargetticket.class.php
+++ b/inc/notificationtargetticket.class.php
@@ -42,15 +42,14 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject {
    const HEADERTAG = '=-=-=-=';
    const FOOTERTAG = '=_=_=_=';
 
-   function validateSendTo($event, array $infos, $notify_me = false) {
-
+   function validateSendTo($event, array $infos, $notify_me = false, $emitter = null) {
       // Always send notification for satisfaction : if send on ticket closure
       // Always send notification for new ticket
       if (in_array($event, ['satisfaction', 'new'])) {
          return true;
       }
 
-      return parent::validateSendTo($event, $infos, $notify_me);
+      return parent::validateSendTo($event, $infos, $notify_me, $emitter);
    }
 
 


### PR DESCRIPTION
Internal ref: 19947.

The setting 'notification_to_myself' allow a user to enable/disable notifications triggered by his own events.

However, this setting is ignored when actions are handled by the mailgate since the notification system need a connected user to check this setting.

This was fixed by allowing to specify an additional "emitter" parameter to the notification so it can use it instead of the current connected user (= use the sender of the email for mailgate).

This fix should be good enough for now, but if there is a notification remodel in the future it should maybe use a concrete notion of emitter/source and never rely on the current user.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
