### PR TITLE
fix(clone): cloning relations too

### DIFF
--- a/inc/changetemplate.class.php
+++ b/inc/changetemplate.class.php
@@ -40,11 +40,21 @@ if (!defined('GLPI_ROOT')) {
  * since version 9.5.0
 **/
 class ChangeTemplate extends ITILTemplate {
+   use Glpi\Features\Clonable;
+
    public $second_level_menu         = "change";
    public $third_level_menu          = "ChangeTemplate";
 
    static function getTypeName($nb = 0) {
       return _n('Change template', 'change templates', $nb);
+   }
+
+   public function getCloneRelations() :array {
+      return [
+         ChangeTemplateHiddenField::class,
+         ChangeTemplateMandatoryField::class,
+         ChangeTemplatePredefinedField::class,
+      ];
    }
 
    public static function getExtraAllowedFields($withtypeandcategory = 0, $withitemtype = 0) {

--- a/inc/problemtemplate.class.php
+++ b/inc/problemtemplate.class.php
@@ -40,11 +40,21 @@ if (!defined('GLPI_ROOT')) {
  * since version 9.5.0
 **/
 class ProblemTemplate extends ITILTemplate {
+   use Glpi\Features\Clonable;
+
    public $second_level_menu         = "problem";
    public $third_level_menu          = "ProblemTemplate";
 
    static function getTypeName($nb = 0) {
       return _n('Problem template', 'Problem templates', $nb);
+   }
+
+   public function getCloneRelations() :array {
+      return [
+         ProblemTemplateHiddenField::class,
+         ProblemTemplateMandatoryField::class,
+         ProblemTemplatePredefinedField::class,
+      ];
    }
 
 }

--- a/inc/tickettemplate.class.php
+++ b/inc/tickettemplate.class.php
@@ -40,11 +40,21 @@ if (!defined('GLPI_ROOT')) {
  * since version 0.83
 **/
 class TicketTemplate extends ITILTemplate {
+   use Glpi\Features\Clonable;
+
    public $second_level_menu         = "ticket";
    public $third_level_menu          = "TicketTemplate";
 
    static function getTypeName($nb = 0) {
       return _n('Ticket template', 'Ticket templates', $nb);
+   }
+
+   public function getCloneRelations() :array {
+      return [
+         TicketTemplateHiddenField::class,
+         TicketTemplateMandatoryField::class,
+         TicketTemplatePredefinedField::class,
+      ];
    }
 
    public static function getExtraAllowedFields($withtypeandcategory = 0, $withitemtype = 0) {


### PR DESCRIPTION
The clone function for ticket template
 does not take into account relationships (hidden fields, predefined fields, mandatory fields).

This PR fix this

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 21229
