### PR TITLE
Handle RFC5987 format in Content-Disposition header; fixes #8148

### DIFF
--- a/tests/emails-tests/19-attachement-rfc5987-multiline.eml
+++ b/tests/emails-tests/19-attachement-rfc5987-multiline.eml
@@ -1,0 +1,75 @@
+Return-Path: normal@glpi-project.org
+Received: from 192.168.1.3 (LHLO mail.glpi-project.org) (192.168.1.3)
+ by mail.glpi-project.org with LMTP; Thu, 7 Jun 2018 12:05:51 +0200
+ (CEST)
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+    by mail.glpi-project.org (Postfix) with ESMTP id 6E50A7E807FE
+    for <unittests@glpi-project.org>; Thu,  7 Jun 2018 12:05:51 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+    by mail.glpi-project.org (Postfix) with ESMTP id 5C15F7E80423
+    for <unittests@glpi-project.org>; Thu,  7 Jun 2018 12:05:51 +0200 (CEST)
+Received: from mail.glpi-project.org ([127.0.0.1])
+    by localhost (mail.glpi-project.org [127.0.0.1]) (amavisd-new, port 10026)
+    with ESMTP id zZ35QyFtsE9R for <unittests@glpi-project.org>;
+    Thu,  7 Jun 2018 12:05:51 +0200 (CEST)
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+    by mail.glpi-project.org (Postfix) with ESMTP id 214627E807E8
+    for <unittests@glpi-project.org>; Thu,  7 Jun 2018 12:05:51 +0200 (CEST)
+Date: Thu, 7 Jun 2018 12:05:51 +0200 (CEST)
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <1695134010.1757889.1528365951040.JavaMail.zimbra@glpi-project.org>
+In-Reply-To: <1954034179.1757759.1528365914864.JavaMail.zimbra@glpi-project.org>
+Subject: Attachement having filename using RFC5987 (multiple lines)
+MIME-Version: 1.0
+Content-Type: multipart/alternative; 
+    boundary="----=_Part_1757883_1359581901.1528365951028"
+
+------=_Part_1757883_1359581901.1528365951028
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+Attached image has special chars in its filename
+
+------=_Part_1757883_1359581901.1528365951028
+Content-Type: multipart/related; 
+    boundary="----=_Part_1757884_1267006027.1528365951028"
+
+------=_Part_1757884_1267006027.1528365951028
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+<body>
+Attached image has special chars in its filename
+<img src="cid:6f1f48de7c56cc3412e74008ad9f7c640091f5e3@zimbra">
+</body>
+</html>
+------=_Part_1757884_1267006027.1528365951028
+Content-Type: image/gif;
+ name="=?UTF-8?B?MTktyoLHt8OoyZXJqcmQyasgyLzJpsOiyoHIvy5naWY=?="
+Content-Disposition: attachment;
+ filename*0*=UTF-8''19-%CA%82%C7%B7%C3%A8%C9%95%C9%A9%C9%90%C9%AB%20%C8%BC;
+ filename*1*=%C9%A6%C3%A2%CA%81%C8%BF.gif
+Content-Transfer-Encoding: base64
+Content-ID: <6f1f48de7c56cc3412e74008ad9f7c640091f5e3@zimbra>
+
+R0lGODlhDwAPAIcAAP///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEA
+AAAh+QQEAAAAACwAAAAADwAPAAAIGgABCBxIsKDBgwgTKlzIsKHDhxAjSpxI8WFAADs=
+------=_Part_1757884_1267006027.1528365951028--
+
+------=_Part_1757883_1359581901.1528365951028--
+

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -331,6 +331,7 @@ class MailCollector extends DbTestCase {
                'Inlined image with no Content-Disposition',
                'This is a mail without subject.', // No subject = name is set using ticket contents
                'Image tag splitted on multiple lines',
+               'Attachement having filename using RFC5987 (multiple lines)',
             ]
          ],
          // Mails having "normal" user as observer (add_cc_to_observer = true)
@@ -379,6 +380,7 @@ class MailCollector extends DbTestCase {
          '01-test.JPG',
          '15-image001.png',
          '18-blank.gif',
+         '19-ʂǷèɕɩɐɫ ȼɦâʁȿ.gif',
       ];
 
       $iterator = $DB->request(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8148

Requires https://github.com/laminas/laminas-mail/pull/108 to work correctly on short filenames (when filename in content-disposition is not splitted info mutilple lines). This part will be done in #8265 .