### PR TITLE
Fix class name case

### DIFF
--- a/inc/notificationtargetsavedsearch_alert.class.php
+++ b/inc/notificationtargetsavedsearch_alert.class.php
@@ -34,7 +34,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
-class NotificationTargetSavedsearch_Alert extends NotificationTarget {
+class NotificationTargetSavedSearch_Alert extends NotificationTarget {
 
 
    function getEvents() {


### PR DESCRIPTION
Internal ref: 20507.

Class case was incorrect, this had some unexpected effects like broken hooks for the collaborative tools plugin.

The plugin is iterating on `$CFG_GLPI['notificationtemplates_types']` and adding hooks for each items types.

In `$CFG_GLPI['notificationtemplates_types']`, the type is `SavedSearch_Alert` so the hook would be set to `NotificationTargetSavedSearch_Alert` and never work since the real class was `NotificationTargetsavedSearch_Alert`.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
