### PR TITLE
feat(console): add clean cache command

### DIFF
--- a/inc/console/system/cleancachecommand.class.php
+++ b/inc/console/system/cleancachecommand.class.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\System;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CleanCacheCommand extends Command {
+
+   protected function configure() {
+      parent::configure();
+
+      $this->setName('glpi:system:clean_cache');
+      $this->setAliases(['system:clean_cache']);
+      $this->setDescription('Clean GLPI cache.');
+   }
+
+   protected function execute(InputInterface $input, OutputInterface $output) {
+
+      global $GLPI_CACHE;
+      $GLPI_CACHE->clear();
+
+      $output->writeln('<comment>cleaning cache done !!</comment>');
+
+      return 0; // Success
+   }
+}

--- a/inc/console/system/clearcachecommand.class.php
+++ b/inc/console/system/clearcachecommand.class.php
@@ -38,17 +38,16 @@ if (!defined('GLPI_ROOT')) {
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CleanCacheCommand extends Command {
+class ClearCacheCommand extends Command {
 
    protected function configure() {
       parent::configure();
 
-      $this->setName('glpi:system:clean_cache');
-      $this->setAliases(['system:clean_cache']);
-      $this->setDescription('Clean GLPI cache.');
+      $this->setName('glpi:system:clear_cache');
+      $this->setAliases(['system:clear_cache']);
+      $this->setDescription('Clear GLPI cache.');
    }
 
    protected function execute(InputInterface $input, OutputInterface $output) {
@@ -56,7 +55,7 @@ class CleanCacheCommand extends Command {
       global $GLPI_CACHE;
       $GLPI_CACHE->clear();
 
-      $output->writeln('<comment>cleaning cache done !!</comment>');
+      $output->writeln('<info>'. __('Cache reset successful') . '</info>');
 
       return 0; // Success
    }


### PR DESCRIPTION
Add new command "clean cache"

```
dev  ~/dev/GLPI/9.5-bugfixes   add_clean_cache_command  php bin/console glpi:system:clean_cache        
cleaning cache done !!
 dev  ~/dev/GLPI/9.5-bugfixes   add_clean_cache_command  
```


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
