### PR TITLE
Fix associated elements in ticket list

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3494,7 +3494,7 @@ JAVASCRIPT;
                 || (isset($searchopt[$ID]["forcegroupby"]) && $searchopt[$ID]["forcegroupby"])) {
                $ADDITONALFIELDS .= " IFNULL(GROUP_CONCAT(DISTINCT CONCAT(IFNULL(`$table$addtable`.`$key`,
                                                                          '".self::NULLVALUE."'),
-                                                   '".self::SHORTSEP."', $tocomputeid) SEPARATOR '".self::LONGSEP."'), '".self::NULLVALUE.self::SHORTSEP."')
+                                                   '".self::SHORTSEP."', $tocomputeid)ORDER BY $tocomputeid SEPARATOR '".self::LONGSEP."'), '".self::NULLVALUE.self::SHORTSEP."')
                                     AS `".$NAME."_$key`, ";
             } else {
                $ADDITONALFIELDS .= "`$table$addtable`.`$key` AS `".$NAME."_$key`, ";


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4107

I don't know exactly why it fails depending on the database you have.
In my case it was with 10.3.27-MariaDB-1:10.3.27+maria~stretch-log.
When I executed the SQL with that database the result was:

ITEM_Ticket_13 | ITEM_Ticket_13_itemtype
1507$#$4631$$##$$1891$#$4632 | Computer$#$4632$$##$$Monitor$#$4631

When it should be:

ITEM_Ticket_13 | ITEM_Ticket_13_itemtype
1507$#$4631$$##$$1891$#$4632 | Computer$#$4631$$##$$Monitor$#$4632

To avoid this I forced to also order by the id the field "ITEM_Ticket_13_itemtype"