### PR TITLE
Optimize Github Actions run times

### DIFF
--- a/.github/actions/docker-compose-app.yml
+++ b/.github/actions/docker-compose-app.yml
@@ -8,3 +8,6 @@ services:
       - type: "bind"
         source: "${APPLICATION_ROOT:-..}"
         target: "/var/glpi"
+      - type: "bind"
+        source: "${APPLICATION_HOME}"
+        target: "/home/glpi"

--- a/.github/actions/docker-compose-app.yml
+++ b/.github/actions/docker-compose-app.yml
@@ -1,0 +1,10 @@
+version: "3.5"
+
+services:
+  app:
+    container_name: "app"
+    image: "ghcr.io/glpi-project/${PHP_IMAGE:-githubactions-php}"
+    volumes: 
+      - type: "bind"
+        source: "${APPLICATION_ROOT:-..}"
+        target: "/var/glpi"

--- a/.github/actions/docker-compose-services.yml
+++ b/.github/actions/docker-compose-services.yml
@@ -1,0 +1,15 @@
+version: "3.5"
+
+services:
+  db:
+    container_name: "db"
+    image: "ghcr.io/glpi-project/${DB_IMAGE:-githubactions-mariadb}"
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    shm_size: '1gb'
+  dovecot:
+    container_name: "dovecot"
+    image: "ghcr.io/glpi-project/githubactions-dovecot"
+  openldap:
+    container_name: "openldap"
+    image: "ghcr.io/glpi-project/githubactions-openldap"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,37 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
+      - name: "Restore dependencies cache"
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ runner.temp }}/app_home/.composer/cache/
+            ${{ runner.temp }}/app_home/.npm/_cacache/
+          key: "app_home_deps-${{ matrix.php-version }}-${{ hashFiles('composer.lock', 'package-lock.json') }}"
+          restore-keys: |
+            app_home_deps-${{ matrix.php-version }}-
+            app_home_deps-
+      - name: "Restore lint cache"
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ runner.temp }}/app_home/phpcs.cache
+          key: "app_home_lint-${{ matrix.php-version }}"
+          restore-keys: |
+            app_home_lint-
       - name: "Initialize containers"
         run: |
+          echo "Init app container home"
+          mkdir -p ${{ runner.temp }}/app_home
           echo "Pull and start containers"
           export APPLICATION_ROOT=`pwd`
+          export APPLICATION_HOME=${{ runner.temp }}/app_home
           export PHP_IMAGE=githubactions-php:${{ matrix.php-version }}
           docker-compose --file .github/actions/docker-compose-app.yml --project-directory `pwd` up --no-start
           docker-compose --file .github/actions/docker-compose-app.yml --project-directory `pwd` start
           echo "Change files rights to give write access to app container user"
           setfacl --recursive --modify u:1000:rwx `pwd`
+          setfacl --recursive --modify u:1000:rwx ${{ runner.temp }}/app_home
       - name: Validate composer config
         run: |
           docker exec app composer validate --strict
@@ -61,7 +83,8 @@ jobs:
           docker exec app php -d memory_limit=1G -r 'define("GLOB_BRACE", 0); include "./vendor/maglnet/composer-require-checker/bin/composer-require-checker.php";' check --config-file=.composer-require-checker.config.json
       - name: "PHP CS"
         run: |
-          docker exec app vendor/bin/phpcs -d memory_limit=512M -p --extensions=php --standard=vendor/glpi-project/coding-standard/GlpiStandard/ --ignore="/.git/,^/var/glpi/(config|files|lib|marketplace|node_modules|plugins|tests/config|vendor)/" ./
+          docker exec app touch /home/glpi/phpcs.cache
+          docker exec app vendor/bin/phpcs --cache /home/glpi/phpcs.cache -d memory_limit=512M -p --extensions=php --standard=vendor/glpi-project/coding-standard/GlpiStandard/ --ignore="/.git/,^/var/glpi/(config|files|lib|marketplace|node_modules|plugins|tests/config|vendor)/" ./
       - name: "ESLint"
         run: |
           docker exec app node_modules/.bin/eslint . && echo "ESLint found no errors"
@@ -87,11 +110,25 @@ jobs:
       - name: "Checkout"
         if: env.skip != 'true'
         uses: "actions/checkout@v2"
+      - name: "Restore dependencies cache"
+        if: env.skip != 'true'
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ runner.temp }}/app_home/.composer/cache/
+            ${{ runner.temp }}/app_home/.npm/_cacache/
+          key: "app_home_deps-${{ matrix.php-version }}-${{ hashFiles('composer.lock', 'package-lock.json') }}"
+          restore-keys: |
+            app_home_deps-${{ matrix.php-version }}-
+            app_home_deps-
       - name: "Initialize containers"
         if: env.skip != 'true'
         run: |
