### PR TITLE
Handle upload of large files

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2255,6 +2255,7 @@ class Config extends CommonDBTM {
                2 => __('Default values'), // Prefs
                3 => __('Assets'),
                4 => __('Assistance'),
+               12 => __('Management'),
             ];
             if (Config::canUpdate()) {
                $tabs[9]  = __('Logs purge');
@@ -2341,6 +2342,10 @@ class Config extends CommonDBTM {
 
             case 11:
                Impact::showConfigForm();
+               break;
+
+            case 12:
+               $item->showFormManagement();
                break;
          }
       }
@@ -3402,6 +3407,67 @@ class Config extends CommonDBTM {
 
       echo '</table>';
       Html::closeForm();
+   }
+
+   /**
+    * Security form related to management entries.
+    *
+    * @since x.x.x
+    *
+    * @return void|boolean (display) Returns false if there is a rights error.
+    */
+   function showFormManagement () {
+      global $CFG_GLPI;
+
+      if (!self::canView()) {
+         return;
+      }
+
+      $rand = mt_rand();
+      $canedit = Session::haveRight(self::$rightname, UPDATE);
+
+      echo '<div class="center" id="tabsbody">';
+      if ($canedit) {
+         echo '<form name="form" action="' . Toolbox::getItemTypeFormURL(__CLASS__) . '" method="post" data-track-changes="true">';
+      }
+      echo '<table class="tab_cadre_fixe">';
+      echo '<tr><th colspan="4">' . __('Documents setup') . '</th></tr>';
+
+      echo '<tr class="tab_bg_2">';
+      echo '<td>';
+      echo '<label for="dropdown_document_max_size' . $rand . '">';
+      echo __('Document files maximum size (Mio)');
+      echo '</label>';
+      echo '</td>';
+      echo '<td>';
+      Dropdown::showNumber(
+         'document_max_size',
+         [
+            'value' => $CFG_GLPI['document_max_size'],
+            'min'   => 1,
+            'max'   => 250,
+            'rand'  => $rand,
+         ]
+      );
+      echo '</td>';
+      echo '<td colspan="2"></td>';
+      echo '</tr>';
+
+      if ($canedit) {
+         echo '<tr class="tab_bg_2">';
+         echo '<td colspan="4" class="center">';
+         echo '<input type="submit" name="update" class="submit" value="' . _sx('button', 'Save') . '">';
+         echo '</td>';
+         echo '</tr>';
+      }
+
+      echo '</table>';
+
+      if ($canedit) {
+         Html::closeForm();
+      }
+
+      echo '</div>';
    }
 
    public function rawSearchOptions() {

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -448,11 +448,10 @@ class Document extends CommonDBTM {
     * Get max upload size from php config
    **/
    static function getMaxUploadSize() {
+      global $CFG_GLPI;
 
-      $max_size  = Toolbox::return_bytes_from_ini_vars(ini_get("upload_max_filesize"));
-      $max_size /= 1024*1024;
       //TRANS: %s is a size
-      return sprintf(__('%s Mio max'), round($max_size, 1));
+      return sprintf(__('%s Mio max'), $CFG_GLPI['document_max_size']);
    }
 
 

--- a/inc/documenttype.class.php
+++ b/inc/documenttype.class.php
@@ -183,4 +183,36 @@ class DocumentType  extends CommonDropdown {
          return $display;
       }
    }
+
+   /**
+    * Return pattern that can be used to validate that name of an uploaded file matches accepted extensions.
+    *
+    * @return string
+    */
+   public static function getUploadableFilePattern(): string {
+      global $DB;
+
+      $valid_type_iterator = $DB->request([
+         'FROM'   => 'glpi_documenttypes',
+         'WHERE'  => [
+            'is_uploadable'   => 1
+         ]
+      ]);
+
+      $valid_ext_patterns = [];
+      foreach ($valid_type_iterator as $valid_type) {
+         $valid_ext = $valid_type['ext'];
+         if (preg_match('/\/.+\//', $valid_ext)) {
+            // Filename matches pattern
+            // Remove surrounding '/' as it will be included in a larger pattern
+            // and protect by surrounding parenthesis to prevent conflict with other patterns
+            $valid_ext_patterns[] = '(' . substr($valid_ext, 1, -1) . ')';
+         } else {
+            // Filename ends with allowed ext
+            $valid_ext_patterns[] = '\.' . preg_quote($valid_type['ext'], '/') . '$';
+         }
+      }
+
+      return '/(' . implode('|', $valid_ext_patterns) . ')/i';
+   }
 }

