### PR TITLE
Cache holidays to improve SLA/OLA computations; fixes #7989

### DIFF
--- a/inc/calendar_holiday.class.php
+++ b/inc/calendar_holiday.class.php
@@ -206,5 +206,117 @@ class Calendar_Holiday extends CommonDBRelation {
       }
       return true;
    }
+
+   function post_addItem() {
+
+      $this->invalidateCalendarCache($this->fields['calendars_id']);
+
+      parent::post_addItem();
+   }
+
+   function post_updateItem($history = 1) {
+
+      if (in_array('calendars_id', $this->updates)) {
+         $this->invalidateCalendarCache($this->oldvalues['calendars_id']);
+      }
+
+      $this->invalidateCalendarCache($this->fields['calendars_id']);
+
+      parent::post_updateItem($history);
+   }
+
+   function post_deleteFromDB() {
+
+      $this->invalidateCalendarCache($this->fields['calendars_id']);
+
+      parent::post_deleteFromDB();
+   }
+
+   /**
+    * Return holidays related to given calendar.
+    *
+    * @param int $calendars_id
+    *
+    * @return array
+    */
+   public function getHolidaysForCalendar(int $calendars_id): array {
+      global $DB, $GLPI_CACHE;
+
+      $cache_key = $this->getCalendarHolidaysCacheKey($calendars_id);
+      if (($holidays = $GLPI_CACHE->get($cache_key)) === null) {
+         $holidays_iterator = $DB->request(
+            [
+               'SELECT'     => ['begin_date', 'end_date', 'is_perpetual'],
+               'FROM'       => Holiday::getTable(),
+               'INNER JOIN' => [
+                  Calendar_Holiday::getTable() => [
+                     'FKEY'   => [
+                        Calendar_Holiday::getTable() => Holiday::getForeignKeyField(),
+                        Holiday::getTable()          => 'id',
+                     ],
+                  ],
+               ],
+               'WHERE'      => [
+                  Calendar_Holiday::getTableField(Calendar::getForeignKeyField()) => $calendars_id,
+               ],
+            ]
+         );
+         $holidays = iterator_to_array($holidays_iterator);
+         $GLPI_CACHE->set($cache_key, $holidays);
+      }
+
+      return $holidays;
+   }
+
+   /**
+    * Invalidate cache for given holiday.
+    *
+    * @param int $holidays_id
+    *
+    * @return bool
+    */
+   public function invalidateHolidayCache(int $holidays_id): bool {
+      global $DB;
+
+      $success = true;
+
+      $iterator = $DB->request(
+         [
+            'SELECT'     => [Calendar::getForeignKeyField()],
+            'FROM'       => self::getTable(),
+            'WHERE'      => [
+               Holiday::getForeignKeyField() => $holidays_id,
+            ],
+         ]
+      );
+      foreach ($iterator as $link) {
+         $success = $success && $this->invalidateCalendarCache($link[Calendar::getForeignKeyField()]);
+      }
+
+      return $success;
+   }
+
+   /**
+    * Get cache key of cache entry containing holidays of given calendar.
+    *
+    * @param int $calendars_id
+    *
+    * @return string
+    */
+   private function getCalendarHolidaysCacheKey(int $calendars_id): string {
+      return sprintf('calendar-%s-holidays', $calendars_id);
+   }
+
+   /**
+    * Invalidate holidays cache of given calendar.
+    *
+    * @param int $calendars_id
+    *
+    * @return bool
+    */
+   private function invalidateCalendarCache(int $calendars_id): bool {
+      global $GLPI_CACHE;
+      return $GLPI_CACHE->delete($this->getCalendarHolidaysCacheKey($calendars_id));
+   }
 }
 

--- a/inc/holiday.class.php
+++ b/inc/holiday.class.php
@@ -122,4 +122,36 @@ class Holiday extends CommonDropdown {
       return $input;
    }
 
