### PR TITLE
Use entity id if present; to avoid difficult to undesrtand cases

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -2642,17 +2642,13 @@ class CommonDBTM extends CommonGLPI {
             if ($this->isEntityAssign()) {
                if (isset($params['entities_id'])) {
                   $entity = $this->fields['entities_id'] = $params['entities_id'];
-               } else if(isset($this->fields['entities_id'])) {
-                  //entity has been explicitely set already
+               } else if (isset($this->fields['entities_id'])) {
+                  //It's an existing object to be displayed
                   $entity = $this->fields['entities_id'];
                } else if ($this->isNewID($ID)
                           || ($params['withtemplate'] == 2)) {
                   //It's a new object to be added
                   $entity = $_SESSION['glpiactive_entity'];
-
-               } else {
-                  //It's an existing object to be displayed
-                  $entity = $this->fields['entities_id'];
                }
 
                echo "<input type='hidden' name='entities_id' value='$entity'>";

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -2642,7 +2642,9 @@ class CommonDBTM extends CommonGLPI {
             if ($this->isEntityAssign()) {
                if (isset($params['entities_id'])) {
                   $entity = $this->fields['entities_id'] = $params['entities_id'];
-
+               } else if(isset($this->fields['entities_id'])) {
+                  //entity has been explicitely set already
+                  $entity = $this->fields['entities_id'];
                } else if ($this->isNewID($ID)
                           || ($params['withtemplate'] == 2)) {
                   //It's a new object to be added


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

When a Domain is created in a sub-entity; if we switch to any parent entity and try to create a Record for this domain, current entity was used; instead of Domain one.
This depends on how we were called. If we're from an `ajax/common.tabs.php`  call, everything is fine. If we used (as when adding a domain record) an iframe; behavior is different.
