### PR TITLE
Try using current location as map default

### DIFF
--- a/inc/mapgeolocation.class.php
+++ b/inc/mapgeolocation.class.php
@@ -83,58 +83,84 @@ trait MapGeolocation {
       }
 
       $(function(){
-         map_elt = initMap($('#setlocation_container'), 'setlocation', '200px');
-
-         var osmGeocoder = new L.Control.OSMGeocoder({
-            collapsed: false,
-            placeholder: '".__s('Search')."',
-            text: '".__s('Search')."'
-         });
-         map_elt.addControl(osmGeocoder);
-         _autoSearch();
-
-         function onMapClick(e) {
-            var popup = L.popup();
-            popup
-               .setLatLng(e.latlng)
-               .setContent('SELECTPOPUP')
-               .openOn(map_elt);
-         }
-
-         map_elt.on('click', onMapClick);
-
-         map_elt.on('popupopen', function(e){
-            var _popup = e.popup;
-            var _container = $(_popup._container);
-
-            var _clat = _popup._latlng.lat.toString();
-            var _clng = _popup._latlng.lng.toString();
-
-            _popup.setContent('<p><a href=\'#\'>".__s('Set location here')."</a></p>');
-
-            $(_container).find('a').on('click', function(e){
-               e.preventDefault();
-               _popup.remove();
-               $('*[name=latitude]').val(_clat);
-               $('*[name=longitude]').val(_clng).trigger('change');
+         var finalizeMap = function() {
+            var osmGeocoder = new L.Control.OSMGeocoder({
+               collapsed: false,
+               placeholder: '".__s('Search')."',
+               text: '".__s('Search')."'
             });
-         });
-
-         var _curlat = $('*[name=latitude]').val();
-         var _curlng = $('*[name=longitude]').val();
-
-         if (_curlat && _curlng) {
-            _setLocation(_curlat, _curlng);
-         }
-
-         $('*[name=latitude],*[name=longitude]').on('change', function(){
+            map_elt.addControl(osmGeocoder);
+            _autoSearch();
+   
+            function onMapClick(e) {
+               var popup = L.popup();
+               popup
+                  .setLatLng(e.latlng)
+                  .setContent('SELECTPOPUP')
+                  .openOn(map_elt);
+            }
+   
+            map_elt.on('click', onMapClick);
+   
+            map_elt.on('popupopen', function(e){
+               var _popup = e.popup;
+               var _container = $(_popup._container);
+   
+               var _clat = _popup._latlng.lat.toString();
+               var _clng = _popup._latlng.lng.toString();
+   
+               _popup.setContent('<p><a href=\'#\'>".__s('Set location here')."</a></p>');
+   
+               $(_container).find('a').on('click', function(e){
+                  e.preventDefault();
+                  _popup.remove();
+                  $('*[name=latitude]').val(_clat);
+                  $('*[name=longitude]').val(_clng).trigger('change');
+               });
+            });
+   
             var _curlat = $('*[name=latitude]').val();
             var _curlng = $('*[name=longitude]').val();
-
+   
             if (_curlat && _curlng) {
                _setLocation(_curlat, _curlng);
             }
-         });
+   
+            $('*[name=latitude],*[name=longitude]').on('change', function(){
+               var _curlat = $('*[name=latitude]').val();
+               var _curlng = $('*[name=longitude]').val();
+   
+               if (_curlat && _curlng) {
+                  _setLocation(_curlat, _curlng);
+               }
+            });
+         }
+         navigator.geolocation.getCurrentPosition(function(pos) {
+            // Try to determine an appropriate zoom level based on accuracy
+            var acc = pos.coords.accuracy;
+            if (acc > 3000) {
+                // Very low accuracy. Most likely a device without GPS or a cellular connection
+                var zoom = 10;
+            } else if (acc > 1000) {
+                // Low accuracy
+                var zoom = 15;
+            } else if (acc > 500) {
+                // Medium accuracy
+                var zoom = 17;
+            } else {
+                // High accuracy
+                var zoom = 20;
+            }
+            map_elt = initMap($('#setlocation_container'), 'setlocation', '200px', {
+                position: [pos.coords.latitude, pos.coords.longitude],
+                zoom: zoom
+            });
+            finalizeMap();
+         }, function() {
+            map_elt = initMap($('#setlocation_container'), 'setlocation', '200px');
+            finalizeMap();
+         }, {enableHighAccuracy: true});
+         
       });";
       echo Html::scriptBlock($js);
    }

--- a/js/common.js
+++ b/js/common.js
@@ -803,7 +803,7 @@ function _eltRealSize(_elt) {
    return _s;
 }
 
-var initMap = function(parent_elt, map_id, height) {
+var initMap = function(parent_elt, map_id, height, initial_view = {position: [43.6112422, 3.8767337], zoom: 6}) {
    // default parameters
    map_id = (typeof map_id !== 'undefined') ? map_id : 'map';
    height = (typeof height !== 'undefined') ? height : '200px';
@@ -831,7 +831,7 @@ var initMap = function(parent_elt, map_id, height) {
 
    //add map, set a default arbitrary location
    parent_elt.append($('<div id="'+map_id+'" style="height: ' + height + '"></div>'));
-   var map = L.map(map_id, {fullscreenControl: true}).setView([43.6112422, 3.8767337], 6);
+   var map = L.map(map_id, {fullscreenControl: true}).setView(initial_view.position, initial_view.zoom);
 
    //setup tiles and © messages
    L.tileLayer('https://{s}.tile.osm.org/{z}/{x}/{y}.png', {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Try to make it easier to assign geolocation data by defaulting the map view to the current location (Or as close as we can approximate) if the user allows us to use their location. If not, fall back on the previous defaults.
If we can get geolocation data, the map zoom level is adjusted based on the reported accuracy.
This only works over HTTPS or localhost. If those requirements don't apply to the user, they will see the original functionality.

Tested on a desktop (very-low accuracy) and a cell phone (high accuracy) and the zoom levels seemed appropriate.