### PR TITLE
Try to use browser accepted languages on unauthenticated pages

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -120,6 +120,10 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
       Html::redirect($_SESSION["glpiroot"]);
    }
 
+   if (!isset($_SESSION["glpilanguage"])) {
+      $_SESSION["glpilanguage"] = Session::getPreferredLanguage();
+   }
+
    // Override cfg_features by session value
    foreach ($CFG_GLPI['user_pref_field'] as $field) {
       if (!isset($_SESSION["glpi$field"]) && isset($CFG_GLPI[$field])) {

--- a/install/install.php
+++ b/install/install.php
@@ -93,7 +93,7 @@ function choose_language() {
    // fix missing param for js drodpown
    $CFG_GLPI['ajax_limit_count'] = 15;
 
-   Dropdown::showLanguages("language", ['value' => "en_GB"]);
+   Dropdown::showLanguages("language", ['value' => $_SESSION['glpilanguage']]);
    echo "</p>";
    echo "";
    echo "<p class='submit'><input type='hidden' name='install' value='lang_select'>";
@@ -601,6 +601,8 @@ function checkConfigFile() {
 if (!isset($_SESSION['can_process_install']) || !isset($_POST["install"])) {
    $_SESSION = [];
 
+   $_SESSION["glpilanguage"] = Session::getPreferredLanguage();
+
    checkConfigFile();
 
    // Add a flag that will be used to validate that installation can be processed.
@@ -609,7 +611,7 @@ if (!isset($_SESSION['can_process_install']) || !isset($_POST["install"])) {
    // to change GLPI base URL without even being authenticated.
    $_SESSION['can_process_install'] = true;
 
-   header_html("Select your language");
+   header_html(__("Select your language"));
    choose_language();
 
 } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When accessing pages without being logged-in, displayed language will now be based on `Accept-Language` header, or fallback to default GLPI language if accepted languages are not available.

Impacted pages are:
 - login, logout, and password reset pages,
 - public FAQ,
 - update page.

On second commit, I updated the language selection of installation process to use the preferred language by default.