### PR TITLE
Ensure mysqlnd is the driver used by mysqli; see #7675

### DIFF
--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -93,7 +93,6 @@ include_once (GLPI_ROOT . "/inc/autoload.function.php");
       'GLPI_DEMO_MODE'              => '0',
       // TODO GLPI_FORCE_EMPTY_SQL_MODE need to be set to 0 after review of all sql queries
       'GLPI_FORCE_EMPTY_SQL_MODE'   => '1', // for compatibility with mysql 5.7
-      'GLPI_FORCE_NATIVE_SQL_TYPES' => '1', // force mysql driver to retrieve int and float types correctly (and not convert them to strings)
    ];
 
    // Define constants values based on server env variables (i.e. defined using apache SetEnv directive)

--- a/inc/dbconnection.class.php
+++ b/inc/dbconnection.class.php
@@ -351,18 +351,27 @@ class DBConnection extends CommonDBTM {
     *  Display a common mysql connection error
    **/
    static function displayMySQLError() {
+      global $DB;
+
+      $error = $DB instanceof DBmysql ? $DB->error : 1;
+      switch ($error) {
+         case 2:
+            $en_msg = "Use of mysqlnd driver is required for exchanges with the MySQL server.";
+            $fr_msg = "L'utilisation du driver mysqlnd est requise pour les échanges avec le serveur MySQL.";
+            break;
+         case 1:
+         default:
+            $fr_msg = "Le serveur Mysql est inaccessible. Vérifiez votre configuration.";
+            $en_msg = "A link to the SQL server could not be established. Please check your configuration.";
+            break;
+      }
 
       if (!isCommandLine()) {
          Html::nullHeader("Mysql Error", '');
-         echo "<div class='center'><p class ='b'>
-                A link to the SQL server could not be established. Please check your configuration.
-                </p><p class='b'>
-                Le serveur Mysql est inaccessible. Vérifiez votre configuration</p>
-               </div>";
+         echo "<div class='center'><p class ='b'>$en_msg</p><p class='b'>$fr_msg</p></div>";
          Html::nullFooter();
       } else {
-         echo "A link to the SQL server could not be established. Please check your configuration.\n";
-         echo "Le serveur Mysql est inaccessible. Vérifiez votre configuration\n";
+         echo "$en_msg\n$fr_msg\n";
       }
 
       die(1);

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -209,7 +209,8 @@ class DBmysql {
          }
 
          // force mysqlnd to return int and float types correctly (not as strings)
-         if (GLPI_FORCE_NATIVE_SQL_TYPES) {
+         // we still check if constant is defined to prevent warnings during requirements checks
+         if (defined('MYSQLI_OPT_INT_AND_FLOAT_NATIVE')) {
             $this->dbh->options(MYSQLI_OPT_INT_AND_FLOAT_NATIVE, true);
          }
 

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -194,6 +194,9 @@ class DBmysql {
       if ($this->dbh->connect_error) {
          $this->connected = false;
          $this->error     = 1;
+      } else if (!defined('MYSQLI_OPT_INT_AND_FLOAT_NATIVE')) {
+         $this->connected = false;
+         $this->error     = 2;
       } else {
          $dbenc = isset($this->dbenc) ? $this->dbenc : "utf8";
          $this->dbh->set_charset($dbenc);
@@ -209,10 +212,7 @@ class DBmysql {
          }
 
          // force mysqlnd to return int and float types correctly (not as strings)
-         // we still check if constant is defined to prevent warnings during requirements checks
-         if (defined('MYSQLI_OPT_INT_AND_FLOAT_NATIVE')) {
-            $this->dbh->options(MYSQLI_OPT_INT_AND_FLOAT_NATIVE, true);
-         }
+         $this->dbh->options(MYSQLI_OPT_INT_AND_FLOAT_NATIVE, true);
 
          if (GLPI_FORCE_EMPTY_SQL_MODE) {
             $this->dbh->query("SET SESSION sql_mode = ''");

--- a/inc/system/requirement/mysqlimysqlnd.class.php
+++ b/inc/system/requirement/mysqlimysqlnd.class.php
@@ -49,7 +49,7 @@ class MysqliMysqlnd extends Extension {
 
    protected function check() {
       $extension_loaded = extension_loaded('mysqli');
-      $driver_is_mysqlnd = function_exists('mysqli_fetch_all');
+      $driver_is_mysqlnd = defined('MYSQLI_OPT_INT_AND_FLOAT_NATIVE');
 
       // We check for "mysqli_fetch_all" function to be sure that the used driver is "mysqlnd".
       // Indeed, it is mandatory to be able to use MYSQLI_OPT_INT_AND_FLOAT_NATIVE option.

--- a/inc/system/requirement/mysqlimysqlnd.class.php
+++ b/inc/system/requirement/mysqlimysqlnd.class.php
@@ -37,42 +37,28 @@ if (!defined('GLPI_ROOT')) {
 }
 
 /**
- * @since 9.5.0
+ * @since 9.5.1
  */
-class Extension extends AbstractRequirement {
+class MysqliMysqlnd extends Extension {
 
    /**
-    * Required extension name.
-    *
-    * @var string
     */
-   protected $name;
-
-   /**
-    * @param string $name    Required extension name.
-    * @param bool $optional  Indicated if extension is optional.
-    */
-   public function __construct(string $name, bool $optional = false) {
-      $this->title = sprintf(__('%s extension test'), $name);
-      $this->name = $name;
-      $this->optional = $optional;
+   public function __construct() {
+      parent::__construct('mysqli');
    }
 
    protected function check() {
-      $this->validated = extension_loaded($this->name);
-      $this->buildValidationMessage();
-   }
+      $extension_loaded = extension_loaded('mysqli');
+      $driver_is_mysqlnd = function_exists('mysqli_fetch_all');
 
-   /**
-    * Defines the validation message based on self properties.
-    *
-    * @return void
-    */
-   protected function buildValidationMessage() {
-      if ($this->validated) {
+      // We check for "mysqli_fetch_all" function to be sure that the used driver is "mysqlnd".
+      // Indeed, it is mandatory to be able to use MYSQLI_OPT_INT_AND_FLOAT_NATIVE option.
+      $this->validated = $extension_loaded && $driver_is_mysqlnd;
+
+      if ($extension_loaded && $driver_is_mysqlnd) {
          $this->validation_messages[] = sprintf(__('%s extension is installed'), $this->name);
-      } else if ($this->optional) {
-         $this->validation_messages[] = sprintf(__('%s extension is not present'), $this->name);
+      } else if ($extension_loaded && !$driver_is_mysqlnd) {
+         $this->validation_messages[] = sprintf(__('%s extension is installed but is not using mysqlnd driver'), $this->name);
       } else {
          $this->validation_messages[] = sprintf(__('%s extension is missing'), $this->name);
       }

--- a/inc/system/requirementsmanager.class.php
+++ b/inc/system/requirementsmanager.class.php
@@ -38,6 +38,7 @@ use Glpi\System\Requirement\ExtensionClass;
 use Glpi\System\Requirement\ExtensionFunction;
 use Glpi\System\Requirement\LogsWriteAccess;
 use Glpi\System\Requirement\MemoryLimit;
+use Glpi\System\Requirement\MysqliMysqlnd;
 use Glpi\System\Requirement\PhpVersion;
 use Glpi\System\Requirement\ProtectedWebAccess;
 use Glpi\System\Requirement\SeLinux;
@@ -70,7 +71,7 @@ class RequirementsManager {
 
       $requirements[] = new MemoryLimit(64 * 1024 *1024);
 
-      $requirements[] = new Extension('mysqli');
+      $requirements[] = new MysqliMysqlnd();
       $requirements[] = new Extension('ctype');
       $requirements[] = new Extension('fileinfo');
       $requirements[] = new Extension('json');

--- a/tests/units/Glpi/System/Requirement/MysqliMysqlnd.php
+++ b/tests/units/Glpi/System/Requirement/MysqliMysqlnd.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+*/
+
+namespace tests\units\Glpi\System\Requirement;
+
+class MysqliMysqlnd extends \GLPITestCase {
+
+   public function testCheckUsingMysqlnd() {
+
+      $this->newTestedInstance();
+      $this->function->extension_loaded = true;
+      $this->function->function_exists = true;
+      $this->boolean($this->testedInstance->isValidated())->isEqualTo(true);
+      $this->array($this->testedInstance->getValidationMessages())
+         ->isEqualTo(['mysqli extension is installed']);
+   }
+
+   public function testCheckUsingAlternativeDriver() {
+
+      $this->newTestedInstance();
+      $this->function->extension_loaded = true;
+      $this->function->function_exists = false;
+      $this->boolean($this->testedInstance->isValidated())->isEqualTo(false);
+      $this->array($this->testedInstance->getValidationMessages())
+         ->isEqualTo(['mysqli extension is installed but is not using mysqlnd driver']);
+   }
+
+   public function testCheckOnMissingExtension() {
+
+      $this->newTestedInstance();
+      $this->function->extension_loaded = false;
+      $this->boolean($this->testedInstance->isValidated())->isEqualTo(false);
+      $this->array($this->testedInstance->getValidationMessages())
+         ->isEqualTo(['mysqli extension is missing']);
+   }
+}

--- a/tests/units/Glpi/System/Requirement/MysqliMysqlnd.php
+++ b/tests/units/Glpi/System/Requirement/MysqliMysqlnd.php
@@ -38,7 +38,7 @@ class MysqliMysqlnd extends \GLPITestCase {
 
       $this->newTestedInstance();
       $this->function->extension_loaded = true;
-      $this->function->function_exists = true;
+      $this->function->defined = true;
       $this->boolean($this->testedInstance->isValidated())->isEqualTo(true);
       $this->array($this->testedInstance->getValidationMessages())
          ->isEqualTo(['mysqli extension is installed']);
@@ -48,7 +48,7 @@ class MysqliMysqlnd extends \GLPITestCase {
 
       $this->newTestedInstance();
       $this->function->extension_loaded = true;
-      $this->function->function_exists = false;
+      $this->function->defined = false;
       $this->boolean($this->testedInstance->isValidated())->isEqualTo(false);
       $this->array($this->testedInstance->getValidationMessages())
          ->isEqualTo(['mysqli extension is installed but is not using mysqlnd driver']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #7675

Usage of `MYSQLI_OPT_INT_AND_FLOAT_NATIVE` seems now required, as we cannot ensure that everything works fine without this option.

`MYSQLI_OPT_INT_AND_FLOAT_NATIVE` option is only available when mysqli uses mysqlnd driver.