### PR TITLE
Fix missing escaping in API search queries; fixes #7414

### DIFF
--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -1236,7 +1236,7 @@ abstract class API extends CommonGLPI {
          // make text search
          foreach ($params['searchText']  as $filter_field => $filter_value) {
             if (!empty($filter_value)) {
-               $search = Search::makeTextSearch($filter_value);
+               $search = Search::makeTextSearch($DB->escape($filter_value));
                $where.= " AND (`$table`.`$filter_field` $search)";
             }
          }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7414
