### PR TITLE
Update Plugin, Search, and other PHPDoc

### DIFF
--- a/inc/application/errorhandler.class.php
+++ b/inc/application/errorhandler.class.php
@@ -105,7 +105,7 @@ class ErrorHandler {
    /**
     * Last fatal error trace.
     *
-    * @var array
+    * @var string
     */
    private $last_fatal_trace;
 

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -62,11 +62,6 @@ class Change extends CommonITILObject {
 
 
 
-   /**
-    * Name of the type
-    *
-    * @param $nb : number of item in the type (default 0)
-   **/
    static function getTypeName($nb = 0) {
       return _n('Change', 'Changes', $nb);
    }

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -45,13 +45,46 @@ use Glpi\Marketplace\Controller as MarketplaceController;
 class Plugin extends CommonDBTM {
 
    // Class constant : Plugin state
+   /**
+    * @var int Unknown plugin state
+    */
    const UNKNOWN        = -1;
+
+   /**
+    * @var int Plugin was discovered but not installed
+    *
+    * @note Plugins are never actually set to this status?
+    */
    const ANEW           = 0;
+
+   /**
+    * @var int Plugin is installed and enabled
+    */
    const ACTIVATED      = 1;
+
+   /**
+    * @var int Plugin is not installed
+    */
    const NOTINSTALLED   = 2;
+
+   /**
+    * @var int Plugin is installed but needs configured before it can be enabled
+    */
    const TOBECONFIGURED = 3;
+
+   /**
+    * @var int Plugin is installed but not enabled
+    */
    const NOTACTIVATED   = 4;
+
+   /**
+    * @var int Plugin was previously discovered, but the plugin directory is missing now. The DB needs cleaned.
+    */
    const TOBECLEANED    = 5;
+
+   /**
+    * @var int The plugin's files are for a newer version than installed. An update is needed.
+    */
    const NOTUPDATED     = 6;
 
    static $rightname = 'config';
@@ -64,14 +97,14 @@ class Plugin extends CommonDBTM {
    private static $plugins_init = false;
 
    /**
-    * Activated plugin list, indexed by their ID.
+    * Activated plugin list
     *
     * @var string[]
     */
    private static $activated_plugins = [];
 
    /**
-    * Loaded plugin list, indexed by their ID.
+    * Loaded plugin list
     *
     * @var string[]
     */
@@ -269,9 +302,9 @@ class Plugin extends CommonDBTM {
    /**
     * Load lang file for a plugin
     *
-    * @param $plugin_key    Name of hook to use
-    * @param $forcelang     force a specific lang (default '')
-    * @param $coretrytoload lang trying to be load from core (default '')
+    * @param string $plugin_key    System name (Plugin directory)
+    * @param string $forcelang     Force a specific lang (default '')
+    * @param string $coretrytoload Lang trying to be loaded from core (default '')
     *
     * @return void
    **/
@@ -393,7 +426,7 @@ class Plugin extends CommonDBTM {
    /**
     * Check plugin state.
     *
-    * @param string $plugin_key
+    * @param string $plugin_key System name (Plugin directory)
     *
     * return void
     */
@@ -556,7 +589,7 @@ class Plugin extends CommonDBTM {
 
 
    /**
-    * Get plugin informations based on its old name.
+    * Get plugin information based on its old name.
     *
     * @param string $oldname
     *
@@ -614,9 +647,9 @@ class Plugin extends CommonDBTM {
 
 
    /**
-    * uninstall a plugin
+    * Uninstall a plugin
     *
-    * @param $ID ID of the plugin
+    * @param integer $ID ID of the plugin (The `id` field, not directory)
    **/
    function uninstall($ID) {
       $message = '';
@@ -663,8 +696,8 @@ class Plugin extends CommonDBTM {
    /**
     * Install a plugin
     *
-    * @param int   $ID      ID of the plugin
-    * @param array $params  Additionnal params to pass to install hook.
+    * @param integer $ID      ID of the plugin (The `id` field, not directory)
+    * @param array   $params  Additional params to pass to install hook.
     *
     * @return void
     *
@@ -728,7 +761,7 @@ class Plugin extends CommonDBTM {
    /**
     * activate a plugin
     *
-    * @param $ID ID of the plugin
+    * @param integer $ID ID of the plugin (The `id` field, not directory)
     *
     * @return boolean about success
    **/
@@ -825,9 +858,9 @@ class Plugin extends CommonDBTM {
 
 
    /**
-    * unactivate a plugin
+    * Unactivate a plugin
     *
-    * @param $ID ID of the plugin
+    * @param integer $ID ID of the plugin (The `id` field, not directory)
     *
     * @return boolean
    **/
@@ -993,9 +1026,9 @@ class Plugin extends CommonDBTM {
    /**
     * Migrate itemtype from integer (0.72) to string (0.80)
     *
-    * @param $types        array of (num=>name) of type manage by the plugin
-    * @param $glpitables   array of GLPI table name used by the plugin
-    * @param $plugtables   array of Plugin table name which have an itemtype
+    * @param array $types        Array of (num=>name) of type manage by the plugin
+    * @param array $glpitables   Array of GLPI table name used by the plugin
+    * @param array $plugtables   Array of Plugin table name which have an itemtype
     *
     * @return void
    **/
@@ -1172,7 +1205,7 @@ class Plugin extends CommonDBTM {
 
 
    /**
-    * @param $width
+    * @param integer $width
    **/
    function showSystemInformations($width) {
 
@@ -1201,8 +1234,8 @@ class Plugin extends CommonDBTM {
    /**
     * Define a new class managed by a plugin
     *
-    * @param $itemtype        class name
-    * @param $attrib    array of attributes, a hashtable with index in
+    * @param string $itemtype Class name
+    * @param array  $attrib   Array of attributes, a hashtable with index in
     *                         (classname, typename, reservation_types)
     *
     * @return bool
@@ -1276,12 +1309,12 @@ class Plugin extends CommonDBTM {
    /**
     * This function executes a hook.
     *
-    * @param $name   Name of hook to fire
-    * @param $param  Parameters if needed : if object limit to the itemtype (default NULL)
+    * @param string  $name   Name of hook to fire
+    * @param mixed   $param  Parameters if needed : if object limit to the itemtype (default NULL)
     *
     * @return mixed $data
    **/
-   static function doHook ($name, $param = null) {
+   static function doHook($name, $param = null) {
       global $PLUGIN_HOOKS;
 
       if ($param == null) {
@@ -1331,8 +1364,8 @@ class Plugin extends CommonDBTM {
    /**
     * This function executes a hook.
     *
-    * @param $name   Name of hook to fire
-    * @param $parm   Parameters (default NULL)
+    * @param string $name   Name of hook to fire
+    * @param mixed  $parm   Parameters (default NULL)
     *
     * @return mixed $data
    **/
@@ -1391,7 +1424,7 @@ class Plugin extends CommonDBTM {
    /**
     * Get dropdowns for plugins
     *
-    * @return Array containing plugin dropdowns
+    * @return array Array containing plugin dropdowns
    **/
    static function getDropdowns() {
 
@@ -1407,14 +1440,14 @@ class Plugin extends CommonDBTM {
 
 
    /**
-    * get information from a plugin
+    * Get information from a plugin
     *
-    * @param $plugin String name of the plugin
-    * @param $info   String wanted info (name, version, ...), NULL for all
+    * @param string $plugin System name (Plugin directory)
+    * @param string $info   Wanted info (name, version, ...), NULL for all
     *
     * @since 0.84
     *
-    * @return String or Array (when $info is NULL)
+    * @return string|array The specific information value requested or an array of all information if $info is null.
    **/
    static function getInfo($plugin, $info = null) {
 
@@ -1435,7 +1468,7 @@ class Plugin extends CommonDBTM {
    }
 
    /**
-    * Returns plugin informations from directory.
+    * Returns plugin information from directory.
     *
     * @param string $directory
     *
@@ -1474,7 +1507,7 @@ class Plugin extends CommonDBTM {
    /**
     * Get database relations for plugins
     *
-    * @return Array containing plugin database relations
+    * @return array Array containing plugin database relations
    **/
    static function getDatabaseRelations() {
 
@@ -1495,7 +1528,7 @@ class Plugin extends CommonDBTM {
     *
     * @param $itemtype
     *
-    * @return Array containing plugin search options for given type
+    * @return array Array containing plugin search options for given type
    **/
    static function getAddSearchOptions($itemtype) {
 
@@ -1536,7 +1569,7 @@ class Plugin extends CommonDBTM {
     *
     * @param string $itemtype Item type
     *
-    * @return array an *indexed* array of search options
+    * @return array An *indexed* array of search options
     *
     * @see https://glpi-developer-documentation.rtfd.io/en/master/devapi/search.html
    **/
@@ -1572,7 +1605,7 @@ class Plugin extends CommonDBTM {
    }
 
    /**
-    * test is a import plugin is enable
+    * Check if there is a plugin enabled that supports importing items
     *
     * @return boolean
     *
@@ -1585,7 +1618,7 @@ class Plugin extends CommonDBTM {
    }
 
    /**
-    * Get an internationnalized message for incomatible plugins (either core or php version)
+    * Get an internationalized message for incompatible plugins (either core or php version)
     *
     * @param string $type Either 'php' or 'core', defaults to 'core'
     * @param string $min  Minimal required version
@@ -1621,7 +1654,7 @@ class Plugin extends CommonDBTM {
    }
 
    /**
-    * Get an internationnalized message for missing requirement (extension, other plugin, ...)
+    * Get an internationalized message for missing requirement (extension, other plugin, ...)
     *
     * @param string $type Type of what is missing, one of:
     *                     - ext (PHP module)
@@ -1676,7 +1709,7 @@ class Plugin extends CommonDBTM {
     *
     * @since 9.2
     *
-    * @param integer $plugid Plugin id
+    * @param string $name System name (Plugin directory)
     *
     * @return boolean
     */
@@ -2006,7 +2039,7 @@ class Plugin extends CommonDBTM {
     *
     * @since 9.3.2
     *
-    * @param string $plugin_key  Plugin system name
+    * @param string $plugin_key  System name (Plugin directory)
     *
     * @return boolean
     */
@@ -2022,7 +2055,7 @@ class Plugin extends CommonDBTM {
     *
     * @since 9.5.0
     *
-    * @param string $plugin_key  Plugin system name
+    * @param string $plugin_key  System name (Plugin directory)
     *
     * @return boolean
     */
@@ -2073,7 +2106,7 @@ class Plugin extends CommonDBTM {
     * @since 9.3.2
     * @deprecated 9.5.0
     *
-    * @param integer $name Plugin name
+    * @param integer $name System name (Plugin directory)
     *
     * @return void
     */

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -6755,7 +6755,7 @@ JAVASCRIPT;
     * @param string  $itemtype     Item type
     * @param boolean $withplugins  Get search options from plugins (true by default)
     *
-    * @return &array The reference to the array of search options for the given item type
+    * @return array The reference to the array of search options for the given item type
    **/
    static function &getOptions($itemtype, $withplugins = true) {
       global $CFG_GLPI;

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -86,8 +86,8 @@ class Search {
    /**
     * Display result table for search engine for an type
     *
-    * @param $itemtype item type to manage
-    * @param $params search params passed to prepareDatasForSearch function
+    * @param string $itemtype Item type to manage
+    * @param array  $params   Search params passed to prepareDatasForSearch function
     *
     * @return void
    **/
@@ -98,8 +98,8 @@ class Search {
    /**
     * Display result table for search engine for an type as a map
     *
-    * @param string $itemtype item type to manage
-    * @param array  $params   search params passed to prepareDatasForSearch function
+    * @param string $itemtype Item type to manage
+    * @param array  $params   Search params passed to prepareDatasForSearch function
     *
     * @return void
    **/
@@ -303,16 +303,16 @@ class Search {
 
 
    /**
-    * Get datas based on search parameters
+    * Get data based on search parameters
     *
     * @since 0.85
     *
-    * @param $itemtype            item type to manage
-    * @param $params              search params passed to prepareDatasForSearch function
-    * @param $forcedisplay  array of columns to display (default empty = empty use display pref and search criterias)
+    * @param string $itemtype      Item type to manage
+    * @param array  $params        Search params passed to prepareDatasForSearch function
+    * @param array  $forcedisplay  Array of columns to display (default empty = empty use display pref and search criteria)
     *
-    * @return data array
-   **/
+    * @return array The data
+    **/
    static function getDatas($itemtype, $params, array $forcedisplay = []) {
 
       $data = self::prepareDatasForSearch($itemtype, $params, $forcedisplay);
@@ -328,12 +328,12 @@ class Search {
     *
     * @since 0.85
     *
-    * @param $itemtype            item type
-    * @param $params        array of parameters
-    *                             may include sort, order, start, list_limit, deleted, criteria, metacriteria
-    * @param $forcedisplay  array of columns to display (default empty = empty use display pref and search criterias)
+    * @param string $itemtype      Item type
+    * @param array  $params        Array of parameters
+    *                               may include sort, order, start, list_limit, deleted, criteria, metacriteria
+    * @param array  $forcedisplay  Array of columns to display (default empty = empty use display pref and search criterias)
     *
-    * @return array prepare to be used for a search (include criterias and others needed informations)
+    * @return array prepare to be used for a search (include criteria and others needed information)
    **/
    static function prepareDatasForSearch($itemtype, array $params, array $forcedisplay = []) {
       global $CFG_GLPI;
@@ -526,7 +526,7 @@ class Search {
    /**
     * Construct SQL request depending of search parameters
     *
-    * add to data array a field sql containing an array of requests :
+    * Add to data array a field sql containing an array of requests :
     *      search : request to get items limited to wanted ones
     *      count : to count all items based on search criterias
     *                    may be an array a request : need to add counts
@@ -534,7 +534,7 @@ class Search {
     *
     * @since 0.85
     *
-    * @param $data    array of search datas prepared to generate SQL
+    * @param array $data  Array of search datas prepared to generate SQL
     *
     * @return void
    **/
@@ -1472,7 +1472,7 @@ class Search {
    /**
     * Display datas extracted from DB
     *
-    * @param $data array of search datas prepared to get datas
+    * @param array $data Array of search datas prepared to get datas
     *
     * @return void
    **/
@@ -1893,7 +1893,8 @@ class Search {
    /**
     * @since 0.90
     *
-    * @param $is_deleted
+    * @param boolean $is_deleted
+    * @param string  $itemtype
     *
     * @return string
    */
@@ -1917,9 +1918,9 @@ class Search {
    /**
     * Compute title (use case of PDF OUTPUT)
     *
-    * @param $data array data of search
+    * @param array $data Array data of search
     *
-    * @return string title
+    * @return string Title
    **/
    static function computeTitle($data) {
       $title = "";
@@ -2144,11 +2145,11 @@ class Search {
    /**
     * Get meta types available for search engine
     *
-    * @param $itemtype type to display the form
+    * @param string $itemtype Type to display the form
     *
-    * @return Array of available itemtype
+    * @return array Array of available itemtype
    **/
-   static function getMetaItemtypeAvailable ($itemtype) {
+   static function getMetaItemtypeAvailable($itemtype) {
 
       // Display meta search items
       $linked = [];
@@ -2242,8 +2243,8 @@ class Search {
     *
     * Params need to parsed before using Search::manageParams function
     *
-    * @param $itemtype        type to display the form
-    * @param $params    array of parameters may include sort, is_deleted, criteria, metacriteria
+    * @param string $itemtype  Type to display the form
+    * @param array  $params    Array of parameters may include sort, is_deleted, criteria, metacriteria
     *
     * @return void
    **/
@@ -3353,9 +3354,9 @@ JAVASCRIPT;
    /**
     * Generic Function to add default select to a request
     *
-    * @param $itemtype device type
+    * @param string $itemtype device type
     *
-    * @return select string
+    * @return string Select string
    **/
    static function addDefaultSelect($itemtype) {
       global $DB;
@@ -3408,7 +3409,7 @@ JAVASCRIPT;
     * @param boolean $meta         boolean is a meta
     * @param integer $meta_type    meta type table ID (default 0)
     *
-    * @return select string
+    * @return string Select string
    **/
    static function addSelect($itemtype, $ID, $meta = 0, $meta_type = 0) {
       global $DB, $CFG_GLPI;
@@ -3762,9 +3763,9 @@ JAVASCRIPT;
    /**
     * Generic Function to add default where to a request
     *
-    * @param $itemtype device type
+    * @param string $itemtype device type
     *
-    * @return select string
+    * @return string Where string
    **/
    static function addDefaultWhere($itemtype) {
       $condition = '';
@@ -4066,15 +4067,15 @@ JAVASCRIPT;
    /**
     * Generic Function to add where to a request
     *
-    * @param $link         link string
-    * @param $nott         is it a negative search ?
-    * @param $itemtype     item type
-    * @param $ID           ID of the item to search
-    * @param $searchtype   searchtype used (equals or contains)
-    * @param $val          item num in the request
-    * @param $meta         is a meta search (meta=2 in search.class.php) (default 0)
+    * @param string  $link         Link string
+    * @param boolean $nott         Is it a negative search ?
+    * @param string  $itemtype     Item type
+    * @param integer $ID           ID of the item to search
+    * @param string  $searchtype   Searchtype used (equals or contains)
+    * @param string  $val          Item num in the request
+    * @param integer $meta         Is a meta search (meta=2 in search.class.php) (default 0)
     *
-    * @return select string
+    * @return string Where string
    **/
    static function addWhere($link, $nott, $itemtype, $ID, $searchtype, $val, $meta = 0) {
 
@@ -4686,11 +4687,11 @@ JAVASCRIPT;
    /**
     * Generic Function to add Default left join to a request
     *
-    * @param $itemtype                    reference ID
-    * @param $ref_table                   reference table
-    * @param &$already_link_tables  array of tables already joined
+    * @param string $itemtype             Reference item type
+    * @param string $ref_table            Reference table
+    * @param array &$already_link_tables  Array of tables already joined
     *
-    * @return Left join string
+    * @return string Left join string
    **/
    static function addDefaultJoin($itemtype, $ref_table, array &$already_link_tables) {
 
@@ -4864,17 +4865,17 @@ JAVASCRIPT;
    /**
     * Generic Function to add left join to a request
     *
-    * @param $itemtype                    item type
-    * @param $ref_table                   reference table
-    * @param $already_link_tables  array  of tables already joined
-    * @param $new_table                   new table to join
-    * @param $linkfield                   linkfield for LeftJoin
-    * @param $meta                        is it a meta item ? (default 0)
-    * @param $meta_type                   meta type table (default 0)
-    * @param $joinparams           array  join parameters (condition / joinbefore...)
-    * @param $field                string field to display (needed for translation join) (default '')
+    * @param string  $itemtype             Item type
+    * @param string  $ref_table            Reference table
+    * @param array   $already_link_tables  Array of tables already joined
+    * @param string  $new_table            New table to join
+    * @param string  $linkfield            Linkfield for LeftJoin
+    * @param boolean $meta                 Is it a meta item ? (default 0)
+    * @param integer $meta_type            Meta type table (default 0)
+    * @param array   $joinparams           Array join parameters (condition / joinbefore...)
+    * @param string  $field                Field to display (needed for translation join) (default '')
     *
-    * @return Left join string
+    * @return string Left join string
    **/
    static function addLeftJoin($itemtype, $ref_table, array &$already_link_tables, $new_table,
                                $linkfield, $meta = 0, $meta_type = 0, $joinparams = [], $field = '') {
@@ -5148,11 +5149,11 @@ JAVASCRIPT;
    /**
     * Generic Function to add left join for meta items
     *
-    * @param $from_type                   reference item type ID
-    * @param $to_type                     item type to add
-    * @param $already_link_tables2  array of tables already joined
+    * @param string $from_type             Reference item type ID
+    * @param string $to_type               Item type to add
+    * @param array  $already_link_tables2  Array of tables already joined
     *
-    * @return Meta Left join string
+    * @return string Meta Left join string
    **/
    static function addMetaLeftJoin($from_type, $to_type, array &$already_link_tables2,
                                    $joinparams = []) {
@@ -5398,7 +5399,7 @@ JAVASCRIPT;
     * @param integer $ID       ID of the SEARCH_OPTION item
     * @param array   $data     array retrieved data array
     *
-    * @return string to print
+    * @return string String to print
    **/
    static function displayConfigItem($itemtype, $ID, $data = []) {
 
@@ -5464,7 +5465,7 @@ JAVASCRIPT;
     * @param array   $addobjectparams array added parameters for union search
     * @param string  $orig_itemtype   Original itemtype, used for union_search_type
     *
-    * @return string to print
+    * @return string String to print
    **/
    static function giveItem($itemtype, $ID, array $data, $meta = 0,
                             array $addobjectparams = [], $orig_itemtype = null) {
@@ -6516,10 +6517,10 @@ JAVASCRIPT;
    /**
     * Completion of the URL $_GET values with the $_SESSION values or define default values
     *
-    * @param $itemtype                 item type to manage
-    * @param $params          array    params to parse
-    * @param $usesession               Use datas save in session (true by default)
-    * @param $forcebookmark            force trying to load parameters from default bookmark:
+    * @param string  $itemtype        Item type to manage
+    * @param array   $params          Params to parse
+    * @param boolean $usesession      Use datas save in session (true by default)
+    * @param boolean $forcebookmark   Force trying to load parameters from default bookmark:
     *                                  used for global search (false by default)
     *
     * @return array parsed params
@@ -6663,12 +6664,12 @@ JAVASCRIPT;
    /**
     * Clean search options depending of user active profile
     *
-    * @param $itemtype              item type to manage
-    * @param $action                action which is used to manupulate searchoption
+    * @param string  $itemtype     Item type to manage
+    * @param integer $action       Action which is used to manupulate searchoption
     *                               (default READ)
-    * @param $withplugins  boolean  get plugins options (true by default)
+    * @param boolean $withplugins  Get plugins options (true by default)
     *
-    * @return clean $SEARCH_OPTION array
+    * @return array Clean $SEARCH_OPTION array
    **/
    static function getCleanedOptions($itemtype, $action = READ, $withplugins = true) {
       global $CFG_GLPI;
@@ -6727,8 +6728,8 @@ JAVASCRIPT;
     *
     * Get an option number in the SEARCH_OPTION array
     *
-    * @param $itemtype
-    * @param $field     name
+    * @param string $itemtype  Item type
+    * @param string $field     Name
     *
     * @return integer
    **/
@@ -6751,10 +6752,10 @@ JAVASCRIPT;
    /**
     * Get the SEARCH_OPTION array
     *
-    * @param $itemtype
-    * @param $withplugins boolean get search options from plugins (true by default)
+    * @param string  $itemtype     Item type
+    * @param boolean $withplugins  Get search options from plugins (true by default)
     *
-    * @return the reference to  array of search options for the given item type
+    * @return &array The reference to the array of search options for the given item type
    **/
    static function &getOptions($itemtype, $withplugins = true) {
       global $CFG_GLPI;
@@ -6992,8 +6993,8 @@ JAVASCRIPT;
    /**
     * Is the search item related to infocoms
     *
-    * @param $itemtype  item type
-    * @param $searchID  ID of the element in $SEARCHOPTION
+    * @param string  $itemtype  Item type
+    * @param integer $searchID  ID of the element in $SEARCHOPTION
     *
     * @return boolean
    **/
@@ -7012,8 +7013,8 @@ JAVASCRIPT;
 
 
    /**
-    * @param $itemtype
-    * @param $field_num
+    * @param string  $itemtype
+    * @param integer $field_num
    **/
    static function getActionsFor($itemtype, $field_num) {
 
@@ -7174,15 +7175,15 @@ JAVASCRIPT;
    /**
     * Print generic Header Column
     *
-    * @param $type            display type (0=HTML, 1=Sylk,2=PDF,3=CSV)
-    * @param $value           value to display
-    * @param &$num            column number
-    * @param $linkto          link display element (HTML specific) (default '')
-    * @param $issort          is the sort column ? (default 0)
-    * @param $order           order type ASC or DESC (defaut '')
-    * @param $options  string options to add (default '')
+    * @param integer          $type     Display type (0=HTML, 1=Sylk, 2=PDF, 3=CSV)
+    * @param string           $value    Value to display
+    * @param integer          &$num     Column number
+    * @param string           $linkto   Link display element (HTML specific) (default '')
+    * @param boolean|integer  $issort   Is the sort column ? (default 0)
+    * @param string           $order    Order type ASC or DESC (defaut '')
+    * @param string           $options  Options to add (default '')
     *
-    * @return string to display
+    * @return string HTML to display
    **/
    static function showHeaderItem($type, $value, &$num, $linkto = "", $issort = 0, $order = "",
                                   $options = "") {
@@ -7230,13 +7231,13 @@ JAVASCRIPT;
    /**
     * Print generic normal Item Cell
     *
-    * @param $type         display type (0=HTML, 1=Sylk,2=PDF,3=CSV)
-    * @param $value        value to display
-    * @param &$num         column number
-    * @param $row          row number
-    * @param $extraparam   extra parameters for display (default '')
+    * @param integer $type        Display type (0=HTML, 1=Sylk, 2=PDF, 3=CSV)
+    * @param string  $value       Value to display
+    * @param integer &$num        Column number
+    * @param integer $row         Row number
+    * @param string  $extraparam  Extra parameters for display (default '')
     *
-    *@return string to display
+    * @return string HTML to display
    **/
    static function showItem($type, $value, &$num, $row, $extraparam = '') {
 
@@ -7315,10 +7316,10 @@ JAVASCRIPT;
    /**
     * Print generic error
     *
-    * @param $type display type (0=HTML, 1=Sylk,2=PDF,3=CSV)
-    * @param $message message to display, if empty "no item found" will be displayed
+    * @param integer $type     Display type (0=HTML, 1=Sylk, 2=PDF, 3=CSV)
+    * @param string  $message  Message to display, if empty "no item found" will be displayed
     *
-    * @return string to display
+    * @return string HTML to display
    **/
    static function showError($type, $message = "") {
       if (strlen($message) == 0) {
@@ -7343,11 +7344,11 @@ JAVASCRIPT;
    /**
     * Print generic footer
     *
-    * @param integer $type  display type (0=HTML, 1=Sylk,2=PDF,3=CSV)
+    * @param integer $type  Display type (0=HTML, 1=Sylk, 2=PDF, 3=CSV)
     * @param string  $title title of file : used for PDF (default '')
     * @param integer $count Total number of results
     *
-    * @return string to display
+    * @return string HTML to display
    **/
    static function showFooter($type, $title = "", $count = null) {
 
@@ -7432,12 +7433,12 @@ JAVASCRIPT;
    /**
     * Print generic footer
     *
-    * @param $type   display type (0=HTML, 1=Sylk,2=PDF,3=CSV)
-    * @param $rows   number of rows
-    * @param $cols   number of columns
-    * @param $fixed  used tab_cadre_fixe table for HTML export ? (default 0)
+    * @param integer         $type   Display type (0=HTML, 1=Sylk, 2=PDF, 3=CSV)
+    * @param integer         $rows   Number of rows
+    * @param integer         $cols   Number of columns
+    * @param boolean|integer $fixed  Used tab_cadre_fixe table for HTML export ? (default 0)
     *
-    * @return string to display
+    * @return string HTML to display
    **/
    static function showHeader($type, $rows, $cols, $fixed = 0) {
 
@@ -7505,11 +7506,11 @@ JAVASCRIPT;
    /**
     * Print begin of header part
     *
-    * @param $type         display type (0=HTML, 1=Sylk,2=PDF,3=CSV)
+    * @param integer $type   Display type (0=HTML, 1=Sylk, 2=PDF, 3=CSV)
     *
     * @since 0.85
     *
-    * @return string to display
+    * @return string HTML to display
    **/
    static function showBeginHeader($type) {
 
@@ -7535,7 +7536,7 @@ JAVASCRIPT;
    /**
     * Print end of header part
     *
-    * @param $type         display type (0=HTML, 1=Sylk,2=PDF,3=CSV)
+    * @param integer $type   Display type (0=HTML, 1=Sylk, 2=PDF, 3=CSV)
     *
     * @since 0.85
     *
@@ -7565,11 +7566,11 @@ JAVASCRIPT;
    /**
     * Print generic new line
     *
-    * @param $type         display type (0=HTML, 1=Sylk,2=PDF,3=CSV)
-    * @param $odd          is it a new odd line ? (false by default)
-    * @param $is_deleted   is it a deleted search ? (false by default)
+    * @param integer $type        Display type (0=HTML, 1=Sylk, 2=PDF, 3=CSV)
+    * @param boolean $odd         Is it a new odd line ? (false by default)
+    * @param boolean $is_deleted  Is it a deleted search ? (false by default)
     *
-    * @return string to display
+    * @return string HTML to display
    **/
    static function showNewLine($type, $odd = false, $is_deleted = false) {
 
@@ -7603,9 +7604,9 @@ JAVASCRIPT;
    /**
     * Print generic end line
     *
-    * @param $type display type (0=HTML, 1=Sylk,2=PDF,3=CSV)
+    * @param integer $type  Display type (0=HTML, 1=Sylk, 2=PDF, 3=CSV)
     *
-    * @return string to display
+    * @return string HTML to display
    **/
    static function showEndLine($type) {
 
@@ -7632,7 +7633,7 @@ JAVASCRIPT;
 
 
    /**
-    * @param $joinparams   array
+    * @param array $joinparams
     */
    static function computeComplexJoinID(array $joinparams) {
 
@@ -7680,10 +7681,10 @@ JAVASCRIPT;
    /**
     * Clean display value for csv export
     *
-    * @param $value string value
+    * @param string $value value
     *
-    * @return clean value
-   **/
+    * @return string Clean value
+    **/
    static function csv_clean($value) {
 
       $value = str_replace("\"", "''", $value);
@@ -7698,10 +7699,10 @@ JAVASCRIPT;
    /**
     * Clean display value for sylk export
     *
-    * @param $value string value
+    * @param string $value value
     *
-    * @return clean value
-   **/
+    * @return string Clean value
+    **/
    static function sylk_clean($value) {
 
       $value = preg_replace('/\x0A/', ' ', $value);
@@ -7719,10 +7720,10 @@ JAVASCRIPT;
    /**
     * Create SQL search condition
     *
-    * @param $field           name (should be ` protected)
-    * @param $val    string   value to search
-    * @param $not    boolean  is a negative search ? (false by default)
-    * @param $link            with previous criteria (default 'AND')
+    * @param string  $field  Nname (should be ` protected)
+    * @param string  $val    Value to search
+    * @param boolean $not    Is a negative search ? (false by default)
+    * @param string  $link   With previous criteria (default 'AND')
     *
     * @return search SQL string
    **/
@@ -7782,10 +7783,10 @@ JAVASCRIPT;
    /**
     * Create SQL search condition
     *
-    * @param $val string   value to search
-    * @param $not boolean  is a negative search ? (false by default)
+    * @param string  $val  Value to search
+    * @param boolean $not  Is a negative search ? (false by default)
     *
-    * @return search string
+    * @return string Search string
    **/
    static function makeTextSearch($val, $not = false) {
 
@@ -7807,8 +7808,8 @@ JAVASCRIPT;
    /**
     * @since 0.84
     *
-    * @param $pattern
-    * @param $subject
+    * @param string $pattern
+    * @param string $subject
    **/
    static function explodeWithID($pattern, $subject) {
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -99,31 +99,16 @@ class Ticket extends CommonITILObject {
    }
 
 
-   /**
-    * Name of the type
-    *
-    * @param $nb : number of item in the type (default 0)
-   **/
    static function getTypeName($nb = 0) {
       return _n('Ticket', 'Tickets', $nb);
    }
 
 
-   /**
-    * @see CommonGLPI::getMenuShorcut()
-    *
-    * @since 0.85
-   **/
    static function getMenuShorcut() {
       return 't';
    }
 
 
-   /**
-    * @see CommonGLPI::getAdditionalMenuContent()
-    *
-    * @since 0.85
-   **/
    static function getAdditionalMenuContent() {
 
       if (static::canCreate()) {
@@ -141,11 +126,6 @@ class Ticket extends CommonITILObject {
    }
 
 
-   /**
-    * @see CommonGLPI::getAdditionalMenuLinks()
-    *
-    * @since 0.85
-   **/
    static function getAdditionalMenuLinks() {
       global $CFG_GLPI;
 
@@ -281,9 +261,6 @@ class Ticket extends CommonITILObject {
    }
 
 
-   /**
-    * @see CommonDBTM::canMassiveAction()
-   **/
    function canMassiveAction($action, $field, $value) {
 
       switch ($action) {
@@ -3226,13 +3203,6 @@ class Ticket extends CommonITILObject {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @param $field
-    * @param $values
-    * @param $options   array
-   **/
    static function getSpecificValueToDisplay($field, $values, array $options = []) {
 
       if (!is_array($values)) {
@@ -3254,16 +3224,6 @@ class Ticket extends CommonITILObject {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @param $field
-    * @param $name            (default '')
-    * @param $values          (default '')
-    * @param $options   array
-    *
-    * @return string
-   **/
    static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = []) {
 
       if (!is_array($values)) {
@@ -3285,10 +3245,10 @@ class Ticket extends CommonITILObject {
    /**
     * Dropdown of ticket type
     *
-    * @param $name            select name
-    * @param $options   array of options:
+    * @param string $name     Select name
+    * @param array  $options  Array of options:
     *    - value     : integer / preselected value (default 0)
-    *    - toadd     : array / array of specific values to add at the begining
+    *    - toadd     : array / array of specific values to add at the beginning
     *    - on_change : string / value to transmit to "onChange"
     *    - display   : boolean / display or get string (default true)
     *
@@ -3323,7 +3283,7 @@ class Ticket extends CommonITILObject {
    /**
     * Get ticket types
     *
-    * @return array of types
+    * @return array Array of types
    **/
    static function getTypes() {
 
@@ -3339,7 +3299,7 @@ class Ticket extends CommonITILObject {
    /**
     * Get ticket type Name
     *
-    * @param $value type ID
+    * @param integer $value Type ID
    **/
    static function getTicketTypeName($value) {
 
@@ -3360,7 +3320,7 @@ class Ticket extends CommonITILObject {
    /**
     * get the Ticket status list
     *
-    * @param $withmetaforsearch boolean (false by default)
+    * @param boolean $withmetaforsearch  (false by default)
     *
     * @return array
    **/
@@ -3434,7 +3394,7 @@ class Ticket extends CommonITILObject {
    /**
     * Calculate Ticket TCO for an item
     *
-    *@param $item CommonDBTM object of the item
+    *@param CommonDBTM $item  Object of the item
     *
     *@return float
    **/
@@ -3480,11 +3440,11 @@ class Ticket extends CommonITILObject {
    /**
     * Print the helpdesk form
     *
-    * @param $ID              integer  ID of the user who want to display the Helpdesk
-    * @param $ticket_template boolean  ticket template for preview : false if not used for preview
+    * @param integer $ID               ID of the user who want to display the Helpdesk
+    * @param boolean $ticket_template  Ticket template for preview : false if not used for preview
     *                                  (false by default)
     *
-    * @return void
+    * @return boolean|void
    **/
    function showFormHelpdesk($ID, $ticket_template = false) {
       global $CFG_GLPI;
@@ -3984,9 +3944,9 @@ class Ticket extends CommonITILObject {
    }
 
    /**
-    * Display a single oberver selector
+    * Display a single observer selector
     *
-    *  * @param $options array options for default values ($options of showActorAddFormOnCreate)
+    * @param array $options  Options for default values ($options of showActorAddFormOnCreate)
    **/
    static function showFormHelpdeskObserver($options = []) {
       global $CFG_GLPI;
@@ -4139,16 +4099,16 @@ class Ticket extends CommonITILObject {
     * Use force_template first, then try on template define for type and category
     * then use default template of active profile of connected user and then use default entity one
     *
-    * @param $force_template      integer itiltemplate_id to used (case of preview for example)
+    * @param integer $force_template      Itiltemplate_id to used (case of preview for example)
     *                             (default 0)
-    * @param $type                integer type of the ticket (default 0)
-    * @param $itilcategories_id   integer ticket category (default 0)
-    * @param $entities_id         integer (default -1)
+    * @param integer $type                Type of the ticket (default 0)
+    * @param integer $itilcategories_id   Ticket category (default 0)
+    * @param integer $entities_id         (default -1)
     *
     * @since 0.84
     * @deprecated 9.5.0
     *
-    * @return ticket template object
+    * @return ITILTemplate ticket template object
    **/
    function getTicketTemplateToUse($force_template = 0, $type = 0, $itilcategories_id = 0,
                                    $entities_id = -1) {
@@ -5082,9 +5042,9 @@ class Ticket extends CommonITILObject {
 
 
    /**
-    * @param $start
-    * @param $status             (default ''process)
-    * @param $showgrouptickets   (true by default)
+    * @param integer $start
+    * @param string  $status             (default ''process)
+    * @param boolean $showgrouptickets   (true by default)
     */
    static function showCentralList($start, $status = "process", $showgrouptickets = true) {
       global $DB;
@@ -5642,7 +5602,7 @@ class Ticket extends CommonITILObject {
    /**
     * Get tickets count
     *
-    * @param $foruser boolean : only for current login user as requester (false by default)
+    * @param boolean $foruser  Only for current login user as requester (false by default)
    **/
    static function showCentralCount($foruser = false) {
       global $DB, $CFG_GLPI;
@@ -6296,9 +6256,9 @@ class Ticket extends CommonITILObject {
    /**
     * Give cron information
     *
-    * @param $name : task's name
+    * @param string $name  Task's name
     *
-    * @return array of information
+    * @return array Array of information
    **/
    static function cronInfo($name) {
 
@@ -6322,7 +6282,7 @@ class Ticket extends CommonITILObject {
    /**
     * Cron for ticket's automatic close
     *
-    * @param $task : crontask object
+    * @param CronTask $task
     *
     * @return integer (0 : nothing done - 1 : done)
    **/
@@ -6397,7 +6357,7 @@ class Ticket extends CommonITILObject {
    /**
     * Cron for alert old tickets which are not solved
     *
-    * @param $task : crontask object
+    * @param CronTask $task
     *
     * @return integer (0 : nothing done - 1 : done)
    **/
@@ -6451,7 +6411,7 @@ class Ticket extends CommonITILObject {
    /**
     * Cron for ticketsatisfaction's automatic generated
     *
-    * @param $task : crontask object
+    * @param CronTask $task
     *
     * @return integer (0 : nothing done - 1 : done)
    **/
@@ -6704,8 +6664,8 @@ class Ticket extends CommonITILObject {
    /**
     * @since 0.90
     *
-    * @param $tickets_id
-    * @param $action         (default 'add')
+    * @param integer $tickets_id
+    * @param string  $action      (default 'add')
    **/
    static function getSplittedSubmitButtonHtml($tickets_id, $action = "add") {
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix PHPDoc for parameters in Plugin and Search classes. The plugin class fixes should reduce the number of IDE warnings for plugin devs.
Add documentation to plugin state constants.
Remove doc blocks for some overridden methods that don't add anything new to the documentation.
Fix variable type of `$last_fatal_trace` in ErrorHandler (This is assigned the value of Exception::getTraceAsString later. I couldn't see where it can be an array).
Fix some param docs in Ticket class.