### PR TITLE
Fix plugin unloading

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -247,12 +247,12 @@ class Plugin extends CommonDBTM {
    private function unload($plugin_key) {
       global $LOADED_PLUGINS;
 
-      if (isset(self::$activated_plugins[$plugin_key])) {
-         unset(self::$activated_plugins[$plugin_key]);
+      if (($key = array_search($plugin_key, self::$activated_plugins)) !== false) {
+         unset(self::$activated_plugins[$key]);
       }
 
-      if (isset(self::$loaded_plugins[$plugin_key])) {
-         unset(self::$loaded_plugins[$plugin_key]);
+      if (($key = array_search($plugin_key, self::$loaded_plugins)) !== false) {
+         unset(self::$loaded_plugins[$key]);
       }
 
       if (isset($LOADED_PLUGINS[$plugin_key])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The arrays used for active and loaded plugins have default keys and not indexed by directory name or plugin ID. This causes plugins to stay loaded until the page refreshes and the DB is checked again.
It causes an issue when you call Plugin::uninstall followed by Plugin::isInstalled because it still shows as installed when it isn't.