### PR TITLE
UUID for OS-capable Itemtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The present file will list all changes made to the project; according to the
 ## [x.x.x] unreleased
 
 ### Added
+- Added UUID to all other itemtypes that are related to Operating Systems (Phones, Printers, etc)
 
 ### Changed
 

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -274,6 +274,13 @@ class Monitor extends CommonDBTM {
       echo "</td></tr>";
 
       echo "<tr class='tab_bg_1'>";
+      echo "<td>".__('UUID')."</td>";
+      echo "<td>";
+      Html::autocompletionTextField($this, 'uuid');
+      echo "</td>";
+      echo "</tr>";
+
+      echo "<tr class='tab_bg_1'>";
       echo "<td>".__('Size')."</td>";
       echo "<td>";
       Html::autocompletionTextField($this, "size");

--- a/inc/networkequipment.class.php
+++ b/inc/networkequipment.class.php
@@ -395,6 +395,12 @@ class NetworkEquipment extends CommonDBTM {
       Html::autocompletionTextField($this, "ram");
       echo "</td></tr>";
 
+      echo "<tr class='tab_bg_1'>";
+      echo "<td>".__('UUID')."</td>";
+      echo "<td>";
+      Html::autocompletionTextField($this, 'uuid');
+      echo "</td></tr>";
+
       // Display auto inventory informations
       if (!empty($ID)
          && $this->fields["is_dynamic"]) {

--- a/inc/peripheral.class.php
+++ b/inc/peripheral.class.php
@@ -276,6 +276,13 @@ class Peripheral extends CommonDBTM {
       echo "</textarea></td></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
+      echo "<td>".__('UUID')."</td>\n";
+      echo "<td>";
+      Html::autocompletionTextField($this, 'uuid');
+      echo "</td>\n";
+      echo "</tr>\n";
+
+      echo "<tr class='tab_bg_1'>";
       echo "<td>".__('Brand')."</td>\n";
       echo "<td>";
       Html::autocompletionTextField($this, "brand");

--- a/inc/phone.class.php
+++ b/inc/phone.class.php
@@ -285,6 +285,13 @@ class Phone extends CommonDBTM {
       echo "</td></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
+      echo "<td>".__('UUID')."</td>";
+      echo "<td >";
+      Html::autocompletionTextField($this, 'uuid');
+      echo "</td>";
+      echo "</tr>\n";
+
+      echo "<tr class='tab_bg_1'>";
       echo "<td>".__('Flags')."</td>";
       echo "<td>";
       // micro?

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -416,6 +416,12 @@ class Printer  extends CommonDBTM {
       echo "</td></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
+      echo "<td>".__('UUID')."</td>\n";
+      echo "<td>";
+      Html::autocompletionTextField($this, 'uuid');
+      echo "</td></tr>\n";
+
+      echo "<tr class='tab_bg_1'>";
       echo "<td>"._n('Port', 'Ports', Session::getPluralNumber())."</td>";
       echo "<td>\n<table>";
       // serial interface

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -3978,6 +3978,7 @@ CREATE TABLE `glpi_monitors` (
   `states_id` int(11) NOT NULL DEFAULT '0',
   `ticket_tco` decimal(20,4) DEFAULT '0.0000',
   `is_dynamic` tinyint(1) NOT NULL DEFAULT '0',
+  `uuid` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
@@ -3998,6 +3999,7 @@ CREATE TABLE `glpi_monitors` (
   KEY `is_dynamic` (`is_dynamic`),
   KEY `serial` (`serial`),
   KEY `otherserial` (`otherserial`),
+  KEY `uuid` (`uuid`),
   KEY `date_creation` (`date_creation`),
   KEY `is_recursive` (`is_recursive`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
@@ -4112,6 +4114,7 @@ CREATE TABLE `glpi_networkequipments` (
   `states_id` int(11) NOT NULL DEFAULT '0',
   `ticket_tco` decimal(20,4) DEFAULT '0.0000',
   `is_dynamic` tinyint(1) NOT NULL DEFAULT '0',
+  `uuid` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
@@ -4132,6 +4135,7 @@ CREATE TABLE `glpi_networkequipments` (
   KEY `is_dynamic` (`is_dynamic`),
   KEY `serial` (`serial`),
   KEY `otherserial` (`otherserial`),
+  KEY `uuid` (`uuid`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
@@ -4742,6 +4746,7 @@ CREATE TABLE `glpi_peripherals` (
   `states_id` int(11) NOT NULL DEFAULT '0',
   `ticket_tco` decimal(20,4) DEFAULT '0.0000',
   `is_dynamic` tinyint(1) NOT NULL DEFAULT '0',
+  `uuid` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
@@ -4763,6 +4768,7 @@ CREATE TABLE `glpi_peripherals` (
   KEY `is_dynamic` (`is_dynamic`),
   KEY `serial` (`serial`),
   KEY `otherserial` (`otherserial`),
+  KEY `uuid` (`uuid`),
   KEY `date_creation` (`date_creation`),
   KEY `is_recursive` (`is_recursive`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
@@ -4988,6 +4994,7 @@ CREATE TABLE `glpi_printers` (
   `states_id` int(11) NOT NULL DEFAULT '0',
   `ticket_tco` decimal(20,4) DEFAULT '0.0000',
   `is_dynamic` tinyint(1) NOT NULL DEFAULT '0',
+  `uuid` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
@@ -5010,6 +5017,7 @@ CREATE TABLE `glpi_printers` (
   KEY `is_dynamic` (`is_dynamic`),
   KEY `serial` (`serial`),
   KEY `otherserial` (`otherserial`),
+  KEY `uuid` (`uuid`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -4851,6 +4851,7 @@ CREATE TABLE `glpi_phones` (
   `states_id` int(11) NOT NULL DEFAULT '0',
   `ticket_tco` decimal(20,4) DEFAULT '0.0000',
   `is_dynamic` tinyint(1) NOT NULL DEFAULT '0',
+  `uuid` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
@@ -4873,6 +4874,7 @@ CREATE TABLE `glpi_phones` (
   KEY `is_dynamic` (`is_dynamic`),
   KEY `serial` (`serial`),
   KEY `otherserial` (`otherserial`),
+  KEY `uuid` (`uuid`),
   KEY `date_creation` (`date_creation`),
   KEY `is_recursive` (`is_recursive`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/install/update_95_xx.php
+++ b/install/update_95_xx.php
@@ -59,6 +59,15 @@ function update95toXX() {
        require $update_dir . $update_script . '.php';
    }
 
+   $to_add_uuid = ['Monitor', 'NetworkEquipment', 'Peripheral', 'Phone', 'Printer'];
+
+   foreach ($to_add_uuid as $class) {
+      $migration->addField($class::getTable(), 'uuid', 'string', [
+         'after'  => 'is_dynamic',
+         'null'   => true
+      ]);
+   }
+
    // ************ Keep it at the end **************
    foreach ($ADDTODISPLAYPREF as $type => $tab) {
       $rank = 1;

--- a/install/update_95_xx.php
+++ b/install/update_95_xx.php
@@ -66,6 +66,7 @@ function update95toXX() {
          'after'  => 'is_dynamic',
          'null'   => true
       ]);
+      $migration->addKey($class::getTable(), 'uuid');
    }
 
    // ************ Keep it at the end **************

--- a/install/update_95_xx/uuids.php
+++ b/install/update_95_xx/uuids.php
@@ -29,52 +29,19 @@
  * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
  * ---------------------------------------------------------------------
  */
-
 /**
- * Update from 9.5.x to x.x.x
- *
- * @return bool for success (will die for most error)
-**/
-function update95toXX() {
-   global $DB, $migration;
+ * @var DB $DB
+ * @var Migration $migration
+ */
 
-   $updateresult     = true;
-   $ADDTODISPLAYPREF = [];
-   $update_dir = __DIR__ . '/update_95_xx/';
+/** Add UUIDs */
 
-   //TRANS: %s is the number of new version
-   $migration->displayTitle(sprintf(__('Update to %s'), 'x.x.x'));
-   $migration->setVersion('x.x.x');
+$to_add_uuid = ['Monitor', 'NetworkEquipment', 'Peripheral', 'Phone', 'Printer'];
 
-   $update_scripts = [
-      'comment_fields',
-      'devicebattery',
-      'domains',
-      'reservationitem',
-      'softwares',
-      'recurrentchange',
-      'uuids'
-   ];
-
-   foreach ($update_scripts as $update_script) {
-       require $update_dir . $update_script . '.php';
-   }
-
-   // ************ Keep it at the end **************
-   foreach ($ADDTODISPLAYPREF as $type => $tab) {
-      $rank = 1;
-      foreach ($tab as $newval) {
-         $DB->updateOrInsert("glpi_displaypreferences", [
-            'rank'      => $rank++
-         ], [
-            'users_id'  => "0",
-            'itemtype'  => $type,
-            'num'       => $newval,
-         ]);
-      }
-   }
-
-   $migration->executeMigration();
-
-   return $updateresult;
+foreach ($to_add_uuid as $class) {
+   $migration->addField($class::getTable(), 'uuid', 'string', [
+      'after'  => 'is_dynamic',
+      'null'   => true
+   ]);
+   $migration->addKey($class::getTable(), 'uuid');
 }

--- a/tests/functionnal/Monitor.php
+++ b/tests/functionnal/Monitor.php
@@ -74,7 +74,8 @@ class Monitor extends DbTestCase {
          'ticket_tco' => '0.0000',
          'is_dynamic' => 0,
          'date_creation' => $date,
-         'is_recursive' => 0
+         'is_recursive' => 0,
+         'uuid' => null,
       ];
    }
 
@@ -97,7 +98,7 @@ class Monitor extends DbTestCase {
       $monitor = getItemByTypeName('Monitor', '_test_monitor01');
 
       $expected = Monitor::getMonitorFields($added, $date);
-      $this->array($monitor->fields)->isIdenticalTo($expected);
+      $this->array($monitor->fields)->isEqualTo($expected);
       return $monitor;
    }
 
@@ -119,6 +120,6 @@ class Monitor extends DbTestCase {
 
       $expected = Monitor::getMonitorFields($added, $date);
 
-      $this->array($clonedMonitor->fields)->isIdenticalTo($expected);
+      $this->array($clonedMonitor->fields)->isEqualTo($expected);
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

For next major version, not 9.5.0.

Adds a UUID field to ~~phones~~ all OS-capable itemtypes. Needed for Jamf plugin mainly since I ended up using extra classes/tables to store that extra field for phones. This was critical for me to effectively match iPhones for merging in the same way I handle iPads which imported as computers.
iOS/iPadOS UUID is static, but Android also has "Settings.Secure.ANDROID_ID" which is set on first boot but changes upon a factory reset (still may be suitable as a UUID). There may be another static ID for Android or any other phone firmware/OS that other plugins/inventory agents can utilize for uniquely identifying phones just like we do with computers.