### PR TITLE
Fix associated elements in ticket template

### DIFF
--- a/front/tickettemplatepredefinedfield.form.php
+++ b/front/tickettemplatepredefinedfield.form.php
@@ -32,4 +32,9 @@
 
 $itiltype = 'Ticket';
 $fieldtype = 'Predefined';
+
+if (isset($_POST['items_tickets_id']) && isset($_POST['add_items_id'])) {
+   $_POST['items_tickets_id'] = $_POST['items_tickets_id']."_".$_POST['add_items_id'];
+}
+
 include __DIR__ . '/itiltemplatefield.form.php';


### PR DESCRIPTION
Internal ref: 20838.

Associated items in ticket templates are broken because the selected item's id is not saved in DB:
![image](https://user-images.githubusercontent.com/42734840/95226686-871ee000-07fd-11eb-9ed0-e54e8e640688.png)

The following code from glpi 9.4 was missing:
https://github.com/glpi-project/glpi/blob/9.4/bugfixes/front/tickettemplatepredefinedfield.form.php#L44

| Q             | A
| ------------- | ---
| Bug fix?      | yes/
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

