### PR TITLE
ITIL Object Kanban Views

### DIFF
--- a/ajax/kanban.php
+++ b/ajax/kanban.php
@@ -51,8 +51,7 @@ $action = $_REQUEST['action'];
 
 $nonkanban_actions = ['update', 'bulk_add_item', 'add_item', 'move_item', 'show_card_edit_form', 'delete_item'];
 if (isset($_REQUEST['itemtype'])) {
-   $traits = class_uses($_REQUEST['itemtype'], true);
-   if (!in_array($_REQUEST['action'], $nonkanban_actions) && (!$traits || !in_array(Kanban::class, $traits, true))) {
+   if (!in_array($_REQUEST['action'], $nonkanban_actions) && !Toolbox::hasTrait($_REQUEST['itemtype'], Kanban::class)) {
       // Bad request
       // For all actions, except those in $nonkanban_actions, we expect to be manipulating the Kanban itself.
       Toolbox::logError("Invalid itemtype parameter");
@@ -128,7 +127,7 @@ if ($_REQUEST['action'] === 'update') {
    $checkParams(['inputs']);
    $item = new $itemtype();
    $inputs = [];
-   parse_str($_REQUEST['inputs'], $inputs);
+   parse_str(html_entity_decode($_REQUEST['inputs']), $inputs);
 
    $bulk_item_list = preg_split('/\r\n|[\r\n]/', $inputs['bulk_item_list']);
    if (!empty($bulk_item_list)) {

--- a/css/includes/components/_kanban.scss
+++ b/css/includes/components/_kanban.scss
@@ -39,19 +39,6 @@
       font-size: 14px;
       padding: 10px;
 
-      input[type=text][name=filter]:not([type=submit]):not([type=button]) {
-         flex: 1 0 auto;
-         border-radius: unset;
-         background-color: white !important;
-         padding: 5px 10px;
-         font-size: 13px;
-      }
-      input[type=button].kanban-add-column:not([type=submit]):not([type=text]) {
-         margin-left: 5px;
-         padding: 7px 10px;
-         font-size: 13px;
-      }
-
       .fas {
          margin: auto auto auto 10px;
          font-size: 1.2em;
@@ -69,17 +56,11 @@
       z-index: 10;
 
       input {
-         border-radius: unset !important;
-
          &[type="checkbox"] {
             margin-right: 5px;
          }
          &:not([type="checkbox"]) {
             display: block;
-         }
-         &:not([type="submit"]):not([type="checkbox"]) {
-            width: 90%;
-            padding: 5px 10px;
          }
          &[type="submit"] {
             margin: auto;
@@ -171,7 +152,7 @@
 
          .kanban-column {
             margin-right: 16px;
-            min-width: 200px;
+            width: 350px;
             height: 600px;
             border-radius: 5px;
             flex-direction: column;
@@ -260,7 +241,7 @@
                }
 
                .kanban-column-title {
-                  margin-left: 15px;
+                  margin-left: 2px;
                   padding: 3px 12px;
                }
 
@@ -287,25 +268,11 @@
 
                .kanban-add-form {
                   input {
-                     border-radius: unset !important;
-                     display: block;
                      margin: 8px 0 0;
-                     padding: 5px 10px;
-
-                     &:not([type="submit"]) {
-                        width: 90%;
-                     }
-                     &[type="submit"] {
-                        margin: auto;
-                     }
                   }
 
                   textarea {
-                     border-radius: unset !important;
-                     width: 90%;
-                     resize: vertical;
                      margin: 8px 0;
-                     padding: 5px 10px;
                   }
                }
 
@@ -351,7 +318,6 @@
                      }
 
                      padding: 5px 10px 0;
-                     font-size: 1.1em;
                      font-weight: bold;
 
                      a:hover {
@@ -408,34 +374,42 @@
       &.itilstatus {
          &.assigned, &.new {
             background-color: #49bf4d;
+            color: #000f01;
          }
 
          &.accepted {
             background-color: green;
+            color: rgb(255, 255, 255);
          }
 
          &.refused {
             background-color: rgb(167, 47, 0);
+            color: rgb(19, 5, 0);
          }
 
          &.test, &.qualif, &.waiting {
             background-color: orange;
+            color: rgb(27, 18, 0);
          }
 
          &.approval {
             background-color: #8cabdb;
+            color: rgb(18, 24, 36)
          }
 
          &.eval {
             background-color: lightblue;
+            color: rgb(30, 38, 41);
          }
 
          &.closed, &.solved, &.observe, &.canceled {
             background-color: black;
+            color: white;
          }
 
          &.planned {
             background-color: #1b2f62;
+            color: #f3f3f5;
          }
       }
    }

--- a/css/includes/components/_kanban.scss
+++ b/css/includes/components/_kanban.scss
@@ -39,6 +39,19 @@
       font-size: 14px;
       padding: 10px;
 
+      input[type=text][name=filter]:not([type=submit]):not([type=button]) {
+         flex: 1 0 auto;
+         border-radius: unset;
+         background-color: white !important;
+         padding: 5px 10px;
+         font-size: 13px;
+      }
+      input[type=button].kanban-add-column:not([type=submit]):not([type=text]) {
+         margin-left: 5px;
+         padding: 7px 10px;
+         font-size: 13px;
+      }
+
       .fas {
          margin: auto auto auto 10px;
          font-size: 1.2em;
@@ -165,6 +178,11 @@
             flex: 1 0 auto;
             text-align: center;
             border-top: 5px solid $header-border-color;
+
+            &[data-drop-only=true] .kanban-body {
+               background: #fffa90;
+               color: #777620;
+            }
 
             &.ui-sortable-helper {
                cursor: grab;
@@ -382,10 +400,46 @@
             min-width: 200px;
             height: 600px;
             margin: 0 8px 0 0;
-            border-radius: 5px;
+            border-radius: 5px
          }
       }
    }
+   .kanban-color-preview, .kanban-column-title {
+      &.itilstatus {
+         &.assigned, &.new {
+            background-color: #49bf4d;
+         }
+
+         &.accepted {
+            background-color: green;
+         }
+
+         &.refused {
+            background-color: rgb(167, 47, 0);
+         }
+
+         &.test, &.qualif, &.waiting {
+            background-color: orange;
+         }
+
+         &.approval {
+            background-color: #8cabdb;
+         }
+
+         &.eval {
+            background-color: lightblue;
+         }
+
+         &.closed, &.solved, &.observe, &.canceled {
+            background-color: black;
+         }
+
+         &.planned {
+            background-color: #1b2f62;
+         }
+      }
+   }
+
    .kanban-color-preview {
       width: 1em;
       height: 1em;
@@ -400,7 +454,6 @@
       color: #777620;
       height: 40px;
       margin-top: 5px;
-
       &.invalid-position {
          border: 2px dashed #d3413c;
          background: #ff7370;

--- a/front/change.form.php
+++ b/front/change.form.php
@@ -158,7 +158,11 @@ if (isset($_POST["add"])) {
 
 } else {
    Html::header(Change::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "helpdesk", "change");
-   $change->display($_REQUEST);
+   if (isset($_GET['showglobalkanban']) && $_GET['showglobalkanban']) {
+      $change::showKanban(0);
+   } else {
+      $change->display($_REQUEST);
+   }
 
    if (isset($_GET['id']) && ($_GET['id'] > 0) && isset($_GET['_sol_to_kb'])) {
       Ajax::createIframeModalWindow(

--- a/front/problem.form.php
+++ b/front/problem.form.php
@@ -160,7 +160,11 @@ if (isset($_POST["add"])) {
    Html::redirect(Problem::getFormURLWithID($id));
 } else {
    Html::header(Problem::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "helpdesk", "problem");
-   $problem->display($_REQUEST);
+   if (isset($_GET['showglobalkanban']) && $_GET['showglobalkanban']) {
+      $problem::showKanban(0);
+   } else {
+      $problem->display($_REQUEST);
+   }
 
    if (isset($_GET['id']) && ($_GET['id'] > 0) && isset($_GET['_sol_to_kb'])) {
       Ajax::createIframeModalWindow(

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -241,7 +241,12 @@ if (isset($_GET["id"]) && ($_GET["id"] > 0)) {
        && isset($_REQUEST['items_id'])) {
       $_REQUEST['items_id'] = [$_REQUEST['itemtype'] => [$_REQUEST['items_id']]];
    }
-   $track->display($_REQUEST);
+
+   if (isset($_GET['showglobalkanban']) && $_GET['showglobalkanban']) {
+      $track::showKanban(0);
+   } else {
+      $track->display($_REQUEST);
+   }
 }
 
 

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -45,6 +45,7 @@ abstract class CommonITILObject extends CommonDBTM {
    use \Glpi\Features\Clonable;
    use \Glpi\Features\UserMention;
    use \Glpi\Features\Timeline;
+   use \Glpi\Features\Kanban;
 
    /// Users by type
    protected $users       = [];
@@ -7405,6 +7406,7 @@ abstract class CommonITILObject extends CommonDBTM {
       if ($tplclass::canView()) {
          $links['template'] = $tplclass::getSearchURL(false);
       }
+      $links['summary_kanban'] = static::getFormURL(false).'?showglobalkanban=1';
 
       return $links;
    }
@@ -8176,4 +8178,297 @@ abstract class CommonITILObject extends CommonDBTM {
     * @return string class name
     */
    abstract public static function getContentTemplatesParametersClass(): string;
+
+   static function getDataToDisplayOnKanban($ID, $criteria = []) {
+      global $DB, $CFG_GLPI;
+
+      $items      = [];
+
+      $itil_table = static::getTable();
+      $request = [
+         'SELECT' => [
+            $itil_table.'.*',
+         ],
+         'FROM'   => $itil_table,
+         'WHERE'  => ['is_deleted' => 0] + $criteria,
+      ] + getEntitiesRestrictCriteria();
+
+      $iterator = $DB->request($request);
+      while ($data = $iterator->next()) {
+         // Create a fake item to get just the actors without loading all other information about items.
+         $temp_item = new static;
+         $temp_item->fields['id'] = $data['id'];
+         $temp_item->loadActors();
+
+         // Build team member data
+         $supported_teamtypes = [
+            'User' => ['id', 'firstname', 'realname'],
+            'Group' => ['id', 'name'],
+            'Supplier' => ['id', 'name'],
+         ];
+         $members = [
+            'User'      => $temp_item->getUsers(CommonITILActor::ASSIGN),
+            'Group'     => $temp_item->getGroups(CommonITILActor::ASSIGN),
+            'Supplier'   => $temp_item->getSuppliers(CommonITILActor::ASSIGN),
+         ];
+         $team = [];
+         foreach ($supported_teamtypes as $itemtype => $fields) {
+            $fields[] = 'id';
+            $fields[] = new QueryExpression($DB->quoteValue($itemtype).' AS '.$DB->quoteName('itemtype'));
+
+            $member_ids = array_map(static function($e) use($itemtype) {
+               return $e[$itemtype::getForeignKeyField()];
+            }, $members[$itemtype]);
+            if (count($member_ids)) {
+               $itemtable = $itemtype::getTable();
+               $all_items = $DB->request([
+                  'SELECT'    => $fields,
+                  'FROM'      => $itemtable,
+                  'WHERE'     => [
+                     "{$itemtable}.id"   => $member_ids
+                  ]
+               ]);
+               $all_members[$itemtype] = [];
+               while ($member_data = $all_items->next()) {
+                  $team[] = $member_data;
+               }
+            }
+         }
+
+         $data['_itemtype'] = static::class;
+         $data['_team'] = $team;
+         if (static::class === Ticket::class) {
+            $ticket_table = Ticket::getTable();
+            $tt_table = Ticket_Ticket::getTable();
+            $links = [];
+            $link_iterator = $DB->request([
+               'FROM'   => new \QueryUnion([
+                  [
+                     'SELECT' => [
+                        new QueryExpression($DB::quoteName('tickets_id_1').' AS '.$DB::quoteName('tickets_id')),
+                        'status'
+                     ],
+                     'FROM'   => $tt_table,
+                     'LEFT JOIN' => [
+                        $ticket_table => [
+                           'ON'  => [
+                              $ticket_table  => 'id',
+                              $tt_table      => 'tickets_id_1'
+                           ]
+                        ]
+                     ],
+                     'WHERE'  => [
+                        'tickets_id_1' => $data['id'],
+                        'link' => Ticket_Ticket::PARENT_OF
+                     ]
+                  ],
+                  [
+                     'SELECT' => [
+                        new QueryExpression($DB::quoteName('tickets_id_2').' AS '.$DB::quoteName('tickets_id')),
+                        'status'
+                     ],
+                     'FROM'   => $tt_table,
+                     'LEFT JOIN' => [
+                        $ticket_table => [
+                           'ON'  => [
+                              $ticket_table  => 'id',
+                              $tt_table      => 'tickets_id_1'
+                           ]
+                        ]
+                     ],
+                     'WHERE'  => [
+                        'tickets_id_2' => $data['id'],
+                        'link' => Ticket_Ticket::SON_OF
+                     ]
+                  ]
+               ])
+            ]);
+            while ($link_data = $link_iterator->next()) {
+               $links[$link_data['tickets_id']] = $link_data;
+            }
+            if ($links) {
+               if (count($links)) {
+                  $data['_steps'] = $links;
+               }
+            }
+         } else {
+            $data['_steps'] = [];
+         }
+         $data['_readonly'] = false;
+         $items[$data['id']] = $data;
+      }
+
+      return $items;
+   }
+
+   static function getKanbanColumns($ID, $column_field = null, $column_ids = [], $get_default = false) {
+      if (!in_array($column_field, ['status'])) {
+         return [];
+      }
+
+      $columns = [];
+      $criteria = [];
+      if (!empty($column_ids)) {
+         $card_column_ids = array_filter($column_ids, static function($column_id) {
+            // Never show closed items since there would be too many items. This column will instead be a drop-zone only.
+            return (int) $column_id !== self::CLOSED;
+         }, ARRAY_FILTER_USE_BOTH);
+         $criteria = [
+            'status'   => $card_column_ids
+         ];
+      }
+      $items      = self::getDataToDisplayOnKanban($ID, $criteria);
+
+      $extracolumns = self::getAllKanbanColumns($column_field, $column_ids, $get_default);
+      foreach ($extracolumns as $column_id => $column) {
+         $columns[$column_id] = $column;
+      }
+
+      foreach ($items as $item) {
+         if (!array_key_exists($item[$column_field], $columns)) {
+            continue;
+         }
+         $itemtype = $item['_itemtype'];
+         $card = [
+            'id'              => "{$itemtype}-{$item['id']}",
+            'title'           => Html::link($item['name'], $itemtype::getFormURLWithID($item['id'])),
+            'title_tooltip'   => Html::resume_text(RichText::getTextFromHtml($item['content'], false, true), 100),
+            'is_deleted'      => $item['is_deleted'] ?? false,
+         ];
+
+         $content = "<div class='kanban-plugin-content'>";
+         $plugin_content_pre = Plugin::doHookFunction('pre_kanban_content', [
+            'itemtype' => $itemtype,
+            'items_id' => $item['id'],
+         ]);
+         if (!empty($plugin_content_pre['content'])) {
+            $content .= $plugin_content_pre['content'];
+         }
+         $content .= "</div>";
+         // Core content
+         $content .= "<div class='kanban-core-content'>";
+         if (isset($item['_steps']) && count($item['_steps'])) {
+            $done = count(array_filter($item['_steps'], static function($l) {
+               return in_array($l['status'], static::getClosedStatusArray());
+            }));
+            $total = count($item['_steps']);
+            $content .= "<div class='flex-break'></div>";
+            $content .= sprintf(__('%s / %s tasks complete'), $done, $total);
+         }
+         $content .= "<div class='flex-break'></div>";
+
+         $content .= "</div>";
+         $content .= "<div class='kanban-plugin-content'>";
+         $plugin_content_post = Plugin::doHookFunction('post_kanban_content', [
+            'itemtype' => $itemtype,
+            'items_id' => $item['id'],
+         ]);
+         if (!empty($plugin_content_post['content'])) {
+            $content .= $plugin_content_post['content'];
+         }
+         $content .= "</div>";
+
+         $card['content'] = $content;
+         $card['_team'] = $item['_team'];
+         $card['_readonly'] = $item['_readonly'];
+         $card['_form_link'] = $itemtype::getFormUrlWithID($item['id']);
+         $columns[$item[$column_field]]['items'][] = $card;
+      }
+
+      // If no specific columns were asked for, drop empty columns.
+      // If specific columns were asked for, such as when loading a user's Kanban view, we must preserve them.
+      // We always preserve the 'No Status' column.
+      foreach ($columns as $column_id => $column) {
+         if ($column_id !== 0 && !in_array($column_id, $column_ids) &&
+            (!isset($column['items']) || !count($column['items']))) {
+            unset($columns[$column_id]);
+         }
+      }
+      return $columns;
+   }
+
+   static function showKanban($ID) {
+      $itilitem = new static();
+
+      if (($ID <= 0 && !Project::canView()) ||
+         ($ID > 0 && (!$itilitem->getFromDB($ID) || !$itilitem->canView()))) {
+         return false;
+      }
+
+      $supported_itemtypes = [];
+      if (static::canCreate()) {
+         $supported_itemtypes[static::class] = [
+            'name' => static::getTypeName(1),
+            'icon' => static::getIcon(),
+            'fields' => [
+               'name'   => [
+                  'placeholder'  => __('Name')
+               ],
+               'content'   => [
+                  'placeholder'  => __('Content'),
+                  'type'         => 'textarea'
+               ],
+               'users_id'  => [
+                  'type'         => 'hidden',
+                  'value'        => $_SESSION['glpiID']
+               ]
+            ]
+         ];
+      }
+      $column_field = [
+         'id' => 'status',
+         'extra_fields' => []
+      ];
+
+      $itemtype = static::class;
+      $rights = [
+         'create_item'                    => self::canCreate(),
+         'delete_item'                    => self::canDelete(),
+         'create_column'                  => false,
+         'modify_view'                    => true,
+         'order_card'                     => true,
+         'create_card_limited_columns'    => []
+      ];
+
+      TemplateRenderer::getInstance()->display('components/kanban/kanban.html.twig', [
+         'kanban_id'                   => 'kanban',
+         'rights'                      => $rights,
+         'supported_itemtypes'         => $supported_itemtypes,
+         'max_team_images'             => 3,
+         'column_field'                => $column_field,
+         'item'                        => [
+            'itemtype'  => $itemtype,
+            'items_id'  => $ID
+         ]
+      ]);
+   }
+
+   static function getAllForKanban($active = true, $current_id = -1) {
+      // ITIL items only have a global view
+      $items = [
+         -1 => __('Global')
+      ];
+      return $items;
+   }
+
+   static function getAllKanbanColumns($column_field = null, $column_ids = [], $get_default = false) {
+
+      if ($column_field === null) {
+         $column_field = 'status';
+      }
+      $columns = [];
+      if ($column_field === null || $column_field === 'status') {
+         $all_statuses = static::getAllStatusArray();
+         foreach ($all_statuses as $status_id => $status) {
+            $columns['status'][$status_id] = [
+               'name'         => $status,
+               'color_class'  => 'itilstatus '.static::getStatusKey($status_id),
+               'drop_only'    => (int) $status_id === self::CLOSED
+            ];
+         }
+      } else {
+         return [];
+      }
+      return $columns[$column_field];
+   }
 }

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -8309,10 +8309,6 @@ abstract class CommonITILObject extends CommonDBTM {
       $columns = [];
       $criteria = [];
       if (!empty($column_ids)) {
-         $card_column_ids = array_filter($column_ids, static function($column_id) {
-            // Never show closed items since there would be too many items. This column will instead be a drop-zone only.
-            return (int) $column_id !== self::CLOSED;
-         }, ARRAY_FILTER_USE_BOTH);
          $criteria = [
             'status'   => $card_column_ids
          ];

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -8310,7 +8310,7 @@ abstract class CommonITILObject extends CommonDBTM {
       $criteria = [];
       if (!empty($column_ids)) {
          $criteria = [
-            'status'   => $card_column_ids
+            'status'   => $column_ids
          ];
       }
       $items      = self::getDataToDisplayOnKanban($ID, $criteria);

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -8180,7 +8180,7 @@ abstract class CommonITILObject extends CommonDBTM {
    abstract public static function getContentTemplatesParametersClass(): string;
 
    static function getDataToDisplayOnKanban($ID, $criteria = []) {
-      global $DB, $CFG_GLPI;
+      global $DB;
 
       $items      = [];
 

--- a/inc/define.php
+++ b/inc/define.php
@@ -505,9 +505,9 @@ $CFG_GLPI['javascript'] = [
    'helpdesk'  => [
       'dashboard' => $dashboard_libs,
       'planning'  => ['clipboard', 'fullcalendar', 'tinymce', 'planning'],
-      'ticket'    => array_merge(['rateit', 'tinymce'], $dashboard_libs),
-      'problem'   => ['tinymce'],
-      'change'    => ['tinymce'],
+      'ticket'    => array_merge(['rateit', 'tinymce', 'kanban'], $dashboard_libs),
+      'problem'   => ['tinymce', 'kanban'],
+      'change'    => ['tinymce', 'kanban'],
       'stat'      => ['charts']
    ],
    'tools'     => [

--- a/inc/item_kanban.class.php
+++ b/inc/item_kanban.class.php
@@ -58,6 +58,13 @@ class Item_Kanban extends CommonDBRelation {
       $oldstate = self::loadStateForItem($itemtype, $items_id);
       $users_id = $force_global ? 0 : Session::getLoginUserID();
       $state = $item->prepareKanbanStateForUpdate($oldstate, $state, $users_id);
+      $all_columns = $item->getAllKanbanColumns();
+      foreach ($state as $column_i => $column) {
+         if ($all_columns[$column['column']]['drop_only']) {
+            unset($state[$column_i]);
+         }
+      }
+
       if ($state === null || $state === 'null' || $state === false) {
          // Save was probably denied in prepareKanbanStateForUpdate or an invalid state was given
          return false;

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -1928,7 +1930,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
    }
 
    static function getDataToDisplayOnKanban($ID, $criteria = []) {
-      global $DB;
+      global $DB, $CFG_GLPI;
 
       $items      = [];
 
@@ -1951,7 +1953,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
                ]
             ]
          ] + $project_visibility['LEFT JOIN'],
-         'WHERE'     => $project_visibility['WHERE']
+         'WHERE'     => $project_visibility['WHERE'],
       ];
       if ($ID > 0) {
          $request['WHERE']['glpi_projects.projects_id'] = $ID;

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -30,8 +30,6 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Application\View\TemplateRenderer;
-
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -402,14 +402,14 @@ class GLPIKanbanRights {
 
          // Dropdown for overflow (Card)
 
-         let card_overflow_dropdown = "<ul id='kanban-item-overflow-dropdown' class='kanban-dropdown  dropdown-menu' style='display: none'>";
+         let card_overflow_dropdown = "<ul id='kanban-item-overflow-dropdown' class='kanban-dropdown dropdown-menu' style='display: none'>";
          card_overflow_dropdown += `
-            <li class='kanban-item-goto'>
+            <li class='kanban-item-goto dropdown-item'>
                <a href="#"><i class="fas fa-share"></i>${__('Go to')}</a>
             </li>`;
          if (self.rights.canDeleteItem()) {
             card_overflow_dropdown += `
-                <li class='kanban-item-remove'>
+                <li class='kanban-item-remove  dropdown-item'>
                    <span>
                       <i class="fas fa-trash-alt"></i>${__('Delete')}
                    </span>
@@ -1915,7 +1915,7 @@ class GLPIKanbanRights {
             $(column_left).append("<i class='fas fa-caret-right fa-lg kanban-collapse-column btn btn-sm btn-ghost-secondary' title='" + __('Toggle collapse') + "'/>");
          }
          $(column_left).append("<span class='kanban-column-title badge "+(column['color_class'] || '')+"' style='background-color: "+column['header_color']+"; color: "+column['header_fg_color']+";'>" + column['name'] + "</span></span>");
-         $(column_right).append("<span class='kanban_nb bg-secondary'>"+count+"</span>");
+         $(column_right).append("<span class='kanban_nb badge bg-secondary'>"+count+"</span>");
          $(column_right).append(getColumnToolbarElement(column));
          $(column_el).prepend(column_header);
          // Re-apply header text color to handle the actual background color now that the element is actually in the DOM.

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -401,13 +401,15 @@ class GLPIKanbanRights {
          kanban_container.append(column_overflow_dropdown);
 
          // Dropdown for overflow (Card)
+
          let card_overflow_dropdown = "<ul id='kanban-item-overflow-dropdown' class='kanban-dropdown  dropdown-menu' style='display: none'>";
+         card_overflow_dropdown += `
+            <li class='kanban-item-goto'>
+               <a href="#"><i class="fas fa-share"></i>${__('Go to')}</a>
+            </li>`;
          if (self.rights.canDeleteItem()) {
             card_overflow_dropdown += `
-                <li class='kanban-item-goto dropdown-item'>
-                   <a href="#"><i class="fas fa-share"></i>${__('Go to')}</a>
-                </li>
-                <li class='kanban-item-remove dropdown-item'>
+                <li class='kanban-item-remove'>
                    <span>
                       <i class="fas fa-trash-alt"></i>${__('Delete')}
                    </span>
@@ -562,7 +564,9 @@ class GLPIKanbanRights {
          let already_processed = [];
          $.each(self.user_state.state, function(position, column) {
             if (column['visible'] !== false && column !== 'false') {
-               appendColumn(column['column'], self.columns[column['column']], columns_container);
+               if (self.columns[column['column']] !== undefined) {
+                  appendColumn(column['column'], self.columns[column['column']], columns_container);
+               }
             }
             already_processed.push(column['column']);
          });
@@ -916,7 +920,11 @@ class GLPIKanbanRights {
                } else {
                   list_item += "<input type='checkbox' class='form-check-input' />";
                }
-               list_item += "<span class='kanban-color-preview' style='background-color: "+column['header_color']+"'></span>";
+               if (typeof column['color_class'] !== "undefined") {
+                  list_item += "<span class='kanban-color-preview "+column['color_class']+"'></span>";
+               } else {
+                  list_item += "<span class='kanban-color-preview' style='background-color: "+column['header_color']+"'></span>";
+               }
                list_item += column['name'] + "</li>";
                list += list_item;
             });
@@ -1268,7 +1276,7 @@ class GLPIKanbanRights {
       **/
       const getTeamBadge = function(teammember) {
          const itemtype = teammember["itemtype"];
-         const items_id = teammember["items_id"];
+         const items_id = teammember["id"];
 
          if (self.team_badge_cache[itemtype] === undefined ||
                  self.team_badge_cache[itemtype][items_id] === undefined) {
@@ -1331,8 +1339,8 @@ class GLPIKanbanRights {
                   if (card["_team"] !== undefined) {
                      Object.values(card["_team"]).slice(0, self.max_team_images).forEach(function(teammember) {
                         if (teammember['itemtype'] === 'User') {
-                           if (self.team_badge_cache['User'][teammember['items_id']] === undefined) {
-                              users[teammember['items_id']] = teammember;
+                           if (self.team_badge_cache['User'][teammember['id']] === undefined) {
+                              users[teammember['id']] = teammember;
                            }
                         }
                      });
@@ -1539,13 +1547,27 @@ class GLPIKanbanRights {
        * @returns {boolean} True if the color is more light.
        */
       const isLightColor = function(hex) {
-         const c = hex.substring(1);
+         const c = hex.startsWith('#') ? hex.substring(1) : hex;
          const rgb = parseInt(c, 16);
          const r = (rgb >> 16) & 0xff;
          const g = (rgb >>  8) & 0xff;
          const b = (rgb >>  0) & 0xff;
          const lightness = 0.2126 * r + 0.7152 * g + 0.0722 * b;
          return lightness > 110;
+      };
+
+      /**
+       * Convert a CSS RGB or RGBA string to a hex string including the '#' character.
+       * @param {string} rgb The RGB or RGBA string
+       * @returns {string} The hex color string
+       */
+      const rgbToHex = function(rgb) {
+         const pattern = /^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+\.?\d*))?\)$/;
+         const hex = rgb.match(pattern).slice(1).map((n, i) => (i === 3 ? Math.round(parseFloat(n) * 255) : parseFloat(n))
+            .toString(16).padStart(2, '0') // Convert to hex values
+            .replace('NaN', '') // Handle NaN values
+         ).join('');
+         return `#${hex}`;
       };
 
       /**
@@ -1884,10 +1906,6 @@ class GLPIKanbanRights {
          }
          const cards = column['items'] !== undefined ? column['items'] : [];
 
-         const header_color = column['header_color'];
-         const is_header_light = header_color ? isLightColor(header_color) : !self.dark_theme;
-         const header_text_class = is_header_light ? 'kanban-text-dark' : 'kanban-text-light';
-
          const column_header = $("<header class='kanban-column-header'></header>");
          const column_content = $("<div class='kanban-column-header-content'></div>").appendTo(column_header);
          const count = column['items'] !== undefined ? column['items'].length : 0;
@@ -1896,33 +1914,50 @@ class GLPIKanbanRights {
          if (self.rights.canModifyView()) {
             $(column_left).append("<i class='fas fa-caret-right fa-lg kanban-collapse-column btn btn-sm btn-ghost-secondary' title='" + __('Toggle collapse') + "'/>");
          }
-         $(column_left).append("<span class='kanban-column-title badge "+header_text_class+"' style='background-color: "+column['header_color']+"; color: "+column['header_fg_color']+";'>" + column['name'] + "</span></span>");
-         $(column_right).append("<span class='kanban_nb badge bg-secondary'>"+count+"</span>");
+         $(column_left).append("<span class='kanban-column-title badge "+(column['color_class'] || '')+"' style='background-color: "+column['header_color']+"; color: "+column['header_fg_color']+";'>" + column['name'] + "</span></span>");
+         $(column_right).append("<span class='kanban_nb bg-secondary'>"+count+"</span>");
          $(column_right).append(getColumnToolbarElement(column));
          $(column_el).prepend(column_header);
+         // Re-apply header text color to handle the actual background color now that the element is actually in the DOM.
+         const column_title = $('#'+column['id']).find('.kanban-column-title').eq(0);
+         let header_color = column_title.css('background-color') ? rgbToHex(column_title.css('background-color')) : '#ffffff';
+         const is_header_light = header_color ? isLightColor(header_color) : !self.dark_theme;
+         const header_text_class = is_header_light ? 'kanban-text-dark' : 'kanban-text-light';
+         column_title.removeClass('kanban-text-light kanban-text-dark');
+         column_title.addClass(header_text_class);
 
-         $("<ul class='kanban-body card-body'></ul>").appendTo(column_el);
+         const column_body = $("<ul class='kanban-body card-body'></ul>").appendTo(column_el);
 
-         let added = [];
-         $.each(self.user_state.state, function(i, c) {
-            if (c['column'] === column_id) {
-               $.each(c['cards'], function(i2, card) {
-                  $.each(cards, function(i3, card2) {
-                     if (card2['id'] === card) {
-                        appendCard(column_el, card2);
-                        added.push(card2['id']);
-                        return false;
-                     }
+         column_el.attr('data-drop-only', column['drop_only']);
+
+         if (!column['drop_only']) {
+            let added = [];
+            $.each(self.user_state.state, function (i, c) {
+               if (c['column'] === column_id) {
+                  $.each(c['cards'], function (i2, card) {
+                     $.each(cards, function (i3, card2) {
+                        if (card2['id'] === card) {
+                           appendCard(column_el, card2);
+                           added.push(card2['id']);
+                           return false;
+                        }
+                     });
                   });
-               });
-            }
-         });
+               }
+            });
 
-         $.each(cards, function(card_id, card) {
-            if (added.indexOf(card['id']) < 0) {
-               appendCard(column_el, card, revalidate);
-            }
-         });
+            $.each(cards, function (card_id, card) {
+               if (added.indexOf(card['id']) < 0) {
+                  appendCard(column_el, card, revalidate);
+               }
+            });
+         } else {
+            $(`
+               <li class="position-relative" style="width: 250px">
+                  ${__('This column cannot support showing cards due to how many cards would be shown. You can still drag cards into this column.')}
+               </li>
+            `).appendTo(column_body);
+         }
 
          refreshSortables();
       };
@@ -2080,7 +2115,7 @@ class GLPIKanbanRights {
                column_id: column_id
             }
          }).done(function(column) {
-            if (column !== undefined) {
+            if (column !== undefined && column.length > 0) {
                self.columns[column_id] = column[column_id];
                appendColumn(column_id, self.columns[column_id], null, revalidate);
             }

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -798,7 +798,7 @@ class GLPIKanbanRights {
          });
          $('#kanban-bulk-add-dropdown li').on('click', function(e) {
             e.preventDefault();
-            const selection = $(e.target);
+            const selection = $(e.target).closest('li');;
             // Traverse all the way up to the top-level overflow dropdown
             const dropdown = selection.closest('.kanban-dropdown');
             // Get the button that triggered the dropdown and then get the column that it is a part of
@@ -1672,7 +1672,7 @@ class GLPIKanbanRights {
 
          const uniqueID = Math.floor(Math.random() * 999999);
          const formID = "form_add_" + itemtype + "_" + uniqueID;
-         let add_form = "<form id='" + formID + "' class='kanban-add-form kanban-bulk-add-form kanban-form no-track dropdown-menu'>";
+         let add_form = "<form id='" + formID + "' class='kanban-add-form kanban-bulk-add-form kanban-form no-track'>";
 
          add_form += `
             <div class='kanban-item-header'>

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -798,7 +798,7 @@ class GLPIKanbanRights {
          });
          $('#kanban-bulk-add-dropdown li').on('click', function(e) {
             e.preventDefault();
-            const selection = $(e.target).closest('li');;
+            const selection = $(e.target).closest('li');
             // Traverse all the way up to the top-level overflow dropdown
             const dropdown = selection.closest('.kanban-dropdown');
             // Get the button that triggered the dropdown and then get the column that it is a part of

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -2115,7 +2115,7 @@ class GLPIKanbanRights {
                column_id: column_id
             }
          }).done(function(column) {
-            if (column !== undefined && column.length > 0) {
+            if (column !== undefined && Object.keys(column).length > 0) {
                self.columns[column_id] = column[column_id];
                appendColumn(column_id, self.columns[column_id], null, revalidate);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Expand supported Kanban types to include ITIL Objects to offer a new way to view service requests, changes, and problems.

Done:
- [x] Basic global Kanban support including:
  - Drag and drop between columns to change status
  - Built-in state saving for card ordering
  - Show/hide columns based on the ITIL Object's statuses
- [x] Column header colors

To do:
- [x] Fix ability to add items from the Kanban.
- [x] Teams (badges shown on the cards). Use Assigned users, groups and suppliers.
- [x] Handle child tickets
- [ ] Handle planned tasks?
- [x] Fix card actions

~A quick warning if testing: There is currently no limit to the number of cards shown in the closed column so having a large number of closed items will cause performance issues.~
~Also, since this was initially done before the Modern UI work, it relies on jQuery dialogs as does the existing Kanban code to view the items in a Kanban. You won be able to click the title of the cards to open the items.~

![Screenshot from 2020-08-30 18-49-25](https://user-images.githubusercontent.com/17678637/91671116-ba30ce00-eaf1-11ea-85fb-56c7e7e91464.png)