+          echo "Init app container home"
+          mkdir -p ${{ runner.temp }}/app_home
           echo "Pull and start containers"
           export APPLICATION_ROOT=`pwd`
+          export APPLICATION_HOME=${{ runner.temp }}/app_home
           export PHP_IMAGE=githubactions-php:${{ matrix.php-version }}
           export DB_IMAGE=githubactions-${{ matrix.db-image }}
           docker-compose --file .github/actions/docker-compose-app.yml --file .github/actions/docker-compose-services.yml --project-directory `pwd` up --no-start
@@ -104,6 +141,7 @@ jobs:
           done
           echo "Change files rights to give write access to app container user"
           setfacl --recursive --modify u:1000:rwx `pwd`
+          setfacl --recursive --modify u:1000:rwx ${{ runner.temp }}/app_home
       - name: "Initialize databases"
         if: env.skip != 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
           - {php-version: "7.2"} # Lint on lower PHP version to detected too early usage of new syntaxes
           - {php-version: "7.4"} # Lint on higher PHP version to detected deprecated elements usage
     steps:
+      - name: "Cancel previous runs"
+        uses: "styfle/cancel-workflow-action@0.5.0"
+        with:
+          access_token: "${{ github.token }}"
       - name: "Checkout"
         uses: "actions/checkout@v2"
       - name: "Restore dependencies cache"
@@ -107,6 +111,11 @@ jobs:
       # No jobs will be skipped on nightly build and on push on main branches.
       skip: ${{ (github.event_name == 'pull_request' || github.repository != 'glpi-project/glpi') && matrix.always == false}}
     steps:
+      - name: "Cancel previous runs"
+        if: env.skip != 'true'
+        uses: "styfle/cancel-workflow-action@0.5.0"
+        with:
+          access_token: "${{ github.token }}"
       - name: "Checkout"
         if: env.skip != 'true'
         uses: "actions/checkout@v2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,44 +27,44 @@ jobs:
         include:
           - {php-version: "7.2"} # Lint on lower PHP version to detected too early usage of new syntaxes
           - {php-version: "7.4"} # Lint on higher PHP version to detected deprecated elements usage
-    services:
-      app:
-        image: "ghcr.io/glpi-project/githubactions-php:${{ matrix.php-version }}"
-        options: >-
-          --volume /glpi:/var/glpi
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
-      - name: "Deploy source into app container"
+      - name: "Initialize containers"
         run: |
-          sudo cp --no-target-directory --preserve --recursive `pwd` /glpi
-          sudo chown -R 1000:1000 /glpi
+          echo "Pull and start containers"
+          export APPLICATION_ROOT=`pwd`
+          export PHP_IMAGE=githubactions-php:${{ matrix.php-version }}
+          docker-compose --file .github/actions/docker-compose-app.yml --project-directory `pwd` up --no-start
+          docker-compose --file .github/actions/docker-compose-app.yml --project-directory `pwd` start
+          echo "Change files rights to give write access to app container user"
+          setfacl --recursive --modify u:1000:rwx `pwd`
       - name: Validate composer config
         run: |
-          docker exec ${{ job.services.app.id }} composer validate --strict
+          docker exec app composer validate --strict
       - name: "Install dependencies"
         run: |
-          docker exec ${{ job.services.app.id }} rm composer.lock
-          docker exec ${{ job.services.app.id }} composer --version
-          docker exec ${{ job.services.app.id }} echo "node version: $(node --version)"
-          docker exec ${{ job.services.app.id }} echo "npm version: $(npm --version)"
-          docker exec ${{ job.services.app.id }} composer config --unset platform
-          docker exec ${{ job.services.app.id }} bin/console dependencies install --composer-options="--prefer-dist --no-progress"
+          docker exec app rm composer.lock
+          docker exec app composer --version
+          docker exec app echo "node version: $(node --version)"
+          docker exec app echo "npm version: $(npm --version)"
+          docker exec app composer config --unset platform
+          docker exec app bin/console dependencies install --composer-options="--prefer-dist --no-progress"
       - name: "PHP Parallel Lint"
         run: |
-          docker exec ${{ job.services.app.id }} vendor/bin/parallel-lint  --exclude ./files/ --exclude ./plugins/ --exclude ./tools/vendor/ --exclude ./vendor/ .
+          docker exec app vendor/bin/parallel-lint  --exclude ./files/ --exclude ./plugins/ --exclude ./tools/vendor/ --exclude ./vendor/ .
       - name: "Check for missing dependencies / bad symbols"
         # Alpine linux does not implement GLOB_BRACE.
         # We have to define it to 0 to prevent "Warning: Use of undefined constant GLOB_BRACE - assumed 'GLOB_BRACE'" error.
         # This is not a problem as long as we do not use braces in "scan-files" section of the config file.
         run: |
