### PR TITLE
Fix removal of source dir files in release script; see #7292 and #7307

### DIFF
--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -67,7 +67,6 @@ git --git-dir="$SOURCE_DIR/.git" checkout-index --all --force --prefix="$WORKING
 echo "Building application"
 $WORKING_DIR/glpi/tools/build_glpi.sh
 
-\find files/ -type f ! -name 'remove.txt' -exec rm -rf {} \;
 echo "Creating tarball";
 tar -c -z -f $TARBALL_PATH -C $WORKING_DIR glpi
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix #7292, was merged into refactored 9.5 script, resulting in a cleaning inside the source directory instead of the target one.

#7307 does the cleaning job right.