### PR TITLE
don't validate idor token when displaying criteria

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2698,6 +2698,9 @@ JAVASCRIPT;
          'from_meta'       => true,
          'num'             => $num,
          'p'               => $request["p"],
+         '_idor_token'     => Session::getNewIDORToken("", [
+            'parent_itemtype' => $request['itemtype']
+         ])
       ];
       Ajax::updateItemOnSelectEvent(
          $field_id,

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -1312,9 +1312,9 @@ class Session {
       }
 
       $_SESSION['glpiidortokens'][$token] = [
-         'itemtype' => $itemtype,
          'expires'  => time() + GLPI_IDOR_EXPIRES
-      ] + $add_params;
+      ] + ($itemtype !== "" ? ['itemtype' => $itemtype] : [])
+        + $add_params;
 
       return $token;
    }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Since 9.5.3 and the addition of security idor tokens, we added globally check for all search engine ajax call.
Maybe too globally.

![image](https://user-images.githubusercontent.com/418844/101488890-7b1bdf80-3960-11eb-8658-f7dbb834d296.png)

When asking for a new global rule (blue part) and after selecting itemtype, the second part doesn't display due to an idor check (with ajax call contains action=display_criteria parameter).

Afaik, the original security issue was found for action=display_searchoption case.

i have no idea how to fix the ajax call because, it rely on a dynamic itemtype=__VALUE__ parameter (we validate itemtype with idor checks)

So i suggest to remove idor validation for the current problematic case.
