### PR TITLE
Fix Domain alerts

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -335,7 +335,8 @@ $CFG_GLPI["notificationtemplates_types"]  = ['CartridgeItem', 'Change', 'Consuma
                                              'ObjectLock', 'PlanningRecall', 'Problem',
                                              'Project', 'ProjectTask', 'Reservation',
                                              'SoftwareLicense', 'Ticket', 'User',
-                                             'SavedSearch_Alert', 'Certificate', 'Glpi\\Marketplace\\Controller'];
+                                             'SavedSearch_Alert', 'Certificate', 'Glpi\\Marketplace\\Controller',
+                                             'Domain'];
 
 $CFG_GLPI["contract_types"]               = array_merge(['Computer', 'Monitor', 'NetworkEquipment',
                                                   'Peripheral', 'Phone', 'Printer', 'Project', 'Line',

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -667,6 +667,16 @@ $tables['glpi_crontasks'] = [
       'mode'          => 2,
       'lastrun'       => null,
       'logs_lifetime' => 30,
+   ], [
+      'id'            => 38,
+      'itemtype'      => 'Domain',
+      'name'          => 'DomainsAlert',
+      'frequency'     => 86400,
+      'param'         => null,
+      'state'         => 1,
+      'mode'          => 2,
+      'lastrun'       => null,
+      'logs_lifetime' => 30,
    ],
 ];
 

--- a/install/update_951_952.php
+++ b/install/update_951_952.php
@@ -101,6 +101,18 @@ function update951to952() {
    }
    /* /Fix document_item migration */
 
+   /* Register missing DomainAlert crontask */
+   CronTask::Register(
+      'Domain',
+      'DomainsAlert',
+      DAY_TIMESTAMP,
+      [
+         'mode'  => CronTask::MODE_EXTERNAL,
+         'state' => CronTask::STATE_DISABLE,
+      ]
+   );
+   /* /Register missing DomainAlert crontask */
+
    // ************ Keep it at the end **************
    $migration->executeMigration();
 

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -291,8 +291,8 @@ class DbUtils extends DbTestCase {
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'id'))->isGreaterThan(0)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'context'))->isGreaterThan(0)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_tickets', 'entities_id'))->isIdenticalTo(2)
-            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'itemtype', ['frequency' => '86400']))->isIdenticalTo(14)
-            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'id', ['frequency' => '86400']))->isIdenticalTo(17)
+            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'itemtype', ['frequency' => '86400']))->isIdenticalTo(15)
+            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'id', ['frequency' => '86400']))->isIdenticalTo(18)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'context', ['name' => 'version']))->isIdenticalTo(1)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'id', ['context' => 'fakecontext']))->isIdenticalTo(0);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7835 

1. `Domain::DomainsAlert` crontask was not registered.
2. `Domain` was not part of `$CFG_GLPI["notificationtemplates_types"]`.