### PR TITLE
Add missing 'is_recursive' search option to assets

### DIFF
--- a/inc/cartridgeitem.class.php
+++ b/inc/cartridgeitem.class.php
@@ -252,22 +252,7 @@ class CartridgeItem extends CommonDBTM {
 
 
    function rawSearchOptions() {
-      $tab = [];
-
-      $tab[] = [
-         'id'                 => 'common',
-         'name'               => __('Characteristics')
-      ];
-
-      $tab[] = [
-         'id'                 => '1',
-         'table'              => $this->getTable(),
-         'field'              => 'name',
-         'name'               => __('Name'),
-         'datatype'           => 'itemlink',
-         'massiveaction'      => false,
-         'autocomplete'       => true,
-      ];
+      $tab = parent::rawSearchOptions();
 
       $tab[] = [
          'id'                 => '2',
@@ -428,15 +413,6 @@ class CartridgeItem extends CommonDBTM {
                ]
             ]
          ]
-      ];
-
-      $tab[] = [
-         'id'                 => '86',
-         'table'              => $this->getTable(),
-         'field'              => 'is_recursive',
-         'name'               => __('Child entities'),
-         'datatype'           => 'bool',
-         'searchtype'         => 'equals'
       ];
 
       // add objectlock search options

--- a/inc/cartridgeitem.class.php
+++ b/inc/cartridgeitem.class.php
@@ -430,6 +430,15 @@ class CartridgeItem extends CommonDBTM {
          ]
       ];
 
