### PR TITLE
avoid loading non existent class

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -6031,7 +6031,8 @@ JAVASCRIPT;
                   $itemtypes = [];
                   foreach ($data[$ID] as $key => $val) {
                      if (is_numeric($key)) {
-                        if (!empty($val['name'])) {
+                        if (!empty($val['itemtype'])
+                              && ($item = getItemForItemtype($val['itemtype']))) {
                            $item = new $val['name']();
                            $name = $item->getTypeName();
                            $itemtypes[] = __($name);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal ref !20635

When calling 131 searchoption (from ticket) with api, an fatal may occurs if the glpi_items_tickets contains an bad itemtype (disabled plugin for example)

```
[12-Oct-2020 13:05:13 UTC] [12-Oct-2020 13:05:13 UTC] PHP Fatal error:  Uncaught Error: Class 'PluginDomainDomain' not found in inc\search.class.php:5947
Stack trace:
#0 inc\search.class.php(1441): Search::giveItem('Ticket', 'Ticket_131', Array)
#1 inc\search.class.php(314): Search::constructData(Array)
#2 inc\api.class.php(1603): Search::getDatas('Ticket', Array, Array)
#3 inc\apirest.class.php(193): API->searchItems('Ticket', Array)
#4 apirest.php(48): APIRest->call()
#5 {main}
  thrown in inc\search.class.php on line 5947
```

strangely, above the current case, there is the same protection for items_id (we currently fix the itemtype part)
