### PR TITLE
Fix mailcollector image when tag is splitted on multiple lines; fixes #7964

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -6690,7 +6690,7 @@ class Ticket extends CommonITILObject {
             // Set tag if image matches
             foreach ($files as $data => $filename) {
                if (preg_match("/".$data."/i", $src)) {
-                  $html = preg_replace("`<img.*src=['|\"]".$src."['|\"][^>]*\>`", "<p>".Document::getImageTag($tags[$filename])."</p>", $html);
+                  $html = preg_replace("/<img.*src=['|\"]".preg_quote($src, '/')."['|\"][^>]*\>/s", "<p>".Document::getImageTag($tags[$filename])."</p>", $html);
                }
             }
          }

--- a/tests/emails-tests/18-image-on-multiple-lines.eml
+++ b/tests/emails-tests/18-image-on-multiple-lines.eml
@@ -1,0 +1,58 @@
+Return-Path: normal@glpi-project.org
+Received: from 192.168.1.3 (LHLO mail.glpi-project.org) (192.168.1.3)
+ by mail.glpi-project.org with LMTP; Thu, 7 Jun 2018 12:05:51 +0200
+ (CEST)
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+    by mail.glpi-project.org (Postfix) with ESMTP id 6E50A7E807FE
+    for <unittests@glpi-project.org>; Thu,  7 Jun 2018 12:05:51 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+    by mail.glpi-project.org (Postfix) with ESMTP id 5C15F7E80423
+    for <unittests@glpi-project.org>; Thu,  7 Jun 2018 12:05:51 +0200 (CEST)
+Received: from mail.glpi-project.org ([127.0.0.1])
+    by localhost (mail.glpi-project.org [127.0.0.1]) (amavisd-new, port 10026)
+    with ESMTP id zZ35QyFtsE9R for <unittests@glpi-project.org>;
+    Thu,  7 Jun 2018 12:05:51 +0200 (CEST)
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+    by mail.glpi-project.org (Postfix) with ESMTP id 214627E807E8
+    for <unittests@glpi-project.org>; Thu,  7 Jun 2018 12:05:51 +0200 (CEST)
+Date: Thu, 7 Jun 2018 12:05:51 +0200 (CEST)
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <1695134010.1757889.1528365951040.JavaMail.zimbra@glpi-project.org>
+In-Reply-To: <1954034179.1757759.1528365914864.JavaMail.zimbra@glpi-project.org>
+Subject: Image tag splitted on multiple lines
+MIME-Version: 1.0
+Content-Type: multipart/alternative; 
+    boundary="----=_Part_1757883_1359581901.1528365951028"
+
+------=_Part_1757883_1359581901.1528365951028
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+Image:
+
+------=_Part_1757883_1359581901.1528365951028
+Content-Type: multipart/related; 
+    boundary="----=_Part_1757884_1267006027.1528365951028"
+
+------=_Part_1757884_1267006027.1528365951028
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+<body>
+Image: <img
+src="cid:6f1f48de7c56cc3412e74008ad9f7c640091f5e3@zimbra">
+</body>
+</html>
+------=_Part_1757884_1267006027.1528365951028
+Content-Type: image/gif; name=18-blank.gif
+Content-Disposition: attachment; filename=18-blank.gif
+Content-Transfer-Encoding: base64
+Content-ID: <6f1f48de7c56cc3412e74008ad9f7c640091f5e3@zimbra>
+
+R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+------=_Part_1757884_1267006027.1528365951028--
+
+------=_Part_1757883_1359581901.1528365951028--
+

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -330,6 +330,7 @@ class MailCollector extends DbTestCase {
                'тест2',
                'Inlined image with no Content-Disposition',
                'This is a mail without subject.', // No subject = name is set using ticket contents
+               'Image tag splitted on multiple lines',
             ]
          ],
          // Mails having "normal" user as observer (add_cc_to_observer = true)
@@ -344,7 +345,7 @@ class MailCollector extends DbTestCase {
 
       foreach ($actors_specs as $actor_specs) {
          $iterator = $DB->request([
-            'SELECT' => ['t.id', 't.name', 'tu.users_id'],
+            'SELECT' => ['t.id', 't.name', 't.content', 'tu.users_id'],
             'FROM'   => \Ticket::getTable() . " AS t",
             'INNER JOIN'   => [
                \Ticket_User::getTable() . " AS tu"  => [
@@ -365,6 +366,7 @@ class MailCollector extends DbTestCase {
          $names = [];
          while ($data = $iterator->next()) {
             $names[] = $data['name'];
+            $this->string($data['content'])->notContains('cid:'); // check that image were correctly imported
          }
 
          $this->array($names)->isIdenticalTo($actor_specs['tickets_names']);
@@ -376,6 +378,7 @@ class MailCollector extends DbTestCase {
          '01-Screenshot-2018-4-12 Observatoire - France très haut débit.png',
          '01-test.JPG',
          '15-image001.png',
+         '18-blank.gif',
       ];
 
       $iterator = $DB->request(
@@ -399,12 +402,12 @@ class MailCollector extends DbTestCase {
          ]
       );
 
-      $this->integer(count($iterator))->isIdenticalTo(count($expected_docs));
-
       $filenames = [];
       while ($data = $iterator->next()) {
          $filenames[] = $data['filename'];
       }
       $this->array($filenames)->isIdenticalTo($expected_docs);
+
+      $this->integer(count($iterator))->isIdenticalTo(count($expected_docs));
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7964 

Sometimes, the img tag inside an email is splitted on multiple lines (see new eml file in tests), and in this case, image was not attached correctly to ticket.

Failure before fix : https://app.circleci.com/pipelines/github/glpi-project/glpi/5821/workflows/4d95aec6-f944-4809-9cce-fd56fb183156/jobs/47318