### PR TITLE
Fix entity tree expand

### DIFF
--- a/ajax/entitytreesons.php
+++ b/ajax/entitytreesons.php
@@ -78,7 +78,7 @@ if (isset($_GET['node'])) {
          $nodes[] = $path;
       }
    } else { // standard node
-      $node_id = $_GET['node'];
+      $node_id = preg_replace('/r$/', '', $_GET['node']);
       $iterator = $DB->request([
          'SELECT' => [
             'ent.id',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This change has no functionnal impact on 9.5 branch (problem was detected on debug mode on master branch due to displaying of SQL warnings).

SQL warning was `1292: Truncated incorrect DOUBLE value: '0r'`.

On line 58, root ID is suffixed by a `r`, and this `r` was not remove before sending SQL request. It was working only due to the fact that SQL forced casting to a number by truncating the `r`.