### PR TITLE
Prevent exception on install command if mysqli is missing; fixes #7473

### DIFF
--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -274,7 +274,7 @@ class Application extends BaseApplication {
     */
    private function initDb() {
 
-      if (!class_exists('DB', false)) {
+      if (!class_exists('DB', false) || !class_exists('mysqli', false)) {
          return;
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7473 
