### PR TITLE
Fix holiday transfer; closes #7227

### DIFF
--- a/inc/holiday.class.php
+++ b/inc/holiday.class.php
@@ -118,9 +118,9 @@ class Holiday extends CommonDropdown {
 
       $input = parent::prepareInputForUpdate($input);
 
-      if (empty($input['end_date'])
+      if (isset($input['begin_date']) && (empty($input['end_date'])
           || ($input['end_date'] == 'NULL')
-          || ($input['end_date'] < $input['begin_date'])) {
+          || ($input['end_date'] < $input['begin_date']))) {
 
          $input['end_date'] = $input['begin_date'];
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7227

On 9.5 branch, unit tests has been added on more objects. Holidays was explicitely excluded, activating it gives the issue in tests, current fix fixes it :)