### PR TITLE
Fix right error when using 'with_document' in API

### DIFF
--- a/inc/api/api.class.php
+++ b/inc/api/api.class.php
@@ -42,6 +42,7 @@ use Auth;
 use Change;
 use CommonDevice;
 use CommonGLPI;
+use CommonITILObject;
 use Config;
 use Contract;
 use Document;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

