### PR TITLE
TinyMCE: Fix paste with context menu

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3895,6 +3895,12 @@ JS;
                         $('.mce-edit-area').addClass('required');
                      }
                   });
+                  editor.on('paste', function (e) {
+                     // Remove required on paste event
+                     // This is only needed when pasting with right click (context menu)
+                     // Pasting with Ctrl+V is already handled by keyup event above
+                     $('.mce-edit-area').removeClass('required');
+                  });
                }
                editor.on('SaveContent', function (contentEvent) {
                   contentEvent.content = contentEvent.content.replace(/\\r?\\n/g, '');


### PR DESCRIPTION
### Issue 

The `required` class is only removed on keyup event.
Pasting data though the context menu (right click -> paste) doesn't trigger this event.

### Fix

Added a new listener for the 'paste' event that, when triggered, remove the `required` class.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21051
