### PR TITLE
Do not create tinyMCE instance if no textarea is defined; fixes #6953

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3704,8 +3704,10 @@ class Html {
    **/
    static function setRichTextContent($name, $content, $rand, $readonly = false) {
 
-      // Init html editor
-      Html::initEditorSystem($name, $rand, true, $readonly);
+      // Init html editor (if name of textarea is provided)
+      if (!empty($name)) {
+         Html::initEditorSystem($name, $rand, true, $readonly);
+      }
 
       // Neutralize non valid HTML tags
       $content = html::clean($content, false, 1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6953 

In ITIL timeline, method is used to display rich text outside a textarea (`echo Html::setRichTextContent('', $content, '', true);`). As `$name` is empty, it instanciate a phantom tinyMCE instance and plugs event on it, which leads to JS errors.