### PR TITLE
Prevent blocking of telemetry cron on cURL failure

### DIFF
--- a/inc/telemetry.class.php
+++ b/inc/telemetry.class.php
@@ -293,7 +293,8 @@ class Telemetry extends CommonGLPI {
          if ($errstr != '') {
             $message .= ": $errstr";
          }
-         throw new \RuntimeException($message);
+         Toolbox::logError($message);
+         return null; // null = Action aborted
       }
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This will prevent the "telemetry" cron task to stay stuck on "running" when there is a problem with telemetry server.