### PR TITLE
update docblock

### DIFF
--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -1149,7 +1149,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
     * @param $params array  (contains, knowbaseitemcategories_id, faq)
     * @param $type   string search type : browse / search (default search)
     *
-    * @return String : SQL request
+    * @return array : SQL request
    **/
    static function getListRequest(array $params, $type = 'search') {
       global $DB;


### PR DESCRIPTION
method returns an array, not a string

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
