### PR TITLE
Prevent usage of calendars having no working days

### DIFF
--- a/inc/calendar.class.php
+++ b/inc/calendar.class.php
@@ -409,6 +409,11 @@ class Calendar extends CommonDropdown {
          return false;
       }
 
+      if (!$this->hasAWorkingDay()) {
+         // Invalid calendar (no working day = unable to find any date inside calendar hours)
+         return false;
+      }
+
       $actualtime = strtotime($start);
       $timestart  = strtotime($start);
       $datestart  = date('Y-m-d', $timestart);

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -1164,7 +1164,8 @@ abstract class CommonITILObject extends CommonDBTM {
          } else {
             // Using calendar
             if (($calendars_id > 0)
-                && $calendar->getFromDB($calendars_id)) {
+                && $calendar->getFromDB($calendars_id)
+                && $calendar->hasAWorkingDay()) {
                if ($this->fields['time_to_resolve'] > 0) {
                   // compute new due date using calendar
                   $this->updates[]                 = "time_to_resolve";
@@ -1204,7 +1205,8 @@ abstract class CommonITILObject extends CommonDBTM {
             // Change doesn't have internal_time_to_resolve
             // Using calendar
             if (($calendars_id > 0)
-                && $calendar->getFromDB($calendars_id)) {
+                && $calendar->getFromDB($calendars_id)
+                && $calendar->hasAWorkingDay()) {
                if ($this->fields['internal_time_to_resolve'] > 0) {
                   // compute new internal_time_to_resolve using calendar
                   $this->updates[]                          = "internal_time_to_resolve";

--- a/inc/levelagreement.class.php
+++ b/inc/levelagreement.class.php
@@ -872,7 +872,7 @@ abstract class LevelAgreement extends CommonDBChild {
             $cal          = new Calendar();
             $work_in_days = ($this->fields['definition_time'] == 'day');
 
-            if ($cal->getFromDB($this->fields['calendars_id'])) {
+            if ($cal->getFromDB($this->fields['calendars_id']) && $cal->hasAWorkingDay()) {
                return $cal->computeEndDate($start_date, $delay,
                                            $additional_delay, $work_in_days,
                                            $this->fields['end_of_working_day']);
@@ -915,7 +915,7 @@ abstract class LevelAgreement extends CommonDBChild {
                // Based on a calendar
                if ($this->fields['calendars_id'] > 0) {
                   $cal = new Calendar();
-                  if ($cal->getFromDB($this->fields['calendars_id'])) {
+                  if ($cal->getFromDB($this->fields['calendars_id']) && $cal->hasAWorkingDay()) {
                      return $cal->computeEndDate($start_date, $delay,
                                                  $level->fields['execution_time'] + $additional_delay,
                                                  $work_in_days);

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -6516,9 +6516,8 @@ class Ticket extends CommonITILObject {
 
             if ($delay > 0) {
                $calendars_id = Entity::getUsedConfig('calendars_id', $entity['id']);
-               if ($calendars_id > 0) {
-                  $calendar = new Calendar;
-                  $calendar->getFromDB($calendars_id);
+               $calendar = new Calendar();
+               if ($calendars_id && $calendar->getFromDB($calendars_id) && $calendar->hasAWorkingDay()) {
                   $end_date = $calendar->computeEndDate(
                      date('Y-m-d H:i:s'),
                      - $delay * DAY_TIMESTAMP,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Internal id: 19766

Crontask `closeticket` wass running into an infinite loop if entity uses a calendar having no working day.