### PR TITLE
Fix AND NOT meta search

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -974,12 +974,7 @@ class Search {
 
             if (isset($criterion['link'])
                   && in_array($criterion['link'], array_keys(self::getLogicalOperators()))) {
-               if (strstr($criterion['link'], "NOT")) {
-                  $tmplink = " ".str_replace(" NOT", "", $criterion['link']);
-                  $NOT     = 1;
-               } else {
-                  $tmplink = " ".$criterion['link'];
-               }
+               $tmplink = " ".$criterion['link'];
             } else {
                $tmplink = " AND ";
             }
@@ -987,6 +982,8 @@ class Search {
             // Manage Link if not first item
             if (!empty($sql)) {
                $LINK = $tmplink;
+            } else if (strstr($tmplink, "NOT")) {
+               $NOT = 1;
             }
 
             if (isset($criterion['criteria']) && count($criterion['criteria'])) {
@@ -5378,7 +5375,7 @@ JAVASCRIPT;
                                     AS `glpi_items_softwareversions_$to_type`
                               ON (`glpi_items_softwareversions_$to_type`.`softwareversions_id`
                                        = `glpi_softwareversions_$to_type`.`id`
-                                  AND `glpi_items_softwareversions_$to_type`.`itemtype` = '$from_type'
+                                  AND `glpi_items_softwareversions_$to_type`.`itemtype` = '$to_type'
                                   AND `glpi_items_softwareversions_$to_type`.`is_deleted` = 0)
                            $LINK `$to_table`
                               ON (`glpi_items_softwareversions_$to_type`.`items_id`

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -371,7 +371,7 @@ class Search extends DbTestCase {
          ->contains("(`glpi_users`.`id` = '2')")
          ->contains("OR (`glpi_users`.`id` = '3')")
          // match having
-         ->matches("/HAVING\s*\(`ITEM_Budget_2`\s+<>\s+5\)\s+AND\s+\(\(`ITEM_Printer_1`\s+NOT LIKE\s+'%HP%'\s+OR\s+`ITEM_Printer_1`\s+IS NULL\)\s*\)/");
+         ->matches("/HAVING\s*\(`ITEM_Budget_2`\s+<>\s+5\)\s+AND NOT\s+\(`ITEM_Printer_1`\s+LIKE\s+'%HP%'\s*\)/");
    }
 
    function testViewCriterion() {

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -103,6 +103,14 @@ class Search extends DbTestCase {
          ->hasKey('data')
             ->array['last_errors']->isIdenticalTo([])
             ->array['data']->isNotEmpty();
+
+      $this->string($data['sql']['search'])
+         ->matches('/'
+            . 'LEFT JOIN\s*`glpi_items_softwareversions`\s*AS\s*`glpi_items_softwareversions_[^`]+_Software`\s*ON\s*\('
+            . '`glpi_items_softwareversions_[^`]+_Software`\.`items_id`\s*=\s*`glpi_computers`.`id`'
+            . '\s*AND\s*`glpi_items_softwareversions_[^`]+_Software`\.`itemtype`\s*=\s*\'Computer\''
+            . '\s*AND\s*`glpi_items_softwareversions_[^`]+_Software`\.`is_deleted`\s*=\s*0'
+            . '\)/im');
    }
 
    public function testMetaComputerUser() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21081

This changes fixes the exact case from ticket !21081, but I am really not confident in it as I do not really understand all the consequences. Indeed, there are too many operations to many usages related to $LINK and $NOT variables, making code really hard to understand.