### PR TITLE
[9.4] Prevent creation of a task having an empty content; fixes #7737

### DIFF
--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -229,6 +229,12 @@ abstract class CommonITILTask  extends CommonDBTM {
 
    function prepareInputForUpdate($input) {
 
+      if (array_key_exists('content', $input) && empty($input['content'])) {
+         Session::addMessageAfterRedirect(__("You can't remove description of a task."),
+                                          false, ERROR);
+         return false;
+      }
+
       Toolbox::manageBeginAndEndPlanDates($input['plan']);
 
       if (isset($input['_planningrecall'])) {
@@ -380,7 +386,14 @@ abstract class CommonITILTask  extends CommonDBTM {
 
 
    function prepareInputForAdd($input) {
+
       $itemtype = $this->getItilObjectItemType();
+
+      if (empty($input['content'])) {
+         Session::addMessageAfterRedirect(__("You can't add a task without description."),
+                                          false, ERROR);
+         return false;
+      }
 
       Toolbox::manageBeginAndEndPlanDates($input['plan']);
 

--- a/tests/functionnal/TicketTask.php
+++ b/tests/functionnal/TicketTask.php
@@ -186,6 +186,7 @@ class TicketTask extends DbTestCase {
       foreach ($tasksstates as $taskstate) {
          $this->integer(
             $task->add([
+               'content'      => sprintf('Task with "%s" state', $taskstate),
                'state'        => $taskstate,
                'tickets_id'   => $ticketId,
                'users_id_tech'=> $uid
@@ -223,6 +224,7 @@ class TicketTask extends DbTestCase {
       foreach ($tasksstates as $taskstate) {
          $this->integer(
             $task->add([
+               'content'      => sprintf('Task with "%s" state', $taskstate),
                'state'        => $taskstate,
                'tickets_id'   => $ticketId,
                'users_id_tech'=> $uid


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7737
