### PR TITLE
Inherit geolocation data

### DIFF
--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -272,6 +272,15 @@ class Entity extends CommonTreeDropdown {
 
       $input['max_closedate'] = $_SESSION["glpi_currenttime"];
 
+      if (empty($input['latitude']) && empty($input['longitude']) && empty($input['altitude']) &&
+         !empty($input[static::getForeignKeyField()])) {
+         $parent = new static();
+         $parent->getFromDB($input[static::getForeignKeyField()]);
+         $input['latitude'] = $parent->fields['latitude'];
+         $input['longitude'] = $parent->fields['longitude'];
+         $input['altitude'] = $parent->fields['altitude'];
+      }
+
       if (!Session::isCron()) { // Filter input for connected
          $input = $this->checkRightDatas($input);
       }

--- a/inc/location.class.php
+++ b/inc/location.class.php
@@ -517,4 +517,17 @@ class Location extends CommonTreeDropdown {
    static function getIcon() {
       return "fas fa-map-marker-alt";
    }
+
+   public function prepareInputForAdd($input) {
+      $input = parent::prepareInputForAdd($input);
+      if (empty($input['latitude']) && empty($input['longitude']) && empty($input['altitude']) &&
+         !empty($input[static::getForeignKeyField()])) {
+         $parent = new static();
+         $parent->getFromDB($input[static::getForeignKeyField()]);
+         $input['latitude'] = $parent->fields['latitude'];
+         $input['longitude'] = $parent->fields['longitude'];
+         $input['altitude'] = $parent->fields['altitude'];
+      }
+      return $input;
+   }
 }

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -245,4 +245,39 @@ class Entity extends DbTestCase {
       $this->runChangeEntityParent(true);
    }
 
+   public function testInheritGeolocation() {
+      $ent0 = getItemByTypeName('Entity', '_test_root_entity', true);
+      $ent1 = new \Entity();
+      $ent1_id = $ent1->add([
+         'entities_id'  => $ent0,
+         'name'         => 'inherit_geo_test_parent',
+         'latitude'     => '48.8566',
+         'longitude'    => '2.3522',
+         'altitude'     => '115'
+      ]);
+      $this->integer((int) $ent1_id)->isGreaterThan(0);
+      $ent2 = new \Entity();
+      $ent2_id = $ent2->add([
+         'entities_id'  => $ent1_id,
+         'name'         => 'inherit_geo_test_child',
+      ]);
+      $this->integer((int) $ent2_id)->isGreaterThan(0);
+      $this->string($ent2->fields['latitude'])->isEqualTo($ent1->fields['latitude']);
+      $this->string($ent2->fields['longitude'])->isEqualTo($ent1->fields['longitude']);
+      $this->string($ent2->fields['altitude'])->isEqualTo($ent1->fields['altitude']);
+
+      // Make sure we don't overwrite data a user sets
+      $ent3 = new \Entity();
+      $ent3_id = $ent3->add([
+         'entities_id'  => $ent1_id,
+         'name'         => 'inherit_geo_test_child2',
+         'latitude'     => '41.3851',
+         'longitude'    => '2.1734',
+         'altitude'     => '39'
+      ]);
+      $this->integer((int) $ent3_id)->isGreaterThan(0);
+      $this->string($ent3->fields['latitude'])->isEqualTo('41.3851');
+      $this->string($ent3->fields['longitude'])->isEqualTo('2.1734');
+      $this->string($ent3->fields['altitude'])->isEqualTo('39');
+   }
 }

--- a/tests/functionnal/Location.php
+++ b/tests/functionnal/Location.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+
+/* Test for inc/location.class.php */
+
+class Location extends DbTestCase {
+
+   public function testInheritGeolocation() {
+      $location1 = new \Location();
+      $location1_id = $location1->add([
+         'name'         => 'inherit_geo_test_parent',
+         'latitude'     => '48.8566',
+         'longitude'    => '2.3522',
+         'altitude'     => '115'
+      ]);
+      $this->integer((int) $location1_id)->isGreaterThan(0);
+      $location2 = new \Location();
+      $location2_id = $location2->add([
+         'locations_id' => $location1_id,
+         'name'         => 'inherit_geo_test_child',
+      ]);
+      $this->integer((int) $location2_id)->isGreaterThan(0);
+      $this->string($location2->fields['latitude'])->isEqualTo($location1->fields['latitude']);
+      $this->string($location2->fields['longitude'])->isEqualTo($location1->fields['longitude']);
+      $this->string($location2->fields['altitude'])->isEqualTo($location1->fields['altitude']);
+
+      // Make sure we don't overwrite data a user sets
+      $location3 = new \Location();
+      $location3_id = $location3->add([
+         'locations_id' => $location1_id,
+         'name'         => 'inherit_geo_test_child2',
+         'latitude'     => '41.3851',
+         'longitude'    => '2.1734',
+         'altitude'     => '39'
+      ]);
+      $this->integer((int) $location3_id)->isGreaterThan(0);
+      $this->string($location3->fields['latitude'])->isEqualTo('41.3851');
+      $this->string($location3->fields['longitude'])->isEqualTo('2.1734');
+      $this->string($location3->fields['altitude'])->isEqualTo('39');
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If you don't specify any geolocation data in Locations and Entities, this information is now copied from the parent automatically.

https://glpi.userecho.com/communities/1/topics/914-use-parent-geolocation-data-when-no-data-available