### PR TITLE
Fix global search; closes #7514

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -3721,7 +3721,7 @@ class CommonDBTM extends CommonGLPI {
          return $options;
       }
 
-      if (defined('TU_USER') && $itemtype != null) {
+      if (defined('TU_USER') && $itemtype != null && $itemtype != 'AllAssets') {
          $item = new $itemtype;
          $all_options = $item->searchOptions();
       }

--- a/inc/dbutils.class.php
+++ b/inc/dbutils.class.php
@@ -185,9 +185,7 @@ final class DbUtils {
 
       if (isset($CFG_GLPI['glpitablesitemtype'][$itemtype])) {
          return $CFG_GLPI['glpitablesitemtype'][$itemtype];
-      } else if (class_exists($itemtype)) {
-         $CFG_GLPI['glpitablesitemtype'][$itemtype] = $itemtype::getTable();
-         return $CFG_GLPI['glpitablesitemtype'][$itemtype];
+
       } else {
          $prefix = "glpi_";
 

--- a/inc/dbutils.class.php
+++ b/inc/dbutils.class.php
@@ -185,7 +185,9 @@ final class DbUtils {
 
       if (isset($CFG_GLPI['glpitablesitemtype'][$itemtype])) {
          return $CFG_GLPI['glpitablesitemtype'][$itemtype];
-
+      } else if (class_exists($itemtype)) {
+         $CFG_GLPI['glpitablesitemtype'][$itemtype] = $itemtype::getTable();
+         return $CFG_GLPI['glpitablesitemtype'][$itemtype];
       } else {
          $prefix = "glpi_";
 

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -556,11 +556,12 @@ class Search {
       $searchopt        = &self::getOptions($data['itemtype']);
 
       $blacklist_tables = [];
+      $orig_table = ($data['itemtype'] == 'AllAssets' ? getTableForItemType($data['itemtype']) : $data['itemtype']::getTable());
       if (isset($CFG_GLPI['union_search_type'][$data['itemtype']])) {
          $itemtable          = $CFG_GLPI['union_search_type'][$data['itemtype']];
-         $blacklist_tables[] = getTableForItemType($data['itemtype']);
+         $blacklist_tables[] = $orig_table;
       } else {
-         $itemtable = $data['itemtype']::getTable();
+         $itemtable = $orig_table;
       }
 
       // hack for AllAssets
@@ -3213,7 +3214,8 @@ JAVASCRIPT;
 
       $is_fkey_composite_on_self = getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) == $table
          && $searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table);
-      if (($is_fkey_composite_on_self || $table != getTableForItemType($itemtype))
+      $orig_table = ($itemtype == 'AllAssets' ? getTableForItemType($itemtype) : $itemtype::getTable());
+      if (($is_fkey_composite_on_self || $table != $orig_table)
           && ($searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table))) {
          $addtable .= "_".$searchopt[$ID]["linkfield"];
       }
@@ -3363,7 +3365,7 @@ JAVASCRIPT;
    static function addDefaultSelect($itemtype) {
       global $DB;
 
-      $itemtable = getTableForItemType($itemtype);
+      $itemtable = ($itemtype == 'AllAssets' ? getTableForItemType($itemtype) : $itemtype::getTable());
       $item      = null;
       $mayberecursive = false;
       if ($itemtype != 'AllAssets') {
@@ -3430,7 +3432,9 @@ JAVASCRIPT;
 
       $is_fkey_composite_on_self = getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) == $table
          && $searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table);
-      if (((($is_fkey_composite_on_self || $table != getTableForItemType($itemtype))
+
+      $orig_table = ($itemtype == 'AllAssets' ? getTableForItemType($itemtype) : $itemtype::getTable());
+      if (((($is_fkey_composite_on_self || $table != $orig_table)
             && (!isset($CFG_GLPI["union_search_type"][$itemtype])
                 || ($CFG_GLPI["union_search_type"][$itemtype] != $table)))
            || !empty($complexjoin))
@@ -4092,8 +4096,9 @@ JAVASCRIPT;
       $addtable  = '';
       $is_fkey_composite_on_self = getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) == $table
          && $searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table);
+      $orig_table = ($itemtype == 'AllAssets' ? getTableForItemType($itemtype) : $itemtype::getTable());
       if (($table != 'asset_types')
-          && ($is_fkey_composite_on_self || $table != $itemtype::getTable())
+          && ($is_fkey_composite_on_self || $table != $orig_table)
           && ($searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table))) {
          $addtable = "_".$searchopt[$ID]["linkfield"];
          $table   .= $addtable;

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -549,7 +549,7 @@ class Search {
       $searchopt        = &self::getOptions($data['itemtype']);
 
       $blacklist_tables = [];
-      $orig_table = ($data['itemtype'] == 'AllAssets' ? getTableForItemType($data['itemtype']) : $data['itemtype']::getTable());
+      $orig_table = self::getOrigTableName($data);
       if (isset($CFG_GLPI['union_search_type'][$data['itemtype']])) {
          $itemtable          = $CFG_GLPI['union_search_type'][$data['itemtype']];
          $blacklist_tables[] = $orig_table;
@@ -3207,7 +3207,7 @@ JAVASCRIPT;
 
       $is_fkey_composite_on_self = getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) == $table
          && $searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table);
-      $orig_table = ($itemtype == 'AllAssets' ? getTableForItemType($itemtype) : $itemtype::getTable());
+      $orig_table = self::getOrigTableName($data);
       if (($is_fkey_composite_on_self || $table != $orig_table)
           && ($searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table))) {
          $addtable .= "_".$searchopt[$ID]["linkfield"];
@@ -3426,7 +3426,7 @@ JAVASCRIPT;
       $is_fkey_composite_on_self = getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) == $table
          && $searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table);
 
-      $orig_table = ($itemtype == 'AllAssets' ? getTableForItemType($itemtype) : $itemtype::getTable());
+      $orig_table = self::getOrigTableName($data);
       if (((($is_fkey_composite_on_self || $table != $orig_table)
             && (!isset($CFG_GLPI["union_search_type"][$itemtype])
                 || ($CFG_GLPI["union_search_type"][$itemtype] != $table)))
@@ -4089,7 +4089,7 @@ JAVASCRIPT;
       $addtable  = '';
       $is_fkey_composite_on_self = getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) == $table
          && $searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table);
-      $orig_table = ($itemtype == 'AllAssets' ? getTableForItemType($itemtype) : $itemtype::getTable());
+      $orig_table = self::getOrigTableName($data);
       if (($table != 'asset_types')
           && ($is_fkey_composite_on_self || $table != $orig_table)
           && ($searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table))) {
@@ -7836,5 +7836,16 @@ JAVASCRIPT;
                         AND `$alias`.`language` = '".
                               $_SESSION['glpilanguage']."'
                         AND `$alias`.`field` = '$field')";
+   }
+
+   /**
+    * Get table name
+    *
+    * @param array $data Search data
+    *
+    * @return string
+    */
+   public static function getOrigTableName(array $data): string {
+      return (is_a($data['itemtype'], CommonDBTM::class, true)) ? $data['itemtype']::getTable() : getTableForItemType($data['itemtype']);
    }
 }

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -549,7 +549,7 @@ class Search {
       $searchopt        = &self::getOptions($data['itemtype']);
 
       $blacklist_tables = [];
-      $orig_table = self::getOrigTableName($data);
+      $orig_table = self::getOrigTableName($data['itemtype']);
       if (isset($CFG_GLPI['union_search_type'][$data['itemtype']])) {
          $itemtable          = $CFG_GLPI['union_search_type'][$data['itemtype']];
          $blacklist_tables[] = $orig_table;
@@ -3207,7 +3207,7 @@ JAVASCRIPT;
 
       $is_fkey_composite_on_self = getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) == $table
          && $searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table);
-      $orig_table = self::getOrigTableName($data);
+      $orig_table = self::getOrigTableName($itemtype);
       if (($is_fkey_composite_on_self || $table != $orig_table)
           && ($searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table))) {
          $addtable .= "_".$searchopt[$ID]["linkfield"];
@@ -3426,7 +3426,7 @@ JAVASCRIPT;
       $is_fkey_composite_on_self = getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) == $table
          && $searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table);
 
