### PR TITLE
Show parent device in form header for network ports

### DIFF
--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -1247,7 +1247,7 @@ class NetworkPort extends CommonDBChild {
       ]);
 
       if ($iterator->count()) {
-         return sprintf('%s on %s', parent::computeFriendlyName(), $iterator->next()['name']);
+         return sprintf(__('%s on %s'), parent::computeFriendlyName(), $iterator->next()['name']);
       }
 
       return parent::computeFriendlyName();

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -1237,4 +1237,19 @@ class NetworkPort extends CommonDBChild {
       return $specificities;
    }
 
+   public function computeFriendlyName() {
+      global $DB;
+
+      $iterator = $DB->request([
+         'SELECT' => ['name'],
+         'FROM'   => $this->fields['itemtype']::getTable(),
+         'WHERE'  => ['id' => $this->fields['items_id']]
+      ]);
+
+      if ($iterator->count()) {
+         return sprintf('%s on %s', parent::computeFriendlyName(), $iterator->next()['name']);
+      }
+
+      return parent::computeFriendlyName();
+   }
 }

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -1247,7 +1247,7 @@ class NetworkPort extends CommonDBChild {
       ]);
 
       if ($iterator->count()) {
-         return sprintf(__('%s on %s'), parent::computeFriendlyName(), $iterator->next()['name']);
+         return sprintf(__('%1$s on %2$s'), parent::computeFriendlyName(), $iterator->next()['name']);
       }
 
       return parent::computeFriendlyName();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7651 

Instead of showing "eth0" for example, show "eth0 on HQCoreSwitch". The parent item is shown as a field in the form, but I think it is intuitive to have it shown in the form header as well especially since it is visible regardless of which tab you are looking at.