### PR TITLE
Add plugin lifecycle hooks

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -636,6 +636,7 @@ class Plugin extends CommonDBTM {
             'state'   => self::NOTINSTALLED,
          ]);
          $this->unload($this->fields['directory']);
+         self::doHook('post_plugin_uninstall', $this->fields['directory']);
 
          $type = INFO;
          $message = sprintf(__('Plugin %1$s has been uninstalled!'), $this->fields['name']);
@@ -699,6 +700,7 @@ class Plugin extends CommonDBTM {
                                       'state' => self::TOBECONFIGURED]);
                   $message = sprintf(__('Plugin %1$s has been installed and must be configured!'), $this->fields['name']);
                }
+               self::doHook('post_plugin_install', $this->fields['directory']);
             }
          } else {
             $type = WARNING;
@@ -786,6 +788,7 @@ class Plugin extends CommonDBTM {
             if (isset($_SESSION['glpimenu'])) {
                unset($_SESSION['glpimenu']);
             }
+            self::doHook('post_plugin_enable', $this->fields['directory']);
 
             Session::addMessageAfterRedirect(
                sprintf(__('Plugin %1$s has been activated!'), $this->fields['name']),
@@ -830,6 +833,7 @@ class Plugin extends CommonDBTM {
             'state' => self::NOTACTIVATED
          ]);
          $this->unload($this->fields['directory']);
+         self::doHook('post_plugin_disable', $this->fields['directory']);
 
          // reset menu
          if (isset($_SESSION['glpimenu'])) {
@@ -870,6 +874,11 @@ class Plugin extends CommonDBTM {
          ]
       );
 
+      $dirs = array_keys(self::$activated_plugins);
+      foreach ($dirs as $dir) {
+         self::doHook('post_plugin_disable', $dir);
+      }
+
       self::$activated_plugins = [];
       self::$loaded_plugins = [];
 
@@ -892,6 +901,7 @@ class Plugin extends CommonDBTM {
          CronTask::Unregister($this->fields['directory']);
 
          $this->unload($this->fields['directory']);
+         self::doHook('post_plugin_clean', $this->fields['directory']);
          $this->delete(['id' => $ID]);
       }
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add plugin hooks for the different stages of a plugin's lifecycle (install, enable, disable, uninstall, and clean).
Currently, other plugins are not told when the state of a plugin changes. This can cause issues if plugins build on top of others. For example, a plugin linking Problems to Alerts from the news plugin. We can hook into when an alert is deleted to cleanup records in the link table, but if the plugin is completely uninstalled, we need to know in order to truncate the table. Otherwise, if the News plugin is reinstalled, we will have stale data.