### PR TITLE
Fix Kanban add item action

### DIFF
--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -1514,7 +1514,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
       echo "<td>".__('User')."</td>";
       echo "<td>";
       User::dropdown(['name'   => 'users_id',
-                           'value'  => $this->fields["users_id"],
+                           'value'  => $ID ? $this->fields["users_id"] : Session::getLoginUserID(),
                            'right'  => 'see_project',
                            'entity' => $this->fields["entities_id"]]);
       echo "</td>";

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -691,6 +691,24 @@
                }
             );
          }
+
+         $(self.element + ' .kanban-container').on('submit', '.kanban-add-form', function(e) {
+            e.preventDefault();
+            var form = $(e.target);
+            var data = {};
+            data['inputs'] = form.serialize();
+            data['itemtype'] = form.prop('id').split('_')[2];
+            data['action'] = 'add_item';
+
+            $.ajax({
+               method: 'POST',
+               //async: false,
+               url: (self.ajax_root + "kanban.php"),
+               data: data
+            }).done(function() {
+               self.refresh();
+            });
+         });
       };
 
       /**
@@ -1405,23 +1423,6 @@
          add_form += "</form>";
          $(column_el.find('.kanban-body')[0]).append(add_form);
          $('#' + formID).get(0).scrollIntoView(false);
-         $("#" + formID).on('submit', function(e) {
-            e.preventDefault();
-            var form = $(e.target);
-            var data = {};
-            data['inputs'] = form.serialize();
-            data['itemtype'] = form.prop('id').split('_')[2];
-            data['action'] = 'add_item';
-
-            $.ajax({
-               method: 'POST',
-               //async: false,
-               url: (self.ajax_root + "kanban.php"),
-               data: data
-            }).done(function() {
-               self.refresh();
-            });
-         });
       };
 
       /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7608 

Fix issue where adding a second item (and possibly after waiting for a Kanban refresh) in the Kanban would open the new Project form instead of adding the item automatically. Issue was caused by the submit event listener not being set properly after the initial Kanban refresh.