### PR TITLE
Limit CI build matrix on tier repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,9 @@ jobs:
       openldap:
         image: "ghcr.io/glpi-project/githubactions-openldap"
     env:
-      # Skip jobs that should not be always run on pull requests (to limit workers usage).
+      # Skip jobs that should not be always run on pull requests or on push on tier repository (to limit workers usage).
       # No jobs will be skipped on nightly build and on push on main branches.
-      skip: ${{ github.event_name == 'pull_request' && matrix.always == false }}
+      skip: ${{ (github.event_name == 'pull_request' || github.repository != 'glpi-project/glpi') && matrix.always == false}}
     steps:
       - name: "Checkout"
         if: env.skip != 'true'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Currently, when pushing on a branch that match `master|.*/bugfixes|feature/.*|fix/.*`, all PHP versions and MariaDB/MySQL versions are tested. On tier repositories that has Github Actions workers usage limitations (private forks), it may be a problem.

With this PR, only PHP 7.4/MariaDB 10.3 versions will be tested.