### PR TITLE
Prevents addslashes_deep and stripslashes_deep to corrupt Objects

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -911,7 +911,7 @@ class Toolbox {
       $value = ((array) $value === $value)
                   ? array_map([__CLASS__, 'addslashes_deep'], $value)
                   : (is_null($value)
-                       ? null : (is_resource($value)
+                       ? null : (is_resource($value) || is_object($value)
                        ? $value : $DB->escape(
                           str_replace(
                              ['&#039;', '&#39;', '&#x27;', '&apos;', '&quot;'],
@@ -937,7 +937,7 @@ class Toolbox {
       $value = ((array) $value === $value)
                   ? array_map([__CLASS__, 'stripslashes_deep'], $value)
                   : (is_null($value)
-                        ? null : (is_resource($value)
+                        ? null : (is_resource($value) || is_object($value)
                                     ? $value :stripslashes($value)));
 
       return $value;


### PR DESCRIPTION
Adds email real uniqueID management see: https://github.com/laminas/laminas-mail/blob/2.13.x/src/Storage/Imap.php that recommend to use UniqueId for email, and not the default counter
fixes #8345

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8345 
