### PR TITLE
Fix software license items form; fixes #7853

### DIFF
--- a/inc/item_softwarelicense.class.php
+++ b/inc/item_softwarelicense.class.php
@@ -490,13 +490,9 @@ class Item_SoftwareLicense extends CommonDBRelation {
          echo "<table class='tab_cadre_fixe'>";
          echo "<tr class='tab_bg_2 center'>";
          echo "<td>";
-         $itemtypes = [];
-         foreach ($CFG_GLPI['software_types'] as $itemtype) {
-            $itemtypes[$itemtype] = $itemtype::getTypeName(1);
-         }
 
          $rand = mt_rand();
-         Dropdown::showItemTypes('itemtype', $itemtypes, [
+         Dropdown::showItemTypes('itemtype', $CFG_GLPI['software_types'], [
             'value'                 => 'Computer',
             'rand'                  => $rand,
             'width'                 => 'unset',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7853 

`Dropdown::showItemTypes()` expects a list of itemtypes to build its key/values.

In english, it was almost working as many itemtypes has a label that equals classname (i.e. 'Computer::getTypeName(1) == "Computer"', 'Monitor::getTypeName(1) == "Monitor"'), but in other languages, list was empty as passed values were not corresponding to valid itemtypes.