### PR TITLE
Always display max_closedate for surveys

### DIFF
--- a/ajax/ticketsatisfaction.php
+++ b/ajax/ticketsatisfaction.php
@@ -88,12 +88,10 @@ if (isset($_POST['inquest_config']) && isset($_POST['entities_id'])) {
                                  'unit'  => 'day']);
       echo "</td></tr>";
 
-      if ($max_closedate != '') {
-         echo "<tr class='tab_bg_1'><td>". __('For tickets closed after')."</td><td>";
-         Html::showDateTimeField("max_closedate", ['value'      => $max_closedate,
-                                                        'timestep'   => 1]);
-         echo "</td></tr>";
-      }
+      echo "<tr class='tab_bg_1'><td>". __('For tickets closed after')."</td><td>";
+      Html::showDateTimeField("max_closedate", ['value'      => $max_closedate,
+                                                      'timestep'   => 1]);
+      echo "</td></tr>";
 
       if ($_POST['inquest_config'] == 2) {
          echo "<tr class='tab_bg_1'>";


### PR DESCRIPTION
Internal ref: 20967.

For surveys, the `max_closedate` input doesn't display until it has a value (value is set to current date if `inquest_rate` is updated.
This is confusing since the user is unaware this option exist unless he modifies the `inquest_rate` parameter (see internal ref).

Before:
![image](https://user-images.githubusercontent.com/42734840/97549744-0fde0580-19d1-11eb-9a9a-7cad7faeba1a.png)

After:
![image](https://user-images.githubusercontent.com/42734840/97549934-49af0c00-19d1-11eb-8cda-eb65479e9548.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
