### PR TITLE
Fix locale string

### DIFF
--- a/inc/marketplace/view.class.php
+++ b/inc/marketplace/view.class.php
@@ -139,7 +139,7 @@ class View extends CommonGLPI {
       if (!GLPINetwork::isServicesAvailable()) {
          array_push(
             $messages,
-            sprintf(__("%1$s services website seems not available from your network or offline"), 'GLPI Network'),
+            sprintf(__('%1$s services website seems not available from your network or offline'), 'GLPI Network'),
             "<a href='".$CFG_GLPI['root_doc']."/front/config.form.php?forcetab=Config$5'>".
             __("Maybe you could setup a proxy").
             "</a> ".


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Due to usage of double quotes, `$s` was evaluated an replaced by an empty string, triggering an error: `Uncaught Exception ValueError: Unknown format specifier " "`.
