### PR TITLE
allow repeated ajax calls to show session messages

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -693,6 +693,7 @@ class Html {
       displayAjaxMessageAfterRedirect = function() {
          // attach MESSAGE_AFTER_REDIRECT to body
          $('.message_after_redirect').remove();
+         $('[id^=\"message_after_redirect_\"]').remove();
          $.ajax({
             url:  '".$CFG_GLPI['root_doc']."/ajax/displayMessageAfterRedirect.php',
             success: function(html) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | unsure
| New feature?  | unsure
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

Some of my developments use AJAX. When the request fails I want to show a error message by calling the JS function **displayAjaxMessageAfterRedirect** ( in HTML::displayAjaxMessageAfterRedirect() ). If the user tries again and the AJAX fails with a different error message, the 1st error message is displayed instead the 2nd.

This is because GLPI adds a div with the error message with an ID attribute, and when a 2nd AJAX request is handled the 2nd message is created in the DOM with the same ID. This is invalid to have several identical IDs in the DOM, and the JS which shows the error uses the 1st ID found.

![image](https://user-images.githubusercontent.com/14139801/96227933-1f9f2800-0f95-11eb-9372-fac8a746da24.png)


Here is an example : a random number is appended to 2 warnings and 2 errors to show that only the 1st set of mesages are displayed
![Peek 16-10-2020 09-43](https://user-images.githubusercontent.com/14139801/96227209-1792b880-0f94-11eb-8a1b-27618d65092d.gif)


The solution is th delete the DIV tags before popping the toats.
Here is an example with the fix
![Peek 16-10-2020 09-45](https://user-images.githubusercontent.com/14139801/96227444-6b050680-0f94-11eb-9377-2f208ca16e9b.gif)


Note : each time an error pops, the same JS snippet is added to the DOM. Repeating errors grows the web page. With HTML5 (not HTML4) it is allowed to add class to SCRIPT  tags. This may be used with a random number to make the JS snippet clean the other copies in the DOM and prevent the DOM growing. (not done in this PR)