### PR TITLE
Clear output buffer before sending files

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -861,6 +861,11 @@ class Toolbox {
       $etag = md5_file($file);
       $lastModified = filemtime($file);
 
+      // Make sure there is nothing in the output buffer (In case stuff was added by core or misbehaving plugin).
+      // If there is any extra data, the sent file will be corrupted.
+      while (ob_get_level() > 0) {
+         ob_end_clean();
+      }
       // Now send the file with header() magic
       header("Last-Modified: ".gmdate("D, d M Y H:i:s", $lastModified)." GMT");
       header("Etag: $etag");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While troubleshooting a document issue, I noticed one of the plugins I had installed added some data to the output buffer when it was initialized and thereby corrupted any sent files. It would be good for GLPI to handle clearing the output buffer before sending files. No headers or data should be buffered before the Toolbox::sendFile function.