### PR TITLE
Don't show debug messages in API responses

### DIFF
--- a/inc/application/errorhandler.class.php
+++ b/inc/application/errorhandler.class.php
@@ -347,8 +347,8 @@ class ErrorHandler {
     */
    private function outputDebugMessage(string $error_type, string $message, string $log_level, bool $force = false) {
 
-      if (!$force
-          && (!isset($_SESSION['glpi_use_mode']) || $_SESSION['glpi_use_mode'] != \Session::DEBUG_MODE)) {
+      if ((!$force
+          && (!isset($_SESSION['glpi_use_mode']) || $_SESSION['glpi_use_mode'] != \Session::DEBUG_MODE)) || isAPI()) {
          return;
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7823

Don't show debug messages (HTML elements) in API responses because it breaks response parsing.