### PR TITLE
Fix error message when creating user with an empty name; fixes #7735

### DIFF
--- a/front/user.form.php
+++ b/front/user.form.php
@@ -61,9 +61,7 @@ if (isset($_GET['getvcard'])) {
 } else if (isset($_POST["add"])) {
    $user->check(-1, CREATE, $_POST);
 
-   // Pas de nom pas d'ajout
-   if (!empty($_POST["name"])
-       && ($newID = $user->add($_POST))) {
+   if (($newID = $user->add($_POST))) {
       Event::log($newID, "users", 4, "setup",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
       if ($_SESSION['glpibackcreated']) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7735 

`name` field check is already done on `User::prepareInputForAdd()` method.