### PR TITLE
Handle definition of xxx_types config handled by a plugin

### DIFF
--- a/inc/item_devices.class.php
+++ b/inc/item_devices.class.php
@@ -231,8 +231,15 @@ class Item_Devices extends CommonDBRelation {
       ];
 
       foreach ($device_types as $device_type) {
-         if (isset($CFG_GLPI['item' . strtolower($device_type) . '_types'])) {
-            $itemtypes = $CFG_GLPI['item' . strtolower($device_type) . '_types'];
+         $cfg_key = 'item' . strtolower($device_type) . '_types';
+         if ($plug = isPluginItemType($device_type)) {
+            // For plugins, 'item' prefix should be placed between plugin name and class name.
+            // Nota: 'self::itemAffinity()' and 'self::getConcernedItems()' also expect this order in config key.
+            $cfg_key = strtolower('plugin' . $plug['plugin'] . 'item' . $plug['class']) . '_types';
+         }
+
+         if (isset($CFG_GLPI[$cfg_key])) {
+            $itemtypes = $CFG_GLPI[$cfg_key];
             if ($itemtypes == '*' || in_array($itemtype, $itemtypes)) {
                if (method_exists($device_type, 'rawSearchOptionsToAdd')) {
                   $options = array_merge(

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -1309,11 +1309,13 @@ class Plugin extends CommonDBTM {
 
       // Handle plugins specific configurations
       foreach ($attrib as $key => $value) {
-         if (preg_match('/^plugin[a-z]+_types$/', $key) && $value) {
-            if (!array_key_exists($key, $CFG_GLPI)) {
-               $CFG_GLPI[$key] = [];
+         if (preg_match('/^plugin[a-z]+_types$/', $key)) {
+            if ($value) {
+               if (!array_key_exists($key, $CFG_GLPI)) {
+                  $CFG_GLPI[$key] = [];
+               }
+               $CFG_GLPI[$key][] = $itemtype;
             }
-            $CFG_GLPI[$key] = $itemtype;
             unset($attrib[$key]);
          }
       }

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -1309,7 +1309,7 @@ class Plugin extends CommonDBTM {
 
       // Handle plugins specific configurations
       foreach ($attrib as $key => $value) {
-         if (preg_match('/^plugin[az]+_types$/', $key) && $value) {
+         if (preg_match('/^plugin[a-z]+_types$/', $key) && $value) {
             if (!array_key_exists($key, $CFG_GLPI)) {
                $CFG_GLPI[$key] = [];
             }
@@ -1323,8 +1323,8 @@ class Plugin extends CommonDBTM {
          trigger_error(
             sprintf(
                'Unknown attributes "%s" used in "%s" class registration',
-               $itemtype,
-               implode('", "', array_keys($attrib))
+               implode('", "', array_keys($attrib)),
+               $itemtype
             ),
             E_USER_WARNING
          );

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -1288,7 +1288,7 @@ class Plugin extends CommonDBTM {
          if (class_exists($itemtype::getItem_DeviceType())) {
             $CFG_GLPI['device_types'][] = $itemtype;
          }
-         unset($attrib[$att]);
+         unset($attrib['device_types']);
       }
 
       if (isset($attrib['addtabon'])) {
@@ -1298,11 +1298,36 @@ class Plugin extends CommonDBTM {
          foreach ($attrib['addtabon'] as $form) {
             CommonGLPI::registerStandardTab($form, $itemtype);
          }
+         unset($attrib['addtabon']);
       }
 
       //Manage entity forward from a source itemtype to this itemtype
       if (isset($attrib['forwardentityfrom'])) {
          CommonDBTM::addForwardEntity($attrib['forwardentityfrom'], $itemtype);
+         unset($attrib['forwardentityfrom']);
+      }
+
+      // Handle plugins specific configurations
+      foreach ($attrib as $key => $value) {
+         if (preg_match('/^plugin[az]+_types$/', $key) && $value) {
+            if (!array_key_exists($key, $CFG_GLPI)) {
+               $CFG_GLPI[$key] = [];
+            }
+            $CFG_GLPI[$key] = $itemtype;
+            unset($attrib[$key]);
+         }
+      }
+
+      // Warn for unmanaged keys
+      if (!empty($attrib)) {
+         trigger_error(
+            sprintf(
+               'Unknown attributes "%s" used in "%s" class registration',
+               $itemtype,
+               implode('", "', array_keys($attrib))
+            ),
+            E_USER_WARNING
+         );
       }
 
       return true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Replaces #8276 and #8277.

Give ability for a plugin to defines a `xxx_types` entry in `$CFG_GLPI` (e.g. `pluginautomationdevice_types`). This can give access to item affinities logic for a new type of devices.