### PR TITLE
Fix Object/Int comparison in templates

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -3655,7 +3655,7 @@ class Ticket extends CommonITILObject {
                    || (isset($options['_predefined_fields'][$predeffield])
                        && ($options[$predeffield] == $options['_predefined_fields'][$predeffield]))
                    || (isset($options[$key])
-                       && ($options[$key] != $tt->getID()))) {
+                       && ($options[$key]->getID() != $tt->getID()))) {
                   $options[$predeffield]            = $predefvalue;
                   $predefined_fields[$predeffield] = $predefvalue;
                }


### PR DESCRIPTION
Fix this warning: 

![image](https://user-images.githubusercontent.com/42734840/99540578-fae10a80-29af-11eb-97e4-d2a46d1503f3.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes/
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21085
