### PR TITLE
Prevent exception on sodium decrypt; fixes #7848

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -284,8 +284,18 @@ class Toolbox {
       }
 
       $content = base64_decode($content);
+
       $nonce = mb_substr($content, 0, SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES, '8bit');
+      if (mb_strlen($nonce, '8bit') !== SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES) {
+         trigger_error(
+            'Unable to extract nonce from content. It may not have been crypted with sodium functions.',
+            E_USER_ERROR
+         );
+         return '';
+      }
+
       $ciphertext = mb_substr($content, SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES, null, '8bit');
+
       $plaintext = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt(
          $ciphertext,
          $nonce,
@@ -293,7 +303,10 @@ class Toolbox {
          $key
       );
       if ($plaintext === false) {
-         Toolbox::logError('Unable to decrypt content. It may have been crypted with another key.');
+         trigger_error(
+            'Unable to decrypt content. It may have been crypted with another key.',
+            E_USER_ERROR
+         );
          return '';
       }
       return $plaintext;

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -378,6 +378,44 @@ class Toolbox extends \GLPITestCase {
       $this->string(\Toolbox::sodiumDecrypt(''))->isEmpty();
    }
 
+   /**
+    * Test invalid content. If not handled correctly, following sodium exception would be raised and fail the test.
+    * "SodiumException: public nonce size should be SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES bytes"
+    */
+   public function testSodiumDecryptInvalid() {
+      $result = null;
+
+      $this->when(
+         function () use (&$result) {
+            $result = \Toolbox::sodiumDecrypt('not a valid value');
+         }
+      )->error
+         ->withType(E_USER_ERROR)
+         ->withMessage('Unable to extract nonce from content. It may not have been crypted with sodium functions.')
+         ->exists();
+
+      $this->string($result)->isEmpty();
+   }
+
+   /**
+    * Test content crypted with another key.
+    */
+   public function testSodiumDecryptBadKey() {
+      $result = null;
+
+      $this->when(
+         function () use (&$result) {
+            // 'test' string crypted with a valid key used just for that
+            $result = \Toolbox::sodiumDecrypt('CUdPSEgzKroDOwM1F8lbC8WDcQUkGCxIZpdTEpp5W/PLSb70WmkaKP0Q7QY=');
+         }
+      )->error
+         ->withType(E_USER_ERROR)
+         ->withMessage('Unable to decrypt content. It may have been crypted with another key.')
+         ->exists();
+
+      $this->string($result)->isEmpty();
+   }
+
    protected function cleanProvider() {
       return [
          ['mystring', 'mystring', null, 15, 0.56, false],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7848 

I think `SodiumException: public nonce size should be SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES bytes` is mainly related to calls to `Toolbox::sodiumDecrypt()` method passing a values that has not be crypted using sodium functions.
If value is shorter than 24 bytes, the nonce will not matches  `SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES` length, and this an exception will be trigerred.