### PR TITLE
Fix usage of novalidatecert IMAP/POP3 param; fixes #7693

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "iamcal/lib_autolink": "^1.7",
         "laminas/laminas-cache": "^2.8",
         "laminas/laminas-i18n": "^2.10",
-        "laminas/laminas-mail": "^2.10",
+        "laminas/laminas-mail": "^2.12",
         "laminas/laminas-mime": "^2.7",
         "laminas/laminas-serializer": "^2.8",
         "mexitek/phpcolors": "^0.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0a619b67a42b0ed750e2c683e459560",
+    "content-hash": "b02bc8f26ffd1180af415b27f7e74424",
     "packages": [
         {
             "name": "blueimp/jquery-file-upload",
@@ -755,16 +755,16 @@
         },
         {
             "name": "laminas/laminas-mail",
-            "version": "2.11.0",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-mail.git",
-                "reference": "4c5545637eea3dc745668ddff1028692ed004c4b"
+                "reference": "5e8bc77db515c2a207ee25df5f3464f121daf225"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-mail/zipball/4c5545637eea3dc745668ddff1028692ed004c4b",
-                "reference": "4c5545637eea3dc745668ddff1028692ed004c4b",
+                "url": "https://api.github.com/repos/laminas/laminas-mail/zipball/5e8bc77db515c2a207ee25df5f3464f121daf225",
+                "reference": "5e8bc77db515c2a207ee25df5f3464f121daf225",
                 "shasum": ""
             },
             "require": {
@@ -774,7 +774,7 @@
                 "laminas/laminas-stdlib": "^2.7 || ^3.0",
                 "laminas/laminas-validator": "^2.10.2",
                 "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^5.6 || ^7.0",
+                "php": "^7.1",
                 "true/punycode": "^2.1"
             },
             "replace": {
@@ -784,8 +784,8 @@
                 "laminas/laminas-coding-standard": "~1.0.0",
                 "laminas/laminas-config": "^2.6",
                 "laminas/laminas-crypt": "^2.6 || ^3.0",
-                "laminas/laminas-servicemanager": "^2.7.10 || ^3.3.1",
-                "phpunit/phpunit": "^5.7.25 || ^6.4.4 || ^7.1.4"
+                "laminas/laminas-servicemanager": "^3.2.1",
+                "phpunit/phpunit": "^7.5.20"
             },
             "suggest": {
                 "laminas/laminas-crypt": "Crammd5 support in SMTP Auth",
@@ -794,8 +794,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.11.x-dev",
-                    "dev-develop": "2.12.x-dev"
+                    "dev-master": "2.12.x-dev",
+                    "dev-develop": "2.13.x-dev"
                 },
                 "laminas": {
                     "component": "Laminas\\Mail",
@@ -823,7 +823,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-06-30T20:17:23+00:00"
+            "time": "2020-07-30T16:09:35+00:00"
         },
         {
             "name": "laminas/laminas-mime",
@@ -1953,12 +1953,6 @@
                 "guid",
                 "identifier",
                 "uuid"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/ramsey",
-                    "type": "github"
-                }
             ],
             "time": "2020-03-29T20:13:32+00:00"
         },
@@ -4750,20 +4744,6 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-20T08:37:50+00:00"
         },
         {
@@ -4872,20 +4852,6 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-30T18:50:54+00:00"
         },
         {
@@ -5258,20 +5224,6 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-20T08:37:50+00:00"
         }
     ],

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -188,6 +188,9 @@ class Auth extends CommonGLPI {
          if ($protocol === null) {
             throw new \RuntimeException(sprintf(__('Unsupported mail server type:%s.'), $config['type']));
          }
+         if ($config['validate-cert'] === false) {
+            $protocol->setNoValidateCert(true);
+         }
          $protocol->connect(
             $config['address'],
             $config['port'],

--- a/inc/mail/protocol/protocolinterface.class.php
+++ b/inc/mail/protocol/protocolinterface.class.php
@@ -39,6 +39,15 @@ if (!defined('GLPI_ROOT')) {
 interface ProtocolInterface {
 
    /**
+    * Do not validate SSL certificate
+    *
+    * @param  bool $novalidatecert Set to true to disable certificate validation
+    *
+    * @return self
+    */
+   public function setNoValidateCert(bool $novalidatecert);
+
+   /**
     * Open connection to server.
     *
     * @param  string      $host  hostname or IP address of POP3 server

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -1305,6 +1305,10 @@ class MailCollector  extends CommonDBTM {
          $params['folder'] = $config['mailbox'];
       }
 
+      if ($config['validate-cert'] === false) {
+         $params['novalidatecert'] = true;
+      }
+
       try {
          $storage = Toolbox::getMailServerStorageInstance($config['type'], $params);
          if ($storage === null) {

--- a/tests/imap/Toolbox.php
+++ b/tests/imap/Toolbox.php
@@ -113,6 +113,7 @@ class Toolbox extends \GLPITestCase {
       // Create valid classes
       eval(<<<CLASS
 class PluginTesterFakeProtocol implements Glpi\Mail\Protocol\ProtocolInterface {
+   public function setNoValidateCert(bool \$novalidatecert) {}
    public function connect(\$host, \$port = null, \$ssl = false) {}
    public function login(\$user, \$password) {}
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7693 

laminas/mail 2.12 will add support of `novalidatecert` option.
Not yet released, will require to update composer files.