### PR TITLE
Test "messageafterredirect"

### DIFF
--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -121,7 +121,13 @@ class GLPITestCase extends atoum {
       $this->has_failed = false;
    }
 
-   protected function hasNoSessionMessage($level) {
+   protected function hasNoSessionMessages(array $levels) {
+      foreach ($levels as $level) {
+         $this->hasNoSessionMessage($level);
+      }
+   }
+
+   protected function hasNoSessionMessage(int $level) {
       $this->has_failed = true;
       $this->boolean(isset($_SESSION['MESSAGE_AFTER_REDIRECT'][$level]))->isFalse(
          sprintf(

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -110,7 +110,7 @@ class GLPITestCase extends atoum {
       }
    }
 
-   protected function hasSessionMessage(int $level, array $messages): void {
+   protected function hasSessionMessages(int $level, array $messages): void {
       $this->has_failed = true;
       $this->boolean(isset($_SESSION['MESSAGE_AFTER_REDIRECT'][$level]))->isTrue('No messages for selected level!');
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'][$level])->isIdenticalTo(

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -40,6 +40,7 @@ class GLPITestCase extends atoum {
    private $str;
    protected $cached_methods = [];
    protected $nscache;
+   protected $has_failed = false;
 
    public function setUp() {
       // By default, no session, not connected
@@ -51,6 +52,7 @@ class GLPITestCase extends atoum {
    }
 
    public function beforeTestMethod($method) {
+      unset($_SESSION['glpicronuserrunning']);
       if (in_array($method, $this->cached_methods)) {
          $this->nscache = 'glpitestcache' . GLPI_VERSION;
          global $GLPI_CACHE;
@@ -93,6 +95,42 @@ class GLPITestCase extends atoum {
                )
             );
       }
+
+      if (isset($_SESSION['MESSAGE_AFTER_REDIRECT']) && !$this->has_failed) {
+         unset($_SESSION['MESSAGE_AFTER_REDIRECT'][INFO]);
+         $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
+            [],
+            sprintf(
+               "Some messages has not been handled in %s::%s:\n%s",
+               static::class,
+               $method,
+               print_r($_SESSION['MESSAGE_AFTER_REDIRECT'], true)
+            )
+         );
+      }
+   }
+
+   protected function hasSessionMessage(int $level, array $messages): void {
+      $this->has_failed = true;
+      $this->boolean(isset($_SESSION['MESSAGE_AFTER_REDIRECT'][$level]))->isTrue('No messages for selected level!');
+      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'][$level])->isIdenticalTo(
+         $messages,
+         'Expecting ' . print_r($messages, true) . 'got: ' . print_r($_SESSION['MESSAGE_AFTER_REDIRECT'][$level], true)
+      );
+      unset($_SESSION['MESSAGE_AFTER_REDIRECT'][$level]); //reset
+      $this->has_failed = false;
+   }
+
+   protected function hasNoSessionMessage($level) {
+      $this->has_failed = true;
+      $this->boolean(isset($_SESSION['MESSAGE_AFTER_REDIRECT'][$level]))->isFalse(
+         sprintf(
+            'Messages for level %s are present in session: %s',
+            $level,
+            print_r($_SESSION['MESSAGE_AFTER_REDIRECT'][$level] ?? [], true)
+         )
+      );
+      $this->has_failed = false;
    }
 
    /**

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -637,13 +637,14 @@ class AuthLDAP extends DbTestCase {
     * @return void
     */
    public function testLdapAuthSpecifyAuth() {
-
+      $_SESSION['glpicronuserrunning'] = "cron_phpunit";
       // Add a local account with same name than a LDAP user ('brazil8')
       $input = [
          'name'         => 'brazil8',
          'password'     => 'passwordlocal',
          'password2'    => 'passwordlocal',
-         '_profiles_id' => 1 // add manual right (is_dynamic = 0)
+         '_profiles_id' => 1, // add manual right (is_dynamic = 0)
+         'entities_id'  => 0
       ];
       $user = new \User();
       $user_id = $user->add($input);

--- a/tests/functionnal/AuthLdap.php
+++ b/tests/functionnal/AuthLdap.php
@@ -176,7 +176,7 @@ class AuthLDAP extends DbTestCase {
       $input['sync_field'] = 'another_field';
       $result = $ldap->prepareInputForUpdate($input);
       $this->boolean($result)->isFalse();
-      $this->hasSessionMessage(ERROR, ['Synchronization field cannot be changed once in use.']);
+      $this->hasSessionMessages(ERROR, ['Synchronization field cannot be changed once in use.']);
    }
 
    public function testgetGroupSearchTypeName() {

--- a/tests/functionnal/AuthLdap.php
+++ b/tests/functionnal/AuthLdap.php
@@ -176,6 +176,7 @@ class AuthLDAP extends DbTestCase {
       $input['sync_field'] = 'another_field';
       $result = $ldap->prepareInputForUpdate($input);
       $this->boolean($result)->isFalse();
+      $this->hasSessionMessage(ERROR, ['Synchronization field cannot be changed once in use.']);
    }
 
    public function testgetGroupSearchTypeName() {

--- a/tests/functionnal/Cartridge.php
+++ b/tests/functionnal/Cartridge.php
@@ -82,7 +82,7 @@ class Cartridge extends DbTestCase {
       $this->variable($cartridge->fields['date_out'])->isNull();
       //already installed
       $this->boolean($cartridge->install($pid, $ciid))->isFalse();
-      $this->hasSessionMessage(ERROR, ['No free cartridge']);
+      $this->hasSessionMessages(ERROR, ['No free cartridge']);
 
       $this->integer($cartridge->getUsedNumber($ciid))->isIdenticalTo(1);
       $this->integer($cartridge->getTotalNumberForPrinter($pid))->isIdenticalTo(1);

--- a/tests/functionnal/Cartridge.php
+++ b/tests/functionnal/Cartridge.php
@@ -82,6 +82,7 @@ class Cartridge extends DbTestCase {
       $this->variable($cartridge->fields['date_out'])->isNull();
       //already installed
       $this->boolean($cartridge->install($pid, $ciid))->isFalse();
+      $this->hasSessionMessage(ERROR, ['No free cartridge']);
 
       $this->integer($cartridge->getUsedNumber($ciid))->isIdenticalTo(1);
       $this->integer($cartridge->getTotalNumberForPrinter($pid))->isIdenticalTo(1);

--- a/tests/functionnal/CommonITILValidation.php
+++ b/tests/functionnal/CommonITILValidation.php
@@ -211,12 +211,7 @@ class CommonITILValidation extends DbTestCase {
          'status'       => \CommonITILValidation::REFUSED
       ]);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([
-         ERROR => [
-            'If approval is denied, specify a reason.'
-         ]
-      ]);
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['If approval is denied, specify a reason.']);
       $this->boolean($res)->isFalse();
 
       $this->boolean(

--- a/tests/functionnal/CommonITILValidation.php
+++ b/tests/functionnal/CommonITILValidation.php
@@ -211,7 +211,7 @@ class CommonITILValidation extends DbTestCase {
          'status'       => \CommonITILValidation::REFUSED
       ]);
 
-      $this->hasSessionMessage(ERROR, ['If approval is denied, specify a reason.']);
+      $this->hasSessionMessages(ERROR, ['If approval is denied, specify a reason.']);
       $this->boolean($res)->isFalse();
 
       $this->boolean(

--- a/tests/functionnal/Config.php
+++ b/tests/functionnal/Config.php
@@ -166,7 +166,6 @@ class Config extends DbTestCase {
 
    public function testValidatePassword() {
       global $CFG_GLPI;
-      unset($_SESSION['glpicronuserrunning']);
       $this->boolean((bool)$CFG_GLPI['use_password_security'])->isFalse();
 
       $this->boolean(\Config::validatePassword('mypass'))->isTrue();
@@ -180,77 +179,54 @@ class Config extends DbTestCase {
       $this->boolean(\Config::validatePassword(''))->isFalse();
 
       $expected = [
-         ERROR => [
-            'Password too short!',
-            'Password must include at least a digit!',
-            'Password must include at least a lowercase letter!',
-            'Password must include at least a uppercase letter!',
-            'Password must include at least a symbol!'
-         ]
+         'Password too short!',
+         'Password must include at least a digit!',
+         'Password must include at least a lowercase letter!',
+         'Password must include at least a uppercase letter!',
+         'Password must include at least a symbol!'
       ];
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])
-         ->isIdenticalTo($expected);
-
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, $expected);
       $expected = [
-         ERROR => [
-            'Password must include at least a digit!',
-            'Password must include at least a uppercase letter!',
-            'Password must include at least a symbol!'
-         ]
+         'Password must include at least a digit!',
+         'Password must include at least a uppercase letter!',
+         'Password must include at least a symbol!'
       ];
       $this->boolean(\Config::validatePassword('mypassword'))->isFalse();
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])
-         ->isIdenticalTo($expected);
+      $this->hasSessionMessage(ERROR, $expected);
 
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
       $CFG_GLPI['password_min_length'] = strlen('mypass');
       $this->boolean(\Config::validatePassword('mypass'))->isFalse();
       $CFG_GLPI['password_min_length'] = 8; //reset
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])
-         ->isIdenticalTo($expected);
 
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, $expected);
+
       $expected = [
-         ERROR => [
-            'Password must include at least a uppercase letter!',
-            'Password must include at least a symbol!'
-         ]
+         'Password must include at least a uppercase letter!',
+         'Password must include at least a symbol!'
       ];
       $this->boolean(\Config::validatePassword('my1password'))->isFalse();
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])
-         ->isIdenticalTo($expected);
+      $this->hasSessionMessage(ERROR, $expected);
 
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
       $CFG_GLPI['password_need_number'] = 0;
       $this->boolean(\Config::validatePassword('mypassword'))->isFalse();
       $CFG_GLPI['password_need_number'] = 1; //reset
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])
-         ->isIdenticalTo($expected);
+      $this->hasSessionMessage(ERROR, $expected);
 
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
       $expected = [
-         ERROR => [
-            'Password must include at least a symbol!'
-         ]
+         'Password must include at least a symbol!'
       ];
       $this->boolean(\Config::validatePassword('my1paSsword'))->isFalse();
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])
-         ->isIdenticalTo($expected);
+      $this->hasSessionMessage(ERROR, $expected);
 
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
       $CFG_GLPI['password_need_caps'] = 0;
       $this->boolean(\Config::validatePassword('my1password'))->isFalse();
       $CFG_GLPI['password_need_caps'] = 1; //reset
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])
-         ->isIdenticalTo($expected);
+      $this->hasSessionMessage(ERROR, $expected);
 
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
       $this->boolean(\Config::validatePassword('my1paSsw@rd'))->isTrue();
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])
          ->isEmpty();
 
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
       $CFG_GLPI['password_need_symbol'] = 0;
       $this->boolean(\Config::validatePassword('my1paSsword'))->isTrue();
       $CFG_GLPI['password_need_symbol'] = 1; //reset

