### PR TITLE
Do not throw an axception when sodium decrypt fails; see #7645

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -292,8 +292,9 @@ class Toolbox {
          $nonce,
          $key
       );
-      if (!is_string($plaintext)) {
-         throw new \RuntimeException('Unable to decrypt content');
+      if ($plaintext === false) {
+         Toolbox::logError('Unable to decrypt content. It may have been crypted with another key.');
+         return '';
       }
       return $plaintext;
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7645

It may happen that stored data in DB was crypted with another key than the current one. In this case, throwing an exception seems too much, as it may prevent to display the form that can be used to fix the stored value.