### PR TITLE
fix(plugin): sanitize after plugin override

### DIFF
--- a/inc/includes.php
+++ b/inc/includes.php
@@ -72,10 +72,7 @@ if (isset($_POST)) {
    }
    $_POST = Toolbox::sanitize($_POST);
 }
-if (isset($_GET)) {
-   $_UGET = $_GET; //keep raw, as a workaround
-   $_GET  = Toolbox::sanitize($_GET);
-}
+
 if (isset($_REQUEST)) {
    $_UREQUEST = $_REQUEST; //keep raw, as a workaround
    $_REQUEST  = Toolbox::sanitize($_REQUEST);
@@ -105,6 +102,10 @@ if (!isset($PLUGINS_INCLUDED)) {
    $plugin->init(true);
 }
 
+if (isset($_GET)) {
+   $_UGET = $_GET; //keep raw, as a workaround
+   $_GET  = Toolbox::sanitize($_GET);
+}
 
 if (!isset($_SESSION["MESSAGE_AFTER_REDIRECT"])) {
    $_SESSION["MESSAGE_AFTER_REDIRECT"]=[];


### PR DESCRIPTION
since a while, GLPI sanitize $_GET from ```include.class.php```

But this change takes place before the plugins are loaded.

if plugin want to override some data into $_GET, it is not taken into account because plugin are called after.

This Pr prevent this




| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
