### PR TITLE
Fix 'Warning: strpos(): Empty needle' on isApi()

### DIFF
--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -60,7 +60,8 @@ function isAPI() {
                  '://' . ($_SERVER['HTTP_HOST'] ?? "").
                  ($_SERVER['REQUEST_URI'] ?? "");
 
-   if (strpos($called_url, $CFG_GLPI['url_base_api'] ?? "") !== false) {
+   $base_api_url = $CFG_GLPI['url_base_api'] ?? ""; // $CFG_GLPI may be not defined if DB is not available
+   if (!empty($base_api_url) && strpos($called_url, $base_api_url) !== false) {
       return true;
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Prevent `Warning: strpos(): Empty needle in /var/www/glpi/inc/autoload.function.php on line 63`.