-          docker exec ${{ job.services.app.id }} php -d memory_limit=1G -r 'define("GLOB_BRACE", 0); include "./vendor/maglnet/composer-require-checker/bin/composer-require-checker.php";' check --config-file=.composer-require-checker.config.json
+          docker exec app php -d memory_limit=1G -r 'define("GLOB_BRACE", 0); include "./vendor/maglnet/composer-require-checker/bin/composer-require-checker.php";' check --config-file=.composer-require-checker.config.json
       - name: "PHP CS"
         run: |
-          docker exec ${{ job.services.app.id }} vendor/bin/phpcs -d memory_limit=512M -p --extensions=php --standard=vendor/glpi-project/coding-standard/GlpiStandard/ --ignore="/.git/,^/var/glpi/(config|files|lib|marketplace|node_modules|plugins|tests/config|vendor)/" ./
+          docker exec app vendor/bin/phpcs -d memory_limit=512M -p --extensions=php --standard=vendor/glpi-project/coding-standard/GlpiStandard/ --ignore="/.git/,^/var/glpi/(config|files|lib|marketplace|node_modules|plugins|tests/config|vendor)/" ./
       - name: "ESLint"
         run: |
-          docker exec ${{ job.services.app.id }} node_modules/.bin/eslint . && echo "ESLint found no errors"
+          docker exec app node_modules/.bin/eslint . && echo "ESLint found no errors"
 
   tests:
     name: "Test on PHP ${{ matrix.php-version }} using ${{ matrix.db-image }}"
@@ -79,21 +79,6 @@ jobs:
           - {php-version: "7.4", db-image: "mariadb:10.1", always: false}
           - {php-version: "7.4", db-image: "mysql:5.6", always: false}
           - {php-version: "7.4", db-image: "mysql:8.0", always: false}
-    services:
-      app:
-        image: "ghcr.io/glpi-project/githubactions-php:${{ matrix.php-version }}"
-        options: >-
-          --volume /glpi:/var/glpi
-      db:
-        image: "ghcr.io/glpi-project/githubactions-${{ matrix.db-image }}"
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-        options: >-
-          --shm-size=1g
-      dovecot:
-        image: "ghcr.io/glpi-project/githubactions-dovecot"
-      openldap:
-        image: "ghcr.io/glpi-project/githubactions-openldap"
     env:
       # Skip jobs that should not be always run on pull requests or on push on tier repository (to limit workers usage).
       # No jobs will be skipped on nightly build and on push on main branches.
@@ -102,81 +87,93 @@ jobs:
       - name: "Checkout"
         if: env.skip != 'true'
         uses: "actions/checkout@v2"
-      - name: "Deploy source into app container"
+      - name: "Initialize containers"
         if: env.skip != 'true'
         run: |
-          sudo cp --no-target-directory --preserve --recursive `pwd` /glpi
-          sudo chown -R 1000:1000 /glpi
+          echo "Pull and start containers"
+          export APPLICATION_ROOT=`pwd`
+          export PHP_IMAGE=githubactions-php:${{ matrix.php-version }}
+          export DB_IMAGE=githubactions-${{ matrix.db-image }}
+          docker-compose --file .github/actions/docker-compose-app.yml --file .github/actions/docker-compose-services.yml --project-directory `pwd` up --no-start
+          docker-compose --file .github/actions/docker-compose-app.yml --file .github/actions/docker-compose-services.yml --project-directory `pwd` start
+          for CONTAINER in {"db","dovecot","openldap"}; do
+            until [ "`/usr/bin/docker inspect --format='{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{else}}{{print \"healthy\"}}{{end}}' $CONTAINER`" == "healthy" ]; do
+              echo "Waiting for $CONTAINER to be ready..."
+              sleep 2
+            done
+          done
+          echo "Change files rights to give write access to app container user"
+          setfacl --recursive --modify u:1000:rwx `pwd`
       - name: "Initialize databases"
         if: env.skip != 'true'
         run: |
