### PR TITLE
Async sending of ITIL objects notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The present file will list all changes made to the project; according to the
 
 #### Deprecated
 - Usage of `GLPI_FORCE_EMPTY_SQL_MODE` constant
+- Usage of `CommonDBTM::notificationqueueonaction` property
 - `RuleImportComputer` and `RuleImportComputerCollection`
 
 #### Removed
@@ -685,7 +686,7 @@ new whole window
 - `RuleDictionnarySoftwareCollection::versionExists()` signature has changed
 - `NotificationTemplate::getDataToSend()` signature has changed
 - `QueuedMail` has been renamed to `QueuedNotification`
-- `CommonDBTM::mailqueueonaction()` has been renamed to `CommonDBTM::notificationqueueonaction()`
+- `CommonDBTM::mailqueueonaction` has been renamed to `CommonDBTM::notificationqueueonaction`
 - `NotificationTarget::getSender()` no longer takes any parameters (was not used)
 - `TableExists()` has been moved to `DBMysql::tableExists()`
 - `FieldExists()` has been moved to `DBMysql::fieldExists()`

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -142,6 +142,15 @@ class CommonDBTM extends CommonGLPI {
    protected $usenotepad = false;
 
    /**
+    * Flag to determine whether or not queued notifications should be deduplicated.
+    * Deduplication is done when a new notification is raised.
+    * Any existing notification for same object, event and recipient is dropped to be replaced by the new one.
+    *
+    * @var boolean
+    */
+   public $deduplicate_queued_notifications = true;
+
+   /**
     * Flag to determine whether or not notification queu should be flushed immediately when an
     * action is performed on item.
     *
@@ -1194,6 +1203,7 @@ class CommonDBTM extends CommonGLPI {
                   $this->clearSavedInput();
                }
                if ($this->notificationqueueonaction) {
+                  Toolbox::deprecated('$notificationqueueonaction property usage is deprecated');
                   QueuedNotification::forceSendFor($this->getType(), $this->fields['id']);
                }
                return $this->fields['id'];
@@ -1573,6 +1583,7 @@ class CommonDBTM extends CommonGLPI {
             }
 
             if ($this->notificationqueueonaction) {
+               Toolbox::deprecated('$notificationqueueonaction property usage is deprecated');
                QueuedNotification::forceSendFor($this->getType(), $this->fields['id']);
             }
 
@@ -1874,6 +1885,7 @@ class CommonDBTM extends CommonGLPI {
                Plugin::doHook("item_delete", $this);
             }
             if ($this->notificationqueueonaction) {
+               Toolbox::deprecated('$notificationqueueonaction property usage is deprecated');
                QueuedNotification::forceSendFor($this->getType(), $this->fields['id']);
             }
 
@@ -2045,6 +2057,7 @@ class CommonDBTM extends CommonGLPI {
          }
          Plugin::doHook("item_restore", $this);
          if ($this->notificationqueueonaction) {
+            Toolbox::deprecated('$notificationqueueonaction property usage is deprecated');
             QueuedNotification::forceSendFor($this->getType(), $this->fields['id']);
          }
          return true;

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -53,9 +53,7 @@ abstract class CommonITILObject extends CommonDBTM {
    /// Use user entity to select entity of the object
    protected $userentity_oncreate = false;
 
-
-   /// From CommonDBTM
-   public $notificationqueueonaction = true;
+   public $deduplicate_queued_notifications = false;
 
    const MATRIX_FIELD         = '';
    const URGENCY_MASK_FIELD   = '';

--- a/inc/queuednotification.class.php
+++ b/inc/queuednotification.class.php
@@ -146,7 +146,8 @@ class QueuedNotification extends CommonDBTM {
       }
 
       // Drop existing mails in queue for the same event and item  and recipient
-      if (isset($input['itemtype']) && !empty($input['itemtype'])
+      $item = isset($input['itemtype']) ? getItemForItemtype($input['itemtype']) : false;
+      if ($item instanceof CommonDBTM && $item->deduplicate_queued_notifications
           && isset($input['entities_id']) && ($input['entities_id'] >= 0)
           && isset($input['items_id']) && ($input['items_id'] >= 0)
           && isset($input['notificationtemplates_id']) && !empty($input['notificationtemplates_id'])

--- a/tests/functionnal/NotificationEventAjax.php
+++ b/tests/functionnal/NotificationEventAjax.php
@@ -82,7 +82,6 @@ class NotificationEventAjax extends DbTestCase {
       $this->login();
 
       $ticket = new \Ticket();
-      $ticket->notificationqueueonaction = false;
       $uid = getItemByTypeName('User', TU_USER, true);
       $this->integer(
          (int)$ticket->add([

--- a/tests/functionnal/QueuedNotification.php
+++ b/tests/functionnal/QueuedNotification.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+use Notification_NotificationTemplate;
+use Project;
+
+class QueuedNotification extends DbTestCase {
+
+   public function testAddNotificationWithDeduplication() {
+      $queued_notification = new \QueuedNotification();
+
+      $root_entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+
+      $project_notification_id = getItemByTypeName('NotificationTemplate', 'Projects', true);
+
+      $project = new Project();
+      $project_id_1 = $project->add(['name' => 'Test project 1', 'entities_id' => $root_entity_id]);
+      $this->integer($project_id_1)->isGreaterThan(0);
+      $project_id_2 = $project->add(['name' => 'Test project 2', 'entities_id' => $root_entity_id]);
+      $this->integer($project_id_2)->isGreaterThan(0);
+
+      // First notification
+      $queued_id_1 = $queued_notification->add(
+         [
+            'itemtype'                 => 'Project',
+            'items_id'                 => $project_id_1,
+            'entities_id'              => $root_entity_id,
+            'notificationtemplates_id' => $project_notification_id,
+            'sender'                   => 'mailer@glpi-project.org',
+            'recipient'                => 'test-user@glpi-project.org',
+            'name'                     => 'Test notification 1',
+            'body_text'                => 'Text of notification 1',
+            'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
+         ]
+      );
+      $this->integer($queued_id_1)->isGreaterThan(0);
+      $this->boolean($queued_notification->getFromDB($queued_id_1))->isTrue();
+
+      // Notification with same item and recipient, should trigger previous notification deletion
+      $queued_id_2 = $queued_notification->add(
+         [
+            'itemtype'                 => 'Project',
+            'items_id'                 => $project_id_1,
+            'entities_id'              => $root_entity_id,
+            'notificationtemplates_id' => $project_notification_id,
+            'sender'                   => 'mailer@glpi-project.org',
+            'recipient'                => 'test-user@glpi-project.org',
+            'name'                     => 'Test notification 2',
+            'body_text'                => 'Text of notification 2',
+            'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
+         ]
+      );
+      $this->integer($queued_id_2)->isGreaterThan(0);
+      $this->boolean($queued_notification->getFromDB($queued_id_2))->isTrue();
+      // Previous notifications have been removed
+      $this->boolean($queued_notification->getFromDB($queued_id_1))->isFalse();
+
+      // Notification with different recipient, should not trigger previous notification deletion
+      $queued_id_3 = $queued_notification->add(
+         [
+            'itemtype'                 => 'Project',
+            'items_id'                 => $project_id_1,
+            'entities_id'              => $root_entity_id,
+            'notificationtemplates_id' => $project_notification_id,
+            'sender'                   => 'mailer@glpi-project.org',
+            'recipient'                => 'another-user@glpi-project.org',
+            'name'                     => 'Test notification 3',
+            'body_text'                => 'Text of notification 3',
+            'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
+         ]
+      );
+      $this->integer($queued_id_2)->isGreaterThan(0);
+      $this->boolean($queued_notification->getFromDB($queued_id_3))->isTrue();
+      // Previous notifications have not been removed
+      $this->boolean($queued_notification->getFromDB($queued_id_2))->isTrue();
+
+      // Notification with different item, should not trigger previous notification deletion
+      $this->integer($project_id_1)->isGreaterThan(0);
+      $queued_id_4 = $queued_notification->add(
+         [
+            'itemtype'                 => 'Project',
+            'items_id'                 => $project_id_2,
+            'entities_id'              => $root_entity_id,
+            'notificationtemplates_id' => $project_notification_id,
+            'sender'                   => 'mailer@glpi-project.org',
+            'recipient'                => 'test-user@glpi-project.org',
+            'name'                     => 'Test notification 4',
+            'body_text'                => 'Text of notification 4',
+            'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
+         ]
+      );
+      $this->integer($queued_id_2)->isGreaterThan(0);
+      $this->boolean($queued_notification->getFromDB($queued_id_4))->isTrue();
+      // Previous notifications have not been removed
+      $this->boolean($queued_notification->getFromDB($queued_id_3))->isTrue();
+      $this->boolean($queued_notification->getFromDB($queued_id_2))->isTrue();
+   }
+
+   public function testAddNotificationWithoutDeduplication() {
+      $queued_notification = new \QueuedNotification();
+
+      $root_entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+
+      $ticket_notification_id = getItemByTypeName('NotificationTemplate', 'Tickets', true);
+
+      $ticket = new Project();
+      $ticket_id_1 = $ticket->add(['name' => 'Test ticket 1', 'entities_id' => $root_entity_id]);
+      $this->integer($ticket_id_1)->isGreaterThan(0);
+      $ticket_id_2 = $ticket->add(['name' => 'Test ticket 2', 'entities_id' => $root_entity_id]);
+      $this->integer($ticket_id_2)->isGreaterThan(0);
+
+      // First notification
+      $queued_id_1 = $queued_notification->add(
+         [
+            'itemtype'                 => 'Ticket',
+            'items_id'                 => $ticket_id_1,
+            'entities_id'              => $root_entity_id,
+            'notificationtemplates_id' => $ticket_notification_id,
+            'sender'                   => 'mailer@glpi-project.org',
+            'recipient'                => 'test-user@glpi-project.org',
+            'name'                     => 'Test notification 1',
+            'body_text'                => 'Text of notification 1',
+            'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
+         ]
+      );
+      $this->integer($queued_id_1)->isGreaterThan(0);
+      $this->boolean($queued_notification->getFromDB($queued_id_1))->isTrue();
+
+      // Notification with same item and recipient, should trigger previous notification deletion
+      $queued_id_2 = $queued_notification->add(
+         [
+            'itemtype'                 => 'Ticket',
+            'items_id'                 => $ticket_id_1,
+            'entities_id'              => $root_entity_id,
+            'notificationtemplates_id' => $ticket_notification_id,
+            'sender'                   => 'mailer@glpi-project.org',
+            'recipient'                => 'test-user@glpi-project.org',
+            'name'                     => 'Test notification 2',
+            'body_text'                => 'Text of notification 2',
+            'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
+         ]
+      );
+      $this->integer($queued_id_2)->isGreaterThan(0);
+      $this->boolean($queued_notification->getFromDB($queued_id_2))->isTrue();
+      // Previous notifications have not been removed
+      $this->boolean($queued_notification->getFromDB($queued_id_1))->isTrue();
+
+      // Notification with different recipient, should not trigger previous notification deletion
+      $queued_id_3 = $queued_notification->add(
+         [
+            'itemtype'                 => 'Ticket',
+            'items_id'                 => $ticket_id_1,
+            'entities_id'              => $root_entity_id,
+            'notificationtemplates_id' => $ticket_notification_id,
+            'sender'                   => 'mailer@glpi-project.org',
+            'recipient'                => 'another-user@glpi-project.org',
+            'name'                     => 'Test notification 3',
+            'body_text'                => 'Text of notification 3',
+            'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
+         ]
+      );
+      $this->integer($queued_id_2)->isGreaterThan(0);
+      $this->boolean($queued_notification->getFromDB($queued_id_3))->isTrue();
+      // Previous notifications have not been removed
+      $this->boolean($queued_notification->getFromDB($queued_id_2))->isTrue();
+      $this->boolean($queued_notification->getFromDB($queued_id_1))->isTrue();
+
+      // Notification with different item, should not trigger previous notification deletion
+      $this->integer($ticket_id_1)->isGreaterThan(0);
+      $queued_id_4 = $queued_notification->add(
+         [
+            'itemtype'                 => 'Ticket',
+            'items_id'                 => $ticket_id_2,
+            'entities_id'              => $root_entity_id,
+            'notificationtemplates_id' => $ticket_notification_id,
+            'sender'                   => 'mailer@glpi-project.org',
+            'recipient'                => 'test-user@glpi-project.org',
+            'name'                     => 'Test notification 4',
+            'body_text'                => 'Text of notification 4',
+            'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
+         ]
+      );
+      $this->integer($queued_id_2)->isGreaterThan(0);
+      $this->boolean($queued_notification->getFromDB($queued_id_4))->isTrue();
+      // Previous notifications have not been removed
+      $this->boolean($queued_notification->getFromDB($queued_id_3))->isTrue();
+      $this->boolean($queued_notification->getFromDB($queued_id_2))->isTrue();
+      $this->boolean($queued_notification->getFromDB($queued_id_1))->isTrue();
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Notifications related to ITIL objects are synchronously sent. This was done, if I remember right, to be sure that every notification be sent to recipients before deduplication process can drop some of them. Problem is that notification sending can crash, due to a too large memory usage, when documents attached to tickets are voluminous.

I propose to do it in another way. Instead of forcing synchronous send of notifications, we could just prevent the deduplication process to be runned.