### PR TITLE
Avoid Plugin Error on use getAllTypesForHelpdesk function

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -5017,8 +5017,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       // Drop not available plugins
       foreach (array_keys($ptypes) as $itemtype) {
-         if (isset($_SESSION["glpiactiveprofile"]["helpdesk_item_type"])
-             && !in_array($itemtype, $_SESSION["glpiactiveprofile"]["helpdesk_item_type"])) {
+         if (!isset($_SESSION["glpiactiveprofile"]["helpdesk_item_type"])
+             || !in_array($itemtype, $_SESSION["glpiactiveprofile"]["helpdesk_item_type"])) {
             unset($ptypes[$itemtype]);
          }
       }

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -5007,7 +5007,8 @@ abstract class CommonITILObject extends CommonDBTM {
       foreach ($CFG_GLPI["ticket_types"] as $itemtype) {
          if ($item = getItemForItemtype($itemtype)) {
             if (!isPluginItemType($itemtype) // No plugin here
-                && in_array($itemtype, $_SESSION["glpiactiveprofile"]["helpdesk_item_type"])) {
+                && isset($_SESSION["glpiactiveprofile"]["helpdesk_item_type"])
+                  && in_array($itemtype, $_SESSION["glpiactiveprofile"]["helpdesk_item_type"])) {
                $types[$itemtype] = $item->getTypeName(1);
             }
          }
@@ -5016,7 +5017,8 @@ abstract class CommonITILObject extends CommonDBTM {
 
       // Drop not available plugins
       foreach (array_keys($ptypes) as $itemtype) {
-         if (!in_array($itemtype, $_SESSION["glpiactiveprofile"]["helpdesk_item_type"])) {
+         if (isset($_SESSION["glpiactiveprofile"]["helpdesk_item_type"])
+             && !in_array($itemtype, $_SESSION["glpiactiveprofile"]["helpdesk_item_type"])) {
             unset($ptypes[$itemtype]);
          }
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7413 

When use getAllTypesForHelpdesk function on a plugin hook.php file, there are php warning for existence of $_SESSION["glpiactiveprofile"].


