### PR TITLE
Do not run PHP 7.4 tests on GLPI 9.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,9 +327,18 @@ workflows:
       - php_7_4_test_suite:
           requires:
             - checkout
+          filters:
+            branches:
+              ignore: 9.4/bugfixes
       - php_7_4_mysql_5_6_test_suite:
           requires:
             - checkout
+          filters:
+            branches:
+              ignore: 9.4/bugfixes
       - php_7_4_mysql_8_0_test_suite:
           requires:
             - checkout
+          filters:
+            branches:
+              ignore: 9.4/bugfixes


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
