### PR TITLE
Enable to not have devicepci on asset component

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -317,7 +317,7 @@ $CFG_GLPI['itemdevicefirmware_types']     = ['Computer', 'Peripheral', 'Phone', 
 
 $CFG_GLPI['itemdevicesimcard_types']      = ['Computer', 'Peripheral', 'Phone', 'NetworkEquipment', 'Printer'];
 
-$CFG_GLPI['itemdevicegeneric_types']      = ['*'];
+$CFG_GLPI['itemdevicegeneric_types']      = ['Computer', 'Peripheral', 'Phone', 'NetworkEquipment', 'Printer'];
 
 $CFG_GLPI['itemdevicepci_types']          = ['*'];
 


### PR DESCRIPTION
not  really blocking but enoying 

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Fixed tickets | 
