### PR TITLE
Fix reversed ticket links from massive action

### DIFF
--- a/inc/ticket_ticket.class.php
+++ b/inc/ticket_ticket.class.php
@@ -92,9 +92,9 @@ class Ticket_Ticket extends CommonDBRelation {
                   foreach ($ids as $id) {
                      $input2                          = [];
                      $input2['id']                    = $input['tickets_id_1'];
-                     $input2['_link']['tickets_id_1'] = $input['tickets_id_1'];
+                     $input2['_link']['tickets_id_1'] = $id;
                      $input2['_link']['link']         = $input['link'];
-                     $input2['_link']['tickets_id_2'] = $id;
+                     $input2['_link']['tickets_id_2'] = $input['tickets_id_1'];
                      if ($item->can($input['tickets_id_1'], UPDATE)) {
                         if ($ticket->update($input2)) {
                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8400

fixes #8400
Before selecting TicketA and doing the Link Tickets massive action and setting any link type like "Son Of" and TicketB, the result is TicketA is linked to TicketB with "Parent Of" instead. This PR fixes that link by switching around which tickets are considered number 1 and 2.