### PR TITLE
error and complete callback support for ajaxform

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -6119,9 +6119,16 @@ JAVASCRIPT;
    /**
     * This function provides a mecanism to send html form by ajax
     *
+    * @param string $selector selector of a HTML form
+    * @param string $success  jacascript code of the success callback
+    * @param string $error    jacascript code of the error callback
+    * @param string $complete jacascript code of the complete callback
+    *
+    * @see https://api.jquery.com/jQuery.ajax/
+    *
     * @since 9.1
    **/
-   static function ajaxForm($selector, $success = "console.log(html);") {
+   static function ajaxForm($selector, $success = "console.log(html);", $error = "console.error(html)", $complete = '') {
       echo Html::scriptBlock("
       $(function() {
          var lastClicked = null;
@@ -6146,6 +6153,12 @@ JAVASCRIPT;
                data: formData,
                success: function(html) {
                   $success
+               },
+               error: function(html) {
+                  $error
+               },
+               complete: function(html) {
+                  $complete
                }
             });
          });


### PR DESCRIPTION
I need to handle possible errors when running an AJAX request. Html::ajaxForm() is nice, but does not support all callbacks.

As this change is minor, I submit it for GLPI 9.5.x, but I'm ok to merge in 9.6 as it is simple to maintain a version embedded in a plugin.