### PR TITLE
Remove useless patchwork/jsqueeze lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,6 @@
         "glpi-project/coding-standard": "^0.7",
         "mikey179/vfsstream": "^1.6",
         "natxet/cssmin": "^3.0",
-        "patchwork/jsqueeze": "^2.0",
         "php-parallel-lint/php-parallel-lint": "^1.1",
         "scrutinizer/ocular": "1.6|^1.7.1",
         "sensiolabs/security-checker": "^6.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e337a9a2202c07105a2202199e5dd6ca",
+    "content-hash": "8a4c7eb816c29cf5b540e863c14674e8",
     "packages": [
         {
             "name": "blueimp/jquery-file-upload",
@@ -4305,54 +4305,6 @@
                 "minify"
             ],
             "time": "2018-01-09T11:15:01+00:00"
-        },
-        {
-            "name": "patchwork/jsqueeze",
-            "version": "v2.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/tchwork/jsqueeze.git",
-                "reference": "693d64850eab2ce6a7c8f7cf547e1ab46e69d542"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/tchwork/jsqueeze/zipball/693d64850eab2ce6a7c8f7cf547e1ab46e69d542",
-                "reference": "693d64850eab2ce6a7c8f7cf547e1ab46e69d542",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Patchwork\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "(Apache-2.0 or GPL-2.0)"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                }
-            ],
-            "description": "Efficient JavaScript minification in PHP",
-            "homepage": "https://github.com/tchwork/jsqueeze",
-            "keywords": [
-                "compression",
-                "javascript",
-                "minification"
-            ],
-            "abandoned": true,
-            "time": "2016-04-19T09:28:22+00:00"
         },
         {
             "name": "php-parallel-lint/php-parallel-lint",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since #7429 , `patchwork/jsqueeze` is not used anymore.