### PR TITLE
RuleRight: link specific group

### DIFF
--- a/inc/ruleright.class.php
+++ b/inc/ruleright.class.php
@@ -121,6 +121,10 @@ class RuleRight extends Rule {
                         $output['groups_id'] = $action->fields["value"];
                         break;
 
+                     case 'specific_groups_id':
+                        $output["_ldap_rules"]['groups_id'][] = $action->fields["value"];
+                        break;
+
                      case "is_active" :
                         $output["is_active"] = $action->fields["value"];
                         break;
@@ -349,6 +353,10 @@ class RuleRight extends Rule {
       $actions['_entities_id_default']['name']              = __('Default entity');
       $actions['_entities_id_default']['linkfield']         = 'entities_id';
       $actions['_entities_id_default']['type']              = 'dropdown';
+
+      $actions['specific_groups_id']['name'] = _n('Group', 'Groups', Session::getPluralNumber());
+      $actions['specific_groups_id']['type'] = 'dropdown';
+      $actions['specific_groups_id']['table'] = 'glpi_groups';
 
       $actions['groups_id']['table']                        = 'glpi_groups';
       $actions['groups_id']['field']                        = 'name';

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -656,9 +656,9 @@ class User extends CommonDBTM {
       $this->syncLdapGroups();
       $this->syncDynamicEmails();
 
+      $this->applyGroupsRules();
       $rulesplayed = $this->applyRightRules();
       $picture     = $this->syncLdapPhoto();
-      $this->applyGroupsRules();
 
       //add picture in user fields
       if (!empty($picture)) {
@@ -916,8 +916,8 @@ class User extends CommonDBTM {
       $this->updateUserEmails();
       $this->syncLdapGroups();
       $this->syncDynamicEmails();
-      $this->applyRightRules();
       $this->applyGroupsRules();
+      $this->applyRightRules();
 
       if (in_array('password', $this->updates)) {
          $alert = new Alert();

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -658,6 +658,7 @@ class User extends CommonDBTM {
 
       $rulesplayed = $this->applyRightRules();
       $picture     = $this->syncLdapPhoto();
+      $this->applyGroupsRules();
 
       //add picture in user fields
       if (!empty($picture)) {
@@ -916,6 +917,7 @@ class User extends CommonDBTM {
       $this->syncLdapGroups();
       $this->syncDynamicEmails();
       $this->applyRightRules();
+      $this->applyGroupsRules();
 
       if (in_array('password', $this->updates)) {
          $alert = new Alert();
@@ -5601,5 +5603,23 @@ JAVASCRIPT;
 
    static function getIcon() {
       return "fas fa-user";
+   }
+
+   /**
+    * Add groups stored in "_ldap_rules/groups_id" special input
+    */
+   public function applyGroupsRules() {
+      if (!isset($this->input["_ldap_rules"]['groups_id'])) {
+         return;
+      }
+
+      $group_ids = array_unique($this->input["_ldap_rules"]['groups_id']);
+      foreach ($group_ids as $group_id) {
+         $group_user = new Group_User();
+         $group_user->add([
+            'groups_id' => $group_id,
+            'users_id'  => $this->getId()
+         ]);
+      }
    }
 }

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -33,6 +33,8 @@
 namespace tests\units;
 
 use \DbTestCase;
+use Group;
+use Group_User;
 
 /* Test for inc/authldap.class.php */
 
@@ -1275,6 +1277,19 @@ class AuthLDAP extends DbTestCase {
          'field'       => 'entities_id',
          'value'       => 1, // '_test_child_1' entity
       ]);
+
+      // Test specific_groups_id rule
+      $group = new Group();
+      $group_id = $group->add(["name" => "testgroup"]);
+      $this->integer($group_id);
+
+      $actions->add([
+         'rules_id'    => $rules_id,
+         'action_type' => 'assign',
+         'field'       => 'specific_groups_id',
+         'value'       => $group_id, // '_test_child_1' entity
+      ]);
+
       // login the user to force a real synchronisation and get it's glpi id
       $this->login('brazil6', 'password', false);
       $users_id = \User::getIdByName('brazil6');
@@ -1291,5 +1306,13 @@ class AuthLDAP extends DbTestCase {
          }
       }
       $this->boolean($found)->isTrue();
+
+      // Check group
+      $gu = new Group_User();
+      $gus = $gu->find([
+         'groups_id' => $group_id,
+         'users_id' => $users_id,
+      ]);
+      $this->array($gus)->hasSize(1);
    }
 }


### PR DESCRIPTION
Internal ref: 20162.

Add an new action for authorizations assignment rules that link a group to the user.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
