### PR TITLE
Bump ECMAScript to 2015

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
       - run:
           name: ESLint
           command: |
-            node_modules/.bin/eslint ./js && node_modules/.bin/eslint --env=node --parser-options=ecmaVersion:6 --rule 'indent: ["error", 4]' ./webpack.config.js && echo "ESLint found no errors"
+            node_modules/.bin/eslint . && echo "ESLint found no errors"
 
   # PHP 7.2 test suite.
   php_7_2_test_suite:

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,17 @@
 {
+    "root": true,
+    "ignorePatterns": [
+        "/config/*",
+        "/files/*",
+        "/lib/*",
+        "/marketplace/*",
+        "/node_modules/*",
+        "/plugins/*",
+        "/public/lib/*",
+        "/public/build/*",
+        "/tests/config/*",
+        "/vendor/*"
+    ],
     "env": {
         "browser": true,
         "jquery": true
@@ -13,7 +26,7 @@
         "_nx": true
     },
     "parserOptions": {
-        "ecmaVersion": 5
+        "ecmaVersion": 6
     },
     "rules": {
         "indent": [
@@ -50,5 +63,13 @@
             "error",
             "always"
         ]
-    }
+    },
+    "overrides": [
+        {
+            "files": ["webpack.config.js"],
+            "env": {
+                "node": true
+            }
+        }
+    ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,7 @@ jobs:
           docker exec ${{ job.services.app.id }} vendor/bin/phpcs -d memory_limit=512M -p --extensions=php --standard=vendor/glpi-project/coding-standard/GlpiStandard/ --ignore="/.git/,^/var/glpi/(config|files|lib|marketplace|node_modules|plugins|tests/config|vendor)/" ./
       - name: "ESLint"
         run: |
-          docker exec ${{ job.services.app.id }} node_modules/.bin/eslint ./js && echo "ESLint found no errors"
-          docker exec ${{ job.services.app.id }} node_modules/.bin/eslint --env=node --parser-options=ecmaVersion:6 --rule 'indent: ["error", 4]' ./webpack.config.js && echo "ESLint found no errors"
+          docker exec ${{ job.services.app.id }} node_modules/.bin/eslint . && echo "ESLint found no errors"
 
   tests:
     name: "Test on PHP ${{ matrix.php-version }} using ${{ matrix.db-image }}"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,191 +42,191 @@ const libOutputPath = 'public/lib';
  * GLPI core files build configuration.
  */
 var glpiConfig = {
-    entry: {
-        'glpi': path.resolve(__dirname, 'js/main.js'),
-    },
-    output: {
-        filename: '[name].js',
-        path: path.resolve(__dirname, 'public/build'),
-    },
+   entry: {
+      'glpi': path.resolve(__dirname, 'js/main.js'),
+   },
+   output: {
+      filename: '[name].js',
+      path: path.resolve(__dirname, 'public/build'),
+   },
 };
 
 /*
  * External libraries files build configuration.
  */
 var libsConfig = {
-    entry: function () {
-        // Create an entry per *.js file in lib/bundle directory.
-        // Entry name will be name of the file (without ext).
-        var entries = {};
+   entry: function () {
+      // Create an entry per *.js file in lib/bundle directory.
+      // Entry name will be name of the file (without ext).
+      var entries = {};
 
-        let files = glob.sync(path.resolve(__dirname, 'lib/bundles') + '/!(*.min).js');
-        files.forEach(function (file) {
-            entries[path.basename(file, '.js')] = file;
-        });
+      let files = glob.sync(path.resolve(__dirname, 'lib/bundles') + '/!(*.min).js');
+      files.forEach(function (file) {
+         entries[path.basename(file, '.js')] = file;
+      });
 
-        return entries;
-    },
-    output: {
-        filename: '[name].js',
-        path: path.resolve(__dirname, libOutputPath),
-    },
-    module: {
-        rules: [
-            {
-                // Load scripts with no compilation for packages that are directly providing "dist" files.
-                // This prevents useless compilation pass and can also
-                // prevents incompatibility issues with the webpack require feature.
-                test: /\.js$/,
-                include: [
-                    path.resolve(__dirname, 'node_modules/@fullcalendar'),
-                    path.resolve(__dirname, 'node_modules/codemirror'),
-                    path.resolve(__dirname, 'node_modules/cystoscape'),
-                    path.resolve(__dirname, 'node_modules/cytoscape-context-menus'),
-                    path.resolve(__dirname, 'node_modules/gridstack'),
-                    path.resolve(__dirname, 'node_modules/jquery-migrate'),
-                    path.resolve(__dirname, 'node_modules/jstree'),
-                    path.resolve(__dirname, 'node_modules/photoswipe'),
-                    path.resolve(__dirname, 'node_modules/rrule'),
-                    path.resolve(__dirname, 'vendor/blueimp/jquery-file-upload'),
-                ],
-                use: ['script-loader'],
+      return entries;
+   },
+   output: {
+      filename: '[name].js',
+      path: path.resolve(__dirname, libOutputPath),
+   },
+   module: {
+      rules: [
+         {
+            // Load scripts with no compilation for packages that are directly providing "dist" files.
+            // This prevents useless compilation pass and can also
+            // prevents incompatibility issues with the webpack require feature.
+            test: /\.js$/,
+            include: [
+               path.resolve(__dirname, 'node_modules/@fullcalendar'),
+               path.resolve(__dirname, 'node_modules/codemirror'),
+               path.resolve(__dirname, 'node_modules/cystoscape'),
+               path.resolve(__dirname, 'node_modules/cytoscape-context-menus'),
+               path.resolve(__dirname, 'node_modules/gridstack'),
+               path.resolve(__dirname, 'node_modules/jquery-migrate'),
+               path.resolve(__dirname, 'node_modules/jstree'),
+               path.resolve(__dirname, 'node_modules/photoswipe'),
+               path.resolve(__dirname, 'node_modules/rrule'),
+               path.resolve(__dirname, 'vendor/blueimp/jquery-file-upload'),
+            ],
+            use: ['script-loader'],
+         },
+         {
+            // Build styles
+            test: /\.css$/,
+            use: [MiniCssExtractPlugin.loader, 'css-loader'],
+         },
+         {
+            // Copy images and fonts
+            test: /\.((gif|png|jp(e?)g)|(eot|ttf|svg|woff2?))$/,
+            use: {
+               loader: 'file-loader',
+               options: {
+                  name: function (filename) {
+                     // Keep only relative path
+                     var sanitizedPath = path.relative(__dirname, filename);
+
+                     // Sanitize name
+                     sanitizedPath = sanitizedPath.replace(/[^\\/\w-.]/, '');
+
+                     // Remove the first directory (lib, node_modules, ...) and empty parts
+                     // and replace directory separator by '/' (windows case)
+                     sanitizedPath = sanitizedPath.split(path.sep)
+                        .filter(function (part, index) {
+                           return '' != part && index != 0;
+                        }).join('/');
+
+                     return sanitizedPath;
+                  },
+               },
             },
-            {
-                // Build styles
-                test: /\.css$/,
-                use: [MiniCssExtractPlugin.loader, 'css-loader'],
-            },
-            {
-                // Copy images and fonts
-                test: /\.((gif|png|jp(e?)g)|(eot|ttf|svg|woff2?))$/,
-                use: {
-                    loader: 'file-loader',
-                    options: {
-                        name: function (filename) {
-                            // Keep only relative path
-                            var sanitizedPath = path.relative(__dirname, filename);
-
-                            // Sanitize name
-                            sanitizedPath = sanitizedPath.replace(/[^\\/\w-.]/, '');
-
-                            // Remove the first directory (lib, node_modules, ...) and empty parts
-                            // and replace directory separator by '/' (windows case)
-                            sanitizedPath = sanitizedPath.split(path.sep)
-                                .filter(function (part, index) {
-                                    return '' != part && index != 0;
-                                }).join('/');
-
-                            return sanitizedPath;
-                        },
-                    },
-                },
-            },
-        ],
-    },
-    node: {
-        // console is present in all browsers, no need to import "console-browserify"
-        // prevent circular dependency util -> console-browserify -> assert -> util
-        // (assert.js:164 Uncaught TypeError: util.inherits is not a function)
-        console: true,
-    },
-    plugins: [
-        new CleanWebpackPlugin(), // Clean lib dir content
-        new MiniCssExtractPlugin({ filename: '[name].css' }), // Extract styles into CSS files
-    ],
-    resolve: {
-        // Use only main file in requirement resolution as we do not yet handle modules correctly
-        mainFields: [
-            'main',
-        ],
-    },
+         },
+      ],
+   },
+   node: {
+      // console is present in all browsers, no need to import "console-browserify"
+      // prevent circular dependency util -> console-browserify -> assert -> util
+      // (assert.js:164 Uncaught TypeError: util.inherits is not a function)
+      console: true,
+   },
+   plugins: [
+      new CleanWebpackPlugin(), // Clean lib dir content
+      new MiniCssExtractPlugin({ filename: '[name].css' }), // Extract styles into CSS files
+   ],
+   resolve: {
+      // Use only main file in requirement resolution as we do not yet handle modules correctly
+      mainFields: [
+         'main',
+      ],
+   },
 };
 
 var libs = {
-    '@fullcalendar': [
-        {
-            context: 'core',
-            from: 'locales/*.js',
-        }
-    ],
-    'flatpickr': [
-        {
-            context: 'dist',
-            from: 'l10n/*.js',
-        },
-        {
-            context: 'dist',
-            from: 'themes/*.css',
-        }
-    ],
-    'jquery-ui': [
-        {
-            context: 'ui',
-            from: 'i18n/*.js',
-        }
-    ],
-    'select2': [
-        {
-            context: 'dist',
-            from: 'js/i18n/*.js',
-        }
-    ],
-    'tinymce-i18n': [
-        {
-            from: 'langs/*.js',
-        }
-    ],
+   '@fullcalendar': [
+      {
+         context: 'core',
+         from: 'locales/*.js',
+      }
+   ],
+   'flatpickr': [
+      {
+         context: 'dist',
+         from: 'l10n/*.js',
+      },
+      {
+         context: 'dist',
+         from: 'themes/*.css',
+      }
+   ],
+   'jquery-ui': [
+      {
+         context: 'ui',
+         from: 'i18n/*.js',
+      }
+   ],
+   'select2': [
+      {
+         context: 'dist',
+         from: 'js/i18n/*.js',
+      }
+   ],
+   'tinymce-i18n': [
+      {
+         from: 'langs/*.js',
+      }
+   ],
 };
 
 for (let packageName in libs) {
-    let libPackage = libs[packageName];
-    let to = libOutputPath + '/' + packageName.replace(/^@/, ''); // remove leading @ in case of prefixed package
+   let libPackage = libs[packageName];
+   let to = libOutputPath + '/' + packageName.replace(/^@/, ''); // remove leading @ in case of prefixed package
 
-    let copyPatterns = [];
+   let copyPatterns = [];
 
-    for (let e = 0; e < libPackage.length; e++) {
-        let packageEntry = libPackage[e];
+   for (let e = 0; e < libPackage.length; e++) {
+      let packageEntry = libPackage[e];
 
-        let context = 'node_modules/' + packageName;
-        if (Object.prototype.hasOwnProperty.call(packageEntry, 'context')) {
-            context += '/' + packageEntry.context;
-        }
+      let context = 'node_modules/' + packageName;
+      if (Object.prototype.hasOwnProperty.call(packageEntry, 'context')) {
+         context += '/' + packageEntry.context;
+      }
 
-        let copyParams = {
-            context: path.resolve(__dirname, context),
-            from:    packageEntry.from,
-            to:      path.resolve(__dirname, to),
-            toType:  'dir',
-        };
+      let copyParams = {
+         context: path.resolve(__dirname, context),
+         from:    packageEntry.from,
+         to:      path.resolve(__dirname, to),
+         toType:  'dir',
+      };
 
-        if (Object.prototype.hasOwnProperty.call(packageEntry, 'ignore')) {
-            copyParams.ignore = packageEntry.ignore;
-        }
+      if (Object.prototype.hasOwnProperty.call(packageEntry, 'ignore')) {
+         copyParams.ignore = packageEntry.ignore;
+      }
 
-        copyPatterns.push(copyParams);
-    }
+      copyPatterns.push(copyParams);
+   }
 
-    libsConfig.plugins.push(new CopyWebpackPlugin({patterns:copyPatterns}));
+   libsConfig.plugins.push(new CopyWebpackPlugin({patterns:copyPatterns}));
 }
 
 module.exports = function() {
-    var configs = [glpiConfig, libsConfig];
+   var configs = [glpiConfig, libsConfig];
 
-    for (let config of configs) {
-        config.mode = 'none'; // Force 'none' mode, as optimizations will be done on release process
-        config.devtool = 'source-map'; // Add sourcemap to files
+   for (let config of configs) {
+      config.mode = 'none'; // Force 'none' mode, as optimizations will be done on release process
+      config.devtool = 'source-map'; // Add sourcemap to files
 
-        // Limit verbosity to only usefull informations
-        config.stats = {
-            all: false,
-            errors: true,
-            errorDetails: true,
-            warnings: true,
+      // Limit verbosity to only usefull informations
+      config.stats = {
+         all: false,
+         errors: true,
+         errorDetails: true,
+         warnings: true,
 
-            entrypoints: true,
-            timings: true,
-        };
-    }
+         entrypoints: true,
+         timings: true,
+      };
+   }
 
-    return configs;
+   return configs;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

With IE support officially dropped, all remaining browsers support at least ECMAScript 2015 (ES6) which adds a ton of new features to JS.
I also added node support to fix an error in PHPStorm where it would not recognize 'require' in the webpack config.