### PR TITLE
Search inside displayed ids on dropdowns; closes #6928

### DIFF
--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -2379,6 +2379,11 @@ class Dropdown {
                   $swhere["namet.value"] = ['LIKE', $search];
                }
 
+               if ($_SESSION['glpiis_ids_visible']
+                   && is_numeric($post['searchText']) && (int)$post['searchText'] == $post['searchText']) {
+                  $swhere[$table . '.' . $item->getIndexName()] = ['LIKE', "%{$post['searchText']}%"];
+               }
+
                // search also in displaywith columns
                if ($displaywith && count($post['displaywith'])) {
                   foreach ($post['displaywith'] as $with) {
@@ -2730,6 +2735,11 @@ class Dropdown {
          if (!empty($post['searchText'])) {
             $search = Search::makeTextSearchValue($post['searchText']);
             $orwhere = ["$table.$field" => ['LIKE', $search]];
+
+            if ($_SESSION['glpiis_ids_visible']
+                && is_numeric($post['searchText']) && (int)$post['searchText'] == $post['searchText']) {
+               $orwhere[$table . '.' . $item->getIndexName()] = ['LIKE', "%{$post['searchText']}%"];
+            }
 
             if (Session::haveTranslations($post['itemtype'], $field)) {
                $orwhere['namet.value'] = ['LIKE', $search];

--- a/tests/functionnal/Dropdown.php
+++ b/tests/functionnal/Dropdown.php
@@ -625,6 +625,89 @@ class Dropdown extends DbTestCase {
                ],
                'count' => 1
             ]
+         ], [
+            // search using id on CommonTreeDropdown but without "glpiis_ids_visible" set to true -> no results
+            'params' => [
+               'display_emptychoice'   => 0,
+               'itemtype'              => 'TaskCategory',
+               'searchText'            => getItemByTypeName('TaskCategory', '_subcat_1', true),
+            ],
+            'expected'  => [
+               'results' => [
+               ],
+               'count' => 0
+            ],
+            'session_params' => [
+               'glpiis_ids_visible' => false
+            ]
+         ], [
+            // search using id on CommonTreeDropdown with "glpiis_ids_visible" set to true -> results
+            'params' => [
+               'display_emptychoice'   => 0,
+               'itemtype'              => 'TaskCategory',
+               'searchText'            => getItemByTypeName('TaskCategory', '_subcat_1', true),
+            ],
+            'expected'  => [
+               'results' => [
+                  0 => [
+                     'text'      => 'Root entity',
+                     'children'  => [
+                        0 => [
+                           'id'             => getItemByTypeName('TaskCategory', '_cat_1', true),
+                           'text'           => '_cat_1',
+                           'level'          => 1,
+                           'disabled'       => true
+                        ],
+                        1 => [
+                           'id'             => getItemByTypeName('TaskCategory', '_subcat_1', true),
+                           'text'           => '_subcat_1 (' . getItemByTypeName('TaskCategory', '_subcat_1', true) . ')',
+                           'level'          => 2,
+                           'title'          => '_cat_1 > _subcat_1 - Comment for sub-category _subcat_1',
+                           'selection_text' => '_cat_1 > _subcat_1',
+                        ]
+                     ]
+                  ]
+               ],
+               'count' => 1
+            ],
+            'session_params' => [
+               'glpiis_ids_visible' => true
+            ]
+         ], [
+            // search using id on "not a CommonTreeDropdown" but without "glpiis_ids_visible" set to true -> no results
+            'params' => [
+               'display_emptychoice'   => 0,
+               'itemtype'              => 'DocumentType',
+               'searchText'            => getItemByTypeName('DocumentType', 'markdown', true),
+            ],
+            'expected'  => [
+               'results' => [
+               ],
+               'count' => 0
+            ],
+            'session_params' => [
+               'glpiis_ids_visible' => false
+            ]
+         ], [
+            // search using id on "not a CommonTreeDropdown" with "glpiis_ids_visible" set to true -> results
+            'params' => [
+               'display_emptychoice'   => 0,
+               'itemtype'              => 'DocumentType',
+               'searchText'            => getItemByTypeName('DocumentType', 'markdown', true),
+            ],
+            'expected'  => [
+               'results' => [
+                  0 => [
+                     'id'             => getItemByTypeName('DocumentType', 'markdown', true),
+                     'text'           => 'markdown (' . getItemByTypeName('DocumentType', 'markdown', true) . ')',
+                     'title'          => 'markdown',
+                  ]
+               ],
+               'count' => 1
+            ],
+            'session_params' => [
+               'glpiis_ids_visible' => true
+            ]
          ]
       ];
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6928 

This will enable searching on ids inside dropdowns (but only if ids are displayed).

Example:
![image](https://user-images.githubusercontent.com/33253653/85109394-8bed6300-b211-11ea-8d11-ed5a2760d18f.png)
![image](https://user-images.githubusercontent.com/33253653/85109441-a3c4e700-b211-11ea-8cae-fd275c82824a.png)
