### PR TITLE
Fix group member move selections

### DIFF
--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -827,7 +827,7 @@ class Group extends CommonTreeDropdown {
                                          'check_itemtype'   => 'Group',
                                          'check_items_id'   => $ID,
                                          'container'        => 'mass'.__CLASS__.$rand,
-                                         'extraparams'      => ['is_tech' => $tech,
+                                         'extraparams'      => ['is_tech' => $tech ? 1 : 0,
                                                                   'massive_action_fields' => ['field']],
                                          'specific_actions' => [__CLASS__.
                                                                     MassiveAction::CLASS_ACTION_SEPARATOR.


### PR DESCRIPTION
fixes #6967

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6967 

Fix massive action form dropdown for moving group item members so that an item can only be moved into groups that allow items. There was an issue were any group that could be responsible for assets would be shown event if it could not contain items.