### PR TITLE
GLPI Network services timeout

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -1668,7 +1668,8 @@ class Toolbox {
       $opts = [
          CURLOPT_URL             => $url,
          CURLOPT_USERAGENT       => "GLPI/".trim($CFG_GLPI["version"]),
-         CURLOPT_RETURNTRANSFER  => 1
+         CURLOPT_RETURNTRANSFER  => 1,
+         CURLOPT_CONNECTTIMEOUT  => 5,
       ] + $eopts;
 
       if (!empty($CFG_GLPI["proxy_name"])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Sometime, it may arrives glpi network services are down.
To avoid stucking on Setup > General > GLPI Network tab, i set connection timeout to 5s.
It lets the page responds in a max time of 10s (5s for checking services status, 5s foc checking key informations)
