### PR TITLE
fix(search): use no sort for virtual field

### DIFF
--- a/inc/datacenter.class.php
+++ b/inc/datacenter.class.php
@@ -159,6 +159,7 @@ class Datacenter extends CommonDBTM {
             'name'               => __('Data center position'),
             'datatype'           => 'specific',
             'nosearch'           => true,
+            'nosort'             => true,
             'massiveaction'      => false
          ],
       ];


### PR DESCRIPTION
When we try to sort computer list by datacenter position SQL error occurs

```sql
SQL Error "1054": Unknown column 'ITEM_Computer_178' in 'order clause' in query "SELECT DISTINCT `glpi_computers`.`id` AS id, 'glpi' AS currentuser, `glpi_computers`.`entities_id`, `glpi_computers`.`is_recursive`, `glpi_computers`.`name` AS `ITEM_Computer_1`, `glpi_computers`.`id` AS `ITEM_Computer_1_id`, `glpi_entities`.`completename` AS `ITEM_Computer_80`, `glpi_states`.`completename` AS `ITEM_Computer_31`, `glpi_manufacturers`.`name` AS `ITEM_Computer_23`, `glpi_computers`.`serial` AS `ITEM_Computer_5`, `glpi_computertypes`.`name` AS `ITEM_Computer_4`, `glpi_computermodels`.`name` AS `ITEM_Computer_40`, `glpi_operatingsystems_9719987b154aaf3b42c3db32aef59090`.`name` AS `ITEM_Computer_45`, `glpi_locations`.`completename` AS `ITEM_Computer_3`, `glpi_computers`.`date_mod` AS `ITEM_Computer_19`, GROUP_CONCAT(DISTINCT CONCAT(IFNULL(`glpi_deviceprocessors_7083fb7d2b7a8b8abd619678acc5b604`.`designation`, '__NULL__'), '$#$',`glpi_deviceprocessors_7083fb7d2b7a8b8abd619678acc5b604`.`id`) ORDER BY `glpi_deviceprocessors_7083fb7d2b7a8b8abd619678acc5b604`.`id` SEPARATOR '$$##$$') AS `ITEM_Computer_17`, GROUP_CONCAT(DISTINCT CONCAT(IFNULL(`glpi_ipaddresses_0cc35feab42e5909929ff742b4834540`.`name`, '__NULL__'), '$#$',`glpi_ipaddresses_0cc35feab42e5909929ff742b4834540`.`id`) ORDER BY `glpi_ipaddresses_0cc35feab42e5909929ff742b4834540`.`id` SEPARATOR '$$##$$') AS `ITEM_Computer_126`, GROUP_CONCAT(DISTINCT CONCAT(IFNULL(`glpi_devicemotherboards_c98c96e9d3586c7178ca400a70495158`.`designation`, '__NULL__'), '$#$',`glpi_devicemotherboards_c98c96e9d3586c7178ca400a70495158`.`id`) ORDER BY `glpi_devicemotherboards_c98c96e9d3586c7178ca400a70495158`.`id` SEPARATOR '$$##$$') AS `ITEM_Computer_14`, `glpi_computers`.`id` AS `ITEM_Computer_178_id`, `glpi_computers`.`name` AS `ITEM_Computer_178_name` FROM `glpi_computers`LEFT JOIN `glpi_entities` ON (`glpi_computers`.`entities_id` = `glpi_entities`.`id` )LEFT JOIN `glpi_states` ON (`glpi_computers`.`states_id` = `glpi_states`.`id` )LEFT JOIN `glpi_manufacturers` ON (`glpi_computers`.`manufacturers_id` = `glpi_manufacturers`.`id` )LEFT JOIN `glpi_computertypes` ON (`glpi_computers`.`computertypes_id` = `glpi_computertypes`.`id` )LEFT JOIN `glpi_computermodels` ON (`glpi_computers`.`computermodels_id` = `glpi_computermodels`.`id` ) LEFT JOIN `glpi_items_operatingsystems` ON (`glpi_computers`.`id` = `glpi_items_operatingsystems`.`items_id` AND `glpi_items_operatingsystems`.`itemtype` = 'Computer' ) LEFT JOIN `glpi_operatingsystems` AS `glpi_operatingsystems_9719987b154aaf3b42c3db32aef59090` ON (`glpi_items_operatingsystems`.`operatingsystems_id` = `glpi_operatingsystems_9719987b154aaf3b42c3db32aef59090`.`id` )LEFT JOIN `glpi_locations` ON (`glpi_computers`.`locations_id` = `glpi_locations`.`id` ) LEFT JOIN `glpi_items_deviceprocessors` ON (`glpi_computers`.`id` = `glpi_items_deviceprocessors`.`items_id` AND `glpi_items_deviceprocessors`.`itemtype` = 'Computer' ) LEFT JOIN `glpi_deviceprocessors` AS `glpi_deviceprocessors_7083fb7d2b7a8b8abd619678acc5b604` ON (`glpi_items_deviceprocessors`.`deviceprocessors_id` = `glpi_deviceprocessors_7083fb7d2b7a8b8abd619678acc5b604`.`id` ) LEFT JOIN `glpi_ipaddresses` AS `glpi_ipaddresses_0cc35feab42e5909929ff742b4834540` ON (`glpi_computers`.`id` = `glpi_ipaddresses_0cc35feab42e5909929ff742b4834540`.`mainitems_id` AND `glpi_ipaddresses_0cc35feab42e5909929ff742b4834540`.`mainitemtype` = 'Computer' AND `glpi_ipaddresses_0cc35feab42e5909929ff742b4834540`.`is_deleted` = 0 ) LEFT JOIN `glpi_items_devicemotherboards` ON (`glpi_computers`.`id` = `glpi_items_devicemotherboards`.`items_id` AND `glpi_items_devicemotherboards`.`itemtype` = 'Computer' ) LEFT JOIN `glpi_devicemotherboards` AS `glpi_devicemotherboards_c98c96e9d3586c7178ca400a70495158` ON (`glpi_items_devicemotherboards`.`devicemotherboards_id` = `glpi_devicemotherboards_c98c96e9d3586c7178ca400a70495158`.`id` ) WHERE `glpi_computers`.`is_deleted` = 0 AND `glpi_computers`.`is_template` = 0 GROUP BY `glpi_computers`.`id` ORDER BY `ITEM_Computer_178` DESC LIMIT 0, 20"
```

In GLPI, the search options with a 'virtual' field are not sortable, 

Example 

```php
      $tab[] = [
         'id'                 => '9',
         'table'              => $this->getTable(),
         'field'              => '_virtual',
         'name'               => _n('Cartridge', 'Cartridges', Session::getPluralNumber()),
         'datatype'           => 'specific',
         'massiveaction'      => false,
         'nosearch'           => true,
         'nosort'             => true,
         'additionalfields'   => ['alarm_threshold']
      ];
```
```php
      $tab[] = [
         'id'                 => '17',
         'table'              => $this->getTable(),
         'field'              => '_virtual_planned_duration',
         'name'               => __('Planned duration'),
         'datatype'           => 'specific',
         'nosearch'           => true,
         'massiveaction'      => false,
         'nosort'             => true
      ];
```
due to a limitation of search lcass.

This PR fix blank page and SQL error

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 21084
