### PR TITLE
Permit usage of port in base URL

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3460,7 +3460,7 @@ HTML;
     */
    public static function isValidWebUrl($url): bool {
       return (preg_match(
-         '#^http[s]?://[a-z0-9\-_]+(\.([a-z0-9\-]+\.)?[a-z]+)?(/.*)?$#i',
+         '#^http[s]?://[a-z0-9\-_]+(\.([a-z0-9\-]+\.)?[a-z]+)?(:\d+)?(/.*)?$#i',
          $url
       ) === 1);
    }

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -903,6 +903,12 @@ class Toolbox extends \GLPITestCase {
          ['http://my.host.com/', true],
          ['http://my.host.com/glpi/', true],
          ['http://my.host.com /', false],
+         ['http://localhost:8080', true],
+         ['http://localhost:8080/', true],
+         ['http://my.host.com:8080/glpi/', true],
+         ['http://my.host.com:8080 /', false],
+         ['http://my.host.com: 8080/', false],
+         ['http://my.host.com :8080/', false],
       ];
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

With #7476 and #7477, it is not possible anymore to define a port on base URLs. This PR fixes this.