### PR TITLE
Fix <emails> in notifications 2

### DIFF
--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -179,6 +179,8 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
             $documents_to_attach = $documents_ids; // Attach all documents
          } else {
             $mmail->Body = '';
+            $current->fields['body_html'] = Toolbox::doubleEncodeEmails($current->fields['body_html']);
+            $current->fields['body_html'] = Html::entity_decode_deep($current->fields['body_html']);
 
             $inline_docs = [];
             $doc = new Document();

--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -179,7 +179,6 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
             $documents_to_attach = $documents_ids; // Attach all documents
          } else {
             $mmail->Body = '';
-            $current->fields['body_html'] = Html::entity_decode_deep($current->fields['body_html']);
 
             $inline_docs = [];
             $doc = new Document();

--- a/inc/notificationtargetticket.class.php
+++ b/inc/notificationtargetticket.class.php
@@ -169,7 +169,6 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject {
       // Common case of this is when the ticket was created from a forwarded email
       // Without double encoding, these emails are interpreted as html and not
       // rendered in the final mail
-      $regex = "/(&lt;[^;]+?@[^;]+?&gt;)/";
       $data['##ticket.description##'] = Toolbox::doubleEncodeEmails($data['##ticket.description##']);
 
       $data['##ticket.content##'] = $data['##ticket.description##'];

--- a/inc/notificationtargetticket.class.php
+++ b/inc/notificationtargetticket.class.php
@@ -170,9 +170,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject {
       // Without double encoding, these emails are interpreted as html and not
       // rendered in the final mail
       $regex = "/(&lt;[^;]+?@[^;]+?&gt;)/";
-      $data['##ticket.description##'] = preg_replace_callback($regex, function($matches) {
-         return htmlentities($matches[1]);
-      }, $data['##ticket.description##']);
+      $data['##ticket.description##'] = Toolbox::doubleEncodeEmails($data['##ticket.description##']);
 
       $data['##ticket.content##'] = $data['##ticket.description##'];
       // Specific data

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3473,4 +3473,20 @@ HTML;
          $url
       ) === 1);
    }
+
+   /**
+    * Search for html encoded <email> (&lt;email&gt;) in the given string and
+    * encode them a second time
+    *
+    * @param string $string
+    *
+    * @return string
+    */
+   public static function doubleEncodeEmails($string) {
+      $regex = "/(&lt;[^;]+?@[^;]+?&gt;)/";
+      $string = preg_replace_callback($regex, function($matches) {
+         return htmlentities($matches[1]);
+      }, $string);
+      return $string;
+   }
 }


### PR DESCRIPTION
Following #8330, \<emails\> were correctly escaped in the mail queue but were still not displayed when receiving the actual email.
I figured there must be yet another HTML decoding step taking place before sending the mail, found it in notificationeventmailing and removed it.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21113
