### PR TITLE
Strip unusable sourcemaps from bundled libs; fixes #8302

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5675,6 +5675,12 @@
             "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
             "dev": true
         },
+        "strip-sourcemap-loader": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/strip-sourcemap-loader/-/strip-sourcemap-loader-0.0.1.tgz",
+            "integrity": "sha1-xJK1SH3pCFNIrgfZJ7u9JR2Ptg0=",
+            "dev": true
+        },
         "strtok3": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "glob": "^7.1.6",
         "mini-css-extract-plugin": "^0.9.0",
         "script-loader": "^0.7.2",
+        "strip-sourcemap-loader": "^0.0.1",
         "terser": "^4.7.0",
         "webpack": "^4.41.2",
         "webpack-cli": "^3.3.10"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,6 +77,7 @@ var libsConfig = {
             // Load scripts with no compilation for packages that are directly providing "dist" files.
             // This prevents useless compilation pass and can also
             // prevents incompatibility issues with the webpack require feature.
+            // It also removes existing sourcemaps that cannot be used correctly.
             test: /\.js$/,
             include: [
                path.resolve(__dirname, 'node_modules/@fullcalendar'),
@@ -90,7 +91,7 @@ var libsConfig = {
                path.resolve(__dirname, 'node_modules/rrule'),
                path.resolve(__dirname, 'vendor/blueimp/jquery-file-upload'),
             ],
-            use: ['script-loader'],
+            use: ['script-loader', 'strip-sourcemap-loader'],
          },
          {
             // Build styles


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8302 

Remove sourceMappingURL directives for all external libs that are included by a simple copy of the js script.
This will prevent these directives to conflict with the directives added by webpack compilation process.
