### PR TITLE
Fix scrollbar from softwares list on computer

### DIFF
--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -482,7 +482,7 @@ class Ajax {
 
                // remove scroll event bind, select2 bind it on parent with scrollbars (the tab currently)
                // as the select2 disapear with this tab reload, remove the event to prevent issues (infinite scroll to top)
-               $('#tabs$rand .ui-tabs-panel[aria-expanded=true]').unbind('scroll');
+               $('#tabs$rand .ui-tabs-panel[aria-hidden=false]').unbind('scroll');
 
                // Save tab
                var currenthref = $('#tabs$rand ul>li a').eq(current_index).attr('href');


### PR DESCRIPTION
With GLPI 9.5.1 and split layout,

When we diplayeds software from computer, if we change display (number of items), scroolbar is break.


![image](https://user-images.githubusercontent.com/7335054/93570083-c42c4b00-f992-11ea-98be-b919690c38d0.png)


this RP prevent this.

Explaination : 

```reloadtab``` function unbin scroll to prevent ifinite scroll to top, by using a DOM selector with attr ```[aria-expanded=true]```  which no longuer exist

```js
$('#tabs$rand .ui-tabs-panel[aria-expanded=true]').unbind('scroll');
```


HTML is constructed like this

```html
<div id="ui-id-27" aria-live="polite" aria-labelledby="ui-id-26" role="tabpanel" class="ui-tabs-panel ui-corner-bottom ui-widget-content" aria-hidden="false">
```

```aria-expanded=true``` need to be replaced by ```[aria-hidden=false]```


Best regards

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed internal tickets | 20736
