### PR TITLE
Fix disk 'Free percentage' search option

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -4601,6 +4601,7 @@ JAVASCRIPT;
             case "number" :
             case "decimal" :
             case "timestamp" :
+            case "progressbar" :
                $search  = ["/\&lt;/", "/\&gt;/"];
                $replace = ["<", ">"];
                $val     = preg_replace($search, $replace, $val);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes ability to search using `>` or `<` operators.

![image](https://user-images.githubusercontent.com/33253653/97452108-b2947680-1934-11eb-8ef8-474d9a5001cf.png)
