### PR TITLE
Anonymous helpdesk: improve entity check

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -2881,7 +2881,8 @@ abstract class CommonITILObject extends CommonDBTM {
             $k = $d['groups_id'];
             echo "$mandatory$groupicon&nbsp;";
             if ($group->getFromDB($k)) {
-               if (Entity::getUsedConfig('anonymize_support_agents')
+               $entity = $this->getEntityID();
+               if (Entity::getUsedConfig('anonymize_support_agents', $entity)
                   && Session::getCurrentInterface() == 'helpdesk'
                   && $type == CommonITILActor::ASSIGN
                ) {
@@ -4033,7 +4034,8 @@ abstract class CommonITILObject extends CommonDBTM {
                $userdata      = "<a href='mailto:$email'>$email</a>";
             }
 
-            if (Entity::getUsedConfig('anonymize_support_agents')
+            $entity = $this->getEntityID();
+            if (Entity::getUsedConfig('anonymize_support_agents', $entity)
                && Session::getCurrentInterface() == 'helpdesk'
                && $type == CommonITILActor::ASSIGN
             ) {
@@ -6145,7 +6147,8 @@ abstract class CommonITILObject extends CommonDBTM {
          // Fifth column
          $fifth_col = "";
 
-         $anonymize_helpdesk = Entity::getUsedConfig('anonymize_support_agents')
+         $entity = $item->getEntityID();
+         $anonymize_helpdesk = Entity::getUsedConfig('anonymize_support_agents', $entity)
             && Session::getCurrentInterface() == 'helpdesk';
 
          foreach ($item->getUsers(CommonITILActor::ASSIGN) as $d) {
@@ -7014,7 +7017,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
                echo "<span class='h_user_name'>";
                $userdata = getUserName($item_i['users_id'], 2);
-               if (Entity::getUsedConfig('anonymize_support_agents')
+               $entity = $this->getEntityID();
+               if (Entity::getUsedConfig('anonymize_support_agents', $entity)
                   && Session::getCurrentInterface() == 'helpdesk'
                   && ITILFollowup::getById($item_i['id'])->isFromSupportAgent()
                ) {

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1235,7 +1235,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
             $tmp['##followup.isprivate##']   = Dropdown::getYesNo($followup['is_private']);
 
             // Check if the author need to be anonymized
-            if (Entity::getUsedConfig('anonymize_support_agents')
+            if (Entity::getUsedConfig('anonymize_support_agents', $item->getField('entities_id'))
                && ITILFollowup::getById($followup['id'])->isFromSupportAgent()
             ) {
                $tmp['##followup.author##'] = __("Helpdesk");

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5517,10 +5517,13 @@ JAVASCRIPT;
          switch ($table.'.'.$field) {
             case "glpi_users.name" :
                if ($itemtype == 'Ticket'
-                  && Entity::getUsedConfig('anonymize_support_agents')
                   && Session::getCurrentInterface() == 'helpdesk'
-                  && $orig_id == 5) {
-                  // Support agent
+                  && $orig_id == 5
+                  && Entity::getUsedConfig(
+                     'anonymize_support_agents',
+                     $itemtype::getById($data['id'])->getEntityId()
+                  )
+               ) {
                   return __("Helpdesk");
                }
 
@@ -6161,9 +6164,13 @@ JAVASCRIPT;
       //// Default case
 
       if ($itemtype == 'Ticket'
-         && Entity::getUsedConfig('anonymize_support_agents')
          && Session::getCurrentInterface() == 'helpdesk'
-         && $orig_id == 8) {
+         && $orig_id == 8
+         && Entity::getUsedConfig(
+            'anonymize_support_agents',
+            $itemtype::getById($data['id'])->getEntityId()
+         )
+      ) {
          // Assigned groups
          return __("Helpdesk group");
       }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -864,7 +864,8 @@ class Ticket extends CommonITILObject {
       $this->addStandardTab('Problem_Ticket', $ong, $options);
       $this->addStandardTab('Change_Ticket', $ong, $options);
 
-      if (!(Entity::getUsedConfig('anonymize_support_agents')
+      $entity = $this->getEntityID();
+      if (!(Entity::getUsedConfig('anonymize_support_agents', $entity)
          && Session::getCurrentInterface() == 'helpdesk')
       ) {
          $this->addStandardTab('Log', $ong, $options);


### PR DESCRIPTION
Following #7015.
Internal ref: 20024.

A little improvement of the "Anonymous helpdesk" feature.
Instead of checking the current entity of the user, we now check the entity of the ticket.

Example: 
We have two entities A and B (B being a sub-entity of A).
A -> Anonymous helpdesk **disabled**
B -> Anonymous helpdesk **enabled**

Before the change, a user on the A entity will be able to see the names of all the tech on any tickets from A or B.

After the change, this same user will still see the technicians' names for tickets on A but not for tickets on B.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
