### PR TITLE
Fix mandatory fields for recurrent ticket

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -794,15 +794,10 @@ abstract class CommonITILObject extends CommonDBTM {
       if (count($tt->mandatory)) {
          $mandatory_missing = [];
          $fieldsname        = $tt->getAllowedFieldsNames(true);
-         $is_first_update   = $this->fields['date_creation'] == $this->fields['date_mod'];
          foreach ($tt->mandatory as $key => $val) {
             if ((!$check_allowed_fields_for_template || in_array($key, $allowed_fields))
                 && (isset($input[$key])
                     && (empty($input[$key]) || ($input[$key] == 'NULL'))
-                    // Take only into account already set items : do not block
-                    // old tickets unless they haven't been modified yet, this
-                    // is useful for recurrent ticket with mandatory params.
-                    && (!empty($this->fields[$key]) || $is_first_update)
                 )) {
                $mandatory_missing[$key] = $fieldsname[$val];
             }

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -794,12 +794,15 @@ abstract class CommonITILObject extends CommonDBTM {
       if (count($tt->mandatory)) {
          $mandatory_missing = [];
          $fieldsname        = $tt->getAllowedFieldsNames(true);
+         $is_first_update   = $this->fields['date_creation'] == $this->fields['date_mod'];
          foreach ($tt->mandatory as $key => $val) {
             if ((!$check_allowed_fields_for_template || in_array($key, $allowed_fields))
                 && (isset($input[$key])
                     && (empty($input[$key]) || ($input[$key] == 'NULL'))
-                    // Take only into account already set items : do not block old tickets
-                    && (!empty($this->fields[$key]))
+                    // Take only into account already set items : do not block
+                    // old tickets unless they haven't been modified yet, this
+                    // is useful for recurrent ticket with mandatory params.
+                    && (!empty($this->fields[$key]) || $is_first_update)
                 )) {
                $mandatory_missing[$key] = $fieldsname[$val];
             }


### PR DESCRIPTION
Internal ref: 20833.

If you put a dropdown (let's say category) as mandatory in your ticket template, you obviously can't create the ticket through the UI without specifying the category.

However, if you have an existing ticket without category, it can be updated without issues despite lacking this mandatory category value.

The comments in the code indicate that this was done to avoid impacting existing tickets: if you add a new mandatory field, you can still update your old tickets without having to comply to the new mandatory settings.

However this prevent an interesting use case: a user might want to set up mandatory fields for a **recurrent** ticket, forcing these fields to be set during the first update.

These changes allow this by removing ticket that were created but not yet updated from the 'retroactive protection' described above.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

