### PR TITLE
Fix import of mono-part HTML emails; fixes #8263

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -1664,26 +1664,24 @@ class MailCollector  extends CommonDBTM {
    function getBody(\Laminas\Mail\Storage\Message $message) {
       $content = null;
 
-      //if message is not multipart, just return its content
-      if (!$message->isMultipart()) {
-         $content = $this->getDecodedContent($message);
-      } else {
-         //if message is multipart, check for html contents then text contents
-         foreach (new RecursiveIteratorIterator($message) as $part) {
-            if (!$part->getHeaders()->has('content-type')
-               || !(($content_type = $part->getHeader('content-type')) instanceof ContentType)) {
-               continue;
-            }
-            if ($content_type->getType() == 'text/html') {
-               $this->body_is_html = true;
-               $content = $this->getDecodedContent($part);
-               //do not check for text part if we found html one.
-               break;
-            }
-            if ($content_type->getType() == 'text/plain' && $content === null) {
-               $this->body_is_html = false;
-               $content = $this->getDecodedContent($part);
-            }
+      $parts = !$message->isMultipart()
+         ? new ArrayIterator([$message])
+         : new RecursiveIteratorIterator($message);
+
+      foreach ($parts as $part) {
+         if (!$part->getHeaders()->has('content-type')
+            || !(($content_type = $part->getHeader('content-type')) instanceof ContentType)) {
+            continue;
+         }
+         if ($content_type->getType() == 'text/html') {
+            $this->body_is_html = true;
+            $content = $this->getDecodedContent($part);
+            //do not check for text part if we found html one.
+            break;
+         }
+         if ($content_type->getType() == 'text/plain' && $content === null) {
+            $this->body_is_html = false;
+            $content = $this->getDecodedContent($part);
          }
       }
 

--- a/tests/emails-tests/09-reply-to-tech.eml
+++ b/tests/emails-tests/09-reply-to-tech.eml
@@ -29,6 +29,10 @@ This message have reply to header, requester should be get from this header.
 Content-Type: text/html; charset="UTF-8"
 Content-Transfer-Encoding: quoted-printable
 
-This message have reply to header, requester should be get from this header.
+<html>
+<body>
+<p>This message have reply to header, requester should be get from this header.</p>
+</body>
+</html>
 
 --000000000000f50df905a9fce128--

--- a/tests/emails-tests/21-monopart-html.eml
+++ b/tests/emails-tests/21-monopart-html.eml
@@ -1,0 +1,14 @@
+Date: Thu, 7 Jun 2018 12:05:51 +0200 (CEST)
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <1695134010.1757889.1528365951040.JavaMail.zimbra@glpi-project.org>
+Subject: Mono-part HTML message
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+<body>
+<p>This HTML message does not use <strong>"multipart/alternative"</strong> format.</p>
+</body>
+</html>

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -332,6 +332,7 @@ class MailCollector extends DbTestCase {
                'This is a mail without subject.', // No subject = name is set using ticket contents
                'Image tag splitted on multiple lines',
                'Attachement having filename using RFC5987 (multiple lines)',
+               'Mono-part HTML message',
             ]
          ],
          // Mails having "normal" user as observer (add_cc_to_observer = true)
@@ -342,6 +343,15 @@ class MailCollector extends DbTestCase {
                'Ticket with observer',
             ]
          ],
+      ];
+
+      // Tickets on which content should be checked (key is ticket name)
+      $tickets_contents = [
+         // Plain text on mono-part email
+         'PHP fatal error' => 'On some cases, doing the following:&lt;br /&gt;# blahblah&lt;br /&gt;&lt;br /&gt;Will cause a PHP fatal error:&lt;br /&gt;# blahblah&lt;br /&gt;&lt;br /&gt;Best regards,',
+         // HTML on multi-part email
+         'Re: [GLPI #0038927] Update - Issues with new Windows 10 machine' => '&lt;p&gt;This message have reply to header, requester should be get from this header.&lt;/p&gt;',
+         'Mono-part HTML message' => '&lt;p&gt;This HTML message does not use &lt;strong&gt;"multipart/alternative"&lt;/strong&gt; format.&lt;/p&gt;',
       ];
 
       foreach ($actors_specs as $actor_specs) {
@@ -366,8 +376,15 @@ class MailCollector extends DbTestCase {
 
          $names = [];
          while ($data = $iterator->next()) {
-            $names[] = $data['name'];
+            $name = $data['name'];
+
+            if (array_key_exists($name, $tickets_contents)) {
+               $this->string($data['content'])->isEqualTo($tickets_contents[$name]);
+            }
+
             $this->string($data['content'])->notContains('cid:'); // check that image were correctly imported
+
+            $names[] = $name;
          }
 
          $this->array($names)->isIdenticalTo($actor_specs['tickets_names']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8263

`$this->body_is_html = true;` was not set to true for mono-part messages. Main result is that new lines were replaced by `<br />`.  In most of case, ticket content contained extra line break, but if these line breaks were at a bad place (e.g. beween `table` and `thead` HTML tags), resulting HTML was completely corrupted during htmlawed cleaning.