### PR TITLE
remove multiple param from queuenotification mode criteria, fix #8067

### DIFF
--- a/inc/notification_notificationtemplate.class.php
+++ b/inc/notification_notificationtemplate.class.php
@@ -269,7 +269,7 @@ class Notification_NotificationTemplate extends CommonDBRelation {
    static function showFormMassiveAction() {
 
       echo __('Mode')."<br>";
-      self::dropdownMode(['name' => 'mode', 'multiple' => false]);
+      self::dropdownMode(['name' => 'mode']);
       echo "<br><br>";
 
       echo NotificationTemplate::getTypeName(1)."<br>";
@@ -328,7 +328,7 @@ class Notification_NotificationTemplate extends CommonDBRelation {
       echo "<tr class='tab_bg_1'>";
       echo "<td>" . __('Mode') . "</td>";
       echo "<td>";
-      self::dropdownMode(['name' => 'mode', 'value' => $this->getField('mode'), 'multiple' => false]);
+      self::dropdownMode(['name' => 'mode', 'value' => $this->getField('mode')]);
       echo "</td>";
 
       echo "<td>". NotificationTemplate::getTypeName(1)."</td>";
@@ -453,7 +453,6 @@ class Notification_NotificationTemplate extends CommonDBRelation {
          case 'mode' :
             $options['value']    = $values[$field];
             $options['name']     = $name;
-            $options['multiple'] = false;
             return self::dropdownMode($options);
       }
       return parent::getSpecificValueToSelect($field, $name, $values, $options);
@@ -471,7 +470,6 @@ class Notification_NotificationTemplate extends CommonDBRelation {
       $p['name']     = 'modes';
       $p['display']  = true;
       $p['value']    = '';
-      $p['multiple'] = true;
 
       if (is_array($options) && count($options)) {
          foreach ($options as $key => $val) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8067

I don't know why default `multiple` param for `Notification_NotificationTemplate::dropdownMode` was set to true.
All usages force this param to `false` except one, and this last doesn't work properly.

So i choose to remove the param
