### PR TITLE
Fix SML dates computation tests

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1280,7 +1280,7 @@ class Ticket extends CommonITILObject {
              && ($input[$olaField] != $this->fields[$olaField]
                  || isset($input['_'.$olaField]))) {
 
-            $date = date('Y-m-d H:i:s');
+            $date = $_SESSION['glpi_currenttime'];
 
             // Get datas to initialize OLA and set it
             $ola_data = $this->getDatasToAddOLA($input[$olaField], $this->fields['entities_id'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. During OLA affect, base date was set to `date('Y-m-d H:i:s')`, making it difficult to test. I switched to `$_SESSION['glpi_currenttime']`.
2. `internal_time_to_own` start reference date was not always same as `$ticket-field['date']` (due to point 1), now it should.
3. `internal_time_to_resolve` start reference date is `$ticket->fields['ola_ttr_begin_date']`, which was not always equal to `$ticket->fields['date']` or `$ticket->fields['date_mod']` (due to point 1), now it should.