-      $orig_table = self::getOrigTableName($data);
+      $orig_table = self::getOrigTableName($itemtype);
       if (((($is_fkey_composite_on_self || $table != $orig_table)
             && (!isset($CFG_GLPI["union_search_type"][$itemtype])
                 || ($CFG_GLPI["union_search_type"][$itemtype] != $table)))
@@ -4089,7 +4089,7 @@ JAVASCRIPT;
       $addtable  = '';
       $is_fkey_composite_on_self = getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) == $table
          && $searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table);
-      $orig_table = self::getOrigTableName($data);
+      $orig_table = self::getOrigTableName($itemtype);
       if (($table != 'asset_types')
           && ($is_fkey_composite_on_self || $table != $orig_table)
           && ($searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table))) {
@@ -7839,13 +7839,13 @@ JAVASCRIPT;
    }
 
    /**
-    * Get table name
+    * Get table name for item type
     *
-    * @param array $data Search data
+    * @param string $itemtype
     *
     * @return string
     */
-   public static function getOrigTableName(array $data): string {
-      return (is_a($data['itemtype'], CommonDBTM::class, true)) ? $data['itemtype']::getTable() : getTableForItemType($data['itemtype']);
+   public static function getOrigTableName(string $itemtype): string {
+      return (is_a($itemtype, CommonDBTM::class, true)) ? $itemtype::getTable() : getTableForItemType($itemtype);
    }
 }

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -558,7 +558,7 @@ class Search {
       $blacklist_tables = [];
       if (isset($CFG_GLPI['union_search_type'][$data['itemtype']])) {
          $itemtable          = $CFG_GLPI['union_search_type'][$data['itemtype']];
-         $blacklist_tables[] = $data['itemtype']::getTable();
+         $blacklist_tables[] = getTableForItemType($data['itemtype']);
       } else {
          $itemtable = $data['itemtype']::getTable();
       }
@@ -3213,7 +3213,7 @@ JAVASCRIPT;
 
       $is_fkey_composite_on_self = getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) == $table
          && $searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table);