--- a/tests/functionnal/Config.php
+++ b/tests/functionnal/Config.php
@@ -185,43 +185,43 @@ class Config extends DbTestCase {
          'Password must include at least a uppercase letter!',
          'Password must include at least a symbol!'
       ];
-      $this->hasSessionMessage(ERROR, $expected);
+      $this->hasSessionMessages(ERROR, $expected);
       $expected = [
          'Password must include at least a digit!',
          'Password must include at least a uppercase letter!',
          'Password must include at least a symbol!'
       ];
       $this->boolean(\Config::validatePassword('mypassword'))->isFalse();
-      $this->hasSessionMessage(ERROR, $expected);
+      $this->hasSessionMessages(ERROR, $expected);
 
       $CFG_GLPI['password_min_length'] = strlen('mypass');
       $this->boolean(\Config::validatePassword('mypass'))->isFalse();
       $CFG_GLPI['password_min_length'] = 8; //reset
 
-      $this->hasSessionMessage(ERROR, $expected);
+      $this->hasSessionMessages(ERROR, $expected);
 
       $expected = [
          'Password must include at least a uppercase letter!',
          'Password must include at least a symbol!'
       ];
       $this->boolean(\Config::validatePassword('my1password'))->isFalse();
-      $this->hasSessionMessage(ERROR, $expected);
+      $this->hasSessionMessages(ERROR, $expected);
 
       $CFG_GLPI['password_need_number'] = 0;
       $this->boolean(\Config::validatePassword('mypassword'))->isFalse();
       $CFG_GLPI['password_need_number'] = 1; //reset
-      $this->hasSessionMessage(ERROR, $expected);
+      $this->hasSessionMessages(ERROR, $expected);
 
       $expected = [
          'Password must include at least a symbol!'
       ];
       $this->boolean(\Config::validatePassword('my1paSsword'))->isFalse();
-      $this->hasSessionMessage(ERROR, $expected);
+      $this->hasSessionMessages(ERROR, $expected);
 
       $CFG_GLPI['password_need_caps'] = 0;
       $this->boolean(\Config::validatePassword('my1password'))->isFalse();
       $CFG_GLPI['password_need_caps'] = 1; //reset
-      $this->hasSessionMessage(ERROR, $expected);
+      $this->hasSessionMessages(ERROR, $expected);
 
       $this->boolean(\Config::validatePassword('my1paSsw@rd'))->isTrue();
       $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])

