### PR TITLE
Remove vendor cleaning in release process

### DIFF
--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -83,16 +83,3 @@ do
     rm -rf $WORKING_DIR/$node
 done
 find $WORKING_DIR/pics/ -depth -type f -iname "*.eps" -exec rm -rf {} \;
-
-# Remove useless files and directories in vendor subdirs
-vendor_dirs=( "doc*" "example*" "test*" )
-for directory in "${vendor_dirs[@]}"
-do
-    find $WORKING_DIR/vendor -depth -type d -iname $directory -exec rm -rf {} \;
-done
-vendor_filenames=( "build.xml" "changelog.md" "composer.json" "phpunit.xml.dist" "readme.md" )
-for filename in "${vendor_filenames[@]}"
-do
-    find $WORKING_DIR/vendor -depth -type f -iname $filename -exec rm -rf {} \;
-done
-


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It may happen that an external lib has classes inside a directory named `test` that are not meant to be used in test suite (for instance, in Twig: https://github.com/twigphp/Twig/tree/3.x/src/Node/Expression/Test).

Without this cleaning process, archive goes from 44MB to 46MB (tested on feat/modern-ui branch).

Even if the archive weighs 2MB more, as we used the `--prefer-dist` option in `composer install` call, I consider that it is the responsibility of external lib maintainers to exclude these files from their packages, using [archive option of `composer.json`](https://getcomposer.org/doc/04-schema.md#archive).