### PR TITLE
Fix external links search option; fixes #7915

### DIFF
--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -659,7 +659,7 @@ class Link extends CommonDBTM {
 
       if (!Session::isCron()
           && !isCommandLine() && isset($_SESSION['glpiactiveentities_string'])) {
-         $newtab['joinparams']['condition'] = getEntitiesRestrictCriteria('NEWTABLE');
+         $newtab['joinparams']['condition'] = getEntitiesRestrictRequest('AND', 'NEWTABLE');
       }
       $tab[] = $newtab;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7915 

`joinparam` conditions are still based on SQL string.