### PR TITLE
fix(core): add done state to task from actiontime

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1826,6 +1826,7 @@ class Ticket extends CommonITILObject {
          $toadd = ["type"        => $type,
                   "tickets_id"   => $this->fields['id'],
                   "actiontime"   => $this->input["actiontime"],
+                  "state"        => Planning::DONE,
                   "content"      => __("Auto-created task") ];
 
          if (isset($this->input["plan"]) && count($this->input["plan"])) {


### PR DESCRIPTION
Signed-off-by: Stanislas <skita@teclib.com>

Add 'done' status to task when is created from actiontime.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 20863