-          docker exec ${{ job.services.db.id }} mysql --user=root --execute="CREATE DATABASE \`glpi\`;"
-          docker exec ${{ job.services.db.id }} mysql --user=root --execute="CREATE DATABASE \`glpitest0723\`;"
-          cat tests/glpi-0.72.3-empty.sql | docker exec --interactive ${{ job.services.db.id }} mysql --user=root glpitest0723
+          docker exec db mysql --user=root --execute="CREATE DATABASE \`glpi\`;"
+          docker exec db mysql --user=root --execute="CREATE DATABASE \`glpitest0723\`;"
+          cat tests/glpi-0.72.3-empty.sql | docker exec --interactive db mysql --user=root glpitest0723
       - name: "Install dependencies"
         if: env.skip != 'true'
         run: |
-          docker exec ${{ job.services.app.id }} rm composer.lock
-          docker exec ${{ job.services.app.id }} composer --version
-          docker exec ${{ job.services.app.id }} echo "node version: $(node --version)"
-          docker exec ${{ job.services.app.id }} echo "npm version: $(npm --version)"
-          docker exec ${{ job.services.app.id }} composer config --unset platform
-          docker exec ${{ job.services.app.id }} bin/console dependencies install --composer-options="--prefer-dist --no-progress"
+          docker exec app rm composer.lock
+          docker exec app composer --version
+          docker exec app echo "node version: $(node --version)"
+          docker exec app echo "npm version: $(npm --version)"
+          docker exec app composer config --unset platform
+          docker exec app bin/console dependencies install --composer-options="--prefer-dist --no-progress"
       - name: "PHP Parallel Lint"
         if: env.skip != 'true'
         run: |
-          docker exec ${{ job.services.app.id }} vendor/bin/parallel-lint  --exclude ./files/ --exclude ./marketplace/ --exclude ./plugins/ --exclude ./tools/vendor/ --exclude ./vendor/ .
+          docker exec app vendor/bin/parallel-lint  --exclude ./files/ --exclude ./marketplace/ --exclude ./plugins/ --exclude ./tools/vendor/ --exclude ./vendor/ .
       - name: "PHP Security checker"
         if: env.skip != 'true'
         run: |
-          docker exec ${{ job.services.app.id }} vendor/bin/security-checker security:check
+          docker exec app vendor/bin/security-checker security:check
       - name: "Install DB tests"
         if: env.skip != 'true'
         run: |
-          docker exec ${{ job.services.app.id }} bin/console glpi:database:install --config-dir=./tests --no-interaction --reconfigure --db-name=glpi --db-host=db --db-user=root
-          docker exec ${{ job.services.app.id }} bin/console glpi:database:update --config-dir=./tests --no-interaction | grep -q "No migration needed." || (echo "glpi:database:update command FAILED" && exit 1)
+          docker exec app bin/console glpi:database:install --config-dir=./tests --no-interaction --reconfigure --db-name=glpi --db-host=db --db-user=root
+          docker exec app bin/console glpi:database:update --config-dir=./tests --no-interaction | grep -q "No migration needed." || (echo "glpi:database:update command FAILED" && exit 1)
       - name: "Update DB tests"
         if: env.skip != 'true'
         run: |
-          docker exec ${{ job.services.app.id }} bin/console glpi:database:configure --config-dir=./tests --no-interaction --reconfigure --db-name=glpitest0723 --db-host=db --db-user=root
-          docker exec ${{ job.services.app.id }} bin/console glpi:database:update --config-dir=./tests --allow-unstable --no-interaction
-          docker exec ${{ job.services.app.id }} bin/console glpi:database:update --config-dir=./tests --allow-unstable --no-interaction | grep -q "Aucune migration requise." || (echo "glpi:database:update command FAILED" && exit 1)
-          docker exec ${{ job.services.app.id }} bin/console glpi:migration:myisam_to_innodb --config-dir=./tests --no-interaction
-          docker exec ${{ job.services.app.id }} bin/console glpi:migration:myisam_to_innodb --config-dir=./tests --no-interaction | grep -q "Aucune migration requise." || (echo "glpi:migration:myisam_to_innodb command FAILED" && exit 1)
-          docker exec ${{ job.services.app.id }} bin/console glpi:migration:timestamps --config-dir=./tests --no-interaction
-          docker exec ${{ job.services.app.id }} bin/console glpi:migration:timestamps --config-dir=./tests --no-interaction | grep -q "Aucune migration requise." || (echo "glpi:migration:timestamps command FAILED" && exit 1)
+          docker exec app bin/console glpi:database:configure --config-dir=./tests --no-interaction --reconfigure --db-name=glpitest0723 --db-host=db --db-user=root
+          docker exec app bin/console glpi:database:update --config-dir=./tests --allow-unstable --no-interaction
+          docker exec app bin/console glpi:database:update --config-dir=./tests --allow-unstable --no-interaction | grep -q "Aucune migration requise." || (echo "glpi:database:update command FAILED" && exit 1)
+          docker exec app bin/console glpi:migration:myisam_to_innodb --config-dir=./tests --no-interaction
+          docker exec app bin/console glpi:migration:myisam_to_innodb --config-dir=./tests --no-interaction | grep -q "Aucune migration requise." || (echo "glpi:migration:myisam_to_innodb command FAILED" && exit 1)
+          docker exec app bin/console glpi:migration:timestamps --config-dir=./tests --no-interaction
+          docker exec app bin/console glpi:migration:timestamps --config-dir=./tests --no-interaction | grep -q "Aucune migration requise." || (echo "glpi:migration:timestamps command FAILED" && exit 1)
       - name: "Database tests"
         if: env.skip != 'true'
         run: |
