### PR TITLE
Reduce query count on home page and fix full list display; see #6765

### DIFF
--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1865,21 +1865,14 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
    static function showCentralList($start, $status = 'todo', $showgrouptickets = true) {
       global $CFG_GLPI;
 
-      $req = self::getTaskList($status, $showgrouptickets);
-      $numrows = 0;
-      if ($req !== false) {
-         $numrows = $req->numrows();
-      }
+      $iterator = self::getTaskList($status, $showgrouptickets);
 
-      $number = 0;
-      if ($_SESSION['glpidisplay_count_on_home'] > 0 && $req !== false) {
-         $start = (int)$start;
-         $limit = (int)$_SESSION['glpidisplay_count_on_home'];
-         $req = self::getTaskList($status, $showgrouptickets, $start, $limit);
-         $number = $req->numrows();
-      }
+      $total_row_count = count($iterator);
+      $displayed_row_count = (int)$_SESSION['glpidisplay_count_on_home'] > 0
+         ? min((int)$_SESSION['glpidisplay_count_on_home'], $total_row_count)
+         : $total_row_count;
 
-      if ($numrows > 0) {
+      if ($displayed_row_count > 0) {
          echo "<table class='tab_cadrehov'>";
          echo "<tr class='noHover'><th colspan='4'>";
 
@@ -1926,26 +1919,26 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                }
                echo "<a href=\"".$CFG_GLPI["root_doc"]."/front/ticket.php?".
                       Toolbox::append_params($options, '&amp;')."\">".
-                      Html::makeTitle($title, $number, $numrows)."</a>";
+                      Html::makeTitle($title, $displayed_row_count, $total_row_count)."</a>";
                break;
          }
 
          echo "</th></tr>";
-         if ($number) {
-            echo "<tr>";
-            echo "<th style='width: 75px;'>".__('ID')." </th>";
-            $type = "";
-            if ($itemtype == "TicketTask") {
-               $type = Ticket::getTypeName();
-            } else if ($itemtype == "ProblemTask") {
-               $type = Problem::getTypeName();
-            }
-            echo "<th style='width: 20%;'>".__('Title')." (".strtolower($type).")</th>";
-            echo "<th>".__('Description')."</th>";
-            echo "</tr>";
-            foreach ($req as $row) {
-               self::showVeryShort($row['id'], $itemtype);
-            }
+         echo "<tr>";
+         echo "<th style='width: 75px;'>".__('ID')." </th>";
+         $type = "";
+         if ($itemtype == "TicketTask") {
+            $type = Ticket::getTypeName();
+         } else if ($itemtype == "ProblemTask") {
+            $type = Problem::getTypeName();
+         }
+         echo "<th style='width: 20%;'>".__('Title')." (".strtolower($type).")</th>";
+         echo "<th>".__('Description')."</th>";
+         echo "</tr>";
+         $i = 0;
+         while ($i < $displayed_row_count && ($data = $iterator->next())) {
+            self::showVeryShort($data['id'], $itemtype);
+            $i++;
          }
          echo "</table>";
       }

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -700,20 +700,12 @@ class Problem extends CommonITILObject {
       ];
       $iterator = $DB->request($criteria);
 
-      $numrows = count($iterator);
-      $number = 0;
+      $total_row_count = count($iterator);
+      $displayed_row_count = (int)$_SESSION['glpidisplay_count_on_home'] > 0
+         ? min((int)$_SESSION['glpidisplay_count_on_home'], $total_row_count)
+         : $total_row_count;
 
-      if ($_SESSION['glpidisplay_count_on_home'] > 0) {
-         $citerator = $DB->request(
-            $criteria + [
-               'START' => (int)$start,
-               'LIMIT' => (int)$_SESSION['glpidisplay_count_on_home']
-            ]
-         );
-         $number = count($citerator);
-      }
-
-      if ($numrows > 0) {
+      if ($displayed_row_count > 0) {
          echo "<table class='tab_cadrehov'>";
          echo "<tr class='noHover'><th colspan='3'>";
 
@@ -738,7 +730,7 @@ class Problem extends CommonITILObject {
 
                   echo "<a href=\"".$CFG_GLPI["root_doc"]."/front/problem.php?".
                          Toolbox::append_params($options, '&amp;')."\">".
-                         Html::makeTitle(__('Problems on pending status'), $number, $numrows)."</a>";
+                         Html::makeTitle(__('Problems on pending status'), $displayed_row_count, $total_row_count)."</a>";
                   break;
 
                case "process" :
@@ -754,7 +746,7 @@ class Problem extends CommonITILObject {
 
                   echo "<a href=\"".$CFG_GLPI["root_doc"]."/front/problem.php?".
                          Toolbox::append_params($options, '&amp;')."\">".
-                         Html::makeTitle(__('Problems to be processed'), $number, $numrows)."</a>";
+                         Html::makeTitle(__('Problems to be processed'), $displayed_row_count, $total_row_count)."</a>";
                   break;
 
                default :
@@ -770,7 +762,7 @@ class Problem extends CommonITILObject {
 
                   echo "<a href=\"".$CFG_GLPI["root_doc"]."/front/problem.php?".
                          Toolbox::append_params($options, '&amp;')."\">".
-                         Html::makeTitle(__('Your problems in progress'), $number, $numrows)."</a>";
+                         Html::makeTitle(__('Your problems in progress'), $displayed_row_count, $total_row_count)."</a>";
             }
 
          } else {
@@ -788,7 +780,7 @@ class Problem extends CommonITILObject {
 
                   echo "<a href=\"".$CFG_GLPI["root_doc"]."/front/problem.php?".
                          Toolbox::append_params($options, '&amp;')."\">".
-                         Html::makeTitle(__('Problems on pending status'), $number, $numrows)."</a>";
+                         Html::makeTitle(__('Problems on pending status'), $displayed_row_count, $total_row_count)."</a>";
                   break;
 
                case "process" :
@@ -804,7 +796,7 @@ class Problem extends CommonITILObject {
 
                   echo "<a href=\"".$CFG_GLPI["root_doc"]."/front/problem.php?".
                          Toolbox::append_params($options, '&amp;')."\">".
-                         Html::makeTitle(__('Problems to be processed'), $number, $numrows)."</a>";
+                         Html::makeTitle(__('Problems to be processed'), $displayed_row_count, $total_row_count)."</a>";
                   break;
 
                default :
@@ -820,18 +812,18 @@ class Problem extends CommonITILObject {
 
                   echo "<a href=\"".$CFG_GLPI["root_doc"]."/front/problem.php?".
                         Toolbox::append_params($options, '&amp;')."\">".
-                        Html::makeTitle(__('Your problems in progress'), $number, $numrows)."</a>";
+                        Html::makeTitle(__('Your problems in progress'), $displayed_row_count, $total_row_count)."</a>";
             }
          }
 
          echo "</th></tr>";
-         if ($number) {
-            echo "<tr><th></th>";
-            echo "<th>"._n('Requester', 'Requesters', 1)."</th>";
-            echo "<th>".__('Description')."</th></tr>";
-            while ($result = $iterator->next()) {
-               self::showVeryShort($result['id'], $forcetab);
-            }
+         echo "<tr><th></th>";
+         echo "<th>"._n('Requester', 'Requesters', 1)."</th>";
+         echo "<th>".__('Description')."</th></tr>";
+         $i = 0;
+         while ($i < $displayed_row_count && ($data = $iterator->next())) {
+            self::showVeryShort($data['id'], $forcetab);
+            $i++;
          }
          echo "</table>";
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -5269,20 +5269,12 @@ class Ticket extends CommonITILObject {
          $criteria = array_merge_recursive($criteria, $JOINS);
       }
       $iterator = $DB->request($criteria);
-      $numrows = count($iterator);
-      $number = 0;
+      $total_row_count = count($iterator);
+      $displayed_row_count = (int)$_SESSION['glpidisplay_count_on_home'] > 0
+         ? min((int)$_SESSION['glpidisplay_count_on_home'], $total_row_count)
+         : $total_row_count;
 
-      if ($_SESSION['glpidisplay_count_on_home'] > 0) {
-         $iterator = $DB->request(
-            $criteria + [
-               'START' => (int)$start,
-               'LIMIT' => (int)$_SESSION['glpidisplay_count_on_home']
-            ]
-         );
-         $number = count($iterator);
-      }
-
-      if ($numrows > 0) {
+      if ($displayed_row_count > 0) {
          echo "<table class='tab_cadrehov'>";
          echo "<tr class='noHover'><th colspan='4'>";
 
@@ -5307,7 +5299,7 @@ class Ticket extends CommonITILObject {
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                          Toolbox::append_params($options, '&amp;')."\">".
-                         Html::makeTitle(__('Your tickets to close'), $number, $numrows)."</a>";
+                         Html::makeTitle(__('Your tickets to close'), $displayed_row_count, $total_row_count)."</a>";
                   break;
 
                case "waiting" :
@@ -5323,7 +5315,7 @@ class Ticket extends CommonITILObject {
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                          Toolbox::append_params($options, '&amp;')."\">".
-                         Html::makeTitle(__('Tickets on pending status'), $number, $numrows)."</a>";
+                         Html::makeTitle(__('Tickets on pending status'), $displayed_row_count, $total_row_count)."</a>";
                   break;
 
                case "process" :
@@ -5339,7 +5331,7 @@ class Ticket extends CommonITILObject {
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                          Toolbox::append_params($options, '&amp;')."\">".
-                         Html::makeTitle(__('Tickets to be processed'), $number, $numrows)."</a>";
+                         Html::makeTitle(__('Tickets to be processed'), $displayed_row_count, $total_row_count)."</a>";
                   break;
 
                case "observed":
@@ -5355,7 +5347,7 @@ class Ticket extends CommonITILObject {
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                          Toolbox::append_params($options, '&amp;')."\">".
-                         Html::makeTitle(__('Your observed tickets'), $number, $numrows)."</a>";
+                         Html::makeTitle(__('Your observed tickets'), $displayed_row_count, $total_row_count)."</a>";
                   break;
 
                case "requestbyself" :
@@ -5372,7 +5364,7 @@ class Ticket extends CommonITILObject {
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                          Toolbox::append_params($options, '&amp;')."\">".
-                         Html::makeTitle(__('Your tickets in progress'), $number, $numrows)."</a>";
+                         Html::makeTitle(__('Your tickets in progress'), $displayed_row_count, $total_row_count)."</a>";
             }
 
          } else {
@@ -5390,7 +5382,7 @@ class Ticket extends CommonITILObject {
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                          Toolbox::append_params($options, '&amp;')."\">".
-                         Html::makeTitle(__('Tickets on pending status'), $number, $numrows)."</a>";
+                         Html::makeTitle(__('Tickets on pending status'), $displayed_row_count, $total_row_count)."</a>";
                   break;
 
                case "process" :
@@ -5406,7 +5398,7 @@ class Ticket extends CommonITILObject {
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                          Toolbox::append_params($options, '&amp;')."\">".
-                         Html::makeTitle(__('Tickets to be processed'), $number, $numrows)."</a>";
+                         Html::makeTitle(__('Tickets to be processed'), $displayed_row_count, $total_row_count)."</a>";
                   break;
 
                case "tovalidate" :
@@ -5433,7 +5425,7 @@ class Ticket extends CommonITILObject {
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                         Toolbox::append_params($options, '&amp;')."\">".
-                        Html::makeTitle(__('Your tickets to validate'), $number, $numrows)."</a>";
+                        Html::makeTitle(__('Your tickets to validate'), $displayed_row_count, $total_row_count)."</a>";
 
                   break;
 
@@ -5451,7 +5443,7 @@ class Ticket extends CommonITILObject {
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                         Toolbox::append_params($options, '&amp;')."\">".
-                        Html::makeTitle(__('Your tickets having rejected approval status'), $number, $numrows)."</a>";
+                        Html::makeTitle(__('Your tickets having rejected approval status'), $displayed_row_count, $total_row_count)."</a>";
 
                   break;
 
@@ -5468,7 +5460,7 @@ class Ticket extends CommonITILObject {
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                         Toolbox::append_params($options, '&amp;')."\">".
-                        Html::makeTitle(__('Your tickets having rejected solution'), $number, $numrows)."</a>";
+                        Html::makeTitle(__('Your tickets having rejected solution'), $displayed_row_count, $total_row_count)."</a>";
 
                   break;
 
@@ -5497,7 +5489,7 @@ class Ticket extends CommonITILObject {
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                         Toolbox::append_params($options, '&amp;')."\">".
-                        Html::makeTitle(__('Your tickets to close'), $number, $numrows)."</a>";
+                        Html::makeTitle(__('Your tickets to close'), $displayed_row_count, $total_row_count)."</a>";
                   break;
 
                case "observed" :
@@ -5513,7 +5505,7 @@ class Ticket extends CommonITILObject {
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                         Toolbox::append_params($options, '&amp;')."\">".
-                        Html::makeTitle(__('Your observed tickets'), $number, $numrows)."</a>";
+                        Html::makeTitle(__('Your observed tickets'), $displayed_row_count, $total_row_count)."</a>";
                   break;
 
                case "survey" :
@@ -5547,7 +5539,7 @@ class Ticket extends CommonITILObject {
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                          Toolbox::append_params($options, '&amp;')."\">".
-                         Html::makeTitle(__('Satisfaction survey'), $number, $numrows)."</a>";
+                         Html::makeTitle(__('Satisfaction survey'), $displayed_row_count, $total_row_count)."</a>";
                   break;
 
                case "requestbyself" :
@@ -5564,19 +5556,19 @@ class Ticket extends CommonITILObject {
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                         Toolbox::append_params($options, '&amp;')."\">".
-                        Html::makeTitle(__('Your tickets in progress'), $number, $numrows)."</a>";
+                        Html::makeTitle(__('Your tickets in progress'), $displayed_row_count, $total_row_count)."</a>";
             }
          }
 
          echo "</th></tr>";
-         if ($number) {
-            echo "<tr><th style='width: 75px;'>".__('ID')."</th>";
-            echo "<th style='width: 20%;'>"._n('Requester', 'Requesters', 1)."</th>";
-            echo "<th style='width: 20%;'>"._n('Associated element', 'Associated elements', Session::getPluralNumber())."</th>";
-            echo "<th>".__('Description')."</th></tr>";
-            while ($data = $iterator->next()) {
-               self::showVeryShort($data['id'], $forcetab);
-            }
+         echo "<tr><th style='width: 75px;'>".__('ID')."</th>";
+         echo "<th style='width: 20%;'>"._n('Requester', 'Requesters', 1)."</th>";
+         echo "<th style='width: 20%;'>"._n('Associated element', 'Associated elements', Session::getPluralNumber())."</th>";
+         echo "<th>".__('Description')."</th></tr>";
+         $i = 0;
+         while ($i < $displayed_row_count && ($data = $iterator->next())) {
+            self::showVeryShort($data['id'], $forcetab);
+            $i++;
          }
          echo "</table>";
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. For each list, the full query was done to get the total count, the a query with limits where done to only get displayed items. I remove this second query as we can use the first one to display elements.
2. If `$_SESSION['glpidisplay_count_on_home']` was equal to `0`, items were not displayed (`$number = 0;` was causing `if ($number) {}` to be evaluate as false).