### PR TITLE
Prevent failure of "glpi:security:change_key" command

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -289,7 +289,7 @@ class Toolbox {
       if (mb_strlen($nonce, '8bit') !== SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES) {
          trigger_error(
             'Unable to extract nonce from content. It may not have been crypted with sodium functions.',
-            E_USER_ERROR
+            E_USER_WARNING
          );
          return '';
       }
@@ -305,7 +305,7 @@ class Toolbox {
       if ($plaintext === false) {
          trigger_error(
             'Unable to decrypt content. It may have been crypted with another key.',
-            E_USER_ERROR
+            E_USER_WARNING
          );
          return '';
       }

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -390,7 +390,7 @@ class Toolbox extends \GLPITestCase {
             $result = \Toolbox::sodiumDecrypt('not a valid value');
          }
       )->error
-         ->withType(E_USER_ERROR)
+         ->withType(E_USER_WARNING)
          ->withMessage('Unable to extract nonce from content. It may not have been crypted with sodium functions.')
          ->exists();
 
@@ -409,7 +409,7 @@ class Toolbox extends \GLPITestCase {
             $result = \Toolbox::sodiumDecrypt('CUdPSEgzKroDOwM1F8lbC8WDcQUkGCxIZpdTEpp5W/PLSb70WmkaKP0Q7QY=');
          }
       )->error
-         ->withType(E_USER_ERROR)
+         ->withType(E_USER_WARNING)
          ->withMessage('Unable to decrypt content. It may have been crypted with another key.')
          ->exists();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. `E_USER_ERROR` error level result in script exiting (it is a fatal error).
With `E_USER_ERROR`:
![image](https://user-images.githubusercontent.com/33253653/92576235-90ae3a00-f289-11ea-89ba-d937aa24a4f4.png)
With `E_USER_WARNING`:
![image](https://user-images.githubusercontent.com/33253653/92576354-ba676100-f289-11ea-990a-6cf4eef30b92.png)

2. Old key was not fetch before its replacement, so migration was corrupting all existing passwords.