### PR TITLE
Regen Kanban badge colors when changing theme type

### DIFF
--- a/js/kanban.js
+++ b/js/kanban.js
@@ -1127,6 +1127,16 @@
        * @see generateUserBadge()
       **/
       var preloadBadgeCache = function(options) {
+         var cached_colors = JSON.parse(window.sessionStorage.getItem('badge_colors'));
+         if (cached_colors !== null && cached_colors['_dark_theme'] !== self.dark_theme) {
+            window.sessionStorage.removeItem('badge_colors');
+            self.team_badge_cache = {
+               User: {},
+               Group: {},
+               Supplier: {},
+               Contact: {}
+            };
+         }
          var users = [];
          $.each(self.columns, function(column_id, column) {
             if (column['items'] !== undefined) {
@@ -1234,7 +1244,8 @@
                   User: {},
                   Group: {},
                   Supplier: {},
-                  Contact: {}
+                  Contact: {},
+                  _dark_theme: self.dark_theme
                };
             }
             cached_colors[itemtype][teammember['id']] = bg_color;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Store if the user is using a dark theme or not along with the badge colors. When preloading the badge cache, we check if they are still using that type. If not, we clear the badge color cache and force it to regen so we get matching colors (Not light blue on white or dark grey on black).