### PR TITLE
Fix ticket items search results; see #8099

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -6031,8 +6031,8 @@ JAVASCRIPT;
                   $itemtypes = [];
                   foreach ($data[$ID] as $key => $val) {
                      if (is_numeric($key)) {
-                        if (!empty($val['itemtype'])
-                              && ($item = getItemForItemtype($val['itemtype']))) {
+                        if (!empty($val['name'])
+                              && ($item = getItemForItemtype($val['name']))) {
                            $item = new $val['name']();
                            $name = $item->getTypeName();
                            $itemtypes[] = __($name);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal ref !20635

Fix in #8099 seems not correct, as it checks `$val['itemtype']` instead of `$val['name']`.