### PR TITLE
Edit saved searches

### DIFF
--- a/ajax/savedsearch.php
+++ b/ajax/savedsearch.php
@@ -83,6 +83,7 @@ if ($_GET['action'] == 'reorder') {
    echo json_encode(['res' => true]);
 }
 
+// Create or update a saved search
 if ($_GET['action'] == 'create') {
    header("Content-Type: text/html; charset=UTF-8");
 
@@ -92,8 +93,23 @@ if ($_GET['action'] == 'create') {
       $_GET['type']  =(int)$_GET['type'];
    }
 
+   $id = 0;
+   $saved_search = new SavedSearch();
+
+   // If an id was supplied in the query and that the matching saved searche
+   // is private OR the current used is allowed to edit public searches, then
+   // pass the id to showForm
+   if ($saved_search->getFromDB($_GET['id'] ?? 0)) {
+      $is_private = $saved_search->fields['is_private'];
+      $can_update_public = Session::haveRight(SavedSearch::$rightname, UPDATE);
+
+      if ($is_private || $can_update_public) {
+         $id = $saved_search->getID();
+      }
+   }
+
    $savedsearch->showForm(
-      0, [
+      $id, [
          'type'      => $_GET['type'],
          'url'       => rawurldecode($_GET["url"]),
          'itemtype'  => $_GET["itemtype"],

--- a/ajax/savedsearch.php
+++ b/ajax/savedsearch.php
@@ -97,7 +97,7 @@ if ($_GET['action'] == 'create') {
    $saved_search = new SavedSearch();
 
    // If an id was supplied in the query and that the matching saved searche
-   // is private OR the current used is allowed to edit public searches, then
+   // is private OR the current user is allowed to edit public searches, then
    // pass the id to showForm
    if ($saved_search->getFromDB($_GET['id'] ?? 0)) {
       $is_private = $saved_search->fields['is_private'];

--- a/ajax/savedsearch.php
+++ b/ajax/savedsearch.php
@@ -99,7 +99,7 @@ if ($_GET['action'] == 'create') {
    // If an id was supplied in the query and that the matching saved search
    // is private OR the current user is allowed to edit public searches, then
    // pass the id to showForm
-   if ($saved_search->getFromDB($_GET['id'] ?? 0)) {
+   if (($requested_id = $_GET['id'] ?? 0) > 0 && $saved_search->getFromDB($requested_id)) {
       $is_private = $saved_search->fields['is_private'];
       $can_update_public = Session::haveRight(SavedSearch::$rightname, UPDATE);
 

--- a/ajax/savedsearch.php
+++ b/ajax/savedsearch.php
@@ -96,7 +96,7 @@ if ($_GET['action'] == 'create') {
    $id = 0;
    $saved_search = new SavedSearch();
 
-   // If an id was supplied in the query and that the matching saved searche
+   // If an id was supplied in the query and that the matching saved search
    // is private OR the current user is allowed to edit public searches, then
    // pass the id to showForm
    if ($saved_search->getFromDB($_GET['id'] ?? 0)) {

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -5423,6 +5423,10 @@ td.diff {
          font-size: 1.5em;
          color: #ccc !important;
       }
+
+      &.active {
+         color: #fed175 !important;
+      }
    }
 
    &.bookmark_default {
@@ -5437,6 +5441,10 @@ td.diff {
 
    &.reset-search:hover, &.bookmark_record.save:hover, &.fold-search:hover {
       color: #999 !important;
+
+      &.active {
+         color: #feb010 !important;
+      }
    }
 }
 

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2305,6 +2305,15 @@ class Search {
 
       echo "</ul>";
       echo "<div class='search_actions'>";
+
+      // Keep track of the current savedsearches on reload
+      if (isset($_GET['savedsearches_id'])) {
+         echo Html::input("savedsearches_id", [
+            'type' => "hidden",
+            'value' => $_GET['savedsearches_id'],
+         ]);
+      }
+
       $linked = self::getMetaItemtypeAvailable($itemtype);
       echo "<span id='addsearchcriteria$rand_criteria' class='secondary'>
                <i class='fas fa-plus-square'></i>
@@ -2331,7 +2340,11 @@ class Search {
                Ajax::createIframeModalWindow('loadbookmark',
                                        SavedSearch::getSearchURL() . "?action=load&type=" . SavedSearch::SEARCH,
                                        ['title'         => __('Load a saved search')]);
-               SavedSearch::showSaveButton(SavedSearch::SEARCH, $itemtype);
+               SavedSearch::showSaveButton(
+                  SavedSearch::SEARCH,
+                  $itemtype,
+                  isset($_GET['savedsearches_id'])
+               );
             }
 
             if ($p['showreset']) {


### PR DESCRIPTION
Allow edition of saved searches.

To make it easier to notice that you are on a saved search, the "star" icon is now highlighted :
![image](https://user-images.githubusercontent.com/42734840/100888593-972e0580-34b6-11eb-925d-53d83517678f.png)

Clicking the "star" icon when you are already on a saved search allow you to update the search:
![image](https://user-images.githubusercontent.com/42734840/100890156-3a334f00-34b8-11eb-8fd0-ff590ad4f867.png)

The 'Save as a new search" button allow you to copy the modified search to a new one instead of overriding the current one.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Internal tickets | !21016
