### PR TITLE
fix(ui): fix min dashboard css for lower resolution

### DIFF
--- a/css/dashboard.scss
+++ b/css/dashboard.scss
@@ -91,6 +91,44 @@ $break_tablet: 1400px;
          font-size: 11px !important;
       }
 
+      .big-number {
+         .formatted-number {
+            display: flex;
+
+            .number, .suffix {
+               font-size: 3em;
+               font-weight: normal;
+            }
+         }
+
+         .label {
+            max-width: calc(100% - 2em);
+         }
+      }
+
+
+      //only for mini dashboard and small screen width
+      @media screen and (max-width: 1280px) {
+         .main-icon {
+            font-size: 1.5em;
+            right: 3px;
+            top: 3px;
+         }
+         .big-number .label {
+            font-size: 10px !important;
+         }
+         .big-number {
+            .formatted-number {
+               .number, .suffix {
+                  font-size: 2.5em;
+               }
+            }
+            .label {
+               max-width: calc(100%);
+            }
+         }
+      }
+
       .grid-stack .grid-stack-item.lock-bottom {
          min-height: 0;
          height: 0;


### PR DESCRIPTION
For lower resolution (ie 1280 * 1024 or less), long label from mini dashboard (big number type) goes beyond the widget (see "tickets waiting your validation)

![image](https://user-images.githubusercontent.com/7335054/96680674-3e773300-1376-11eb-86eb-14b9b08ba960.png)

 I propose this : 

- put main-icon to top
- give 100% of width for label
- reduce number font size (3 to 2.5)

And the result

![image](https://user-images.githubusercontent.com/7335054/96680903-a75eab00-1376-11eb-9116-7188d36451fe.png)

This affect only min dashboard for screen with width lower of 1280 

Best regards

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 20871
