### PR TITLE
Complete Clonable trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,12 @@ The present file will list all changes made to the project; according to the
 #### Deprecated
 - Usage of `GLPI_FORCE_EMPTY_SQL_MODE` constant
 - Usage of `CommonDBTM::notificationqueueonaction` property
-- `RuleImportComputer` and `RuleImportComputerCollection`
+- `Calendar::duplicate()`
+- `CommonDBTM::clone()`
+- `CommonDBTM::prepareInputForClone()`
+- `CommonDBTM::post_clone()`
+- `RuleImportComputer` class
+- `RuleImportComputerCollection` class
 
 #### Removed
 - `Update::declareOldItems()`

--- a/inc/calendar.class.php
+++ b/inc/calendar.class.php
@@ -38,7 +38,9 @@ if (!defined('GLPI_ROOT')) {
  * Calendar Class
 **/
 class Calendar extends CommonDropdown {
-   use Glpi\Features\Clonable;
+   use Glpi\Features\Clonable {
+      post_clone as protected post_cloneTrait;
+   }
 
    // From CommonDBTM
    public $dohistory                   = true;
@@ -121,7 +123,7 @@ class Calendar extends CommonDropdown {
 
       switch ($ma->getAction()) {
          case 'duplicate' : // For calendar duplicate in another entity
-            if (method_exists($item, 'duplicate')) {
+            if (Toolbox::hasTrait($item, \Glpi\Features\Clonable::class)) {
                $input = $ma->getInput();
                $options = [];
                if ($item->isEntityAssign()) {
@@ -132,7 +134,7 @@ class Calendar extends CommonDropdown {
                      if (!$item->isEntityAssign()
                          || ($input['entities_id'] != $item->getEntityID())) {
                         if ($item->can(-1, CREATE, $options)) {
-                           if ($item->duplicate($options)) {
+                           if ($item->clone($options)) {
                               $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
                            } else {
                               $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
@@ -219,7 +221,7 @@ class Calendar extends CommonDropdown {
 
    public function post_clone($source, $history) {
       $this->updateDurationCache($this->getID());
-      $this->cloneRelations($source, $history);
+      $this->post_cloneTrait($source, $history);
    }
 
 

--- a/inc/calendar.class.php
+++ b/inc/calendar.class.php
@@ -38,9 +38,7 @@ if (!defined('GLPI_ROOT')) {
  * Calendar Class
 **/
 class Calendar extends CommonDropdown {
-   use Glpi\Features\Clonable {
-      post_clone as protected post_cloneTrait;
-   }
+   use Glpi\Features\Clonable;
 
    // From CommonDBTM
    public $dohistory                   = true;
@@ -219,9 +217,11 @@ class Calendar extends CommonDropdown {
       return (bool) $this->clone($input);
    }
 
+   /**
+    * @see Glpi\Features\Clonable::post_clone
+    */
    public function post_clone($source, $history) {
       $this->updateDurationCache($this->getID());
-      $this->post_cloneTrait($source, $history);
    }
 
 

--- a/inc/calendar.class.php
+++ b/inc/calendar.class.php
@@ -196,12 +196,13 @@ class Calendar extends CommonDropdown {
    /**
     * Clone a calendar to another entity : name is updated
     *
-    * @param $options array Array of new values to set
-    * @return boolean|integer The new ID on success or false on failure
+    * @param array $options Array of new values to set
+    * @return boolean True on success or false on failure
     * @deprecated x.x.x Use the {@link \Glpi\Features\Clonable} trait instead
     */
    function duplicate($options = []) {
 
+      Toolbox::deprecated('Use clone()');
       $input = Toolbox::addslashes_deep($this->fields);
       unset($input['id']);
 
@@ -213,11 +214,7 @@ class Calendar extends CommonDropdown {
          }
       }
 
-      if ($newID = $this->clone($input)) {
-         return $newID;
-      }
-
-      return false;
+      return (bool) $this->clone($input);
    }
 
    public function post_clone($source, $history) {

--- a/inc/calendar.class.php
+++ b/inc/calendar.class.php
@@ -220,8 +220,7 @@ class Calendar extends CommonDropdown {
       return false;
    }
 
-   public function post_clone($source, $history)
-   {
+   public function post_clone($source, $history) {
       $this->updateDurationCache($this->getID());
       $this->cloneRelations($source, $history);
    }

--- a/inc/calendar.class.php
+++ b/inc/calendar.class.php
@@ -196,8 +196,9 @@ class Calendar extends CommonDropdown {
    /**
     * Clone a calendar to another entity : name is updated
     *
-    * @param $options array of new values to set
-    * @return boolean True on success
+    * @param $options array Array of new values to set
+    * @return boolean|integer The new ID on success or false on failure
+    * @deprecated x.x.x Use the {@link \Glpi\Features\Clonable} trait instead
     */
    function duplicate($options = []) {
 
@@ -213,11 +214,16 @@ class Calendar extends CommonDropdown {
       }
 
       if ($newID = $this->clone($input)) {
-         $this->updateDurationCache($newID);
-         return true;
+         return $newID;
       }
 
       return false;
+   }
+
+   public function post_clone($source, $history)
+   {
+      $this->updateDurationCache($this->getID());
+      $this->cloneRelations($source, $history);
    }
 
 

--- a/inc/commondbconnexity.class.php
+++ b/inc/commondbconnexity.class.php
@@ -80,7 +80,10 @@ class CommonDBConnexityItemNotFound extends \Exception {
  * @since 0.84
 **/
 abstract class CommonDBConnexity extends CommonDBTM {
-   use Glpi\Features\Clonable;
+   use Glpi\Features\Clonable {
+      post_clone as protected post_cloneTrait;
+      prepareInputForClone as protected prepareInputForCloneTrait;
+   }
 
    const DONT_CHECK_ITEM_RIGHTS  = 1; // Don't check the parent => always can*Child
    const HAVE_VIEW_RIGHT_ON_ITEM = 2; // canXXXChild = true if parent::canView == true

--- a/inc/commondbconnexity.class.php
+++ b/inc/commondbconnexity.class.php
@@ -80,6 +80,7 @@ class CommonDBConnexityItemNotFound extends \Exception {
  * @since 0.84
 **/
 abstract class CommonDBConnexity extends CommonDBTM {
+   use Glpi\Features\Clonable;
 
    const DONT_CHECK_ITEM_RIGHTS  = 1; // Don't check the parent => always can*Child
    const HAVE_VIEW_RIGHT_ON_ITEM = 2; // canXXXChild = true if parent::canView == true
@@ -89,6 +90,9 @@ abstract class CommonDBConnexity extends CommonDBTM {
    /// Disable auto forwarding information about entities ?
    static public $disableAutoEntityForwarding   = false;
 
+   public function getCloneRelations() :array {
+      return [];
+   }
 
    /**
     * Return the SQL request to get all the connexities corresponding to $itemtype[$items_id]

--- a/inc/commondbconnexity.class.php
+++ b/inc/commondbconnexity.class.php
@@ -80,10 +80,8 @@ class CommonDBConnexityItemNotFound extends \Exception {
  * @since 0.84
 **/
 abstract class CommonDBConnexity extends CommonDBTM {
-   use Glpi\Features\Clonable {
-      post_clone as protected post_cloneTrait;
-      prepareInputForClone as protected prepareInputForCloneTrait;
-   }
+
+   use Glpi\Features\Clonable;
 
    const DONT_CHECK_ITEM_RIGHTS  = 1; // Don't check the parent => always can*Child
    const HAVE_VIEW_RIGHT_ON_ITEM = 2; // canXXXChild = true if parent::canView == true
@@ -93,8 +91,10 @@ abstract class CommonDBConnexity extends CommonDBTM {
    /// Disable auto forwarding information about entities ?
    static public $disableAutoEntityForwarding   = false;
 
+
    public function getCloneRelations() :array {
-      return [];
+      return [
+      ];
    }
 
    /**
@@ -178,7 +178,7 @@ abstract class CommonDBConnexity extends CommonDBTM {
       while ($row = $iterator->next()) {
          $input = Toolbox::addslashes_deep($row);
          $item = new static();
-         $item->getFromDB($input['id']);
+         $item->getFromDB($input[static::getIndexName()]);
          $res[] = $item;
       }
       return $res;

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -1229,6 +1229,7 @@ class CommonDBTM extends CommonGLPI {
    function clone(array $override_input = [], bool $history = true) {
       global $DB, $CFG_GLPI;
 
+      \Toolbox::deprecated();
       if ($DB->isSlave()) {
          return false;
       }
@@ -1401,6 +1402,7 @@ class CommonDBTM extends CommonGLPI {
     * @deprecated x.x.x Use the {@link \Glpi\Features\Clonable} trait
    **/
    function prepareInputForClone($input) {
+      \Toolbox::deprecated();
       unset($input['id']);
       unset($input['date_mod']);
       unset($input['date_creation']);
@@ -1428,6 +1430,7 @@ class CommonDBTM extends CommonGLPI {
     * @deprecated x.x.x Use the {@link \Glpi\Features\Clonable} trait
    **/
    function post_clone($source, $history) {
+      \Toolbox::deprecated();
    }
 
 

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -1076,7 +1076,7 @@ class CommonDBTM extends CommonGLPI {
       }
 
       // This means we are not adding a cloned object
-      if (!isset($input['clone'])) {
+      if (!Toolbox::hasTrait($this, \Glpi\Features\Clonable::class) || !isset($input['clone'])) {
          // This means we are asked to clone the object (old way). This will clone the clone method
          // that will set the clone parameter to true
          if (isset($input['_oldID'])) {
@@ -1224,6 +1224,7 @@ class CommonDBTM extends CommonGLPI {
     * @param boolean $history do history log ? (true by default)
     *
     * @return integer the new ID of the clone (or false if fail)
+    * @deprecated x.x.x Use the {@link \Glpi\Features\Clonable} trait instead
     */
    function clone(array $override_input = [], bool $history = true) {
       global $DB, $CFG_GLPI;
@@ -1397,6 +1398,7 @@ class CommonDBTM extends CommonGLPI {
     * @param array $input datas used to add the item
     *
     * @return array the modified $input array
+    * @deprecated x.x.x Use the {@link \Glpi\Features\Clonable} trait
    **/
    function prepareInputForClone($input) {
       unset($input['id']);
@@ -1423,6 +1425,7 @@ class CommonDBTM extends CommonGLPI {
     * @param $history do history log ?
     *
     * @return void
+    * @deprecated x.x.x Use the {@link \Glpi\Features\Clonable} trait
    **/
    function post_clone($source, $history) {
    }

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -38,9 +38,7 @@ if (!defined('GLPI_ROOT')) {
  * CommonITILObject Class
 **/
 abstract class CommonITILObject extends CommonDBTM {
-   use \Glpi\Features\Clonable {
-      post_clone as protected post_cloneTrait;
-   }
+   use \Glpi\Features\Clonable;
 
    /// Users by type
    protected $users       = [];
@@ -2027,9 +2025,9 @@ abstract class CommonITILObject extends CommonDBTM {
    }
 
    /**
-   * @see Glpi\Features\Clonable::post_clone
-   */
-   function post_clone($source, $history) {
+    * @see Glpi\Features\Clonable::post_clone
+    */
+   public function post_clone($source, $history) {
       global $DB;
       $update = [];
       if (isset($source->fields['users_id_lastupdater'])) {
@@ -2043,7 +2041,6 @@ abstract class CommonITILObject extends CommonDBTM {
          $update,
          ['id' => $this->getID()]
       );
-      $this->post_cloneTrait($source, $history);
    }
 
    public function getCloneRelations(): array {

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -38,7 +38,9 @@ if (!defined('GLPI_ROOT')) {
  * CommonITILObject Class
 **/
 abstract class CommonITILObject extends CommonDBTM {
-   use \Glpi\Features\Clonable;
+   use \Glpi\Features\Clonable {
+      post_clone as protected post_cloneTrait;
+   }
 
    /// Users by type
    protected $users       = [];
@@ -2041,7 +2043,7 @@ abstract class CommonITILObject extends CommonDBTM {
          $update,
          ['id' => $this->getID()]
       );
-
+      $this->post_cloneTrait($source, $history);
    }
 
    public function getCloneRelations(): array {

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -38,6 +38,7 @@ if (!defined('GLPI_ROOT')) {
  * CommonITILObject Class
 **/
 abstract class CommonITILObject extends CommonDBTM {
+   use \Glpi\Features\Clonable;
 
    /// Users by type
    protected $users       = [];
@@ -2024,7 +2025,7 @@ abstract class CommonITILObject extends CommonDBTM {
    }
 
    /**
-   * @see CommonDBTM::post_clone
+   * @see Glpi\Features\Clonable::post_clone
    */
    function post_clone($source, $history) {
       global $DB;
@@ -2043,6 +2044,10 @@ abstract class CommonITILObject extends CommonDBTM {
 
    }
 
+   public function getCloneRelations(): array
+   {
+      return [];
+   }
 
    /**
     * @since 0.84

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -2044,8 +2044,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
    }
 
-   public function getCloneRelations(): array
-   {
+   public function getCloneRelations(): array {
       return [];
    }
 

--- a/inc/features/clonable.class.php
+++ b/inc/features/clonable.class.php
@@ -143,8 +143,6 @@ trait Clonable {
     * @param $history
     */
    public function post_clone($source, $history) {
-      // For 9.5.x BC
-      parent::post_clone($source, $history);
       $this->cloneRelations($source, $history);
    }
 }

--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Features\Clonable;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -543,7 +545,9 @@ class MassiveAction {
             //TRANS: select action 'update' (before doing it)
             $actions[$self_pref.'update'] = _x('button', 'Update');
 
-            $actions[$self_pref.'clone'] = _x('button', 'Clone');
+            if (Toolbox::hasTrait($itemtype, Clonable::class)) {
+               $actions[$self_pref . 'clone'] = _x('button', 'Clone');
+            }
          }
 
          Infocom::getMassiveActionsForItemtype($actions, $itemtype, $is_deleted, $checkitem);

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -47,7 +47,9 @@ if (!defined('GLPI_ROOT')) {
  * port, then, the fields of NetworkName are display. Thus, NetworkPort UI remain similar to 0.83
 **/
 class NetworkPort extends CommonDBChild {
-   use \Glpi\Features\Clonable;
+   use Glpi\Features\Clonable {
+      post_clone as protected post_cloneTrait;
+   }
 
    // From CommonDBChild
    static public $itemtype             = 'itemtype';
@@ -224,7 +226,7 @@ class NetworkPort extends CommonDBChild {
    }
 
    function post_clone($source, $history) {
-      parent::post_clone($source, $history);
+      $this->post_cloneTrait($source, $history);
       $instantiation = $source->getInstantiation();
       if ($instantiation !== false) {
          $instantiation->fields[$instantiation->getIndexName()] = $this->getID();
@@ -232,9 +234,6 @@ class NetworkPort extends CommonDBChild {
       }
    }
 
-   public function getCloneRelations(): array {
-      return [];
-   }
 
    /**
     * \brief split input fields when validating a port

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -48,6 +48,8 @@ if (!defined('GLPI_ROOT')) {
 **/
 class NetworkPort extends CommonDBChild {
 
+   use Glpi\Features\Clonable;
+
    // From CommonDBChild
    static public $itemtype             = 'itemtype';
    static public $items_id             = 'items_id';
@@ -59,6 +61,9 @@ class NetworkPort extends CommonDBChild {
 
    static $rightname                   = 'networking';
 
+   public function getCloneRelations() :array {
+      return [];
+   }
 
    function getForbiddenStandardMassiveAction() {
 
@@ -223,7 +228,6 @@ class NetworkPort extends CommonDBChild {
    }
 
    function post_clone($source, $history) {
-      $this->post_cloneTrait($source, $history);
       $instantiation = $source->getInstantiation();
       if ($instantiation !== false) {
          $instantiation->fields[$instantiation->getIndexName()] = $this->getID();

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -47,9 +47,6 @@ if (!defined('GLPI_ROOT')) {
  * port, then, the fields of NetworkName are display. Thus, NetworkPort UI remain similar to 0.83
 **/
 class NetworkPort extends CommonDBChild {
-   use Glpi\Features\Clonable {
-      post_clone as protected post_cloneTrait;
-   }
 
    // From CommonDBChild
    static public $itemtype             = 'itemtype';

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -48,8 +48,6 @@ if (!defined('GLPI_ROOT')) {
 **/
 class NetworkPort extends CommonDBChild {
 
-   use Glpi\Features\Clonable;
-
    // From CommonDBChild
    static public $itemtype             = 'itemtype';
    static public $items_id             = 'items_id';
@@ -61,9 +59,6 @@ class NetworkPort extends CommonDBChild {
 
    static $rightname                   = 'networking';
 
-   public function getCloneRelations() :array {
-      return [];
-   }
 
    function getForbiddenStandardMassiveAction() {
 

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -47,6 +47,7 @@ if (!defined('GLPI_ROOT')) {
  * port, then, the fields of NetworkName are display. Thus, NetworkPort UI remain similar to 0.83
 **/
 class NetworkPort extends CommonDBChild {
+   use \Glpi\Features\Clonable;
 
    // From CommonDBChild
    static public $itemtype             = 'itemtype';
@@ -229,6 +230,10 @@ class NetworkPort extends CommonDBChild {
          $instantiation->fields[$instantiation->getIndexName()] = $this->getID();
          return $instantiation->clone([], $history);
       }
+   }
+
+   public function getCloneRelations(): array {
+      return [];
    }
 
    /**

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -46,6 +46,9 @@ use Sabre\VObject\Property\IntegerValue;
  * @since 0.85
 **/
 class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface {
+   use Glpi\Features\Clonable {
+      prepareInputForClone as protected prepareInputForCloneTrait;
+   }
    use Glpi\Features\PlanningEvent;
    use VobjectConverterTrait;
 
@@ -2040,6 +2043,6 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
 
    public function prepareInputForClone($input) {
       $input['uuid'] = \Ramsey\Uuid\Uuid::uuid4();
-      return parent::prepareInputForClone($input);
+      return $this->prepareInputForCloneTrait($input);
    }
 }

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -2040,6 +2040,6 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
 
    public function prepareInputForClone($input) {
       $input['uuid'] = \Ramsey\Uuid\Uuid::uuid4();
-      return $this->prepareInputForCloneTrait($input);
+      return $input;
    }
 }

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -46,9 +46,6 @@ use Sabre\VObject\Property\IntegerValue;
  * @since 0.85
 **/
 class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface {
-   use Glpi\Features\Clonable {
-      prepareInputForClone as protected prepareInputForCloneTrait;
-   }
    use Glpi\Features\PlanningEvent;
    use VobjectConverterTrait;
 

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -42,7 +42,9 @@ if (!defined('GLPI_ROOT')) {
  *   - actions
 **/
 class Rule extends CommonDBTM {
-   use Glpi\Features\Clonable;
+   use Glpi\Features\Clonable {
+      prepareInputForClone as protected prepareInputForCloneTrait;
+   }
 
    public $dohistory             = true;
 
@@ -3227,6 +3229,6 @@ class Rule extends CommonDBTM {
 
       $input = Toolbox::addslashes_deep($input);
 
-      return parent::prepareInputForClone($input);
+      return $this->prepareInputForCloneTrait($input);
    }
 }

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -42,9 +42,7 @@ if (!defined('GLPI_ROOT')) {
  *   - actions
 **/
 class Rule extends CommonDBTM {
-   use Glpi\Features\Clonable {
-      prepareInputForClone as protected prepareInputForCloneTrait;
-   }
+   use Glpi\Features\Clonable;
 
    public $dohistory             = true;
 
@@ -3229,6 +3227,6 @@ class Rule extends CommonDBTM {
 
       $input = Toolbox::addslashes_deep($input);
 
-      return $this->prepareInputForCloneTrait($input);
+      return $input;
    }
 }

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3309,4 +3309,24 @@ HTML;
       }, $string);
       return $string;
    }
+
+   /**
+    * Checks if the given class or object has the specified trait.
+    * This function checks the class itself and all parent classes for the trait.
+    * @since x.x.x
+    * @param string|object $class The class or object
+    * @param string $trait The trait
+    * @return bool True if the class or its parents have the specified trait
+    */
+   public static function hasTrait($class, string $trait): bool {
+      // Get traits of all parent classes
+      do {
+         $traits = class_uses($class, true);
+         if (in_array($trait, $traits, true)) {
+            return true;
+         }
+      } while ($class = get_parent_class($class));
+
+      return false;
+   }
 }

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -38,6 +38,10 @@ use Glpi\Exception\ForgetPasswordException;
 use Sabre\VObject;
 
 class User extends CommonDBTM {
+   use Glpi\Features\Clonable {
+      prepareInputForClone as protected prepareInputForCloneTrait;
+      post_clone as protected post_cloneTrait;
+   }
 
    // From CommonDBTM
    public $dohistory         = true;
@@ -63,6 +67,17 @@ class User extends CommonDBTM {
 
    private $entities = null;
 
+   public function getCloneRelations() :array {
+      return [
+         Profile_User::class,
+         Group_User::class
+      ];
+   }
+
+   public function post_clone($source, $history) {
+      //FIXME? clone config
+      $this->post_cloneTrait($source, $history);
+   }
 
    static function getTypeName($nb = 0) {
       return _n('User', 'Users', $nb);
@@ -645,7 +660,7 @@ class User extends CommonDBTM {
          }
          $input['name'] = $possibleName;
       }
-      return $input;
+      return $this->prepareInputForCloneTrait($input);
    }
 
 

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -38,10 +38,7 @@ use Glpi\Exception\ForgetPasswordException;
 use Sabre\VObject;
 
 class User extends CommonDBTM {
-   use Glpi\Features\Clonable {
-      prepareInputForClone as protected prepareInputForCloneTrait;
-      post_clone as protected post_cloneTrait;
-   }
+   use Glpi\Features\Clonable;
 
    // From CommonDBTM
    public $dohistory         = true;
@@ -76,7 +73,6 @@ class User extends CommonDBTM {
 
    public function post_clone($source, $history) {
       //FIXME? clone config
-      $this->post_cloneTrait($source, $history);
    }
 
    static function getTypeName($nb = 0) {
@@ -660,7 +656,7 @@ class User extends CommonDBTM {
          }
          $input['name'] = $possibleName;
       }
-      return $this->prepareInputForCloneTrait($input);
+      return $input;
    }
 
 

--- a/tests/functionnal/Calendar.php
+++ b/tests/functionnal/Calendar.php
@@ -261,8 +261,8 @@ class Calendar extends DbTestCase {
       $calendar = new \Calendar();
       $this->boolean($calendar->getFromDB($id))->isTrue();
 
-      $other_id = $calendar->duplicate();
-      $this->variable($other_id)->isNotIdenticalTo(false);
+      $this->boolean($calendar->duplicate())->isTrue();
+      $other_id = $calendar->fields['id'];
       $this->integer($other_id)->isGreaterThan($id);
       $this->boolean($calendar->getFromDB($other_id))->isTrue();
       //should have been duplicated too.

--- a/tests/functionnal/Calendar.php
+++ b/tests/functionnal/Calendar.php
@@ -261,10 +261,7 @@ class Calendar extends DbTestCase {
       $calendar = new \Calendar();
       $this->boolean($calendar->getFromDB($id))->isTrue();
 
-      $this->boolean($calendar->duplicate())->isTrue();
-      $other_id = $calendar->fields['id'];
-      $this->integer($other_id)->isGreaterThan($id);
-      $this->boolean($calendar->getFromDB($other_id))->isTrue();
+      $this->integer($calendar->clone())->isGreaterThan($id);
       //should have been duplicated too.
       $this->checkXmas($calendar);
 

--- a/tests/functionnal/Calendar.php
+++ b/tests/functionnal/Calendar.php
@@ -261,8 +261,8 @@ class Calendar extends DbTestCase {
       $calendar = new \Calendar();
       $this->boolean($calendar->getFromDB($id))->isTrue();
 
-      $this->boolean($calendar->duplicate())->isTrue();
-      $other_id = $calendar->fields['id'];
+      $other_id = $calendar->duplicate();
+      $this->variable($other_id)->isNotIdenticalTo(false);
       $this->integer($other_id)->isGreaterThan($id);
       $this->boolean($calendar->getFromDB($other_id))->isTrue();
       //should have been duplicated too.

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -1391,7 +1391,6 @@ class Ticket extends DbTestCase {
    public function testClone() {
       $this->login();
       $this->setEntity('Root entity', true);
-      $ticket = new \Ticket();
       $ticket = getItemByTypeName('Ticket', '_ticket01');
 
       $date = date('Y-m-d H:i:s');

--- a/tests/units/Glpi/Features/Clonable.php
+++ b/tests/units/Glpi/Features/Clonable.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Features;
+
+/**
+ * Test for the {@link \Glpi\Features\Clonable} feature
+ */
+class Clonable extends \DbTestCase {
+
+   public function massiveActionTargetingProvider() {
+      return [
+         [\Computer::class, true],
+         [\Monitor::class, true],
+         [\Software::class, true],
+         [\Ticket::class, true],
+         [\Plugin::class, false],
+         [\Config::class, false]
+      ];
+   }
+
+   /**
+    * @param $class
+    * @param $result
+    * @dataProvider massiveActionTargetingProvider
+    */
+   public function testMassiveActionTargeting($class, $result) {
+      $this->login();
+      $ma_prefix = 'MassiveAction' . \MassiveAction::CLASS_ACTION_SEPARATOR;
+      $actions = \MassiveAction::getAllMassiveActions($class);
+      $this->boolean(array_key_exists($ma_prefix . 'clone', $actions))->isIdenticalTo($result);
+   }
+}

--- a/tests/units/Glpi/Features/Clonable.php
+++ b/tests/units/Glpi/Features/Clonable.php
@@ -2,7 +2,7 @@
 /**
  * ---------------------------------------------------------------------
  * GLPI - Gestionnaire Libre de Parc Informatique
- * Copyright (C) 2015-2020 Teclib' and contributors.
+ * Copyright (C) 2015-2021 Teclib' and contributors.
  *
  * http://glpi-project.org
  *

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -33,6 +33,10 @@
 namespace tests\units;
 
 use Glpi\Api\Deprecated\TicketFollowup;
+use Glpi\Features\Clonable;
+use Glpi\Features\DCBreadcrumb;
+use Glpi\Features\Kanban;
+use Glpi\Features\PlanningEvent;
 use ITILFollowup;
 use Ticket;
 
@@ -987,5 +991,28 @@ class Toolbox extends \GLPITestCase {
          ->withType(E_USER_DEPRECATED)
          ->withMessage('Calling this function is deprecated')
          ->exists();
+   }
+
+   public function hasTraitProvider() {
+      return [
+         [\Computer::class, Clonable::class, true],
+         [\Monitor::class, Clonable::class, true],
+         [\CommonITILObject::class, Clonable::class, true],
+         [\Ticket::class, Clonable::class, true],
+         [\Plugin::class, Clonable::class, false],
+         [\Project::class, Kanban::class, true],
+         [\Computer::class, Kanban::class, false],
+         [\Computer::class, DCBreadcrumb::class, true],
+         [\Ticket::class, DCBreadcrumb::class, false],
+         [\CommonITILTask::class, PlanningEvent::class, true],
+         [\Computer::class, PlanningEvent::class, false],
+      ];
+   }
+
+   /**
+    * @dataProvider hasTraitProvider
+    */
+   public function testHasTrait($class, $trait, $result) {
+      $this->boolean(\Toolbox::hasTrait($class, $trait))->isIdenticalTo((bool)$result);
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

- Move all clone related functions into Clonable trait. Currently they are in CommonDBTM, but not all child itemtypes can be cloned. For example, Plugins and Config cannot/should not be cloned.
- Limit clone massive action to Clonable itemtypes only.
- Add a utility function Toolbox::hasTrait to check if an itemtype or its parents has a specific trait.
- Add test for checking clone action for Clonable itemtypes and Toolbox::hasTrait test.