### PR TITLE
ITIL actor alternative email should not be forced; fixes #7596

### DIFF
--- a/inc/commonitilactor.class.php
+++ b/inc/commonitilactor.class.php
@@ -342,6 +342,20 @@ abstract class CommonITILActor extends CommonDBRelation {
    }
 
    function prepareInputForUpdate($input) {
+      if (isset($input['alternative_email']) && $input['alternative_email'] == '') {
+         if (isset($input['users_id'])) {
+            $actor = new User();
+            if ($actor->getFromDB($input["users_id"])) {
+               $input['alternative_email'] = $actor->getDefaultEmail();
+            }
+         }
+         if (isset($input['suppliers_id'])) {
+            $actor = new Supplier;
+            if ($actor->getFromDB($input["suppliers_id"])) {
+               $input['alternative_email'] = $actor->fields['email'];
+            }
+         }
+      }
       if (isset($input['alternative_email']) && $input['alternative_email'] != ''
           && !NotificationMailing::isUserAddressValid($input['alternative_email'])) {
          Session::addMessageAfterRedirect(

--- a/inc/commonitilactor.class.php
+++ b/inc/commonitilactor.class.php
@@ -194,7 +194,6 @@ abstract class CommonITILActor extends CommonDBRelation {
       if ((count($emails) ==  1)
           && !empty($default_email)
           && NotificationMailing::isUserAddressValid($default_email)) {
-         echo "<input type='hidden' name='alternative_email' value='".$default_email."'>";
          echo $default_email;
 
       } else if (count($emails) > 1) {

--- a/inc/commonitilactor.class.php
+++ b/inc/commonitilactor.class.php
@@ -342,20 +342,6 @@ abstract class CommonITILActor extends CommonDBRelation {
    }
 
    function prepareInputForUpdate($input) {
-      if ($input['alternative_email'] == '') {
-         if (isset($input['users_id'])) {
-            $actor = new User();
-            if ($actor->getFromDB($input["users_id"])) {
-               $input['alternative_email'] = $actor->getDefaultEmail();
-            }
-         }
-         if (isset($input['suppliers_id'])) {
-            $actor = new Supplier;
-            if ($actor->getFromDB($input["suppliers_id"])) {
-               $input['alternative_email'] = $actor->fields['email'];
-            }
-         }
-      }
       if (isset($input['alternative_email']) && !NotificationMailing::isUserAddressValid($input['alternative_email'])) {
          Session::addMessageAfterRedirect(
             __('Invalid email address'),

--- a/inc/commonitilactor.class.php
+++ b/inc/commonitilactor.class.php
@@ -342,7 +342,8 @@ abstract class CommonITILActor extends CommonDBRelation {
    }
 
    function prepareInputForUpdate($input) {
-      if (isset($input['alternative_email']) && !NotificationMailing::isUserAddressValid($input['alternative_email'])) {
+      if (isset($input['alternative_email']) && $input['alternative_email'] != ''
+          && !NotificationMailing::isUserAddressValid($input['alternative_email'])) {
          Session::addMessageAfterRedirect(
             __('Invalid email address'),
             false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7596

#7600 was not a correct fix, as forcing `alternative_email` will result in not taking care of user default email update.
Keeping this value blank will result in having the email computed when notification is sent, which seems more logical to me.

With this PR, `prepareInputForUpdate` will act as `prepareInputForAdd`.