### PR TITLE
PHPDoc: Fix a lot of inherited docs

### DIFF
--- a/inc/certificate.class.php
+++ b/inc/certificate.class.php
@@ -369,9 +369,6 @@ class Certificate extends CommonDBTM {
       return $ong;
    }
 
-   /**
-    * @see CommonDBTM::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
 
       if (isset($input["id"]) && ($input["id"] > 0)) {

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -150,9 +150,6 @@ class Change extends CommonITILObject {
    }
 
 
-   /**
-    * @see CommonDBTM::getSpecificMassiveActions()
-   **/
    function getSpecificMassiveActions($checkitem = null) {
 
       $actions = parent::getSpecificMassiveActions($checkitem);
@@ -1267,11 +1264,6 @@ class Change extends CommonITILObject {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see commonDBTM::getRights()
-    **/
    function getRights($interface = 'central') {
 
       $values = parent::getRights();

--- a/inc/change_problem.class.php
+++ b/inc/change_problem.class.php
@@ -65,9 +65,6 @@ class Change_Problem extends CommonDBRelation{
    }
 
 
-   /**
-    * @see CommonGLPI::getTabNameForItem()
-   **/
    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
 
       if (static::canView()) {

--- a/inc/change_ticket.class.php
+++ b/inc/change_ticket.class.php
@@ -63,11 +63,6 @@ class Change_Ticket extends CommonDBRelation{
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonGLPI::getTabNameForItem()
-   **/
    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
 
       if (static::canView()) {
@@ -92,9 +87,6 @@ class Change_Ticket extends CommonDBRelation{
    }
 
 
-   /**
-    * @since 0.85
-   **/
    static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0) {
 
       switch ($item->getType()) {
@@ -110,11 +102,6 @@ class Change_Ticket extends CommonDBRelation{
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBTM::showMassiveActionsSubForm()
-   **/
    static function showMassiveActionsSubForm(MassiveAction $ma) {
 
       switch ($ma->getAction()) {
@@ -141,11 +128,6 @@ class Change_Ticket extends CommonDBRelation{
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBTM::processMassiveActionsForOneItemtype()
-   **/
    static function processMassiveActionsForOneItemtype(MassiveAction $ma, CommonDBTM $item,
                                                        array $ids) {
 

--- a/inc/commondbchild.class.php
+++ b/inc/commondbchild.class.php
@@ -369,9 +369,6 @@ abstract class CommonDBChild extends CommonDBConnexity {
    }
 
 
-   /**
-    * @since 0.84
-   **/
    function addNeededInfoToInput($input) {
 
       // is entity missing and forwarding on ?
@@ -398,9 +395,6 @@ abstract class CommonDBChild extends CommonDBConnexity {
    }
 
 
-   /**
-    * @since 0.84
-   **/
    function prepareInputForAdd($input) {
 
       if (!is_array($input)) {
@@ -417,9 +411,6 @@ abstract class CommonDBChild extends CommonDBConnexity {
    }
 
 
-   /**
-    * @since 0.84
-   **/
    function prepareInputForUpdate($input) {
 
       if (!is_array($input)) {

--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -611,9 +611,6 @@ abstract class CommonDBRelation extends CommonDBConnexity {
    }
 
 
-   /**
-    * @since 0.84
-   **/
    function addNeededInfoToInput($input) {
 
       // is entity missing and forwarding on ?
@@ -648,11 +645,6 @@ abstract class CommonDBRelation extends CommonDBConnexity {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @param $input
-   **/
    function prepareInputForAdd($input) {
 
       if (!is_array($input)) {
@@ -663,9 +655,6 @@ abstract class CommonDBRelation extends CommonDBConnexity {
    }
 
 
-   /**
-    * @since 0.84
-   **/
    function prepareInputForUpdate($input) {
 
       if (!is_array($input)) {
@@ -1172,11 +1161,6 @@ abstract class CommonDBRelation extends CommonDBConnexity {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBTM::showMassiveActionsSubForm()
-   **/
    static function showMassiveActionsSubForm(MassiveAction $ma) {
 
       $specificities = static::getRelationMassiveActionsSpecificities();

--- a/inc/devicecase.class.php
+++ b/inc/devicecase.class.php
@@ -79,11 +79,6 @@ class DeviceCase extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableHeader()
-   **/
    static function getHTMLTableHeader($itemtype, HTMLTableBase $base,
                                       HTMLTableSuperHeader $super = null,
                                       HTMLTableHeader $father = null, array $options = []) {
@@ -102,11 +97,6 @@ class DeviceCase extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableCellForItem()
-   **/
    function getHTMLTableCellForItem(HTMLTableRow $row = null, CommonDBTM $item = null,
                                     HTMLTableCell $father = null, array $options = []) {
 

--- a/inc/devicecontrol.class.php
+++ b/inc/devicecontrol.class.php
@@ -98,11 +98,6 @@ class DeviceControl extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableHeader()
-   **/
    static function getHTMLTableHeader($itemtype, HTMLTableBase $base,
                                       HTMLTableSuperHeader $super = null,
                                       HTMLTableHeader $father = null, array $options = []) {
@@ -123,11 +118,6 @@ class DeviceControl extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableCellForItem()
-   **/
    function getHTMLTableCellForItem(HTMLTableRow $row = null, CommonDBTM $item = null,
                                     HTMLTableCell $father = null, array $options = []) {
 

--- a/inc/devicedrive.class.php
+++ b/inc/devicedrive.class.php
@@ -102,11 +102,6 @@ class DeviceDrive extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableHeader()
-   **/
    static function getHTMLTableHeader($itemtype, HTMLTableBase $base,
                                       HTMLTableSuperHeader $super = null,
                                       HTMLTableHeader $father = null, array $options = []) {
@@ -129,11 +124,6 @@ class DeviceDrive extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableCellForItem()
-   **/
    function getHTMLTableCellForItem(HTMLTableRow $row = null, CommonDBTM $item = null,
                                     HTMLTableCell $father = null, array $options = []) {
 

--- a/inc/devicegeneric.class.php
+++ b/inc/devicegeneric.class.php
@@ -68,11 +68,6 @@ class DeviceGeneric extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableHeader()
-   **/
    static function getHTMLTableHeader($itemtype, HTMLTableBase $base,
                                       HTMLTableSuperHeader $super = null,
                                       HTMLTableHeader $father = null, array $options = []) {
@@ -91,11 +86,6 @@ class DeviceGeneric extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableCellForItem()
-   **/
    function getHTMLTableCellForItem(HTMLTableRow $row = null, CommonDBTM $item = null,
                                     HTMLTableCell $father = null, array $options = []) {
 

--- a/inc/devicegraphiccard.class.php
+++ b/inc/devicegraphiccard.class.php
@@ -127,29 +127,16 @@ class DeviceGraphicCard extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.85
-    * @see CommonDropdown::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
       return $this->prepareInputForAddOrUpdate($input);
    }
 
 
-   /**
-    * @since 0.85
-    * @see CommonDropdown::prepareInputForUpdate()
-   **/
    function prepareInputForUpdate($input) {
       return $this->prepareInputForAddOrUpdate($input);
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableHeader()
-   **/
    static function getHTMLTableHeader($itemtype, HTMLTableBase $base,
                                       HTMLTableSuperHeader $super = null,
                                       HTMLTableHeader $father = null, array $options = []) {
@@ -170,11 +157,6 @@ class DeviceGraphicCard extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableCellForItem()
-   **/
    function getHTMLTableCellForItem(HTMLTableRow $row = null, CommonDBTM $item = null,
                                     HTMLTableCell $father = null, array $options = []) {
 
@@ -198,13 +180,6 @@ class DeviceGraphicCard extends CommonDevice {
    }
 
 
-   /**
-    * Criteria used for import function
-    *
-    * @see CommonDevice::getImportCriteria()
-    *
-    * @since 0.84
-   **/
    function getImportCriteria() {
 
       return ['designation'       => 'equal',

--- a/inc/deviceharddrive.class.php
+++ b/inc/deviceharddrive.class.php
@@ -134,29 +134,16 @@ class DeviceHardDrive extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.85
-    * @see CommonDropdown::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
       return $this->prepareInputForAddOrUpdate($input);
    }
 
 
-   /**
-    * @since 0.85
-    * @see CommonDropdown::prepareInputForUpdate()
-   **/
    function prepareInputForUpdate($input) {
       return $this->prepareInputForAddOrUpdate($input);
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableHeader()
-   **/
    static function getHTMLTableHeader($itemtype, HTMLTableBase $base,
                                       HTMLTableSuperHeader $super = null,
                                       HTMLTableHeader $father = null, array $options = []) {

--- a/inc/devicememory.class.php
+++ b/inc/devicememory.class.php
@@ -122,29 +122,16 @@ class DeviceMemory extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.85
-    * @see CommonDropdown::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
       return $this->prepareInputForAddOrUpdate($input);
    }
 
 
-   /**
-    * @since 0.85
-    * @see CommonDropdown::prepareInputForUpdate()
-   **/
    function prepareInputForUpdate($input) {
       return $this->prepareInputForAddOrUpdate($input);
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableHeader()
-   **/
    static function getHTMLTableHeader($itemtype, HTMLTableBase $base,
                                       HTMLTableSuperHeader $super = null,
                                       HTMLTableHeader $father = null, array $options = []) {
@@ -166,11 +153,6 @@ class DeviceMemory extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableCellForItem()
-   **/
    function getHTMLTableCellForItem(HTMLTableRow $row = null, CommonDBTM $item = null,
                                     HTMLTableCell $father = null, array $options = []) {
 
@@ -199,13 +181,6 @@ class DeviceMemory extends CommonDevice {
    }
 
 
-   /**
-    * Criteria used for import function
-    *
-    * @see CommonDevice::getImportCriteria()
-    *
-    * @since 0.84
-   **/
    function getImportCriteria() {
 
       return ['designation'          => 'equal',

--- a/inc/devicemotherboard.class.php
+++ b/inc/devicemotherboard.class.php
@@ -80,11 +80,6 @@ class DeviceMotherboard extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableHeader()
-   **/
    static function getHTMLTableHeader($itemtype, HTMLTableBase $base,
                                       HTMLTableSuperHeader $super = null,
                                       HTMLTableHeader $father = null, array $options = []) {
@@ -103,11 +98,6 @@ class DeviceMotherboard extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableCellForItem()
-   **/
    function getHTMLTableCellForItem(HTMLTableRow $row = null, CommonDBTM $item = null,
                                     HTMLTableCell $father = null, array $options = []) {
 
@@ -125,13 +115,6 @@ class DeviceMotherboard extends CommonDevice {
    }
 
 
-   /**
-    * Criteria used for import function
-    *
-    * @see CommonDevice::getImportCriteria()
-    *
-    * @since 0.84
-   **/
    function getImportCriteria() {
 
       return ['designation'      => 'equal',

--- a/inc/devicenetworkcard.class.php
+++ b/inc/devicenetworkcard.class.php
@@ -147,11 +147,6 @@ class DeviceNetworkCard extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableHeader()
-   **/
    static function getHTMLTableHeader($itemtype, HTMLTableBase $base,
                                       HTMLTableSuperHeader $super = null,
                                       HTMLTableHeader $father = null, array $options = []) {
@@ -175,11 +170,6 @@ class DeviceNetworkCard extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableCellForItem()
-   **/
    static function getHTMLTableCellsForItem(HTMLTableRow $row = null, CommonDBTM $item = null,
                                             HTMLTableCell $father = null, array $options = []) {
 

--- a/inc/devicepowersupply.class.php
+++ b/inc/devicepowersupply.class.php
@@ -91,11 +91,6 @@ class DevicePowerSupply extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableHeader()
-   **/
    static function getHTMLTableHeader($itemtype, HTMLTableBase $base,
                                       HTMLTableSuperHeader $super = null,
                                       HTMLTableHeader $father = null, array $options = []) {
@@ -114,11 +109,6 @@ class DevicePowerSupply extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableCellForItem()
-   **/
    function getHTMLTableCellForItem(HTMLTableRow $row = null, CommonDBTM $item = null,
                                     HTMLTableCell $father = null, array $options = []) {
 

--- a/inc/deviceprocessor.class.php
+++ b/inc/deviceprocessor.class.php
@@ -140,20 +140,11 @@ class DeviceProcessor extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.85
-    * @see CommonDropdown::prepareInputForUpdate()
-   **/
    function prepareInputForUpdate($input) {
       return $this->prepareInputForAddOrUpdate($input);
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableHeader()
-   **/
    static function getHTMLTableHeader($itemtype, HTMLTableBase $base,
                                       HTMLTableSuperHeader $super = null,
                                       HTMLTableHeader $father = null, array $options = []) {
@@ -172,11 +163,6 @@ class DeviceProcessor extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableCellForItem()
-   **/
    function getHTMLTableCellForItem(HTMLTableRow $row = null, CommonDBTM $item = null,
                                     HTMLTableCell $father = null, array $options = []) {
 
@@ -194,13 +180,6 @@ class DeviceProcessor extends CommonDevice {
    }
 
 
-   /**
-    * Criteria used for import function
-    *
-    * @see CommonDevice::getImportCriteria()
-    *
-    * @since 0.84
-   **/
    function getImportCriteria() {
 
       return ['designation'          => 'equal',

--- a/inc/devicesoundcard.class.php
+++ b/inc/devicesoundcard.class.php
@@ -88,11 +88,6 @@ class DeviceSoundCard extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableHeader()
-   **/
    static function getHTMLTableHeader($itemtype, HTMLTableBase $base,
                                       HTMLTableSuperHeader $super = null,
                                       HTMLTableHeader $father = null, array $options = []) {
@@ -113,11 +108,6 @@ class DeviceSoundCard extends CommonDevice {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDevice::getHTMLTableCellForItem()
-   **/
    function getHTMLTableCellForItem(HTMLTableRow $row = null, CommonDBTM $item = null,
                                     HTMLTableCell $father = null, array $options = []) {
 

--- a/inc/displaypreference.class.php
+++ b/inc/displaypreference.class.php
@@ -53,9 +53,6 @@ class DisplayPreference extends CommonDBTM {
 
 
 
-   /**
-    * @see CommonDBTM::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
       global $DB;
 
@@ -73,10 +70,9 @@ class DisplayPreference extends CommonDBTM {
 
 
    /**
+    * {@inheritDoc}
     * @since 0.85
-    *
-    * @see CommonDBTM::processMassiveActionsForOneItemtype()
-   **/
+    */
    static function processMassiveActionsForOneItemtype(MassiveAction $ma, CommonDBTM $item,
                                                        array $ids) {
 
@@ -727,11 +723,6 @@ class DisplayPreference extends CommonDBTM {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see commonDBTM::getRights()
-   **/
    function getRights($interface = 'central') {
 
       //TRANS: short for : Search result user display

--- a/inc/displaypreference.class.php
+++ b/inc/displaypreference.class.php
@@ -69,10 +69,6 @@ class DisplayPreference extends CommonDBTM {
    }
 
 
-   /**
-    * {@inheritDoc}
-    * @since 0.85
-    */
    static function processMassiveActionsForOneItemtype(MassiveAction $ma, CommonDBTM $item,
                                                        array $ids) {
 

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -188,9 +188,6 @@ class Document extends CommonDBTM {
    }
 
 
-   /**
-    * @see CommonDBTM::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
       global $CFG_GLPI;
 
@@ -320,9 +317,6 @@ class Document extends CommonDBTM {
    }
 
 
-   /**
-    * @see CommonDBTM::prepareInputForUpdate()
-   **/
    function prepareInputForUpdate($input) {
 
       // security (don't accept filename from $_REQUEST)
@@ -1435,11 +1429,6 @@ class Document extends CommonDBTM {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBTM::getMassiveActionsForItemtype()
-   **/
    static function getMassiveActionsForItemtype(array &$actions, $itemtype, $is_deleted = 0,
                                                 CommonDBTM $checkitem = null) {
       $action_prefix = 'Document_Item'.MassiveAction::CLASS_ACTION_SEPARATOR;

--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -52,9 +52,6 @@ class Document_Item extends CommonDBRelation{
    static public $take_entity_2 = false;
 
 
-   /**
-    * @since 0.84
-   **/
    function getForbiddenStandardMassiveAction() {
 
       $forbidden   = parent::getForbiddenStandardMassiveAction();
@@ -63,10 +60,6 @@ class Document_Item extends CommonDBRelation{
    }
 
 
-   /**
-    * @since 0.85.5
-    * @see CommonDBRelation::canCreateItem()
-   **/
    function canCreateItem() {
 
       if ($this->fields['itemtype'] == 'Ticket') {
@@ -939,11 +932,6 @@ class Document_Item extends CommonDBRelation{
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBRelation::getRelationMassiveActionsPeerForSubForm()
-   **/
    static function getRelationMassiveActionsPeerForSubForm(MassiveAction $ma) {
 
       switch ($ma->getAction()) {
@@ -959,11 +947,6 @@ class Document_Item extends CommonDBRelation{
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBRelation::getRelationMassiveActionsSpecificities()
-   **/
    static function getRelationMassiveActionsSpecificities() {
       $specificities              = parent::getRelationMassiveActionsSpecificities();
       $specificities['itemtypes'] = Document::getItemtypesThatCanHave();

--- a/inc/documenttype.class.php
+++ b/inc/documenttype.class.php
@@ -112,9 +112,6 @@ class DocumentType  extends CommonDropdown {
    }
 
 
-   /**
-    * @since 0.84
-   **/
    static function getSpecificValueToDisplay($field, $values, array $options = []) {
       global $CFG_GLPI;
 

--- a/inc/dropdowntranslation.class.php
+++ b/inc/dropdowntranslation.class.php
@@ -63,9 +63,6 @@ class DropdownTranslation extends CommonDBChild {
    }
 
 
-   /**
-    * @see CommonGLPI::getTabNameForItem()
-   **/
    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
 
       if (self::canBeTranslated($item)) {

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -178,20 +178,12 @@ class Entity extends CommonTreeDropdown {
    }
 
 
-   /**
-    * @since 0.84
-    *
-    * @see CommonDBTM::canViewItem()
-   **/
    function canViewItem() {
       // Check the current entity
       return Session::haveAccessToEntity($this->getField('id'));
    }
 
 
-   /**
-    * @see CommonDBTM::isNewID()
-   **/
    static function isNewID($ID) {
       return (($ID < 0) || !strlen($ID));
    }
@@ -320,9 +312,6 @@ class Entity extends CommonTreeDropdown {
    }
 
 
-   /**
-    * @see CommonTreeDropdown::defineTabs()
-   **/
    function defineTabs($options = []) {
 
       $ong = [];
@@ -3346,11 +3335,6 @@ class Entity extends CommonTreeDropdown {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see commonDBTM::getRights()
-   **/
    function getRights($interface = 'central') {
 
       $values = parent::getRights();

--- a/inc/fieldblacklist.class.php
+++ b/inc/fieldblacklist.class.php
@@ -191,9 +191,6 @@ class Fieldblacklist extends CommonDropdown {
    }
 
 
-   /**
-    * @see CommonDBTM::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
 
       $input = parent::prepareInputForAdd($input);
@@ -201,9 +198,6 @@ class Fieldblacklist extends CommonDropdown {
    }
 
 
-   /**
-    * @see CommonDBTM::prepareInputForUpdate()
-   **/
    function prepareInputForUpdate($input) {
 
       $input = parent::prepareInputForUpdate($input);

--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -320,9 +320,6 @@ class Group extends CommonTreeDropdown {
    }
 
 
-   /**
-    * @see CommonDBTM::getSpecificMassiveActions()
-   **/
    function getSpecificMassiveActions($checkitem = null) {
 
       $isadmin = static::canUpdate();
@@ -342,11 +339,6 @@ class Group extends CommonTreeDropdown {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBTM::showMassiveActionsSubForm()
-   **/
    static function showMassiveActionsSubForm(MassiveAction $ma) {
 
       $input = $ma->getInput();
@@ -381,11 +373,6 @@ class Group extends CommonTreeDropdown {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBTM::processMassiveActionsForOneItemtype()
-   **/
    static function processMassiveActionsForOneItemtype(MassiveAction $ma, CommonDBTM $item,
                                                        array $ids) {
 

--- a/inc/group_user.class.php
+++ b/inc/group_user.class.php
@@ -622,11 +622,6 @@ class Group_User extends CommonDBRelation{
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBRelation::getRelationInputForProcessingOfMassiveActions()
-   **/
    static function getRelationInputForProcessingOfMassiveActions($action, CommonDBTM $item,
                                                                  array $ids, array $input) {
       switch ($action) {

--- a/inc/holiday.class.php
+++ b/inc/holiday.class.php
@@ -94,9 +94,6 @@ class Holiday extends CommonDropdown {
    }
 
 
-   /**
-    * @see CommonDBTM::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
 
       $input = parent::prepareInputForAdd($input);
@@ -111,9 +108,6 @@ class Holiday extends CommonDropdown {
    }
 
 
-   /**
-    * @see CommonDBTM::prepareInputForUpdate()
-   **/
    function prepareInputForUpdate($input) {
 
       $input = parent::prepareInputForUpdate($input);

--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -121,9 +121,6 @@ class Infocom extends CommonDBChild {
    }
 
 
-   /**
-    * @see CommonGLPI::getTabNameForItem()
-   **/
    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
 
       // Can exists on template
@@ -249,9 +246,6 @@ class Infocom extends CommonDBChild {
    }
 
 
-   /**
-    * @see CommonDBChild::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
       if (!$this->getFromDBforDevice($input['itemtype'], $input['items_id'])) {
          if ($item = static::getItemFromArray(static::$itemtype, static::$items_id, $input)) {
@@ -370,9 +364,6 @@ class Infocom extends CommonDBChild {
    }
 
 
-   /**
-    * @see CommonDBChild::prepareInputForUpdate()
-   **/
    function prepareInputForUpdate($input) {
 
       //Check if one or more dates needs to be updated
@@ -1972,11 +1963,6 @@ class Infocom extends CommonDBChild {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBTM::getMassiveActionsForItemtype()
-   **/
    static function getMassiveActionsForItemtype(array &$actions, $itemtype, $is_deleted = 0,
                                                 CommonDBTM $checkitem = null) {
 
@@ -1990,11 +1976,6 @@ class Infocom extends CommonDBChild {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBTM::processMassiveActionsForOneItemtype()
-   **/
    static function processMassiveActionsForOneItemtype(MassiveAction $ma, CommonDBTM $item,
                                                        array $ids) {
 

--- a/inc/ipaddress.class.php
+++ b/inc/ipaddress.class.php
@@ -158,34 +158,22 @@ class IPAddress extends CommonDBChild {
    }
 
 
-   /**
-    * @see CommonDBChild::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
       return parent::prepareInputForAdd($this->prepareInput($input));
    }
 
 
-   /**
-    * @see CommonDBChild::prepareInputForUpdate()
-   **/
    function prepareInputForUpdate($input) {
       return parent::prepareInputForUpdate($this->prepareInput($input));
    }
 
 
-   /**
-    * @see CommonDBTM::post_addItem()
-   **/
    function post_addItem() {
       IPAddress_IPNetwork::addIPAddress($this);
       parent::post_addItem();
    }
 
 
-   /**
-    * @see CommonDBTM::post_updateItem()
-   **/
    function post_updateItem($history = 1) {
 
       if ((isset($this->oldvalues['name']))

--- a/inc/ipnetwork.class.php
+++ b/inc/ipnetwork.class.php
@@ -340,9 +340,6 @@ class IPNetwork extends CommonImplicitTreeDropdown {
    }
 
 
-   /**
-    * @see CommonImplicitTreeDropdown::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
 
       $preparedInput = $this->prepareInput($input);
@@ -360,9 +357,6 @@ class IPNetwork extends CommonImplicitTreeDropdown {
    }
 
 
-   /**
-    * @see CommonImplicitTreeDropdown::prepareInputForUpdate()
-   **/
    function prepareInputForUpdate($input) {
 
       $preparedInput = $this->prepareInput($input);
@@ -391,9 +385,6 @@ class IPNetwork extends CommonImplicitTreeDropdown {
    }
 
 
-   /**
-    * @see CommonImplicitTreeDropdown::post_updateItem()
-   **/
    function post_updateItem($history = 1) {
 
       if ($this->networkUpdate) {

--- a/inc/item_devicebattery.class.php
+++ b/inc/item_devicebattery.class.php
@@ -45,9 +45,6 @@ class Item_DeviceBattery extends Item_Devices {
    static protected $notable = false;
 
 
-   /**
-    * @since 0.85
-    **/
    static function getSpecificities($specif = '') {
       return [
          'serial'             => parent::getSpecificities('serial'),

--- a/inc/item_devicecase.class.php
+++ b/inc/item_devicecase.class.php
@@ -45,9 +45,6 @@ class Item_DeviceCase extends Item_Devices {
    static protected $notable = false;
 
 
-   /**
-    * @since 0.85
-   **/
    static function getSpecificities($specif = '') {
       return ['serial' => parent::getSpecificities('serial'),
                    'otherserial' => parent::getSpecificities('otherserial'),

--- a/inc/item_devicecontrol.class.php
+++ b/inc/item_devicecontrol.class.php
@@ -45,9 +45,6 @@ class Item_DeviceControl extends Item_Devices {
    static protected $notable = false;
 
 
-   /**
-    * @since 0.85
-   **/
    static function getSpecificities($specif = '') {
 
       return ['serial' => parent::getSpecificities('serial'),

--- a/inc/item_devicedrive.class.php
+++ b/inc/item_devicedrive.class.php
@@ -45,9 +45,6 @@ class Item_DeviceDrive extends Item_Devices {
    static protected $notable = false;
 
 
-   /**
-    * @since 0.85
-   **/
    static function getSpecificities($specif = '') {
 
       return ['serial' => parent::getSpecificities('serial'),

--- a/inc/item_devicegeneric.class.php
+++ b/inc/item_devicegeneric.class.php
@@ -42,9 +42,6 @@ class Item_DeviceGeneric extends Item_Devices {
    static protected $notable = false;
 
 
-   /**
-    * @since 0.85
-   **/
    static function getSpecificities($specif = '') {
       return ['serial' => parent::getSpecificities('serial'),
                    'otherserial' => parent::getSpecificities('otherserial'),

--- a/inc/item_devicegraphiccard.class.php
+++ b/inc/item_devicegraphiccard.class.php
@@ -44,9 +44,7 @@ class Item_DeviceGraphicCard extends Item_Devices {
 
    static protected $notable = false;
 
-   /**
-    * @since 0.85
-   **/
+
    static function getSpecificities($specif = '') {
 
       return ['memory' => ['long name'  => sprintf(__('%1$s (%2$s)'), _n('Memory', 'Memories', 1),

--- a/inc/item_deviceharddrive.class.php
+++ b/inc/item_deviceharddrive.class.php
@@ -44,9 +44,6 @@ class Item_DeviceHardDrive extends Item_Devices {
 
    static protected $notable = false;
 
-   /**
-    * @since 0.85
-   **/
    static function getSpecificities($specif = '') {
 
       return ['capacity' => ['long name'  => sprintf(__('%1$s (%2$s)'), __('Capacity'),

--- a/inc/item_devicememory.class.php
+++ b/inc/item_devicememory.class.php
@@ -49,9 +49,6 @@ class Item_DeviceMemory extends Item_Devices {
    static protected $notable = false;
 
 
-   /**
-    * @since 0.85
-   **/
    static function getSpecificities($specif = '') {
 
       return ['size'   => ['long name'  => sprintf(__('%1$s (%2$s)'), __('Size'),

--- a/inc/item_devicemotherboard.class.php
+++ b/inc/item_devicemotherboard.class.php
@@ -45,9 +45,6 @@ class Item_DeviceMotherboard extends Item_Devices {
    static protected $notable = false;
 
 
-   /**
-    * @since 0.85
-   **/
    static function getSpecificities($specif = '') {
       return ['serial' => parent::getSpecificities('serial'),
                   'otherserial' => parent::getSpecificities('otherserial'),

--- a/inc/item_devicenetworkcard.class.php
+++ b/inc/item_devicenetworkcard.class.php
@@ -49,9 +49,6 @@ class Item_DeviceNetworkCard extends Item_Devices {
    static protected $notable = false;
 
 
-   /**
-    * @since 0.85
-   **/
    static function getSpecificities($specif = '') {
 
       return ['mac'    => ['long name'  => __('MAC address'),

--- a/inc/item_devicepci.class.php
+++ b/inc/item_devicepci.class.php
@@ -49,9 +49,6 @@ class Item_DevicePci extends Item_Devices {
    static protected $notable = false;
 
 
-   /**
-    * @since 0.85
-   **/
    static function getSpecificities($specif = '') {
 
       return ['serial' => parent::getSpecificities('serial'),

--- a/inc/item_devicepowersupply.class.php
+++ b/inc/item_devicepowersupply.class.php
@@ -44,9 +44,6 @@ class Item_DevicePowerSupply extends Item_Devices {
 
    static protected $notable = false;
 
-   /**
-    * @since 0.85
-   **/
    static function getSpecificities($specif = '') {
 
       return ['serial' => parent::getSpecificities('serial'),

--- a/inc/item_deviceprocessor.class.php
+++ b/inc/item_deviceprocessor.class.php
@@ -45,9 +45,6 @@ class Item_DeviceProcessor extends Item_Devices {
    static protected $notable = false;
 
 
-   /**
-    * @since 0.85
-    **/
    static function getSpecificities($specif = '') {
 
       return ['frequency' => ['long name'  => sprintf(__('%1$s (%2$s)'), __('Frequency'),

--- a/inc/item_devices.class.php
+++ b/inc/item_devices.class.php
@@ -84,9 +84,6 @@ class Item_Devices extends CommonDBRelation {
       return $name;
    }
 
-   /**
-    * @since 0.85
-   **/
    static function getTypeName($nb = 0) {
       $device_type = static::getDeviceType();
       return $device_type::getTypeName($nb);
@@ -107,11 +104,6 @@ class Item_Devices extends CommonDBRelation {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBTM::getForbiddenStandardMassiveAction()
-   **/
    function getForbiddenStandardMassiveAction() {
 
       $forbidden = parent::getForbiddenStandardMassiveAction();
@@ -1254,11 +1246,6 @@ class Item_Devices extends CommonDBRelation {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see commonDBTM::getRights()
-    **/
    function getRights($interface = 'central') {
 
       $values = parent::getRights();
@@ -1282,12 +1269,6 @@ class Item_Devices extends CommonDBRelation {
    }
 
 
-
-   /**
-    * @since 0.85
-    *
-    * @see CommonGLPI::defineTabs()
-   **/
    function defineTabs($options = []) {
 
       $ong = [];

--- a/inc/item_devicesimcard.class.php
+++ b/inc/item_devicesimcard.class.php
@@ -54,9 +54,6 @@ class Item_DeviceSimcard extends Item_Devices {
       return _n('Simcard', 'Simcards', $nb);
    }
 
-   /**
-    * @since 0.85
-    **/
    static function getSpecificities($specif = '') {
       return [
              'serial'         => parent::getSpecificities('serial'),

--- a/inc/item_devicesoundcard.class.php
+++ b/inc/item_devicesoundcard.class.php
@@ -49,9 +49,6 @@ class Item_DeviceSoundCard extends Item_Devices {
    static protected $notable = false;
 
 
-   /**
-    * @since 0.85
-   **/
    static function getSpecificities($specif = '') {
 
       return ['serial' => parent::getSpecificities('serial'),

--- a/inc/item_disk.class.php
+++ b/inc/item_disk.class.php
@@ -60,9 +60,6 @@ class Item_Disk extends CommonDBChild {
    }
 
 
-   /**
-    * @see CommonGLPI::getTabNameForItem()
-   **/
    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
 
       // can exists for template
@@ -94,11 +91,6 @@ class Item_Disk extends CommonDBChild {
    }
 
 
-   /**
-    * @see CommonGLPI::defineTabs()
-    *
-    * @since 0.85
-   **/
    function defineTabs($options = []) {
 
       $ong = [];

--- a/inc/item_problem.class.php
+++ b/inc/item_problem.class.php
@@ -52,9 +52,6 @@ class Item_Problem extends CommonDBRelation{
 
 
 
-   /**
-    * @since 0.84
-   **/
    function getForbiddenStandardMassiveAction() {
 
       $forbidden   = parent::getForbiddenStandardMassiveAction();
@@ -63,9 +60,6 @@ class Item_Problem extends CommonDBRelation{
    }
 
 
-   /**
-    * @see CommonDBTM::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
 
       // Avoid duplicate entry

--- a/inc/item_project.class.php
+++ b/inc/item_project.class.php
@@ -63,9 +63,6 @@ class Item_Project extends CommonDBRelation{
    }
 
 
-   /**
-    * @see CommonDBTM::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
 
       // Avoid duplicate entry

--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -119,9 +119,6 @@ class Item_Ticket extends CommonDBRelation{
    }
 
 
-   /**
-    * @see CommonDBTM::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
 
       // Avoid duplicate entry
@@ -1107,11 +1104,6 @@ class Item_Ticket extends CommonDBRelation{
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBTM::processMassiveActionsForOneItemtype()
-   **/
    static function processMassiveActionsForOneItemtype(MassiveAction $ma, CommonDBTM $item,
                                                        array $ids) {
 

--- a/inc/itilcategory.class.php
+++ b/inc/itilcategory.class.php
@@ -323,9 +323,6 @@ class ITILCategory extends CommonTreeDropdown {
       return -1;
    }
 
-   /**
-    * @since 9.5.0
-   **/
    function prepareInputForAdd($input) {
       $input = parent::prepareInputForAdd($input);
 
@@ -340,9 +337,6 @@ class ITILCategory extends CommonTreeDropdown {
    }
 
 
-   /**
-    * @since 9.5.0
-   **/
    function prepareInputForUpdate($input) {
       $input = parent::prepareInputForUpdate($input);
 

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -1045,11 +1045,6 @@ JAVASCRIPT;
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see commonDBTM::getRights()
-    **/
    function getRights($interface = 'central') {
 
       $values = parent::getRights();

--- a/inc/itiltemplate.class.php
+++ b/inc/itiltemplate.class.php
@@ -538,11 +538,6 @@ abstract class ITILTemplate extends CommonDropdown {
    }
 
 
-   /**
-    * @since 0.90
-    *
-    * @see CommonDBTM::getSpecificMassiveActions()
-   **/
    function getSpecificMassiveActions($checkitem = null) {
 
       $isadmin = static::canUpdate();
@@ -558,11 +553,6 @@ abstract class ITILTemplate extends CommonDropdown {
    }
 
 
-   /**
-    * @since 0.90
-    *
-    * @see CommonDBTM::showMassiveActionsSubForm()
-   **/
    static function showMassiveActionsSubForm(MassiveAction $ma) {
 
       switch ($ma->getAction()) {
@@ -576,11 +566,6 @@ abstract class ITILTemplate extends CommonDropdown {
    }
 
 
-   /**
-    * @since 0.90
-    *
-    * @see CommonDBTM::processMassiveActionsForOneItemtype()
-   **/
    static function processMassiveActionsForOneItemtype(MassiveAction $ma, CommonDBTM $item,
                                                        array $ids) {
 

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -620,9 +620,6 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
       return $criteria;
    }
 
-   /**
-    * @see CommonDBTM::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
 
       // set new date if not exists
@@ -1900,11 +1897,6 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
       return $tab;
    }
 
-   /**
-    * @since 0.85
-    *
-    * @see commonDBTM::getRights()
-   **/
    function getRights($interface = 'central') {
 
       if ($interface == 'central') {

--- a/inc/knowbaseitemtranslation.class.php
+++ b/inc/knowbaseitemtranslation.class.php
@@ -77,9 +77,6 @@ class KnowbaseItemTranslation extends CommonDBChild {
    }
 
 
-   /**
-    * @see CommonGLPI::getTabNameForItem()
-   **/
    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
 
       if (!$withtemplate) {

--- a/inc/line.class.php
+++ b/inc/line.class.php
@@ -61,9 +61,6 @@ class Line extends CommonDropdown {
    }
 
 
-   /**
-    * @see CommonGLPI::defineTabs()
-    **/
    function defineTabs($options = []) {
 
       $ong = [];

--- a/inc/location.class.php
+++ b/inc/location.class.php
@@ -370,11 +370,6 @@ class Location extends CommonTreeDropdown {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonTreeDropdown::getTabNameForItem()
-   **/
    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
 
       if (!$withtemplate) {
@@ -390,9 +385,6 @@ class Location extends CommonTreeDropdown {
    }
 
 
-   /**
-    * @since 0.85
-   **/
    static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0) {
 
       if ($item->getType() == __CLASS__) {

--- a/inc/lock.class.php
+++ b/inc/lock.class.php
@@ -588,7 +588,7 @@ class Lock {
     * @since 0.85
     *
     * @see CommonDBTM::getMassiveActionsForItemtype()
-   **/
+    **/
    static function getMassiveActionsForItemtype(array &$actions, $itemtype, $is_deleted = 0,
                                                 CommonDBTM $checkitem = null) {
 
@@ -606,7 +606,7 @@ class Lock {
     * @since 0.85
     *
     * @see CommonDBTM::showMassiveActionsSubForm()
-   **/
+    **/
    static function showMassiveActionsSubForm(MassiveAction $ma) {
 
       switch ($ma->getAction()) {
@@ -641,7 +641,7 @@ class Lock {
     * @since 0.85
     *
     * @see CommonDBTM::processMassiveActionsForOneItemtype()
-   **/
+    **/
    static function processMassiveActionsForOneItemtype(MassiveAction $ma, CommonDBTM $baseitem,
                                                        array $ids) {
       global $DB;

--- a/inc/log.class.php
+++ b/inc/log.class.php
@@ -1263,11 +1263,6 @@ class Log extends CommonDBTM {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see commonDBTM::getRights()
-   **/
    function getRights($interface = 'central') {
 
       $values = [ READ => __('Read')];

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -176,9 +176,6 @@ class MailCollector  extends CommonDBTM {
    }
 
 
-   /**
-    * @see CommonGLPI::defineTabs()
-   **/
    function defineTabs($options = []) {
 
       $ong = [];
@@ -191,9 +188,6 @@ class MailCollector  extends CommonDBTM {
    }
 
 
-   /**
-    * @see CommonGLPI::getTabNameForItem()
-   **/
    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
 
       if (!$withtemplate) {

--- a/inc/manufacturer.class.php
+++ b/inc/manufacturer.class.php
@@ -46,10 +46,6 @@ class Manufacturer extends CommonDropdown {
    }
 
 
-   /**
-    * @since 0.85
-    * @see CommonDropdown::displaySpecificTypeField()
-   **/
    function displaySpecificTypeField($ID, $field = []) {
 
       switch ($field['type']) {
@@ -60,10 +56,6 @@ class Manufacturer extends CommonDropdown {
    }
 
 
-   /**
-    * @since 0.85
-    * @see CommonDropdown::getAdditionalFields()
-   **/
    function getAdditionalFields() {
 
       return [['name'  => 'none',
@@ -115,10 +107,6 @@ class Manufacturer extends CommonDropdown {
    }
 
 
-   /**
-    * @since 0.85
-    * @see CommonDBTM::post_addItem()
-   **/
    function post_addItem() {
 
       $this->post_workOnItem();
@@ -126,10 +114,6 @@ class Manufacturer extends CommonDropdown {
    }
 
 
-   /**
-    * @since 0.85
-    * @see CommonDBTM::post_updateItem()
-   **/
    function post_updateItem($history = 1) {
 
       $this->post_workOnItem();

--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -676,9 +676,6 @@ class MassiveAction {
    }
 
 
-   /**
-    * @see CommonDBTM::showMassiveActionsSubForm()
-   **/
    static function showMassiveActionsSubForm(MassiveAction $ma) {
       global $CFG_GLPI;
 
@@ -1090,9 +1087,6 @@ class MassiveAction {
    }
 
 
-   /**
-    * @see CommonDBTM::processMassiveActionsForOneItemtype()
-   **/
    static function processMassiveActionsForOneItemtype(MassiveAction $ma, CommonDBTM $item,
                                                        array $ids) {
       global $CFG_GLPI;

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -81,9 +81,6 @@ class Monitor extends CommonDBTM {
    }
 
 
-   /**
-    * @see CommonGLPI::defineTabs()
-   **/
    function defineTabs($options = []) {
 
       $ong = [];
@@ -111,9 +108,6 @@ class Monitor extends CommonDBTM {
       return $ong;
    }
 
-   /**
-    * @see CommonDBTM::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
 
       if (isset($input["id"]) && ($input["id"] > 0)) {
@@ -352,9 +346,6 @@ class Monitor extends CommonDBTM {
    }
 
 
-   /**
-    * @see CommonDBTM::getSpecificMassiveActions()
-   **/
    function getSpecificMassiveActions($checkitem = null) {
 
       $actions = parent::getSpecificMassiveActions($checkitem);

--- a/inc/networkequipment.class.php
+++ b/inc/networkequipment.class.php
@@ -409,9 +409,6 @@ class NetworkEquipment extends CommonDBTM {
    }
 
 
-   /**
-    * @see CommonDBTM::getSpecificMassiveActions()
-   **/
    function getSpecificMassiveActions($checkitem = null) {
 
       $isadmin = static::canUpdate();

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -181,9 +181,6 @@ class NetworkPort extends CommonDBChild {
       return true;
    }
 
-   /**
-    * @see CommonDBTM::prepareInputForUpdate
-    */
    function prepareInputForUpdate($input) {
       if (!isset($input["_no_history"])) {
          $input['_no_history'] = false;
@@ -196,9 +193,6 @@ class NetworkPort extends CommonDBChild {
       return $input;
    }
 
-   /**
-    * @see CommonDBTM::post_updateItem
-    */
    function post_updateItem($history = 1) {
       global $DB;
 
@@ -227,9 +221,6 @@ class NetworkPort extends CommonDBChild {
       $this->updateDependencies(!$this->input['_no_history']);
    }
 
-   /**
-   * @see CommonDBTM::post_clone
-   */
    function post_clone($source, $history) {
       parent::post_clone($source, $history);
       $instantiation = $source->getInstantiation();
@@ -379,9 +370,6 @@ class NetworkPort extends CommonDBChild {
    }
 
 
-   /**
-    * @see CommonDBTM::prepareInputForAdd
-    */
    function prepareInputForAdd($input) {
 
       if (isset($input["logical_number"]) && (strlen($input["logical_number"]) == 0)) {
@@ -400,9 +388,6 @@ class NetworkPort extends CommonDBChild {
       return parent::prepareInputForAdd($input);
    }
 
-   /**
-    * @see CommonDBTM::post_addItem
-    */
    function post_addItem() {
       $this->updateDependencies(!$this->input['_no_history']);
    }
@@ -983,9 +968,6 @@ class NetworkPort extends CommonDBChild {
    }
 
 
-   /**
-    * @see CommonDBTM::getSpecificMassiveActions()
-   **/
    function getSpecificMassiveActions($checkitem = null) {
 
       $isadmin = $checkitem !== null && $checkitem->canUpdate();

--- a/inc/networkport_vlan.class.php
+++ b/inc/networkport_vlan.class.php
@@ -270,11 +270,6 @@ class NetworkPort_Vlan extends CommonDBRelation {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBRelation::showRelationMassiveActionsSubForm()
-   **/
    static function showRelationMassiveActionsSubForm(MassiveAction $ma, $peer_number) {
 
       if ($ma->getAction() == 'add') {
@@ -283,11 +278,6 @@ class NetworkPort_Vlan extends CommonDBRelation {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBRelation::getRelationInputForProcessingOfMassiveActions()
-   **/
    static function getRelationInputForProcessingOfMassiveActions($action, CommonDBTM $item,
                                                                  array $ids, array $input) {
       if ($action == 'add') {

--- a/inc/networkportaggregate.class.php
+++ b/inc/networkportaggregate.class.php
@@ -83,9 +83,6 @@ class NetworkPortAggregate extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::getInstantiationHTMLTableHeaders
-   **/
    function getInstantiationHTMLTableHeaders(HTMLTableGroup $group, HTMLTableSuperHeader $super,
                                              HTMLTableSuperHeader $internet_super = null,
                                              HTMLTableHeader $father = null,
@@ -99,9 +96,6 @@ class NetworkPortAggregate extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::getInstantiationHTMLTable()
-   **/
    function getInstantiationHTMLTable(NetworkPort $netport, HTMLTableRow $row,
                                       HTMLTableCell $father = null, array $options = []) {
 

--- a/inc/networkportalias.class.php
+++ b/inc/networkportalias.class.php
@@ -81,9 +81,6 @@ class NetworkPortAlias extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::getInstantiationHTMLTableHeaders
-   **/
    function getInstantiationHTMLTableHeaders(HTMLTableGroup $group, HTMLTableSuperHeader $super,
                                              HTMLTableSuperHeader $internet_super = null,
                                              HTMLTableHeader $father = null,
@@ -96,9 +93,6 @@ class NetworkPortAlias extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::getInstantiationHTMLTable()
-   **/
    function getInstantiationHTMLTable(NetworkPort $netport, HTMLTableRow $row,
                                       HTMLTableCell $father = null, array $options = []) {
 

--- a/inc/networkportdialup.class.php
+++ b/inc/networkportdialup.class.php
@@ -45,9 +45,6 @@ class NetworkPortDialup extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::getInstantiationHTMLTableHeaders
-   **/
    function getInstantiationHTMLTableHeaders(HTMLTableGroup $group, HTMLTableSuperHeader $super,
                                              HTMLTableSuperHeader $internet_super = null,
                                              HTMLTableHeader $father = null,
@@ -60,9 +57,6 @@ class NetworkPortDialup extends NetworkPortInstantiation {
    }
 
 
-   /**
-   * @see NetworkPortInstantiation::getInstantiationHTMLTable()
-   **/
    function getInstantiationHTMLTable(NetworkPort $netport, HTMLTableRow $row,
                                       HTMLTableCell $father = null, array $options = []) {
 
@@ -70,9 +64,6 @@ class NetworkPortDialup extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::showInstantiationForm()
-   **/
    function showInstantiationForm(NetworkPort $netport, $options, $recursiveItems) {
 
       echo "<tr class='tab_bg_1'>";

--- a/inc/networkportethernet.class.php
+++ b/inc/networkportethernet.class.php
@@ -118,9 +118,6 @@ class NetworkPortEthernet extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::getInstantiationHTMLTableHeaders
-   **/
    function getInstantiationHTMLTableHeaders(HTMLTableGroup $group, HTMLTableSuperHeader $super,
                                              HTMLTableSuperHeader $internet_super = null,
                                              HTMLTableHeader $father = null,
@@ -144,9 +141,6 @@ class NetworkPortEthernet extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::getPeerInstantiationHTMLTable()
-   **/
    protected function getPeerInstantiationHTMLTable(NetworkPort $netport, HTMLTableRow $row,
                                                     HTMLTableCell $father = null,
                                                     array $options = []) {
@@ -169,9 +163,6 @@ class NetworkPortEthernet extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::getInstantiationHTMLTable()
-   **/
    function getInstantiationHTMLTable(NetworkPort $netport, HTMLTableRow $row,
                                       HTMLTableCell $father = null, array $options = []) {
 

--- a/inc/networkportfiberchannel.class.php
+++ b/inc/networkportfiberchannel.class.php
@@ -80,9 +80,6 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::showInstantiationForm()
-    */
    function showInstantiationForm(NetworkPort $netport, $options, $recursiveItems) {
 
       if (!$options['several']) {
@@ -119,9 +116,6 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::getInstantiationHTMLTableHeaders
-   **/
    function getInstantiationHTMLTableHeaders(HTMLTableGroup $group, HTMLTableSuperHeader $super,
                                              HTMLTableSuperHeader $internet_super = null,
                                              HTMLTableHeader $father = null,
@@ -145,9 +139,6 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::getPeerInstantiationHTMLTable()
-    **/
    protected function getPeerInstantiationHTMLTable(NetworkPort $netport, HTMLTableRow $row,
                                                     HTMLTableCell $father = null,
                                                     array $options = []) {
@@ -168,9 +159,6 @@ class NetworkPortFiberchannel extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::getInstantiationHTMLTable()
-    **/
    function getInstantiationHTMLTable(NetworkPort $netport, HTMLTableRow $row,
                                       HTMLTableCell $father = null, array $options = []) {
 

--- a/inc/networkportmigration.class.php
+++ b/inc/networkportmigration.class.php
@@ -92,11 +92,6 @@ class NetworkPortMigration extends CommonDBChild {
       parent::post_deleteItem();
    }
 
-   /**
-    * @see CommonGLPI::defineTabs()
-    *
-    * @since 0.85
-   **/
    function defineTabs($options = []) {
 
       $ong = [];
@@ -312,9 +307,6 @@ class NetworkPortMigration extends CommonDBChild {
    }
 
 
-   /**
-    * @see CommonDBTM::getSpecificMassiveActions()
-   **/
    function getSpecificMassiveActions($checkitem = null) {
 
       $isadmin = static::canUpdate();
@@ -327,11 +319,6 @@ class NetworkPortMigration extends CommonDBChild {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBTM::showMassiveActionsSubForm()
-   **/
    static function showMassiveActionsSubForm(MassiveAction $ma) {
       switch ($ma->getAction()) {
          case 'transform_to' :
@@ -345,11 +332,6 @@ class NetworkPortMigration extends CommonDBChild {
    }
 
 
-   /**
-    * @since 0.85
-    *
-    * @see CommonDBTM::processMassiveActionsForOneItemtype()
-   **/
    static function processMassiveActionsForOneItemtype(MassiveAction $ma, CommonDBTM $item,
                                                        array $ids) {
       switch ($ma->getAction()) {

--- a/inc/networkportwifi.class.php
+++ b/inc/networkportwifi.class.php
@@ -50,9 +50,6 @@ class NetworkPortWifi extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::showInstantiationForm()
-   **/
    function showInstantiationForm(NetworkPort $netport, $options, $recursiveItems) {
 
       if (!$options['several']) {
@@ -86,9 +83,6 @@ class NetworkPortWifi extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::getInstantiationHTMLTableHeaders
-   **/
    function getInstantiationHTMLTableHeaders(HTMLTableGroup $group, HTMLTableSuperHeader $super,
                                              HTMLTableSuperHeader $internet_super = null,
                                              HTMLTableHeader $father = null,
@@ -105,9 +99,6 @@ class NetworkPortWifi extends NetworkPortInstantiation {
    }
 
 
-   /**
-    * @see NetworkPortInstantiation::getInstantiationHTMLTable()
-   **/
    function getInstantiationHTMLTable(NetworkPort $netport, HTMLTableRow $row,
                                       HTMLTableCell $father = null, array $options = []) {
 

--- a/inc/notepad.class.php
+++ b/inc/notepad.class.php
@@ -126,9 +126,6 @@ class Notepad extends CommonDBChild {
       }
    }
 
-   /**
-    * @see CommonGLPI::getTabNameForItem()
-   **/
    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
 
       if (Session::haveRight($item::$rightname, READNOTE)) {

--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -457,11 +457,6 @@ class Notification extends CommonDBTM {
       return $actions;
    }
 
-   /**
-   * @since version 0.85
-   *
-   * @see CommonDBTM::showMassiveActionsSubForm()
-   **/
    static function showMassiveActionsSubForm(MassiveAction $ma) {
       switch ($ma->getAction()) {
          case 'add_template':
@@ -657,10 +652,6 @@ class Notification extends CommonDBTM {
    }
 
 
-   /**
-    * @since 0.90.4
-    * @see CommonDBTM::prepareInputForAdd()
-   **/
    function prepareInputForAdd($input) {
 
       if (isset($input["itemtype"]) && empty($input["itemtype"])) {
@@ -673,10 +664,6 @@ class Notification extends CommonDBTM {
    }
 
 
-   /**
-    * @since 0.90.4
-    * @see CommonDBTM::prepareInputForUpdate()
-   **/
    function prepareInputForUpdate($input) {
 
       if (isset($input["itemtype"]) && empty($input["itemtype"])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

A lot of PHPDoc is missing because it is overridden with a `@see` tag instead of inherited. There are more instances not fixed by this commit, but I wanted to keep this PR small to make it easier tor review.
I kept any `@since` tags in overridden docs as they all seemed to be missing in the parent docs or different.