### PR TITLE
Prevent exception on maillcollector connection

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -371,7 +371,7 @@ class MailCollector  extends CommonDBTM {
    public function displayFoldersList($input_id = "") {
       try {
          $this->connect();
-      } catch (\Laminas\Mail\Protocol\Exception\RuntimeException $e) {
+      } catch (Throwable $e) {
          Toolbox::logError($e->getMessage());
          echo __('An error occured trying to connect to collector.');
          return;
@@ -578,7 +578,12 @@ class MailCollector  extends CommonDBTM {
 
             $collector->uid          = -1;
             //Connect to the Mail Box
-            $collector->connect();
+            try {
+               $collector->connect();
+            } catch (Throwable $e) {
+               Toolbox::logError('An error occured trying to connect to collector.', $e->getMessage());
+               continue;
+            }
 
             foreach ($collector->storage as $uid => $message) {
                $head = $collector->getHeaders($message);
@@ -668,7 +673,7 @@ class MailCollector  extends CommonDBTM {
          //Connect to the Mail Box
          try {
             $this->connect();
-         } catch (\Laminas\Mail\Protocol\Exception\RuntimeException $e) {
+         } catch (Throwable $e) {
             Toolbox::logError($e->getTraceAsString());
             Session::addMessageAfterRedirect(
                __('An error occured trying to connect to collector.') . "<br/>" . $e->getMessage(),

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -372,7 +372,12 @@ class MailCollector  extends CommonDBTM {
       try {
          $this->connect();
       } catch (Throwable $e) {
-         Toolbox::logError($e->getMessage());
+         Toolbox::logError(
+            'An error occured trying to connect to collector.',
+            $e->getMessage(),
+            "\n",
+            $e->getTraceAsString()
+         );
          echo __('An error occured trying to connect to collector.');
          return;
       }
@@ -581,7 +586,12 @@ class MailCollector  extends CommonDBTM {
             try {
                $collector->connect();
             } catch (Throwable $e) {
-               Toolbox::logError('An error occured trying to connect to collector.', $e->getMessage());
+               Toolbox::logError(
+                  'An error occured trying to connect to collector.',
+                  $e->getMessage(),
+                  "\n",
+                  $e->getTraceAsString()
+               );
                continue;
             }
 
@@ -674,7 +684,12 @@ class MailCollector  extends CommonDBTM {
          try {
             $this->connect();
          } catch (Throwable $e) {
-            Toolbox::logError($e->getTraceAsString());
+            Toolbox::logError(
+               'An error occured trying to connect to collector.',
+               $e->getMessage(),
+               "\n",
+               $e->getTraceAsString()
+            );
             Session::addMessageAfterRedirect(
                __('An error occured trying to connect to collector.') . "<br/>" . $e->getMessage(),
                false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Calling `Mailcollector::connect()` can throw many exception types (due to a problem connection problem, or due to an invalid encryption key). As GLPI does not handle correctly exception (i.e. it results in a blank page), we should catch all of them an display/log an error message.