### PR TITLE
fix Ticket tests typo

### DIFF
--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -1759,9 +1759,9 @@ class Ticket extends DbTestCase {
 
       // check with very limited rights and redo "associate myself"
       $_SESSION['glpiactiveprofile']['ticket'] = \CREATE
-                                               + \Ticket::READMY;
-                                               + \Ticket::READALL;
-                                               + \Ticket::READGROUP;
+                                               + \Ticket::READMY
+                                               + \Ticket::READALL
+                                               + \Ticket::READGROUP
                                                + \Ticket::OWN; // OWN right must allow self-assign
       $this->integer((int) $ticket_user->add($input_ticket_user))->isGreaterThan(0);
       // restore rights


### PR DESCRIPTION
Typos in Ticket functional tests.

Needs valdiation before chery-picking to maintained minor version.