### PR TITLE
Fix js filter (select2:unselecting)

### DIFF
--- a/js/log_filters.js
+++ b/js/log_filters.js
@@ -44,7 +44,7 @@ $(function() {
    var bindFilterChange = function () {
       // Workaround to prevent opening of dropdown when removing item using the "x" button.
       // Without this workaround, orphan dropdowns remains in page when reloading tab.
-      $('.log_history_filter_row .select2-hidden-accessible').on('select2:unselecting', function(ev) {
+      $(document).on('select2:unselecting', '.log_history_filter_row .select2-hidden-accessible', function(ev) {
          if (ev.params.args.originalEvent) {
             ev.params.args.originalEvent.stopPropagation();
          }


### PR DESCRIPTION
The jquery filter meant to catch `select2:unselecting` events was not working properly.
For example, when removing any filters from the "Users", "Fields" or "Update" dropdowns of the log page, options were "stuck" in the top left corner:

![image](https://user-images.githubusercontent.com/42734840/93222189-fa898080-f76e-11ea-984f-d7df8f16a73f.png)

These changes fixes this by using DOM event delegation.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
