### PR TITLE
Fix security checks when default username case changed; fixes #8081

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -5126,7 +5126,7 @@ JAVASCRIPT;
                     'name'       => array_keys($passwords)];
 
       foreach ($DB->request('glpi_users', $crit) as $data) {
-         if (Auth::checkPassword($passwords[$data['name']], $data['password'])) {
+         if (Auth::checkPassword($passwords[strtolower($data['name'])], $data['password'])) {
             $default_password_set[] = $data['name'];
          }
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8081

SQL is case insensitive, so query may return a row with an item having a name in a different case than expected. As PHP array keys are case sensitive, accessing `$passwords[$data['name']]` will produce `*** PHP Warning (2): Undefined array key "TECH" in /var/www/glpi/inc/user.class.php at line 5129`.