-      if (($is_fkey_composite_on_self || $table != $itemtype::getTable())
+      if (($is_fkey_composite_on_self || $table != getTableForItemType($itemtype))
           && ($searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table))) {
          $addtable .= "_".$searchopt[$ID]["linkfield"];
       }
@@ -3363,7 +3363,7 @@ JAVASCRIPT;
    static function addDefaultSelect($itemtype) {
       global $DB;
 
-      $itemtable = $itemtype::getTable();
+      $itemtable = getTableForItemType($itemtype);
       $item      = null;
       $mayberecursive = false;
       if ($itemtype != 'AllAssets') {
@@ -3430,7 +3430,7 @@ JAVASCRIPT;
 
       $is_fkey_composite_on_self = getTableNameForForeignKeyField($searchopt[$ID]["linkfield"]) == $table
          && $searchopt[$ID]["linkfield"] != getForeignKeyFieldForTable($table);
-      if (((($is_fkey_composite_on_self || $table != $itemtype::getTable())
+      if (((($is_fkey_composite_on_self || $table != getTableForItemType($itemtype))
             && (!isset($CFG_GLPI["union_search_type"][$itemtype])
                 || ($CFG_GLPI["union_search_type"][$itemtype] != $table)))
            || !empty($complexjoin))

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3358,7 +3358,7 @@ JAVASCRIPT;
    static function addDefaultSelect($itemtype) {
       global $DB;
 
-      $itemtable = ($itemtype == 'AllAssets' ? getTableForItemType($itemtype) : $itemtype::getTable());
+      $itemtable = self::getOrigTableName($itemtype);
       $item      = null;
       $mayberecursive = false;
       if ($itemtype != 'AllAssets') {

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -92,11 +92,7 @@ class Search {
     * @return void
    **/
    static function showList($itemtype, $params) {
-
-      $data = self::prepareDatasForSearch($itemtype, $params);
-      self::constructSQL($data);
-      self::constructData($data);
-      self::displayData($data);
+      self::displayData(self::getDatas($itemtype, $params));
    }
 
    /**
@@ -133,10 +129,7 @@ class Search {
          'searchtype'   => 'contains',
          'value'        => 'NULL'
       ];
-      $data = self::prepareDatasForSearch($itemtype, $params);
-      self::constructSQL($data);
-      self::constructData($data);
-      self::displayData($data);
+      self::displayData(self::getDatas($itemtype, $params));
 
       if ($data['data']['totalcount'] > 0) {
          $target = $data['search']['target'];
@@ -1481,7 +1474,7 @@ class Search {
     *
     * @return void
    **/
-   static function displayData(array &$data) {
+   static function displayData(array $data) {
       global $CFG_GLPI;
 
       $item = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7514 

since 2ee3984be7b7374f7201a7a13a2273b953e7a408, calling `getTableForItem` will work in every case; `::getTable` requires an existing class.
Current fix is a partial revert of that commit.

Note: we would need unit tests on 'AllAsset' :-/
