### PR TITLE
Fix missing notification when adding a member to a project task

### DIFF
--- a/inc/projecttaskteam.class.php
+++ b/inc/projecttaskteam.class.php
@@ -137,4 +137,18 @@ class ProjectTaskTeam extends CommonDBRelation {
       return $team;
    }
 
+   public function post_addItem() {
+      if (!isset($this->input['_disablenotif'])) {
+         // Read again to be sure that the data is up to date
+         $this->getFromDB($this->fields['id']);
+
+         // Get linked task
+         $task = new ProjectTask();
+         $task->getFromDB($this->fields['projecttasks_id']);
+
+         // Raise update event on task
+         NotificationEvent::raiseEvent("update", $task);
+      }
+   }
+
 }


### PR DESCRIPTION
Internal ref: 20148.

Affecting a new member on a project task should trigger an update notification.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
