### PR TITLE
Fix ticket dashboards titles

### DIFF
--- a/css/dashboard.scss
+++ b/css/dashboard.scss
@@ -771,11 +771,10 @@ $break_tablet: 1400px;
       }
 
       .label {
-         max-width: calc(100% - 2em);
-
-         @media screen and (max-width: $break_tablet) {
-            max-width: calc(100%)
-         }
+         max-width: calc(100%);
+         overflow: hidden;
+         text-overflow: ellipsis;
+         white-space: nowrap;
       }
    }
    .main-icon {

--- a/inc/dashboard/widget.class.php
+++ b/inc/dashboard/widget.class.php
@@ -273,6 +273,7 @@ class Widget extends CommonGLPI {
          ? "href='{$p['url']}'"
          : "";
 
+      $label = $p['label'];
       $html = <<<HTML
       <style>
          #{$p['id']} {
@@ -290,7 +291,7 @@ class Widget extends CommonGLPI {
          class="card big-number $class"
          title="{$p['alt']}">
          <span class="content">$formatted_number</span>
-         <div class="label">{$p['label']}</div>
+         <div class="label" title="{$label}">{$label}</div>
          <i class="main-icon {$p['icon']}" style="color: {$fg_color}"></i>
       </a>
 HTML;


### PR DESCRIPTION
Introduced by https://github.com/glpi-project/glpi/pull/8151.

Tickets dashboard titles are broken on latest 9.5/bugfixes:
![image](https://user-images.githubusercontent.com/42734840/97279131-df646300-183a-11eb-9a5c-52ac5457cd4f.png)

This is caused by a font size increase (11px -> 2em in #8151).
To fix this I've allowed the line to use 100% of the available width and added a text-ellipsis in case the text may still be too long in some other languages (in this case the user can hover on the text to see the full title thanks to the new title attribute).

After (with example of a long title for the last one) : 
![image](https://user-images.githubusercontent.com/42734840/97279498-5e599b80-183b-11eb-8666-fa9abd1f3444.png)


FYI the labels were much smaller in 9.5.1 (font size is em based, 


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
