### PR TITLE
Fix form refresh after problem actor email update

### DIFF
--- a/front/problem_user.form.php
+++ b/front/problem_user.form.php
@@ -48,7 +48,14 @@ Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
 
 if (isset($_POST["update"])) {
    $link->check($_POST["id"], UPDATE);
-   $link->update($_POST);
+
+   if ($link->update($_POST)) {
+      echo "<script type='text/javascript' >\n";
+      echo "window.parent.location.reload();";
+      echo "</script>";
+   } else {
+      Html::back();
+   }
 
 } else if (isset($_POST['delete'])) {
    $link->check($_POST['id'], DELETE);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When updating a problem actor followup email, popup stay blank when clicking on submit button.