### PR TITLE
Fix behavior of --force param in install command

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2342,18 +2342,26 @@ class Toolbox {
    /**
     * Create the GLPI default schema
     *
-    * @since 9.1
-    *
-    * @param string $lang Language to install
+    * @param string  $lang Language to install
+    * @param DBmysql $db   Database instance to use, will fallback to a new instance of DB if null
     *
     * @return void
+    *
+    * @since 9.1
+    * @since 9.4.7 Added $db parameter
    **/
-   static function createSchema($lang = 'en_GB') {
-      global $CFG_GLPI, $DB;
+   static function createSchema($lang = 'en_GB', DBmysql $database = null) {
+      global $DB;
 
-      include_once (GLPI_CONFIG_DIR . "/config_db.php");
+      if (null === $database) {
+         // Use configured DB if no $db is defined in parameters
+         include_once (GLPI_CONFIG_DIR . "/config_db.php");
+         $database = new DB();
+      }
 
-      $DB = new DB();
+      // Set global $DB as it is used in "Config::setConfigurationValues()" just after schema creation
+      $DB = $database;
+
       if (!$DB->runFile(GLPI_ROOT ."/install/mysql/glpi-empty.sql")) {
          echo "Errors occurred inserting default database";
       } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If a DB config file was already existing, it was loading by initial includes, and was not reloaded by `Toolbox::createSchema()` (it cannot be reloaded as it is a class definition).
Result is that DB was (re)installed using previously existing configuration when using --force param in db:install command, althought the config file was rewritten with new config values.