### PR TITLE
Fix editable items in planning without ajaxurl

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -511,7 +511,7 @@ var GLPIPlanning  = {
             var start    = event.start;
             var ajaxurl  = event.extendedProps.ajaxurl+"&start="+start.toISOString();
             var editable = event.extendedProps._editable; // do not know why editable property is not available
-            if (ajaxurl && editable && !disable_edit) {
+            if (event.extendedProps.ajaxurl && editable && !disable_edit) {
                info.jsEvent.preventDefault(); // don't let the browser navigate
                $('<div></div>')
                   .dialog({

--- a/js/planning.js
+++ b/js/planning.js
@@ -508,9 +508,9 @@ var GLPIPlanning  = {
          },
          eventClick: function(info) {
             var event    = info.event;
-            var start    = event.start;
             var editable = event.extendedProps._editable; // do not know why editable property is not available
             if (event.extendedProps.ajaxurl && editable && !disable_edit) {
+               var start    = event.start;
                var ajaxurl  = event.extendedProps.ajaxurl+"&start="+start.toISOString();
                info.jsEvent.preventDefault(); // don't let the browser navigate
                $('<div></div>')

--- a/js/planning.js
+++ b/js/planning.js
@@ -509,9 +509,9 @@ var GLPIPlanning  = {
          eventClick: function(info) {
             var event    = info.event;
             var start    = event.start;
-            var ajaxurl  = event.extendedProps.ajaxurl+"&start="+start.toISOString();
             var editable = event.extendedProps._editable; // do not know why editable property is not available
             if (event.extendedProps.ajaxurl && editable && !disable_edit) {
+               var ajaxurl  = event.extendedProps.ajaxurl+"&start="+start.toISOString();
                info.jsEvent.preventDefault(); // don't let the browser navigate
                $('<div></div>')
                   .dialog({


### PR DESCRIPTION
Url are broken for items with `editable => true` prop.
The js code try to use the ajaxurl even if it is undefined.

Fixed the condition to check the url properly.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