-          docker exec ${{ job.services.app.id }} bin/console glpi:database:configure --config-dir=./tests --no-interaction --reconfigure --db-name=glpi --db-host=db --db-user=root
-          docker exec ${{ job.services.app.id }} vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/database
-          docker exec ${{ job.services.app.id }} bin/console glpi:database:configure --config-dir=./tests --no-interaction --reconfigure --db-name=glpi --db-host=db --db-user=root
+          docker exec app bin/console glpi:database:configure --config-dir=./tests --no-interaction --reconfigure --db-name=glpi --db-host=db --db-user=root
+          docker exec app vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/database
+          docker exec app bin/console glpi:database:configure --config-dir=./tests --no-interaction --reconfigure --db-name=glpi --db-host=db --db-user=root
       - name: "Unit tests"
         if: env.skip != 'true'
         run: |
-          docker exec ${{ job.services.app.id }} vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --bootstrap-file tests/bootstrap.php --no-code-coverage -d tests/units
+          docker exec app vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --bootstrap-file tests/bootstrap.php --no-code-coverage -d tests/units
       - name: "Functionnal tests"
         if: env.skip != 'true'
         run: |
-          docker exec ${{ job.services.app.id }} vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/functionnal
+          docker exec app vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/functionnal
       - name: "LDAP tests"
         if: env.skip != 'true'
         run: |
-          for f in `ls tests/LDAP/ldif/*.ldif`; do cat $f | docker exec --interactive ${{ job.services.openldap.id }} ldapadd -x -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure ; done
-          docker exec ${{ job.services.app.id }} vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/LDAP
+          for f in `ls tests/LDAP/ldif/*.ldif`; do cat $f | docker exec --interactive openldap ldapadd -x -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure ; done
+          docker exec app vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/LDAP
       - name: "IMAP tests"
         if: env.skip != 'true'
         run: |
-          for f in `ls tests/emails-tests/*.eml`; do cat $f | docker exec --user glpi --interactive ${{ job.services.dovecot.id }} getmail_maildir /home/glpi/Maildir/ ; done
-          docker exec ${{ job.services.app.id }} sed -e 's/127.0.0.1/dovecot/g' -i tests/imap/MailCollector.php
-          docker exec ${{ job.services.app.id }} sed -e 's/127.0.0.1/dovecot/g' -i tests/imap/Toolbox.php
-          docker exec ${{ job.services.app.id }} vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/imap
+          for f in `ls tests/emails-tests/*.eml`; do cat $f | docker exec --user glpi --interactive dovecot getmail_maildir /home/glpi/Maildir/ ; done
+          docker exec app sed -e 's/127.0.0.1/dovecot/g' -i tests/imap/MailCollector.php
+          docker exec app sed -e 's/127.0.0.1/dovecot/g' -i tests/imap/Toolbox.php
+          docker exec app vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/imap
       - name: "WEB tests"
         if: env.skip != 'true'
         run: |
-          docker exec ${{ job.services.app.id }} php -S localhost:8088 tests/router.php &>/dev/null &
-          docker exec ${{ job.services.app.id }} vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/web
+          docker exec app php -S localhost:8088 tests/router.php &>/dev/null &
+          docker exec app vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --bootstrap-file tests/bootstrap.php --no-code-coverage --max-children-number 1 -d tests/web
       - name: "CSS compilation tests"
         if: env.skip != 'true'
         run: |
-          docker exec ${{ job.services.app.id }} bin/console build:compile_scss
+          docker exec app bin/console build:compile_scss


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1) Use `docker-compose` to start containers. This prevent containers to be initialized even when all job steps are skipped (we gain about 50 seconds for each of the 5 skipped jobs).

2) Add cache on dependencies and on PHPCS.

3) Cancel any running/queued workflow running for a given branch when a new commit is pushed on this branch.
Cancelling a job will trigger a notification for failed build, so if you consider it is a problem, we can remove this commit.