### PR TITLE
Test on MariaDB 10.5 and review DB matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,23 +7,19 @@ executors:
   php_7_2_mariadb:
     docker:
       - image: glpi/circleci-env-core:php_7.2_fpm-node
-      - image: circleci/mariadb:10.2-ram
+      - image: circleci/mariadb:10.1-ram
   php_7_3_mariadb:
     docker:
       - image: glpi/circleci-env-core:php_7.3_fpm-node
-      - image: circleci/mariadb:10.3-ram
+      - image: circleci/mariadb:10.5-ram
   php_7_4_mariadb:
     docker:
       - image: glpi/circleci-env-core:php_7.4_fpm-node
-      - image: circleci/mariadb:10.4-ram
+      - image: circleci/mariadb:10.5-ram
   php_7_4_mysql_5_6:
     docker:
       - image: glpi/circleci-env-core:php_7.4_fpm-node
       - image: circleci/mysql:5.6-ram
-  php_7_4_mysql_5_7:
-    docker:
-      - image: glpi/circleci-env-core:php_7.4_fpm-node
-      - image: circleci/mysql:5.7-ram
   php_7_4_mysql_8_0:
     docker:
       - image: glpi/circleci-env-core:php_7.4_fpm-node
@@ -234,13 +230,6 @@ jobs:
       - build
       - run_full_test_suite
 
-  # PHP 7.4 test suite using MySQL 5.7.
-  php_7_4_mysql_5_7_test_suite:
-    executor: php_7_4_mysql_5_7
-    steps:
-      - build
-      - run_full_test_suite
-
   # PHP 7.4 test suite using MySQL 8.0.
   php_7_4_mysql_8_0_test_suite:
     executor: php_7_4_mysql_8_0
@@ -293,14 +282,6 @@ workflows:
               only: /.*/ # run also on tag creation
             branches:
               ignore: /.*/ # do not run on branch update
-      - php_7_4_mysql_5_7_test_suite:
-          requires:
-            - checkout
-          filters:
-            tags:
-              only: /.*/ # run also on tag creation
-            branches:
-              ignore: /.*/ # do not run on branch update
       - php_7_4_mysql_8_0_test_suite:
           requires:
             - checkout
@@ -336,9 +317,6 @@ workflows:
           requires:
             - checkout
       - php_7_4_mysql_5_6_test_suite:
-          requires:
-            - checkout
-      - php_7_4_mysql_5_7_test_suite:
           requires:
             - checkout
       - php_7_4_mysql_8_0_test_suite:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
         include:
           - {php-version: "7.2", db-image: "mariadb:10.1"}
           - {php-version: "7.2", db-image: "mysql:5.6"}
-          - {php-version: "7.4", db-image: "mariadb:10.4"} # MariaDB 10.5 is not yet a stable release, keep 10.4 checks for now
           - {php-version: "7.4", db-image: "mariadb:10.5"}
           - {php-version: "7.4", db-image: "mysql:8.0"}
     services:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

MariaDB 10.5 stable version has been released, so we should now run tests using it.
Also, it seems a bit overkill to test all supported DB versions. Testing on the lowest and the highest versions should be enough to detect main incompatibilities.