--- a/inc/glpiuploadhandler.class.php
+++ b/inc/glpiuploadhandler.class.php
@@ -120,7 +120,7 @@ class GLPIUploadHandler extends UploadHandler {
 
    static function uploadFiles($params = []) {
 
-      global $DB;
+      global $CFG_GLPI, $DB;
 
       $default_params = [
          'name'           => '',
@@ -135,37 +135,17 @@ class GLPIUploadHandler extends UploadHandler {
          $name = $rand_name . $name;
       }
 
-      $valid_type_iterator = $DB->request([
-         'FROM'   => 'glpi_documenttypes',
-         'WHERE'  => [
-            'is_uploadable'   => 1
-         ]
-      ]);
-
-      $valid_ext_patterns = [];
-      foreach ($valid_type_iterator as $valid_type) {
-         $valid_ext = $valid_type['ext'];
-         if (preg_match('/\/.+\//', $valid_ext)) {
-            // Filename matches pattern
-            // Remove surrounding '/' as it will be included in a larger pattern
-            // and protect by surrounding parenthesis to prevent conflict with other patterns
-            $valid_ext_patterns[] = '(' . substr($valid_ext, 1, -1) . ')';
-         } else {
-            // Filename ends with allowed ext
-            $valid_ext_patterns[] = '\.' . preg_quote($valid_type['ext'], '/') . '$';
-         }
-      }
-
       $upload_dir     = GLPI_TMP_DIR.'/';
       $upload_handler = new self(
          [
-            'accept_file_types'         => '/(' . implode('|', $valid_ext_patterns) . ')/i',
+            'accept_file_types'         => DocumentType::getUploadableFilePattern(),
             'image_versions'            => [
                'auto_orient' => false,
             ],
             'param_name'                => $pname,
             'replace_dots_in_filenames' => false,
             'upload_dir'                => $upload_dir,
+            'max_file_size'             => $CFG_GLPI['document_max_size'] * 1024 * 1024,
          ],
          false
       );

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -1761,6 +1761,19 @@ class Toolbox {
       return $val;
    }
 
+
+   /**
+    * Get max upload size from php config.
+    *
+    * @return int
+    */
+   static function getPhpUploadSizeLimit(): int {
+      $post_max   = Toolbox::return_bytes_from_ini_vars(ini_get("post_max_size"));
+      $upload_max = Toolbox::return_bytes_from_ini_vars(ini_get("upload_max_filesize"));
+      $max_size   = $post_max > 0 ? min($post_max, $upload_max) : $upload_max;
+      return $max_size;
+   }
+
    /**
     * Parse imap open connect string
     *

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -293,7 +293,9 @@ $default_prefs = [
    'default_dashboard_mini_ticket'           => 'mini_tickets',
    'admin_email_noreply'                     => '',
    'admin_email_noreply_name'                => '',
-   Impact::CONF_ENABLED                      => exportArrayToDB(Impact::getDefaultItemtypes())
+   Impact::CONF_ENABLED                      => exportArrayToDB(Impact::getDefaultItemtypes()),
+   // Default size corresponds to the 'upload_max_filesize' directive in Mio (rounded down) or 1 Mio if 'upload_max_filesize' is too low.
+   'document_max_size'                       => max(1, floor(Toolbox::return_bytes_from_ini_vars(ini_get('upload_max_filesize')) / 1024 / 1024)),
 ];
 
 $tables['glpi_configs'] = [];

--- a/install/update_95_xx.php
+++ b/install/update_95_xx.php
@@ -49,12 +49,13 @@ function update95toXX() {
    $update_scripts = [
       'comment_fields',
       'devicebattery',
+      'documents',
       'domains',
       'native_inventory',
+      'recurrentchange',
       'reservationitem',
       'softwares',
-      'recurrentchange',
-      'uuids'
+      'uuids',
    ];
 
    foreach ($update_scripts as $update_script) {

--- a/install/update_95_xx/documents.php
+++ b/install/update_95_xx/documents.php
@@ -1,3 +1,4 @@
+<?php
 /**
  * ---------------------------------------------------------------------
  * GLPI - Gestionnaire Libre de Parc Informatique
@@ -28,9 +29,13 @@
  * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
  * ---------------------------------------------------------------------
  */
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
 
-// jQuery File Upload plugin
-require('../../vendor/blueimp/jquery-file-upload/js/jquery.fileupload');
-require('../../vendor/blueimp/jquery-file-upload/js/jquery.iframe-transport');
-require('../../vendor/blueimp/jquery-file-upload/js/jquery.fileupload-process');
-require('../../vendor/blueimp/jquery-file-upload/js/jquery.fileupload-validate');
+// Add a config entry for document max size.
+// Default size corresponds to the 'upload_max_filesize' directive in Mio (rounded down)
+// or 1 Mio if 'upload_max_filesize' is too low.
+$upload_max = Toolbox::return_bytes_from_ini_vars(ini_get('upload_max_filesize'));
+$migration->addConfig(['document_max_size' => max(1, floor($upload_max / 1024 / 1024))]);

--- a/tests/functionnal/Config.php
+++ b/tests/functionnal/Config.php
@@ -85,6 +85,7 @@ class Config extends DbTestCase {
          'Config$2'      => 'Default values',
          'Config$3'      => 'Assets',
          'Config$4'      => 'Assistance',
+         'Config$12'     => 'Management',
          'GLPINetwork$1' => 'GLPI Network',
          'Log$1'         => 'Historical',
       ];
@@ -110,6 +111,7 @@ class Config extends DbTestCase {
          'Config$2'      => 'Default values',
          'Config$3'      => 'Assets',
          'Config$4'      => 'Assistance',
+         'Config$12'     => 'Management',
          'Config$9'      => 'Logs purge',
          'Config$5'      => 'System',
          'Config$10'     => 'Security',

--- a/tests/functionnal/DocumentType.php
+++ b/tests/functionnal/DocumentType.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+use Toolbox;
+
+/* Test for inc/documenttype.class.php */
+
+class DocumentType extends DbTestCase {
+
+   public function testGetUploadableFilePattern() {
+      $doctype = new \DocumentType();
+
+      // Clear types to prevent test to be impacted by potential default types changes
+      $this->boolean($doctype->deleteByCriteria(['1']))->isTrue();
+
+      $this->integer((int)$doctype->add(Toolbox::addslashes_deep(['name' => 'JPG' ,'ext' => '/\.jpe?g$/'])))->isGreaterThan(0);
+      $this->integer((int)$doctype->add(Toolbox::addslashes_deep(['name' => 'DOC' ,'ext' => 'doc'])))->isGreaterThan(0);
+      $this->integer((int)$doctype->add(Toolbox::addslashes_deep(['name' => 'XML' ,'ext' => 'xml'])))->isGreaterThan(0);
+      $this->integer((int)$doctype->add(Toolbox::addslashes_deep(['name' => 'Tarball' ,'ext' => 'tar.gz'])))->isGreaterThan(0);
+
+      // Validate generated pattern
+      $pattern = \DocumentType::getUploadableFilePattern();
+      $this->string($pattern)->isIdenticalTo('/((\.jpe?g$)|\.doc$|\.xml$|\.tar\.gz$)/i');
+
+      // Validate matches
+      $this->integer(preg_match($pattern, 'test.jpg'))->isEqualTo(1);
+      $this->integer(preg_match($pattern, 'test.jpeg'))->isEqualTo(1);
+      $this->integer(preg_match($pattern, 'test.jpag'))->isEqualTo(0);
+      $this->integer(preg_match($pattern, 'test.doc'))->isEqualTo(1);
+      $this->integer(preg_match($pattern, 'test.xml'))->isEqualTo(1);
+      $this->integer(preg_match($pattern, 'testxml'))->isEqualTo(0);
+      $this->integer(preg_match($pattern, 'test.tar.gz'))->isEqualTo(1);
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8176 

While searching how to fix #8176 , I noticed multiple things:
1. `maxChunkSize` option can be used to split upload on multiple request when using `fileupload` jQuery plugin.
2. Uploading from file input was using `fileupload` jQuery plugin capabilities, but uploading from image pasting into rich text editor was not.
3. Upload using `drop` event was configured to be handled by `fileupload` jQuery plugin but was also manually handled.

So, after some iterations, I finally mutualize code and use `fileupload` jQuery plugin for all uploads, which permits to upload large files chunks by chunks.

~~In the end, there is no more limitation on uploaded files size.
I think administrators may want to keep a limit, so, if everyone is OK with that, I will put back a limitation that could be set in GLPI configuration (set by default to `upload_max_filesize` PHP configuration).~~

In the end, I added a limitation that can be configured, and added a browser side validation of file size and type.