### PR TITLE
Fix <emails> in notifications

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -60,7 +60,7 @@ class Html {
       // Change <email@domain> to email@domain so it is not removed by htmLawed
       $regex = "/(<[^>]+?@[^;]+?>)/";
       $value = preg_replace_callback($regex, function($matches) {
-         return substr($matches[1], 1, (count($matches[1]) - 2));
+         return substr($matches[1], 1, (strlen($matches[1]) - 2));
       }, $value);
 
       // Clean MS office tags

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -57,6 +57,12 @@ class Html {
    static function clean($value, $striptags = true, $keep_bad = 2) {
       $value = Html::entity_decode_deep($value);
 
+      // Change <email@domain> to email@domain so it is not removed by htmLawed
+      $regex = "/(<[^>]+?@[^;]+?>)/";
+      $value = preg_replace_callback($regex, function($matches) {
+         return substr($matches[1], 1, (count($matches[1]) - 2));
+      }, $value);
+
       // Clean MS office tags
       $value = str_replace(["<![if !supportLists]>", "<![endif]>"], '', $value);
 

--- a/inc/notificationtargetticket.class.php
+++ b/inc/notificationtargetticket.class.php
@@ -165,6 +165,15 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject {
       $data = parent::getDataForObject($item, $options, $simple);
       /*$data['##ticket.description##'] = Html::clean($data['##ticket.description##']);*/
 
+      // Double encode emails stored between '<' and '>' tags
+      // Common case of this is when the ticket was created from a forwarded email
+      // Without double encoding, these emails are interpreted as html and not
+      // rendered in the final mail
+      $regex = "/(&lt;[A-Za-z0-9.!#$%&'*+\-\/=?^_`{|}~]*?@[A-Za-z0-9.!#$%&'*+\-\/=?^_`{|}~]*?&gt;)/";
+      $data['##ticket.description##'] = preg_replace_callback($regex, function($matches) {
+         return htmlentities($matches[1]);
+      }, $data['##ticket.description##']);
+
       $data['##ticket.content##'] = $data['##ticket.description##'];
       // Specific data
       $data['##ticket.urlvalidation##']

--- a/inc/notificationtargetticket.class.php
+++ b/inc/notificationtargetticket.class.php
@@ -169,7 +169,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject {
       // Common case of this is when the ticket was created from a forwarded email
       // Without double encoding, these emails are interpreted as html and not
       // rendered in the final mail
-      $regex = "/(&lt;[A-Za-z0-9.!#$%&'*+\-\/=?^_`{|}~]*?@[A-Za-z0-9.!#$%&'*+\-\/=?^_`{|}~]*?&gt;)/";
+      $regex = "/(&lt;[^;]+?@[^;]+?&gt;)/";
       $data['##ticket.description##'] = preg_replace_callback($regex, function($matches) {
          return htmlentities($matches[1]);
       }, $data['##ticket.description##']);


### PR DESCRIPTION
Given this ticket:
![image](https://user-images.githubusercontent.com/42734840/100222253-1ef59c00-2f1a-11eb-9a30-12a30e6daf59.png)

The emails surrounded between< and >will be missing from the notification content:
![image](https://user-images.githubusercontent.com/42734840/100222396-4f3d3a80-2f1a-11eb-85c0-d354f6b1b4db.png)

Encoding these emails a second time before sending the notification seems to fix the issue.

After fix:
![image](https://user-images.githubusercontent.com/42734840/100222225-156c3400-2f1a-11eb-988c-a4ce0c697f61.png)

This fix feel kind of hacky, if someone want to spend time to find a better solution he is welcome to do so :)

Some thoughts on this:
* If you check the sources (tinymce) from the client you can cleary see that only the \<emails\> are encoded: 
![image](https://user-images.githubusercontent.com/42734840/100223001-35e8be00-2f1b-11eb-8f0a-c2852e204dd6.png)
* However in the database both the html tags and the \<emails\> are encoded:
![image](https://user-images.githubusercontent.com/42734840/100223150-6597c600-2f1b-11eb-889c-3ea46217969b.png)
* Either the \<emails\> should be double encoded in the database or the others tags should not be encoded at all (isn't encoding html in the database a bad practice anyway ?)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21113
