### PR TITLE
Fix exception on logs crontask; fixes #7633

### DIFF
--- a/inc/crontasklog.class.php
+++ b/inc/crontasklog.class.php
@@ -60,11 +60,12 @@ class CronTaskLog extends CommonDBTM{
 
       $result = $DB->delete(
          'glpi_crontasklogs', [
-            'crontasks_id' => 'id',
-            new \QueryExpression("UNIX_TIMESTAMP(date) < UNIX_TIMESTAMP()-$secs")
+            'crontasks_id' => $id,
+            new \QueryExpression("UNIX_TIMESTAMP(" . $DB->quoteName("date") . ") < UNIX_TIMESTAMP()-$secs")
          ]
       );
-      return $result->rowCount();
+
+      return $result ? $DB->affectedRows() : 0;
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7633

1. `$id` was not passed to delete params.
2. `rowCount` is not available on a delete operation.