### PR TITLE
Prevent deprecation notice on installation

### DIFF
--- a/inc/glpikey.class.php
+++ b/inc/glpikey.class.php
@@ -132,16 +132,6 @@ class GLPIKey {
    public function generate() {
       global $DB;
 
-      $sodium_key = null;
-      $old_key = false;
-
-      try {
-         $sodium_key = $this->get();
-      } catch (\RuntimeException $e) {
-         $sodium_key = null;
-         $old_key = @$this->getLegacyKey();
-      }
-
       $key = sodium_crypto_aead_chacha20poly1305_ietf_keygen();
       $success = (bool)file_put_contents($this->keyfile, $key);
       if (!$success) {
@@ -149,6 +139,16 @@ class GLPIKey {
       }
 
       if ($DB instanceof DBmysql) {
+         $sodium_key = null;
+         $old_key = false;
+
+         try {
+            $sodium_key = $this->get();
+         } catch (\RuntimeException $e) {
+            $sodium_key = null;
+            $old_key = @$this->getLegacyKey();
+         }
+
          return $this->migrateFieldsInDb($sodium_key, $old_key)
             && $this->migrateConfigsInDb($sodium_key, $old_key);
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Call to `GLPIKey::getLegacyKey()` is deprecated and, in case of an installation, this call is useless as result will not be used.