### PR TITLE
fix(linked_ticket): fix cascade resolution

### DIFF
--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -349,24 +349,24 @@ class ITILSolution extends CommonDBChild {
          Ticket_Ticket::manageLinkedTicketsOnSolved($this->item->getID(), $this);
       }
 
-      $status = $item::SOLVED;
-
-      //handle autoclose, for tickets only
-      if ($item->getType() == Ticket::getType()) {
-         $autoclosedelay =  Entity::getUsedConfig(
-            'autoclose_delay',
-            $this->item->getEntityID(),
-            '',
-            Entity::CONFIG_NEVER
-         );
-
-         // 0 = immediatly
-         if ($autoclosedelay == 0) {
-            $status = $item::CLOSED;
-         }
-      }
-
       if (!isset($this->input['_linked_ticket'])) {
+         $status = $item::SOLVED;
+
+         //handle autoclose, for tickets only
+         if ($item->getType() == Ticket::getType()) {
+            $autoclosedelay =  Entity::getUsedConfig(
+               'autoclose_delay',
+               $this->item->getEntityID(),
+               '',
+               Entity::CONFIG_NEVER
+            );
+
+            // 0 = immediatly
+            if ($autoclosedelay == 0) {
+               $status = $item::CLOSED;
+            }
+         }
+
          $this->item->update([
             'id'     => $this->item->getID(),
             'status' => $status

--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -366,10 +366,13 @@ class ITILSolution extends CommonDBChild {
          }
       }
 
-      $this->item->update([
-         'id'     => $this->item->getID(),
-         'status' => $status
-      ]);
+      if (!isset($this->input['_linked_ticket'])) {
+         $this->item->update([
+            'id'     => $this->item->getID(),
+            'status' => $status
+         ]);
+      }
+
       parent::post_addItem();
    }
 


### PR DESCRIPTION

Fix cascade resolution for duplicate tickets

Actually, when linked tickets are manage, GLPI try to update status, but it's already done by parent ticket.

This PR fix this.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Internal 21194
