### PR TITLE
Fix higher version fetching in plugins marketplace

### DIFF
--- a/inc/marketplace/api/plugins.class.php
+++ b/inc/marketplace/api/plugins.class.php
@@ -204,10 +204,18 @@ class Plugins {
                });
             }
 
-            $first_found_version = current($plugin['versions']);
-            if (is_array($first_found_version)) {
-               $plugin['installation_url'] = $first_found_version['download_url'];
-               $plugin['version'] = $first_found_version['num'];
+            $versions = $plugin['versions'];
+            usort(
+               $versions,
+               function ($a, $b) {
+                  return version_compare($a['num'], $b['num']);
+               }
+            );
+
+            $higher_version = end($versions);
+            if (is_array($higher_version)) {
+               $plugin['installation_url'] = $higher_version['download_url'];
+               $plugin['version'] = $higher_version['num'];
             }
          }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Marketplace API may not send versions from higher to lower, so it is preferable to do a sort on GLPI side to be sure to expose the higher version.

Marketplace API could be updated too, to fix version displayed for users using GLPI < 9.5.3, but keep the sorting on GLPI side can't hurt.