### PR TITLE
Prevent console commands to be executed if DB is not up-to-date

### DIFF
--- a/inc/console/abstractcommand.class.php
+++ b/inc/console/abstractcommand.class.php
@@ -64,11 +64,18 @@ abstract class AbstractCommand extends Command implements GlpiCommandInterface {
    protected $output;
 
    /**
-    * Flag to indicate if command requires a BD connection.
+    * Flag to indicate if command requires a DB connection.
     *
     * @var boolean
     */
    protected $requires_db = true;
+
+   /**
+    * Flag to indicate if command requires an up-to-date DB.
+    *
+    * @var boolean
+    */
+   protected $requires_db_up_to_date = true;
 
    protected function initialize(InputInterface $input, OutputInterface $output) {
 
@@ -198,5 +205,10 @@ abstract class AbstractCommand extends Command implements GlpiCommandInterface {
    public function mustCheckMandatoryRequirements(): bool {
 
       return true;
+   }
+
+   public function requiresUpToDateDb(): bool {
+
+      return $this->requires_db && $this->requires_db_up_to_date;
    }
 }

--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -69,6 +69,13 @@ class Application extends BaseApplication {
    const ERROR_MISSING_REQUIREMENTS = 128; // start application codes at 128 be sure to be different from commands codes
 
    /**
+    * Error code returned when DB is not up-to-date.
+    *
+    * @var integer
+    */
+   const ERROR_DB_OUTDATED = 129;
+
+   /**
     * Pointer to $CFG_GLPI.
     * @var array
     */
@@ -223,6 +230,16 @@ class Application extends BaseApplication {
    protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output) {
 
       $begin_time = microtime(true);
+
+      if ($command instanceof GlpiCommandInterface && $command->requiresUpToDateDb()
+          && (!array_key_exists('dbversion', $this->config) || (trim($this->config['dbversion']) != GLPI_SCHEMA_VERSION))) {
+         $output->writeln(
+            '<error>'
+            . __('The version of the database is not compatible with the version of the installed files. An update is necessary.')
+            . '</error>'
+         );
+         return self::ERROR_DB_OUTDATED;
+      }
 
       if ($command instanceof GlpiCommandInterface && $command->mustCheckMandatoryRequirements()
           && !$this->checkCoreMandatoryRequirements()) {

--- a/inc/console/command/glpicommandinterface.class.php
+++ b/inc/console/command/glpicommandinterface.class.php
@@ -39,9 +39,16 @@ if (!defined('GLPI_ROOT')) {
 interface GlpiCommandInterface {
 
    /**
-    * Defines whether or mandatory requirements must be checked before running command.
+    * Defines whether or not mandatory requirements must be checked before running command.
     *
     * @return boolean
     */
    public function mustCheckMandatoryRequirements(): bool;
+
+   /**
+    * Defines whether or not command requires an up-to-date database to be executed.
+    *
+    * @return boolean
+    */
+   public function requiresUpToDateDb(): bool;
 }

--- a/inc/console/database/abstractconfigurecommand.class.php
+++ b/inc/console/database/abstractconfigurecommand.class.php
@@ -93,6 +93,8 @@ abstract class AbstractConfigureCommand extends AbstractCommand implements Force
     */
    const ERROR_DB_CONFIG_FILE_NOT_SAVED = 4;
 
+   protected $requires_db_up_to_date = false;
+
    protected function configure() {
 
       parent::configure();

--- a/inc/console/database/updatecommand.class.php
+++ b/inc/console/database/updatecommand.class.php
@@ -64,6 +64,8 @@ class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionComma
     */
    const ERROR_MISSING_SECURITY_KEY_FILE = 2;
 
+   protected $requires_db_up_to_date = false;
+
    protected function configure() {
       parent::configure();
 

--- a/inc/console/maintenance/disablemaintenancemodecommand.class.php
+++ b/inc/console/maintenance/disablemaintenancemodecommand.class.php
@@ -44,6 +44,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DisableMaintenanceModeCommand extends AbstractCommand {
 
+   protected $requires_db_up_to_date = false;
+
    protected function configure() {
       parent::configure();
 

--- a/inc/console/maintenance/enablemaintenancemodecommand.class.php
+++ b/inc/console/maintenance/enablemaintenancemodecommand.class.php
@@ -45,6 +45,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class EnableMaintenanceModeCommand extends AbstractCommand {
 
+   protected $requires_db_up_to_date = false;
+
    protected function configure() {
       parent::configure();
 

--- a/inc/console/system/clearcachecommand.class.php
+++ b/inc/console/system/clearcachecommand.class.php
@@ -42,6 +42,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ClearCacheCommand extends Command {
 
+   protected $requires_db_up_to_date = false;
+
    protected function configure() {
       parent::configure();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Executing some commands before having an up-to-date DB may produce unexpected results. This PR will disallow execution of most of existing commands in this case, except for install, update, maintenance enable/disable and cache clear commands.