### PR TITLE
Fix email attachement decoding logic

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -2068,12 +2068,12 @@ class MailCollector  extends CommonDBTM {
 
       $charset = $content_type->getParameter('charset');
       if (strtoupper($charset) != 'UTF-8') {
-         if (in_array($charset, array_map('strtoupper', mb_list_encodings()))) {
+         if (in_array(strtoupper($charset), array_map('strtoupper', mb_list_encodings()))) {
             $contents = mb_convert_encoding($contents, 'UTF-8', $charset);
          } else {
             // Convert Windows charsets names
-            if (preg_match('/^WINDOWS-\d{4}$/', $charset)) {
-               $charset = preg_replace('/^WINDOWS-(\d{4})$/', 'CP$1', $charset);
+            if (preg_match('/^WINDOWS-\d{4}$/i', $charset)) {
+               $charset = preg_replace('/^WINDOWS-(\d{4})$/i', 'CP$1', $charset);
             }
 
             if ($converted = iconv($charset, 'UTF-8//TRANSLIT', $contents)) {

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -2062,7 +2062,7 @@ class MailCollector  extends CommonDBTM {
 
       if (!$part->getHeaders()->has('content-type')
          || !(($content_type = $part->getHeader('content-type')) instanceof ContentType)
-          | preg_match('/^text\//', $content_type->getType()) !== 1) {
+         || preg_match('/^text\//', $content_type->getType()) !== 1) {
          return $contents; // No charset conversion content type header is not set or content is not text/*
       }
 

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -2067,7 +2067,7 @@ class MailCollector  extends CommonDBTM {
       }
 
       $charset = $content_type->getParameter('charset');
-      if (strtoupper($charset) != 'UTF-8') {
+      if ($charset !== null && strtoupper($charset) != 'UTF-8') {
          if (in_array(strtoupper($charset), array_map('strtoupper', mb_list_encodings()))) {
             $contents = mb_convert_encoding($contents, 'UTF-8', $charset);
          } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Should prevent following issue:
```
PHP Notice (8): iconv(): Detected an illegal character in input string in /var/www/glpi/inc/mailcollector.class.php at line 2079
 Backtrace :
 inc/mailcollector.class.php:2079                   iconv()
 inc/mailcollector.class.php:1616                   MailCollector->getDecodedContent()
 inc/mailcollector.class.php:1516                   MailCollector->getRecursiveAttached()
 inc/mailcollector.class.php:1657                   MailCollector->getRecursiveAttached()
 inc/mailcollector.class.php:992                    MailCollector->getAttached()
 inc/mailcollector.class.php:754                    MailCollector->buildTicket()
 front/mailcollector.form.php:88                    MailCollector->collect()
 ```