### PR TITLE
Fix img size when embedded in timeline items

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7317,10 +7317,13 @@ abstract class CommonITILObject extends CommonDBTM {
                   $imgsize = getimagesize($docpath);
                   echo Html::imageGallery([
                      [
-                        'src' => $docsrc,
-                        'w'   => $imgsize[0],
-                        'h'   => $imgsize[1]
+                        'src'             => $docsrc,
+                        'thumbnail_src'   => $docsrc . '&context=timeline',
+                        'w'               => $imgsize[0],
+                        'h'               => $imgsize[1]
                      ]
+                  ], [
+                     'gallery_item_class' => 'timeline_img_preview'
                   ]);
                }
             }

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -4984,7 +4984,8 @@ JS;
             'fullscreen'   => true,
             'zoom'         => true,
          ],
-         'rand'   => mt_rand()
+         'rand'               => mt_rand(),
+         'gallery_item_class' => ''
       ];
 
       if (is_array($options) && count($options)) {
@@ -5038,11 +5039,14 @@ JS;
       $out .= "<div class='pswp__caption__center'></div>";
       $out .= "</div></div></div></div>";
 
-      $out .= "<div class='pswp-img{$p['rand']} timeline_img_preview' itemscope itemtype='http://schema.org/ImageGallery'>";
+      $out .= "<div class='pswp-img{$p['rand']} {$p['gallery_item_class']}' itemscope itemtype='http://schema.org/ImageGallery'>";
       foreach ($imgs as $img) {
+         if (!isset($img['thumbnail_src'])) {
+            $img['thumbnail_src'] = $img['src'];
+         }
          $out .= "<figure itemprop='associatedMedia' itemscope itemtype='http://schema.org/ImageObject'>";
          $out .= "<a href='{$img['src']}' itemprop='contentUrl' data-index='0'>";
-         $out .= "<img src='{$img['src']}&context=timeline' itemprop='thumbnail'>";
+         $out .= "<img src='{$img['thumbnail_src']}' itemprop='thumbnail'>";
          $out .= "</a>";
          $out .= "</figure>";
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | possibly
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Item 2 in #8321 

Add an optional parameter to specify classes for the gallery items
  - The `timeline_img_preview` class which was previously applied every time was moved to only be added when creating the gallery for non-embedded images in the timeline

Add an optional `thumbnail_src` parameter to images. If not specified, the `src` parameter is used for both the main image and thumbnail.
  - The forced `timeline` context for the thumbnail image was removed and is instead passed implicitly from the timeline code. This means that in other cases like embedding an image in a followup, the image can take up more space in the followup.

The possible BC break here is if someone was using this code and relying on the `timeline_img_preview` class to size their thumbnails. They may see larger than expected thumbnail elements unless they manually pass the class as the `gallery_item_class` parameter. They may also start getting the full size image loading as the thumbnail.
I found no cases of the image gallery code being called in any plugins that I had installed.