### PR TITLE
Add GLPI Network registration key config entry in update

### DIFF
--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -2043,6 +2043,10 @@ HTML
    }
    // /remove superflu is_helpdesk_visible
 
+   // GLPI Network registration key config
+   $migration->addConfig(['glpinetwork_registration_key' => null]);
+   // /GLPI Network registration key config
+
    // ************ Keep it at the end **************
    foreach ($ADDTODISPLAYPREF as $type => $tab) {
       $rank = 1;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This will prevent undefined index when accessing `$CFG_GLPI['glpinetwork_registration_key']` in case key has not already been set, even if there is no code doing this for the moment.