### PR TITLE
fix(transfer): prevent PHP notice

### DIFF
--- a/inc/commonitilvalidation.class.php
+++ b/inc/commonitilvalidation.class.php
@@ -312,7 +312,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
    function prepareInputForUpdate($input) {
 
       $forbid_fields = [];
-      if ($this->fields["users_id_validate"] == Session::getLoginUserID()) {
+      if ($this->fields["users_id_validate"] == Session::getLoginUserID() && isset($input["status"])) {
          if (($input["status"] == self::REFUSED)
              && (!isset($input["comment_validation"])
                  || ($input["comment_validation"] == ''))) {


### PR DESCRIPTION
Signed-off-by: Stanislas <skita@teclib.com>

When transferring a computer, if it's linked to ticket containing validation request (TicketValidation), 
PHP notices appears.

![image](https://user-images.githubusercontent.com/7335054/96837726-2ae7cd00-1447-11eb-81fa-f041ab9575c4.png)

Because ```CommonDBTM``` only passed  ```entities_id``` and ```_transfert``` keys  when ```forwardEntityInformations```


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 15923
