### PR TITLE
Fix displayed dashboard title

### DIFF
--- a/inc/dashboard/grid.class.php
+++ b/inc/dashboard/grid.class.php
@@ -1326,7 +1326,7 @@ HTML;
       foreach (self::$all_dashboards as $key => $dashboard) {
          if ($can_view_all
          || self::canViewSpecificicDashboard($key)) {
-            $options_dashboards[$key] = $dashboard['title'] ?? $key;;
+            $options_dashboards[$key] = $dashboard['name'] ?? $key;;
          }
       }
 


### PR DESCRIPTION
fixes #7510 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7510 

Non-existent title column was causing the dashboards to always show the key. The title is stored in 'name' instead.

Something I wasn't sure of, was if the key is supposed to be regenerated when the title is saved/changed. If not, would it be better to make it unique? It looks like dashboards are global now, but if private dashboards get added or dashboards available to specific groups, there could be key/naming conflicts. For example, user 1 names a dashboard "My Dashboard" and user 2 tries to make a dashboard named "My Dashboard" as well. Both have the key "my-dashboard".