### PR TITLE
WIP - feat(rule): add action for RuleTicket engine

### DIFF
--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -2370,6 +2370,11 @@ class Rule extends CommonDBTM {
                if ($type=='defaultfromuser' || $type=='fromuser' || $type=='fromitem') {
                   return Dropdown::getYesNo($value);
                }
+
+               // $type == append_regex_result_from_user_group display text
+               if ($type=='append_regex_result_from_user_group') {
+                  return $this->displayAdditionRuleActionValue($value);
+               }
                // $type == assign
                $tmp = Dropdown::getDropdownName($action["table"], $value);
                return (($tmp == '&nbsp;') ? NOT_AVAILABLE : $tmp);

--- a/inc/ruleaction.class.php
+++ b/inc/ruleaction.class.php
@@ -388,20 +388,21 @@ class RuleAction extends CommonDBChild {
 
    static function getActions() {
 
-      return ['assign'              => __('Assign'),
-                   'append'              => __('Add'),
-                   'regex_result'        => __('Assign the value from regular expression'),
-                   'append_regex_result' => __('Add the result of regular expression'),
-                   'affectbyip'          => __('Assign: equipment by IP address'),
-                   'affectbyfqdn'        => __('Assign: equipment by name + domain'),
-                   'affectbymac'         => __('Assign: equipment by MAC address'),
-                   'compute'             => __('Recalculate'),
-                   'do_not_compute'      => __('Do not calculate'),
-                   'send'                => __('Send'),
-                   'add_validation'      => __('Send'),
-                   'fromuser'            => __('Copy from user'),
-                   'defaultfromuser'     => __('Copy default from user'),
-                   'fromitem'            => __('Copy from item')];
+      return ['assign'                              => __('Assign'),
+                   'append'                              => __('Add'),
+                   'regex_result'                        => __('Assign the value from regular expression'),
+                   'append_regex_result'                 => __('Add the result of regular expression'),
+                   'append_regex_result_from_user_group' => __('Add the result of regular expression from requester\'s groups'),
+                   'affectbyip'                          => __('Assign: equipment by IP address'),
+                   'affectbyfqdn'                        => __('Assign: equipment by name + domain'),
+                   'affectbymac'                         => __('Assign: equipment by MAC address'),
+                   'compute'                             => __('Recalculate'),
+                   'do_not_compute'                      => __('Do not calculate'),
+                   'send'                                => __('Send'),
+                   'add_validation'                      => __('Send'),
+                   'fromuser'                            => __('Copy from user'),
+                   'defaultfromuser'                     => __('Copy default from user'),
+                   'fromitem'                            => __('Copy from item')];
    }
 
 
@@ -487,6 +488,7 @@ class RuleAction extends CommonDBChild {
          //If a regex value is used, then always display an autocompletiontextfield
          case "regex_result" :
          case "append_regex_result" :
+         case "append_regex_result_from_user_group":
             Html::autocompletionTextField($this, "value", $param);
             break;
 

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -358,6 +358,28 @@ class RuleTicket extends Rule {
                      }
                   }
                   break;
+
+               case 'append_regex_result_from_user_group':
+                  if (isset($this->regex_results[0])) {
+                     $regexvalue = RuleAction::getRegexResultById($action->fields["value"],
+                                                                  $this->regex_results[0]);
+                  } else {
+                     $regexvalue = $action->fields["value"];
+                  }
+
+                  // Add groups of requester
+                  if (!isset($output['_groups_id_requester'])) {
+                     $output['_groups_id_requester'] = [];
+                  }
+
+                  foreach (Group_User::getUserGroups($input['_users_id_requester']) as $g) {
+                     preg_match($regexvalue, $g['name'], $matches, PREG_OFFSET_CAPTURE, 0);
+                     if (!empty($matches)) {
+                        $output['_groups_id_requester'][$g['id']] = $g['id'];
+                     }
+                  }
+
+               break;
             }
          }
       }
@@ -618,7 +640,7 @@ class RuleTicket extends Rule {
       $actions['_groups_id_requester']['type']              = 'dropdown';
       $actions['_groups_id_requester']['table']             = 'glpi_groups';
       $actions['_groups_id_requester']['condition']         = ['is_requester' => 1];
-      $actions['_groups_id_requester']['force_actions']     = ['assign', 'append', 'fromitem', 'defaultfromuser'];
+      $actions['_groups_id_requester']['force_actions']     = ['assign', 'append', 'fromitem', 'defaultfromuser', 'append_regex_result_from_user_group'];
       $actions['_groups_id_requester']['permitseveral']     = ['append'];
       $actions['_groups_id_requester']['appendto']          = '_additional_groups_requesters';
 


### PR DESCRIPTION
This PR allows you to add a requester group to the ticket from the list of requester groups based on a regex


Example : action to get the group with brackets from those of the user and set it as requester group

 ![image](https://user-images.githubusercontent.com/7335054/90621031-7f868600-e213-11ea-8e0f-c97f18344aab.png)

Best regards

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

