### PR TITLE
Fix checked files in headers update script

### DIFF
--- a/.github/actions/check_services_health.sh
+++ b/.github/actions/check_services_health.sh
@@ -28,7 +28,7 @@
 #  * You should have received a copy of the GNU General Public License
 #  * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
 #  * ---------------------------------------------------------------------
-#  */
+# */
 
 for CONTAINER in {"db","dovecot","openldap"}; do
   HEALTHY=false

--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -28,7 +28,7 @@
 #  * You should have received a copy of the GNU General Public License
 #  * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
 #  * ---------------------------------------------------------------------
-#  */
+# */
 
 SCRIPT_DIR=$(dirname $0)
 WORKING_DIR=$(readlink -f "$SCRIPT_DIR/..")

--- a/tools/modify_headers.pl
+++ b/tools/modify_headers.pl
@@ -46,17 +46,17 @@ foreach (readdir(DIRHANDLE)){
 	if ($_ ne '..' && $_ ne '.'){
 		if (-d "$dir/$_"){
 			# Excluded directories
-			if ($_ !~ m/.git/i && $_ !~ m/lib/i && $_ !~ m/plugins/i && $_ !~ m/vendor/i){
+			if ($_ !~ m/^(.git|config|css_compiled|files|lib|marketplace|node_modules|plugins|vendor)$/i){
 				do_dir("$dir/$_");
 			}
 		} else {
 	 		if(!(-l "$dir/$_")){
-				# Included filetypes - php, css, js, scss => default comment style
-				if ((index($_,".php",0)!=-1)||(index($_,".css",0)!=-1)||(index($_,".scss",0)!=-1)||(index($_,".js",0)!=-1)){
+				# Included filetypes - css, js, php, scss => default comment style
+				if ($_ =~ /\.(css|js|php|scss)$/i){
 					do_file("$dir/$_", "");
 	 			}
-				# Included filetypes - sql, sh, pl => Add a specific comment style (#)
-				if ((index($_,".sql",0)!=-1)||(index($_,".sh",0)!=-1)||(index($_,".pl",0)!=-1)){
+				# Included filetypes - pl, sh, sql => Add a specific comment style (#)
+				if ($_ =~ /\.(pl|sh|sql)$/i){
 					do_file("$dir/$_", "# ");
 	 			}
 			}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Prevent some directories to be parsed (`config`, `css_compiled`, `files`, `marketplace`, `node_modules`).
2. Check files formats in extension only, to prevent `.json` to match `.js` format.
3. Remove an empty space that caused shell scripts to be altered when running headers modification script.