### PR TITLE
Deprecate usage of XML-RPC API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The present file will list all changes made to the project; according to the
 
 ### Changed
 
+### Deprecated
+- Usage of XML-RPC API is deprecated.
+
 ### API changes
 
 #### Added

--- a/apirest.php
+++ b/apirest.php
@@ -41,6 +41,11 @@ ini_set('session.use_cookies', 0);
 
 include_once (GLPI_ROOT . "/inc/based_config.php");
 
+// Init loggers
+$GLPI = new GLPI();
+$GLPI->initLogger();
+$GLPI->initErrorHandler();
+
 //init cache
 $GLPI_CACHE = Config::getCache('cache_db');
 

--- a/apixmlrpc.php
+++ b/apixmlrpc.php
@@ -40,6 +40,11 @@ define('DO_NOT_CHECK_HTTP_REFERER', 1);
 
 include_once (GLPI_ROOT . "/inc/based_config.php");
 
+// Init loggers
+$GLPI = new GLPI();
+$GLPI->initLogger();
+$GLPI->initErrorHandler();
+
 //init cache
 $GLPI_CACHE = Config::getCache('cache_db');
 

--- a/inc/api/apixmlrpc.class.php
+++ b/inc/api/apixmlrpc.class.php
@@ -69,6 +69,8 @@ class APIXmlrpc extends API {
     * @return mixed xmlrpc response
     */
    public function call() {
+      Toolbox::logInfo('Deprecated: Usage of XML-RPC has been deprecated. Please use REST API.');
+
       $resource = $this->parseIncomingParams();
 
       // retrieve session (if exist)

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2484,10 +2484,6 @@ class Config extends CommonDBTM {
                'required'  => false,
                'function'  => 'apcu_fetch'
             ],
-            //for XMLRPC API
-            'xmlrpc'     => [
-               'required'  => false
-            ],
             //for CAS lib
             'CAS'     => [
                'required' => false,

--- a/inc/system/requirementsmanager.class.php
+++ b/inc/system/requirementsmanager.class.php
@@ -84,7 +84,6 @@ class RequirementsManager {
       $requirements[] = new Extension('ldap', true); // to sync/connect from LDAP
       $requirements[] = new Extension('apcu', true); // to enhance perfs
       $requirements[] = new Extension('Zend OPcache', true); // to enhance perfs
-      $requirements[] = new Extension('xmlrpc', true); // for XMLRPC API
       $requirements[] = new ExtensionClass('CAS', 'phpCAS', true); // for CAS lib
       $requirements[] = new Extension('exif', true); // for security reasons (images checks)
       $requirements[] = new Extension('zip', true); // to handle zip packages on marketplace

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -527,6 +527,13 @@ class Toolbox {
    }
 
    /**
+    * PHP notice log
+    */
+   static function logNotice() {
+      self::log(null, Logger::NOTICE, func_get_args());
+   }
+
+   /**
     * PHP info log
     */
    static function logInfo() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

XML-RPC extension has been dropped from core PHP extensions in PHP 8.0 and Pecl package has no available releases yet.

Thus, even if I cannot be sure of that, I guess most of people are already using the REST API.

I tried to put a deprecation warning, but it breaks XML response when errors are displayed in output.