### PR TITLE
Fix font-family inside tabs

### DIFF
--- a/css/jquery-glpi.css
+++ b/css/jquery-glpi.css
@@ -264,6 +264,10 @@ html .ui-autocomplete {
 
 .ui-widget {
   font-family: Verdana,Arial,sans-serif;
+  font-size: 1.1em;
+}
+.ui-widget .ui-widget {
+  font-size: 1em;
 }
 
 .ui-widget input, .ui-widget select, .ui-widget textarea, .ui-widget button

--- a/css/jquery-glpi.css
+++ b/css/jquery-glpi.css
@@ -262,6 +262,10 @@ html .ui-autocomplete {
 
 /* SELECT2 */
 
+.ui-widget {
+  font-family: Verdana,Arial,sans-serif;
+}
+
 .ui-widget input, .ui-widget select, .ui-widget textarea, .ui-widget button
 {
   font-family: 'Bitstream Vera Sans', arial, Tahoma, 'Sans serif';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21096

Put back styles that were present in GLPI 9.4 (see https://github.com/glpi-project/glpi/blob/9.4/bugfixes/lib/jquery/css/smoothness/jquery-ui-1.10.4.custom.css#L785 ).