### PR TITLE
Fix is_dynamic display for computer_item tab

### DIFF
--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -1668,6 +1668,20 @@ abstract class CommonDBRelation extends CommonDBConnexity {
    }
 
    /**
+    * Get SELECT param for getTypeItemsQueryParams
+    *
+    * @param CommonDBTM $item
+    *
+    * @return array
+    */
+   public static function getTypeItemsQueryParams_Select(CommonDBTM $item): array {
+      return [
+         $item->getTable() . '.*',
+         static::getTable() . '.id AS linkid',
+      ];
+   }
+
+   /**
     * Get items for an itemtype
     *
     * @since 9.3.1
@@ -1698,10 +1712,7 @@ abstract class CommonDBRelation extends CommonDBConnexity {
       }
 
       $params = [
-         'SELECT' => [
-            $item->getTable() . '.*',
-            static::getTable() . '.id AS linkid'
-         ],
+         'SELECT' => static::getTypeItemsQueryParams_Select($item),
          'FROM'   => $item->getTable(),
          'WHERE'  => $where,
          'LEFT JOIN' => [

--- a/inc/computer_item.class.php
+++ b/inc/computer_item.class.php
@@ -395,7 +395,8 @@ class Computer_Item extends CommonDBRelation{
                   ((isset($data['is_deleted']) && $data['is_deleted'])?"class='tab_bg_2_2'":"").
                  ">".$name."</td>";
             if (Plugin::haveImport()) {
-               echo "<td>".Dropdown::getYesNo($data['is_dynamic'])."</td>";
+               $dynamic_field = static::getTable() . '_is_dynamic';
+               echo "<td>".Dropdown::getYesNo($data[$dynamic_field])."</td>";
             }
             echo "<td>".Dropdown::getDropdownName("glpi_entities",
                                                                $data['entities_id']);
@@ -842,5 +843,20 @@ class Computer_Item extends CommonDBRelation{
       $params = parent::getListForItemParams($item, $noent);
       $params['WHERE'][self::getTable() . '.is_deleted'] = 0;
       return $params;
+   }
+
+   /**
+    * Get SELECT param for getTypeItemsQueryParams
+    *
+    * @param CommonDBTM $item
+    *
+    * @return array
+    */
+   public static function getTypeItemsQueryParams_Select(CommonDBTM $item): array {
+      $table = static::getTable();
+      $select = parent::getTypeItemsQueryParams_Select($item);
+      $select[] = "$table.is_dynamic AS {$table}_is_dynamic";
+
+      return $select;
    }
 }


### PR DESCRIPTION
### Issue

Assuming we have the following Computer <=> Monitor connection: 
![image](https://user-images.githubusercontent.com/42734840/97867651-8602a500-1d0e-11eb-9bd1-a075b7a25aa9.png)

View from Computer:
![image](https://user-images.githubusercontent.com/42734840/97867704-9d419280-1d0e-11eb-8621-4849a781626a.png)

View from Monitor:
![image](https://user-images.githubusercontent.com/42734840/97867685-93b82a80-1d0e-11eb-944a-37868b800cfc.png)

As you can see, the "Automatic inventory" fields do not match.
The correct information is the one displayed from the monitor's view.

The computer's view is incorrect because it show the "Automatic inventory" state of the linked monitor (instead of the state of the **connection** between the two items).

### Fix

Use `is_dynamic` field from the connection.

### Q/A

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !18575
