### PR TITLE
Fix itilcategory dropdown in tickets/changes/problems

### DIFF
--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -953,8 +953,11 @@ class Change extends CommonITILObject {
       if ($canupdate) {
          $conditions = ['is_change' => 1];
 
-         $opt = ['value'  => $this->fields["itilcategories_id"],
-                      'entity' => $this->fields["entities_id"]];
+         $opt = [
+            'value'  => $this->fields["itilcategories_id"],
+            'entity' => Session::getActiveEntities(),
+         ];
+
          /// Auto submit to load template
          if (!$ID) {
             $opt['on_change'] = 'this.form.submit()';

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -1348,8 +1348,10 @@ class Problem extends CommonITILObject {
       if ($canupdate) {
          $conditions = ['is_problem' => 1];
 
-         $opt = ['value'  => $this->fields["itilcategories_id"],
-                      'entity' => $this->fields["entities_id"]];
+         $opt = [
+            'value'  => $this->fields["itilcategories_id"],
+            'entity' => Session::getActiveEntities(),
+         ];
          /// Auto submit to load template
          if (!$ID) {
             $opt['on_change'] = 'this.form.submit()';

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -1414,4 +1414,15 @@ class Session {
    public static function getActiveEntity() {
       return $_SESSION['glpiactive_entity'];
    }
+
+   /**
+    * Get active entity id.
+    *
+    * @since 9.5
+    *
+    * @return int
+    */
+   public static function getActiveEntities() {
+      return $_SESSION['glpiactiveentities'];
+   }
 }

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -1416,11 +1416,11 @@ class Session {
    }
 
    /**
-    * Get active entity id.
+    * Get active entities id.
     *
     * @since 9.5
     *
-    * @return int
+    * @return array
     */
    public static function getActiveEntities() {
       return $_SESSION['glpiactiveentities'];

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -1423,6 +1423,6 @@ class Session {
     * @return array
     */
    public static function getActiveEntities() {
-      return $_SESSION['glpiactiveentities'];
+      return $_SESSION['glpiactiveentities'] ?? [];
    }
 }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -4565,8 +4565,11 @@ class Ticket extends CommonITILObject {
       if ($canupdate || $can_requester) {
          $conditions = [];
 
-         $opt = ['value'  => $this->fields["itilcategories_id"],
-                      'entity' => $this->fields["entities_id"]];
+         $opt = [
+            'value'  => $this->fields["itilcategories_id"],
+            'entity' => Session::getActiveEntities(),
+         ];
+
          if (Session::getCurrentInterface() == "helpdesk") {
             $conditions['is_helpdeskvisible'] = 1;
          }


### PR DESCRIPTION
Internal ref: 20757.

Given the following ITIL categories in multiple entities:
![image](https://user-images.githubusercontent.com/42734840/94034134-f3432200-fdc1-11ea-8a2c-7c9673f65ee3.png)

---

Before (categories in child entities are ignored):
![image](https://user-images.githubusercontent.com/42734840/94034149-f9d19980-fdc1-11ea-8a96-7285a2e64a59.png)

---

After:
![image](https://user-images.githubusercontent.com/42734840/94034168-fe964d80-fdc1-11ea-804c-39a9f9dfceba.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
