### PR TITLE
Show number of rows affected in SQL Requests debug

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -318,6 +318,7 @@ class DBmysql {
       if ($is_debug && $CFG_GLPI["debug_sql"]) {
          $TIME                                   = $TIMER->getTime();
          $DEBUG_SQL["times"][$SQL_TOTAL_REQUEST] = $TIME;
+         $DEBUG_SQL['rows'][$SQL_TOTAL_REQUEST] = $this->affectedRows();
       }
       if ($this->execution_time === true) {
          $this->execution_time = $TIMER->getTime(0, true);

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -811,13 +811,15 @@ class Html {
             echo "took  ".array_sum($DEBUG_SQL['times'])."s</div>";
 
             echo "<table class='tab_cadre'><tr><th>N&#176; </th><th>Queries</th><th>Time</th>";
-            echo "<th>Errors</th></tr>";
+            echo "<th>Rows</th><th>Errors</th></tr>";
 
             foreach ($DEBUG_SQL['queries'] as $num => $query) {
                echo "<tr class='tab_bg_".(($num%2)+1)."'><td>$num</td><td>";
                echo self::cleanSQLDisplay($query);
                echo "</td><td>";
                echo $DEBUG_SQL['times'][$num];
+               echo "</td><td>";
+               echo $DEBUG_SQL['rows'][$num] ?? 0;
                echo "</td><td>";
                if (isset($DEBUG_SQL['errors'][$num])) {
                   echo $DEBUG_SQL['errors'][$num];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

May help when troubleshooting performance related issues reported by GLPI users as well as some other development use cases given more information than just the total time a query takes. It could give more information to the GLPI developer such as how many entities are being fetched which may influence subsequent queries.
Beyond performance, this extra information can help a GLPI developer see how much an action affects the DB data from within GLPI.
This extra column indicates the number of rows fetched, updated, inserted, deleted, etc.