### PR TITLE
Fix ITILObject create form change tracking

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7476,8 +7476,13 @@ abstract class CommonITILObject extends CommonDBTM {
       $rand = mt_rand();
 
       if (isset($options['template_preview']) && !$options['template_preview']) {
-         echo "<form method='post' name='form_ticket' enctype='multipart/form-data' action='".
-                static::getFormURL()."' data-track-changes='true'>";
+         $output = "<form method='post' name='form_ticket' enctype='multipart/form-data' action='".static::getFormURL()."''";
+         if ($ID) {
+            $output .= " data-track-changes='true'";
+         }
+         $output .= '>';
+         echo $output;
+
          if (isset($options['_projecttasks_id'])) {
             echo "<input type='hidden' name='_projecttasks_id' value='".$options['_projecttasks_id']."'>";
          }

--- a/js/common.js
+++ b/js/common.js
@@ -1141,16 +1141,13 @@ window.glpiUnsavedFormChanges = false;
 $(document).ready(function() {
    // Try to limit tracking to item forms by binding to inputs under glpi_tabs only.
    // Forms must have the data-track-changes attribute set to true.
-   // Form fields may have their data-track-changes attribute set to false to override the tracking on that input.
+   // Form fields may have their data-track-changes attribute set to empty (false) to override the tracking on that input.
    var glpiTabs = $('#page .glpi_tabs');
-   glpiTabs.on('input', 'form[data-track-changes="true"] input:not([data-track-changes="false"]),' +
+   glpiTabs.on('input', 'form[data-track-changes="true"] input:not([data-track-changes=""]),' +
       'form[data-track-changes="true"] textarea:not([data-track-changes="false"])', function() {
       window.glpiUnsavedFormChanges = true;
    });
-   glpiTabs.on('change', 'form[data-track-changes="true"] select:not([data-track-changes="false"])', function() {
-      window.glpiUnsavedFormChanges = true;
-   });
-   glpiTabs.on('select2:select', 'form[data-track-changes="true"] select:not([data-track-changes="false"])', function() {
+   glpiTabs.on('change', 'form[data-track-changes="true"] select:not([data-track-changes=""])', function() {
       window.glpiUnsavedFormChanges = true;
    });
    $(window).on('beforeunload', function(e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7389

fixes #7389

Remove tracking on CommonITILObject create forms
 - The migration of data is already handled here and the warning is useless when some fields cause the form to reload on purpose.

Fix issue with false data-track-changes. False values become empty not false so the wrong value was tested.
Drop redundant Select2 listener
 - The select change event is already fired when using Select2. Event call order doesn't seem to matter here (change event should be fired after select2).