### PR TITLE
Don't count deleted software on install tab

### DIFF
--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -1539,7 +1539,7 @@ abstract class CommonDBRelation extends CommonDBConnexity {
          $noent = true;
       }
 
-      $inverse = $item->getType() == static::$itemtype_1;
+      $inverse = $item->getType() == static::$itemtype_1 || static::$itemtype_1 === 'itemtype';
 
       $link_type  = static::$itemtype_1;
       $link_id    = static::$items_id_1;

--- a/inc/item_softwareversion.class.php
+++ b/inc/item_softwareversion.class.php
@@ -1559,6 +1559,9 @@ class Item_SoftwareVersion extends CommonDBRelation {
 
    protected static function getListForItemParams(CommonDBTM $item, $noent = false) {
       $table = self::getTable(__CLASS__);
+
+      $params = parent::getListForItemParams($item);
+      unset($params['SELECT'], $params['ORDER']);
       $params['WHERE'] = [
          $table.'.items_id'   => $item->getID(),
          $table.'.itemtype'   => $item::getType(),
@@ -1573,10 +1576,10 @@ class Item_SoftwareVersion extends CommonDBRelation {
    static function countForItem(CommonDBTM $item) {
       global $DB;
 
-      $iterator = $DB->request([
-         'COUNT' => 'cpt',
-         'FROM'   => self::getTable(__CLASS__)
-      ] + self::getListForItemParams($item));
+      $params = self::getListForItemParams($item);
+      unset($params['SELECT'], $params['ORDER']);
+      $params['COUNT'] = 'cpt';
+      $iterator = $DB->request($params);
       return $iterator->next()['cpt'];
    }
 }

--- a/inc/item_softwareversion.class.php
+++ b/inc/item_softwareversion.class.php
@@ -1558,8 +1558,15 @@ class Item_SoftwareVersion extends CommonDBRelation {
 
 
    protected static function getListForItemParams(CommonDBTM $item, $noent = false) {
-      $params = parent::getListForItemParams($item, $noent);
-      $params['WHERE'][self::getTable(__CLASS__) . '.is_deleted'] = 0;
+      $table = self::getTable(__CLASS__);
+      $params['WHERE'] = [
+         $table.'.items_id'   => $item->getID(),
+         $table.'.itemtype'   => $item::getType(),
+         $table.'.is_deleted' => 0
+      ];
+      if ($noent === false) {
+         $params = array_merge($params, getEntitiesRestrictCriteria($table, '', '', 'auto'));
+      }
       return $params;
    }
 
@@ -1568,12 +1575,8 @@ class Item_SoftwareVersion extends CommonDBRelation {
 
       $iterator = $DB->request([
          'COUNT' => 'cpt',
-         'FROM'   => self::getTable(__CLASS__),
-         'WHERE'  => [
-            'items_id'  => $item->getID(),
-            'itemtype'  => $item::getType()
-         ]
-      ]);
+         'FROM'   => self::getTable(__CLASS__)
+      ] + self::getListForItemParams($item));
       return $iterator->next()['cpt'];
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8421

fixes #8421

Moved list criteria to `getListForItemParams` which was previously unused and restricted it to non-deleted items only.