### PR TITLE
Some dashboard fillters can't load

### DIFF
--- a/ajax/dashboard.php
+++ b/ajax/dashboard.php
@@ -84,7 +84,6 @@ switch ($_REQUEST['action']) {
 
 $grid = new Grid($_REQUEST['dashboard'] ?? "");
 
-session_write_close();
 header("Content-Type: text/html; charset=UTF-8");
 switch ($_REQUEST['action']) {
    case 'add_new':
@@ -105,6 +104,7 @@ switch ($_REQUEST['action']) {
       break;
 
    case 'get_card':
+      session_write_close();
       echo $grid->getCardHtml($_REQUEST['card_id'], $_REQUEST);
       break;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

![image](https://user-images.githubusercontent.com/418844/102770824-12335f00-4385-11eb-8c55-9d67eb5a6895.png)


Due to the idor token mechanism, displaying filter need a write enabled session.
Previously, we locked the session to display dashboard's cards by ajax (to avoid sequential load)

This is only needed for this cards loading, not all ajax html calls

