### PR TITLE
Execute full matrix only on master and bugfixes branches and tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,8 @@ jobs:
           - {php-version: "7.4", db-image: "percona:8.0", always: false}
     env:
       # Skip jobs that should not be always run on pull requests or on push on tier repository (to limit workers usage).
-      # No jobs will be skipped on nightly build and on push on main branches.
-      skip: ${{ (github.event_name == 'pull_request' || github.repository != 'glpi-project/glpi') && matrix.always == false}}
+      # No jobs will be skipped on nightly build, manual dispatch or push on main branches (master and */bugfixes) or tags.
+      skip: ${{ matrix.always == false && (github.event_name == 'pull_request' || github.repository != 'glpi-project/glpi' || !(github.event_name == 'workflow_dispatch' || github.ref == 'refs/head/master' || endsWith(github.ref, '/bugfixes') || startsWith(github.ref, 'refs/tags'))) }}
     steps:
       - name: "Cancel previous runs"
         if: env.skip != 'true'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Prevent execution of full jobs matrix a branch prefixed by `feature/`, `bugfix/` or `security/` is pushed on current repository.

Full matrix will only be executed:
 - on push on master branch,
 - on push on */bugfixes branch,
 - on tag creation,
 - on manual dispatch.