### PR TITLE
GLPI expects this to be set in various places

### DIFF
--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -90,6 +90,7 @@ class GLPITestCase extends atoum {
       Session::start();
 
       $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
+      $_SESSION['glpiactive_entity'] = 0;
 
       global $CFG_GLPI;
       foreach ($CFG_GLPI['user_pref_field'] as $field) {

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -180,8 +180,7 @@ class CommonDBTM extends DbTestCase {
       $this->array($comp->fields)->isEmpty();
 
       $this->boolean($comp->getEmpty())->isTrue();
-      // Empty value if $_SESSION['glpiactive_entity'] is not set
-      $this->array($comp->fields)->string['entities_id']->isIdenticalTo('');
+      $this->array($comp->fields)->integer['entities_id']->isEqualTo(0);
 
       $_SESSION["glpiactive_entity"] = 12;
       $this->boolean($comp->getEmpty())->isTrue();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

On a a feature branch of mine, a minor change has a side effect to enter a loop that relies on `$_SESSION['glpiactive_entity']`; even on already existing tests/classes that has not been changed (more than 80 tests are failing).