### PR TITLE
Add unique for reservation items + drop is_deleted

### DIFF
--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -642,10 +642,11 @@ class Migration {
     *
     * @param string $oldtable The name of the table already inside the database
     * @param string $newtable The copy of the old table
+    * @param bool   $insert   Copy content ? True by default
     *
     * @return void
    **/
-   function copyTable($oldtable, $newtable) {
+   function copyTable($oldtable, $newtable, bool $insert = true) {
       global $DB;
 
       if (!$DB->tableExists($newtable)
@@ -658,11 +659,11 @@ class Migration {
          $query = "CREATE TABLE `$newtable` LIKE `$oldtable`";
          $DB->queryOrDie($query, $this->version." create $newtable");
 
-         //nedds DB::insert to support subqeries to get migrated
-         $query = "INSERT INTO `$newtable`
-                          (SELECT *
-                           FROM `$oldtable`)";
-         $DB->queryOrDie($query, $this->version." copy from $oldtable to $newtable");
+         if ($insert) {
+            //needs DB::insert to support subqueries to get migrated
+            $query = "INSERT INTO `$newtable` (SELECT * FROM `$oldtable`)";
+            $DB->queryOrDie($query, $this->version." copy from $oldtable to $newtable");
+         }
       }
    }
 

--- a/inc/reservationitem.class.php
+++ b/inc/reservationitem.class.php
@@ -580,7 +580,6 @@ class ReservationItem extends CommonDBChild {
             ],
             'WHERE'        => [
                'glpi_reservationitems.is_active'   => 1,
-               'glpi_reservationitems.is_deleted'  => 0,
                "$itemtable.is_deleted"             => 0,
             ] + getEntitiesRestrictCriteria($itemtable, '', $_SESSION['glpiactiveentities'], $item->maybeRecursive()),
             'ORDERBY'      => [

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -5717,13 +5717,12 @@ CREATE TABLE `glpi_reservationitems` (
   `items_id` int(11) NOT NULL DEFAULT '0',
   `comment` text COLLATE utf8_unicode_ci,
   `is_active` tinyint(1) NOT NULL DEFAULT '1',
-  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `is_active` (`is_active`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
-  KEY `is_deleted` (`is_deleted`)
+  UNIQUE KEY `unicity` (`itemtype`,`items_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 

--- a/install/update_95_xx.php
+++ b/install/update_95_xx.php
@@ -46,8 +46,9 @@ function update95toXX() {
    $migration->setVersion('x.x.x');
 
    require __DIR__ . '/update_95_xx/softwares.php';
-   include __DIR__ . '/update_95_xx/domains.php';
+   require __DIR__ . '/update_95_xx/domains.php';
    require __DIR__ . '/update_95_xx/devicebattery.php';
+   require __DIR__ . '/update_95_xx/reservationitem.php';
 
    //add is_fqdn on some domain records types
    $fields = [

--- a/install/update_95_xx/reservationitem.php
+++ b/install/update_95_xx/reservationitem.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+$migration->displayMessage("Adding unicity key to reservationitem");
+$table = ReservationItem::getTable();
+
+// Drop is_deleted
+$migration->dropKey($table, 'is_deleted');
+$migration->dropField($table, "is_deleted");
+
+// Find duplicates by itemtype/items_id couple
+$duplicates_by_itemtype = $DB->request([
+   'SELECT'  => ['itemtype', 'items_id'],
+   'COUNT'   => 'cpt',
+   'FROM'    => $table,
+   'WHERE'   => [],
+   'GROUPBY' => ['itemtype', 'items_id'],
+   'HAVING'  => ['cpt' => ['>' , 1]]
+]);
+
+foreach ($duplicates_by_itemtype as $duplicates) {
+   // Get ids of all duplicate for this itemtype/items_id couple expect the first
+   // LIMIT $duplicates['cpt'] is there because we need a LIMIT clause to use OFFSET
+   $to_delete = $DB->request([
+      'SELECT' =>  'id',
+      'FROM' => $table,
+      'WHERE' => [
+         'itemtype' => $duplicates['itemtype'],
+         'items_id' => $duplicates['items_id'],
+      ],
+      'LIMIT' => $duplicates['cpt'],
+      'START' => 1
+   ]);
+
+   // Reduce to an array of ids
+   $to_delete = array_map(function ($value) {
+      return $value['id'];
+   }, iterator_to_array($to_delete));
+
+   $DB->delete($table, ['id' => $to_delete]);
+}
+
+// Add unicity key
+$migration->addKey(
+   $table,
+   ['itemtype', 'items_id'],
+   'unicity',
+   'UNIQUE'
+);

--- a/install/update_95_xx/reservationitem.php
+++ b/install/update_95_xx/reservationitem.php
@@ -59,7 +59,9 @@ $quote_tmp_table = $DB->quoteName($tmp_table);
 $select = $DB->request([
    'FROM' => $table
 ])->getSql();
-$DB->query("INSERT IGNORE INTO $quote_tmp_table $select");
+
+// "IGNORE" keyword used to avoid duplicates
+$DB->queryOrDie("INSERT IGNORE INTO $quote_tmp_table $select");
 
 // Replace table with the new version
 $migration->dropTable($table);


### PR DESCRIPTION
Internal ref: 19770.
Followup of #7318.

Items have 3 states regarding reservation:
*  reservable (= there is ONE entry in `glpi_reservations_items ` with is_active = 1)
*  reservable but not active (= there is ONE entry in `glpi_reservations_items` with is_active = 0)
*  not reservable (= no entry in glpi_reservations_items).

If for some reason there is multiple entry for one item in `glpi_reservations_items ` then reservations are broken for this item.
-> Adding a unique key to prevent this.

I've also dropped the is_deleted field as it never used (there is no trashbin for this itemtype).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