+   function post_updateItem($history = 1) {
+
+      $this->invalidateCalendarHolidayCache();
+
+      parent::post_updateItem($history);
+   }
+
+   function post_deleteFromDB() {
+
+      $this->invalidateCalendarHolidayCache();
+
+      parent::post_deleteFromDB();
+   }
+
+   function cleanDBonPurge() {
+
+      $this->deleteChildrenAndRelationsFromDb(
+         [
+            Calendar_Holiday::class,
+         ]
+      );
+   }
+
+   /**
+    * Invalidate holidays cache on linked calendars.
+    *
+    * @return void
+    */
+   private function invalidateCalendarHolidayCache(): void {
+      $calendar_holiday = new Calendar_Holiday();
+      $calendar_holiday->invalidateHolidayCache($this->fields['id']);
+   }
 }

--- a/tests/functionnal/Calendar.php
+++ b/tests/functionnal/Calendar.php
@@ -186,8 +186,9 @@ class Calendar extends DbTestCase {
    public function testIsHoliday() {
       $calendar = new \Calendar();
       // get Default calendar
-      $default_id = getItemByTypeName('Calendar', 'Default', true);
-      $this->boolean($calendar->getFromDB($default_id))->isTrue();
+      $this->boolean($calendar->getFromDB(getItemByTypeName('Calendar', 'Default', true)))->isTrue();
+
+      $this->addXmas($calendar);
 
       $dates= [
          '2019-05-01'   => true,
@@ -201,11 +202,7 @@ class Calendar extends DbTestCase {
          $this->boolean($calendar->isHoliday($date))->isFalse;
       }
 
-      //Clone calendar and add holidays
-      $clone_id = $calendar->clone();
-      $this->integer($clone_id)->isGreaterThan($default_id);
-      $this->boolean($calendar->getFromDB($clone_id))->isTrue();
-
+      //Add holidays
       $calendar_holiday = new \Calendar_Holiday();
       $holiday = new \Holiday();
       $hid = (int)$holiday->add([

--- a/tests/functionnal/Calendar_Holiday.php
+++ b/tests/functionnal/Calendar_Holiday.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Calendar;
+use DbTestCase;
+use Holiday;
+
+/* Test for inc/calendar_holiday.class.php */
+
+class Calendar_Holiday extends DbTestCase {
+
+   public function testGetHolidaysForCalendar() {
+
+      $calendar_holiday = new \Calendar_Holiday();
+
+      $default_calendar_id = getItemByTypeName('Calendar', 'Default', true);
+
+      // No default holidays
+      $holidays = $calendar_holiday->getHolidaysForCalendar($default_calendar_id);
+      $this->array($holidays)->isEqualTo([]);
+
+      // Add holidays
+      $this->addHolidaysToCalendar($default_calendar_id);
+
+      $holidays = $calendar_holiday->getHolidaysForCalendar($default_calendar_id);
+      $this->array($holidays)->isEqualTo(
+         [
+            ['begin_date' => '2000-01-01', 'end_date' => '2000-01-01', 'is_perpetual' => 1],
+            ['begin_date' => '2020-04-06', 'end_date' => '2020-04-17', 'is_perpetual' => 0],
+            ['begin_date' => '2020-08-03', 'end_date' => '2020-08-21', 'is_perpetual' => 0],
+            ['begin_date' => '2020-12-21', 'end_date' => '2020-12-25', 'is_perpetual' => 0],
+         ]
+      );
+
+      // Check that calendar filtering is not buggy
+      $calendar = new Calendar();
+      $calendar_id = $calendar->add(['name' => 'Test']);
+      $this->integer($calendar_id)->isGreaterThan(0);
+
+      $holidays = $calendar_holiday->getHolidaysForCalendar($calendar_id);
+      $this->array($holidays)->isEqualTo([]);
+   }
+
+   public function testHolidaysCache() {
+      global $GLPI_CACHE;
+
+      $holiday = new Holiday();
+      $calendar_holiday = new \Calendar_Holiday();
+
+      $default_calendar_id = getItemByTypeName('Calendar', 'Default', true);
+      $cache_key = sprintf('calendar-%s-holidays', $default_calendar_id);
+
+      // No default cache (cache is set on reading operations)
+      $this->boolean($GLPI_CACHE->has($cache_key))->isFalse();
+
+      // Validate that cache is set on reading
+      $this->validateHolidayCacheMatchesMethodResult($default_calendar_id);
+
+      // Validate that there is no DB operation when cache is set
+      global $DB;
+      $db_back = $DB;
+      $DB = null; // Setting $DB to null will result in an error if something tries to request DB
+      $holidays = $calendar_holiday->getHolidaysForCalendar($default_calendar_id);
+      $DB = $db_back;
+      $this->array($GLPI_CACHE->get($cache_key))->isEqualTo($holidays);
+
+      // Validate that cache is invalidated when holidays are added
+      $this->boolean($GLPI_CACHE->has($cache_key))->isTrue();
+      $this->addHolidaysToCalendar($default_calendar_id);
+      $this->boolean($GLPI_CACHE->has($cache_key))->isFalse();
+      $this->validateHolidayCacheMatchesMethodResult($default_calendar_id);
+
+      // Validate that cache is invalidated when holidays are updated
+      $holiday_id = getItemByTypeName('Holiday', 'Spring holidays', true);
+      $this->boolean($GLPI_CACHE->has($cache_key))->isTrue();
+      $holiday->update(['id' => $holiday_id, 'begin_date' => '2020-03-01']);
+      $this->boolean($GLPI_CACHE->has($cache_key))->isFalse();
+      $this->validateHolidayCacheMatchesMethodResult($default_calendar_id);
+
+      // Validate that cache is invalidated when calendar_holiday is deleted
+      $holiday_id = getItemByTypeName('Holiday', 'Spring holidays', true);
+      $this->boolean($calendar_holiday->getFromDBByCrit(['holidays_id' => $holiday_id]))->isTrue();
+      $this->boolean($GLPI_CACHE->has($cache_key))->isTrue();
+      $this->boolean($calendar_holiday->delete(['id' => $calendar_holiday->fields['id']]))->isTrue();
+      $this->boolean($GLPI_CACHE->has($cache_key))->isFalse();
+      $this->validateHolidayCacheMatchesMethodResult($default_calendar_id);
+
+      // Validate that cache is invalidated when holiday is deleted
+      $holiday_id = getItemByTypeName('Holiday', 'Summer holidays', true);
+      $this->boolean($GLPI_CACHE->has($cache_key))->isTrue();
+      $this->boolean($holiday->delete(['id' => $holiday_id, true]))->isTrue();
+      $this->boolean($GLPI_CACHE->has($cache_key))->isFalse();
+      $this->validateHolidayCacheMatchesMethodResult($default_calendar_id);
+
+      // Validate that cache is invalidated when calendar_holiday is updated
+      // Cannot be tested as `CommonDBRelation::prepareInputForUpdate()` refuses the update.
+      // I choosed to keep invalidation code in `Calendar_Holiday::post_updateItem()` to be sure to handle this case
+      // if update becomes possible in the future.
+      /*
+      $calendar = new Calendar();
+      $calendar_id = $calendar->add(['name' => 'Test']);
+      $this->integer($calendar_id)->isGreaterThan(0);
+
+      $this->validateHolidayCacheMatchesMethodResult($calendar_id);
+
+      $holiday_id = getItemByTypeName('Holiday', 'Winter holidays', true);
+      $this->boolean($calendar_holiday->getFromDBByCrit(['holidays_id' => $holiday_id]))->isTrue();
+      $this->boolean(
+         $calendar_holiday->update(['id' => $calendar_holiday->fields['id'], 'calendars_id' => $calendar_id])
+      )->isTrue();
+      $this->boolean($GLPI_CACHE->has($cache_key))->isFalse(); // Previously associated calendar cache is invalidated
+      $this->boolean($GLPI_CACHE->has(sprintf('calendar-%s-holidays', $calendar_id)))->isFalse();
+      */
+   }
+
+   /**
+    * Add some holidays on given calendar.
+    *
+    * @param int $calendar_id
+    *
+    * @return void
+    */
+   private function addHolidaysToCalendar(int $calendar_id): void {
+      $holiday = new Holiday();
+      $calendar_holiday = new \Calendar_Holiday();
+
+      $holiday_id = (int)$holiday->add(
+         [
+            'name'         => 'New Year՛s Day',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+            'begin_date'   => '2000-01-01',
+            'end_date'     => '2000-01-01',
+            'is_perpetual' => 1,
+         ]
+      );
+      $this->integer($holiday_id)->isGreaterThan(0);
+      $calendar_holiday_id = (int)$calendar_holiday->add(
+         [
+            'holidays_id'  => $holiday_id,
+            'calendars_id' => $calendar_id,
+         ]
+      );
+      $this->integer($calendar_holiday_id)->isGreaterThan(0);
+
+      $holiday_id = (int)$holiday->add(
+         [
+            'name'         => 'Spring holidays',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+            'begin_date'   => '2020-04-06',
+            'end_date'     => '2020-04-17',
+            'is_perpetual' => 0,
+         ]
+      );
+      $this->integer($holiday_id)->isGreaterThan(0);
+      $calendar_holiday_id = (int)$calendar_holiday->add(
+         [
+            'holidays_id'  => $holiday_id,
+            'calendars_id' => $calendar_id,
+         ]
+      );
+      $this->integer($calendar_holiday_id)->isGreaterThan(0);
+
+      $holiday_id = (int)$holiday->add(
+         [
+            'name'         => 'Summer holidays',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+            'begin_date'   => '2020-08-03',
+            'end_date'     => '2020-08-21',
+            'is_perpetual' => 0,
+         ]
+      );
+      $this->integer($holiday_id)->isGreaterThan(0);
+      $calendar_holiday_id = (int)$calendar_holiday->add(
+         [
+            'holidays_id'  => $holiday_id,
+            'calendars_id' => $calendar_id,
+         ]
+      );
+      $this->integer($calendar_holiday_id)->isGreaterThan(0);
+
+      $holiday_id = (int)$holiday->add(
+         [
+            'name'         => 'Winter holidays',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+            'begin_date'   => '2020-12-21',
+            'end_date'     => '2020-12-25',
+            'is_perpetual' => 0,
+         ]
+      );
+      $this->integer($holiday_id)->isGreaterThan(0);
+      $calendar_holiday_id = (int)$calendar_holiday->add(
+         [
+            'holidays_id'  => $holiday_id,
+            'calendars_id' => $calendar_id,
+         ]
+      );
+      $this->integer($calendar_holiday_id)->isGreaterThan(0);
+   }
+
+   /**
+    * Validate that holidays cache for given calendar matches "getHolidaysForCalendar" method result.
+    *
+    * @param int $calendar_id
+    *
+    * @return void
+    */
+   private function validateHolidayCacheMatchesMethodResult(int $calendar_id): void {
+      global $GLPI_CACHE;
+
+      $calendar_holiday = new \Calendar_Holiday();
+      $cache_key = sprintf('calendar-%s-holidays', $calendar_id);
+
+      $holidays = $calendar_holiday->getHolidaysForCalendar($calendar_id);
+      $this->boolean($GLPI_CACHE->has($cache_key))->isTrue();
+      $this->array($GLPI_CACHE->get($cache_key))->isEqualTo($holidays);
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7989 

Cache holidays for each calendar to prevent doing a SQL query for each `isHoliday` check. This may greatly improve performances when SLA/OLA are computed on high date ranges, or when many items are shown on the same page.
