### PR TITLE
fix(central): add incoming ticket too

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -5100,12 +5100,13 @@ class Ticket extends CommonITILObject {
             );
             break;
 
-         case "process" : // planned or assigned tickets
+         case "process" : // planned or assigned or incoming tickets
             $WHERE = array_merge(
                $WHERE,
                $search_assign,
-               ['glpi_tickets.status' => self::getProcessStatusArray()]
+               ['glpi_tickets.status' => [self::ASSIGNED, self::PLANNED, self::INCOMING]]
             );
+
             break;
 
          case "toapprove" : //tickets waiting for approval
@@ -5280,6 +5281,7 @@ class Ticket extends CommonITILObject {
       if (count($JOINS)) {
          $criteria = array_merge_recursive($criteria, $JOINS);
       }
+
       $iterator = $DB->request($criteria);
       $total_row_count = count($iterator);
       $displayed_row_count = (int)$_SESSION['glpidisplay_count_on_home'] > 0
@@ -5331,15 +5333,22 @@ class Ticket extends CommonITILObject {
                   break;
 
                case "process" :
-                  $options['criteria'][0]['field']      = 12; // status
-                  $options['criteria'][0]['searchtype'] = 'equals';
-                  $options['criteria'][0]['value']      = 'process';
-                  $options['criteria'][0]['link']       = 'AND';
 
-                  $options['criteria'][1]['field']      = 8; // groups_id_assign
-                  $options['criteria'][1]['searchtype'] = 'equals';
-                  $options['criteria'][1]['value']      = 'mygroups';
-                  $options['criteria'][1]['link']       = 'AND';
+                  $options['criteria'][2]['field']      = 8; // groups_id_assign
+                  $options['criteria'][2]['searchtype'] = 'equals';
+                  $options['criteria'][2]['value']      = 'mygroups';
+                  $options['criteria'][2]['link']       = 'AND';
+
+                  $options['criteria'][4]['link']                       = 'AND';
+                  $options['criteria'][4]['criteria'][0]['link']        = 'AND';
+                  $options['criteria'][4]['criteria'][0]['field']       = 12;
+                  $options['criteria'][4]['criteria'][0]['searchtype']  = 'equals';
+                  $options['criteria'][4]['criteria'][0]['value']       = 1;
+
+                  $options['criteria'][4]['criteria'][1]['link']        = 'OR';
+                  $options['criteria'][4]['criteria'][1]['field']       = 12;
+                  $options['criteria'][4]['criteria'][1]['searchtype']  = 'equals';
+                  $options['criteria'][4]['criteria'][1]['value']       = 'process';
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                          Toolbox::append_params($options, '&amp;')."\">".

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -5104,7 +5104,7 @@ class Ticket extends CommonITILObject {
             $WHERE = array_merge(
                $WHERE,
                $search_assign,
-               ['glpi_tickets.status' => [self::ASSIGNED, self::PLANNED, self::INCOMING]]
+               ['glpi_tickets.status' => array_merge(self::getProcessStatusArray(), [self::INCOMING])]
             );
 
             break;
@@ -5334,21 +5334,31 @@ class Ticket extends CommonITILObject {
 
                case "process" :
 
-                  $options['criteria'][2]['field']      = 8; // groups_id_assign
-                  $options['criteria'][2]['searchtype'] = 'equals';
-                  $options['criteria'][2]['value']      = 'mygroups';
-                  $options['criteria'][2]['link']       = 'AND';
-
-                  $options['criteria'][4]['link']                       = 'AND';
-                  $options['criteria'][4]['criteria'][0]['link']        = 'AND';
-                  $options['criteria'][4]['criteria'][0]['field']       = 12;
-                  $options['criteria'][4]['criteria'][0]['searchtype']  = 'equals';
-                  $options['criteria'][4]['criteria'][0]['value']       = 1;
-
-                  $options['criteria'][4]['criteria'][1]['link']        = 'OR';
-                  $options['criteria'][4]['criteria'][1]['field']       = 12;
-                  $options['criteria'][4]['criteria'][1]['searchtype']  = 'equals';
-                  $options['criteria'][4]['criteria'][1]['value']       = 'process';
+                  $options['criteria'] = [
+                     [
+                        'field'        => 8,
+                        'searchtype'   => 'equals',
+                        'value'        => 'mygroups',
+                        'link'         => 'AND',
+                     ],
+                     [
+                        'link' => 'AND',
+                        'criteria' => [
+                           [
+                              'link'        => 'AND',
+                              'field'       => 12,
+                              'searchtype'  => 'equals',
+                              'value'       => Ticket::INCOMING,
+                           ],
+                           [
+                              'link'        => 'OR',
+                              'field'       => 12,
+                              'searchtype'  => 'equals',
+                              'value'       => 'process',
+                           ]
+                        ]
+                     ]
+                  ];
 
                   echo "<a href=\"".Ticket::getSearchURL()."?".
                          Toolbox::append_params($options, '&amp;')."\">".


### PR DESCRIPTION
GLPI allows you to assign a group to a ticket and leave the status as new.

But the central page -> group view -> tickets to be processed 

does not take into account the new status

This PR fix this

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 21256
