### PR TITLE
Allow manually entering date and time

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -2870,6 +2870,10 @@ HTML;
             {$mode}
             onChange: function(selectedDates, dateStr, instance) {
                {$p['on_change']}
+            },
+            allowInput: true,
+            onClose(dates, currentdatestring, picker){
+               picker.setDate(picker.altInput.value, true, picker.config.altFormat)
             }
          });
       });
@@ -3045,6 +3049,10 @@ HTML;
             {$max_attr}
             onChange: function(selectedDates, dateStr, instance) {
                {$p['on_change']}
+            },
+            allowInput: true,
+            onClose(dates, currentdatestring, picker){
+               picker.setDate(picker.altInput.value, true, picker.config.altFormat)
             }
          });
       });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Partially addresses #7858 but still no `Today` button.

This change allows you to tab into date and time fields and manually enter a date like you were able to before.
Since the actual field value doesn't update while you type, it is forcibly set after flatpickr closes.