### PR TITLE
Fix redirect to item created from a template

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -1067,7 +1067,10 @@ class CommonDBTM extends CommonGLPI {
             $id_to_clone = $input['id'];
          }
          if (isset($id_to_clone) && $this->getFromDB($id_to_clone)) {
-            return $this->clone($input, $history);
+            if ($clone_id = $this->clone($input, $history)) {
+               $this->getFromDB($clone_id); // Load created items fields
+            }
+            return $clone_id;
          }
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When using a template, the `add` method was not setting `$fields` property with created object values, so redirection to created object was based on template ID as fields were set by `$this->getFromDB($id_to_clone)`.

To reproduce:
1) Set "Go to created item after creation" to "yes".
2) Create a computer from a template.
-> You should be redirected to the created object (without this fix you are redirected to the template itself).