### PR TITLE
Prevent fatal error on installation process; fixes #7399

### DIFF
--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -629,7 +629,13 @@ class Session {
       $TRANSLATE = new Laminas\I18n\Translator\Translator;
       $TRANSLATE->setLocale($trytoload);
 
-      \Locale::setDefault($trytoload);
+      if (class_exists('Locale')) {
+         // Locale class may be missing if intl extension is not installed.
+         // In this case, we may still want to be able to load translations (for instance for requirements checks).
+         \Locale::setDefault($trytoload);
+      } else {
+         Toolbox::logWarning('Missing required intl PHP extension');
+      }
 
       $cache = Config::getCache('cache_trans', 'core', false);
       if ($cache !== false && !defined('TU_USER')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7399 

Languages loading fails into a fatal error if `intl` extension is missing. Problem is that languages may be load before requirements checks done on installation/update process.

This PR will prevent the fatal error to be thrown, but will still show user that requirement is missing :
![image](https://user-images.githubusercontent.com/33253653/85277434-b3e3fd00-b483-11ea-9c1f-31ebaa4fcb82.png)
