### PR TITLE
Fix multiple solutions

### DIFF
--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -280,7 +280,9 @@ class ITILSolution extends CommonDBChild {
    function prepareInputForAdd($input) {
       $input['users_id'] = Session::getLoginUserID();
 
-      if ($this->item == null) {
+      if ($this->item == null
+         || (isset($input['itemtype']) && isset($input['items_id']))
+      ) {
          $this->item = new $input['itemtype'];
          $this->item->getFromDB($input['items_id']);
       }

--- a/tests/functionnal/ITILSolution.php
+++ b/tests/functionnal/ITILSolution.php
@@ -33,6 +33,7 @@
 namespace tests\units;
 
 use \DbTestCase;
+use Ticket;
 
 /* Test for inc/itilsolution.class.php */
 
@@ -353,5 +354,38 @@ class ITILSolution extends DbTestCase {
       $this->boolean($success)->isTrue();
       $expected = 'a href=&quot;/front/document.send.php?docid=';
       $this->string($instance->fields['content'])->contains($expected);
+   }
+
+   public function testAddMultipleSolution() {
+      $em_ticket = new Ticket();
+      $em_solution = new \ITILSolution();
+
+      $tickets = [];
+
+      // Create 10 tickets
+      for ($i=0; $i<10; $i++) {
+         $id = $em_ticket->add([
+            'name'    => "test",
+            'content' => "test",
+         ]);
+         $this->integer($id);
+
+         $ticket = new Ticket();
+         $ticket->getFromDB($id);
+         $tickets[] = $ticket;
+      }
+
+      // Solve all created tickets
+      foreach ($tickets as $ticket) {
+         $id = $em_solution->add([
+            'itemtype' => $ticket::getType(),
+            'items_id' => $ticket->fields['id'],
+            'content'  => 'test'
+         ]);
+         $this->integer($id);
+
+         $ticket->getFromDB($ticket->fields['id']);
+         $this->integer($ticket->fields['status'])->isEqualTo(Ticket::SOLVED);
+      }
    }
 }


### PR DESCRIPTION
Internal ref: 19662.

Items_id and itemtype were ignored after the first addition

This would try to add both solution to ticket 1 and thus fail:
```php
$solution = new ITILSolution();
$solution->add([
   'itemtype' => 'Ticket',
   'items_id' => 1,
   'content' => "xxxxxx"
]);
$solution->add([
   'itemtype' => 'Ticket',
   'items_id' => 2,
   'content' => "xxxxxx"
]);
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
