### PR TITLE
Fix JS minification issues; fixes #7393

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5969,9 +5969,9 @@
             }
         },
         "terser": {
-            "version": "4.6.13",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
-            "integrity": "sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-4.7.0.tgz",
+            "integrity": "sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw==",
             "dev": true,
             "requires": {
                 "commander": "^2.20.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "glob": "^7.1.6",
         "mini-css-extract-plugin": "^0.9.0",
         "script-loader": "^0.7.2",
+        "terser": "^4.7.0",
         "webpack": "^4.41.2",
         "webpack-cli": "^3.3.10"
     }

--- a/tools/RoboFile.php
+++ b/tools/RoboFile.php
@@ -103,10 +103,13 @@ class RoboFile extends \Robo\Tasks
 
          foreach ($it as $js_file) {
             if (!$this->endsWith($js_file->getFilename(), 'min.js')) {
-               $this->taskMinify($js_file->getRealpath())
-                  ->to(preg_replace('/\.js$/', '.min.js', $js_file->getRealpath()))
-                  ->type('js')
-                  ->run();
+               $this->_exec(
+                  sprintf(
+                     __DIR__ . '/../node_modules/.bin/terser %s --mangle --output %s',
+                     $js_file->getRealpath(),
+                     preg_replace('/\.js$/', '.min.js', $js_file->getRealpath())
+                  )
+               );
             }
          }
       }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,7 @@ var libsConfig = {
         // Entry name will be name of the file (without ext).
         var entries = {};
 
-        let files = glob.sync(path.resolve(__dirname, 'lib/bundles') + '/*.js');
+        let files = glob.sync(path.resolve(__dirname, 'lib/bundles') + '/!(*.min).js');
         files.forEach(function (file) {
             entries[path.basename(file, '.js')] = file;
         });
@@ -87,6 +87,7 @@ var libsConfig = {
                     path.resolve(__dirname, 'node_modules/jquery-migrate'),
                     path.resolve(__dirname, 'node_modules/jstree'),
                     path.resolve(__dirname, 'node_modules/photoswipe'),
+                    path.resolve(__dirname, 'node_modules/rrule'),
                     path.resolve(__dirname, 'vendor/blueimp/jquery-file-upload'),
                 ],
                 use: ['script-loader'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7393

`consolidation/robo` JS minification task is based on `patchwork/jsqueeze` library which is not maintained since 4 years. It is incompatible with some new JS syntax, like `const {ReadableWebToNodeStream} = require('readable-web-to-node-stream');` used in `file-type` dependency. So I replaced it by `terser` minification library.

I also prevent creation of bundle from minified files (a dev problem only).