### PR TITLE
Fix shared dashboards + redirect

### DIFF
--- a/front/dashboard_assets.php
+++ b/front/dashboard_assets.php
@@ -39,10 +39,15 @@ include ('../inc/includes.php');
 
 
 Session::checkCentralAccess();
+$default = Glpi\Dashboard\Grid::getDefaultDashboardForMenu('assets');
+
+// Redirect to "/front/computer.php" if no dashboard found
+if ($default == "") {
+   Html::redirect($CFG_GLPI["root_doc"] . "/front/computer.php");
+}
 
 Html::header(__('Assets Dashboard'), $_SERVER['PHP_SELF'], "assets", "dashboard");
 
-$default = Glpi\Dashboard\Grid::getDefaultDashboardForMenu('assets');
 $dashboard = new Glpi\Dashboard\Grid($default);
 $dashboard->showDefault();
 

--- a/front/dashboard_helpdesk.php
+++ b/front/dashboard_helpdesk.php
@@ -39,10 +39,15 @@ include ('../inc/includes.php');
 
 
 Session::checkCentralAccess();
+$default = Glpi\Dashboard\Grid::getDefaultDashboardForMenu('helpdesk');
+
+// Redirect to "/front/ticket.php" if no dashboard found
+if ($default == "") {
+   Html::redirect($CFG_GLPI["root_doc"] . "/front/ticket.php");
+}
 
 Html::header(__('Helpdesk Dashboard'), $_SERVER['PHP_SELF'], "helpdesk", "dashboard");
 
-$default = Glpi\Dashboard\Grid::getDefaultDashboardForMenu('helpdesk');
 $dashboard = new Glpi\Dashboard\Grid($default);
 $dashboard->showDefault();
 

--- a/inc/dashboard/grid.class.php
+++ b/inc/dashboard/grid.class.php
@@ -1521,7 +1521,8 @@ HTML;
       $default    = $_SESSION["glpi$config_key"] ?? "";
       if (strlen($default)) {
          $dasboard = new Dashboard($default);
-         if ($dasboard->load()) {
+
+         if ($dasboard->load() && $dasboard->canViewCurrent()) {
             return $default;
          }
       }


### PR DESCRIPTION
1\)  Fix shared dashboards

If an user : 
- doesn't have the right to see all dashboards
- can see one or more shared dashboards
- can't see the default dashboard for the given page 

Then he get an empty page instead of being able to see the few shared dashboards he is able to see.
Fixed in e5e6a44.

Before:
![image](https://user-images.githubusercontent.com/42734840/96426884-254b7680-11fe-11eb-8e5d-e0e7ca4a9b86.png)

After:
![image](https://user-images.githubusercontent.com/42734840/96426898-2aa8c100-11fe-11eb-8396-622bb1ba1e71.png)

2\) Redirect if no dashboards

When clicking on the "assets" or "assistance" menu, if you can't see any dashboards for this page then you get an almost empty page.
I think it would be better to redirect the user to a useful page instead.

Fixed in 368c753 (url used to redirect were the one used in 9.4 before we added dashboards).

Before:
![image](https://user-images.githubusercontent.com/42734840/96427216-8ffcb200-11fe-11eb-8a73-da197ff55ad0.png)

After:
![image](https://user-images.githubusercontent.com/42734840/96427267-9ee36480-11fe-11eb-97fc-d90da4609756.png)


3\) Default dashboard set by profiles

No change done on this, only a suggestion.
Shouldn't this setting be defined in each profiles instead of the general conf ?
Or even better, keep the global conf but allow profiles to overload it ?

![image](https://user-images.githubusercontent.com/42734840/96427404-cd613f80-11fe-11eb-9d6e-576ef5828284.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
