### PR TITLE
Test on MariaDB 10.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {php-version: "7.4", db-image: "mariadb:10.3", always: true}
-          - {php-version: "7.2", db-image: "mariadb:10.3", always: false}
-          - {php-version: "7.3", db-image: "mariadb:10.3", always: false}
+          - {php-version: "7.4", db-image: "mariadb:10.5", always: true}
+          - {php-version: "7.2", db-image: "mariadb:10.5", always: false}
+          - {php-version: "7.3", db-image: "mariadb:10.5", always: false}
           - {php-version: "7.4", db-image: "mariadb:10.1", always: false}
           - {php-version: "7.4", db-image: "mysql:5.6", always: false}
           - {php-version: "7.4", db-image: "mysql:8.0", always: false}

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3992,8 +3992,8 @@ JAVASCRIPT;
             $condition = "(`glpi_tickettasks`.`is_private` $in ";
 
             // Check for assigned or created tasks
-            $condition .= "OR `users_id` = " . Session::getLoginUserID() . " ";
-            $condition .= "OR `users_id_tech` = " . Session::getLoginUserID() . " ";
+            $condition .= "OR `glpi_tickettasks`.`users_id` = " . Session::getLoginUserID() . " ";
+            $condition .= "OR `glpi_tickettasks`.`users_id_tech` = " . Session::getLoginUserID() . " ";
 
             // Check for parent item visibility unless the user can see all the
             // possible parents

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -32,6 +32,7 @@
 
 namespace tests\units;
 
+use \CommonDBTM;
 use \DbTestCase;
 
 /* Test for inc/search.class.php */
@@ -520,37 +521,10 @@ class Search extends DbTestCase {
          $options = \Search::getCleanedOptions($item->getType());
 
          $multi_criteria = [];
-         foreach ($options as $key=>$data) {
-            if (!is_int($key) || (array_key_exists('nosearch', $data) && $data['nosearch'])) {
+         foreach ($options as $key => $data) {
+            if (!is_array($data) || ($criterion_params = $this->getCriterionParams($item, $key, $data)) === null) {
                continue;
             }
-            $actions = \Search::getActionsFor($item->getType(), $key);
-            $searchtype = array_keys($actions)[0];
-
-            switch ($data['datatype'] ?? null) {
-               case 'bool':
-               case 'integer':
-               case 'number':
-                  $val = 0;
-                  break;
-               case 'datetime':
-                  $val = date('Y-m-d H:i:s');
-                  break;
-               default:
-                  $val = 'val';
-                  if ($searchtype === 'contains') {
-                     // prevent massive usage of like %x% that drastically reduce performances
-                     // on MariaDB 10.4+
-                     $val = '^val$';
-                  }
-                  break;
-            }
-
-            $criterion = [
-               'field'      => $key,
-               'searchtype' => $searchtype,
-               'value'      => $val
-            ];
 
             // do a search query based on current search option
             $data = $this->doSearch(
@@ -558,15 +532,17 @@ class Search extends DbTestCase {
                [
                   'is_deleted'   => 0,
                   'start'        => 0,
-                  'criteria'     => [$criterion],
+                  'criteria'     => [$criterion_params],
                   'metacriteria' => []
                ]
             );
 
-            if (count($multi_criteria) < 50) {
+            $multi_criteria[] = $criterion_params;
+
+            if (count($multi_criteria) > 50) {
                // Limit criteria count to 50 to prevent performances issues
                // and also prevent exceeding of MySQL join limit.
-               $multi_criteria[] = $criterion;
+               break;
             }
          }
 
@@ -608,41 +584,19 @@ class Search extends DbTestCase {
          $metaList = \Search::getMetaItemtypeAvailable($itemtype);
          foreach ($metaList as $metaitemtype) {
             $item = getItemForItemtype($metaitemtype);
-            $i = 0;
-            foreach ($item->searchOptions() as $key=>$data) {
-               if (is_int($key)) {
-                  $actions = \Search::getActionsFor($item->getType(), $key);
-                  $searchtype = array_keys($actions)[0];
-
-                  switch ($data['datatype'] ?? null) {
-                     case 'bool':
-                     case 'integer':
-                     case 'number':
-                        $val = 0;
-                        break;
-                     case 'datetime':
-                        $val = date('Y-m-d H:i:s');
-                        break;
-                     default:
-                        $val = 'val';
-                        if ($searchtype === 'contains') {
-                           // prevent massive usage of like %x% that drastically reduce performances
-                           // on MariaDB 10.4+
-                           $val = '^val$';
-                        }
-                        break;
-                  }
-
-                  $metacriteria[] = [
-                      'itemtype'   => $metaitemtype,
-                      'link'       => 'AND',
-                      'field'      => $key,
-                      'searchtype' => $searchtype,
-                      'value'      => $val,
-                  ];
+            foreach ($item->searchOptions() as $key => $data) {
+               if (!is_array($data) || ($criterion_params = $this->getCriterionParams($item, $key, $data)) === null) {
+                  continue;
                }
-               $i++;
-               if ($i > 5) {
+
+               $criterion_params['itemtype'] = $metaitemtype;
+               $criterion_params['link'] = 'AND';
+
+               $metacriteria[] = $criterion_params;
+
+               if (count($metacriteria) > 50) {
+                  // Limit criteria count to 50 to prevent performances issues
+                  // and also prevent exceeding of MySQL join limit.
                   break;
                }
             }
@@ -655,6 +609,48 @@ class Search extends DbTestCase {
                ->array['last_errors']->isIdenticalTo([])
                ->array['data']->isNotEmpty();
       }
+   }
+
+   /**
+    * Get criterion params for corresponding SO.
+    *
+    * @param CommonDBTM $item
+    * @param string $so_key
+    * @param array $so_data
+    * @return null|array
+    */
+   private function getCriterionParams(CommonDBTM $item, string $so_key, array $so_data): ?array {
+
+      if (!is_int($so_key) || (array_key_exists('nosearch', $so_data) && $so_data['nosearch'])) {
+         return null;
+      }
+      $actions = \Search::getActionsFor($item->getType(), $so_key);
+      $searchtype = array_keys($actions)[0];
+
+      switch ($so_data['datatype'] ?? null) {
+         case 'bool':
+         case 'integer':
+         case 'number':
+            $val = 0;
+            break;
+         case 'datetime':
+            $val = date('Y-m-d H:i:s');
+            break;
+         default:
+            $val = 'val';
+            if ($searchtype === 'contains') {
+               // prevent massive usage of like %x% that drastically reduce performances
+               // on MariaDB 10.4+
+               $val = '^val$';
+            }
+            break;
+      }
+
+      return [
+         'field'      => $so_key,
+         'searchtype' => $searchtype,
+         'value'      => $val
+      ];
    }
 
    public function testIsNotifyComputerGroup() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This PR add checks on MariaDB 10.4 and 10.5 in test suite.

I found that in MariaDB 10.4 and 10.5, usage of `LIKE '%x%'` is a performance killer, and, on our test suite, we have some queries built from a search query that uses a `LIKE '%f%'` on all existing metacriteria (e.g. `Search::testSearchAllMeta()` on `Computer` uses 39 LIKE, and I had to kkil the request on my machine after 15 minutes as it was still running).
To fix this, I modified the test suite in order to prevent usage on '%' in `LIKE` conditions.