### PR TITLE
Mailgate: fix anonymous observers

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -882,10 +882,16 @@ class MailCollector  extends CommonDBTM {
       if (count($head['ccs'])) {
          foreach ($head['ccs'] as $cc) {
             if (($cc != $head[$this->getRequesterField()])
-                && !Toolbox::inArrayCaseCompare($cc, $blacklisted_emails) // not blacklisted emails
-                && (($tmp = User::getOrImportByEmail($cc)) > 0)) {
+               && !Toolbox::inArrayCaseCompare($cc, $blacklisted_emails) // not blacklisted emails
+            ) {
+               // Skip if user is anonymous and anonymous users are not allowed
+               $user_id = User::getOrImportByEmail($cc);
+               if (!$user_id && !$CFG_GLPI['use_anonymous_helpdesk']) {
+                  continue;
+               }
+
                $nb = (isset($tkt['_users_id_observer']) ? count($tkt['_users_id_observer']) : 0);
-               $tkt['_users_id_observer'][$nb] = $tmp;
+               $tkt['_users_id_observer'][$nb] = $user_id;
                $tkt['_users_id_observer_notif']['use_notification'][$nb] = 1;
                $tkt['_users_id_observer_notif']['alternative_email'][$nb] = $cc;
             }
@@ -895,12 +901,18 @@ class MailCollector  extends CommonDBTM {
       if (count($head['tos'])) {
          foreach ($head['tos'] as $to) {
             if (($to != $head[$this->getRequesterField()])
-                && !Toolbox::inArrayCaseCompare($to, $blacklisted_emails) // not blacklisted emails
-                && (($tmp = User::getOrImportByEmail($to)) > 0)) {
-                   $nb = (isset($tkt['_users_id_observer']) ? count($tkt['_users_id_observer']) : 0);
-                   $tkt['_users_id_observer'][$nb] = $tmp;
-                   $tkt['_users_id_observer_notif']['use_notification'][$nb] = 1;
-                   $tkt['_users_id_observer_notif']['alternative_email'][$nb] = $to;
+               && !Toolbox::inArrayCaseCompare($to, $blacklisted_emails) // not blacklisted emails
+            ) {
+               // Skip if user is anonymous and anonymous users are not allowed
+               $user_id = User::getOrImportByEmail($to);
+               if (!$user_id && !$CFG_GLPI['use_anonymous_helpdesk']) {
+                  continue;
+               }
+
+               $nb = (isset($tkt['_users_id_observer']) ? count($tkt['_users_id_observer']) : 0);
+               $tkt['_users_id_observer'][$nb] = $user_id;
+               $tkt['_users_id_observer_notif']['use_notification'][$nb] = 1;
+               $tkt['_users_id_observer_notif']['alternative_email'][$nb] = $to;
             }
          }
       }


### PR DESCRIPTION
Internal ref: 20025.

The additional anonymous users in the TOs and CCs headers were never added even if ticket creation from anonymous users was enabled in the config.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
