### PR TITLE
Deprecate alternative BD connection encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The present file will list all changes made to the project; according to the
 [Keep a Changelog](http://keepachangelog.com/) project.
 
+## [9.5.3] 2020-11-25
+
+### Deprecated
+- Usage of alternative DB connection encoding (`DB::$dbenc` property).
+
 ## [9.5.2] 2020-10-07
 
 ### API changes

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -198,6 +198,9 @@ class DBmysql {
          $this->connected = false;
          $this->error     = 2;
       } else {
+         if (isset($this->dbenc)) {
+            Toolbox::deprecated('Usage of alternative DB connection encoding (`DB::$dbenc` property) is deprecated.');
+         }
          $dbenc = isset($this->dbenc) ? $this->dbenc : "utf8";
          $this->dbh->set_charset($dbenc);
          if ($dbenc === "utf8") {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Honestly, even if I did not tried to use/test it, I do not even understand why this option is present. All tables/columns are created with `utf8` charset, and all communications between web clients (browser, api clients, ...) are expected to use the `utf8` charset.
So using an alternative charset will, at best, require the mysqli driver to convert data from `utf8` to this alternate charset, and the the MySQL server will have to convert it back to `utf8`, and at worse, it will produce buggy behaviours.

I am preparing migration to `utf8mb4` charset for next major release, and handling this custom charset may be a thorn in the side, so I propose to deprecate it now, in order to be able to drop it in next major release.