### PR TITLE
fix(core): add missing 'use'

### DIFF
--- a/inc/event.class.php
+++ b/inc/event.class.php
@@ -41,6 +41,8 @@ use \Session;
 use \Toolbox;
 use \Infocom;
 use \DBConnection;
+use \CronTask;
+use \Document;
 
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");


### PR DESCRIPTION
<!--

Fix PHP error when trying to access to GLPI log (Administration > log)

```
Uncaught Exception Error: Class 'Glpi\CronTask' not found in /var/www/html/GLPI/9.5-bugfixes/inc/event.class.php at line 164
```
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
