### PR TITLE
Replace carriage return in slk exports; closes #7670

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -7700,7 +7700,7 @@ JAVASCRIPT;
       $value = preg_replace('/\x0D/', null, $value);
       $value = str_replace("\"", "''", $value);
       $value = Html::clean($value);
-      $value = str_replace("\n", "<br>", $value);
+      $value = str_replace("\n", " | ", $value);
       $value = str_replace("&gt;", ">", $value);
       $value = str_replace("&lt;", "<", $value);
 

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -7700,6 +7700,7 @@ JAVASCRIPT;
       $value = preg_replace('/\x0D/', null, $value);
       $value = str_replace("\"", "''", $value);
       $value = Html::clean($value);
+      $value = str_replace("\n", "<br>", $value);
       $value = str_replace("&gt;", ">", $value);
       $value = str_replace("&lt;", "<", $value);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7670

Replaced with a `<br>` for now, I don't really know what is expected here.
