### PR TITLE
Add check for invalid address or netmask

### DIFF
--- a/inc/ipnetwork.class.php
+++ b/inc/ipnetwork.class.php
@@ -971,17 +971,16 @@ class IPNetwork extends CommonImplicitTreeDropdown {
 
       foreach (self::searchNetworksContainingIP($item) as $networks_id) {
          if ($network->getFromDB($networks_id)) {
-
-            if ($createRow) {
-               $row = $row->createRow();
-            }
-
             $address = $network->getAddress();
             $netmask = $network->getNetmask();
 
             // Stop if we failed to retrieve address or netmask
             if (!$address || !$netmask) {
                continue;
+            }
+
+            if ($createRow) {
+               $row = $row->createRow();
             }
 
             //TRANS: %1$s is address, %2$s is netmask

--- a/inc/ipnetwork.class.php
+++ b/inc/ipnetwork.class.php
@@ -975,9 +975,22 @@ class IPNetwork extends CommonImplicitTreeDropdown {
             if ($createRow) {
                $row = $row->createRow();
             }
+
+            $address = $network->getAddress();
+            $netmask = $network->getNetmask();
+
+            // Stop if we failed to retrieve address or netmask
+            if (!$address || !$netmask) {
+               continue;
+            }
+
             //TRANS: %1$s is address, %2$s is netmask
-            $content = sprintf(__('%1$s / %2$s'), $network->getAddress()->getTextual(),
-                               $network->getNetmask()->getTextual());
+            $content = sprintf(
+               __('%1$s / %2$s'),
+               $address->getTextual(),
+               $netmask->getTextual()
+            );
+
             if ($network->fields['addressable'] == 1) {
                $content = "<span class='b'>".$content."</span>";
             }


### PR DESCRIPTION
Internal ref: 20133.

`$network->getAddress()` and `$network->getNetmask()` can both return `false` on invalid values but the current code always expect success.

These changes avoid fatal errors if one of the above return `false`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
