### PR TITLE
Prevent secured configs to be altered by sanitize logic; see #8283

### DIFF
--- a/front/config.form.php
+++ b/front/config.form.php
@@ -47,12 +47,16 @@ if (!empty($_POST["update_auth"])) {
    Html::back();
 }
 if (!empty($_POST["update"])) {
-   foreach (['glpinetwork_registration_key', 'proxy_passwd', 'smtp_passwd'] as $field) {
-      if (array_key_exists($field, $_POST)) {
+   $context = array_key_exists('config_context', $_POST) ? $_POST['config_context'] : 'core';
+
+   $glpikey = new GLPIKey();
+   foreach (array_keys($_POST) as $field) {
+      if ($glpikey->isConfigSecured($context, $field)) {
          // Field must not be altered, it will be encrypted and never displayed, so sanitize is not necessary.
          $_POST[$field] = $_UPOST[$field];
       }
    }
+
    $config->update($_POST);
    Html::redirect(Toolbox::getItemTypeFormURL('Config'));
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

#8283 fixes issues with special chars in core configuration fields. This PR extends this fix to all declared configuration fields, including thoose declared by plugins.
Plugin metabase is affected by this issue.
