### PR TITLE
Build for feature and fix branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - master
       - '*/bugfixes'
+      - 'feature/*'
+      - 'fix/*'
     tags:
        - '*'
   # Runs test suite when a PR is opened or synchronyzed


### PR DESCRIPTION
It is not possible to run tests on GH actions on branch other than master and */bugfixes. I propose to add branches prefixed with `feature/` we frequently use, and also with `fix/` for bugfixes (less important).

Goal is I can get GH actions running on my own fork when I push to a feature branch, without having to open a pull request.