### PR TITLE
correction Empty query in function deleteRuleOrder

### DIFF
--- a/inc/rulecollection.class.php
+++ b/inc/rulecollection.class.php
@@ -720,7 +720,7 @@ class RuleCollection extends CommonDBTM {
    function deleteRuleOrder($ranking) {
       global $DB;
 
-      $DB->update(
+      $result = $DB->update(
          'glpi_rules', [
             'ranking' => new \QueryExpression($DB->quoteName('ranking') . ' - 1')
          ], [
@@ -728,7 +728,7 @@ class RuleCollection extends CommonDBTM {
             'ranking'   => ['>', $ranking]
          ]
       );
-      return $DB->query($sql);
+      return $result;
    }
 
 


### PR DESCRIPTION
feor resold resolved :
glpiphplog.ERROR: Toolbox::userErrorHandlerNormal() in /home/dev_glpi/public_html/inc/toolbox.class.php line 683
  *** PHP Warning(2): mysqli::query(): Empty query
  Backtrace :
  :
  inc/dbmysql.class.php:181                          mysqli->query()
  inc/rulecollection.class.php:773                   DBmysql->query()

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
