### PR TITLE
Fix missing icon; fixes #7976

### DIFF
--- a/inc/item_rack.class.php
+++ b/inc/item_rack.class.php
@@ -898,7 +898,7 @@ JAVASCRIPT;
             $icon = "fas fa-server";
             break;
          case "Reserved":
-            $icon = "fa-lock";
+            $icon = "fas fa-lock";
             break;
 
          default:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7976

Checked for other broken icons using:
`grep -rni inc/ -e 'fa-' | grep -vE '(fas |fa |far |fab )'`
This was the only case I saw of an icon with a missing `fa`, `fas`, `far`, or `fab` class.
