### PR TITLE
Fix creation of public saved search

### DIFF
--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -426,7 +426,9 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria {
       }
       if ($ID <= 0) { // add
          echo Html::hidden('users_id', ['value' => $this->fields['users_id']]);
-         echo Html::hidden('is_private', ['value' => $this->fields['is_private']]);
+         if (!self::canCreate()) {
+            echo Html::hidden('is_private', ['value' => $this->fields['is_private']]);
+         }
       } else {
          echo Html::hidden('id', ['value' => $ID]);
       }

--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -427,7 +427,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria {
       if ($ID <= 0) { // add
          echo Html::hidden('users_id', ['value' => $this->fields['users_id']]);
          if (!self::canCreate()) {
-            echo Html::hidden('is_private', ['value' => $this->fields['is_private']]);
+            echo Html::hidden('is_private', ['value' => 1]);
          }
       } else {
          echo Html::hidden('id', ['value' => $ID]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8303

There was a duplicate `is_private` field shown for technicians who could create private searches and it was overriding the user's selection and setting it back to the default which is private.
This hidden input now only shows when the user cannot create a public search and therefore only has one `is_private` field in either case now.