### PR TITLE
split 'not' criteria

### DIFF
--- a/inc/stat.class.php
+++ b/inc/stat.class.php
@@ -1225,11 +1225,10 @@ class Stat extends CommonGLPI {
          case "inter_answersatisfaction" :
             $WHERE["$table.status"] = $closed_status;
             $WHERE[] = [
-               'NOT' => [
-                  "$table.closedate"                        => null,
-                  "glpi_ticketsatisfactions.date_answered"  => null
-               ]
+               ['NOT' => ["$table.closedate" => null]],
+               ['NOT' => ["glpi_ticketsatisfactions.date_answered"  => null]],
             ];
+
             $WHERE[] = getDateCriteria("$table.closedate", $begin, $end);
 
             $date_unix = new QueryExpression(


### PR DESCRIPTION
Satisfaction survey stats is in error

![image](https://user-images.githubusercontent.com/7335054/100070483-47a66480-2e3a-11eb-967e-81ece3874e5f.png)

In fact, I have two satisfaction surveys, one is waiting for an answer and the other is answered.
But the statistics show me that both have been answered.

```sql
+----+------------+------+---------------------+---------------------+--------------+---------+
| id | tickets_id | type | date_begin          | date_answered       | satisfaction | comment |
+----+------------+------+---------------------+---------------------+--------------+---------+
|  1 |         51 |    1 | 2020-11-23 08:04:21 | NULL                |         NULL | NULL    |
|  2 |         55 |    1 | 2020-11-23 13:04:33 | 2020-11-24 09:19:56 |            3 | sdfsdf  |
+----+------------+------+---------------------+---------------------+--------------+---------+
```

"NOT" key in WHERE clause need to be split in two entries

```php
         case "inter_answersatisfaction" :
            $WHERE["$table.status"] = $closed_status;
            $WHERE[] = [
               'NOT' => [
                  "$table.closedate"                        => null,
                  "glpi_ticketsatisfactions.date_answered"  => null
               ]
            ];
```

Like this

```php
         case "inter_answersatisfaction" :
            $WHERE["$table.status"] = $closed_status;
            $WHERE[] = [
               'NOT' => [
                  "$table.closedate"                        => null,
               ],
               'NOT' => [
                  "glpi_ticketsatisfactions.date_answered"  => null
               ]
            ];
            $WHERE[] = getDateCriteria("$table.closedate", $begin, $end);

```

This PR fix this.

After fix it, the result is ok

![image](https://user-images.githubusercontent.com/7335054/100071043-e5019880-2e3a-11eb-92cd-deb1c6a6df6d.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 21095