+      $tab[] = [
+         'id'                 => '86',
+         'table'              => $this->getTable(),
+         'field'              => 'is_recursive',
+         'name'               => __('Child entities'),
+         'datatype'           => 'bool',
+         'searchtype'         => 'equals'
+      ];
+
       // add objectlock search options
       $tab = array_merge($tab, ObjectLock::rawSearchOptionsToAdd(get_class($this)));
 

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -3691,11 +3691,14 @@ class CommonDBTM extends CommonGLPI {
       }
 
       if ($this->isField('is_recursive')) {
-         $tab[] = ['id'       => 86,
-                   'table'    => $this->getTable(),
-                   'field'    => 'is_recursive',
-                   'name'     => __('Child entities'),
-                   'datatype' =>'bool'];
+         $tab[] = [
+            'id'       => 86,
+            'table'      => $this->getTable(),
+            'field'      => 'is_recursive',
+            'name'       => __('Child entities'),
+            'datatype'   => 'bool',
+            'searchtype' => 'equals',
+         ];
       }
 
       // add objectlock search options

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -530,22 +530,7 @@ class Computer extends CommonDBTM {
 
    function rawSearchOptions() {
 
-      $tab = [];
-
-      $tab[] = [
-         'id'                 => 'common',
-         'name'               => __('Characteristics')
-      ];
-
-      $tab[] = [
-         'id'                 => '1',
-         'table'              => $this->getTable(),
-         'field'              => 'name',
-         'name'               => __('Name'),
-         'datatype'           => 'itemlink',
-         'massiveaction'      => false, // implicit key==1
-         'autocomplete'       => true,
-      ];
+      $tab = parent::rawSearchOptions();
 
       $tab[] = [
          'id'                 => '2',
@@ -734,15 +719,6 @@ class Computer extends CommonDBTM {
          'field'              => 'completename',
          'name'               => __('Entity'),
          'datatype'           => 'dropdown'
-      ];
-
-      $tab[] = [
-         'id'                 => '86',
-         'table'              => $this->getTable(),
-         'field'              => 'is_recursive',
-         'name'               => __('Child entities'),
-         'datatype'           => 'bool',
-         'searchtype'         => 'equals'
       ];
 
       // add operating system search options

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -736,6 +736,15 @@ class Computer extends CommonDBTM {
          'datatype'           => 'dropdown'
       ];
 
+      $tab[] = [
+         'id'                 => '86',
+         'table'              => $this->getTable(),
+         'field'              => 'is_recursive',
+         'name'               => __('Child entities'),
+         'datatype'           => 'bool',
+         'searchtype'         => 'equals'
+      ];
+
       // add operating system search options
       $tab = array_merge($tab, Item_OperatingSystem::rawSearchOptionsToAdd(get_class($this)));
 

--- a/inc/consumableitem.class.php
+++ b/inc/consumableitem.class.php
@@ -214,22 +214,7 @@ class ConsumableItem extends CommonDBTM {
 
 
    function rawSearchOptions() {
-      $tab = [];
-
-      $tab[] = [
-         'id'                 => 'common',
-         'name'               => __('Characteristics')
-      ];
-
-      $tab[] = [
-         'id'                 => '1',
-         'table'              => $this->getTable(),
-         'field'              => 'name',
-         'name'               => __('Name'),
-         'datatype'           => 'itemlink',
-         'massiveaction'      => false,
-         'autocomplete'       => true,
-      ];
+      $tab = parent::rawSearchOptions();
 
       $tab[] = [
          'id'                 => '2',
@@ -365,15 +350,6 @@ class ConsumableItem extends CommonDBTM {
          'name'               => __('Entity'),
          'massiveaction'      => false,
          'datatype'           => 'dropdown'
-      ];
-
-      $tab[] = [
-         'id'                 => '86',
-         'table'              => $this->getTable(),
-         'field'              => 'is_recursive',
-         'name'               => __('Child entities'),
-         'datatype'           => 'bool',
-         'searchtype'         => 'equals'
       ];
 
       // add objectlock search options

--- a/inc/consumableitem.class.php
+++ b/inc/consumableitem.class.php
@@ -367,6 +367,15 @@ class ConsumableItem extends CommonDBTM {
          'datatype'           => 'dropdown'
       ];
 
+      $tab[] = [
+         'id'                 => '86',
+         'table'              => $this->getTable(),
+         'field'              => 'is_recursive',
+         'name'               => __('Child entities'),
+         'datatype'           => 'bool',
+         'searchtype'         => 'equals'
+      ];
+
       // add objectlock search options
       $tab = array_merge($tab, ObjectLock::rawSearchOptionsToAdd(get_class($this)));
 

--- a/inc/enclosure.class.php
+++ b/inc/enclosure.class.php
@@ -337,6 +337,15 @@ class Enclosure extends CommonDBTM {
          'datatype'           => 'dropdown'
       ];
 
+      $tab[] = [
+         'id'                 => '86',
+         'table'              => $this->getTable(),
+         'field'              => 'is_recursive',
+         'name'               => __('Child entities'),
+         'datatype'           => 'bool',
+         'searchtype'         => 'equals'
+      ];
+
       $tab = array_merge($tab, Notepad::rawSearchOptionsToAdd());
 
       $tab = array_merge($tab, Datacenter::rawSearchOptionsToAdd(get_class($this)));

--- a/inc/enclosure.class.php
+++ b/inc/enclosure.class.php
@@ -200,22 +200,7 @@ class Enclosure extends CommonDBTM {
    }
 
    function rawSearchOptions() {
-      $tab = [];
-
-      $tab[] = [
-         'id'                 => 'common',
-         'name'               => __('Characteristics')
-      ];
-
-      $tab[] = [
-         'id'                 => '1',
-         'table'              => $this->getTable(),
-         'field'              => 'name',
-         'name'               => __('Name'),
-         'datatype'           => 'itemlink',
-         'massiveaction'      => false, // implicit key==1
-         'autocomplete'       => true,
-      ];
+      $tab = parent::rawSearchOptions();
 
       $tab[] = [
          'id'                 => '2',
@@ -335,15 +320,6 @@ class Enclosure extends CommonDBTM {
          'field'              => 'completename',
          'name'               => __('Entity'),
          'datatype'           => 'dropdown'
-      ];
-
-      $tab[] = [
-         'id'                 => '86',
-         'table'              => $this->getTable(),
-         'field'              => 'is_recursive',
-         'name'               => __('Child entities'),
-         'datatype'           => 'bool',
-         'searchtype'         => 'equals'
       ];
 
       $tab = array_merge($tab, Notepad::rawSearchOptionsToAdd());

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -368,22 +368,7 @@ class Monitor extends CommonDBTM {
 
 
    function rawSearchOptions() {
-      $tab = [];
-
-      $tab[] = [
-         'id'                 => 'common',
-         'name'               => __('Characteristics')
-      ];
-
-      $tab[] = [
-         'id'                 => '1',
-         'table'              => $this->getTable(),
-         'field'              => 'name',
-         'name'               => __('Name'),
-         'datatype'           => 'itemlink',
-         'massiveaction'      => false,
-         'autocomplete'       => true,
-      ];
+      $tab = parent::rawSearchOptions();
 
       $tab[] = [
          'id'                 => '2',
@@ -630,15 +615,6 @@ class Monitor extends CommonDBTM {
          'name'               => __('Global management'),
          'datatype'           => 'bool',
          'massiveaction'      => false
-      ];
-
-      $tab[] = [
-         'id'                 => '86',
-         'table'              => $this->getTable(),
-         'field'              => 'is_recursive',
-         'name'               => __('Child entities'),
-         'datatype'           => 'bool',
-         'searchtype'         => 'equals'
       ];
 
       // add objectlock search options

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -632,6 +632,15 @@ class Monitor extends CommonDBTM {
          'massiveaction'      => false
       ];
 
+      $tab[] = [
+         'id'                 => '86',
+         'table'              => $this->getTable(),
+         'field'              => 'is_recursive',
+         'name'               => __('Child entities'),
+         'datatype'           => 'bool',
+         'searchtype'         => 'equals'
+      ];
+
       // add objectlock search options
       $tab = array_merge($tab, ObjectLock::rawSearchOptionsToAdd(get_class($this)));
 

--- a/inc/networkequipment.class.php
+++ b/inc/networkequipment.class.php
@@ -426,22 +426,7 @@ class NetworkEquipment extends CommonDBTM {
 
 
    function rawSearchOptions() {
-      $tab = [];
-
-      $tab[] = [
-         'id'                 => 'common',
-         'name'               => __('Characteristics')
-      ];
-
-      $tab[] = [
-         'id'                 => '1',
-         'table'              => $this->getTable(),
-         'field'              => 'name',
-         'name'               => __('Name'),
-         'datatype'           => 'itemlink',
-         'massiveaction'      => false,
-         'autocomplete'       => true,
-      ];
+      $tab = parent::rawSearchOptions();
 
       $tab[] = [
          'id'                 => '2',
@@ -643,15 +628,6 @@ class NetworkEquipment extends CommonDBTM {
          'name'               => __('Entity'),
          'massiveaction'      => false,
          'datatype'           => 'dropdown'
-      ];
-
-      $tab[] = [
-         'id'                 => '86',
-         'table'              => $this->getTable(),
-         'field'              => 'is_recursive',
-         'name'               => __('Child entities'),
-         'datatype'           => 'bool',
-         'searchtype'         => 'equals'
       ];
 
       // add operating system search options

--- a/inc/networkequipment.class.php
+++ b/inc/networkequipment.class.php
@@ -650,7 +650,8 @@ class NetworkEquipment extends CommonDBTM {
          'table'              => $this->getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
-         'datatype'           => 'bool'
+         'datatype'           => 'bool',
+         'searchtype'         => 'equals'
       ];
 
       // add operating system search options

--- a/inc/pdu.class.php
+++ b/inc/pdu.class.php
@@ -334,6 +334,15 @@ class PDU extends CommonDBTM {
          'datatype'           => 'dropdown'
       ];
 
+      $tab[] = [
+         'id'                 => '86',
+         'table'              => $this->getTable(),
+         'field'              => 'is_recursive',
+         'name'               => __('Child entities'),
+         'datatype'           => 'bool',
+         'searchtype'         => 'equals'
+      ];
+
       $tab = array_merge($tab, Datacenter::rawSearchOptionsToAdd(get_class($this)));
 
       return $tab;

--- a/inc/pdu.class.php
+++ b/inc/pdu.class.php
@@ -197,22 +197,7 @@ class PDU extends CommonDBTM {
    }
 
    function rawSearchOptions() {
-      $tab = [];
-
-      $tab[] = [
-         'id'                 => 'common',
-         'name'               => __('Characteristics')
-      ];
-
-      $tab[] = [
-         'id'                 => '1',
-         'table'              => $this->getTable(),
-         'field'              => 'name',
-         'name'               => __('Name'),
-         'datatype'           => 'itemlink',
-         'massiveaction'      => false, // implicit key==1
-         'autocomplete'       => true,
-      ];
+      $tab = parent::rawSearchOptions();
 
       $tab[] = [
          'id'                 => '2',
@@ -332,15 +317,6 @@ class PDU extends CommonDBTM {
          'field'              => 'completename',
          'name'               => __('Entity'),
          'datatype'           => 'dropdown'
-      ];
-
-      $tab[] = [
-         'id'                 => '86',
-         'table'              => $this->getTable(),
-         'field'              => 'is_recursive',
-         'name'               => __('Child entities'),
-         'datatype'           => 'bool',
-         'searchtype'         => 'equals'
       ];
 
       $tab = array_merge($tab, Datacenter::rawSearchOptionsToAdd(get_class($this)));

--- a/inc/peripheral.class.php
+++ b/inc/peripheral.class.php
@@ -338,22 +338,7 @@ class Peripheral extends CommonDBTM {
 
 
    function rawSearchOptions() {
-      $tab = [];
-
-      $tab[] = [
-         'id'                 => 'common',
-         'name'               => __('Characteristics')
-      ];
-
-      $tab[] = [
-         'id'                 => '1',
-         'table'              => $this->getTable(),
-         'field'              => 'name',
-         'name'               => __('Name'),
-         'datatype'           => 'itemlink',
-         'massiveaction'      => false,
-         'autocomplete'       => true,
-      ];
+      $tab = parent::rawSearchOptions();
 
       $tab[] = [
          'id'                 => '2',
@@ -536,15 +521,6 @@ class Peripheral extends CommonDBTM {
          'name'               => __('Global management'),
          'datatype'           => 'bool',
          'massiveaction'      => false
-      ];
-
-      $tab[] = [
-         'id'                 => '86',
-         'table'              => $this->getTable(),
-         'field'              => 'is_recursive',
-         'name'               => __('Child entities'),
-         'datatype'           => 'bool',
-         'searchtype'         => 'equals'
       ];
 
       // add objectlock search options

--- a/inc/peripheral.class.php
+++ b/inc/peripheral.class.php
@@ -538,6 +538,15 @@ class Peripheral extends CommonDBTM {
          'massiveaction'      => false
       ];
 
+      $tab[] = [
+         'id'                 => '86',
+         'table'              => $this->getTable(),
+         'field'              => 'is_recursive',
+         'name'               => __('Child entities'),
+         'datatype'           => 'bool',
+         'searchtype'         => 'equals'
+      ];
+
       // add objectlock search options
       $tab = array_merge($tab, ObjectLock::rawSearchOptionsToAdd(get_class($this)));
 

--- a/inc/phone.class.php
+++ b/inc/phone.class.php
@@ -608,6 +608,15 @@ class Phone extends CommonDBTM {
          'massiveaction'      => false
       ];
 
+      $tab[] = [
+         'id'                 => '86',
+         'table'              => $this->getTable(),
+         'field'              => 'is_recursive',
+         'name'               => __('Child entities'),
+         'datatype'           => 'bool',
+         'searchtype'         => 'equals'
+      ];
+
       // add objectlock search options
       $tab = array_merge($tab, ObjectLock::rawSearchOptionsToAdd(get_class($this)));
 

--- a/inc/phone.class.php
+++ b/inc/phone.class.php
@@ -355,22 +355,7 @@ class Phone extends CommonDBTM {
 
 
    function rawSearchOptions() {
-      $tab = [];
-
-      $tab[] = [
-         'id'                 => 'common',
-         'name'               => __('Characteristics')
-      ];
-
-      $tab[] = [
-         'id'                 => '1',
-         'table'              => $this->getTable(),
-         'field'              => 'name',
-         'name'               => __('Name'),
-         'datatype'           => 'itemlink',
-         'massiveaction'      => false,
-         'autocomplete'       => true,
-      ];
+      $tab = parent::rawSearchOptions();
 
       $tab[] = [
          'id'                 => '2',
@@ -606,15 +591,6 @@ class Phone extends CommonDBTM {
          'name'               => __('Global management'),
          'datatype'           => 'bool',
          'massiveaction'      => false
-      ];
-
-      $tab[] = [
-         'id'                 => '86',
-         'table'              => $this->getTable(),
-         'field'              => 'is_recursive',
-         'name'               => __('Child entities'),
-         'datatype'           => 'bool',
-         'searchtype'         => 'equals'
       ];
 
       // add objectlock search options

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -809,7 +809,8 @@ class Printer  extends CommonDBTM {
          'table'              => $this->getTable(),
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
-         'datatype'           => 'bool'
+         'datatype'           => 'bool',
+         'searchtype'         => 'equals'
       ];
 
       // add objectlock search options

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -494,22 +494,7 @@ class Printer  extends CommonDBTM {
    }
 
    function rawSearchOptions() {
-      $tab = [];
-
-      $tab[] = [
-         'id'                 => 'common',
-         'name'               => __('Characteristics')
-      ];
-
-      $tab[] = [
-         'id'                 => '1',
-         'table'              => $this->getTable(),
-         'field'              => 'name',
-         'name'               => __('Name'),
-         'datatype'           => 'itemlink',
-         'massiveaction'      => false,
-         'autocomplete'       => true,
-      ];
+      $tab = parent::rawSearchOptions();
 
       $tab[] = [
          'id'                 => '2',
@@ -802,15 +787,6 @@ class Printer  extends CommonDBTM {
          'name'               => __('Global management'),
          'datatype'           => 'bool',
          'massiveaction'      => false
-      ];
-
-      $tab[] = [
-         'id'                 => '86',
-         'table'              => $this->getTable(),
-         'field'              => 'is_recursive',
-         'name'               => __('Child entities'),
-         'datatype'           => 'bool',
-         'searchtype'         => 'equals'
       ];
 
       // add objectlock search options

--- a/inc/rack.class.php
+++ b/inc/rack.class.php
@@ -336,22 +336,7 @@ class Rack extends CommonDBTM {
    }
 
    function rawSearchOptions() {
-      $tab = [];
-
-      $tab[] = [
-         'id'                 => 'common',
-         'name'               => __('Characteristics')
-      ];
-
-      $tab[] = [
-         'id'                 => '1',
-         'table'              => $this->getTable(),
-         'field'              => 'name',
-         'name'               => __('Name'),
-         'datatype'           => 'itemlink',
-         'massiveaction'      => false, // implicit key==1
-         'autocomplete'       => true,
-      ];
+      $tab = parent::rawSearchOptions();
 
       $tab[] = [
          'id'                 => '2',
@@ -495,15 +480,6 @@ class Rack extends CommonDBTM {
          'field'              => 'completename',
          'name'               => __('Entity'),
          'datatype'           => 'dropdown'
-      ];
-
-      $tab[] = [
-         'id'                 => '86',
-         'table'              => $this->getTable(),
-         'field'              => 'is_recursive',
-         'name'               => __('Child entities'),
-         'datatype'           => 'bool',
-         'searchtype'         => 'equals'
       ];
 
       $tab = array_merge($tab, Notepad::rawSearchOptionsToAdd());

--- a/inc/rack.class.php
+++ b/inc/rack.class.php
@@ -497,6 +497,15 @@ class Rack extends CommonDBTM {
          'datatype'           => 'dropdown'
       ];
 
+      $tab[] = [
+         'id'                 => '86',
+         'table'              => $this->getTable(),
+         'field'              => 'is_recursive',
+         'name'               => __('Child entities'),
+         'datatype'           => 'bool',
+         'searchtype'         => 'equals'
+      ];
+
       $tab = array_merge($tab, Notepad::rawSearchOptionsToAdd());
 
       $tab = array_merge($tab, Datacenter::rawSearchOptionsToAdd(get_class($this)));

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -424,22 +424,7 @@ class Software extends CommonDBTM {
 
    function rawSearchOptions() {
       // Only use for History (not by search Engine)
-      $tab = [];
-
-      $tab[] = [
-         'id'                 => 'common',
-         'name'               => __('Characteristics')
-      ];
-
-      $tab[] = [
-         'id'                 => '1',
-         'table'              => $this->getTable(),
-         'field'              => 'name',
-         'name'               => __('Name'),
-         'datatype'           => 'itemlink',
-         'massiveaction'      => false,
-         'autocomplete'       => true,
-      ];
+      $tab = parent::rawSearchOptions();
 
       $tab[] = [
          'id'                 => '2',
@@ -596,16 +581,6 @@ class Software extends CommonDBTM {
          $newtab['joinparams']['condition'] .= getEntitiesRestrictRequest(' AND', 'NEWTABLE');
       }
       $tab[] = $newtab;
-
-      $tab[] = [
-         'id'                 => '86',
-         'table'              => $this->getTable(),
-         'field'              => 'is_recursive',
-         'name'               => __('Child entities'),
-         'datatype'           => 'bool',
-         'searchtype'         => 'equals',
-         'massiveaction'      => false
-      ];
 
       $tab = array_merge($tab, SoftwareLicense::rawSearchOptionsToAdd());
 

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -603,6 +603,7 @@ class Software extends CommonDBTM {
          'field'              => 'is_recursive',
          'name'               => __('Child entities'),
          'datatype'           => 'bool',
+         'searchtype'         => 'equals',
          'massiveaction'      => false
       ];
 


### PR DESCRIPTION
Internal ref: 20271.

Add missing 'is_recursive' search option to most assets (it was only set in printer, software and network equipment).
This search options is very useful for massive actions.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
