### PR TITLE
Fix visibility filters in solution form; fixes #8167

### DIFF
--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -131,6 +131,8 @@ class ITILSolution extends CommonDBChild {
       $this->item = $item;
       $item->check($item->getID(), READ);
 
+      $entities_id = isset($options['entities_id']) ? $options['entities_id'] : $item->getEntityID();
+
       if ($item instanceof Ticket && $this->isNewItem()) {
          $ti = new Ticket_Ticket();
          $open_child = $ti->countOpenChildren($item->getID());
@@ -169,11 +171,9 @@ class ITILSolution extends CommonDBChild {
          echo "<tr class='tab_bg_2'>";
          echo "<td>"._n('Solution template', 'Solution templates', 1)."</td><td>";
 
-         $entity = isset($options['entities_id']) ? $options['entities_id'] : $this->getEntityID();
-
          SolutionTemplate::dropdown([
             'value'    => 0,
-            'entity'   => $entity,
+            'entity'   => $entities_id,
             'rand'     => $rand_template,
             // Load type and solution from bookmark
             'toupdate' => [
@@ -207,7 +207,7 @@ class ITILSolution extends CommonDBChild {
       if ($canedit) {
          SolutionType::dropdown(['value'  => $this->getField('solutiontypes_id'),
                                  'rand'   => $rand_type,
-                                 'entity' => $this->getEntityID()]);
+                                 'entity' => $entities_id]);
       } else {
          echo Dropdown::getDropdownName('glpi_solutiontypes',
                                         $this->getField('solutiontypes_id'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8167 

On an empty `CommonDBChild` object, `$this->getEntityID()` returns `-1`, so all solutions templates and solutions types were proposed, even on entities that were not available.