### PR TITLE
Fix 'notification_to_myself' setting for mailgate 2

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -701,7 +701,13 @@ class MailCollector  extends CommonDBTM {
 
                // Keep track of the mail author so we can check his
                // notifications preferences later (glpinotification_to_myself)
-               $_SESSION['mailcollector_user'] = $tkt['users_id'];
+               if ($tkt['users_id']) {
+                  $_SESSION['mailcollector_user'] = $tkt['users_id'];
+               } else {
+                  // Special case when we have no users_id (anonymous helpdesk)
+                  // -> use the user email instead
+                  $_SESSION['mailcollector_user'] = $tkt["_users_id_requester_notif"]['alternative_email'][0];
+               }
 
                if (isset($tkt['_blacklisted']) && $tkt['_blacklisted']) {
                   $this->deleteMails($uid, self::REFUSED_FOLDER);

--- a/inc/notificationevent.class.php
+++ b/inc/notificationevent.class.php
@@ -145,13 +145,24 @@ class NotificationEvent extends CommonDBTM {
 
                // If mailcollector_user is set, use the given user preferences
                if (isset($_SESSION['mailcollector_user'])) {
-                  $user = new User();
-                  $res = $user->getFromDB($_SESSION['mailcollector_user']);
+                  $mailcollector_user = $_SESSION['mailcollector_user'];
 
-                  if ($res) {
-                     $user->computePreferences();
-                     $notify_me = $user->fields['notification_to_myself'];
-                     $emitter = $_SESSION['mailcollector_user'];
+                  if (is_int($mailcollector_user)) {
+                     // Try to load the given user and his preferences
+                     $user = new User();
+                     $res = $user->getFromDB($_SESSION['mailcollector_user']);
+
+                     if ($res) {
+                        $user->computePreferences();
+                        $notify_me = $user->fields['notification_to_myself'];
+                        $emitter = $_SESSION['mailcollector_user'];
+                     }
+                  } else {
+                     // Special case for anonymous helpdesk, we have an email
+                     // instead of an ID
+                     // -> load the global conf and use the email as the emitter
+                     $notify_me = $CFG_GLPI['notification_to_myself'];
+                     $emitter = $mailcollector_user;
                   }
                }
             } else {

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -167,9 +167,11 @@ class NotificationTarget extends CommonDBChild {
     * @param boolean $notify_me notify me on my action ?
     *                           ($infos contains users_id to check if the target is me)
     *                           (false by default)
-    * @param int|null $emitter  if this action is executed by the cron, we can
-    *                           supply the id of the user who triggered the event
-    *                           so it can be used instead of getLoginUserID
+    * @param mixed $emitter     if this action is executed by the cron, we can
+    *                           supply the id of the user (or the email if this
+    *                           is an anonymous user with no account) who
+    *                           triggered the event so it can be used instead of
+    *                           getLoginUserID
     *
     * @return boolean
    **/
@@ -178,7 +180,19 @@ class NotificationTarget extends CommonDBChild {
 
       // Override session ID with emitter ID if supplied
       if (!is_null($emitter)) {
-         $users_id = $emitter;
+         if (is_int($emitter)) {
+            // We have an ID, we can use it directly
+            $users_id = $emitter;
+         } else {
+            // We have an email, we need to check that the users_id is -1 which
+            // is the value used for anonymous user and compare the emails
+            if (isset($infos['users_id']) && $infos['users_id'] == -1
+               && isset($infos['email']) && $infos['email'] == $emitter
+            ) {
+               $users_id = -1;
+            }
+         }
+
       }
 
       if (!$notify_me) {

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -179,20 +179,17 @@ class NotificationTarget extends CommonDBChild {
       $users_id = Session::getLoginUserID(false);
 
       // Override session ID with emitter ID if supplied
-      if (!is_null($emitter)) {
-         if (is_int($emitter)) {
-            // We have an ID, we can use it directly
-            $users_id = $emitter;
-         } else {
-            // We have an email, we need to check that the users_id is -1 which
-            // is the value used for anonymous user and compare the emails
-            if (isset($infos['users_id']) && $infos['users_id'] == -1
-               && isset($infos['email']) && $infos['email'] == $emitter
-            ) {
-               $users_id = -1;
-            }
+      if (is_int($emitter)) {
+         // We have an ID, we can use it directly
+         $users_id = $emitter;
+      } else if (is_string($emitter)) {
+         // We have an email, we need to check that the users_id is -1 which
+         // is the value used for anonymous user and compare the emails
+         if (isset($infos['users_id']) && $infos['users_id'] == -1
+            && isset($infos['email']) && $infos['email'] == $emitter
+         ) {
+            $users_id = -1;
          }
-
       }
 
       if (!$notify_me) {


### PR DESCRIPTION
Following #7360.

One case was not covered by the previous changes: anonymous users.
Since they have no real account we must use:
- the global configuration settings for $notify_me
- theirs emais instead of theirs IDs when comparing with a potential email target

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
