### PR TITLE
Fix Change/Problem Analysis/Plans forms; fixes #7635

### DIFF
--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -1190,7 +1190,7 @@ class Change extends CommonITILObject {
 
       $options            = [];
       $options['canedit'] = false;
-      $this->showFormHeader($options);
+      CommonDBTM::showFormHeader($options);
 
       echo "<tr class='tab_bg_2'>";
       echo "<td>".__('Impacts')."</td><td colspan='3'>";
@@ -1230,7 +1230,7 @@ class Change extends CommonITILObject {
 
       $options            = [];
       $options['canedit'] = false;
-      $this->showFormHeader($options);
+      CommonDBTM::showFormHeader($options);
 
       echo "<tr class='tab_bg_2'>";
       echo "<td>".__('Deployment plan')."</td><td colspan='3'>";

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7478,7 +7478,7 @@ abstract class CommonITILObject extends CommonDBTM {
       $ID   = $this->fields['id'];
       $rand = mt_rand();
 
-      if (isset($options['template_preview']) && !$options['template_preview']) {
+      if (!isset($options['template_preview']) || !$options['template_preview']) {
          $output = "<form method='post' name='form_ticket' enctype='multipart/form-data' action='".static::getFormURL()."''";
          if ($ID) {
             $output .= " data-track-changes='true'";

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -1517,7 +1517,7 @@ class Problem extends CommonITILObject {
 
       $options            = [];
       $options['canedit'] = false;
-      $this->showFormHeader($options);
+      CommonDBTM::showFormHeader($options);
 
       echo "<tr class='tab_bg_2'>";
       echo "<td>".__('Impacts')."</td><td colspan='3'>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7635

In GLPI 9.5, `showFormHeader()` method has been overrided in `CommonITILObject`, but its usage outside main form was not taken into account.
Result is that Change/Problem Analysis/Plans forms, that are not defining the `template_preview` had no form HTML tag.
Quick fix is to call the base method in these forms.