### PR TITLE
Fix validation refusal detection

### DIFF
--- a/inc/commonitilvalidation.class.php
+++ b/inc/commonitilvalidation.class.php
@@ -1405,7 +1405,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
       if ($validation_percent > 0) {
          if (($statuses[self::ACCEPTED]*100/$total) >= $validation_percent) {
             $validation_status = self::ACCEPTED;
-         } else if (($statuses[self::REFUSED]*100/$total) >= $validation_percent) {
+         } else if (($statuses[self::REFUSED]*100/$total) + $validation_percent > 100) {
             $validation_status = self::REFUSED;
          }
       } else {

--- a/inc/commonitilvalidation.class.php
+++ b/inc/commonitilvalidation.class.php
@@ -1382,8 +1382,6 @@ abstract class CommonITILValidation  extends CommonDBChild {
    **/
    static function computeValidationStatus(CommonITILObject $item) {
 
-      $validation_status  = self::WAITING;
-
       // Percent of validation
       $validation_percent = $item->fields['validation_percent'];
 
@@ -1402,21 +1400,46 @@ abstract class CommonITILValidation  extends CommonDBChild {
          }
       }
 
+      return self::computeValidation(
+         $statuses[self::ACCEPTED] * 100 / $total,
+         $statuses[self::REFUSED]  * 100 / $total,
+         $validation_percent
+      );
+   }
+
+   /**
+    * Compute the validation status from the percentage of acceptation, the
+    * percentage of refusals and the target acceptation threshold
+    *
+    * @param int $accepted             0-100 (percentage of acceptation)
+    * @param int $refused              0-100 (percentage of refusals)
+    * @param int $validation_percent   0-100 (target accepation threshold)
+    *
+    * @return int the validation status : ACCEPTED|REFUSED|WAITING
+    */
+   public static function computeValidation(
+      int $accepted,
+      int $refused,
+      int $validation_percent
+   ): int {
       if ($validation_percent > 0) {
-         if (($statuses[self::ACCEPTED]*100/$total) >= $validation_percent) {
-            $validation_status = self::ACCEPTED;
-         } else if (($statuses[self::REFUSED]*100/$total) + $validation_percent > 100) {
-            $validation_status = self::REFUSED;
+         if ($accepted >= $validation_percent) {
+            // We have reached the acceptation threshold
+            return self::ACCEPTED;
+         } else if ($refused + $validation_percent > 100) {
+            // We can no longer reach the acceptation threshold
+            return self::REFUSED;
          }
       } else {
-         if ($statuses[self::ACCEPTED]) {
-            $validation_status = self::ACCEPTED;
-         } else if ($statuses[self::REFUSED]) {
-            $validation_status = self::REFUSED;
+         // No validation threshold set, one approval or denial is enough
+         if ($accepted > 0) {
+            return self::ACCEPTED;
+         } else if ($refused > 0) {
+            return self::REFUSED;
          }
       }
 
-      return $validation_status;
+      return self::WAITING;
    }
 
 

--- a/tests/units/CommonITILValidation.php
+++ b/tests/units/CommonITILValidation.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use CommonITILValidation as CoreCommonITILValidation;
+use GLPITestCase;
+
+class CommonITILValidation extends GLPITestCase {
+
+   protected function testComputeValidationProvider(): array {
+      return [
+         // 100% validation required
+         [
+            'accepted'           => 0,
+            'refused'            => 0,
+            'validation_percent' => 100,
+            'result'             => CoreCommonITILValidation::WAITING,
+         ],
+         [
+            'accepted'           => 10,
+            'refused'            => 0,
+            'validation_percent' => 100,
+            'result'             => CoreCommonITILValidation::WAITING,
+         ],
+         [
+            'accepted'           => 90,
+            'refused'            => 0,
+            'validation_percent' => 100,
+            'result'             => CoreCommonITILValidation::WAITING,
+         ],
+         [
+            'accepted'           => 100,
+            'refused'            => 0,
+            'validation_percent' => 100,
+            'result'             => CoreCommonITILValidation::ACCEPTED,
+         ],
+         [
+            'accepted'           => 0,
+            'refused'            => 10,
+            'validation_percent' => 100,
+            'result'             => CoreCommonITILValidation::REFUSED,
+         ],
+         // 50% validation required
+         [
+            'accepted'           => 0,
+            'refused'            => 0,
+            'validation_percent' => 50,
+            'result'             => CoreCommonITILValidation::WAITING,
+         ],
+         [
+            'accepted'           => 10,
+            'refused'            => 0,
+            'validation_percent' => 50,
+            'result'             => CoreCommonITILValidation::WAITING,
+         ],
+         [
+            'accepted'           => 50,
+            'refused'            => 0,
+            'validation_percent' => 50,
+            'result'             => CoreCommonITILValidation::ACCEPTED,
+         ],
+         [
+            'accepted'           => 0,
+            'refused'            => 10,
+            'validation_percent' => 50,
+            'result'             => CoreCommonITILValidation::WAITING,
+         ],
+         [
+            'accepted'           => 0,
+            'refused'            => 50,
+            'validation_percent' => 50,
+            'result'             => CoreCommonITILValidation::WAITING,
+         ],
+         [
+            'accepted'           => 0,
+            'refused'            => 60,
+            'validation_percent' => 50,
+            'result'             => CoreCommonITILValidation::REFUSED,
+         ],
+         // 0% validation required
+         [
+            'accepted'           => 0,
+            'refused'            => 0,
+            'validation_percent' => 0,
+            'result'             => CoreCommonITILValidation::WAITING,
+         ],
+         [
+            'accepted'           => 10,
+            'refused'            => 0,
+            'validation_percent' => 0,
+            'result'             => CoreCommonITILValidation::ACCEPTED,
+         ],
+         [
+            'accepted'           => 0,
+            'refused'            => 10,
+            'validation_percent' => 0,
+            'result'             => CoreCommonITILValidation::REFUSED,
+         ],
+      ];
+   }
+
+   /**
+    * @dataprovider testComputeValidationProvider
+    */
+   public function testComputeValidation(
+      int $accepted,
+      int $refused,
+      int $validation_percent,
+      int $result
+   ): void {
+      $test_result = CoreCommonITILValidation::computeValidation(
+         $accepted,
+         $refused,
+         $validation_percent
+      );
+
+      $this->integer($test_result)->isEqualTo($result);
+   }
+}


### PR DESCRIPTION
Internal ref: 20749.

Consider the following situation:
1) Minimum approval for a given ticket is 100%.
2) There is 10 validators.

If 1 validator refuses the approval, the ticket is still "pending for validation" despite not being able to be validated even if all the 9 remaining validators votes yes.

This is because we use a very simple formula for checking refusal:
`{refusal %} > {minimum_validation %}`

In this case, it translates to 10% > 100% which is false -> no action.

---

These changes implement the following formula:
`{refusal %} + {minimum_validation %} > 100%`

In the case above, it translates to (10% + 100%) > 100% which is true -> approval is denied.



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
