### PR TITLE
fix: Support linking  item_devices created by plugins

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -1252,7 +1252,7 @@ class Plugin extends CommonDBTM {
     *
     * @return bool
    **/
-    static function registerClass($itemtype, $attrib = []) {
+   static function registerClass($itemtype, $attrib = []) {
       global $CFG_GLPI;
 
       $plug = isPluginItemType($itemtype);
@@ -1262,7 +1262,7 @@ class Plugin extends CommonDBTM {
 
       $all_types = preg_grep('/.+_types/', array_keys($attrib));
       $all_types[] = 'networkport_instantiations';
-   
+
       $mapping = [
          'doc_types'       => 'document_types',
          'helpdesk_types'  => 'ticket_types',
@@ -1286,7 +1286,9 @@ class Plugin extends CommonDBTM {
       $blacklist = ['device_types'];
       foreach ($all_types as $att) {
          if (!in_array($att, $blacklist) && isset($attrib[$att]) && $attrib[$att]) {
-            if(!isset($CFG_GLPI[$att]))$CFG_GLPI[$att] = array();
+            if (!isset($CFG_GLPI[$att])) {
+               $CFG_GLPI[$att] = [];
+            }
             $CFG_GLPI[$att][] = $itemtype;
             unset($attrib[$att]);
          }

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -1252,7 +1252,7 @@ class Plugin extends CommonDBTM {
     *
     * @return bool
    **/
-   static function registerClass($itemtype, $attrib = []) {
+    static function registerClass($itemtype, $attrib = []) {
       global $CFG_GLPI;
 
       $plug = isPluginItemType($itemtype);
@@ -1260,9 +1260,9 @@ class Plugin extends CommonDBTM {
          return false;
       }
 
-      $all_types = preg_grep('/.+_types/', array_keys($CFG_GLPI));
+      $all_types = preg_grep('/.+_types/', array_keys($attrib));
       $all_types[] = 'networkport_instantiations';
-
+   
       $mapping = [
          'doc_types'       => 'document_types',
          'helpdesk_types'  => 'ticket_types',
@@ -1271,14 +1271,14 @@ class Plugin extends CommonDBTM {
 
       foreach ($mapping as $orig => $fixed) {
          if (isset($attrib[$orig])) {
-            \Toolbox::deprecated(
+            Toolbox::deprecated(
                sprintf(
                   '%1$s type is deprecated, use %2$s instead.',
                   $orig,
                   $fixed
                )
             );
-            $attrib[$fixed] = $attrib[$orig];
+            $attrib[$orig] = $attrib[$fixed];
             unset($attrib[$orig]);
          }
       }
@@ -1286,6 +1286,7 @@ class Plugin extends CommonDBTM {
       $blacklist = ['device_types'];
       foreach ($all_types as $att) {
          if (!in_array($att, $blacklist) && isset($attrib[$att]) && $attrib[$att]) {
+            if(!isset($CFG_GLPI[$att]))$CFG_GLPI[$att] = array();
             $CFG_GLPI[$att][] = $itemtype;
             unset($attrib[$att]);
          }


### PR DESCRIPTION
in case new Item are attached via a plugin, then they were not catched by 

$all_types = preg_grep('/.+_types/', array_keys($CFG_GLPI));

with single module there is no issue because we can setup the _types value directly from the setup pages but if there is two modules then it might not work depending on the order on the setup pages.

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ?
| Fixed tickets | none