### PR TITLE
change default caldav components used by our caldav server

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -369,7 +369,7 @@ $CFG_GLPI['planning_add_types']           = ['PlanningExternalEvent'];
 // - VJOURNAL: Glpi Reminders/Tasks with "Information" status and not planned, you can retrieve them in the notes tab
 // - VEVENT: all planned events without todo/done status, displayed in the calendar of your client
 // The two first entry fallback on VEVENT if they are disabled
-$CFG_GLPI['caldav_supported_components']  = ['VEVENT'];
+$CFG_GLPI['caldav_supported_components']  = ['VEVENT', 'VJOURNAL'];
 
 $CFG_GLPI["globalsearch_types"]           = ['Computer', 'Contact', 'Contract',
                                              'Document',  'Monitor',

--- a/inc/define.php
+++ b/inc/define.php
@@ -363,7 +363,13 @@ $CFG_GLPI['planning_types']               = ['ChangeTask', 'ProblemTask', 'Remin
                                              'TicketTask', 'ProjectTask', 'PlanningExternalEvent'];
 $CFG_GLPI['planning_add_types']           = ['PlanningExternalEvent'];
 
-$CFG_GLPI['caldav_supported_components']  = ['VEVENT', 'VJOURNAL', 'VTODO'];
+// supported components send by caldav server
+// - VTODO: All possible planning events of GLPI with a status of TODO/DONE,
+//    You can generaly retrieve them in the todo tab of your caldav client
+// - VJOURNAL: Glpi Reminders/Tasks with "Information" status and not planned, you can retrieve them in the notes tab
+// - VEVENT: all planned events without todo/done status, displayed in the calendar of your client
+// The two first entry fallback on VEVENT if they are disabled
+$CFG_GLPI['caldav_supported_components']  = ['VEVENT'];
 
 $CFG_GLPI["globalsearch_types"]           = ['Computer', 'Contact', 'Contract',
                                              'Document',  'Monitor',

--- a/inc/define.php
+++ b/inc/define.php
@@ -366,9 +366,9 @@ $CFG_GLPI['planning_add_types']           = ['PlanningExternalEvent'];
 // supported components send by caldav server
 // - VTODO: All possible planning events of GLPI with a status of TODO/DONE,
 //    You can generaly retrieve them in the todo tab of your caldav client
-// - VJOURNAL: Glpi Reminders/Tasks with "Information" status and not planned, you can retrieve them in the notes tab
-// - VEVENT: all planned events without todo/done status, displayed in the calendar of your client
-// The two first entry fallback on VEVENT if they are disabled
+// - VJOURNAL: Glpi Reminders/Tasks with "Information" status and **not planned**, you can retrieve them in the notes tab
+// - VEVENT: all **planned** events without todo/done status, displayed in the calendar of your client
+// The two first entry fallback on VEVENT if they are disabled (and they are planned, other are not displayed)
 $CFG_GLPI['caldav_supported_components']  = ['VEVENT', 'VJOURNAL'];
 
 $CFG_GLPI["globalsearch_types"]           = ['Computer', 'Contact', 'Contract',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -597,6 +597,9 @@ function loadDataset() {
    $CFG_GLPI['url_base']      = GLPI_URI;
    $CFG_GLPI['url_base_api']  = GLPI_URI . '/apirest.php';
 
+   // make all caldav component available for tests (for default usage we don't VTODO)
+   $CFG_GLPI['caldav_supported_components']  = ['VEVENT', 'VJOURNAL', 'VTODO'];
+
    $conf = Config::getConfigurationValues('phpunit');
    if (isset($conf['dataset']) && $conf['dataset']==$data['_version']) {
       printf("\nGLPI dataset version %s already loaded\n\n", $data['_version']);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal ref 20251

The current behavior is not understandable for users.
I suggest to have only VEVENT component (calendar one) and explain to advanced user they can have todo or memo in their client from glpi planning.
