### PR TITLE
Remove undirectly used acorn from direct dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
         "build": "webpack --config webpack.config.js"
     },
     "devDependencies": {
-        "acorn": "^7.0.0",
         "clean-webpack-plugin": "^3.0.0",
         "copy-webpack-plugin": "^6.0.1",
         "css-loader": "^4.2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`acorn` lib is not directly used and was only added to force a specific version. This is no longer required, so this lib can be removed from dev dependencies.