### PR TITLE
Prevent mail import failure to break collector

### DIFF
--- a/tests/emails-tests/17-malformed-email.eml
+++ b/tests/emails-tests/17-malformed-email.eml
@@ -1,0 +1,3 @@
+Subject: This message is malformed
+
+This is a malformed mail with no headers. It should be rejected properly.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Mails that trigger an exception will not block anymore the mailgate cron. They will be handled as `NotImportedEmail` with a `FAILED_OPERATION` status.