### PR TITLE
fix(core): add content to task for action_time

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1823,9 +1823,10 @@ class Ticket extends CommonITILObject {
          if (isset($this->fields["status"]) && ($this->fields["status"]  == self::SOLVED)) {
             $type = "solved";
          }
-         $toadd = ["type"       => $type,
-                        "tickets_id" => $this->fields['id'],
-                        "actiontime" => $this->input["actiontime"]];
+         $toadd = ["type"        => $type,
+                  "tickets_id"   => $this->fields['id'],
+                  "actiontime"   => $this->input["actiontime"],
+                  "content"      => __("Auto-created task") ];
 
          if (isset($this->input["plan"]) && count($this->input["plan"])) {
             $toadd["plan"] = $this->input["plan"];


### PR DESCRIPTION
When we create a ticket with total duration, a task is created, but GLPI does not provide a description for this task, 

this results in an error after the creation of the ticket.

"You can't add a task without description".

This PR fix this.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 20863
