### PR TITLE
Fix pasted rich text

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -7031,3 +7031,8 @@ div.progress {
    }
 }
 /** /style for relations **/
+
+// Fix line breaks in pasted rich text
+.rich_text_container pre, .rich_text_container span {
+   white-space: pre-wrap;
+}


### PR DESCRIPTION
### Issue

Pasted rich text is not displayed correctly:
![image](https://user-images.githubusercontent.com/42734840/98007617-e7e90a80-1df3-11eb-971f-b05bc18f28b6.png)

### Changes

* Added a new css rule to force line returns.

After:
![image](https://user-images.githubusercontent.com/42734840/98007807-1bc43000-1df4-11eb-8cfb-3a0cf893cc68.png)


### Q/A

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
