### PR TITLE
Enhance 9.5 to x.x migrations

### DIFF
--- a/install/update_95_xx.php
+++ b/install/update_95_xx.php
@@ -50,50 +50,6 @@ function update95toXX() {
    require __DIR__ . '/update_95_xx/devicebattery.php';
    require __DIR__ . '/update_95_xx/reservationitem.php';
 
-   //add is_fqdn on some domain records types
-   $fields = [
-      'CNAME'  => ['target'],
-      'MX'     => ['server'],
-      'SOA'    => ['primary_name_server', 'primary_contact'],
-      'SRV'    => ['target']
-   ];
-
-   $fields_it = $DB->request([
-      'FROM'   => DomainRecordType::getTable(),
-      'WHERE'  => ['name' => array_keys($fields)]
-   ]);
-   while ($field = $fields_it->next()) {
-      if (empty($field['fields'])) {
-         if ($field['name'] === 'CNAME') {
-            //cname field definition has been added
-            $field['fields'] = json_encode([[
-               'key'         => 'target',
-               'label'       => 'Target',
-               'placeholder' => 'sip.example.com.',
-               'is_fqdn'     => true
-            ]]);
-         } else {
-            continue;
-         }
-      }
-      $type_fields = DomainRecordType::decodeFields($field['fields']);
-      $updated = false;
-      foreach ($type_fields as &$conf) {
-         if (in_array($conf['key'], $fields[$field['name']])) {
-            $conf['is_fqdn'] = true;
-            $updated = true;
-         }
-      }
-
-      if ($updated) {
-         $DB->update(
-            DomainRecordType::getTable(),
-            ['fields' => json_encode($type_fields)],
-            ['name' => $field['name']]
-         );
-      }
-   }
-
    // ************ Keep it at the end **************
    foreach ($ADDTODISPLAYPREF as $type => $tab) {
       $rank = 1;

--- a/install/update_95_xx/devicebattery.php
+++ b/install/update_95_xx/devicebattery.php
@@ -1,4 +1,38 @@
 <?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2020 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
 
 $migration->addField('glpi_items_devicebatteries', 'real_capacity', 'integer', [
     'after' => 'states_id'

--- a/install/update_95_xx/domains.php
+++ b/install/update_95_xx/domains.php
@@ -92,7 +92,7 @@ if (countElementsInTable('glpi_domainrecordtypes', ['name' => 'CAA']) === 0) {
          unset($type['id']);
          $migration->addPostQuery(
             $DB->buildInsert(
-               DomainRecordType::getTable(),
+               'glpi_domainrecordtypes',
                $type
             )
          );
@@ -110,3 +110,47 @@ $migration->addField(
       'after'  => 'data'
    ]
 );
+
+//add is_fqdn on some domain records types
+$fields = [
+   'CNAME'  => ['target'],
+   'MX'     => ['server'],
+   'SOA'    => ['primary_name_server', 'primary_contact'],
+   'SRV'    => ['target']
+];
+
+$fields_it = $DB->request([
+   'FROM'   => 'glpi_domainrecordtypes',
+   'WHERE'  => ['name' => array_keys($fields)]
+]);
+while ($field = $fields_it->next()) {
+   if (empty($field['fields'])) {
+      if ($field['name'] === 'CNAME') {
+         //cname field definition has been added
+         $field['fields'] = json_encode([[
+            'key'         => 'target',
+            'label'       => 'Target',
+            'placeholder' => 'sip.example.com.',
+            'is_fqdn'     => true
+         ]]);
+      } else {
+         continue;
+      }
+   }
+   $type_fields = DomainRecordType::decodeFields($field['fields']);
+   $updated = false;
+   foreach ($type_fields as &$conf) {
+      if (in_array($conf['key'], $fields[$field['name']])) {
+         $conf['is_fqdn'] = true;
+         $updated = true;
+      }
+   }
+
+   if ($updated) {
+      $DB->update(
+         'glpi_domainrecordtypes',
+         ['fields' => json_encode($type_fields)],
+         ['name' => $field['name']]
+      );
+   }
+}

--- a/install/update_95_xx/reservationitem.php
+++ b/install/update_95_xx/reservationitem.php
@@ -36,7 +36,7 @@
  */
 
 $migration->displayMessage("Adding unicity key to reservationitem");
-$table = ReservationItem::getTable();
+$table = 'glpi_reservationitems';
 
 // Copy table
 $tmp_table = "tmp_$table";

--- a/install/update_95_xx/softwares.php
+++ b/install/update_95_xx/softwares.php
@@ -32,8 +32,8 @@
 
 // CleanSoftwareCron cron task
 CronTask::register(
-   CleanSoftwareCron::class,
-   CleanSoftwareCron::TASK_NAME,
+   'CleanSoftwareCron',
+   'cleansoftware',
    MONTH_TIMESTAMP,
    [
       'state'         => 0,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Replace some `*::getTable()` to hardcoded table names to prevent unexpected migration result in case tables names changed in the future.
2. Move domain update to domain file.
3. Add missing file header.