### PR TITLE
Prevent tests dataset loading to alter session

### DIFF
--- a/tests/APIBaseClass.php
+++ b/tests/APIBaseClass.php
@@ -49,6 +49,16 @@ abstract class APIBaseClass extends atoum {
    abstract public function initSessionCredentials();
 
    public function setUp() {
+      // To bypass various right checks
+      // This is mandatory to create/update/delete some items during tests.
+      $_SESSION['glpishowallentities'] = 1;
+      $_SESSION['glpiactive_entity']   = 0;
+      $_SESSION['glpiactiveentities']  = [0];
+      $_SESSION['glpiactiveentities_string'] = "'0'";
+
+      // Force "cron" mode to prevent user related behaviors
+      $_SESSION['glpicronuserrunning'] = "cron_phpunit";
+
       // enable api config
       $config = new Config;
       $config->update(['id'                              => 1,
@@ -56,7 +66,6 @@ abstract class APIBaseClass extends atoum {
                             'enable_api_login_credentials'    => true,
                             'enable_api_login_external_token' => true]);
    }
-
 
    /**
     * @tags   api

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -52,7 +52,6 @@ class GLPITestCase extends atoum {
    }
 
    public function beforeTestMethod($method) {
-      unset($_SESSION['glpicronuserrunning']);
       if (in_array($method, $this->cached_methods)) {
          $this->nscache = 'glpitestcache' . GLPI_VERSION;
          global $GLPI_CACHE;

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -42,16 +42,10 @@ class GLPITestCase extends atoum {
    protected $nscache;
    protected $has_failed = false;
 
-   public function setUp() {
-      // By default, no session, not connected
-      $_SESSION = [
-         'glpi_use_mode'         => Session::NORMAL_MODE,
-         'glpi_currenttime'      => date("Y-m-d H:i:s"),
-         'glpiis_ids_visible'    => 0
-      ];
-   }
-
    public function beforeTestMethod($method) {
+      // By default, no session, not connected
+      $this->resetSession();
+
       if (in_array($method, $this->cached_methods)) {
          $this->nscache = 'glpitestcache' . GLPI_VERSION;
          global $GLPI_CACHE;
@@ -106,6 +100,20 @@ class GLPITestCase extends atoum {
                print_r($_SESSION['MESSAGE_AFTER_REDIRECT'], true)
             )
          );
+      }
+   }
+
+   protected function resetSession() {
+      Session::destroy();
+      Session::start();
+
+      $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
+
+      global $CFG_GLPI;
+      foreach ($CFG_GLPI['user_pref_field'] as $field) {
+         if (!isset($_SESSION["glpi$field"]) && isset($CFG_GLPI[$field])) {
+            $_SESSION["glpi$field"] = $CFG_GLPI[$field];
+         }
       }
    }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -581,6 +581,7 @@ function loadDataset() {
    ];
 
    // To bypass various right checks
+   $session_bak = $_SESSION;
    $_SESSION['glpishowallentities'] = 1;
    $_SESSION['glpicronuserrunning'] = "cron_phpunit";
    $_SESSION['glpi_use_mode']       = Session::NORMAL_MODE;
@@ -591,7 +592,6 @@ function loadDataset() {
 
    $DB->beginTransaction();
 
-   // need to set theses in DB, because tests for API use http call and this bootstrap file is not called
    Config::setConfigurationValues('core', ['url_base'     => GLPI_URI,
                                            'url_base_api' => GLPI_URI . '/apirest.php']);
    $CFG_GLPI['url_base']      = GLPI_URI;
@@ -654,6 +654,8 @@ function loadDataset() {
       Config::setConfigurationValues('phpunit', ['dataset' => $data['_version']]);
    }
    $DB->commit();
+
+   $_SESSION = $session_bak; // Unset force session variables
 }
 
 /**

--- a/tests/functionnal/Certificate_Item.php
+++ b/tests/functionnal/Certificate_Item.php
@@ -39,29 +39,37 @@ use DbTestCase;
 class Certificate_Item extends DbTestCase {
 
    public function testRelations() {
+      $this->login();
+
+      $root_entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+
       $this->newTestedInstance();
       $cert = new \Certificate();
 
       $input = [
-         'name'   => 'Test certificate',
+         'name'        => 'Test certificate',
+         'entities_id' => $root_entity_id,
       ];
       $cid1 = (int)$cert->add($input);
       $this->integer($cid1)->isGreaterThan(0);
 
       $input = [
-         'name'   => 'Test certificate 2',
+         'name'        => 'Test certificate 2',
+         'entities_id' => $root_entity_id,
       ];
       $cid2 = (int)$cert->add($input);
       $this->integer($cid2)->isGreaterThan(0);
 
       $input = [
-         'name'   => 'Test certificate 3',
+         'name'        => 'Test certificate 3',
+         'entities_id' => $root_entity_id,
       ];
       $cid3 = (int)$cert->add($input);
       $this->integer($cid3)->isGreaterThan(0);
 
       $input = [
-         'name'   => 'Test certificate 4',
+         'name'        => 'Test certificate 4',
+         'entities_id' => $root_entity_id,
       ];
       $cid4 = (int)$cert->add($input);
       $this->integer($cid4)->isGreaterThan(0);

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -180,8 +180,8 @@ class CommonDBTM extends DbTestCase {
       $this->array($comp->fields)->isEmpty();
 
       $this->boolean($comp->getEmpty())->isTrue();
-      $this->array($comp->fields)
-         ->integer['entities_id']->isIdenticalTo($_SESSION["glpiactive_entity"]);
+      // Empty value if $_SESSION['glpiactive_entity'] is not set
+      $this->array($comp->fields)->string['entities_id']->isIdenticalTo('');
 
       $_SESSION["glpiactive_entity"] = 12;
       $this->boolean($comp->getEmpty())->isTrue();
@@ -1072,13 +1072,12 @@ class CommonDBTM extends DbTestCase {
       array $active_entities,
       array $expected
    ) {
-      $old_active_entities = $_SESSION['glpiactiveentities'];
       $_SESSION['glpiactiveentities'] = $active_entities;
 
       $res = \CommonDBTM::checkTemplateEntity($data, $parent_id, $parent_itemtype);
       $this->array($res)->isEqualTo($expected);
 
       // Reset session
-      $_SESSION['glpiactiveentities'] = $old_active_entities;
+      unset($_SESSION['glpiactiveentities']);
    }
 }

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -42,13 +42,6 @@ class DbUtils extends DbTestCase {
       'testGetSonsOfCached'
    ];
 
-   public function beforeTestMethod($method) {
-      parent::beforeTestMethod($method);
-      if (in_array($method, $this->cached_methods)) {
-         $_SESSION['glpicronuserrunning'] = "cron_phpunit";
-      }
-   }
-
    public function setUp() {
       global $CFG_GLPI;
 
@@ -775,6 +768,11 @@ class DbUtils extends DbTestCase {
     * @extensions apcu
     */
    public function testGetAncestorsOfCached() {
+      $this->login();
+
+      global $GLPI_CACHE;
+      $GLPI_CACHE->clear(); // login produce cache, must be cleared
+
       //run with cache
       //first run: no cache hit expected
       $this->runGetAncestorsOf(true);
@@ -935,6 +933,11 @@ class DbUtils extends DbTestCase {
     * @extensions apcu
     */
    public function testGetSonsOfCached() {
+      $this->login();
+
+      global $GLPI_CACHE;
+      $GLPI_CACHE->clear(); // login produce cache, must be cleared
+
       //run with cache
       //first run: no cache hit expected
       $this->runGetSonsOf(true);

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -45,7 +45,6 @@ class DbUtils extends DbTestCase {
    public function setUp() {
       global $CFG_GLPI;
 
-      parent::setUp();
       // Clean the cache
       unset($CFG_GLPI['glpiitemtypetables']);
       unset($CFG_GLPI['glpitablesitemtype']);

--- a/tests/functionnal/Dropdown.php
+++ b/tests/functionnal/Dropdown.php
@@ -716,6 +716,8 @@ class Dropdown extends DbTestCase {
     * @dataProvider getDropdownValueProvider
     */
    public function testGetDropdownValue($params, $expected, $session_params = []) {
+      $this->login();
+
       $bkp_params = [];
       //set session params if any
       if (count($session_params)) {
@@ -1163,6 +1165,8 @@ class Dropdown extends DbTestCase {
     * @dataProvider getDropdownUsersProvider
     */
    public function testGetDropdownUsers($params, $expected) {
+      $this->login();
+
       $params['_idor_token'] = \Session::getNewIDORToken('User');
       $result = \Dropdown::getDropdownUsers($params, false);
       $this->array($result)->isIdenticalTo($expected);

--- a/tests/functionnal/Glpi/Dashboard/Provider.php
+++ b/tests/functionnal/Glpi/Dashboard/Provider.php
@@ -49,6 +49,7 @@ class Provider extends DbTestCase {
     * @dataProvider itemProvider
     */
    public function testBigNumber(\CommonDBTM $item) {
+      $this->login();
 
       $itemtype = $item->getType();
       $data = [
@@ -124,6 +125,8 @@ class Provider extends DbTestCase {
     * @dataProvider itemFKProvider
     */
    public function testNbItemByFk(\CommonDBTM $item, \CommonDBTM $fk_item) {
+      $this->login();
+
       $result = \Glpi\Dashboard\Provider::nbItemByFk($item, $fk_item);
       $this->array($result)
          ->hasKeys([
@@ -205,6 +208,8 @@ class Provider extends DbTestCase {
 
 
    public function testGetTicketsStatus() {
+      $this->login();
+
       $result = \Glpi\Dashboard\Provider::getTicketsStatus();
       $this->array($result)
          ->hasKeys([
@@ -233,6 +238,8 @@ class Provider extends DbTestCase {
 
 
    public function testTopTicketsCategories() {
+      $this->login();
+
       $result = \Glpi\Dashboard\Provider::multipleNumberTicketByITILCategory();
       $this->array($result)
          ->hasKeys([

--- a/tests/functionnal/Knowbase.php
+++ b/tests/functionnal/Knowbase.php
@@ -197,7 +197,7 @@ class Knowbase extends DbTestCase {
       // Check that tree contains root only (FAQ is not public) for anonymous user
       // Force session reset
       $session_bck = $_SESSION;
-      $this->callSetUp();
+      $this->resetSession();
       $tree_with_no_public_faq = \Knowbase::getJstreeCategoryList();
 
       // Check that tree contains root + category branch containing FAQ item (FAQ is public) for anonymous user

--- a/tests/functionnal/Session.php
+++ b/tests/functionnal/Session.php
@@ -41,13 +41,13 @@ class Session extends \DbTestCase {
       $warn_msg = 'There was a warning. Be carefull.';
       $info_msg = 'All goes well. Or not... Who knows ;)';
 
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isEmpty();
+      $this->array($_SESSION)->notHasKey('MESSAGE_AFTER_REDIRECT');
 
       //test add message in cron mode
       $_SESSION['glpicronuserrunning'] = 'cron_phpunit';
       \Session::addMessageAfterRedirect($err_msg, false, ERROR);
       //adding a message in "cron mode" does not add anything in the session
-      $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isEmpty();
+      $this->array($_SESSION)->notHasKey('MESSAGE_AFTER_REDIRECT');
 
       //set not running from cron
       unset($_SESSION['glpicronuserrunning']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Test bootstraping was altering session to be able to create dataset without being logged, so tests were running with session variables that were not compliant to a normal state.

I had to keep this session altering for API tests (as some add/update/delete operations are done), but it should not be a problem as tested results are retrieved via HTTP requests.

By the way, I noticed that requests done during API tests cannot be encapsulated into a transaction (requests are done by separated processes), so when a test is failing on dev machine, the whole DB have to be reset to be sure to have a clean DB state.