### PR TITLE
History: fix display for deletion of a subitem

### DIFF
--- a/inc/log.class.php
+++ b/inc/log.class.php
@@ -679,7 +679,7 @@ class Log extends CommonDBTM {
                   }
                   $tmp['change'] = sprintf(__('%1$s: %2$s'),
                                            $action_label,
-                                           sprintf(__('%1$s (%2$s)'), $tmp['field'], $data["old_value"]));
+                                           sprintf(__('%1$s (%2$s)'), $tmp['field'], $data["new_value"]));
                   break;
 
                case self::HISTORY_LOCK_SUBITEM :


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/42734840/96129690-3db64b00-0ef7-11eb-92ae-7c9aaff8e108.png)


After:
![image](https://user-images.githubusercontent.com/42734840/96129582-165f7e00-0ef7-11eb-9b35-179dfb3ace89.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
