### PR TITLE
feat(rule): add action for RuleTicket engine

### DIFF
--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -2389,6 +2389,12 @@ class Rule extends CommonDBTM {
                if ($type=='defaultfromuser' || $type=='fromuser' || $type=='fromitem') {
                   return Dropdown::getYesNo($value);
                }
+
+               // $type == regex_result display text
+               if ($type=='regex_result') {
+                  return $this->displayAdditionRuleActionValue($value);
+               }
+
                // $type == assign
                $tmp = Dropdown::getDropdownName($action["table"], $value);
                return (($tmp == '&nbsp;') ? NOT_AVAILABLE : $tmp);

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -366,6 +366,16 @@ class RuleTicket extends Rule {
                            $output["itilcategories_id"] = $target_itilcategory;
                         }
                      }
+                  } else if ($action->fields["field"] == "_groups_id_requester") {
+                     foreach ($this->regex_results as $regex_result) {
+                        $regexvalue          = RuleAction::getRegexResultById($action->fields["value"],
+                                                                     $regex_result);
+                        $group = new Group();
+                        if ($group->getFromDBByCrit(["name" => $regexvalue,
+                                                      "is_requester" => true])) {
+                           $output['_additional_groups_requesters'][$group->getID()] = $group->getID();
+                        }
+                     }
                   }
                   break;
             }
@@ -628,7 +638,7 @@ class RuleTicket extends Rule {
       $actions['_groups_id_requester']['type']              = 'dropdown';
       $actions['_groups_id_requester']['table']             = 'glpi_groups';
       $actions['_groups_id_requester']['condition']         = ['is_requester' => 1];
-      $actions['_groups_id_requester']['force_actions']     = ['assign', 'append', 'fromitem', 'defaultfromuser'];
+      $actions['_groups_id_requester']['force_actions']     = ['assign', 'append', 'fromitem', 'defaultfromuser','regex_result'];
       $actions['_groups_id_requester']['permitseveral']     = ['append'];
       $actions['_groups_id_requester']['appendto']          = '_additional_groups_requesters';
 

--- a/tests/functionnal/RuleTicket.php
+++ b/tests/functionnal/RuleTicket.php
@@ -656,4 +656,109 @@ class RuleTicket extends DbTestCase {
       $this->array($task_data)->hasKey('content');
       $this->string($task_data['content'])->isEqualTo('test content');
    }
+
+   public function testGroupRequesterAssignFromUserGroupsAndRegex() {
+      $this->login();
+
+      // Create rule
+      $ruleticket = new \RuleTicket();
+      $rulecrit   = new \RuleCriteria();
+      $ruleaction = new \RuleAction();
+
+      $ruletid = $ruleticket->add($ruletinput = [
+         'name'         => 'test regex group requester criterion',
+         'match'        => 'AND',
+         'is_active'    => 1,
+         'sub_type'     => 'RuleTicket',
+         'condition'    => \RuleTicket::ONADD,
+         'is_recursive' => 0,
+      ]);
+      $this->checkInput($ruleticket, $ruletid, $ruletinput);
+
+      //create criteria to check if group requester match regex
+      $crit_id = $rulecrit->add($crit_input = [
+         'rules_id'  => $ruletid,
+         'criteria'  => '_groups_id_of_requester',
+         'condition' => \Rule::REGEX_MATCH,
+         'pattern'   => Toolbox::addslashes_deep('/(.+\([^()]*\))/'),   //retrieve groupe with '(' and ')'
+      ]);
+      //change value because of addslashes
+      $crit_input['pattern'] = '/(.+\([^()]*\))/';
+      $this->checkInput($rulecrit, $crit_id, $crit_input);
+
+      //create action to put  group matching on criteria
+      $action_id = $ruleaction->add($action_input = [
+         'rules_id'    => $ruletid,
+         'action_type' => 'regex_result',
+         'field'       => '_groups_id_requester',
+         'value'       => '#0',
+      ]);
+      $this->checkInput($ruleaction, $action_id, $action_input);
+
+      //create 2 new group
+      $group = new \Group();
+      $group_id1 = $group->add($group_input = [
+         "name"         => "group1 (5215)",
+         "is_requester" => true
+      ]);
+      $this->checkInput($group, $group_id1, $group_input);
+
+      //create new group
+      $group_id2 = $group->add($group_input = [
+         "name"         => "group2 (13)",
+         "is_requester" => true
+      ]);
+      $this->checkInput($group, $group_id2, $group_input);
+
+      //Load user post_only
+      $user = new \User();
+      $user->getFromDB(getItemByTypeName('User', 'post-only', true));
+
+      //add user to groups
+      $group_user = new Group_User();
+      $group_user_id1 = $group_user->add($group_user_input = [
+         "groups_id" => $group_id1,
+         "users_id"  => $user->fields['id']
+      ]);
+      $this->checkInput($group_user, $group_user_id1, $group_user_input);
+
+      $group_user = new Group_User();
+      $group_user_id2 = $group_user->add($group_user_input = [
+         "groups_id" => $group_id2,
+         "users_id"  => $user->fields['id']
+      ]);
+      $this->checkInput($group_user, $group_user_id2, $group_user_input);
+
+      // create ticket that trigger rule on creation
+      $ticket = new \Ticket();
+      $ticket->getEmpty();
+      $tickets_id = $ticket->add($ticket_input = [
+         'name'                  => 'Add group requester',
+         'id'                    => 0, //pass id = 0 because in IHM it's passed as POST
+         'content'               => 'test',
+         '_users_id_requester'   => $user->fields['id']
+      ]);
+      unset($ticket_input['_users_id_requester']);
+      $ticket_input['id'] = $tickets_id; //force id to $input
+      $this->checkInput($ticket, $tickets_id, $ticket_input);
+
+      //link between groupe1 and ticket will exist
+      $ticketGroup = new \Group_Ticket();
+      $this->boolean(
+         $ticketGroup->getFromDBByCrit([
+            'tickets_id'         => $tickets_id,
+            'groups_id'          => $group_id1,
+            'type'               => \CommonITILActor::REQUESTER
+         ])
+      )->isTrue();
+
+      //link between groupe2 and ticket will not exist
+      $this->boolean(
+         $ticketGroup->getFromDBByCrit([
+            'tickets_id'         => $tickets_id,
+            'groups_id'          => $group_id2,
+            'type'               => \CommonITILActor::REQUESTER
+         ])
+      )->isTrue();
+   }
 }


### PR DESCRIPTION
This PR allows you to add a requester group to the ticket from the list of requester groups based on a regex


Example : criterion

check if requester group have parenthesis

![image](https://user-images.githubusercontent.com/7335054/90731266-c59e2100-e2c9-11ea-8032-98684dba3f23.png)


Example : Action -> if so, affect the result of a regular expression using the string #0

![image](https://user-images.githubusercontent.com/7335054/90731140-94bdec00-e2c9-11ea-9f52-76bed830225b.png)


Best regards

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

