### PR TITLE
use a clear statement on itilfollowups SQL where

### DIFF
--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -1171,6 +1171,8 @@ JAVASCRIPT;
       $user_table = "",
       $group_table = ""
    ) {
+      $itilfup_table = static::getTable();
+
       // An ITILFollowup parent can only by a CommonItilObject
       if (!is_a($itemtype, "CommonITILObject", true)) {
          throw new InvalidArgumentException(
@@ -1181,7 +1183,7 @@ JAVASCRIPT;
       $rightname = $itemtype::$rightname;
       // Can see all items, no need to go further
       if (Session::haveRight($rightname, $itemtype::READALL)) {
-         return "(`itemtype` = '$itemtype') ";
+         return "(`$itilfup_table`.`itemtype` = '$itemtype') ";
       }
 
       $user   = Session::getLoginUserID();
@@ -1218,15 +1220,15 @@ JAVASCRIPT;
                WHERE `users_id_recipient` = '$user'";
 
             return "(
-               `itemtype` = '$itemtype' AND (
-                  `items_id` IN ($user_query) OR
-                  `items_id` IN ($group_query) OR
-                  `items_id` IN ($recipient_query)
+               `$itilfup_table`.`itemtype` = '$itemtype' AND (
+                  `$itilfup_table`.`items_id` IN ($user_query) OR
+                  `$itilfup_table`.`items_id` IN ($group_query) OR
+                  `$itilfup_table`.`items_id` IN ($recipient_query)
                )
             ) ";
          } else {
             // Can't see any items
-            return "(`itemtype` = '$itemtype' AND 0 = 1) ";
+            return "(`$itilfup_table`.`itemtype` = '$itemtype' AND 0 = 1) ";
          }
       }
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://forum.glpi-project.org/viewtopic.php?id=278917


sql error:
```log
SQL Error "1052": Column 'itemtype' in where clause is ambiguous in query "SELECT DISTINCT `glpi_itilfollowups`.`id` AS id, 'xxxx' AS currentuser, `glpi_itilfollowups`.`content` AS `ITEM_ITILFollowup_1`,   COUNT(DISTINCT `glpi_documents_items`.`id`) AS `ITEM_ITILFollowup_119`, `glpi_itilfollowups`.`itemtype` AS `ITEM_ITILFollowup_6` FROM `glpi_itilfollowups` LEFT JOIN `glpi_documents_items` ON (`glpi_itilfollowups`.`id` = `glpi_documents_items`.`items_id` AND `glpi_documents_items`.`itemtype` = 'ITILFollowup')  WHERE `glpi_itilfollowups`.`is_private` IN ('1','0') AND ((`itemtype` = 'Ticket') OR (`itemtype` = 'Change' AND 0 = 1) OR (`itemtype` = 'Problem' AND 0 = 1) )) AND (    (`glpi_itilfollowups`.`itemtype`  LIKE 'Ticket'  ) ) GROUP BY `glpi_itilfollowups`.`id` HAVING    (`ITEM_ITILFollowup_119`  LIKE '1'  ) ORDER BY ITEM_ITILFollowup_1 ASC "
```

api request:
```
/apirest.php//search/ITILFollowup?range=0-9999999999&&uid_cols=true&criteria[0][field]=119&criteria[0][searchtype]=contains&criteria[0][value]=^1$&criteria[1][field]=6&criteria[1][searchtype]=contains&criteria[1][value]=^Ticket$
```
