### PR TITLE
Bump cytoscape-context-menus from 3.1.0 to 4.0.0

### DIFF
--- a/css/impact.scss
+++ b/css/impact.scss
@@ -2,7 +2,7 @@
 #network_container {
    height: 70vh;
 
-   div {
+   div:not(.cy-context-menus-cxt-menu) {
       z-index: 1 !important;
       position: absolute !important;
    }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1555,9 +1555,9 @@
             "integrity": "sha512-R1nCLnJHGTR5fWEpNQQBPyoigdnfhnk1lOHegzmzz1Kg6yxzVf0hfdRAMa0wPAhtC4kkgyoViiIfZ/zyCqMhEQ=="
         },
         "cytoscape-context-menus": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cytoscape-context-menus/-/cytoscape-context-menus-3.1.0.tgz",
-            "integrity": "sha512-UE7g+zrx43m6WNmkHgiJFUMqxkTHTiciEjufvgSBgyBZOIY/H2U6sSsRtepXukeILs7/8FeHTAbmJRqQsJlpcg=="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cytoscape-context-menus/-/cytoscape-context-menus-4.0.0.tgz",
+            "integrity": "sha512-+WC0r7nExd1e3gwHe2Pk0tcDU8MU1HIfbHs6Z3cfamZY2M+tAvP20X5SoregMQ6IN3IQkg4KU59q1hJlvbwzcw=="
         },
         "cytoscape-dagre": {
             "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "codemirror": "^5.51.0",
         "cytoscape": "^3.13.0",
         "cytoscape-canvas": "^3.0.1",
-        "cytoscape-context-menus": "^3.0.7",
+        "cytoscape-context-menus": "^4.0.0",
         "cytoscape-dagre": "^2.2.1",
         "cytoscape-grid-guide": "^2.3.0",
         "diff-match-patch": "^1.0.4",


### PR DESCRIPTION
Replace #8032.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
