### PR TITLE
Fix inline images migration (Document_Item)

### DIFF
--- a/inc/console/database/updatecommand.class.php
+++ b/inc/console/database/updatecommand.class.php
@@ -166,8 +166,8 @@ class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionComma
       } else if ($force) {
          // Replay last update script even if there is no schema change.
          // It can be used in dev environment when update script has been updated/fixed.
-         include_once(GLPI_ROOT . '/install/update_94_95.php');
-         update94to95();
+         include_once(GLPI_ROOT . '/install/update_951_952.php');
+         update951to952();
 
          $output->writeln('<info>' . __('Last migration replayed.') . '</info>');
       }

--- a/inc/define.php
+++ b/inc/define.php
@@ -41,7 +41,7 @@ if (substr(GLPI_VERSION, -4) === '-dev') {
    );
 } else {
    //for stable version
-   define("GLPI_SCHEMA_VERSION", '9.5.0');
+   define("GLPI_SCHEMA_VERSION", '9.5.2');
 }
 define('GLPI_MIN_PHP', '7.2.0'); // Must also be changed in top of index.php
 define('GLPI_YEAR', '2020');

--- a/inc/update.class.php
+++ b/inc/update.class.php
@@ -474,6 +474,7 @@ class Update extends CommonGLPI {
             include_once "{$updir}update_94_95.php";
             update94to95();
 
+         case "9.5.0":
          case "9.5.1":
             include_once "{$updir}update_951_952.php";
             update951to952();

--- a/inc/update.class.php
+++ b/inc/update.class.php
@@ -473,6 +473,10 @@ class Update extends CommonGLPI {
          case "9.5.0-dev":
             include_once "{$updir}update_94_95.php";
             update94to95();
+
+         case "9.5.1":
+            include_once "{$updir}update_951_952.php";
+            update951to952();
             break;
 
          case GLPI_VERSION:

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -1513,60 +1513,6 @@ HTML
    $migration->addConfig(['ssologout_url' => '']);
    /** SSO logout URL */
 
-   /** A doc_item to rule them all! */
-   $migration->dropKey('glpi_documents_items', 'unicity');
-   $migration->migrationOneTable('glpi_documents_items');
-   $migration->addKey(
-      'glpi_documents_items',
-      ['documents_id', 'itemtype', 'items_id', 'timeline_position'],
-      'unicity',
-      'UNIQUE'
-   );
-   $migration->migrationOneTable('glpi_documents_items');
-
-   $itemtypes = [
-      'ITILFollowup' => 'content',
-      'ITILSolution' => 'content',
-      'Reminder'     => 'text',
-      'KnowbaseItem' => 'answer'
-   ];
-   foreach (['Change', 'Problem', 'Ticket'] as $itiltype) {
-      $itemtypes[$itiltype] = 'content';
-      $itemtypes[$itiltype . 'Task'] = 'content';
-   }
-   $docs_input =[];
-   foreach ($itemtypes as $itemtype => $field) {
-      // Check ticket and child items (followups, tasks, solutions) contents
-      $regexPattern = 'document\\\.send\\\.php\\\?docid=[0-9]+';
-      $user_field = is_a($itemtype, CommonITILObject::class, true) ? 'users_id_recipient' : 'users_id';
-      $result = $DB->request([
-         'SELECT' => ['id', $field, $user_field],
-         'FROM'   => $itemtype::getTable(),
-         'WHERE'  => [
-            $field => ['REGEXP', $regexPattern]
-         ]
-      ]);
-      while ($data = $result->next()) {
-         preg_match('/document\\.send\\.php\\?docid=([0-9]+)/', $data[$field], $matches);
-         $docs_input[] = [
-            'documents_id'       => $matches[1],
-            'itemtype'           => $itemtype,
-            'items_id'           => $data['id'],
-            'timeline_position'  => CommonITILObject::NO_TIMELINE,
-            'users_id'           => $data[$user_field],
-
-            '_disablenotif'      => true, // prevent parent object "update" notification
-         ];
-      }
-   }
-   $ditem = new Document_Item();
-   foreach ($docs_input as $doc_input) {
-      if (!$ditem->alreadyExists($doc_input)) {
-         $ditem->add($doc_input);
-      }
-   }
-   /** /A doc_item to rule them all! */
-
    /** Appliances & webapps */
    require __DIR__ . '/update_94_95/appliances.php';
    /** /Appliances & webapps */

--- a/install/update_94_95.php
+++ b/install/update_94_95.php
@@ -1513,6 +1513,18 @@ HTML
    $migration->addConfig(['ssologout_url' => '']);
    /** SSO logout URL */
 
+   /** Document_Item unicity */
+   $migration->dropKey('glpi_documents_items', 'unicity');
+   $migration->migrationOneTable('glpi_documents_items');
+   $migration->addKey(
+      'glpi_documents_items',
+      ['documents_id', 'itemtype', 'items_id', 'timeline_position'],
+      'unicity',
+      'UNIQUE'
+   );
+   $migration->migrationOneTable('glpi_documents_items');
+   /** /Document_Item unicity */
+
    /** Appliances & webapps */
    require __DIR__ . '/update_94_95/appliances.php';
    /** /Appliances & webapps */

--- a/install/update_951_952.php
+++ b/install/update_951_952.php
@@ -44,16 +44,6 @@ function update951to952() {
    $migration->displayTitle(sprintf(__('Update to %s'), '9.5.2'));
    $migration->setVersion('9.5.2');
 
-   $migration->dropKey('glpi_documents_items', 'unicity');
-   $migration->migrationOneTable('glpi_documents_items');
-   $migration->addKey(
-      'glpi_documents_items',
-      ['documents_id', 'itemtype', 'items_id', 'timeline_position'],
-      'unicity',
-      'UNIQUE'
-   );
-   $migration->migrationOneTable('glpi_documents_items');
-
    /* Fix document_item migration */
    $migration->displayTitle("Building inline images data in " . Document_Item::getTable());
 

--- a/install/update_951_952.php
+++ b/install/update_951_952.php
@@ -44,6 +44,16 @@ function update951to952() {
    $migration->displayTitle(sprintf(__('Update to %s'), '9.5.2'));
    $migration->setVersion('9.5.2');
 
+   $migration->dropKey('glpi_documents_items', 'unicity');
+   $migration->migrationOneTable('glpi_documents_items');
+   $migration->addKey(
+      'glpi_documents_items',
+      ['documents_id', 'itemtype', 'items_id', 'timeline_position'],
+      'unicity',
+      'UNIQUE'
+   );
+   $migration->migrationOneTable('glpi_documents_items');
+
    /* Fix document_item migration */
    $migration->displayTitle("Building inline images data in " . Document_Item::getTable());
 

--- a/install/update_951_952.php
+++ b/install/update_951_952.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2018 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * Update from 9.4.6 to 9.4.7
+ *
+ * @return bool for success (will die for most error)
+ **/
+function update951to952() {
+   global $DB, $migration;
+
+   $updateresult     = true;
+
+   //TRANS: %s is the number of new version
+   $migration->displayTitle(sprintf(__('Update to %s'), '9.5.2'));
+   $migration->setVersion('9.5.2');
+
+   /* Fix document_item migration */
+   $migration->displayTitle("Building inline images data in " . Document_Item::getTable());
+
+   $itemtypes = [
+      'ITILFollowup' => 'content',
+      'ITILSolution' => 'content',
+      'Reminder'     => 'text',
+      'KnowbaseItem' => 'answer'
+   ];
+
+   foreach (['Change', 'Problem', 'Ticket'] as $itiltype) {
+        $itemtypes[$itiltype] = 'content';
+        $itemtypes[$itiltype . 'Task'] = 'content';
+   }
+
+   $docs_input =[];
+   foreach ($itemtypes as $itemtype => $field) {
+      // Check ticket and child items (followups, tasks, solutions) contents
+      $regexPattern = 'document\\\.send\\\.php\\\?docid=[0-9]+';
+      $user_field = is_a($itemtype, CommonITILObject::class, true) ? 'users_id_recipient' : 'users_id';
+      $result = $DB->request([
+         'SELECT' => ['id', $field, $user_field],
+         'FROM'   => $itemtype::getTable(),
+         'WHERE'  => [
+            $field => ['REGEXP', $regexPattern]
+         ]
+      ]);
+
+      while ($data = $result->next()) {
+         preg_match_all('/document\\.send\\.php\\?docid=([0-9]+)/', $data[$field], $matches);
+
+         // No inline documents found in this item, skip to next
+         if (!isset($matches[1])) {
+            continue;
+         }
+
+         foreach ($matches[1] as $docid) {
+            $docs_input[] = [
+               'documents_id'       => $docid,
+               'itemtype'           => $itemtype,
+               'items_id'           => $data['id'],
+               'timeline_position'  => CommonITILObject::NO_TIMELINE,
+               'users_id'           => $data[$user_field],
+               '_disablenotif'      => true, // prevent parent object "update" notification
+            ];
+         }
+      }
+   }
+
+   $ditem = new Document_Item();
+   foreach ($docs_input as $doc_input) {
+      if (!$ditem->alreadyExists($doc_input)) {
+         $ditem->add($doc_input);
+      }
+   }
+   /* /Fix document_item migration */
+
+   // ************ Keep it at the end **************
+   $migration->executeMigration();
+
+   return $updateresult;
+}

--- a/install/update_951_952.php
+++ b/install/update_951_952.php
@@ -31,7 +31,7 @@
  */
 
 /**
- * Update from 9.4.6 to 9.4.7
+ * Update from 9.5.1 to 9.5.2
  *
  * @return bool for success (will die for most error)
  **/


### PR DESCRIPTION
Inline image migration to glpi_documents_items was not working as expected, only the first image of each item was migrated.
This was cause by the use of preg_match (stop at first match) instead of preg_match_all.

These changes fix the migration process and move it to 9.5.2.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
