### PR TITLE
fix(ui): fix mini dashboard CSS

### DIFF
--- a/css/dashboard.scss
+++ b/css/dashboard.scss
@@ -61,6 +61,11 @@ $break_tablet: 1400px;
       width: calc(80% + 28px);
       margin: 0 auto;
       margin-bottom: -35px;
+      z-index: 1;
+
+      & + .search_page {
+         z-index: 2;
+      }
 
       .card {
          padding: 0 3px;


### PR DESCRIPTION

This PR fix height of mini dashoard which overlaps ticket search form

Fix #7867 


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7867 
