### PR TITLE
Fix wrong Event breadcrumbs

### DIFF
--- a/front/event.php
+++ b/front/event.php
@@ -36,7 +36,7 @@ include ('../inc/includes.php');
 
 Session::checkRight("logs", READ);
 
-Html::header(Event::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "log");
+Html::header(Event::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "Glpi\\Event");
 
 // Show last events
 if (isset($_GET["order"])) {


### PR DESCRIPTION
The item should be Glpi\\Event (Logs) and not Log (Historical)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
