### PR TITLE
self-service users should never see private tasks

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6781,7 +6781,9 @@ abstract class CommonITILObject extends CommonDBTM {
          $restrict_task = [
             'OR' => [
                'is_private'   => 0,
-               'users_id'     => Session::getLoginUserID()
+               'users_id'     => Session::getCurrentInterface() == "central"
+                                    ? Session::getLoginUserID()
+                                    : 0
             ]
          ];
       }

--- a/inc/tickettask.class.php
+++ b/inc/tickettask.class.php
@@ -93,8 +93,9 @@ class TicketTask extends CommonITILTask {
       }
 
       // see task created or affected to me
-      if (($this->fields["users_id"] === Session::getLoginUserID())
-          || ($this->fields["users_id_tech"] === Session::getLoginUserID())) {
+      if (Session::getCurrentInterface() == "central"
+          && ($this->fields["users_id"] === Session::getLoginUserID())
+              || ($this->fields["users_id_tech"] === Session::getLoginUserID())) {
          return true;
       }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal !21260

In some case, for example a private task created by a ticket template, self-service user may be the author of a private task and could see it.

I suggest to remove ability to see private task globally for all self-service profiles
