### PR TITLE
fix(dashboard): fix query criteria

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -3345,13 +3345,7 @@ abstract class CommonITILObject extends CommonDBTM {
          'name'               => __('Time to resolve exceedeed'),
          'datatype'           => 'bool',
          'massiveaction'      => false,
-         'computation'        =>
-            'IF(' . $DB->quoteName('TABLE.time_to_resolve') . ' IS NOT NULL
-               AND ' . $DB->quoteName('TABLE.status') . ' <> 4
-               AND (' . $DB->quoteName('TABLE.solvedate') . ' > ' . $DB->quoteName('TABLE.time_to_resolve') . '
-                     OR (' . $DB->quoteName('TABLE.solvedate') . ' IS NULL
-                        AND ' . $DB->quoteName('TABLE.time_to_resolve') . ' < NOW())),
-               1, 0)'
+         'computation'        => self::generateSLAOLAComputation('time_to_resolve')
       ];
 
       $tab[] = [
@@ -3801,6 +3795,34 @@ abstract class CommonITILObject extends CommonDBTM {
       ];
 
       return $tab;
+   }
+
+   static function generateSLAOLAComputation($type, $table = "TABLE") {
+      global $DB;
+
+      switch ($type) {
+         case 'internal_time_to_own':
+         case 'time_to_own':
+            return 'IF('.$DB->quoteName($table.'.'.$type).' IS NOT NULL
+            AND '.$DB->quoteName($table.'.status').' <> '.self::WAITING.'
+            AND ('.$DB->quoteName($table.'.takeintoaccount_delay_stat').'
+                        > TIME_TO_SEC(TIMEDIFF('.$DB->quoteName($table.'.'.$type).',
+                                               '.$DB->quoteName($table.'.date').'))
+                 OR ('.$DB->quoteName($table.'.takeintoaccount_delay_stat').' = 0
+                      AND '.$DB->quoteName($table.'.'.$type).' < NOW())),
+            1, 0)';
+            break;
+
+         case 'internal_time_to_resolve':
+         case 'time_to_resolve':
+            return 'IF(' . $DB->quoteName($table.'.'.$type) . ' IS NOT NULL
+            AND ' . $DB->quoteName($table.'.status') . ' <> 4
+            AND (' . $DB->quoteName($table.'.solvedate') . ' > ' . $DB->quoteName($table.'.'.$type) . '
+                  OR (' . $DB->quoteName($table.'.solvedate') . ' IS NULL
+                     AND ' . $DB->quoteName($table.'.'.$type) . ' < NOW())),
+            1, 0)';
+            break;
+      }
    }
 
    /**

--- a/inc/dashboard/provider.class.php
+++ b/inc/dashboard/provider.class.php
@@ -269,10 +269,21 @@ class Provider extends CommonGLPI {
             $query_criteria['WHERE']+= [
                "$table.status" => Ticket::getNotSolvedStatusArray(),
                'OR' => [
-                  'time_to_resolve'          => ['<', new QueryExpression('NOW()')],
-                  'time_to_own'              => ['<', new QueryExpression('NOW()')],
-                  'internal_time_to_own'     => ['<', new QueryExpression('NOW()')],
-                  'internal_time_to_resolve' => ['<', new QueryExpression('NOW()')],
+                  'IF(`glpi_tickets`.`time_to_resolve` IS NOT NULL
+                  AND `glpi_tickets`.`status` <> 4 AND (`glpi_tickets`.`solvedate` > `glpi_tickets`.`time_to_resolve`
+                  OR (`glpi_tickets`.`solvedate` IS NULL AND `glpi_tickets`.`time_to_resolve` < NOW())), 1, 0) = 1',
+
+                  'IF(`glpi_tickets`.`internal_time_to_resolve` IS NOT NULL AND `glpi_tickets`.`status` <> 4
+                  AND (`glpi_tickets`.`solvedate` > `glpi_tickets`.`internal_time_to_resolve`
+                  OR (`glpi_tickets`.`solvedate` IS NULL AND `glpi_tickets`.`internal_time_to_resolve` < NOW())), 1, 0) = 1',
+
+                  'IF(`glpi_tickets`.`time_to_own` IS NOT NULL AND `glpi_tickets`.`status` <> 4
+                  AND (`glpi_tickets`.`takeintoaccount_delay_stat` > TIME_TO_SEC(TIMEDIFF(`glpi_tickets`.`time_to_own`, `glpi_tickets`.`date`))
+                  OR (`glpi_tickets`.`takeintoaccount_delay_stat` = 0 AND `glpi_tickets`.`time_to_own` < NOW())), 1, 0) = 1',
+
+                  'IF(`glpi_tickets`.`internal_time_to_own` IS NOT NULL AND `glpi_tickets`.`status` <> 4
+                  AND (`glpi_tickets`.`takeintoaccount_delay_stat` > TIME_TO_SEC(TIMEDIFF(`glpi_tickets`.`internal_time_to_own`, `glpi_tickets`.`date`))
+                  OR (`glpi_tickets`.`takeintoaccount_delay_stat` = 0 AND `glpi_tickets`.`internal_time_to_own` < NOW())), 1, 0) = 1',
                ]
             ];
             break;

--- a/inc/dashboard/provider.class.php
+++ b/inc/dashboard/provider.class.php
@@ -40,6 +40,7 @@ use CommonITILActor;
 use CommonITILValidation;
 use CommonTreeDropdown;
 use CommonDBTM;
+use CommonITILObject;
 use Group;
 use Group_Ticket;
 use Problem;
@@ -269,21 +270,10 @@ class Provider extends CommonGLPI {
             $query_criteria['WHERE']+= [
                "$table.status" => Ticket::getNotSolvedStatusArray(),
                'OR' => [
-                  'IF(`glpi_tickets`.`time_to_resolve` IS NOT NULL
-                  AND `glpi_tickets`.`status` <> 4 AND (`glpi_tickets`.`solvedate` > `glpi_tickets`.`time_to_resolve`
-                  OR (`glpi_tickets`.`solvedate` IS NULL AND `glpi_tickets`.`time_to_resolve` < NOW())), 1, 0) = 1',
-
-                  'IF(`glpi_tickets`.`internal_time_to_resolve` IS NOT NULL AND `glpi_tickets`.`status` <> 4
-                  AND (`glpi_tickets`.`solvedate` > `glpi_tickets`.`internal_time_to_resolve`
-                  OR (`glpi_tickets`.`solvedate` IS NULL AND `glpi_tickets`.`internal_time_to_resolve` < NOW())), 1, 0) = 1',
-
-                  'IF(`glpi_tickets`.`time_to_own` IS NOT NULL AND `glpi_tickets`.`status` <> 4
-                  AND (`glpi_tickets`.`takeintoaccount_delay_stat` > TIME_TO_SEC(TIMEDIFF(`glpi_tickets`.`time_to_own`, `glpi_tickets`.`date`))
-                  OR (`glpi_tickets`.`takeintoaccount_delay_stat` = 0 AND `glpi_tickets`.`time_to_own` < NOW())), 1, 0) = 1',
-
-                  'IF(`glpi_tickets`.`internal_time_to_own` IS NOT NULL AND `glpi_tickets`.`status` <> 4
-                  AND (`glpi_tickets`.`takeintoaccount_delay_stat` > TIME_TO_SEC(TIMEDIFF(`glpi_tickets`.`internal_time_to_own`, `glpi_tickets`.`date`))
-                  OR (`glpi_tickets`.`takeintoaccount_delay_stat` = 0 AND `glpi_tickets`.`internal_time_to_own` < NOW())), 1, 0) = 1',
+                  CommonITILObject::generateSLAOLAComputation('time_to_resolve', 'glpi_tickets'),
+                  CommonITILObject::generateSLAOLAComputation('internal_time_to_resolve', 'glpi_tickets'),
+                  CommonITILObject::generateSLAOLAComputation('time_to_own', 'glpi_tickets'),
+                  CommonITILObject::generateSLAOLAComputation('internal_time_to_own', 'glpi_tickets'),
                ]
             ];
             break;

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2620,14 +2620,7 @@ class Ticket extends CommonITILObject {
          'name'               => __('Time to own exceedeed'),
          'datatype'           => 'bool',
          'massiveaction'      => false,
-         'computation'        => 'IF('.$DB->quoteName('TABLE.time_to_own').' IS NOT NULL
-                                            AND '.$DB->quoteName('TABLE.status').' <> '.self::WAITING.'
-                                            AND ('.$DB->quoteName('TABLE.takeintoaccount_delay_stat').'
-                                                        > TIME_TO_SEC(TIMEDIFF('.$DB->quoteName('TABLE.time_to_own').',
-                                                                               '.$DB->quoteName('TABLE.date').'))
-                                                 OR ('.$DB->quoteName('TABLE.takeintoaccount_delay_stat').' = 0
-                                                      AND '.$DB->quoteName('TABLE.time_to_own').' < NOW())),
-                                            1, 0)'
+         'computation'        => self::generateSLAOLAComputation('time_to_own')
       ];
 
       $tab[] = [
@@ -2658,12 +2651,7 @@ class Ticket extends CommonITILObject {
          'name'               => __('Internal time to resolve exceedeed'),
          'datatype'           => 'bool',
          'massiveaction'      => false,
-         'computation'        => 'IF('.$DB->quoteName('TABLE.internal_time_to_resolve').' IS NOT NULL
-                                            AND '.$DB->quoteName('TABLE.status').' <> 4
-                                            AND ('.$DB->quoteName('TABLE.solvedate').' > '.$DB->quoteName('TABLE.internal_time_to_resolve').'
-                                                 OR ('.$DB->quoteName('TABLE.solvedate').' IS NULL
-                                                      AND '.$DB->quoteName('TABLE.internal_time_to_resolve').' < NOW())),
-                                            1, 0)'
+         'computation'        => self::generateSLAOLAComputation('internal_time_to_resolve')
       ];
 
       $tab[] = [
@@ -2694,14 +2682,7 @@ class Ticket extends CommonITILObject {
          'name'               => __('Internal time to own exceedeed'),
          'datatype'           => 'bool',
          'massiveaction'      => false,
-         'computation'        => 'IF('.$DB->quoteName('TABLE.internal_time_to_own').' IS NOT NULL
-                                            AND '.$DB->quoteName('TABLE.status').' <> '.self::WAITING.'
-                                            AND ('.$DB->quoteName('TABLE.takeintoaccount_delay_stat').'
-                                                        > TIME_TO_SEC(TIMEDIFF('.$DB->quoteName('TABLE.internal_time_to_own').',
-                                                                               '.$DB->quoteName('TABLE.date').'))
-                                                 OR ('.$DB->quoteName('TABLE.takeintoaccount_delay_stat').' = 0
-                                                      AND '.$DB->quoteName('TABLE.internal_time_to_own').' < NOW())),
-                                            1, 0)'
+         'computation'        => self::generateSLAOLAComputation('internal_time_to_own')
       ];
 
       $max_date = '99999999';


### PR DESCRIPTION

SQL query used by ticket late widget is not same as query from ticket search form (where clause)

SQL query for widget
```
SELECT * FROM `glpi_tickets` 
WHERE `glpi_tickets`.`is_deleted` = '0' 
AND `glpi_tickets`.`status` IN ('1', '2', '3', '4') 
AND (
   `time_to_resolve` < NOW() 
   OR `time_to_own` < NOW() 
   OR `internal_time_to_own` < NOW() 
   OR `internal_time_to_resolve` < NOW()
   ) 
GROUP BY `glpi_tickets`.`id`
```

SQL query from search form
```
IF(`glpi_tickets`.`time_to_resolve` IS NOT NULL
AND `glpi_tickets`.`status` <> 4 AND (`glpi_tickets`.`solvedate` > `glpi_tickets`.`time_to_resolve`
OR (`glpi_tickets`.`solvedate` IS NULL AND `glpi_tickets`.`time_to_resolve` < NOW())), 1, 0) = 1

IF(`glpi_tickets`.`internal_time_to_resolve` IS NOT NULL AND `glpi_tickets`.`status` <> 4
AND (`glpi_tickets`.`solvedate` > `glpi_tickets`.`internal_time_to_resolve`
OR (`glpi_tickets`.`solvedate` IS NULL AND `glpi_tickets`.`internal_time_to_resolve` < NOW())), 1, 0) = 1


IF(`glpi_tickets`.`time_to_own` IS NOT NULL AND `glpi_tickets`.`status` <> 4
AND (`glpi_tickets`.`takeintoaccount_delay_stat` > TIME_TO_SEC(TIMEDIFF(`glpi_tickets`.`time_to_own`, `glpi_tickets`.`date`))
OR (`glpi_tickets`.`takeintoaccount_delay_stat` = 0 AND `glpi_tickets`.`time_to_own` < NOW())), 1, 0) = 1


IF(`glpi_tickets`.`internal_time_to_own` IS NOT NULL AND `glpi_tickets`.`status` <> 4
AND (`glpi_tickets`.`takeintoaccount_delay_stat` > TIME_TO_SEC(TIMEDIFF(`glpi_tickets`.`internal_time_to_own`, `glpi_tickets`.`date`))
OR (`glpi_tickets`.`takeintoaccount_delay_stat` = 0 AND `glpi_tickets`.`internal_time_to_own` < NOW())), 1, 0) = 1
```
This Pr fix this


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 21300