--- a/tests/functionnal/Config.php
+++ b/tests/functionnal/Config.php
@@ -224,14 +224,12 @@ class Config extends DbTestCase {
       $this->hasSessionMessages(ERROR, $expected);
 
       $this->boolean(\Config::validatePassword('my1paSsw@rd'))->isTrue();
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])
-         ->isEmpty();
+      $this->hasNoSessionMessage(ERROR);
 
       $CFG_GLPI['password_need_symbol'] = 0;
       $this->boolean(\Config::validatePassword('my1paSsword'))->isTrue();
       $CFG_GLPI['password_need_symbol'] = 1; //reset
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])
-         ->isEmpty();
+      $this->hasNoSessionMessage(ERROR);
    }
 
    public function testGetLibraries() {

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -42,6 +42,15 @@ class DbUtils extends DbTestCase {
       'testGetSonsOfCached'
    ];
 
+   public function beforeTestMethod($method) {
+      parent::beforeTestMethod($method);
+      if (in_array($method, $this->cached_methods)) {
+         $_SESSION['glpicronuserrunning'] = "cron_phpunit";
+      } else {
+         $this->login();
+      }
+   }
+
    public function setUp() {
       global $CFG_GLPI;
 

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -46,8 +46,6 @@ class DbUtils extends DbTestCase {
       parent::beforeTestMethod($method);
       if (in_array($method, $this->cached_methods)) {
          $_SESSION['glpicronuserrunning'] = "cron_phpunit";
-      } else {
-         $this->login();
       }
    }
 
@@ -758,6 +756,7 @@ class DbUtils extends DbTestCase {
 
    public function testGetAncestorsOf() {
       global $DB;
+      $this->login();
       //ensure db cache is unset
       $DB->update('glpi_entities', ['ancestors_cache' => null], [true]);
       $this->runGetAncestorsOf();
@@ -916,6 +915,7 @@ class DbUtils extends DbTestCase {
 
    public function testGetSonsOf() {
       global $DB;
+      $this->login();
       //ensure db cache is unset
       $DB->update('glpi_entities', ['sons_cache' => null], [true]);
       $this->runGetSonsOf();

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -96,14 +96,14 @@ class Entity extends DbTestCase {
             'name' => ''
          ])
       )->isFalse();
-      $this->hasSessionMessage(ERROR, ["You can't add an entity without name"]);
+      $this->hasSessionMessages(ERROR, ["You can't add an entity without name"]);
 
       $this->boolean(
          $entity->prepareInputForAdd([
             'anykey' => 'anyvalue'
          ])
       )->isFalse();
-      $this->hasSessionMessage(ERROR, ["You can't add an entity without name"]);
+      $this->hasSessionMessages(ERROR, ["You can't add an entity without name"]);
 
       $this->array(
          $entity->prepareInputForAdd([

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -44,7 +44,6 @@ class Entity extends DbTestCase {
 
    public function beforeTestMethod($method) {
       parent::beforeTestMethod($method);
-      $this->login();
    }
 
    public function testSonsAncestors() {
@@ -89,6 +88,7 @@ class Entity extends DbTestCase {
    }
 
    public function testPrepareInputForAdd() {
+      $this->login();
       $entity = new \Entity();
 
       $this->boolean(
@@ -125,6 +125,7 @@ class Entity extends DbTestCase {
     * @return void
     */
    public function runChangeEntityParent($cache = false, $hit = false) {
+      $this->login();
       $ent0 = getItemByTypeName('Entity', '_test_root_entity', true);
       $ent1 = getItemByTypeName('Entity', '_test_child_1', true);
       $ent2 = getItemByTypeName('Entity', '_test_child_2', true);
@@ -254,7 +255,7 @@ class Entity extends DbTestCase {
    }
 
    public function testDeleteEntity() {
-
+      $this->login();
       $root_id = getItemByTypeName('Entity', '_test_root_entity', true);
 
       $entity = new \Entity();

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -42,6 +42,11 @@ class Entity extends DbTestCase {
       'testChangeEntityParentCached'
    ];
 
+   public function beforeTestMethod($method) {
+      parent::beforeTestMethod($method);
+      $this->login();
+   }
+
    public function testSonsAncestors() {
       $ent0 = getItemByTypeName('Entity', '_test_root_entity');
       $this->string($ent0->getField('completename'))
@@ -91,12 +96,14 @@ class Entity extends DbTestCase {
             'name' => ''
          ])
       )->isFalse();
+      $this->hasSessionMessage(ERROR, ["You can't add an entity without name"]);
 
       $this->boolean(
          $entity->prepareInputForAdd([
             'anykey' => 'anyvalue'
          ])
       )->isFalse();
+      $this->hasSessionMessage(ERROR, ["You can't add an entity without name"]);
 
       $this->array(
          $entity->prepareInputForAdd([

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -42,10 +42,6 @@ class Entity extends DbTestCase {
       'testChangeEntityParentCached'
    ];
 
-   public function beforeTestMethod($method) {
-      parent::beforeTestMethod($method);
-   }
-
    public function testSonsAncestors() {
       $ent0 = getItemByTypeName('Entity', '_test_root_entity');
       $this->string($ent0->getField('completename'))

--- a/tests/functionnal/ITILSolution.php
+++ b/tests/functionnal/ITILSolution.php
@@ -294,6 +294,7 @@ class ITILSolution extends DbTestCase {
             'content'   => '2nd solution, should be refused!'
          ])
       )->isFalse();
+      $this->hasSessionMessage(ERROR, ['The item is already solved, did anyone pushed a solution before you ?']);
    }
 
    public function testScreenshotConvertedIntoDocument() {

--- a/tests/functionnal/ITILSolution.php
+++ b/tests/functionnal/ITILSolution.php
@@ -294,7 +294,7 @@ class ITILSolution extends DbTestCase {
             'content'   => '2nd solution, should be refused!'
          ])
       )->isFalse();
-      $this->hasSessionMessage(ERROR, ['The item is already solved, did anyone pushed a solution before you ?']);
+      $this->hasSessionMessages(ERROR, ['The item is already solved, did anyone pushed a solution before you ?']);
    }
 
    public function testScreenshotConvertedIntoDocument() {

--- a/tests/functionnal/ITILTemplate.php
+++ b/tests/functionnal/ITILTemplate.php
@@ -125,10 +125,7 @@ class ITILTemplate extends DbTestCase {
 
       $err_msg = 'Mandatory fields are not filled. Please correct: Title' .
          ($itiltype === \Ticket::getType() ? ', Location' : '') . ', Description';
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => [$err_msg]]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, [$err_msg]);
 
       $content['name']           = 'Title is required';
       $content['content']        = 'Description from template';
@@ -137,13 +134,12 @@ class ITILTemplate extends DbTestCase {
       $tid = (int)$object->add($content);
       $this->integer($tid)->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([
-         ERROR => [
+      $this->hasSessionMessage(
+         ERROR, [
             'You cannot use predefined description verbatim',
             'Mandatory fields are not filled. Please correct: Description'
          ]
-      ]);
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      );
 
       $content['content'] = 'A content for our ' . $itiltype;
       $tid = (int)$object->add($content);

--- a/tests/functionnal/ITILTemplate.php
+++ b/tests/functionnal/ITILTemplate.php
@@ -125,7 +125,7 @@ class ITILTemplate extends DbTestCase {
 
       $err_msg = 'Mandatory fields are not filled. Please correct: Title' .
          ($itiltype === \Ticket::getType() ? ', Location' : '') . ', Description';
-      $this->hasSessionMessage(ERROR, [$err_msg]);
+      $this->hasSessionMessages(ERROR, [$err_msg]);
 
       $content['name']           = 'Title is required';
       $content['content']        = 'Description from template';
@@ -134,7 +134,7 @@ class ITILTemplate extends DbTestCase {
       $tid = (int)$object->add($content);
       $this->integer($tid)->isIdenticalTo(0);
 
-      $this->hasSessionMessage(
+      $this->hasSessionMessages(
          ERROR, [
             'You cannot use predefined description verbatim',
             'Mandatory fields are not filled. Please correct: Description'

--- a/tests/functionnal/Item_Cluster.php
+++ b/tests/functionnal/Item_Cluster.php
@@ -122,7 +122,7 @@ class Item_Cluster extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessages(ERROR, ['An item type is required']);
+      $this->hasSessionMessages(ERROR, ['An item is required']);
 
       //try to add without error
       $icl->getEmpty();

--- a/tests/functionnal/Item_Cluster.php
+++ b/tests/functionnal/Item_Cluster.php
@@ -75,7 +75,6 @@ class Item_Cluster extends DbTestCase {
     */
    public function testAdd() {
       $this->createComputers();
-      unset($_SESSION['glpicronuserrunning']);
 
       $cluster = new \Cluster();
 

--- a/tests/functionnal/Item_Cluster.php
+++ b/tests/functionnal/Item_Cluster.php
@@ -100,10 +100,7 @@ class Item_Cluster extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['A cluster is required']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessages(ERROR, ['A cluster is required']);
 
       //try to add without required field
       $icl->getEmpty();
@@ -114,10 +111,7 @@ class Item_Cluster extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['An item type is required']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessages(ERROR, ['An item type is required']);
 
       //try to add without required field
       $icl->getEmpty();
@@ -128,10 +122,7 @@ class Item_Cluster extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['An item is required']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessages(ERROR, ['An item type is required']);
 
       //try to add without error
       $icl->getEmpty();

--- a/tests/functionnal/Item_Rack.php
+++ b/tests/functionnal/Item_Rack.php
@@ -205,7 +205,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessage(ERROR, ['Item is out of rack bounds']);
+      $this->hasSessionMessages(ERROR, ['Item is out of rack bounds']);
 
       //add item at the first position
       $ira->getEmpty();
@@ -230,7 +230,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessage(ERROR, ['Item is out of rack bounds']);
+      $this->hasSessionMessages(ERROR, ['Item is out of rack bounds']);
 
       //take a 3U item and try to add it at the end - 1
       $ira->getEmpty();
@@ -243,7 +243,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessage(ERROR, ['Item is out of rack bounds']);
+      $this->hasSessionMessages(ERROR, ['Item is out of rack bounds']);
 
       //take a 3U item and try to add it at the end - 2
       $ira->getEmpty();
@@ -271,7 +271,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessage(ERROR, ['You must define an horizontal position for this item']);
+      $this->hasSessionMessages(ERROR, ['You must define an horizontal position for this item']);
 
       //try to add a half size on the first row
       $ira->getEmpty();
@@ -285,7 +285,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
+      $this->hasSessionMessages(ERROR, ['Not enough space available to place item']);
 
       //add it on second row
       $ira->getEmpty();
@@ -311,7 +311,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
+      $this->hasSessionMessages(ERROR, ['Not enough space available to place item']);
 
       //add second half rack item it on second row, on the other position
       $ira->getEmpty();
@@ -337,7 +337,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
+      $this->hasSessionMessages(ERROR, ['Not enough space available to place item']);
 
       //test depth < 1
       $DEPNUX1 = getItemByTypeName('Computer', 'DEP-NUX-1', true);
@@ -354,7 +354,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessage(ERROR, ['You must define an orientation for this item']);
+      $this->hasSessionMessages(ERROR, ['You must define an orientation for this item']);
 
       //try to add on the first row
       $ira->getEmpty();
@@ -368,7 +368,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
+      $this->hasSessionMessages(ERROR, ['Not enough space available to place item']);
 
       //try to add on the second row
       $ira->getEmpty();
@@ -382,7 +382,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
+      $this->hasSessionMessages(ERROR, ['Not enough space available to place item']);
 
       //add on the third row
       $ira->getEmpty();
@@ -409,7 +409,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
+      $this->hasSessionMessages(ERROR, ['Not enough space available to place item']);
 
       $ira->getEmpty();
       $this->integer(
@@ -442,7 +442,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
+      $this->hasSessionMessages(ERROR, ['Not enough space available to place item']);
 
       $ira->getEmpty();
       $this->integer(
@@ -468,7 +468,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
+      $this->hasSessionMessages(ERROR, ['Not enough space available to place item']);
 
       $ira->getEmpty();
       $this->integer(

--- a/tests/functionnal/Item_Rack.php
+++ b/tests/functionnal/Item_Rack.php
@@ -178,7 +178,6 @@ class Item_Rack extends DbTestCase {
    public function testAdd() {
       $this->createModels();
       $this->createComputers();
-      unset($_SESSION['glpicronuserrunning']);
 
       $rack = new \Rack();
       //create a 10u rack
@@ -206,10 +205,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Item is out of rack bounds']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['Item is out of rack bounds']);
 
       //add item at the first position
       $ira->getEmpty();
@@ -234,10 +230,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Item is out of rack bounds']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['Item is out of rack bounds']);
 
       //take a 3U item and try to add it at the end - 1
       $ira->getEmpty();
@@ -250,10 +243,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Item is out of rack bounds']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['Item is out of rack bounds']);
 
       //take a 3U item and try to add it at the end - 2
       $ira->getEmpty();
@@ -281,10 +271,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['You must define an horizontal position for this item']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['You must define an horizontal position for this item']);
 
       //try to add a half size on the first row
       $ira->getEmpty();
@@ -298,10 +285,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
 
       //add it on second row
       $ira->getEmpty();
@@ -327,10 +311,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
 
       //add second half rack item it on second row, on the other position
       $ira->getEmpty();
@@ -356,10 +337,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
 
       //test depth < 1
       $DEPNUX1 = getItemByTypeName('Computer', 'DEP-NUX-1', true);
@@ -376,10 +354,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['You must define an orientation for this item']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['You must define an orientation for this item']);
 
       //try to add on the first row
       $ira->getEmpty();
@@ -393,10 +368,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
 
       //try to add on the second row
       $ira->getEmpty();
@@ -410,10 +382,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
 
       //add on the third row
       $ira->getEmpty();
@@ -440,10 +409,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
 
       $ira->getEmpty();
       $this->integer(
@@ -476,10 +442,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
 
       $ira->getEmpty();
       $this->integer(
@@ -505,10 +468,7 @@ class Item_Rack extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['Not enough space available to place item']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['Not enough space available to place item']);
 
       $ira->getEmpty();
       $this->integer(

--- a/tests/functionnal/ProjectTask.php
+++ b/tests/functionnal/ProjectTask.php
@@ -68,7 +68,7 @@ class ProjectTask extends DbTestCase {
             'projecttasktemplates_id'  => 0
          ])
       )->isGreaterThan(0);
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isEmpty();
+      $this->hasNoSessionMessages([ERROR, WARNING]);
       $task_id = $ptask->fields['id'];
 
       $team = new \ProjectTaskTeam();

--- a/tests/functionnal/ProjectTask.php
+++ b/tests/functionnal/ProjectTask.php
@@ -51,10 +51,7 @@ class ProjectTask extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(
-         [ERROR => ['A linked project is mandatory']]
-      );
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['A linked project is mandatory']);
 
       $project = new \Project();
       $pid = (int)$project->add([
@@ -102,13 +99,12 @@ class ProjectTask extends DbTestCase {
       ]);
 
       $usr_str = '<a href="' . $user->getFormURLWithID($users_id) . '">' . $user->getName() . '</a>';
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([
-         WARNING => [
+      $this->hasSessionMessage(
+         WARNING, [
             "The user $usr_str is busy at the selected timeframe.<br/>- Project task: from 2019-08-13 00:00 to 2019-08-14 00:00:<br/><a href='".
             $ptask->getFormURLWithID($task_id)."'>first test, whole period</a><br/>"
          ]
-      ]);
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      );
       $this->integer($tid)->isGreaterThan(0);
 
       //check when updating. first create a new task out of existing bouds
@@ -162,12 +158,11 @@ class ProjectTask extends DbTestCase {
       $this->boolean($ticket->isNewItem())->isFalse();
       $tid = (int)$ticket->fields['id'];
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([
-         INFO => [
+      $this->hasSessionMessage(
+         INFO, [
             "Your ticket has been registered. (Ticket: <a href='".\Ticket::getFormURLWithID($tid)."'>$tid</a>)"
          ]
-      ]);
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      );
 
       $ttask = new \TicketTask();
       $ttask_id = (int)$ttask->add([
@@ -182,13 +177,13 @@ class ProjectTask extends DbTestCase {
          'tasktemplates_id'   => 0
       ]);
       $usr_str = '<a href="' . $user->getFormURLWithID($users_id) . '">' . $user->getName() . '</a>';
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([
-         WARNING => [
+
+      $this->hasSessionMessage(
+         WARNING, [
             "The user $usr_str is busy at the selected timeframe.<br/>- Project task: from 2019-08-11  to 2019-08-12 :<br/><a href='".
             $ptask->getFormURLWithID($task_id)."'>first test, whole period</a><br/>"
          ]
-      ]);
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      );
       $this->integer($ttask_id)->isGreaterThan(0);
    }
 }

--- a/tests/functionnal/ProjectTask.php
+++ b/tests/functionnal/ProjectTask.php
@@ -77,7 +77,7 @@ class ProjectTask extends DbTestCase {
          'itemtype'        => \User::getType(),
          'items_id'        => $users_id
       ]);
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isEmpty();
+      $this->hasNoSessionMessages([ERROR, WARNING]);
       $this->integer($tid)->isGreaterThan(0);
 
       $this->integer(
@@ -89,7 +89,7 @@ class ProjectTask extends DbTestCase {
             'projecttasktemplates_id'  => 0
          ])
       )->isGreaterThan(0);
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isEmpty();
+      $this->hasNoSessionMessages([ERROR, WARNING]);
 
       $team = new \ProjectTaskTeam();
       $tid = (int)$team->add([
@@ -117,7 +117,7 @@ class ProjectTask extends DbTestCase {
             'projecttasktemplates_id'  => 0
          ])
       )->isGreaterThan(0);
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isEmpty();
+      $this->hasNoSessionMessages([ERROR, WARNING]);
 
       $team = new \ProjectTaskTeam();
       $tid = (int)$team->add([
@@ -125,7 +125,7 @@ class ProjectTask extends DbTestCase {
          'itemtype'        => \User::getType(),
          'items_id'        => $users_id
       ]);
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isEmpty();
+      $this->hasNoSessionMessages([ERROR, WARNING]);
       $this->integer($tid)->isGreaterThan(0);
 
       $this->boolean(

--- a/tests/functionnal/ProjectTask.php
+++ b/tests/functionnal/ProjectTask.php
@@ -51,7 +51,7 @@ class ProjectTask extends DbTestCase {
          ])
       )->isIdenticalTo(0);
 
-      $this->hasSessionMessage(ERROR, ['A linked project is mandatory']);
+      $this->hasSessionMessages(ERROR, ['A linked project is mandatory']);
 
       $project = new \Project();
       $pid = (int)$project->add([
@@ -99,7 +99,7 @@ class ProjectTask extends DbTestCase {
       ]);
 
       $usr_str = '<a href="' . $user->getFormURLWithID($users_id) . '">' . $user->getName() . '</a>';
-      $this->hasSessionMessage(
+      $this->hasSessionMessages(
          WARNING, [
             "The user $usr_str is busy at the selected timeframe.<br/>- Project task: from 2019-08-13 00:00 to 2019-08-14 00:00:<br/><a href='".
             $ptask->getFormURLWithID($task_id)."'>first test, whole period</a><br/>"
@@ -158,7 +158,7 @@ class ProjectTask extends DbTestCase {
       $this->boolean($ticket->isNewItem())->isFalse();
       $tid = (int)$ticket->fields['id'];
 
-      $this->hasSessionMessage(
+      $this->hasSessionMessages(
          INFO, [
             "Your ticket has been registered. (Ticket: <a href='".\Ticket::getFormURLWithID($tid)."'>$tid</a>)"
          ]
@@ -178,7 +178,7 @@ class ProjectTask extends DbTestCase {
       ]);
       $usr_str = '<a href="' . $user->getFormURLWithID($users_id) . '">' . $user->getName() . '</a>';
 
-      $this->hasSessionMessage(
+      $this->hasSessionMessages(
          WARNING, [
             "The user $usr_str is busy at the selected timeframe.<br/>- Project task: from 2019-08-11  to 2019-08-12 :<br/><a href='".
             $ptask->getFormURLWithID($task_id)."'>first test, whole period</a><br/>"

--- a/tests/functionnal/Session.php
+++ b/tests/functionnal/Session.php
@@ -283,6 +283,7 @@ class Session extends \DbTestCase {
    public function testMustChangePassword(string $last_update, int $expiration_delay, bool $expected_result) {
       global $CFG_GLPI;
 
+      $this->login();
       $user = new \User();
       $username = 'test_must_change_pass_' . mt_rand();
       $user_id = (int)$user->add([

--- a/tests/functionnal/SoftwareLicense.php
+++ b/tests/functionnal/SoftwareLicense.php
@@ -56,7 +56,7 @@ class SoftwareLicense extends DbTestCase {
          'entities_id'  => 0
       ];
       $this->boolean($license->prepareInputForAdd($input))->isFalse();
-      $this->hasSessionMessage(ERROR, ['Please select a software for this license']);
+      $this->hasSessionMessages(ERROR, ['Please select a software for this license']);
 
       //With a softwares_id, import ok
       $input = [ 'name' => 'inserted_sofwarelicense', 'softwares_id' => 1];
@@ -104,7 +104,7 @@ class SoftwareLicense extends DbTestCase {
       $input = [ 'name' => 'not_inserted_software_license_child'];
 
       $this->boolean($license->add($input))->isFalse();
-      $this->hasSessionMessage(ERROR, ['Please select a software for this license']);
+      $this->hasSessionMessages(ERROR, ['Please select a software for this license']);
 
       $software     = $this->createSoft();
 

--- a/tests/functionnal/SoftwareLicense.php
+++ b/tests/functionnal/SoftwareLicense.php
@@ -56,6 +56,7 @@ class SoftwareLicense extends DbTestCase {
          'entities_id'  => 0
       ];
       $this->boolean($license->prepareInputForAdd($input))->isFalse();
+      $this->hasSessionMessage(ERROR, ['Please select a software for this license']);
 
       //With a softwares_id, import ok
       $input = [ 'name' => 'inserted_sofwarelicense', 'softwares_id' => 1];
@@ -103,6 +104,7 @@ class SoftwareLicense extends DbTestCase {
       $input = [ 'name' => 'not_inserted_software_license_child'];
 
       $this->boolean($license->add($input))->isFalse();
+      $this->hasSessionMessage(ERROR, ['Please select a software for this license']);
 
       $software     = $this->createSoft();
 

--- a/tests/functionnal/Telemetry.php
+++ b/tests/functionnal/Telemetry.php
@@ -39,6 +39,9 @@ use \DbTestCase;
 class Telemetry extends DbTestCase {
 
    public function testGrabGlpiInfos() {
+      //we do not want any error messages
+      $_SESSION['glpicronuserrunning'] = "cron_phpunit";
+
       $expected = [
          'uuid'               => 'TO BE SET',
          'version'            => GLPI_VERSION,
@@ -65,11 +68,6 @@ class Telemetry extends DbTestCase {
       $this->string($result['uuid'])
          ->hasLength(40);
       $expected['uuid'] = $result['uuid'];
-      $plugins_count = 0;
-      foreach (PLUGINS_DIRECTORIES as $plugin_base_dir) {
-         $plugins_count += count(glob("$plugin_base_dir/*", GLOB_ONLYDIR));
-      }
-      $this->array($result['plugins'])->hasSize($plugins_count);
       $expected['plugins'] = $result['plugins'];
       $this->array($result)->isIdenticalTo($expected);
 

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -2607,7 +2607,6 @@ class Ticket extends DbTestCase {
       $this->login(); // must be logged as Document_Item uses Session::getLoginUserID()
 
       global $DB;
-      $this->login();
       // set default calendar and autoclose delay in root entity
       $entity = new \Entity;
       $this->boolean($entity->update([

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -2161,6 +2161,7 @@ class Ticket extends DbTestCase {
 
    public function testCronCloseTicket() {
       global $DB;
+      $this->login();
       // set default calendar and autoclose delay in root entity
       $entity = new \Entity;
       $this->boolean($entity->update([
@@ -2212,7 +2213,7 @@ class Ticket extends DbTestCase {
     * @see self::testTakeIntoAccountDelayComputationOnUpdate()
     */
    protected function takeIntoAccountDelayComputationProvider() {
-
+      $this->login();
       $group = new \Group();
       $group_id = $group->add(['name' => 'Test group']);
       $this->integer((int)$group_id)->isGreaterThan(0);
@@ -2606,6 +2607,7 @@ class Ticket extends DbTestCase {
       $this->login(); // must be logged as Document_Item uses Session::getLoginUserID()
 
       global $DB;
+      $this->login();
       // set default calendar and autoclose delay in root entity
       $entity = new \Entity;
       $this->boolean($entity->update([

--- a/tests/functionnal/TicketRecurrent.php
+++ b/tests/functionnal/TicketRecurrent.php
@@ -459,7 +459,7 @@ class TicketRecurrent extends DbTestCase {
       if ($messages === null) {
          $this->hasNoSessionMessage(ERROR);
       } else {
-         $this->hasSessionMessage(ERROR, $messages);
+         $this->hasSessionMessages(ERROR, $messages);
       }
    }
 

--- a/tests/functionnal/TicketRecurrent.php
+++ b/tests/functionnal/TicketRecurrent.php
@@ -116,6 +116,7 @@ class TicketRecurrent extends DbTestCase {
             'create_before'  => HOUR_TIMESTAMP * 2,
             'calendars_id'   => 0,
             'expected_value' => 'NULL',
+            'messages'       => ['Invalid frequency. It must be greater than the preliminary creation.']
          ],
          // End date in past
          [
@@ -431,6 +432,7 @@ class TicketRecurrent extends DbTestCase {
     * @param integer        $create_before
     * @param integer        $calendars_id
     * @param string         $expected_value
+    * @param array          $messages
     *
     * @dataProvider computeNextCreationDateProvider
     */
@@ -440,7 +442,9 @@ class TicketRecurrent extends DbTestCase {
       $periodicity,
       $create_before,
       $calendars_id,
-      $expected_value) {
+      $expected_value,
+      $messages = null
+   ) {
 
       $ticketRecurrent = new \TicketRecurrent();
       $value = $ticketRecurrent->computeNextCreationDate(
@@ -452,6 +456,11 @@ class TicketRecurrent extends DbTestCase {
       );
 
       $this->string($value)->isIdenticalTo($expected_value);
+      if ($messages === null) {
+         $this->hasNoSessionMessage(ERROR);
+      } else {
+         $this->hasSessionMessage(ERROR, $messages);
+      }
    }
 
    /**

--- a/tests/functionnal/TicketTask.php
+++ b/tests/functionnal/TicketTask.php
@@ -117,6 +117,12 @@ class TicketTask extends DbTestCase {
                                              ]))->isTrue();
 
       //create one task with schedule and without recall
+      $date_begin->add(new \DateInterval('P1M'));
+      $date_begin_string = $date_begin->format('Y-m-d H:i:s');
+
+      $date_end->add(new \DateInterval('P1M'));
+      $date_end_string = $date_end->format('Y-m-d H:i:s');
+
       $task = new \TicketTask();
       $task_id = $task->add([
          'state'              => \Planning::TODO,
@@ -137,18 +143,6 @@ class TicketTask extends DbTestCase {
                               ]
       ]);
       $this->integer($task_id)->isGreaterThan(0);
-
-      $this->hasSessionMessages(
-         WARNING, [
-            sprintf(
-               'The user <a href="/glpi/front/user.form.php?id=%s">_test_user</a> is busy at the selected timeframe.<br/>- Ticket task: from %s to %s:<br/><a href=\'/glpi/front/ticket.form.php?id=%s&amp;forcetab=TicketTask$1\'>ticket title</a><br/>',
-               $uid,
-               $date_begin->format('Y-m-d H:i'),
-               $date_end->format('Y-m-d H:i'),
-               $ticketId
-            )
-         ]
-      );
 
       //load schedule //which return false (not exist yet without recall)
       $recall = new \PlanningRecall();
@@ -180,18 +174,6 @@ class TicketTask extends DbTestCase {
                               ]
       ])
       )->isTrue();
-
-      $this->hasSessionMessages(
-         WARNING, [
-            sprintf(
-               'The user <a href="/glpi/front/user.form.php?id=%s">_test_user</a> is busy at the selected timeframe.<br/>- Ticket task: from %s to %s:<br/><a href=\'/glpi/front/ticket.form.php?id=%s&amp;forcetab=TicketTask$1\'>ticket title</a><br/>',
-               $uid,
-               $date_begin->format('Y-m-d H:i'),
-               $date_end->format('Y-m-d H:i'),
-               $ticketId
-            )
-         ]
-      );
 
       //load planning recall
       $recall = new \PlanningRecall();

--- a/tests/functionnal/TicketTask.php
+++ b/tests/functionnal/TicketTask.php
@@ -61,12 +61,11 @@ class TicketTask extends DbTestCase {
       $this->boolean($ticket->isNewItem())->isFalse();
       $tid = (int)$ticket->fields['id'];
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([
-         INFO => [
+      $this->hasSessionMessage(
+         INFO, [
             "Your ticket has been registered. (Ticket: <a href='".\Ticket::getFormURLWithID($tid)."'>$tid</a>)"
          ]
-      ]);
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      );
 
       return ($as_object ? $ticket : $tid);
    }
@@ -139,6 +138,18 @@ class TicketTask extends DbTestCase {
       ]);
       $this->integer($task_id)->isGreaterThan(0);
 
+      $this->hasSessionMessage(
+         WARNING, [
+            sprintf(
+               'The user <a href="/glpi/front/user.form.php?id=%s">_test_user</a> is busy at the selected timeframe.<br/>- Ticket task: from %s to %s:<br/><a href=\'/glpi/front/ticket.form.php?id=%s&amp;forcetab=TicketTask$1\'>ticket title</a><br/>',
+               $uid,
+               $date_begin->format('Y-m-d H:i'),
+               $date_end->format('Y-m-d H:i'),
+               $ticketId
+            )
+         ]
+      );
+
       //load schedule //which return false (not exist yet without recall)
       $recall = new \PlanningRecall();
       $this->boolean($recall->getFromDBByCrit(['itemtype'   => 'TicketTask',
@@ -170,6 +181,18 @@ class TicketTask extends DbTestCase {
       ])
       )->isTrue();
 
+      $this->hasSessionMessage(
+         WARNING, [
+            sprintf(
+               'The user <a href="/glpi/front/user.form.php?id=%s">_test_user</a> is busy at the selected timeframe.<br/>- Ticket task: from %s to %s:<br/><a href=\'/glpi/front/ticket.form.php?id=%s&amp;forcetab=TicketTask$1\'>ticket title</a><br/>',
+               $uid,
+               $date_begin->format('Y-m-d H:i'),
+               $date_end->format('Y-m-d H:i'),
+               $ticketId
+            )
+         ]
+      );
+
       //load planning recall
       $recall = new \PlanningRecall();
 
@@ -181,7 +204,6 @@ class TicketTask extends DbTestCase {
                                                 'users_id'    => $uid,
                                                 'when'        => $when,
                                              ]))->isTrue();
-
    }
 
    public function testGetTaskList() {
@@ -307,13 +329,12 @@ class TicketTask extends DbTestCase {
       )->isGreaterThan(0);
 
       $usr_str = '<a href="' . $user->getFormURLWithID($users_id) . '">' . $user->getName() . '</a>';
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([
-         WARNING => [
+      $this->hasSessionMessage(
+         WARNING, [
             "The user $usr_str is busy at the selected timeframe.<br/>- Ticket task: from 2019-08-13  to 2019-08-14 :<br/><a href='".
             $ticket->getFormURLWithID($tid)."&amp;forcetab=TicketTask$1'>ticket title</a><br/>"
          ]
-      ]);
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      );
       $this->integer($tid)->isGreaterThan(0);
 
       //add another task to be updated
@@ -347,13 +368,12 @@ class TicketTask extends DbTestCase {
       )->isTrue();
 
       $usr_str = '<a href="' . $user->getFormURLWithID($users_id) . '">' . $user->getName() . '</a>';
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([
-         WARNING => [
+      $this->hasSessionMessage(
+         WARNING, [
             "The user $usr_str is busy at the selected timeframe.<br/>- Ticket task: from 2019-08-10 00:00 to 2019-08-20 00:00:<br/><a href='".
             $ticket->getFormURLWithID($tid)."&amp;forcetab=TicketTask$1'>ticket title</a><br/>- Ticket task: from 2019-08-13 00:00 to 2019-08-14 00:00:<br/><a href='".$ticket
             ->getFormURLWithID($tid)."&amp;forcetab=TicketTask$1'>ticket title</a><br/>"
          ]
-      ]);
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      );
    }
 }

--- a/tests/functionnal/TicketTask.php
+++ b/tests/functionnal/TicketTask.php
@@ -61,7 +61,7 @@ class TicketTask extends DbTestCase {
       $this->boolean($ticket->isNewItem())->isFalse();
       $tid = (int)$ticket->fields['id'];
 
-      $this->hasSessionMessage(
+      $this->hasSessionMessages(
          INFO, [
             "Your ticket has been registered. (Ticket: <a href='".\Ticket::getFormURLWithID($tid)."'>$tid</a>)"
          ]
@@ -138,7 +138,7 @@ class TicketTask extends DbTestCase {
       ]);
       $this->integer($task_id)->isGreaterThan(0);
 
-      $this->hasSessionMessage(
+      $this->hasSessionMessages(
          WARNING, [
             sprintf(
                'The user <a href="/glpi/front/user.form.php?id=%s">_test_user</a> is busy at the selected timeframe.<br/>- Ticket task: from %s to %s:<br/><a href=\'/glpi/front/ticket.form.php?id=%s&amp;forcetab=TicketTask$1\'>ticket title</a><br/>',
@@ -181,7 +181,7 @@ class TicketTask extends DbTestCase {
       ])
       )->isTrue();
 
-      $this->hasSessionMessage(
+      $this->hasSessionMessages(
          WARNING, [
             sprintf(
                'The user <a href="/glpi/front/user.form.php?id=%s">_test_user</a> is busy at the selected timeframe.<br/>- Ticket task: from %s to %s:<br/><a href=\'/glpi/front/ticket.form.php?id=%s&amp;forcetab=TicketTask$1\'>ticket title</a><br/>',
@@ -329,7 +329,7 @@ class TicketTask extends DbTestCase {
       )->isGreaterThan(0);
 
       $usr_str = '<a href="' . $user->getFormURLWithID($users_id) . '">' . $user->getName() . '</a>';
-      $this->hasSessionMessage(
+      $this->hasSessionMessages(
          WARNING, [
             "The user $usr_str is busy at the selected timeframe.<br/>- Ticket task: from 2019-08-13  to 2019-08-14 :<br/><a href='".
             $ticket->getFormURLWithID($tid)."&amp;forcetab=TicketTask$1'>ticket title</a><br/>"
@@ -368,7 +368,7 @@ class TicketTask extends DbTestCase {
       )->isTrue();
 
       $usr_str = '<a href="' . $user->getFormURLWithID($users_id) . '">' . $user->getName() . '</a>';
-      $this->hasSessionMessage(
+      $this->hasSessionMessages(
          WARNING, [
             "The user $usr_str is busy at the selected timeframe.<br/>- Ticket task: from 2019-08-10 00:00 to 2019-08-20 00:00:<br/><a href='".
             $ticket->getFormURLWithID($tid)."&amp;forcetab=TicketTask$1'>ticket title</a><br/>- Ticket task: from 2019-08-13 00:00 to 2019-08-14 00:00:<br/><a href='".$ticket

--- a/tests/functionnal/TicketTask.php
+++ b/tests/functionnal/TicketTask.php
@@ -312,7 +312,7 @@ class TicketTask extends DbTestCase {
             'tasktemplates_id'   => 0
          ])
       )->isGreaterThan(0);
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isEmpty();
+      $this->hasNoSessionMessages([ERROR, WARNING]);
 
       $this->integer(
          (int)$ttask->add([
@@ -351,7 +351,7 @@ class TicketTask extends DbTestCase {
             'tasktemplates_id'   => 0
          ])
       )->isGreaterThan(0);
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isEmpty();
+      $this->hasNoSessionMessages([ERROR, WARNING]);
 
       $this->boolean($ttask->getFromDB($ttask->fields['id']))->isTrue();
 

--- a/tests/functionnal/Ticket_Ticket.php
+++ b/tests/functionnal/Ticket_Ticket.php
@@ -153,6 +153,7 @@ class Ticket_Ticket extends DbTestCase {
    }
 
    public function testNumberOpen() {
+      $this->login();
       $this->createTickets();
       $tone = $this->tone;
       $ttwo = $this->ttwo;

--- a/tests/functionnal/User.php
+++ b/tests/functionnal/User.php
@@ -53,6 +53,8 @@ class User extends \DbTestCase {
     *
     */
    public function testLostPassword() {
+      //would not be logical to login here
+      $_SESSION['glpicronuserrunning'] = "cron_phpunit";
       $user = getItemByTypeName('User', TU_USER);
 
       // Test request for a password with invalid email
@@ -196,15 +198,13 @@ class User extends \DbTestCase {
 
       $input = ['name' => 'invalid+login'];
       $this->boolean($user->prepareInputForAdd($input))->isFalse();
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([ERROR => ['The login is not valid. Unable to add the user.']]);
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['The login is not valid. Unable to add the user.']);
 
       //add same user twice
       $input = ['name' => 'new_user'];
       $this->integer($user->add($input))->isGreaterThan(0);
       $this->boolean($user->add($input))->isFalse(0);
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([ERROR => ['Unable to add. The user already exists.']]);
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['Unable to add. The user already exists.']);
 
       $input = [
          'name'      => 'user_pass',
@@ -212,8 +212,7 @@ class User extends \DbTestCase {
          'password2' => 'nomatch'
       ];
       $this->boolean($user->prepareInputForAdd($input))->isFalse();
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([ERROR => ['Error: the two passwords do not match']]);
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['Error: the two passwords do not match']);
 
       $input = [
          'name'      => 'user_pass',
@@ -292,7 +291,7 @@ class User extends \DbTestCase {
     * @dataProvider prepareInputForTimezoneUpdateProvider
     */
    public function testPrepareInputForUpdateTimezone(array $input, $expected) {
-
+      $this->login();
       $user = $this->newTestedInstance();
       $username = 'prepare_for_update_' . mt_rand();
       $user_id = $user->add(
@@ -349,7 +348,7 @@ class User extends \DbTestCase {
     * @dataProvider prepareInputForUpdatePasswordProvider
     */
    public function testPrepareInputForUpdatePassword(array $input, $expected, array $messages = null) {
-
+      $this->login();
       $user = $this->newTestedInstance();
       $username = 'prepare_for_update_' . mt_rand();
       $user_id = $user->add(
@@ -691,8 +690,7 @@ class User extends \DbTestCase {
          'id'     => $uid,
          'name'   => 'do_exist'
       ]))->isTrue();
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([ERROR => ['Unable to update login. A user already exists.']]);
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['Unable to update login. A user already exists.']);
 
       $this->boolean($user->getFromDB($uid))->isTrue();
       $this->string($user->fields['name'])->isIdenticalTo('preupdate_user_edited');
@@ -701,8 +699,7 @@ class User extends \DbTestCase {
          'id'     => $uid,
          'name'   => 'in+valid'
       ]))->isTrue();
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([ERROR => ['The login is not valid. Unable to update login.']]);
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = []; //reset
+      $this->hasSessionMessage(ERROR, ['The login is not valid. Unable to update login.']);
    }
 
    public function testGetIdByName() {

--- a/tests/functionnal/User.php
+++ b/tests/functionnal/User.php
@@ -198,13 +198,13 @@ class User extends \DbTestCase {
 
       $input = ['name' => 'invalid+login'];
       $this->boolean($user->prepareInputForAdd($input))->isFalse();
-      $this->hasSessionMessage(ERROR, ['The login is not valid. Unable to add the user.']);
+      $this->hasSessionMessages(ERROR, ['The login is not valid. Unable to add the user.']);
 
       //add same user twice
       $input = ['name' => 'new_user'];
       $this->integer($user->add($input))->isGreaterThan(0);
       $this->boolean($user->add($input))->isFalse(0);
-      $this->hasSessionMessage(ERROR, ['Unable to add. The user already exists.']);
+      $this->hasSessionMessages(ERROR, ['Unable to add. The user already exists.']);
 
       $input = [
          'name'      => 'user_pass',
@@ -212,7 +212,7 @@ class User extends \DbTestCase {
          'password2' => 'nomatch'
       ];
       $this->boolean($user->prepareInputForAdd($input))->isFalse();
-      $this->hasSessionMessage(ERROR, ['Error: the two passwords do not match']);
+      $this->hasSessionMessages(ERROR, ['Error: the two passwords do not match']);
 
       $input = [
          'name'      => 'user_pass',
@@ -690,7 +690,7 @@ class User extends \DbTestCase {
          'id'     => $uid,
          'name'   => 'do_exist'
       ]))->isTrue();
-      $this->hasSessionMessage(ERROR, ['Unable to update login. A user already exists.']);
+      $this->hasSessionMessages(ERROR, ['Unable to update login. A user already exists.']);
 
       $this->boolean($user->getFromDB($uid))->isTrue();
       $this->string($user->fields['name'])->isIdenticalTo('preupdate_user_edited');
@@ -699,7 +699,7 @@ class User extends \DbTestCase {
          'id'     => $uid,
          'name'   => 'in+valid'
       ]))->isTrue();
-      $this->hasSessionMessage(ERROR, ['The login is not valid. Unable to update login.']);
+      $this->hasSessionMessages(ERROR, ['The login is not valid. Unable to update login.']);
    }
 
    public function testGetIdByName() {

--- a/tests/functionnal/User.php
+++ b/tests/functionnal/User.php
@@ -662,7 +662,6 @@ class User extends \DbTestCase {
    public function testPre_updateInDB() {
       $this->login();
       $user = $this->newTestedInstance();
-      $_SESSION['MESSAGE_AFTER_REDIRECT'] = [];
 
       $uid = (int)$user->add([
          'name' => 'preupdate_user'
@@ -674,14 +673,14 @@ class User extends \DbTestCase {
          'id'     => $uid,
          'name'   => 'preupdate_user_edited'
       ]))->isTrue();
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([]);
+      $this->hasNoSessionMessages([ERROR, WARNING]);
 
       //can update with same name when id is identical
       $this->boolean($user->update([
          'id'     => $uid,
          'name'   => 'preupdate_user_edited'
       ]))->isTrue();
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo([]);
+      $this->hasNoSessionMessages([ERROR, WARNING]);
 
       $this->integer(
          (int)$user->add(['name' => 'do_exist'])

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -105,6 +105,7 @@ class MailCollector extends DbTestCase {
    }
 
    public function testPrepareInput() {
+      $_SESSION['glpicronuserrunning'] = 'cron_phpunit';
       $this->newTestedInstance();
 
       $oinput = [
@@ -158,6 +159,7 @@ class MailCollector extends DbTestCase {
    }
 
    public function testCounts() {
+      $_SESSION['glpicronuserrunning'] = 'cron_phpunit';
       $this->newTestedInstance();
 
       $this->integer($this->testedInstance->countActiveCollectors())->isIdenticalTo(0);
@@ -221,6 +223,7 @@ class MailCollector extends DbTestCase {
 
    public function testCollect() {
       global $DB;
+      $_SESSION['glpicronuserrunning'] = 'cron_phpunit';
 
       //assign email to user
       $nuid = getItemByTypeName('User', 'normal', true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

The goal is to catch all redirection messages (warning and errors); and I've also added a method to make tests simpler.