### PR TITLE
Fix bad comparison in log

### DIFF
--- a/inc/log.class.php
+++ b/inc/log.class.php
@@ -719,7 +719,7 @@ class Log extends CommonDBTM {
             $tablename = '';
             // It's not an internal device
             foreach ($SEARCHOPTION as $key2 => $val2) {
-               if ($key2 == $data["id_search_option"]) {
+               if ($key2 === $data["id_search_option"]) {
                   $tmp['field'] =  $val2["name"];
                   $tablename    =  $val2["table"];
                   $fieldname    = $val2["field"];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | pluginsGLPI/datainjection#211

Issue noticed in Computer historical tab when the item is created by the Data Injection plugin. One or more of the entries has `id_search_options` set to 0. The loose comparison here compares all search options including the group headings like "common". This specific value equals integer 0 if you don't use a strict comparison, so it would throw a notice because there wouldn't be any `table` or `field` values for it.
This issue was only present in 9.5 because previously, the `id_search_options` value was read as a string, which "common" != "0".