### PR TITLE
Include all ITIL objects related documents in notifications; fixes #7840

### DIFF
--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -151,7 +151,7 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
             ];
             if ($item instanceof CommonITILObject) {
                $item->getFromDB($current->fields['items_id']);
-               $doc_crit = $item->getAssociatedDocumentsCriteria();
+               $doc_crit = $item->getAssociatedDocumentsCriteria(true);
                if ($is_html) {
                   // Remove documents having "NO_TIMELINE" position if mail is HTML, as
                   // these documents corresponds to inlined images.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7840 

`CommonITILObject::getAssociatedDocumentsCriteria()` was checking for session rights before inclusion of followups and solutions documents in notifications. As notifications are handled by a crontask, we cannot rely on session.

I added the `$bypass_rights = true` parameter in order to include followups and solution documents without checking rights. Even if it looks like a security bypass, it only reproduces what was done in GLPI 9.4 when documents were directly attached to the ticket.

Alternative solution would be to be able to be able to know the user_id related to the notification beiing sent (it is not stored actually, and it could be null in case of anonymous observers), and to be able to do rights checks based on user_id instead of session (it requires a lot of work).