### PR TITLE
Fix SQL errors on search solution into KB from ticket

### DIFF
--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -1268,7 +1268,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
                if (!empty($addscore)) {
                   foreach ($addscore as $addscore_field) {
                      $expr .= " + MATCH(" . $DB->quoteName($addscore_field) . ")
-                                        AGAINST('" . $DB->quoteName($search_wilcard) . " IN BOOLEAN MODE)";
+                                        AGAINST(" . $DB->quote($search_wilcard) . " IN BOOLEAN MODE)";
                   }
                }
                $expr .=" ) AS SCORE ";
@@ -1288,7 +1288,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
                         'NOT' => [$addscore_field => null],
                         new QueryExpression(
                            "MATCH(" . $DB->quoteName($addscore_field) . ")
-                              AGAINST('" . $DB->quote($search_wilcard) . "' IN BOOLEAN MODE)"
+                              AGAINST(" . $DB->quote($search_wilcard) . " IN BOOLEAN MODE)"
                         )
                      ];
                   }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

Fix SQL errors on search solution into KB from ticket

```
[2020-07-03 10:45:06] glpisqllog.ERROR: DBmysql::query() in C:\wamp64\www\glpi\inc\dbmysql.class.php line 305
  *** MySQL query error:
  SQL: SELECT COUNT(*) AS cpt FROM `glpi_knowbaseitems` LEFT JOIN `glpi_knowbaseitems_users` ON (`glpi_knowbaseitems_users`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_groups_knowbaseitems` ON (`glpi_groups_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_knowbaseitems_profiles` ON (`glpi_knowbaseitems_profiles`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_entities_knowbaseitems` ON (`glpi_entities_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_knowbaseitemtranslations` ON (`glpi_knowbaseitems`.`id` = `glpi_knowbaseitemtranslations`.`knowbaseitems_id` AND `glpi_knowbaseitemtranslations`.`language` = 'fr_FR') WHERE (MATCH(`glpi_knowbaseitems`.`name`,
                        `glpi_knowbaseitems`.`answer`)
                        AGAINST('Accès* VPN*' IN BOOLEAN MODE) OR ( NOT (`glpi_knowbaseitemtranslations`.`name` IS NULL) AND MATCH(`glpi_knowbaseitemtranslations`.`name`)
                              AGAINST(''Accès* VPN*'' IN BOOLEAN MODE)) OR ( NOT (`glpi_knowbaseitemtranslations`.`answer` IS NULL) AND MATCH(`glpi_knowbaseitemtranslations`.`answer`)
                              AGAINST(''Accès* VPN*'' IN BOOLEAN MODE))) AND ((((`glpi_knowbaseitems`.`begin_date` IS NULL) OR (`glpi_knowbaseitems`.`begin_date` < NOW()))) AND (((`glpi_knowbaseitems`.`end_date` IS NULL) OR (`glpi_knowbaseitems`.`end_date` > NOW()))))
  Error: Erreur de syntaxe près de 'Accès* VPN*'' IN BOOLEAN MODE)) OR ( NOT (`glpi_knowbaseitemtrans' à la ligne 4
  Backtrace :
  inc\dbmysqliterator.class.php:95                   
  inc\dbmysql.class.php:856                          DBmysqlIterator->execute()
  inc\knowbaseitem.class.php:1325                    DBmysql->request()
  inc\knowbaseitem.class.php:1436                    KnowbaseItem::getListRequest()
  inc\knowbase.class.php:133                         KnowbaseItem::showList()
  inc\knowbase.class.php:82                          Knowbase::showSearchView()
  inc\commonglpi.class.php:637                       Knowbase::displayTabContentForItem()
  ajax\common.tabs.php:92                            CommonGLPI::displayStandardTab()
  {"user":"2@P555"} 
[2020-07-03 10:45:06] glpisqllog.ERROR: DBmysql::query() in C:\wamp64\www\glpi\inc\dbmysql.class.php line 305
  *** MySQL query error:
  SQL: SELECT `glpi_knowbaseitems`.*, `glpi_knowbaseitemcategories`.`completename` AS `category`, COUNT(`glpi_knowbaseitems_users`.`id`) + COUNT(`glpi_groups_knowbaseitems`.`id`) + COUNT(`glpi_knowbaseitems_profiles`.`id`) + COUNT(`glpi_entities_knowbaseitems`.`id`) AS `visibility_count`, `glpi_knowbaseitemtranslations`.`name` AS `transname`, `glpi_knowbaseitemtranslations`.`answer` AS `transanswer`, (MATCH(`glpi_knowbaseitems`.`name`, `glpi_knowbaseitems`.`answer`)
                           AGAINST('Accès* VPN*' IN BOOLEAN MODE) + MATCH(`glpi_knowbaseitemtranslations`.`name`)
                                        AGAINST('`Accès* VPN*` IN BOOLEAN MODE) + MATCH(`glpi_knowbaseitemtranslations`.`answer`)
                                        AGAINST('`Accès* VPN*` IN BOOLEAN MODE) ) AS SCORE  FROM `glpi_knowbaseitems` LEFT JOIN `glpi_knowbaseitems_users` ON (`glpi_knowbaseitems_users`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_groups_knowbaseitems` ON (`glpi_groups_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_knowbaseitems_profiles` ON (`glpi_knowbaseitems_profiles`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_entities_knowbaseitems` ON (`glpi_entities_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_knowbaseitemtranslations` ON (`glpi_knowbaseitems`.`id` = `glpi_knowbaseitemtranslations`.`knowbaseitems_id` AND `glpi_knowbaseitemtranslations`.`language` = 'fr_FR') LEFT JOIN `glpi_knowbaseitemcategories` ON (`glpi_knowbaseitemcategories`.`id` = `glpi_knowbaseitems`.`knowbaseitemcategories_id`) WHERE (((`glpi_knowbaseitems`.`name` LIKE '%Accès VPN Client GLPI%') OR (`glpi_knowbaseitems`.`answer` LIKE '%Accès VPN Client GLPI%') OR (`glpi_knowbaseitemtranslations`.`name` LIKE '%Accès VPN Client GLPI%') OR (`glpi_knowbaseitemtranslations`.`answer` LIKE '%Accès VPN Client GLPI%'))) AND ((((`glpi_knowbaseitems`.`begin_date` IS NULL) OR (`glpi_knowbaseitems`.`begin_date` < NOW()))) AND (((`glpi_knowbaseitems`.`end_date` IS NULL) OR (`glpi_knowbaseitems`.`end_date` > NOW())))) GROUP BY `glpi_knowbaseitems`.`id`, `glpi_knowbaseitemcategories`.`completename` ORDER BY `SCORE` DESC
  Error: Erreur de syntaxe près de '`Accès* VPN*` IN BOOLEAN MODE) ) AS SCORE  FROM `glpi_knowbaseite' à la ligne 3
  Backtrace :
  inc\dbmysqliterator.class.php:95                   
  inc\dbmysql.class.php:856                          DBmysqlIterator->execute()
  inc\knowbaseitem.class.php:1438                    DBmysql->request()
  inc\knowbase.class.php:133                         KnowbaseItem::showList()
  inc\knowbase.class.php:82                          Knowbase::showSearchView()
  inc\commonglpi.class.php:637                       Knowbase::displayTabContentForItem()
  ajax\common.tabs.php:92                            CommonGLPI::displayStandardTab()
  {"user":"2@P555","mem_usage":"0.018\", 5.03Mio)"}
```
