### PR TITLE
Fix network port form

### DIFF
--- a/inc/networkportinstantiation.class.php
+++ b/inc/networkportinstantiation.class.php
@@ -191,7 +191,7 @@ class NetworkPortInstantiation extends CommonDBChild {
                                                     HTMLTableCell $father = null,
                                                     array $options = []) {
 
-      $this->getInstantiationHTMLTable($netport, $row, $father, $options);
+      self::getInstantiationHTMLTable($netport, $row, $father, $options);
       return null;
 
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8183

Revert back to using `self` on instance method. Using `$this` caused an infinite loop.