### PR TITLE
Fix IMAP auth without login source dropdown

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -848,15 +848,16 @@ class Auth extends CommonGLPI {
                   if (Toolbox::canUseLdap()) {
                      AuthLDAP::tryLdapAuth($this, $login_name, $login_password,
                                              $this->user->fields["auths_id"]);
-                     if (!$this->auth_succeded && $this->user_found) {
+                     if (!$this->auth_succeded && !$this->user_found) {
                         $search_params = [
                            'name'     => addslashes($login_name),
                            'authtype' => $this::LDAP];
                         if (!empty($login_auth)) {
                            $search_params['auths_id'] = $this->user->fields["auths_id"];
                         }
-                        $this->user->getFromDBByCrit($search_params);
-                        $user_deleted_ldap = true;
+                        if ($this->user->getFromDBByCrit($search_params)) {
+                           $user_deleted_ldap = true;
+                        };
                      }
                   }
                }

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -848,7 +848,7 @@ class Auth extends CommonGLPI {
                   if (Toolbox::canUseLdap()) {
                      AuthLDAP::tryLdapAuth($this, $login_name, $login_password,
                                              $this->user->fields["auths_id"]);
-                     if (!$this->auth_succeded && !$this->user_found) {
+                     if (!$this->auth_succeded && $this->user_found) {
                         $search_params = [
                            'name'     => addslashes($login_name),
                            'authtype' => $this::LDAP];


### PR DESCRIPTION
IMAP auth isn't working when you disable the "Display source dropdown on login page" option.
-> Bug introduced in https://github.com/glpi-project/glpi/pull/7954.

Seems to be a typo in the condition to me.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | pending
| Fixed tickets | !21205
