### PR TITLE
Override canDelete, canPurge and canPurgeItem on DomainRecord

### DIFF
--- a/inc/domainrecord.class.php
+++ b/inc/domainrecord.class.php
@@ -164,10 +164,6 @@ class DomainRecord extends CommonDBChild {
       return $tab;
    }
 
-   public function canCreateItem() {
-      return count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes']);
-   }
-
    static function canCreate() {
       if (count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'])) {
          return true;
@@ -180,6 +176,27 @@ class DomainRecord extends CommonDBChild {
          return true;
       }
       return parent::canUpdate();
+   }
+
+
+   static function canDelete() {
+       if (count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'])) {
+           return true;
+       }
+       return parent::canDelete();
+   }
+
+
+   static function canPurge() {
+       if (count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'])) {
+           return true;
+       }
+       return parent::canPurge();
+   }
+
+
+   public function canCreateItem() {
+      return count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes']);
    }
 
 
@@ -196,6 +213,15 @@ class DomainRecord extends CommonDBChild {
          || in_array($this->fields['domainrecordtypes_id'], $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'])
          );
    }
+
+
+   function canPurgeItem() {
+      return parent::canPurgeItem()
+         && ($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'] == [-1]
+         || in_array($this->fields['domainrecordtypes_id'], $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'])
+         );
+   }
+
 
    function defineTabs($options = []) {
       $ong = [];

--- a/inc/domainrecord.class.php
+++ b/inc/domainrecord.class.php
@@ -180,18 +180,18 @@ class DomainRecord extends CommonDBChild {
 
 
    static function canDelete() {
-       if (count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'])) {
-           return true;
-       }
-       return parent::canDelete();
+      if (count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'])) {
+         return true;
+      }
+      return parent::canDelete();
    }
 
 
    static function canPurge() {
-       if (count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'])) {
-           return true;
-       }
-       return parent::canPurge();
+      if (count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'])) {
+         return true;
+      }
+      return parent::canPurge();
    }
 
 


### PR DESCRIPTION
Configured manageable records types now allows removal without
setting right on Domain itself

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 20613 (internal)
