### PR TITLE
Add ability to test deprecations

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -628,17 +628,7 @@ class Toolbox {
     * @return void
     */
    static function deprecated($message = "Called method is deprecated") {
-      try {
-         self::log(null, Logger::NOTICE, [$message]);
-      } finally {
-         if (defined('TU_USER')) {
-            if (isCommandLine()) {
-               echo self::backtrace(null);
-            } else {
-               self::backtrace();
-            }
-         }
-      }
+      trigger_error($message, E_USER_DEPRECATED);
    }
 
 

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -977,4 +977,15 @@ class Toolbox extends \GLPITestCase {
    public function testIsValidWebUrl($url, $result) {
       $this->boolean(\Toolbox::isValidWebUrl($url))->isIdenticalTo((bool)$result, $url);
    }
+
+   public function testDeprecated() {
+      $this->when(
+         function () {
+            \Toolbox::deprecated('Calling this function is deprecated');
+         }
+      )->error()
+         ->withType(E_USER_DEPRECATED)
+         ->withMessage('Calling this function is deprecated')
+         ->exists();
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Calling `Toolbox::log();` with a `notice` level triggers a `RuntimeException` in unit test context.

Directly using `trigger_error` will output almost the same trace (thanks to the GLPI error handling refactored in 9.5), and would give ability to keep some tests on deprecated usages.

Tests that does not "catch" errors will still fails with this kind of message:
![image](https://user-images.githubusercontent.com/33253653/93069156-9e92ff00-f67d-11ea-9047-45c4169a3612.png)