### PR TITLE
Fix RSS feeds duplicates

### DIFF
--- a/inc/rssfeed.class.php
+++ b/inc/rssfeed.class.php
@@ -776,6 +776,7 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria {
     * Show the feed content
     **/
    function showFeedContent() {
+
       if (!$this->canViewItem()) {
          return false;
       }

--- a/inc/rssfeed.class.php
+++ b/inc/rssfeed.class.php
@@ -776,7 +776,6 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria {
     * Show the feed content
     **/
    function showFeedContent() {
-
       if (!$this->canViewItem()) {
          return false;
       }
@@ -913,9 +912,10 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria {
 
       $table = self::getTable();
       $criteria = [
-         'SELECT' => "$table.*",
-         'FROM'   => $table,
-         'ORDER'  => "$table.name"
+         'SELECT'   => "$table.*",
+         'DISTINCT' => true,
+         'FROM'     => $table,
+         'ORDER'    => "$table.name"
       ];
 
       if ($personal) {


### PR DESCRIPTION
Internal ref: 20213.

SQL queries fetching may return duplicates as the user may be in multiple groups, profiles, ...
Using distinct solve this issue.

## Example

### Feed settings
![image](https://user-images.githubusercontent.com/42734840/94433337-71277480-0198-11eb-94ff-0c4e306cb06e.png)

### User is in the two groups specified in the feed's settings
![image](https://user-images.githubusercontent.com/42734840/94433475-a92eb780-0198-11eb-8acc-3dc375f1438a.png)


### Before fix
![image](https://user-images.githubusercontent.com/42734840/94433155-2a397f00-0198-11eb-94be-312d67eb7e2d.png)


### After fix
![image](https://user-images.githubusercontent.com/42734840/94433111-168e1880-0198-11eb-8a8b-e94f46e3284a.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
