### PR TITLE
Fix bad spacing in SQL query

### DIFF
--- a/inc/stat.class.php
+++ b/inc/stat.class.php
@@ -159,7 +159,7 @@ class Stat extends CommonGLPI {
             $criteria = [
                'SELECT'    => [
                   'glpi_locations.id',
-                  'glpi_locations. ' . ($is_tree ? 'name' : 'completename') . 'AS location'
+                  'glpi_locations.' . ($is_tree ? 'name' : 'completename') . ' AS location'
                ],
                'DISTINCT'  => true,
                'FROM'      => 'glpi_locations',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When generating statistics of tickets by location, you would get SQL errors due to a space between the table name and field, and then no space between the field and `AS`.