### PR TITLE
Do no display closed changes when linking to other itil objects

### DIFF
--- a/inc/change_problem.class.php
+++ b/inc/change_problem.class.php
@@ -163,9 +163,12 @@ class Change_Problem extends CommonDBRelation{
 
          echo "<tr class='tab_bg_2'><td>";
          echo "<input type='hidden' name='problems_id' value='$ID'>";
-         Change::dropdown(['used'        => $used,
-                                'entity'      => $problem->getEntityID(),
-                                'entity_sons' => $problem->isRecursive()]);
+         Change::dropdown([
+            'used'        => $used,
+            'entity'      => $problem->getEntityID(),
+            'entity_sons' => $problem->isRecursive(),
+            'condition'   => Change::getOpenCriteria(),
+         ]);
          echo "</td><td class='center'>";
          echo "<input type='submit' name='add' value=\""._sx('button', 'Add')."\" class='submit'>";
          echo "</td><td>";
@@ -276,8 +279,11 @@ class Change_Problem extends CommonDBRelation{
 
          echo "<tr class='tab_bg_2'><td>";
          echo "<input type='hidden' name='changes_id' value='$ID'>";
-         Problem::dropdown(['used'   => $used,
-                                 'entity' => $change->getEntityID()]);
+         Problem::dropdown([
+            'used'   => $used,
+            'entity' => $change->getEntityID(),
+            'condition' => Problem::getOpenCriteria()
+         ]);
          echo "</td><td class='center'>";
          echo "<input type='submit' name='add' value=\""._sx('button', 'Add')."\" class='submit'>";
          echo "</td></tr></table>";

--- a/inc/change_ticket.class.php
+++ b/inc/change_ticket.class.php
@@ -281,10 +281,13 @@ class Change_Ticket extends CommonDBRelation{
 
          echo "<tr class='tab_bg_2'><td>";
          echo "<input type='hidden' name='changes_id' value='$ID'>";
-         Ticket::dropdown(['used'        => $used,
-                                'entity'      => $change->getEntityID(),
-                                'entity_sons' => $change->isRecursive(),
-                                'displaywith' => ['id']]);
+         Ticket::dropdown([
+            'used'        => $used,
+            'entity'      => $change->getEntityID(),
+            'entity_sons' => $change->isRecursive(),
+            'displaywith' => ['id'],
+            'condition'   => Ticket::getOpenCriteria()
+         ]);
          echo "</td><td class='center'>";
          echo "<input type='submit' name='add' value=\""._sx('button', 'Add')."\" class='submit'>";
          echo "</td></tr>";
@@ -402,8 +405,11 @@ class Change_Ticket extends CommonDBRelation{
          echo "<tr class='tab_bg_2'><th colspan='3'>".__('Add a change')."</th></tr>";
          echo "<tr class='tab_bg_2'><td>";
          echo "<input type='hidden' name='tickets_id' value='$ID'>";
-         Change::dropdown(['used'        => $used,
-                                'entity'      => $ticket->getEntityID()]);
+         Change::dropdown([
+            'used'      => $used,
+            'entity'    => $ticket->getEntityID(),
+            'condition' => Change::getOpenCriteria(),
+         ]);
          echo "</td><td class='center'>";
          echo "<input type='submit' name='add' value=\""._sx('button', 'Add')."\" class='submit'>";
          echo "</td><td>";

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -8220,4 +8220,23 @@ abstract class CommonITILObject extends CommonDBTM {
       }
       return false;
    }
+
+   /**
+    * Get criteria needed to match objets with an "open" status (= not resolved
+    * or closed)
+    *
+    * @return array
+    */
+   public static function getOpenCriteria(): array {
+      $table = static::getTable();
+
+      return [
+         'NOT' => [
+            "$table.status" => array_merge(
+               static::getSolvedStatusArray(),
+               static::getClosedStatusArray()
+            )
+         ]
+      ];
+   }
 }

--- a/inc/problem_ticket.class.php
+++ b/inc/problem_ticket.class.php
@@ -289,20 +289,12 @@ class Problem_Ticket extends CommonDBRelation{
 
          echo "<tr class='tab_bg_2'><td class='right'>";
          echo "<input type='hidden' name='problems_id' value='$ID'>";
-         $condition = [
-            'NOT' => [
-               'glpi_tickets.status' => array_merge(
-                  Ticket::getSolvedStatusArray(),
-                  Ticket::getClosedStatusArray()
-               )
-            ]
-         ];
          Ticket::dropdown([
             'used'        => $used,
             'entity'      => $problem->getEntityID(),
             'entity_sons' => $problem->isRecursive(),
-            'condition'   => $condition,
-            'displaywith' => ['id']
+            'displaywith' => ['id'],
+            'condition'   => Ticket::getOpenCriteria()
          ]);
          echo "</td><td class='center'>";
          echo "<input type='submit' name='add' value=\""._sx('button', 'Add')."\" class='submit'>";
@@ -397,19 +389,11 @@ class Problem_Ticket extends CommonDBRelation{
          echo "<tr class='tab_bg_2'><th colspan='3'>".__('Add a problem')."</th></tr>";
          echo "<tr class='tab_bg_2'><td>";
          echo "<input type='hidden' name='tickets_id' value='$ID'>";
-         $condition = [
-            'NOT' => [
-               'glpi_problems.status' => array_merge(
-                  Problem::getSolvedStatusArray(),
-                  Problem::getClosedStatusArray()
-               )
-            ]
-         ];
 
          Problem::dropdown([
             'used'      => $used,
             'entity'    => $ticket->getEntityID(),
-            'condition' => $condition
+            'condition' => Problem::getOpenCriteria()
          ]);
          echo "</td><td class='center'>";
          echo "<input type='submit' name='add' value=\""._sx('button', 'Add')."\" class='submit'>";


### PR DESCRIPTION
Internal ref: 20255.

Standardize Ticket <-> Change <-> Problem relations.
A resolved or closed status on a object imply a read-only state.
This was already the case for some of these relations, now it's the same for all of them.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
