### PR TITLE
overflow with ellipis long texts on y axis in horizontal bars

### DIFF
--- a/css/dashboard.scss
+++ b/css/dashboard.scss
@@ -636,6 +636,22 @@ $break_tablet: 1400px;
          }
       }
 
+      .ct-horizontal-bars {
+         .ct-label.ct-vertical.ct-start {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            display: block;
+
+            &:before {
+               content: "";
+               display: inline-block;
+               height: 100%;
+               vertical-align: middle;
+             }
+         }
+      }
+
       &.gauge {
          .ct-chart {
             max-height: calc(100% - 45px); // prevent gauge to overflow


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal ref 20297

Before:

![image](https://user-images.githubusercontent.com/418844/87287264-2e8bbf80-c4fa-11ea-9bfc-e422ab785508.png)


After:

![image](https://user-images.githubusercontent.com/418844/87287227-229ffd80-c4fa-11ea-978a-99948ca1d3e3.png)

