### PR TITLE
Enhance configuration history

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -3020,14 +3020,11 @@ class Config extends CommonDBTM {
    static function setConfigurationValues($context, array $values = []) {
 
       $glpikey = new GLPIKey();
-      $secured_configs = $glpikey->getConfigs();
 
       $config = new self();
       foreach ($values as $name => $value) {
          // Encrypt config values according to list declared to GLPIKey service
-         if (!empty($value)
-             && array_key_exists($context, $secured_configs)
-             && in_array($name, $secured_configs[$context])) {
+         if (!empty($value) && $glpikey->isConfigSecured($context, $name)) {
             $value = Toolbox::sodiumEncrypt($value);
          }
 
@@ -3760,6 +3757,10 @@ class Config extends CommonDBTM {
       return [$this->getType(), 1];
    }
 
+   public function post_addItem() {
+      $this->logConfigChange($this->fields['context'], $this->fields['name'], (string)$this->fields['value'], '');
+   }
+
    public function post_updateItem($history = 1) {
       global $DB;
 
@@ -3783,13 +3784,37 @@ class Config extends CommonDBTM {
          );
       }
 
-      // Keep it at the end as it alter $this->oldvalues
-      if (count($this->oldvalues)) {
-         foreach ($this->oldvalues as &$value) {
-            $value = $this->fields['name'] . ' ' . $value;
-         }
-         Log::constructHistory($this, $this->oldvalues, $this->fields);
+      if (array_key_exists('value', $this->oldvalues)) {
+         $this->logConfigChange(
+            $this->fields['context'],
+            $this->fields['name'],
+            (string)$this->fields['value'],
+            (string)$this->oldvalues['value']
+         );
       }
+   }
+
+   public function post_purgeItem() {
+      $this->logConfigChange($this->fields['context'], $this->fields['name'], '', (string)$this->fields['value']);
+   }
+
+   /**
+    * Log config change in history.
+    *
+    * @param string $context
+    * @param string $name
+    * @param string $newvalue
+    * @param string $oldvalue
+    *
+    * @return void
+    */
+   private function logConfigChange(string $context, string $name, string $newvalue, string $oldvalue): void {
+      $glpi_key = new GLPIKey();
+      if ($glpi_key->isConfigSecured($context, $name)) {
+         $newvalue = $oldvalue = '********';
+      }
+      $oldvalue = $name . ' ' . $oldvalue;
+      Log::constructHistory($this, ['value' => $oldvalue], ['value' => $newvalue]);
    }
 
    /**

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -3813,7 +3813,7 @@ class Config extends CommonDBTM {
       if ($glpi_key->isConfigSecured($context, $name)) {
          $newvalue = $oldvalue = '********';
       }
-      $oldvalue = $name . ' ' . $oldvalue;
+      $oldvalue = $name . ($context !== 'core' ? ' (' . $context . ') ' : ' ') . $oldvalue;
       Log::constructHistory($this, ['value' => $oldvalue], ['value' => $newvalue]);
    }
 

--- a/inc/glpikey.class.php
+++ b/inc/glpikey.class.php
@@ -211,6 +211,22 @@ class GLPIKey {
    }
 
    /**
+    * Check if configuration is secured.
+    *
+    * @param string $context
+    * @param string $name
+    *
+    * @return bool
+    */
+   public function isConfigSecured(string $context, string $name) :bool {
+
+      $secured_configs = $this->getConfigs();
+
+      return array_key_exists($context, $secured_configs)
+         && in_array($name, $secured_configs[$context]);
+   }
+
+   /**
     * Migrate fields in database
     *
     * @param string       $sodium_key Current key

--- a/inc/log.class.php
+++ b/inc/log.class.php
@@ -106,7 +106,7 @@ class Log extends CommonDBTM {
     *
     * @return boolean for success (at least 1 log entry added)
    **/
-   static function constructHistory(CommonDBTM $item, &$oldvalues, &$values) {
+   static function constructHistory(CommonDBTM $item, $oldvalues, $values) {
 
       if (!count($oldvalues)) {
          return false;

--- a/tests/functionnal/Config.php
+++ b/tests/functionnal/Config.php
@@ -773,14 +773,22 @@ class Config extends DbTestCase {
 
       return [
          [
-            'context'    => 'core',
-            'name'       => 'unexisting_config',
-            'is_secured' => false,
+            'context'          => 'core',
+            'name'             => 'unexisting_config',
+            'is_secured'       => false,
+            'old_value_prefix' => 'unexisting_config ',
          ],
          [
-            'context'    => 'plugin:tester',
-            'name'       => 'passwd',
-            'is_secured' => true,
+            'context'          => 'plugin:tester',
+            'name'             => 'check',
+            'is_secured'       => false,
+            'old_value_prefix' => 'check (plugin:tester) ',
+         ],
+         [
+            'context'          => 'plugin:tester',
+            'name'             => 'passwd',
+            'is_secured'       => true,
+            'old_value_prefix' => 'passwd (plugin:tester) ',
          ]
       ];
    }
@@ -788,7 +796,7 @@ class Config extends DbTestCase {
    /**
     * @dataProvider logConfigChangeProvider
     */
-   public function testLogConfigChange(string $context, string $name, bool $is_secured) {
+   public function testLogConfigChange(string $context, string $name, bool $is_secured, string $old_value_prefix) {
       $history_crit = ['itemtype' => \Config::getType(), 'old_value' => ['LIKE', $name . ' %']];
 
       $expected_history = [];
@@ -810,7 +818,7 @@ class Config extends DbTestCase {
       \Config::setConfigurationValues($context, [$name => 'first value']);
       $expected_history = [
          $history_entry_fields + [
-            'old_value' => $name . ' ' . ($is_secured ? '********' : ''),
+            'old_value' => $old_value_prefix . ($is_secured ? '********' : ''),
             'new_value' => $is_secured ? '********' : 'first value',
          ],
       ];
@@ -822,7 +830,7 @@ class Config extends DbTestCase {
       // History on updated value
       \Config::setConfigurationValues($context, [$name => 'new value']);
       $expected_history[] = $history_entry_fields + [
-         'old_value' => $name . ' ' . ($is_secured ? '********' : 'first value'),
+         'old_value' => $old_value_prefix . ($is_secured ? '********' : 'first value'),
          'new_value' => $is_secured ? '********' : 'new value',
       ];
 
@@ -833,7 +841,7 @@ class Config extends DbTestCase {
       // History on config deletion
       \Config::deleteConfigurationValues($context, [$name]);
       $expected_history[] = $history_entry_fields + [
-         'old_value' => $name . ' ' . ($is_secured ? '********' : 'new value'),
+         'old_value' => $old_value_prefix . ($is_secured ? '********' : 'new value'),
          'new_value' => $is_secured ? '********' : '',
       ];
 

--- a/tests/functionnal/Config.php
+++ b/tests/functionnal/Config.php
@@ -34,6 +34,8 @@ namespace tests\units;
 
 use PHPMailer\PHPMailer\PHPMailer;
 use \DbTestCase;
+use Log;
+use Session;
 
 /* Test for inc/config.class.php */
 
@@ -762,5 +764,81 @@ class Config extends DbTestCase {
             ['NOT' => ['authtype' => \Auth::DB_GLPI], 'password_last_update' => null]
          )
       )->isEqualTo($external_users_count);
+   }
+
+   protected function logConfigChangeProvider() {
+      global $PLUGIN_HOOKS;
+
+      $PLUGIN_HOOKS['secured_configs']['tester'] = ['passwd'];
+
+      return [
+         [
+            'context'    => 'core',
+            'name'       => 'unexisting_config',
+            'is_secured' => false,
+         ],
+         [
+            'context'    => 'plugin:tester',
+            'name'       => 'passwd',
+            'is_secured' => true,
+         ]
+      ];
+   }
+
+   /**
+    * @dataProvider logConfigChangeProvider
+    */
+   public function testLogConfigChange(string $context, string $name, bool $is_secured) {
+      $history_crit = ['itemtype' => \Config::getType(), 'old_value' => ['LIKE', $name . ' %']];
+
+      $expected_history = [];
+      $history_entry_fields = [
+         'itemtype'         => \Config::getType(),
+         'items_id'         => 1,
+         'itemtype_link'    => '',
+         'linked_action'    => 0,
+         'user_name'        => Session::getLoginUserID(false),
+         'date_mod'         => $_SESSION['glpi_currenttime'],
+         'id_search_option' => 1,
+      ];
+
+      $clean_ids = function (&$value, $key) {
+         unset($value['id']);
+      };
+
+      // History on first value
+      \Config::setConfigurationValues($context, [$name => 'first value']);
+      $expected_history = [
+         $history_entry_fields + [
+            'old_value' => $name . ' ' . ($is_secured ? '********' : ''),
+            'new_value' => $is_secured ? '********' : 'first value',
+         ],
+      ];
+
+      $found_history = array_values(getAllDataFromTable(Log::getTable(), $history_crit));
+      array_walk($found_history, $clean_ids);
+      $this->array($found_history)->isEqualTo($expected_history);
+
+      // History on updated value
+      \Config::setConfigurationValues($context, [$name => 'new value']);
+      $expected_history[] = $history_entry_fields + [
+         'old_value' => $name . ' ' . ($is_secured ? '********' : 'first value'),
+         'new_value' => $is_secured ? '********' : 'new value',
+      ];
+
+      $found_history = array_values(getAllDataFromTable(Log::getTable(), $history_crit));
+      array_walk($found_history, $clean_ids);
+      $this->array($found_history)->isEqualTo($expected_history);
+
+      // History on config deletion
+      \Config::deleteConfigurationValues($context, [$name]);
+      $expected_history[] = $history_entry_fields + [
+         'old_value' => $name . ' ' . ($is_secured ? '********' : 'new value'),
+         'new_value' => $is_secured ? '********' : '',
+      ];
+
+      $found_history = array_values(getAllDataFromTable(Log::getTable(), $history_crit));
+      array_walk($found_history, $clean_ids);
+      $this->array($found_history)->isEqualTo($expected_history);
    }
 }

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -137,8 +137,10 @@ class Migration extends \GLPITestCase {
          0 => 'SELECT * FROM `glpi_configs` WHERE `context` = \'core\' AND `name` IN (\'one\', \'two\')',
          1 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'one\'',
          2 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'one\', \'key\')',
-         3 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'two\'',
-         4 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'two\', \'value\')'
+         3 => 'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \''.$_SESSION['glpi_currenttime'].'\', \'1\', \'one \', \'key\')',
+         4 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'two\'',
+         5 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'two\', \'value\')',
+         6 => 'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \''.$_SESSION['glpi_currenttime'].'\', \'1\', \'two \', \'value\')',
       ];
       $this->array($this->queries)->isIdenticalTo($core_queries);
 
@@ -159,8 +161,10 @@ class Migration extends \GLPITestCase {
          0 => 'SELECT * FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` IN (\'one\', \'two\')',
          1 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'one\'',
          2 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'one\', \'key\')',
-         3 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'two\'',
-         4 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'two\', \'value\')'
+         3 => 'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \''.$_SESSION['glpi_currenttime'].'\', \'1\', \'one (test-context) \', \'key\')',
+         4 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'two\'',
+         5 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'two\', \'value\')',
+         6 => 'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \''.$_SESSION['glpi_currenttime'].'\', \'1\', \'two (test-context) \', \'value\')',
       ]);
 
       //test with one existing value => only new key should be inserted
@@ -195,7 +199,8 @@ class Migration extends \GLPITestCase {
       )->isIdenticalTo('Configuration values added for two (core).Task completed.');
 
       $this->array($this->queries)->isIdenticalTo([
-         0 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'two\', \'value\')'
+         0 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'two\', \'value\')',
+         1 => 'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \''.$_SESSION['glpi_currenttime'].'\', \'1\', \'two \', \'value\')',
       ]);
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. An history entry is now created when adding or deleting a configuration value (not only on update).
2. Values are replaced by `********` when entry correspond to a secured config.

There is no need to update existing history as shown values are encrypted.

Example:
![image](https://user-images.githubusercontent.com/33253653/98003374-f84ab680-1dee-11eb-9100-ceed45aee8bc.png)
