### PR TITLE
Fix build script on Alpine Linux

### DIFF
--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -31,7 +31,7 @@
 #  */
 
 SCRIPT_DIR=$(dirname $0)
-WORKING_DIR=$(readlink --canonicalize "$SCRIPT_DIR/..")
+WORKING_DIR=$(readlink -f "$SCRIPT_DIR/..")
 
 if [ -e "$WORKING_DIR/.git" ]
 then

--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -39,7 +39,7 @@ then
     exit
 fi
 
-SOURCE_DIR=$(readlink --canonicalize $1)
+SOURCE_DIR=$(readlink -f $1)
 RELEASE=$2
 WORKING_DIR=/tmp/glpi-$RELEASE
 TARBALL_PATH=/tmp/glpi-$RELEASE.tgz


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes `readlink: unrecognized option: canonicalize`.

See https://github.com/cedric-anne/glpi/actions/runs/124676457 which contains a failing build on 9.5/bugfixes and a working build with current fix.