### PR TITLE
Fix addOrderBy function

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3260,15 +3260,15 @@ JAVASCRIPT;
                   $name1 = 'realname';
                   $name2 = 'firstname';
                }
-               return " ORDER BY ".$table.$addtable.".$name1 $order,
-                                 ".$table.$addtable.".$name2 $order,
-                                 ".$table.$addtable.".`name` $order";
+               return " ORDER BY `".$table.$addtable."`.`$name1` $order,
+                                 `".$table.$addtable."`.`$name2` $order,
+                                 `".$table.$addtable."`.`name` $order";
             }
             return " ORDER BY `".$table.$addtable."`.`name` $order";
 
          case "glpi_networkequipments.ip" :
          case "glpi_ipaddresses.name" :
-            return " ORDER BY INET_ATON($table$addtable.$field) $order ";
+            return " ORDER BY INET_ATON(`$table$addtable`.`$field`) $order ";
       }
 
       //// Default cases

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3225,7 +3225,7 @@ JAVASCRIPT;
       }
 
       if (isset($CFG_GLPI["union_search_type"][$itemtype])) {
-         return " ORDER BY ITEM_{$itemtype}_{$ID} $order ";
+         return " ORDER BY `ITEM_{$itemtype}_{$ID}` $order ";
       }
 
       // Plugin can override core definition for its type
@@ -3308,7 +3308,7 @@ JAVASCRIPT;
          }
       }
 
-      return " ORDER BY ITEM_{$itemtype}_{$ID} $order ";
+      return " ORDER BY `ITEM_{$itemtype}_{$ID}` $order ";
    }
 
 

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1407,7 +1407,7 @@ class Search extends DbTestCase {
          ->contains("`glpi_users_users_id_recipient`.`id` = '{$user_normal_id}'")
 
          // Check that ORDER applies on corresponding table alias
-         ->contains("glpi_users_users_id_recipient.`name` ASC");
+         ->contains("`glpi_users_users_id_recipient`.`name` ASC");
    }
 
    function testSearchAllAssets() {
@@ -1461,6 +1461,25 @@ class Search extends DbTestCase {
             ->matches("/`$type`\.`name`  LIKE '%test%'/");
       }
    }
+
+   public function testSearchWithNamespacedItem() {
+      $search_params = [
+         'is_deleted'   => 0,
+         'start'        => 0,
+         'search'       => 'Search',
+      ];
+      $this->login();
+      $this->setEntity('_test_root_entity', true);
+
+      $data = $this->doSearch('SearchTest\\Computer', $search_params);
+
+      $this->array($data)->hasKey('sql');
+      $this->array($data['sql'])->hasKey('search');
+      $this->string($data['sql']['search'])
+         ->contains("`glpi_computers`.`name` AS `ITEM_SearchTest\Computer_1`")
+         ->contains("`glpi_computers`.`id` AS `ITEM_SearchTest\Computer_1_id`")
+         ->contains("ORDER BY `ITEM_SearchTest\Computer_1` ASC");
+   }
 }
 
 class DupSearchOpt extends \CommonDBTM {
@@ -1478,5 +1497,13 @@ class DupSearchOpt extends \CommonDBTM {
       ];
 
       return $tab;
+   }
+}
+
+namespace SearchTest;
+
+class Computer extends \Computer {
+   static function getTable($classname = null) {
+      return 'glpi_computers';
    }
 }


### PR DESCRIPTION
Enclosed aliases/columns names in backticks, allowing the use o special characters such as '\'.

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8226 
