### PR TITLE
Load plugin commands from all plugins directories

### DIFF
--- a/inc/console/commandloader.class.php
+++ b/inc/console/commandloader.class.php
@@ -36,6 +36,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use AppendIterator;
 use DirectoryIterator;
 use Plugin;
 use RecursiveDirectoryIterator;
@@ -189,9 +190,11 @@ class CommandLoader implements CommandLoaderInterface {
          $this->plugin = new Plugin();
       }
 
-      $basedir = $this->rootdir . DIRECTORY_SEPARATOR . 'plugins';
-
-      $plugins_directories = new DirectoryIterator($basedir);
+      $plugins_directories = new AppendIterator();
+      foreach (PLUGINS_DIRECTORIES as $directory) {
+         $directory = str_replace(GLPI_ROOT, $this->rootdir, $directory);
+         $plugins_directories->append(new DirectoryIterator($directory));
+      }
       /** @var SplFileInfo $plugin_directory */
       foreach ($plugins_directories as $plugin_directory) {
          // Do not load commands of disabled plugins

--- a/tests/units/Glpi/Console/CommandLoader.php
+++ b/tests/units/Glpi/Console/CommandLoader.php
@@ -163,6 +163,68 @@ PHP
                ]
             ],
          ],
+         'tests' => [
+            'fixtures' => [
+               'plugins' => [
+                  'random' => [
+                     'inc' => [
+                        // Not recognized due to bad filename pattern
+                        'testcmd.class.php' => <<<PHP
+<?php
+class PluginRandomTestCmd extends \\Symfony\\Component\\Console\\Command\\Command {
+   protected function configure() {
+      \$this->setName('plugin_random:test');
+   }
+}
+PHP
+                        ,
+
+                        // Plugin command case
+                        'randomcommand.class.php' => <<<PHP
+<?php
+class PluginRandomRandomCommand extends \\Symfony\\Component\\Console\\Command\\Command {
+   protected function configure() {
+      \$this->setName('plugin_random:random');
+   }
+}
+PHP
+                        ,
+
+                        // Plugin namespaced command case (inside "inc" dir)
+                        'checkcommand.class.php' => <<<PHP
+<?php
+namespace GlpiPlugin\\Random;
+class CheckCommand extends \\Symfony\\Component\\Console\\Command\\Command {
+   protected function configure() {
+      \$this->setName('plugin_random:check');
+   }
+}
+PHP
+                        ,
+
+                        'console' => [
+                           // Plugin namespaced command case (inside a sub dir)
+                          'foocommand.class.php' => <<<PHP
+<?php
+namespace GlpiPlugin\\Random\\Console;
+class FooCommand extends \\Symfony\\Component\\Console\\Command\\Command {
+   protected function configure() {
+      \$this->setName('plugin_random:foo');
+   }
+}
+PHP
+                        ],
+                     ],
+                  ],
+                  'misc' => [
+                     'inc' => [
+                        // Not a command case
+                        'something.class.php' => '<?php class PluginRandomSomething {}',
+                     ]
+                  ],
+               ],
+            ],
+         ]
       ];
       vfsStream::setup('glpi', null, $structure);
 
@@ -179,6 +241,9 @@ PHP
          'plugin_awesome:update'     => 'PluginAwesomeUpdateCommand',
          'plugin_awesome:namespaced' => 'GlpiPlugin\\Awesome\\NamespacedCommand',
          'plugin_awesome:another'    => 'GlpiPlugin\\Awesome\\Console\\AnotherCommand',
+         'plugin_random:random'      => 'PluginRandomRandomCommand',
+         'plugin_random:check'       => 'GlpiPlugin\\Random\\CheckCommand',
+         'plugin_random:foo'         => 'GlpiPlugin\\Random\\Console\\FooCommand',
       ];
 
       $all_names_to_class = array_merge($core_names_to_class, $plugins_names_to_class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

With GLPI 9.5, plugins can be installed in multiple directories (defined in `PLUGINS_DIRECTORIES`), but console commands were only loaded from `plugins` directory.