### PR TITLE
Fix status update of tasks served as VEVENT on CalDAV

### DIFF
--- a/inc/caldav/traits/vobjectconvertertrait.class.php
+++ b/inc/caldav/traits/vobjectconvertertrait.class.php
@@ -208,10 +208,11 @@ trait VobjectConverterTrait {
     * Get common item input for given component.
     *
     * @param Component $vcomponent
+    * @param bool      $is_new_item
     *
     * @return array
     */
-   protected function getCommonInputFromVcomponent(Component $vcomponent) {
+   protected function getCommonInputFromVcomponent(Component $vcomponent, bool $is_new_item = true) {
       if (!($vcomponent instanceof VEvent)
           && !($vcomponent instanceof VTodo)
           && !($vcomponent instanceof VJournal)) {
@@ -243,11 +244,12 @@ trait VobjectConverterTrait {
 
       $input['rrule'] = $this->getRRuleInputFromVComponent($vcomponent);
 
-      $state = GLPI_CALDAV_IMPORT_STATE;
-      if ($vcomponent instanceof VTodo) {
-         $state = $this->getStateInputFromVComponent($vcomponent) ?? $state;
+      $state = $this->getStateInputFromVComponent($vcomponent);
+      if ($state !== null) {
+         $input['state'] = $state;
+      } else if ($is_new_item) {
+         $input['state'] = GLPI_CALDAV_IMPORT_STATE;
       }
-      $input['state'] = $state;
 
       return $input;
    }

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -2126,7 +2126,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
          throw new UnexpectedValueException('RRULE not yet implemented for ITIL tasks');
       }
 
-      $input = $this->getCommonInputFromVcomponent($vtodo);
+      $input = $this->getCommonInputFromVcomponent($vtodo, $this->isNewItem());
 
       if (!$this->isNewItem()) {
          // self::prepareInputForUpdate() expect these fields to be set in input.

--- a/inc/planningexternalevent.class.php
+++ b/inc/planningexternalevent.class.php
@@ -442,7 +442,7 @@ JAVASCRIPT;
 
       $vcomp = $vcalendar->getBaseComponent();
 
-      $input = $this->getCommonInputFromVcomponent($vcomp);
+      $input = $this->getCommonInputFromVcomponent($vcomp, $this->isNewItem());
 
       $input['text'] = $input['content'];
       unset($input['content']);

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -2040,7 +2040,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
          throw new UnexpectedValueException('RRULE not yet implemented for Project tasks');
       }
 
-      $input = $this->getCommonInputFromVcomponent($vtodo);
+      $input = $this->getCommonInputFromVcomponent($vtodo, $this->isNewItem());
 
       if ($vtodo->DESCRIPTION instanceof FlatText) {
          // Description is not in HTML format

--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -1061,7 +1061,7 @@ class Reminder extends CommonDBVisible implements
 
       $vcomp = $vcalendar->getBaseComponent();
 
-      $input = $this->getCommonInputFromVcomponent($vcomp);
+      $input = $this->getCommonInputFromVcomponent($vcomp, $this->isNewItem());
 
       $input['text'] = $input['content'];
       unset($input['content']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Internal id. 20251

When tasks as handled as VEVENT by CalDAV server, any update coming from CalDAV client was reseting their status to 0 (information).