### PR TITLE
Use utf8mb4 MySQL character set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,12 +224,13 @@ jobs:
           docker exec app bin/console glpi:migration:myisam_to_innodb --config-dir=./tests --no-interaction | grep -q "Aucune migration requise." || (echo "glpi:migration:myisam_to_innodb command FAILED" && exit 1)
           docker exec app bin/console glpi:migration:timestamps --config-dir=./tests --no-interaction
           docker exec app bin/console glpi:migration:timestamps --config-dir=./tests --no-interaction | grep -q "Aucune migration requise." || (echo "glpi:migration:timestamps command FAILED" && exit 1)
+          docker exec app bin/console glpi:migration:utf8mb4 --config-dir=./tests --no-interaction
+          docker exec app bin/console glpi:migration:utf8mb4 --config-dir=./tests --no-interaction | grep -q "Aucune migration requise." || (echo "glpi:migration:utf8mb4 command FAILED" && exit 1)
       - name: "Database tests"
         if: env.skip != 'true'
         run: |
-          docker exec app bin/console glpi:database:configure --config-dir=./tests --no-interaction --reconfigure --db-name=glpi --db-host=db --db-user=root
+          docker exec app bin/console glpi:database:configure --config-dir=./tests --no-interaction --reconfigure --db-name=glpi --db-host=db --db-user=root --use-utf8mb4
           docker exec app vendor/bin/atoum -p 'php -d memory_limit=512M' --debug --force-terminal --use-dot-report --bootstrap-file tests/bootstrap.php --no-code-coverage --fail-if-skipped-methods --max-children-number 1 -d tests/database
-          docker exec app bin/console glpi:database:configure --config-dir=./tests --no-interaction --reconfigure --db-name=glpi --db-host=db --db-user=root
       - name: "Unit tests"
         if: env.skip != 'true'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The present file will list all changes made to the project; according to the
 ### Deprecated
 - Usage of XML-RPC API is deprecated.
 
+### Removed
+- Usage of alternative DB connection encoding (`DB::$dbenc` property).
+
 ### API changes
 
 #### Added

--- a/composer.lock
+++ b/composer.lock
@@ -59,6 +59,10 @@
                 "upload",
                 "widget"
             ],
+            "support": {
+                "forum": "https://stackoverflow.com/questions/tagged/blueimp+jquery+file-upload",
+                "source": "https://github.com/vkhramtsov/jQuery-File-Upload/tree/v10.31.0"
+            },
             "funding": [
                 {
                     "url": "https://github.com/blueimp",
@@ -111,6 +115,10 @@
                 "brick",
                 "math"
             ],
+            "support": {
+                "issues": "https://github.com/brick/math/issues",
+                "source": "https://github.com/brick/math/tree/master"
+            },
             "funding": [
                 {
                     "url": "https://tidelift.com/funding/github/packagist/brick/math",
@@ -148,6 +156,10 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
+            "support": {
+                "issues": "https://github.com/container-interop/container-interop/issues",
+                "source": "https://github.com/container-interop/container-interop/tree/master"
+            },
             "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
         },
@@ -187,6 +199,10 @@
                 "emoji",
                 "php-emoji"
             ],
+            "support": {
+                "issues": "https://github.com/elvanto/litemoji/issues",
+                "source": "https://github.com/elvanto/litemoji/tree/3.0.1"
+            },
             "time": "2020-11-27T05:08:33+00:00"
         },
         {
@@ -267,6 +283,10 @@
                 "rest",
                 "web service"
             ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.2.0"
+            },
             "funding": [
                 {
                     "url": "https://github.com/GrahamCampbell",
@@ -336,6 +356,10 @@
             "keywords": [
                 "promise"
             ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/1.4.0"
+            },
             "time": "2020-09-30T07:37:28+00:00"
         },
         {
@@ -407,6 +431,10 @@
                 "uri",
                 "url"
             ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/1.7.0"
+            },
             "time": "2020-09-30T07:37:11+00:00"
         },
         {
@@ -466,6 +494,10 @@
                 "autolink",
                 "link"
             ],
+            "support": {
+                "issues": "https://github.com/iamcal/lib_autolink/issues",
+                "source": "https://github.com/iamcal/lib_autolink/tree/master"
+            },
             "time": "2015-05-22T17:10:41+00:00"
         },
         {
@@ -550,6 +582,14 @@
                 "psr-16",
                 "psr-6"
             ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-cache/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-cache/issues",
+                "rss": "https://github.com/laminas/laminas-cache/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -605,6 +645,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-apc/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-apc/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-apc/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-apc"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -660,6 +707,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-apcu/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-apcu/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-apcu/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-apcu"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -712,6 +766,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-blackhole/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-blackhole/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-blackhole/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-blackhole"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -767,6 +828,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-dba/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-dba/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-dba/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-dba"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -822,6 +890,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-ext-mongodb/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-ext-mongodb/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-ext-mongodb/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-ext-mongodb"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -874,6 +949,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-filesystem/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-filesystem/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-filesystem/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-filesystem"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -929,6 +1011,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-memcache/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-memcache/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-memcache/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-memcache"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -981,6 +1070,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-memcached/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-memcached/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-memcached/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-memcached"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -1033,6 +1129,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-memory/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-memory/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-memory/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-memory"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -1085,6 +1188,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-mongodb/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-mongodb/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-mongodb/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-mongodb"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -1137,6 +1247,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-redis/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-redis/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-redis/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-redis"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -1193,6 +1310,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-session/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-session/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-session/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-session"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -1248,6 +1372,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-wincache/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-wincache/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-wincache/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-wincache"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -1304,6 +1435,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-xcache/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-xcache/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-xcache/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-xcache"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -1356,6 +1494,13 @@
                 "cache",
                 "laminas"
             ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-zend-server/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-zend-server/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-zend-server/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-zend-server"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -1420,6 +1565,14 @@
                 "events",
                 "laminas"
             ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-eventmanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-eventmanager/issues",
+                "rss": "https://github.com/laminas/laminas-eventmanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-eventmanager"
+            },
             "time": "2019-12-31T16:44:52+00:00"
         },
         {
@@ -1495,6 +1648,14 @@
                 "i18n",
                 "laminas"
             ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-i18n/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-i18n/issues",
+                "rss": "https://github.com/laminas/laminas-i18n/releases.atom",
+                "source": "https://github.com/laminas/laminas-i18n"
+            },
             "time": "2020-03-29T12:51:08+00:00"
         },
         {
@@ -1549,6 +1710,14 @@
                 "json",
                 "laminas"
             ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-json/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-json/issues",
+                "rss": "https://github.com/laminas/laminas-json/releases.atom",
+                "source": "https://github.com/laminas/laminas-json"
+            },
             "time": "2019-12-31T17:15:04+00:00"
         },
         {
@@ -1598,6 +1767,14 @@
                 "laminas",
                 "loader"
             ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-loader/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-loader/issues",
+                "rss": "https://github.com/laminas/laminas-loader/releases.atom",
+                "source": "https://github.com/laminas/laminas-loader"
+            },
             "time": "2019-12-31T17:18:27+00:00"
         },
         {
@@ -1660,6 +1837,14 @@
                 "laminas",
                 "mail"
             ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-mail/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-mail/issues",
+                "rss": "https://github.com/laminas/laminas-mail/releases.atom",
+                "source": "https://github.com/laminas/laminas-mail"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -1720,6 +1905,14 @@
                 "laminas",
                 "mime"
             ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-mime/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-mime/issues",
+                "rss": "https://github.com/laminas/laminas-mime/releases.atom",
+                "source": "https://github.com/laminas/laminas-mime"
+            },
             "time": "2020-03-29T13:12:07+00:00"
         },
         {
@@ -1781,6 +1974,14 @@
                 "laminas",
                 "serializer"
             ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-serializer/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-serializer/issues",
+                "rss": "https://github.com/laminas/laminas-serializer/releases.atom",
+                "source": "https://github.com/laminas/laminas-serializer"
+            },
             "time": "2019-12-31T17:42:11+00:00"
         },
         {
@@ -1853,6 +2054,14 @@
                 "service-manager",
                 "servicemanager"
             ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-servicemanager/issues",
+                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-servicemanager"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -1909,6 +2118,14 @@
                 "laminas",
                 "stdlib"
             ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-stdlib/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-stdlib/issues",
+                "rss": "https://github.com/laminas/laminas-stdlib/releases.atom",
+                "source": "https://github.com/laminas/laminas-stdlib"
+            },
             "time": "2019-12-31T17:51:15+00:00"
         },
         {
@@ -1988,6 +2205,14 @@
                 "laminas",
                 "validator"
             ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-validator/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-validator/issues",
+                "rss": "https://github.com/laminas/laminas-validator/releases.atom",
+                "source": "https://github.com/laminas/laminas-validator"
+            },
             "time": "2020-03-31T18:57:01+00:00"
         },
         {
@@ -2036,6 +2261,12 @@
                 "laminas",
                 "zf"
             ],
+            "support": {
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
+                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
+                "source": "https://github.com/laminas/laminas-zendframework-bridge"
+            },
             "funding": [
                 {
                     "url": "https://funding.communitybridge.org/projects/laminas-project",
@@ -2114,6 +2345,12 @@
                 "transform",
                 "write"
             ],
+            "support": {
+                "docs": "https://csv.thephpleague.com",
+                "issues": "https://github.com/thephpleague/csv/issues",
+                "rss": "https://github.com/thephpleague/csv/releases.atom",
+                "source": "https://github.com/thephpleague/csv"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sponsors/nyamsprod",
@@ -2169,6 +2406,10 @@
                 "frontend",
                 "ui"
             ],
+            "support": {
+                "issues": "https://github.com/mexitek/phpColors/issues",
+                "source": "https://github.com/mexitek/phpColors"
+            },
             "time": "2020-11-05T06:04:47+00:00"
         },
         {
@@ -2218,6 +2459,10 @@
             "keywords": [
                 "markdown"
             ],
+            "support": {
+                "issues": "https://github.com/michelf/php-markdown/issues",
+                "source": "https://github.com/michelf/php-markdown/tree/1.9.0"
+            },
             "time": "2019-12-02T02:32:27+00:00"
         },
         {
@@ -2300,6 +2545,10 @@
                 "logging",
                 "psr-3"
             ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/2.2.0"
+            },
             "funding": [
                 {
                     "url": "https://github.com/Seldaek",
@@ -2462,6 +2711,10 @@
                 }
             ],
             "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
+            "support": {
+                "issues": "https://github.com/PHPMailer/PHPMailer/issues",
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.2.0"
+            },
             "funding": [
                 {
                     "url": "https://github.com/Synchro",
@@ -2514,6 +2767,9 @@
                 "psr",
                 "psr-6"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/master"
+            },
             "time": "2016-08-06T20:24:11+00:00"
         },
         {
@@ -2563,6 +2819,10 @@
                 "container-interop",
                 "psr"
             ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/master"
+            },
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
@@ -2612,6 +2872,9 @@
                 "psr",
                 "psr-18"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
             "time": "2020-06-29T06:28:15+00:00"
         },
         {
@@ -2662,6 +2925,9 @@
                 "request",
                 "response"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/master"
+            },
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
@@ -2709,6 +2975,9 @@
                 "psr",
                 "psr-3"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.3"
+            },
             "time": "2020-03-23T09:12:05+00:00"
         },
         {
@@ -2757,6 +3026,9 @@
                 "psr-16",
                 "simple-cache"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/master"
+            },
             "time": "2017-10-23T01:57:42+00:00"
         },
         {
@@ -2797,6 +3069,10 @@
                 }
             ],
             "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
@@ -2860,6 +3136,10 @@
                 "queue",
                 "set"
             ],
+            "support": {
+                "issues": "https://github.com/ramsey/collection/issues",
+                "source": "https://github.com/ramsey/collection/tree/1.1.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/ramsey",
@@ -2947,6 +3227,11 @@
                 "identifier",
                 "uuid"
             ],
+            "support": {
+                "issues": "https://github.com/ramsey/uuid/issues",
+                "rss": "https://github.com/ramsey/uuid/releases.atom",
+                "source": "https://github.com/ramsey/uuid"
+            },
             "funding": [
                 {
                     "url": "https://github.com/ramsey",
@@ -2998,6 +3283,10 @@
                 "recurring",
                 "rrule"
             ],
+            "support": {
+                "issues": "https://github.com/rlanvin/php-rrule/issues",
+                "source": "https://github.com/rlanvin/php-rrule/tree/v2.2.1"
+            },
             "time": "2020-12-09T22:13:35+00:00"
         },
         {
@@ -3505,6 +3794,10 @@
                 "scss",
                 "stylesheet"
             ],
+            "support": {
+                "issues": "https://github.com/scssphp/scssphp/issues",
+                "source": "https://github.com/scssphp/scssphp/tree/v1.4.0"
+            },
             "time": "2020-11-07T20:53:41+00:00"
         },
         {
@@ -3561,6 +3854,10 @@
                 "unidiff",
                 "unified diff"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -3634,6 +3931,10 @@
                 "feeds",
                 "rss"
             ],
+            "support": {
+                "issues": "https://github.com/simplepie/simplepie/issues",
+                "source": "https://github.com/simplepie/simplepie/tree/1.5.6"
+            },
             "time": "2020-10-14T07:17:22+00:00"
         },
         {
@@ -3706,6 +4007,9 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v4.4.18"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3783,6 +4087,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.20.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3859,6 +4166,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.20.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3939,6 +4249,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.20.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4015,6 +4328,9 @@
                 "interoperability",
                 "standards"
             ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/master"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4091,6 +4407,10 @@
                 "pdf417",
                 "qrcode"
             ],
+            "support": {
+                "issues": "https://github.com/tecnickcom/TCPDF/issues",
+                "source": "https://github.com/tecnickcom/TCPDF/tree/6.3.5"
+            },
             "time": "2020-02-14T14:20:12+00:00"
         },
         {
@@ -4137,6 +4457,10 @@
                 "idna",
                 "punycode"
             ],
+            "support": {
+                "issues": "https://github.com/true/php-punycode/issues",
+                "source": "https://github.com/true/php-punycode/tree/master"
+            },
             "time": "2016-11-16T10:37:54+00:00"
         },
         {
@@ -4230,6 +4554,10 @@
                 "tar",
                 "zip"
             ],
+            "support": {
+                "issues": "https://github.com/wapmorgan/UnifiedArchive/issues",
+                "source": "https://github.com/wapmorgan/UnifiedArchive/tree/1.0.1"
+            },
             "time": "2020-11-28T13:04:06+00:00"
         }
     ],
@@ -4315,6 +4643,10 @@
                 "test",
                 "unit testing"
             ],
+            "support": {
+                "issues": "https://github.com/atoum/atoum/issues",
+                "source": "https://github.com/atoum/atoum/tree/4.0.0"
+            },
             "time": "2020-11-21T17:23:11+00:00"
         },
         {
@@ -4366,6 +4698,10 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
+            "support": {
+                "issues": "https://github.com/consolidation/annotated-command/issues",
+                "source": "https://github.com/consolidation/annotated-command/tree/4.2.4"
+            },
             "time": "2020-12-10T16:56:39+00:00"
         },
         {
@@ -4422,6 +4758,10 @@
                 }
             ],
             "description": "Provide configuration services for a commandline tool.",
+            "support": {
+                "issues": "https://github.com/consolidation/config/issues",
+                "source": "https://github.com/consolidation/config/tree/2.0.1"
+            },
             "time": "2020-12-06T00:03:30+00:00"
         },
         {
@@ -4470,6 +4810,10 @@
                 }
             ],
             "description": "Improved Psr-3 / Psr\\Log logger based on Symfony Console components.",
+            "support": {
+                "issues": "https://github.com/consolidation/log/issues",
+                "source": "https://github.com/consolidation/log/tree/2.0.2"
+            },
             "time": "2020-12-10T16:26:23+00:00"
         },
         {
@@ -4525,6 +4869,10 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
+            "support": {
+                "issues": "https://github.com/consolidation/output-formatters/issues",
+                "source": "https://github.com/consolidation/output-formatters/tree/4.1.2"
+            },
             "time": "2020-12-12T19:04:59+00:00"
         },
         {
@@ -4622,6 +4970,10 @@
                 }
             ],
             "description": "Modern task runner",
+            "support": {
+                "issues": "https://github.com/consolidation/Robo/issues",
+                "source": "https://github.com/consolidation/Robo/tree/2.2.2"
+            },
             "time": "2020-12-18T22:09:18+00:00"
         },
         {
@@ -4672,6 +5024,10 @@
                 }
             ],
             "description": "Provides a self:update command for Symfony Console applications.",
+            "support": {
+                "issues": "https://github.com/consolidation/self-update/issues",
+                "source": "https://github.com/consolidation/self-update/tree/1.2.0"
+            },
             "time": "2020-04-13T02:49:20+00:00"
         },
         {
@@ -4738,6 +5094,10 @@
                 "stylecheck",
                 "tests"
             ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
             "time": "2020-06-25T14:57:39+00:00"
         },
         {
@@ -4797,6 +5157,10 @@
                 "dot",
                 "notation"
             ],
+            "support": {
+                "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/master"
+            },
             "time": "2017-01-20T21:14:22+00:00"
         },
         {
@@ -4835,6 +5199,10 @@
                 "glpi",
                 "phpcs"
             ],
+            "support": {
+                "issues": "https://github.com/glpi-project/coding-standard/issues",
+                "source": "https://github.com/glpi-project/coding-standard"
+            },
             "time": "2020-06-03T08:54:27+00:00"
         },
         {
@@ -4937,6 +5305,10 @@
                 }
             ],
             "description": "Expands internal property references in PHP arrays file.",
+            "support": {
+                "issues": "https://github.com/grasmash/expander/issues",
+                "source": "https://github.com/grasmash/expander/tree/master"
+            },
             "time": "2017-12-21T22:14:55+00:00"
         },
         {
@@ -5002,6 +5374,10 @@
                 "provider",
                 "service"
             ],
+            "support": {
+                "issues": "https://github.com/thephpleague/container/issues",
+                "source": "https://github.com/thephpleague/container/tree/2.x"
+            },
             "time": "2017-05-10T09:20:27+00:00"
         },
         {
@@ -5072,6 +5448,10 @@
                 "require",
                 "requirements"
             ],
+            "support": {
+                "issues": "https://github.com/maglnet/ComposerRequireChecker/issues",
+                "source": "https://github.com/maglnet/ComposerRequireChecker/tree/2.0.0"
+            },
             "time": "2019-03-19T20:16:54+00:00"
         },
         {
@@ -5118,6 +5498,11 @@
             ],
             "description": "Virtual file system to mock the real file system in unit tests.",
             "homepage": "http://vfs.bovigo.org/",
+            "support": {
+                "issues": "https://github.com/bovigo/vfsStream/issues",
+                "source": "https://github.com/bovigo/vfsStream/tree/master",
+                "wiki": "https://github.com/bovigo/vfsStream/wiki"
+            },
             "time": "2019-10-30T15:31:00+00:00"
         },
         {
@@ -5165,6 +5550,10 @@
                 "css",
                 "minify"
             ],
+            "support": {
+                "issues": "https://github.com/natxet/CssMin/issues",
+                "source": "https://github.com/natxet/CssMin/tree/master"
+            },
             "time": "2018-01-09T11:15:01+00:00"
         },
         {
@@ -5217,6 +5606,10 @@
                 "parser",
                 "php"
             ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.2"
+            },
             "time": "2020-09-26T10:30:38+00:00"
         },
         {
@@ -5317,6 +5710,10 @@
             ],
             "description": "This tool check syntax of PHP files about 20x faster than serial check.",
             "homepage": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
+            "support": {
+                "issues": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/issues",
+                "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/master"
+            },
             "time": "2020-04-04T12:18:32+00:00"
         },
         {
@@ -5366,6 +5763,10 @@
                 "MIT"
             ],
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+            },
             "time": "2020-08-03T20:32:43+00:00"
         },
         {
@@ -5413,6 +5814,10 @@
                 "MIT"
             ],
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/kukulich",
@@ -5474,6 +5879,11 @@
                 "phpcs",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
             "time": "2020-10-23T02:01:07+00:00"
         },
         {
@@ -5524,6 +5934,9 @@
             ],
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/master"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5604,6 +6017,9 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v4.4.18"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5680,6 +6096,9 @@
                 "interoperability",
                 "standards"
             ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v1.1.9"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5739,6 +6158,9 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v5.2.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5797,6 +6219,9 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v5.2.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5874,6 +6299,9 @@
             ],
             "description": "Symfony HttpClient component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v4.4.16"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5949,6 +6377,9 @@
                 "interoperability",
                 "standards"
             ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v1.1.10"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -6020,6 +6451,9 @@
                 "mime",
                 "mime-type"
             ],
+            "support": {
+                "source": "https://github.com/symfony/mime/tree/v4.4.16"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -6079,6 +6513,9 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v5.2.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -6151,6 +6588,9 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v5.2.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -6214,6 +6654,10 @@
                 "check",
                 "validate"
             ],
+            "support": {
+                "issues": "https://github.com/webmozart/assert/issues",
+                "source": "https://github.com/webmozart/assert/tree/master"
+            },
             "time": "2020-07-08T17:02:28+00:00"
         },
         {
@@ -6261,6 +6705,10 @@
                 }
             ],
             "description": "A PHP implementation of Ant's glob.",
+            "support": {
+                "issues": "https://github.com/webmozarts/glob/issues",
+                "source": "https://github.com/webmozarts/glob/tree/4.1.0"
+            },
             "time": "2015-12-29T11:14:33+00:00"
         },
         {
@@ -6307,6 +6755,10 @@
                 }
             ],
             "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "support": {
+                "issues": "https://github.com/webmozart/path-util/issues",
+                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
+            },
             "time": "2015-12-17T08:42:14+00:00"
         }
     ],
@@ -6335,5 +6787,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/inc/central.class.php
+++ b/inc/central.class.php
@@ -329,11 +329,15 @@ class Central extends CommonGLPI {
          if ($DB->areTimezonesAvailable()) {
             $not_tstamp = $DB->notTzMigrated();
             if ($not_tstamp > 0) {
-                $warnings[] = sprintf(
-                    __('%1$s columns are not compatible with timezones usage.'),
-                    $not_tstamp
-                );
+                $warnings[] = sprintf(__('%1$s columns are not compatible with timezones usage.'), $not_tstamp)
+               . ' '
+               . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:timestamps');
             }
+         }
+         if (($non_utf8mb4_tables = $DB->getNonUtf8mb4Tables()->count()) > 0) {
+            $warnings[] = sprintf(__('%1$s tables not migrated to utf8mb4 collation.'), $non_utf8mb4_tables)
+               . ' '
+               . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:utf8mb4');
          }
       }
 

--- a/inc/console/abstractcommand.class.php
+++ b/inc/console/abstractcommand.class.php
@@ -44,6 +44,7 @@ use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 abstract class AbstractCommand extends Command implements GlpiCommandInterface {
 
@@ -209,5 +210,27 @@ abstract class AbstractCommand extends Command implements GlpiCommandInterface {
    public function requiresUpToDateDb(): bool {
 
       return $this->requires_db && $this->requires_db_up_to_date;
+   }
+
+   /**
+    * Ask for user confirmation before continuing command execution.
+    *
+    * @return void
+    */
+   protected function askForConfirmation(): void {
+      if (!$this->input->getOption('no-interaction')) {
+         $question_helper = $this->getHelper('question');
+         $run = $question_helper->ask(
+            $this->input,
+            $this->output,
+            new ConfirmationQuestion(__('Do you want to continue ?') . ' [Yes/no]', true)
+         );
+         if (!$run) {
+            throw new \Glpi\Console\Exception\EarlyExitException(
+               '<comment>' . __('Aborted.') . '</comment>',
+               0 // Success code
+            );
+         }
+      }
    }
 }

--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -244,7 +244,12 @@ class Application extends BaseApplication {
          return self::ERROR_MISSING_REQUIREMENTS;
       }
 
-      $result = parent::doRunCommand($command, $input, $output);
+      try {
+         $result = parent::doRunCommand($command, $input, $output);
+      } catch (\Glpi\Console\Exception\EarlyExitException $e) {
+         $result = $e->getCode();
+         $output->writeln($e->getMessage(), OutputInterface::VERBOSITY_QUIET);
+      }
 
       if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERY_VERBOSE) {
          $output->writeln(

--- a/inc/console/database/abstractconfigurecommand.class.php
+++ b/inc/console/database/abstractconfigurecommand.class.php
@@ -176,10 +176,13 @@ abstract class AbstractConfigureCommand extends AbstractCommand implements Force
     *
     * @param InputInterface $input
     * @param OutputInterface $output
+    * @param bool $use_utf8mb4
+    *
     * @throws InvalidArgumentException
+    *
     * @return string
     */
-   protected function configureDatabase(InputInterface $input, OutputInterface $output) {
+   protected function configureDatabase(InputInterface $input, OutputInterface $output, bool $use_utf8mb4) {
 
       $db_pass     = $input->getOption('db-password');
       $db_host     = $input->getOption('db-host');
@@ -234,6 +237,8 @@ abstract class AbstractConfigureCommand extends AbstractCommand implements Force
          return self::ERROR_DB_CONNECTION_FAILED;
       }
 
+      DBConnection::setConnectionCharset($mysqli, $use_utf8mb4);
+
       ob_start();
       $db_version_data = $mysqli->query('SELECT version()')->fetch_array();
       $checkdb = Config::displayCheckDbEngine(false, $db_version_data[0]);
@@ -249,7 +254,7 @@ abstract class AbstractConfigureCommand extends AbstractCommand implements Force
          '<comment>' . __('Saving configuration file...') . '</comment>',
          OutputInterface::VERBOSITY_VERBOSE
       );
-      if (!DBConnection::createMainConfig($db_hostport, $db_user, $db_pass, $db_name)) {
+      if (!DBConnection::createMainConfig($db_hostport, $db_user, $db_pass, $db_name, $use_utf8mb4)) {
          $message = sprintf(
             __('Cannot write configuration file "%s".'),
             GLPI_CONFIG_DIR . DIRECTORY_SEPARATOR . 'config_db.php'

--- a/inc/console/exception/earlyexitexception.class.php
+++ b/inc/console/exception/earlyexitexception.class.php
@@ -30,42 +30,19 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Console\Database;
+namespace Glpi\Console\Exception;
 
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Exception\ExceptionInterface;
 
-class ConfigureCommand extends AbstractConfigureCommand {
+/**
+ * This exception is used to easilly trigger an exit of current command from a sub method.
+ *
+ * @since x.x.x
+ */
+class EarlyExitException extends \Exception implements ExceptionInterface {
 
-   protected function configure() {
-
-      parent::configure();
-
-      $this->setName('glpi:database:configure');
-      $this->setAliases(['db:configure']);
-      $this->setDescription('Define database configuration');
-
-      $this->addOption(
-         'use-utf8mb4',
-         null,
-         InputOption::VALUE_NONE,
-         __('Use utf8mb4 character set.')
-      );
-   }
-
-   protected function execute(InputInterface $input, OutputInterface $output) {
-
-      $result = $this->configureDatabase($input, $output, $input->getOption('use-utf8mb4'));
-
-      if (self::ABORTED_BY_USER === $result) {
-         return 0; // Considered as success
-      }
-
-      return $result;
-   }
 }

--- a/inc/console/migration/utf8mb4command.class.php
+++ b/inc/console/migration/utf8mb4command.class.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Migration;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use DBConnection;
+use Glpi\Console\AbstractCommand;
+use Glpi\System\Requirement\DbConfiguration;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Utf8mb4Command extends AbstractCommand {
+
+   /**
+    * Error code returned if migration failed on, at least, one table.
+    *
+    * @var integer
+    */
+   const ERROR_MIGRATION_FAILED_FOR_SOME_TABLES = 1;
+
+   /**
+    * Error code returned if DB configuration file cannot be updated.
+    *
+    * @var integer
+    */
+   const ERROR_UNABLE_TO_UPDATE_CONFIG = 2;
+
+   /**
+    * Error code returned if some tables are still using MyISAM engine.
+    *
+    * @var integer
+    */
+   const ERROR_INNODB_REQUIRED = 3;
+
+   /**
+    * Error code returned if DB configuration is not compatible with large indexes.
+    *
+    * @var integer
+    */
+   const ERROR_INCOMPATIBLE_DB_CONFIG = 3;
+
+   protected function configure() {
+      parent::configure();
+
+      $this->setName('glpi:migration:utf8mb4');
+      $this->setDescription(__('Convert database character set from "utf8" to "utf8mb4".'));
+   }
+
+   protected function execute(InputInterface $input, OutputInterface $output) {
+      $this->checkForPrerequisites();
+      $this->upgradeRowFormat();
+      $this->migrateToUtf8mb4();
+
+      return 0; // Success
+   }
+
+   /**
+    * Check for migration prerequisites.
+    *
+    * @return void
+    */
+   private function checkForPrerequisites(): void {
+      // Check that DB configuration is compatible
+      $config_requirement = new DbConfiguration($this->db);
+      if (!$config_requirement->isValidated()) {
+         $msg = '<error>' . __('Database configuration is not compatible with "utf8mb4" usage.') . '</error>';
+         foreach ($config_requirement->getValidationMessages() as $validation_message) {
+            $msg .= "\n" . '<error> - ' . $validation_message . '</error>';
+         }
+         throw new \Glpi\Console\Exception\EarlyExitException($msg, self::ERROR_INCOMPATIBLE_DB_CONFIG);
+      }
+
+      // Check that all tables are using InnoDB engine
+      if (($myisam_count = $this->db->getMyIsamTables()->count()) > 0) {
+         $msg = sprintf(
+            __('%d tables are still using MyISAM storage engine. Run "php bin/console glpi:migration:myisam_to_innodb" to fix this.'),
+            $myisam_count
+         );
+         throw new \Glpi\Console\Exception\EarlyExitException('<error>' . $msg . '</error>', self::ERROR_INNODB_REQUIRED);
+      }
+   }
+
+   /**
+    * Upgrade row format from 'Compact'/'Redundant' to 'Dynamic'.
+    * This is mandatory to support large indexes.
+    *
+    * @return void
+    */
+   private function upgradeRowFormat(): void {
+
+      $table_iterator = $this->db->listTables(
+         'glpi_%',
+         [
+            'row_format'   => ['Compact', 'Redundant'],
+         ]
+      );
+
+      if ($table_iterator->count() === 0) {
+         return;
+      }
+
+      $this->output->writeln(
+         sprintf(
+            '<info>' . __('Found %s table(s) requiring a migration to "ROW_FORMAT=Dynamic".') . '</info>',
+            $table_iterator->count()
+         )
+      );
+
+      $this->askForConfirmation();
+
+      $tables = [];
+      foreach ($table_iterator as $table_data) {
+         $tables[] = $table_data['TABLE_NAME'];
+      }
+      sort($tables);
+
+      $progress_bar = new ProgressBar($this->output);
+      $errors = 0;
+
+      foreach ($progress_bar->iterate($tables) as $table) {
+         $this->writelnOutputWithProgressBar(
+            sprintf(__('Migrating table "%s"...'), $table),
+            $progress_bar,
+            OutputInterface::VERBOSITY_VERY_VERBOSE
+         );
+
+         $result = $this->db->query(
+            sprintf('ALTER TABLE `%s` ROW_FORMAT = DYNAMIC', $table)
+         );
+
+         if (!$result) {
+            $this->writelnOutputWithProgressBar(
+               sprintf(__('<error>Error migrating table "%s".</error>'), $table),
+               $progress_bar,
+               OutputInterface::VERBOSITY_QUIET
+            );
+            $errors++;
+         }
+      }
+
+      $this->output->write(PHP_EOL);
+
+      if ($errors) {
+         throw new \Glpi\Console\Exception\EarlyExitException(
+            '<error>' . __('Errors occured during migration.') . '</error>',
+            self::ERROR_MIGRATION_FAILED_FOR_SOME_TABLES
+         );
+      }
+   }
+
+   /**
+    * Migrate tables to utf8mb4.
+    *
+    * @return void
+    */
+   private function migrateToUtf8mb4(): void {
+
+      $tables = [];
+
+      // Find collations to update at table level
+      $table_iterator = $this->db->getNonUtf8mb4Tables();
+      foreach ($table_iterator as $table_data) {
+         $tables[] = $table_data['TABLE_NAME'];
+      }
+
+      $errors = 0;
+
+      if (count($tables) === 0) {
+         $this->output->writeln('<info>' . __('No migration needed.') . '</info>');
+      } else {
+         sort($tables);
+
+         $this->output->writeln(
+            sprintf(
+               '<info>' . __('Found %s table(s) requiring migration to "utf8mb4".') . '</info>',
+               count($tables)
+            )
+         );
+
+         $this->askForConfirmation();
+
+         // Early update property to prevent warnings related to bad collation detection.
+         $this->db->use_utf8mb4 = true;
+
+         $progress_bar = new ProgressBar($this->output);
+         $errors = 0;
+
+         foreach ($progress_bar->iterate($tables) as $table) {
+            $this->writelnOutputWithProgressBar(
+               sprintf(__('Migrating table "%s"...'), $table),
+               $progress_bar,
+               OutputInterface::VERBOSITY_VERY_VERBOSE
+            );
+
+            $result = $this->db->query(
+               sprintf('ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci', $table)
+            );
+
+            if (!$result) {
+               $this->writelnOutputWithProgressBar(
+                  sprintf(__('<error>Error migrating table "%s".</error>'), $table),
+                  $progress_bar,
+                  OutputInterface::VERBOSITY_QUIET
+               );
+               $errors++;
+            }
+         }
+
+         $this->output->write(PHP_EOL);
+      }
+
+      if (!DBConnection::updateConfigProperty('use_utf8mb4', true)) {
+         throw new \Glpi\Console\Exception\EarlyExitException(
+            '<error>' . __('Unable to update DB configuration file.') . '</error>',
+            self::ERROR_UNABLE_TO_UPDATE_CONFIG
+         );
+      }
+
+      if ($errors) {
+         throw new \Glpi\Console\Exception\EarlyExitException(
+            '<error>' . __('Errors occured during migration.') . '</error>',
+            self::ERROR_MIGRATION_FAILED_FOR_SOME_TABLES
+         );
+      }
+
+      if (count($tables) > 0) {
+         $this->output->writeln('<info>' . __('Migration done.') . '</info>');
+      }
+   }
+}

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -951,7 +951,7 @@ class MailCollector  extends CommonDBTM {
     * @return array ticket fields
     */
    function buildTicket($uid, \Laminas\Mail\Storage\Message $message, $options = []) {
-      global $CFG_GLPI;
+      global $CFG_GLPI, $DB;
 
       $play_rules = (isset($options['play_rules']) && $options['play_rules']);
       $headers = $this->getHeaders($message);
@@ -1216,7 +1216,9 @@ class MailCollector  extends CommonDBTM {
          }
       }
 
-      $tkt['content'] = LitEmoji::encodeShortcode($tkt['content']);
+      if (!$DB->use_utf8mb4) {
+         $tkt['content'] = LitEmoji::encodeShortcode($tkt['content']);
+      }
 
       $tkt = Toolbox::addslashes_deep($tkt);
       return $tkt;

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -236,6 +236,7 @@ class Migration {
    private function fieldFormat($type, $default_value, $nodefault = false) {
 
       $format = '';
+      $collate = DBConnection::getDefaultCollation();
       switch ($type) {
          case 'bool' :
          case 'boolean' :
@@ -265,7 +266,7 @@ class Migration {
 
          case 'str' :
          case 'string' :
-            $format = "VARCHAR(255) COLLATE utf8_unicode_ci";
+            $format = "VARCHAR(255) COLLATE $collate";
             if (!$nodefault) {
                if (is_null($default_value)) {
                   $format .= " DEFAULT NULL";
@@ -313,7 +314,7 @@ class Migration {
             break;
 
          case 'text' :
-            $format = "TEXT COLLATE utf8_unicode_ci";
+            $format = "TEXT COLLATE $collate";
             if (!$nodefault) {
                if (is_null($default_value)) {
                   $format.= " DEFAULT NULL";
@@ -324,7 +325,7 @@ class Migration {
             break;
 
          case 'longtext' :
-            $format = "LONGTEXT COLLATE utf8_unicode_ci";
+            $format = "LONGTEXT COLLATE $collate";
             if (!$nodefault) {
                if (is_null($default_value)) {
                   $format .= " DEFAULT NULL";
@@ -1168,17 +1169,17 @@ class Migration {
          case 'warning':
             $msg       = str_pad("** {$msg}", 100);
             $format    = 'comment';
-            $verbosity = OutputInterface::VERBOSITY_VERBOSE;
+            $verbosity = OutputInterface::VERBOSITY_NORMAL;
             break;
          case 'strong':
             $msg       = str_pad($msg, 100);
             $format    = 'comment';
-            $verbosity = OutputInterface::VERBOSITY_VERBOSE;
+            $verbosity = OutputInterface::VERBOSITY_NORMAL;
             break;
          default:
             $msg       = str_pad($msg, 100);
             $format    = 'comment';
-            $verbosity = OutputInterface::VERBOSITY_VERY_VERBOSE;
+            $verbosity = OutputInterface::VERBOSITY_VERBOSE;
             break;
       }
 

--- a/inc/system/requirement/dbconfiguration.class.php
+++ b/inc/system/requirement/dbconfiguration.class.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\System\Requirement;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use DBmysql;
+
+/**
+ * @since x.x.x
+ */
+class DbConfiguration extends AbstractRequirement {
+
+   /**
+    * DB instance.
+    *
+    * @var DBmysql
+    */
+   private $db;
+
+   public function __construct(DBmysql $db) {
+      $this->title = __('Testing DB configuration');
+      $this->db = $db;
+   }
+
+   protected function check() {
+      $version = preg_replace('/^((\d+\.?)+).*$/', '$1', $this->db->getVersion());
+
+      // On MySQL 5.6, "ROW_FORMAT = Dynamic" fallbacks to "ROW_FORMAT = Compact"
+      // if "innodb_file_format" is not set to "Barracuda".
+      // This variable has been removed in MySQL 8.0 and in MariaDB 10.3.
+      $check_file_format = version_compare($version, '5.7', '<');
+
+      // "innodb_large_prefix" was required for "utf8mb4" indexes of VARCHAR(255) on older DB versions.
+      // This variable has been removed in MySQL 8.0 and in MariaDB 10.3.
+      $check_large_prefix = version_compare($version, '8.0', '<') // MySQL
+         || (version_compare($version, '10.0', '>=') && version_compare($version, '10.3', '<')); // MariaDB
+
+      $query = 'SELECT @@GLOBAL.' . $this->db->quoteName('innodb_page_size as innodb_page_size');
+      if ($check_file_format) {
+         $query .= ', @@GLOBAL.' . $this->db->quoteName('innodb_file_format as innodb_file_format');
+      }
+      if ($check_large_prefix) {
+         $query .= ', @@GLOBAL.' . $this->db->quoteName('innodb_large_prefix as innodb_large_prefix');
+      }
+
+      if (($db_config_res = $this->db->query($query)) === false) {
+         $this->validated = false;
+         $this->validation_messages[] = __('Unable to validate database configuration variables.');
+      }
+
+      $db_config = $db_config_res->fetch_assoc();
+
+      $incompatibilities = [];
+      if ($check_file_format && $db_config['innodb_file_format'] !== 'Barracuda') {
+         $incompatibilities[] = __('"innodb_file_format" must be set to "Barracuda".');
+      }
+      if ($check_large_prefix && (int)$db_config['innodb_large_prefix'] == 0) {
+         $incompatibilities[] = __('"innodb_large_prefix" must be enabled.');
+      }
+      if ((int)$db_config['innodb_page_size'] < 8192) {
+         $incompatibilities[] = '"innodb_page_size" must be >= 8KB.';
+      }
+
+      if (count($incompatibilities) > 0) {
+         $this->validation_messages = $incompatibilities;
+         $this->validated = false;
+      } else {
+         $this->validation_messages[] = __('Database configuration is OK.');
+         $this->validated = true;
+      }
+   }
+}

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2353,14 +2353,15 @@ class Toolbox {
     *
     * @since 0.84
     *
-    * @param string $name     config file name
-    * @param string $content  config file content
+    * @param string $name        config file name
+    * @param string $content     config file content
+    * @param string $config_dir  configuration directory to write on
     *
     * @return boolean
    **/
-   static function writeConfig($name, $content) {
+   static function writeConfig($name, $content, string $config_dir = GLPI_CONFIG_DIR) {
 
-      $name = GLPI_CONFIG_DIR . '/'.$name;
+      $name = $config_dir . '/'.$name;
       $fp   = fopen($name, 'wt');
       if ($fp) {
          $fw = fwrite($fp, $content);

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -42,7 +42,7 @@ CREATE TABLE `glpi_alerts` (
   UNIQUE KEY `unicity` (`itemtype`,`items_id`,`type`),
   KEY `type` (`type`),
   KEY `date` (`date`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_authldapreplicates
@@ -56,7 +56,7 @@ CREATE TABLE `glpi_authldapreplicates` (
   `name` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `authldaps_id` (`authldaps_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_authldaps
@@ -115,7 +115,7 @@ CREATE TABLE `glpi_authldaps` (
   KEY `is_active` (`is_active`),
   KEY `date_creation` (`date_creation`),
   KEY `sync_field` (`sync_field`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_authmails
@@ -132,7 +132,7 @@ CREATE TABLE `glpi_authmails` (
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
   KEY `is_active` (`is_active`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_apiclients
 
@@ -154,7 +154,7 @@ CREATE TABLE `glpi_apiclients` (
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
   KEY `is_active` (`is_active`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_autoupdatesystems
@@ -166,7 +166,7 @@ CREATE TABLE `glpi_autoupdatesystems` (
   `comment` text,
   PRIMARY KEY (`id`),
   KEY `name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_blacklistedmailcontents
@@ -182,7 +182,7 @@ CREATE TABLE `glpi_blacklistedmailcontents` (
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_blacklists
@@ -201,7 +201,7 @@ CREATE TABLE `glpi_blacklists` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_savedsearches
@@ -232,7 +232,7 @@ CREATE TABLE `glpi_savedsearches` (
   KEY `last_execution_time` (`last_execution_time`),
   KEY `last_execution_date` (`last_execution_date`),
   KEY `do_count` (`do_count`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_savedsearches_users
@@ -246,7 +246,7 @@ CREATE TABLE `glpi_savedsearches_users` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`users_id`,`itemtype`),
   KEY `savedsearches_id` (`savedsearches_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_savedsearches_alerts
@@ -267,7 +267,7 @@ CREATE TABLE `glpi_savedsearches_alerts` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   UNIQUE KEY `unicity` (`savedsearches_id`,`operator`, `value`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_budgets
@@ -301,7 +301,7 @@ CREATE TABLE `glpi_budgets` (
   KEY `date_creation` (`date_creation`),
   KEY `locations_id` (`locations_id`),
   KEY `budgettypes_id` (`budgettypes_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_budgettypes
@@ -317,7 +317,7 @@ CREATE TABLE `glpi_budgettypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_businesscriticities
 
@@ -340,7 +340,7 @@ CREATE TABLE `glpi_businesscriticities` (
   UNIQUE KEY `unicity` (`businesscriticities_id`,`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_calendars
@@ -361,7 +361,7 @@ CREATE TABLE `glpi_calendars` (
   KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_calendars_holidays
@@ -374,7 +374,7 @@ CREATE TABLE `glpi_calendars_holidays` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`calendars_id`,`holidays_id`),
   KEY `holidays_id` (`holidays_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_calendarsegments
@@ -391,7 +391,7 @@ CREATE TABLE `glpi_calendarsegments` (
   PRIMARY KEY (`id`),
   KEY `calendars_id` (`calendars_id`),
   KEY `day` (`day`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_cartridgeitems
@@ -425,7 +425,7 @@ CREATE TABLE `glpi_cartridgeitems` (
   KEY `groups_id_tech` (`groups_id_tech`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_cartridgeitems_printermodels
@@ -438,7 +438,7 @@ CREATE TABLE `glpi_cartridgeitems_printermodels` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`printermodels_id`,`cartridgeitems_id`),
   KEY `cartridgeitems_id` (`cartridgeitems_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_cartridgeitemtypes
@@ -454,7 +454,7 @@ CREATE TABLE `glpi_cartridgeitemtypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_cartridges
@@ -477,7 +477,7 @@ CREATE TABLE `glpi_cartridges` (
   KEY `entities_id` (`entities_id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_certificates
@@ -528,7 +528,7 @@ CREATE TABLE `glpi_certificates` (
   KEY `states_id` (`states_id`),
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_certificates_items
@@ -547,7 +547,7 @@ CREATE TABLE `glpi_certificates_items` (
   KEY `item` (`itemtype`,`items_id`),
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_certificatetypes
@@ -567,7 +567,7 @@ CREATE TABLE `glpi_certificatetypes` (
   KEY `name` (`name`),
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_changecosts
@@ -595,7 +595,7 @@ CREATE TABLE `glpi_changecosts` (
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `budgets_id` (`budgets_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_changes
@@ -652,7 +652,7 @@ CREATE TABLE `glpi_changes` (
   KEY `global_validation` (`global_validation`),
   KEY `users_id_lastupdater` (`users_id_lastupdater`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_changes_groups
@@ -666,7 +666,7 @@ CREATE TABLE `glpi_changes_groups` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`changes_id`,`type`,`groups_id`),
   KEY `group` (`groups_id`,`type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_changes_items
@@ -680,7 +680,7 @@ CREATE TABLE `glpi_changes_items` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`changes_id`,`itemtype`,`items_id`),
   KEY `item` (`itemtype`,`items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_changes_problems
@@ -693,7 +693,7 @@ CREATE TABLE `glpi_changes_problems` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`changes_id`,`problems_id`),
   KEY `problems_id` (`problems_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_changes_suppliers
@@ -709,7 +709,7 @@ CREATE TABLE `glpi_changes_suppliers` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`changes_id`,`type`,`suppliers_id`),
   KEY `group` (`suppliers_id`,`type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_changes_tickets
@@ -722,7 +722,7 @@ CREATE TABLE `glpi_changes_tickets` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`changes_id`,`tickets_id`),
   KEY `tickets_id` (`tickets_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_changes_users
@@ -738,7 +738,7 @@ CREATE TABLE `glpi_changes_users` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`changes_id`,`type`,`users_id`,`alternative_email`),
   KEY `user` (`users_id`,`type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_changetasks
@@ -780,7 +780,7 @@ CREATE TABLE `glpi_changetasks` (
   KEY `taskcategories_id` (`taskcategories_id`),
   KEY `tasktemplates_id` (`tasktemplates_id`),
   KEY `is_private` (`is_private`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_changevalidations
@@ -808,7 +808,7 @@ CREATE TABLE `glpi_changevalidations` (
   KEY `submission_date` (`submission_date`),
   KEY `validation_date` (`validation_date`),
   KEY `status` (`status`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_computerantiviruses
@@ -840,7 +840,7 @@ CREATE TABLE `glpi_computerantiviruses` (
   KEY `date_expiration` (`date_expiration`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_disks
@@ -880,7 +880,7 @@ CREATE TABLE `glpi_items_disks` (
   KEY `is_dynamic` (`is_dynamic`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_computermodels
@@ -906,7 +906,7 @@ CREATE TABLE `glpi_computermodels` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_computers
@@ -964,7 +964,7 @@ CREATE TABLE `glpi_computers` (
   KEY `uuid` (`uuid`),
   KEY `date_creation` (`date_creation`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_computers_items
@@ -982,7 +982,7 @@ CREATE TABLE `glpi_computers_items` (
   KEY `item` (`itemtype`,`items_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Previously glpi_computers_softwarelicenses < 9.5.0
@@ -1003,7 +1003,7 @@ CREATE TABLE `glpi_items_softwarelicenses` (
   KEY `softwarelicenses_id` (`softwarelicenses_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Previously glpi_computers_softwareversions < 9.5.0
 ### Dump table glpi_items_softwareversions
@@ -1031,7 +1031,7 @@ CREATE TABLE `glpi_items_softwareversions` (
   KEY `is_deleted` (`is_deleted_item`),
   KEY `is_dynamic` (`is_dynamic`),
   KEY `date_install` (`date_install`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_computertypes
@@ -1047,7 +1047,7 @@ CREATE TABLE `glpi_computertypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_computervirtualmachines
@@ -1082,7 +1082,7 @@ CREATE TABLE `glpi_computervirtualmachines` (
   KEY `uuid` (`uuid`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_operatingsystems
@@ -1120,7 +1120,7 @@ CREATE TABLE `glpi_items_operatingsystems` (
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   UNIQUE KEY `unicity` (`items_id`,`itemtype`, `operatingsystems_id`, `operatingsystemarchitectures_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_operatingsystemkernels
@@ -1134,7 +1134,7 @@ CREATE TABLE `glpi_operatingsystemkernels` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_operatingsystemkernelversions
@@ -1150,7 +1150,7 @@ CREATE TABLE `glpi_operatingsystemkernelversions` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `operatingsystemkernels_id` (`operatingsystemkernels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_operatingsystemeditions
 
@@ -1163,7 +1163,7 @@ CREATE TABLE `glpi_operatingsystemeditions` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_configs
 
@@ -1175,7 +1175,7 @@ CREATE TABLE `glpi_configs` (
   `value` text,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`context`,`name`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_impacts
 
@@ -1195,7 +1195,7 @@ CREATE TABLE `glpi_impactrelations` (
   ),
   KEY `source_asset` (`itemtype_source`, `items_id_source`),
   KEY `impacted_asset` (`itemtype_impacted`, `items_id_impacted`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_impacts_compounds
@@ -1206,7 +1206,7 @@ CREATE TABLE `glpi_impactcompounds` (
   `name` VARCHAR(255) NULL DEFAULT '',
   `color` VARCHAR(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_impactitems
@@ -1227,7 +1227,7 @@ CREATE TABLE `glpi_impactitems` (
   KEY `source` (`itemtype`, `items_id`),
   KEY `parent_id` (`parent_id`),
   KEY `impactcontexts_id` (`impactcontexts_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_impactcontexts
 
@@ -1245,7 +1245,7 @@ CREATE TABLE `glpi_impactcontexts` (
   `show_impact` TINYINT(1) NOT NULL DEFAULT '1',
   `max_depth` INT(11) NOT NULL DEFAULT '5',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_consumableitems
 
@@ -1280,7 +1280,7 @@ CREATE TABLE `glpi_consumableitems` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `otherserial` (`otherserial`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_consumableitemtypes
@@ -1296,7 +1296,7 @@ CREATE TABLE `glpi_consumableitemtypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_consumables
@@ -1320,7 +1320,7 @@ CREATE TABLE `glpi_consumables` (
   KEY `item` (`itemtype`,`items_id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_contacts
@@ -1356,7 +1356,7 @@ CREATE TABLE `glpi_contacts` (
   KEY `usertitles_id` (`usertitles_id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_contacts_suppliers
@@ -1369,7 +1369,7 @@ CREATE TABLE `glpi_contacts_suppliers` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`suppliers_id`,`contacts_id`),
   KEY `contacts_id` (`contacts_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_contacttypes
@@ -1385,7 +1385,7 @@ CREATE TABLE `glpi_contacttypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_contractcosts
@@ -1410,7 +1410,7 @@ CREATE TABLE `glpi_contractcosts` (
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `budgets_id` (`budgets_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_contracts
@@ -1459,7 +1459,7 @@ CREATE TABLE `glpi_contracts` (
   KEY `states_id` (`states_id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_contracts_items
@@ -1474,7 +1474,7 @@ CREATE TABLE `glpi_contracts_items` (
   UNIQUE KEY `unicity` (`contracts_id`,`itemtype`,`items_id`),
   KEY `FK_device` (`items_id`,`itemtype`),
   KEY `item` (`itemtype`,`items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_contracts_suppliers
@@ -1487,7 +1487,7 @@ CREATE TABLE `glpi_contracts_suppliers` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`suppliers_id`,`contracts_id`),
   KEY `contracts_id` (`contracts_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_contracttypes
@@ -1503,7 +1503,7 @@ CREATE TABLE `glpi_contracttypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_crontasklogs
@@ -1522,7 +1522,7 @@ CREATE TABLE `glpi_crontasklogs` (
   KEY `date` (`date`),
   KEY `crontasks_id` (`crontasks_id`),
   KEY `crontasklogs_id_state` (`crontasklogs_id`,`state`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_crontasks
@@ -1550,7 +1550,7 @@ CREATE TABLE `glpi_crontasks` (
   KEY `mode` (`mode`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci COMMENT='Task run by internal / external cron.';
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci COMMENT='Task run by internal / external cron.';
 
 ### Dump table glpi_dashboards_dashboards
 
@@ -1562,7 +1562,7 @@ CREATE TABLE `glpi_dashboards_dashboards` (
   `context` varchar(100) NOT NULL DEFAULT 'core',
   PRIMARY KEY (`id`),
   UNIQUE KEY `key` (`key`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_dashboards_items
 
@@ -1579,7 +1579,7 @@ CREATE TABLE `glpi_dashboards_items` (
   `card_options` text,
   PRIMARY KEY (`id`),
   KEY `dashboards_dashboards_id` (`dashboards_dashboards_id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_dashboards_rights
 
@@ -1592,7 +1592,7 @@ CREATE TABLE `glpi_dashboards_rights` (
   PRIMARY KEY (`id`),
   KEY `dashboards_dashboards_id` (`dashboards_dashboards_id`),
   UNIQUE KEY `unicity` (`dashboards_dashboards_id`, `itemtype`,`items_id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_devicecasemodels
 
@@ -1605,7 +1605,7 @@ CREATE TABLE `glpi_devicecasemodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_devicecases
 
@@ -1630,7 +1630,7 @@ CREATE TABLE `glpi_devicecases` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `devicecasemodels_id` (`devicecasemodels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicecasetypes
@@ -1646,7 +1646,7 @@ CREATE TABLE `glpi_devicecasetypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicecontrolmodels
@@ -1660,7 +1660,7 @@ CREATE TABLE `glpi_devicecontrolmodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_devicecontrols
 
@@ -1686,7 +1686,7 @@ CREATE TABLE `glpi_devicecontrols` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `devicecontrolmodels_id` (`devicecontrolmodels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicedrivemodels
@@ -1700,7 +1700,7 @@ CREATE TABLE `glpi_devicedrivemodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_devicedrives
 
@@ -1727,7 +1727,7 @@ CREATE TABLE `glpi_devicedrives` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `devicedrivemodels_id` (`devicedrivemodels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicegenericmodels
@@ -1741,7 +1741,7 @@ CREATE TABLE `glpi_devicegenericmodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicegenerics
@@ -1771,7 +1771,7 @@ CREATE TABLE `glpi_devicegenerics` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `devicegenericmodels_id` (`devicegenericmodels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicegenerictypes
@@ -1783,7 +1783,7 @@ CREATE TABLE `glpi_devicegenerictypes` (
   `comment` text,
   PRIMARY KEY (`id`),
   KEY `name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicegraphiccardmodels
@@ -1797,7 +1797,7 @@ CREATE TABLE `glpi_devicegraphiccardmodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_devicegraphiccards
 
@@ -1825,7 +1825,7 @@ CREATE TABLE `glpi_devicegraphiccards` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `devicegraphiccardmodels_id` (`devicegraphiccardmodels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_deviceharddrivemodels
@@ -1839,7 +1839,7 @@ CREATE TABLE `glpi_deviceharddrivemodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_deviceharddrives
 
@@ -1867,7 +1867,7 @@ CREATE TABLE `glpi_deviceharddrives` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `deviceharddrivemodels_id` (`deviceharddrivemodels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicememorymodels
@@ -1881,7 +1881,7 @@ CREATE TABLE `glpi_devicememorymodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicememories
@@ -1909,7 +1909,7 @@ CREATE TABLE `glpi_devicememories` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `devicememorymodels_id` (`devicememorymodels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicememorytypes
@@ -1925,7 +1925,7 @@ CREATE TABLE `glpi_devicememorytypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicemotherboardmodels
@@ -1939,7 +1939,7 @@ CREATE TABLE `glpi_devicemotherboardmodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_devicemotherboards
 
@@ -1963,7 +1963,7 @@ CREATE TABLE `glpi_devicemotherboards` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `devicemotherboardmodels_id` (`devicemotherboardmodels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicenetworkcardmodels
@@ -1977,7 +1977,7 @@ CREATE TABLE `glpi_devicenetworkcardmodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_devicenetworkcards
 
@@ -2002,7 +2002,7 @@ CREATE TABLE `glpi_devicenetworkcards` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `devicenetworkcardmodels_id` (`devicenetworkcardmodels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicepcimodels
@@ -2016,7 +2016,7 @@ CREATE TABLE `glpi_devicepcimodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_devicepcis
 
@@ -2041,7 +2041,7 @@ CREATE TABLE `glpi_devicepcis` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `devicepcimodels_id` (`devicepcimodels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicepowersupplymodels
@@ -2055,7 +2055,7 @@ CREATE TABLE `glpi_devicepowersupplymodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicepowersupplies
@@ -2081,7 +2081,7 @@ CREATE TABLE `glpi_devicepowersupplies` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `devicepowersupplymodels_id` (`devicepowersupplymodels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_deviceprocessormodels
@@ -2095,7 +2095,7 @@ CREATE TABLE `glpi_deviceprocessormodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_deviceprocessors
 
@@ -2122,7 +2122,7 @@ CREATE TABLE `glpi_deviceprocessors` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `deviceprocessormodels_id` (`deviceprocessormodels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicesensors
@@ -2151,7 +2151,7 @@ CREATE TABLE `glpi_devicesensors` (
   KEY `states_id` (`states_id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicesensormodels
@@ -2165,7 +2165,7 @@ CREATE TABLE `glpi_devicesensormodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicesensortypes
@@ -2177,7 +2177,7 @@ CREATE TABLE `glpi_devicesensortypes` (
   `comment` text,
   PRIMARY KEY (`id`),
   KEY `name` (`name`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicesimcards
@@ -2203,7 +2203,7 @@ CREATE TABLE IF NOT EXISTS `glpi_devicesimcards` (
    KEY `date_mod` (`date_mod`),
    KEY `date_creation` (`date_creation`),
    KEY `manufacturers_id` (`manufacturers_id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_devicesimcards
@@ -2244,7 +2244,7 @@ CREATE TABLE IF NOT EXISTS `glpi_items_devicesimcards` (
   KEY `lines_id` (`lines_id`),
   KEY `users_id` (`users_id`),
   KEY `groups_id` (`groups_id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicesimcardtypes
@@ -2260,7 +2260,7 @@ CREATE TABLE IF NOT EXISTS `glpi_devicesimcardtypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicesoundcardmodels
@@ -2274,7 +2274,7 @@ CREATE TABLE `glpi_devicesoundcardmodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_devicesoundcards
@@ -2299,7 +2299,7 @@ CREATE TABLE `glpi_devicesoundcards` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `devicesoundcardmodels_id` (`devicesoundcardmodels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_displaypreferences
@@ -2316,7 +2316,7 @@ CREATE TABLE `glpi_displaypreferences` (
   KEY `rank` (`rank`),
   KEY `num` (`num`),
   KEY `itemtype` (`itemtype`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_documentcategories
@@ -2338,7 +2338,7 @@ CREATE TABLE `glpi_documentcategories` (
   UNIQUE KEY `unicity` (`documentcategories_id`,`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_documents
@@ -2374,7 +2374,7 @@ CREATE TABLE `glpi_documents` (
   KEY `sha1sum` (`sha1sum`),
   KEY `tag` (`tag`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_documents_items
@@ -2396,7 +2396,7 @@ CREATE TABLE `glpi_documents_items` (
   KEY `item` (`itemtype`,`items_id`,`entities_id`,`is_recursive`),
   KEY `users_id` (`users_id`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_documenttypes
@@ -2418,7 +2418,7 @@ CREATE TABLE `glpi_documenttypes` (
   KEY `is_uploadable` (`is_uploadable`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_domains
@@ -2452,7 +2452,7 @@ CREATE TABLE `glpi_domains` (
   KEY `is_active` (`is_active`),
   KEY `date_expiration` (`date_expiration`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_dropdowntranslations
@@ -2470,7 +2470,7 @@ CREATE TABLE `glpi_dropdowntranslations` (
   KEY `typeid` (`itemtype`,`items_id`),
   KEY `language` (`language`),
   KEY `field` (`field`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_entities
@@ -2564,7 +2564,7 @@ CREATE TABLE `glpi_entities` (
   KEY `tickettemplates_id` (`tickettemplates_id`),
   KEY `changetemplates_id` (`changetemplates_id`),
   KEY `problemtemplates_id` (`problemtemplates_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_entities_knowbaseitems
@@ -2579,7 +2579,7 @@ CREATE TABLE `glpi_entities_knowbaseitems` (
   KEY `knowbaseitems_id` (`knowbaseitems_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_entities_reminders
@@ -2594,7 +2594,7 @@ CREATE TABLE `glpi_entities_reminders` (
   KEY `reminders_id` (`reminders_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_entities_rssfeeds
@@ -2609,7 +2609,7 @@ CREATE TABLE `glpi_entities_rssfeeds` (
   KEY `rssfeeds_id` (`rssfeeds_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_events
@@ -2627,7 +2627,7 @@ CREATE TABLE `glpi_events` (
   KEY `date` (`date`),
   KEY `level` (`level`),
   KEY `item` (`type`,`items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_fieldblacklists
@@ -2648,7 +2648,7 @@ CREATE TABLE `glpi_fieldblacklists` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_fieldunicities
@@ -2670,7 +2670,7 @@ CREATE TABLE `glpi_fieldunicities` (
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci COMMENT='Stores field unicity criterias';
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci COMMENT='Stores field unicity criterias';
 
 
 ### Dump table glpi_filesystems
@@ -2686,7 +2686,7 @@ CREATE TABLE `glpi_filesystems` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_fqdns
@@ -2708,7 +2708,7 @@ CREATE TABLE `glpi_fqdns` (
   KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_groups
@@ -2754,7 +2754,7 @@ CREATE TABLE `glpi_groups` (
   KEY `is_usergroup` (`is_usergroup`),
   KEY `is_manager` (`is_manager`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_groups_knowbaseitems
@@ -2771,7 +2771,7 @@ CREATE TABLE `glpi_groups_knowbaseitems` (
   KEY `groups_id` (`groups_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_groups_problems
@@ -2785,7 +2785,7 @@ CREATE TABLE `glpi_groups_problems` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`problems_id`,`type`,`groups_id`),
   KEY `group` (`groups_id`,`type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_groups_reminders
@@ -2802,7 +2802,7 @@ CREATE TABLE `glpi_groups_reminders` (
   KEY `groups_id` (`groups_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_groups_rssfeeds
@@ -2819,7 +2819,7 @@ CREATE TABLE `glpi_groups_rssfeeds` (
   KEY `groups_id` (`groups_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_groups_tickets
@@ -2833,7 +2833,7 @@ CREATE TABLE `glpi_groups_tickets` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`tickets_id`,`type`,`groups_id`),
   KEY `group` (`groups_id`,`type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_groups_users
@@ -2851,7 +2851,7 @@ CREATE TABLE `glpi_groups_users` (
   KEY `groups_id` (`groups_id`),
   KEY `is_manager` (`is_manager`),
   KEY `is_userdelegate` (`is_userdelegate`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_holidays
@@ -2875,7 +2875,7 @@ CREATE TABLE `glpi_holidays` (
   KEY `is_perpetual` (`is_perpetual`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_infocoms
@@ -2923,7 +2923,7 @@ CREATE TABLE `glpi_infocoms` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `businesscriticities_id` (`businesscriticities_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_interfacetypes
@@ -2939,7 +2939,7 @@ CREATE TABLE `glpi_interfacetypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_ipaddresses
@@ -2968,7 +2968,7 @@ CREATE TABLE `glpi_ipaddresses` (
   KEY `is_dynamic` (`is_dynamic`),
   KEY `item` (`itemtype`,`items_id`,`is_deleted`),
   KEY `mainitem` (`mainitemtype`,`mainitems_id`,`is_deleted`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_ipaddresses_ipnetworks
@@ -2982,7 +2982,7 @@ CREATE TABLE `glpi_ipaddresses_ipnetworks` (
   UNIQUE KEY `unicity` (`ipaddresses_id`,`ipnetworks_id`),
   KEY `ipnetworks_id` (`ipnetworks_id`),
   KEY `ipaddresses_id` (`ipaddresses_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_ipnetworks
@@ -3026,7 +3026,7 @@ CREATE TABLE `glpi_ipnetworks` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_ipnetworks_vlans
@@ -3038,7 +3038,7 @@ CREATE TABLE `glpi_ipnetworks_vlans` (
   `vlans_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `link` (`ipnetworks_id`,`vlans_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_devicecases
@@ -3069,7 +3069,7 @@ CREATE TABLE `glpi_items_devicecases` (
   KEY `otherserial` (`otherserial`),
   KEY `locations_id` (`locations_id`),
   KEY `states_id` (`states_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_devicecontrols
@@ -3102,7 +3102,7 @@ CREATE TABLE `glpi_items_devicecontrols` (
   KEY `otherserial` (`otherserial`),
   KEY `locations_id` (`locations_id`),
   KEY `states_id` (`states_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_devicedrives
@@ -3135,7 +3135,7 @@ CREATE TABLE `glpi_items_devicedrives` (
   KEY `otherserial` (`otherserial`),
   KEY `locations_id` (`locations_id`),
   KEY `states_id` (`states_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_devicegenerics
@@ -3164,7 +3164,7 @@ CREATE TABLE `glpi_items_devicegenerics` (
   KEY `serial` (`serial`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `otherserial` (`otherserial`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_devicegraphiccards
@@ -3199,7 +3199,7 @@ CREATE TABLE `glpi_items_devicegraphiccards` (
   KEY `otherserial` (`otherserial`),
   KEY `locations_id` (`locations_id`),
   KEY `states_id` (`states_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_deviceharddrives
@@ -3234,7 +3234,7 @@ CREATE TABLE `glpi_items_deviceharddrives` (
   KEY `otherserial` (`otherserial`),
   KEY `locations_id` (`locations_id`),
   KEY `states_id` (`states_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_devicememories
@@ -3269,7 +3269,7 @@ CREATE TABLE `glpi_items_devicememories` (
   KEY `otherserial` (`otherserial`),
   KEY `locations_id` (`locations_id`),
   KEY `states_id` (`states_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_devicemotherboards
@@ -3300,7 +3300,7 @@ CREATE TABLE `glpi_items_devicemotherboards` (
   KEY `otherserial` (`otherserial`),
   KEY `locations_id` (`locations_id`),
   KEY `states_id` (`states_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_devicenetworkcards
@@ -3335,7 +3335,7 @@ CREATE TABLE `glpi_items_devicenetworkcards` (
   KEY `otherserial` (`otherserial`),
   KEY `locations_id` (`locations_id`),
   KEY `states_id` (`states_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_devicepcis
@@ -3368,7 +3368,7 @@ CREATE TABLE `glpi_items_devicepcis` (
   KEY `otherserial` (`otherserial`),
   KEY `locations_id` (`locations_id`),
   KEY `states_id` (`states_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_devicepowersupplies
@@ -3399,7 +3399,7 @@ CREATE TABLE `glpi_items_devicepowersupplies` (
   KEY `otherserial` (`otherserial`),
   KEY `locations_id` (`locations_id`),
   KEY `states_id` (`states_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_deviceprocessors
@@ -3438,7 +3438,7 @@ CREATE TABLE `glpi_items_deviceprocessors` (
   KEY `otherserial` (`otherserial`),
   KEY `locations_id` (`locations_id`),
   KEY `states_id` (`states_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_devicesensors
@@ -3467,7 +3467,7 @@ CREATE TABLE `glpi_items_devicesensors` (
   KEY `serial` (`serial`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `otherserial` (`otherserial`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_devicesoundcards
@@ -3500,7 +3500,7 @@ CREATE TABLE `glpi_items_devicesoundcards` (
   KEY `otherserial` (`otherserial`),
   KEY `locations_id` (`locations_id`),
   KEY `states_id` (`states_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_problems
@@ -3514,7 +3514,7 @@ CREATE TABLE `glpi_items_problems` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`problems_id`,`itemtype`,`items_id`),
   KEY `item` (`itemtype`,`items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_projects
@@ -3528,7 +3528,7 @@ CREATE TABLE `glpi_items_projects` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`projects_id`,`itemtype`,`items_id`),
   KEY `item` (`itemtype`,`items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_items_tickets
@@ -3542,7 +3542,7 @@ CREATE TABLE `glpi_items_tickets` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`itemtype`,`items_id`,`tickets_id`),
   KEY `tickets_id` (`tickets_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_itilcategories
@@ -3593,7 +3593,7 @@ CREATE TABLE `glpi_itilcategories` (
   KEY `is_change` (`is_change`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_itils_projects
@@ -3607,7 +3607,7 @@ CREATE TABLE `glpi_itils_projects` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`itemtype`,`items_id`,`projects_id`),
   KEY `projects_id` (`projects_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_knowbaseitemcategories
@@ -3633,7 +3633,7 @@ CREATE TABLE `glpi_knowbaseitemcategories` (
   KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_knowbaseitems
@@ -3661,7 +3661,7 @@ CREATE TABLE `glpi_knowbaseitems` (
   FULLTEXT KEY `fulltext` (`name`,`answer`),
   FULLTEXT KEY `name` (`name`),
   FULLTEXT KEY `answer` (`answer`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_knowbaseitems_profiles
@@ -3678,7 +3678,7 @@ CREATE TABLE `glpi_knowbaseitems_profiles` (
   KEY `profiles_id` (`profiles_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_knowbaseitems_users
@@ -3691,7 +3691,7 @@ CREATE TABLE `glpi_knowbaseitems_users` (
   PRIMARY KEY (`id`),
   KEY `knowbaseitems_id` (`knowbaseitems_id`),
   KEY `users_id` (`users_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_knowbaseitemtranslations
@@ -3712,7 +3712,7 @@ CREATE TABLE `glpi_knowbaseitemtranslations` (
   FULLTEXT KEY `fulltext` (`name`,`answer`),
   FULLTEXT KEY `name` (`name`),
   FULLTEXT KEY `answer` (`answer`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_lines
@@ -3740,7 +3740,7 @@ CREATE TABLE `glpi_lines` (
   KEY `is_recursive` (`is_recursive`),
   KEY `users_id` (`users_id`),
   KEY `lineoperators_id` (`lineoperators_id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_lineoperators
@@ -3763,7 +3763,7 @@ CREATE TABLE IF NOT EXISTS `glpi_lineoperators` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   UNIQUE KEY `unicity` (`mcc`,`mnc`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 DROP TABLE IF EXISTS `glpi_linetypes`;
@@ -3777,7 +3777,7 @@ CREATE TABLE IF NOT EXISTS `glpi_linetypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_links
 
@@ -3796,7 +3796,7 @@ CREATE TABLE `glpi_links` (
   KEY `entities_id` (`entities_id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_links_itemtypes
@@ -3809,7 +3809,7 @@ CREATE TABLE `glpi_links_itemtypes` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`itemtype`,`links_id`),
   KEY `links_id` (`links_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_locations
@@ -3845,7 +3845,7 @@ CREATE TABLE `glpi_locations` (
   KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_logs
@@ -3867,7 +3867,7 @@ CREATE TABLE `glpi_logs` (
   KEY `itemtype_link` (`itemtype_link`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `id_search_option` (`id_search_option`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_mailcollectors
@@ -3895,7 +3895,7 @@ CREATE TABLE `glpi_mailcollectors` (
   KEY `is_active` (`is_active`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_manufacturers
@@ -3911,7 +3911,7 @@ CREATE TABLE `glpi_manufacturers` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_monitormodels
@@ -3937,7 +3937,7 @@ CREATE TABLE `glpi_monitormodels` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_monitors
@@ -4001,7 +4001,7 @@ CREATE TABLE `glpi_monitors` (
   KEY `uuid` (`uuid`),
   KEY `date_creation` (`date_creation`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_monitortypes
@@ -4017,7 +4017,7 @@ CREATE TABLE `glpi_monitortypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_netpoints
@@ -4037,7 +4037,7 @@ CREATE TABLE `glpi_netpoints` (
   KEY `location_name` (`locations_id`,`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networkaliases
@@ -4054,7 +4054,7 @@ CREATE TABLE `glpi_networkaliases` (
   KEY `entities_id` (`entities_id`),
   KEY `name` (`name`),
   KEY `networknames_id` (`networknames_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networkequipmentmodels
@@ -4080,7 +4080,7 @@ CREATE TABLE `glpi_networkequipmentmodels` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networkequipments
@@ -4136,7 +4136,7 @@ CREATE TABLE `glpi_networkequipments` (
   KEY `otherserial` (`otherserial`),
   KEY `uuid` (`uuid`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networkequipmenttypes
@@ -4152,7 +4152,7 @@ CREATE TABLE `glpi_networkequipmenttypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networkinterfaces
@@ -4164,7 +4164,7 @@ CREATE TABLE `glpi_networkinterfaces` (
   `comment` text,
   PRIMARY KEY (`id`),
   KEY `name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networknames
@@ -4192,7 +4192,7 @@ CREATE TABLE `glpi_networknames` (
   KEY `item` (`itemtype`,`items_id`,`is_deleted`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networkportaggregates
@@ -4208,7 +4208,7 @@ CREATE TABLE `glpi_networkportaggregates` (
   UNIQUE KEY `networkports_id` (`networkports_id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networkportaliases
@@ -4225,7 +4225,7 @@ CREATE TABLE `glpi_networkportaliases` (
   KEY `networkports_id_alias` (`networkports_id_alias`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networkportdialups
@@ -4240,7 +4240,7 @@ CREATE TABLE `glpi_networkportdialups` (
   UNIQUE KEY `networkports_id` (`networkports_id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networkportethernets
@@ -4263,7 +4263,7 @@ CREATE TABLE `glpi_networkportethernets` (
   KEY `speed` (`speed`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_networkportfiberchannels
 
@@ -4285,7 +4285,7 @@ CREATE TABLE `glpi_networkportfiberchannels` (
   KEY `speed` (`speed`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_networkportlocals
 
@@ -4299,7 +4299,7 @@ CREATE TABLE `glpi_networkportlocals` (
   UNIQUE KEY `networkports_id` (`networkports_id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networkports
@@ -4330,7 +4330,7 @@ CREATE TABLE `glpi_networkports` (
   KEY `is_dynamic` (`is_dynamic`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networkports_networkports
@@ -4343,7 +4343,7 @@ CREATE TABLE `glpi_networkports_networkports` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`networkports_id_1`,`networkports_id_2`),
   KEY `networkports_id_2` (`networkports_id_2`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networkports_vlans
@@ -4357,7 +4357,7 @@ CREATE TABLE `glpi_networkports_vlans` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`networkports_id`,`vlans_id`),
   KEY `vlans_id` (`vlans_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networkportwifis
@@ -4381,7 +4381,7 @@ CREATE TABLE `glpi_networkportwifis` (
   KEY `mode` (`mode`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_networks
@@ -4397,7 +4397,7 @@ CREATE TABLE `glpi_networks` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_notepads
@@ -4418,7 +4418,7 @@ CREATE TABLE `glpi_notepads` (
   KEY `date` (`date`),
   KEY `users_id_lastupdater` (`users_id_lastupdater`),
   KEY `users_id` (`users_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_notifications
@@ -4444,7 +4444,7 @@ CREATE TABLE `glpi_notifications` (
   KEY `date_mod` (`date_mod`),
   KEY `is_recursive` (`is_recursive`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 
@@ -4461,7 +4461,7 @@ CREATE TABLE `glpi_notifications_notificationtemplates` (
   KEY `notifications_id` (`notifications_id`),
   KEY `notificationtemplates_id` (`notificationtemplates_id`),
   KEY `mode` (`mode`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 
@@ -4476,7 +4476,7 @@ CREATE TABLE `glpi_notificationtargets` (
   PRIMARY KEY (`id`),
   KEY `items` (`type`,`items_id`),
   KEY `notifications_id` (`notifications_id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_notificationtemplates
@@ -4495,7 +4495,7 @@ CREATE TABLE `glpi_notificationtemplates` (
   KEY `date_mod` (`date_mod`),
   KEY `name` (`name`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_notificationtemplatetranslations
@@ -4510,7 +4510,7 @@ CREATE TABLE `glpi_notificationtemplatetranslations` (
   `content_html` text,
   PRIMARY KEY (`id`),
   KEY `notificationtemplates_id` (`notificationtemplates_id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_notimportedemails
@@ -4529,7 +4529,7 @@ CREATE TABLE `glpi_notimportedemails` (
   PRIMARY KEY (`id`),
   KEY `users_id` (`users_id`),
   KEY `mailcollectors_id` (`mailcollectors_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_objectlocks
@@ -4543,7 +4543,7 @@ CREATE TABLE `glpi_objectlocks` (
   `date_mod` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp of the lock',
   PRIMARY KEY (`id`),
   UNIQUE KEY `item` (`itemtype`,`items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_operatingsystemarchitectures
@@ -4559,7 +4559,7 @@ CREATE TABLE `glpi_operatingsystemarchitectures` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_operatingsystems
@@ -4575,7 +4575,7 @@ CREATE TABLE `glpi_operatingsystems` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_operatingsystemservicepacks
@@ -4591,7 +4591,7 @@ CREATE TABLE `glpi_operatingsystemservicepacks` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_operatingsystemversions
@@ -4607,7 +4607,7 @@ CREATE TABLE `glpi_operatingsystemversions` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_passivedcequipments
@@ -4645,7 +4645,7 @@ CREATE TABLE `glpi_passivedcequipments` (
   KEY `is_deleted` (`is_deleted`),
   KEY `states_id` (`states_id`),
   KEY `manufacturers_id` (`manufacturers_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_passivedcequipmentmodels
@@ -4671,7 +4671,7 @@ CREATE TABLE `glpi_passivedcequipmentmodels` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_peripheralmodels
 
@@ -4689,7 +4689,7 @@ CREATE TABLE `glpi_passivedcequipmenttypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 DROP TABLE IF EXISTS `glpi_peripheralmodels`;
@@ -4713,7 +4713,7 @@ CREATE TABLE `glpi_peripheralmodels` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_peripherals
@@ -4770,7 +4770,7 @@ CREATE TABLE `glpi_peripherals` (
   KEY `uuid` (`uuid`),
   KEY `date_creation` (`date_creation`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_peripheraltypes
@@ -4786,7 +4786,7 @@ CREATE TABLE `glpi_peripheraltypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_phonemodels
@@ -4804,7 +4804,7 @@ CREATE TABLE `glpi_phonemodels` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_phonepowersupplies
@@ -4820,7 +4820,7 @@ CREATE TABLE `glpi_phonepowersupplies` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_phones
@@ -4882,7 +4882,7 @@ CREATE TABLE `glpi_phones` (
   KEY `uuid` (`uuid`),
   KEY `date_creation` (`date_creation`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_phonetypes
@@ -4898,7 +4898,7 @@ CREATE TABLE `glpi_phonetypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_planningrecalls
@@ -4916,7 +4916,7 @@ CREATE TABLE `glpi_planningrecalls` (
   KEY `users_id` (`users_id`),
   KEY `before_time` (`before_time`),
   KEY `when` (`when`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_plugins
@@ -4934,7 +4934,7 @@ CREATE TABLE `glpi_plugins` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`directory`),
   KEY `state` (`state`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_printermodels
@@ -4952,7 +4952,7 @@ CREATE TABLE `glpi_printermodels` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_printers
@@ -5018,7 +5018,7 @@ CREATE TABLE `glpi_printers` (
   KEY `otherserial` (`otherserial`),
   KEY `uuid` (`uuid`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_printertypes
@@ -5034,7 +5034,7 @@ CREATE TABLE `glpi_printertypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_problemcosts
@@ -5060,7 +5060,7 @@ CREATE TABLE `glpi_problemcosts` (
   KEY `end_date` (`end_date`),
   KEY `entities_id` (`entities_id`),
   KEY `budgets_id` (`budgets_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_problems
@@ -5112,7 +5112,7 @@ CREATE TABLE `glpi_problems` (
   KEY `time_to_resolve` (`time_to_resolve`),
   KEY `users_id_lastupdater` (`users_id_lastupdater`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_problems_suppliers
@@ -5128,7 +5128,7 @@ CREATE TABLE `glpi_problems_suppliers` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`problems_id`,`type`,`suppliers_id`),
   KEY `group` (`suppliers_id`,`type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_problems_tickets
@@ -5141,7 +5141,7 @@ CREATE TABLE `glpi_problems_tickets` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`problems_id`,`tickets_id`),
   KEY `tickets_id` (`tickets_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_problems_users
@@ -5157,7 +5157,7 @@ CREATE TABLE `glpi_problems_users` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`problems_id`,`type`,`users_id`,`alternative_email`),
   KEY `user` (`users_id`,`type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_problemtasks
@@ -5199,7 +5199,7 @@ CREATE TABLE `glpi_problemtasks` (
   KEY `taskcategories_id` (`taskcategories_id`),
   KEY `tasktemplates_id` (`tasktemplates_id`),
   KEY `is_private` (`is_private`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_profilerights
@@ -5212,7 +5212,7 @@ CREATE TABLE `glpi_profilerights` (
   `rights` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`profiles_id`,`name`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_profiles
 
@@ -5243,7 +5243,7 @@ CREATE TABLE `glpi_profiles` (
   KEY `tickettemplates_id` (`tickettemplates_id`),
   KEY `changetemplates_id` (`changetemplates_id`),
   KEY `problemtemplates_id` (`problemtemplates_id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_profiles_reminders
@@ -5260,7 +5260,7 @@ CREATE TABLE `glpi_profiles_reminders` (
   KEY `profiles_id` (`profiles_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_profiles_rssfeeds
@@ -5277,7 +5277,7 @@ CREATE TABLE `glpi_profiles_rssfeeds` (
   KEY `profiles_id` (`profiles_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_profiles_users
@@ -5296,7 +5296,7 @@ CREATE TABLE `glpi_profiles_users` (
   KEY `users_id` (`users_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `is_dynamic` (`is_dynamic`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_projectcosts
@@ -5321,7 +5321,7 @@ CREATE TABLE `glpi_projectcosts` (
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `budgets_id` (`budgets_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_projects
@@ -5377,7 +5377,7 @@ CREATE TABLE `glpi_projects` (
   KEY `date_creation` (`date_creation`),
   KEY `projecttemplates_id` (`projecttemplates_id`),
   KEY `is_template` (`is_template`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_projectstates
@@ -5396,7 +5396,7 @@ CREATE TABLE `glpi_projectstates` (
   KEY `is_finished` (`is_finished`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_projecttasks
@@ -5449,7 +5449,7 @@ CREATE TABLE `glpi_projecttasks` (
   KEY `projecttasktemplates_id` (`projecttasktemplates_id`),
   KEY `is_template` (`is_template`),
   KEY `is_milestone` (`is_milestone`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_projecttasktemplates
 
@@ -5494,7 +5494,7 @@ CREATE TABLE `glpi_projecttasktemplates` (
   KEY `projectstates_id` (`projectstates_id`),
   KEY `projecttasktypes_id` (`projecttasktypes_id`),
   KEY `is_milestone` (`is_milestone`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_projecttasks_tickets
@@ -5507,7 +5507,7 @@ CREATE TABLE `glpi_projecttasks_tickets` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`tickets_id`,`projecttasks_id`),
   KEY `projects_id` (`projecttasks_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_projecttaskteams
@@ -5521,7 +5521,7 @@ CREATE TABLE `glpi_projecttaskteams` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`projecttasks_id`,`itemtype`,`items_id`),
   KEY `item` (`itemtype`,`items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_projecttasktypes
@@ -5537,7 +5537,7 @@ CREATE TABLE `glpi_projecttasktypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_projectteams
@@ -5551,7 +5551,7 @@ CREATE TABLE `glpi_projectteams` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`projects_id`,`itemtype`,`items_id`),
   KEY `item` (`itemtype`,`items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_projecttypes
@@ -5567,7 +5567,7 @@ CREATE TABLE `glpi_projecttypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_queuednotifications
@@ -5606,7 +5606,7 @@ CREATE TABLE `glpi_queuednotifications` (
   KEY `send_time` (`send_time`),
   KEY `sent_time` (`sent_time`),
   KEY `mode` (`mode`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_registeredids
@@ -5622,7 +5622,7 @@ CREATE TABLE `glpi_registeredids` (
   KEY `name` (`name`),
   KEY `item` (`items_id`,`itemtype`),
   KEY `device_type` (`device_type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_reminders
@@ -5653,7 +5653,7 @@ CREATE TABLE `glpi_reminders` (
   KEY `state` (`state`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_remindertranslations
 
@@ -5670,7 +5670,7 @@ CREATE TABLE `glpi_remindertranslations` (
   PRIMARY KEY (`id`),
   KEY `item` (`reminders_id`,`language`),
   KEY `users_id` (`users_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_reminders_users
 
@@ -5682,7 +5682,7 @@ CREATE TABLE `glpi_reminders_users` (
   PRIMARY KEY (`id`),
   KEY `reminders_id` (`reminders_id`),
   KEY `users_id` (`users_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_requesttypes
@@ -5712,7 +5712,7 @@ CREATE TABLE `glpi_requesttypes` (
   KEY `is_active` (`is_active`),
   KEY `is_ticketheader` (`is_ticketheader`),
   KEY `is_itilfollowup` (`is_itilfollowup`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_reservationitems
@@ -5732,7 +5732,7 @@ CREATE TABLE `glpi_reservationitems` (
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   UNIQUE KEY `unicity` (`itemtype`,`items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_reservations
@@ -5752,7 +5752,7 @@ CREATE TABLE `glpi_reservations` (
   KEY `reservationitems_id` (`reservationitems_id`),
   KEY `users_id` (`users_id`),
   KEY `resagroup` (`reservationitems_id`,`group`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_rssfeeds
@@ -5777,7 +5777,7 @@ CREATE TABLE `glpi_rssfeeds` (
   KEY `have_error` (`have_error`),
   KEY `is_active` (`is_active`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_rssfeeds_users
@@ -5790,7 +5790,7 @@ CREATE TABLE `glpi_rssfeeds_users` (
   PRIMARY KEY (`id`),
   KEY `rssfeeds_id` (`rssfeeds_id`),
   KEY `users_id` (`users_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_ruleactions
@@ -5805,7 +5805,7 @@ CREATE TABLE `glpi_ruleactions` (
   PRIMARY KEY (`id`),
   KEY `rules_id` (`rules_id`),
   KEY `field_value` (`field`(50),`value`(50))
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_rulecriterias
@@ -5820,7 +5820,7 @@ CREATE TABLE `glpi_rulecriterias` (
   PRIMARY KEY (`id`),
   KEY `rules_id` (`rules_id`),
   KEY `condition` (`condition`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_rulerightparameters
@@ -5836,7 +5836,7 @@ CREATE TABLE `glpi_rulerightparameters` (
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_rules
@@ -5865,7 +5865,7 @@ CREATE TABLE `glpi_rules` (
   KEY `is_recursive` (`is_recursive`),
   KEY `condition` (`condition`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_slalevelactions
@@ -5879,7 +5879,7 @@ CREATE TABLE `glpi_slalevelactions` (
   `value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `slalevels_id` (`slalevels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_slalevelcriterias
@@ -5894,7 +5894,7 @@ CREATE TABLE `glpi_slalevelcriterias` (
   PRIMARY KEY (`id`),
   KEY `slalevels_id` (`slalevels_id`),
   KEY `condition` (`condition`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_slalevels
@@ -5914,7 +5914,7 @@ CREATE TABLE `glpi_slalevels` (
   KEY `name` (`name`),
   KEY `is_active` (`is_active`),
   KEY `slas_id` (`slas_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_slalevels_tickets
@@ -5929,7 +5929,7 @@ CREATE TABLE `glpi_slalevels_tickets` (
   KEY `tickets_id` (`tickets_id`),
   KEY `slalevels_id` (`slalevels_id`),
   UNIQUE KEY `unicity` (`tickets_id`,`slalevels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_olalevelactions
 
@@ -5942,7 +5942,7 @@ CREATE TABLE `glpi_olalevelactions` (
   `value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `olalevels_id` (`olalevels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_olalevelcriterias
@@ -5957,7 +5957,7 @@ CREATE TABLE `glpi_olalevelcriterias` (
   PRIMARY KEY (`id`),
   KEY `olalevels_id` (`olalevels_id`),
   KEY `condition` (`condition`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_olalevels
@@ -5977,7 +5977,7 @@ CREATE TABLE `glpi_olalevels` (
   KEY `name` (`name`),
   KEY `is_active` (`is_active`),
   KEY `olas_id` (`olas_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_olalevels_tickets
@@ -5992,7 +5992,7 @@ CREATE TABLE `glpi_olalevels_tickets` (
   KEY `tickets_id` (`tickets_id`),
   KEY `olalevels_id` (`olalevels_id`),
   UNIQUE KEY `unicity` (`tickets_id`,`olalevels_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_slms
 
@@ -6013,7 +6013,7 @@ CREATE TABLE `glpi_slms` (
   KEY `calendars_id` (`calendars_id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_slas
 
@@ -6038,7 +6038,7 @@ CREATE TABLE `glpi_slas` (
   KEY `date_creation` (`date_creation`),
   KEY `calendars_id` (`calendars_id`),
   KEY `slms_id` (`slms_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_olas
 
@@ -6063,7 +6063,7 @@ CREATE TABLE `glpi_olas` (
   KEY `date_creation` (`date_creation`),
   KEY `calendars_id` (`calendars_id`),
   KEY `slms_id` (`slms_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_softwarecategories
 
@@ -6079,7 +6079,7 @@ CREATE TABLE `glpi_softwarecategories` (
   `sons_cache` longtext,
   PRIMARY KEY (`id`),
   KEY `softwarecategories_id` (`softwarecategories_id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_softwarelicenses
@@ -6142,7 +6142,7 @@ CREATE TABLE `glpi_softwarelicenses` (
   KEY `manufacturers_id` (`manufacturers_id`),
   KEY `states_id` (`states_id`),
   KEY `allow_overquota` (`allow_overquota`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_softwarelicensetypes
@@ -6166,7 +6166,7 @@ CREATE TABLE `glpi_softwarelicensetypes` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `softwarelicensetypes_id` (`softwarelicensetypes_id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_softwares
@@ -6212,7 +6212,7 @@ CREATE TABLE `glpi_softwares` (
   KEY `is_helpdesk_visible` (`is_helpdesk_visible`),
   KEY `groups_id_tech` (`groups_id_tech`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_softwareversions
@@ -6238,7 +6238,7 @@ CREATE TABLE `glpi_softwareversions` (
   KEY `operatingsystems_id` (`operatingsystems_id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_solutiontemplates
@@ -6261,7 +6261,7 @@ CREATE TABLE `glpi_solutiontemplates` (
   KEY `entities_id` (`entities_id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_solutiontypes
@@ -6281,7 +6281,7 @@ CREATE TABLE `glpi_solutiontypes` (
   KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_itilsolutions
@@ -6313,7 +6313,7 @@ CREATE TABLE `glpi_itilsolutions` (
   KEY `users_id_approval` (`users_id_approval`),
   KEY `status` (`status`),
   KEY `itilfollowups_id` (`itilfollowups_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_ssovariables
@@ -6328,7 +6328,7 @@ CREATE TABLE `glpi_ssovariables` (
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_states
@@ -6386,7 +6386,7 @@ CREATE TABLE `glpi_states` (
   KEY `is_visible_appliance` (`is_visible_appliance`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_suppliers
@@ -6420,7 +6420,7 @@ CREATE TABLE `glpi_suppliers` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `is_active` (`is_active`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_suppliers_tickets
@@ -6436,7 +6436,7 @@ CREATE TABLE `glpi_suppliers_tickets` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`tickets_id`,`type`,`suppliers_id`),
   KEY `group` (`suppliers_id`,`type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_suppliertypes
@@ -6452,7 +6452,7 @@ CREATE TABLE `glpi_suppliertypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_taskcategories
@@ -6484,7 +6484,7 @@ CREATE TABLE `glpi_taskcategories` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `knowbaseitemcategories_id` (`knowbaseitemcategories_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_tasktemplates
@@ -6515,7 +6515,7 @@ CREATE TABLE `glpi_tasktemplates` (
   KEY `is_private` (`is_private`),
   KEY `users_id_tech` (`users_id_tech`),
   KEY `groups_id_tech` (`groups_id_tech`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_ticketcosts
@@ -6541,7 +6541,7 @@ CREATE TABLE `glpi_ticketcosts` (
   KEY `end_date` (`end_date`),
   KEY `entities_id` (`entities_id`),
   KEY `budgets_id` (`budgets_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_ticketrecurrents
@@ -6567,7 +6567,7 @@ CREATE TABLE `glpi_ticketrecurrents` (
   KEY `is_active` (`is_active`),
   KEY `tickettemplates_id` (`tickettemplates_id`),
   KEY `next_creation_date` (`next_creation_date`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_recurrentchanges
@@ -6593,7 +6593,7 @@ CREATE TABLE `glpi_recurrentchanges` (
   KEY `is_active` (`is_active`),
   KEY `changetemplates_id` (`changetemplates_id`),
   KEY `next_creation_date` (`next_creation_date`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_tickets
 
@@ -6671,7 +6671,7 @@ CREATE TABLE `glpi_tickets` (
   KEY `date_creation` (`date_creation`),
   KEY `ola_waiting_duration` (`ola_waiting_duration`),
   KEY `olalevels_id_ttr` (`olalevels_id_ttr`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_tickets_tickets
@@ -6684,7 +6684,7 @@ CREATE TABLE `glpi_tickets_tickets` (
   `link` int(11) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`tickets_id_1`,`tickets_id_2`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_tickets_users
@@ -6700,7 +6700,7 @@ CREATE TABLE `glpi_tickets_users` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`tickets_id`,`type`,`users_id`,`alternative_email`),
   KEY `user` (`users_id`,`type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_ticketsatisfactions
@@ -6716,7 +6716,7 @@ CREATE TABLE `glpi_ticketsatisfactions` (
   `comment` text,
   PRIMARY KEY (`id`),
   UNIQUE KEY `tickets_id` (`tickets_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_tickettasks
@@ -6760,7 +6760,7 @@ CREATE TABLE `glpi_tickettasks` (
   KEY `end` (`end`),
   KEY `tasktemplates_id` (`tasktemplates_id`),
   KEY `sourceitems_id` (`sourceitems_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_tickettemplatehiddenfields
@@ -6773,7 +6773,7 @@ CREATE TABLE `glpi_tickettemplatehiddenfields` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`tickettemplates_id`,`num`),
   KEY `tickettemplates_id` (`tickettemplates_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_changeemplatehiddenfields
 
@@ -6785,7 +6785,7 @@ CREATE TABLE `glpi_changetemplatehiddenfields` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`changetemplates_id`,`num`),
   KEY `changetemplates_id` (`changetemplates_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_problemtemplatehiddenfields
 
@@ -6797,7 +6797,7 @@ CREATE TABLE `glpi_problemtemplatehiddenfields` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`problemtemplates_id`,`num`),
   KEY `problemtemplates_id` (`problemtemplates_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_tickettemplatemandatoryfields
 
@@ -6809,7 +6809,7 @@ CREATE TABLE `glpi_tickettemplatemandatoryfields` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`tickettemplates_id`,`num`),
   KEY `tickettemplates_id` (`tickettemplates_id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_changetemplatemandatoryfields
@@ -6822,7 +6822,7 @@ CREATE TABLE `glpi_changetemplatemandatoryfields` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`changetemplates_id`,`num`),
   KEY `changetemplates_id` (`changetemplates_id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_problemtemplatemandatoryfields
 
@@ -6834,7 +6834,7 @@ CREATE TABLE `glpi_problemtemplatemandatoryfields` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`problemtemplates_id`,`num`),
   KEY `problemtemplates_id` (`problemtemplates_id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_tickettemplatepredefinedfields
 
@@ -6846,7 +6846,7 @@ CREATE TABLE `glpi_tickettemplatepredefinedfields` (
   `value` text,
   PRIMARY KEY (`id`),
   KEY `tickettemplates_id` (`tickettemplates_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_changetemplatepredefinedfields
 
@@ -6858,7 +6858,7 @@ CREATE TABLE `glpi_changetemplatepredefinedfields` (
   `value` text,
   PRIMARY KEY (`id`),
   KEY `changetemplates_id` (`changetemplates_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_problemtemplatepredefinedfields
 
@@ -6870,7 +6870,7 @@ CREATE TABLE `glpi_problemtemplatepredefinedfields` (
   `value` text,
   PRIMARY KEY (`id`),
   KEY `problemtemplates_id` (`problemtemplates_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 
@@ -6887,7 +6887,7 @@ CREATE TABLE `glpi_tickettemplates` (
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_changetemplates
@@ -6903,7 +6903,7 @@ CREATE TABLE `glpi_changetemplates` (
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_problemtemplates
 
@@ -6918,7 +6918,7 @@ CREATE TABLE `glpi_problemtemplates` (
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_ticketvalidations
 
@@ -6943,7 +6943,7 @@ CREATE TABLE `glpi_ticketvalidations` (
   KEY `submission_date` (`submission_date`),
   KEY `validation_date` (`validation_date`),
   KEY `status` (`status`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_transfers
@@ -6985,7 +6985,7 @@ CREATE TABLE `glpi_transfers` (
   `keep_disk` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_usercategories
@@ -7001,7 +7001,7 @@ CREATE TABLE `glpi_usercategories` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_useremails
@@ -7018,7 +7018,7 @@ CREATE TABLE `glpi_useremails` (
   KEY `email` (`email`),
   KEY `is_default` (`is_default`),
   KEY `is_dynamic` (`is_dynamic`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_users
@@ -7134,7 +7134,7 @@ CREATE TABLE `glpi_users` (
   KEY `sync_field` (`sync_field`),
   KEY `groups_id` (`groups_id`),
   KEY `users_id_supervisor` (`users_id_supervisor`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_usertitles
@@ -7150,7 +7150,7 @@ CREATE TABLE `glpi_usertitles` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_virtualmachinestates
@@ -7165,7 +7165,7 @@ CREATE TABLE `glpi_virtualmachinestates` (
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_virtualmachinesystems
@@ -7180,7 +7180,7 @@ CREATE TABLE `glpi_virtualmachinesystems` (
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_virtualmachinetypes
@@ -7195,7 +7195,7 @@ CREATE TABLE `glpi_virtualmachinetypes` (
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_vlans
@@ -7216,7 +7216,7 @@ CREATE TABLE `glpi_vlans` (
   KEY `tag` (`tag`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 ### Dump table glpi_wifinetworks
@@ -7238,7 +7238,7 @@ CREATE TABLE `glpi_wifinetworks` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_knowbaseitems_items
 
@@ -7255,7 +7255,7 @@ CREATE TABLE `glpi_knowbaseitems_items` (
   KEY `itemtype` (`itemtype`),
   KEY `item_id` (`items_id`),
   KEY `item` (`itemtype`,`items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_knowbaseitems_revisions
 
@@ -7272,7 +7272,7 @@ CREATE TABLE `glpi_knowbaseitems_revisions` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`knowbaseitems_id`, `revision`, `language`),
   KEY `revision` (`revision`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_knowbaseitems_comments
 
@@ -7287,7 +7287,7 @@ CREATE TABLE `glpi_knowbaseitems_comments` (
   `date_creation` timestamp NULL DEFAULT NULL,
   `date_mod` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_devicebatterymodels
 
@@ -7300,7 +7300,7 @@ CREATE TABLE `glpi_devicebatterymodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_devicebatteries
 
@@ -7327,7 +7327,7 @@ CREATE TABLE `glpi_devicebatteries` (
   KEY `date_creation` (`date_creation`),
   KEY `devicebatterymodels_id` (`devicebatterymodels_id`),
   KEY `devicebatterytypes_id` (`devicebatterytypes_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_items_devicebatteries
 
@@ -7357,7 +7357,7 @@ CREATE TABLE `glpi_items_devicebatteries` (
   KEY `serial` (`serial`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `otherserial` (`otherserial`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_devicebatterytypes`;
 CREATE TABLE `glpi_devicebatterytypes` (
@@ -7370,7 +7370,7 @@ CREATE TABLE `glpi_devicebatterytypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_devicefirmwaremodels
 
@@ -7383,7 +7383,7 @@ CREATE TABLE `glpi_devicefirmwaremodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_devicefirmwares
 
@@ -7410,7 +7410,7 @@ CREATE TABLE `glpi_devicefirmwares` (
   KEY `date_creation` (`date_creation`),
   KEY `devicefirmwaremodels_id` (`devicefirmwaremodels_id`),
   KEY `devicefirmwaretypes_id` (`devicefirmwaretypes_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_items_devicefirmwares
 
@@ -7438,7 +7438,7 @@ CREATE TABLE `glpi_items_devicefirmwares` (
   KEY `serial` (`serial`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `otherserial` (`otherserial`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_devicefirmwaretypes`;
 CREATE TABLE `glpi_devicefirmwaretypes` (
@@ -7451,7 +7451,7 @@ CREATE TABLE `glpi_devicefirmwaretypes` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 -- Datacenters
@@ -7471,7 +7471,7 @@ CREATE TABLE `glpi_datacenters` (
   KEY `is_recursive` (`is_recursive`),
   KEY `locations_id` (`locations_id`),
   KEY `is_deleted` (`is_deleted`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_dcrooms`;
 CREATE TABLE `glpi_dcrooms` (
@@ -7493,7 +7493,7 @@ CREATE TABLE `glpi_dcrooms` (
   KEY `locations_id` (`locations_id`),
   KEY `datacenters_id` (`datacenters_id`),
   KEY `is_deleted` (`is_deleted`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_rackmodels`;
 CREATE TABLE `glpi_rackmodels` (
@@ -7506,7 +7506,7 @@ CREATE TABLE `glpi_rackmodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_racktypes`;
 CREATE TABLE `glpi_racktypes` (
@@ -7523,7 +7523,7 @@ CREATE TABLE `glpi_racktypes` (
   KEY `name` (`name`),
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_racks`;
 CREATE TABLE `glpi_racks` (
@@ -7570,7 +7570,7 @@ CREATE TABLE `glpi_racks` (
   KEY `is_template` (`is_template`),
   KEY `is_deleted` (`is_deleted`),
   KEY `dcrooms_id` (`dcrooms_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_items_racks`;
 CREATE TABLE `glpi_items_racks` (
@@ -7586,7 +7586,7 @@ CREATE TABLE `glpi_items_racks` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `item` (`itemtype`,`items_id`, `is_reserved`),
   KEY `relation` (`racks_id`,`itemtype`,`items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_enclosuremodels`;
 CREATE TABLE `glpi_enclosuremodels` (
@@ -7609,7 +7609,7 @@ CREATE TABLE `glpi_enclosuremodels` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_enclosures`;
 CREATE TABLE `glpi_enclosures` (
@@ -7644,7 +7644,7 @@ CREATE TABLE `glpi_enclosures` (
   KEY `is_deleted` (`is_deleted`),
   KEY `states_id` (`states_id`),
   KEY `manufacturers_id` (`manufacturers_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_items_enclosures`;
 CREATE TABLE `glpi_items_enclosures` (
@@ -7656,7 +7656,7 @@ CREATE TABLE `glpi_items_enclosures` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `item` (`itemtype`,`items_id`),
   KEY `relation` (`enclosures_id`,`itemtype`,`items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_pdumodels`;
 CREATE TABLE `glpi_pdumodels` (
@@ -7679,7 +7679,7 @@ CREATE TABLE `glpi_pdumodels` (
   KEY `name` (`name`),
   KEY `is_rackable` (`is_rackable`),
   KEY `product_number` (`product_number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_pdutypes`;
 CREATE TABLE `glpi_pdutypes` (
@@ -7696,7 +7696,7 @@ CREATE TABLE `glpi_pdutypes` (
   KEY `name` (`name`),
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 DROP TABLE IF EXISTS `glpi_pdus`;
@@ -7732,7 +7732,7 @@ CREATE TABLE `glpi_pdus` (
   KEY `states_id` (`states_id`),
   KEY `manufacturers_id` (`manufacturers_id`),
   KEY `pdutypes_id` (`pdutypes_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_plugs`;
 CREATE TABLE `glpi_plugs` (
@@ -7745,7 +7745,7 @@ CREATE TABLE `glpi_plugs` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_pdus_plugs`;
 CREATE TABLE `glpi_pdus_plugs` (
@@ -7758,7 +7758,7 @@ CREATE TABLE `glpi_pdus_plugs` (
   PRIMARY KEY (`id`),
   KEY `plugs_id` (`plugs_id`),
   KEY `pdus_id` (`pdus_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_pdus_racks`;
 CREATE TABLE `glpi_pdus_racks` (
@@ -7773,7 +7773,7 @@ CREATE TABLE `glpi_pdus_racks` (
   PRIMARY KEY (`id`),
   KEY `racks_id` (`racks_id`),
   KEY `pdus_id` (`pdus_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 -- /Datacenters
 
 DROP TABLE IF EXISTS `glpi_itilfollowuptemplates`;
@@ -7796,7 +7796,7 @@ CREATE TABLE `glpi_itilfollowuptemplates` (
    KEY `date_mod` (`date_mod`),
    KEY `date_creation` (`date_creation`),
    KEY `is_private` (`is_private`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_itilfollowups`;
 CREATE TABLE `glpi_itilfollowups` (
@@ -7827,7 +7827,7 @@ CREATE TABLE `glpi_itilfollowups` (
   KEY `requesttypes_id` (`requesttypes_id`),
   KEY `sourceitems_id` (`sourceitems_id`),
   KEY `sourceof_items_id` (`sourceof_items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_clustertypes`;
 CREATE TABLE `glpi_clustertypes` (
@@ -7844,7 +7844,7 @@ CREATE TABLE `glpi_clustertypes` (
   KEY `is_recursive` (`is_recursive`),
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_clusters`;
 CREATE TABLE `glpi_clusters` (
@@ -7872,7 +7872,7 @@ CREATE TABLE `glpi_clusters` (
   KEY `autoupdatesystems_id` (`autoupdatesystems_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_items_clusters`;
 CREATE TABLE `glpi_items_clusters` (
@@ -7883,7 +7883,7 @@ CREATE TABLE `glpi_items_clusters` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`clusters_id`,`itemtype`,`items_id`),
   KEY `item` (`itemtype`,`items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_planningexternalevents
 
@@ -7922,7 +7922,7 @@ CREATE TABLE `glpi_planningexternalevents` (
   KEY `planningeventcategories_id` (`planningeventcategories_id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_planningexternaleventtemplates
 
@@ -7947,7 +7947,7 @@ CREATE TABLE `glpi_planningexternaleventtemplates` (
    KEY `planningeventcategories_id` (`planningeventcategories_id`),
    KEY `date_mod` (`date_mod`),
    KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_planningeventcategories
 
@@ -7963,7 +7963,7 @@ CREATE TABLE `glpi_planningeventcategories` (
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_items_kanbans
 
@@ -7978,7 +7978,7 @@ CREATE TABLE `glpi_items_kanbans` (
    `date_creation` timestamp NULL DEFAULT NULL,
    PRIMARY KEY (`id`),
    UNIQUE KEY `unicity` (`itemtype`,`items_id`,`users_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 ### Dump table glpi_vobjects
 
@@ -7995,7 +7995,7 @@ CREATE TABLE `glpi_vobjects` (
    KEY `item` (`itemtype`,`items_id`),
    KEY `date_mod` (`date_mod`),
    KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_domaintypes`;
 CREATE TABLE `glpi_domaintypes` (
@@ -8006,7 +8006,7 @@ CREATE TABLE `glpi_domaintypes` (
   `comment` text,
   PRIMARY KEY (`id`),
   KEY `name` (`name`)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_domainrelations`;
 CREATE TABLE `glpi_domainrelations` (
@@ -8017,7 +8017,7 @@ CREATE TABLE `glpi_domainrelations` (
   `comment` text,
   PRIMARY KEY (`id`),
   KEY `name` (`name`)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_domains_items`;
 CREATE TABLE `glpi_domains_items` (
@@ -8032,7 +8032,7 @@ CREATE TABLE `glpi_domains_items` (
   KEY `domainrelations_id` (`domainrelations_id`),
   KEY `FK_device` (`items_id`, `itemtype`),
   KEY `item` (`itemtype`, `items_id`)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_domainrecordtypes`;
 CREATE TABLE `glpi_domainrecordtypes` (
@@ -8044,7 +8044,7 @@ CREATE TABLE `glpi_domainrecordtypes` (
   `comment` text,
   PRIMARY KEY (`id`),
   KEY `name` (`name`)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_domainrecords`;
 CREATE TABLE `glpi_domainrecords` (
@@ -8073,7 +8073,7 @@ CREATE TABLE `glpi_domainrecords` (
   KEY `date_mod` (`date_mod`),
   KEY `is_deleted` (`is_deleted`),
   KEY `date_creation` (`date_creation`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `glpi_appliances`;
 CREATE TABLE `glpi_appliances` (
@@ -8114,7 +8114,7 @@ CREATE TABLE `glpi_appliances` (
   KEY `serial` (`serial`),
   KEY `otherserial` (`otherserial`),
   KEY `is_helpdesk_visible` (`is_helpdesk_visible`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 CREATE TABLE IF NOT EXISTS `glpi_appliances_items` (
@@ -8126,7 +8126,7 @@ CREATE TABLE IF NOT EXISTS `glpi_appliances_items` (
    UNIQUE `unicity` (`appliances_id`,`items_id`,`itemtype`),
    KEY `appliances_id` (`appliances_id`),
    KEY `item` (`itemtype`,`items_id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 CREATE TABLE IF NOT EXISTS `glpi_appliancetypes` (
@@ -8140,7 +8140,7 @@ CREATE TABLE IF NOT EXISTS `glpi_appliancetypes` (
    KEY `name` (`name`),
    KEY `entities_id` (`entities_id`),
    UNIQUE (`externalidentifier`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 
 CREATE TABLE IF NOT EXISTS `glpi_applianceenvironments` (
@@ -8149,7 +8149,7 @@ CREATE TABLE IF NOT EXISTS `glpi_applianceenvironments` (
    `comment` text,
   PRIMARY KEY (`id`),
   KEY `name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `glpi_appliances_items_relations` (
    `id` int(11) NOT NULL auto_increment,
@@ -8161,4 +8161,4 @@ CREATE TABLE IF NOT EXISTS `glpi_appliances_items_relations` (
    KEY `itemtype` (`itemtype`),
    KEY `items_id` (`items_id`),
    KEY `item` (`itemtype`,`items_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE = InnoDB ROW_FORMAT = Dynamic DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;

--- a/install/update.php
+++ b/install/update.php
@@ -52,7 +52,9 @@ $translation_cache->clear(); // Force cache cleaning to prevent usage of outdate
 
 Config::detectRootDoc();
 
-$DB = new DB();
+if (!($DB instanceof DBmysql)) { // $DB can have already been init in install.php script
+   $DB = new DB();
+}
 $DB->disableTableCaching(); //prevents issues on fieldExists upgrading from old versions
 
 Config::loadLegacyConfiguration();

--- a/install/update_95_xx.php
+++ b/install/update_95_xx.php
@@ -76,5 +76,9 @@ function update95toXX() {
 
    $migration->executeMigration();
 
+   $migration->displayWarning(
+      '"utf8mb4" support requires additional migration which can be performed via the "php bin/console glpi:migration:utf8mb4" command.'
+   );
+
    return $updateresult;
 }

--- a/tests/database/DBmysql.php
+++ b/tests/database/DBmysql.php
@@ -70,6 +70,9 @@ class DBmysql extends \GLPITestCase {
          $updated = $update['schema'];
          $updated_idx = $update['index'];
 
+         // TEXT fields were replaced by MEDIUM text during utf8mb4 migration
+         $updated = str_replace('mediumtext', 'text', $updated);
+
          //compare table schema
          $this->string($updated)->isIdenticalTo($fresh);
          //check index

--- a/tests/units/DBConnection.php
+++ b/tests/units/DBConnection.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use org\bovigo\vfs\vfsStream;
+
+/* Test for inc/dbconnection.class.php */
+
+class DBConnection extends \GLPITestCase {
+
+   protected function setConnectionCharsetProvider() {
+      return [
+         [
+            'utf8mb4'          => true,
+            'expected_charset' => 'utf8mb4',
+            'expected_query'   => "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci';"
+         ],
+         [
+            'utf8mb4'          => false,
+            'expected_charset' => 'utf8',
+            'expected_query'   => "SET NAMES 'utf8' COLLATE 'utf8_unicode_ci';"
+         ],
+      ];
+   }
+
+   /**
+    * @dataProvider setConnectionCharsetProvider
+    */
+   public function testSetConnectionCharset(bool $utf8mb4, string $expected_charset, string $expected_query) {
+      $this->mockGenerator->orphanize('__construct');
+      $dbh = new \mock\mysqli;
+      $queries = [];
+      $this->calling($dbh)->set_charset = true;
+      $this->calling($dbh)->query = function ($query) use (&$queries) {
+         $queries[] = $query;
+         return true;
+      };
+
+      \DBConnection::setConnectionCharset($dbh, $utf8mb4);
+      $this->mock($dbh)->call('set_charset')->withArguments($expected_charset)->once();
+      $this->array($queries)->isIdenticalTo([$expected_query]);
+   }
+
+   protected function configFilesProvider() {
+      return [
+         [
+            // Add a new boolean (true) variable without slave
+            'init_config_files'     => [
+               'config_db.php' => <<<PHP
+<?php
+class DB extends DBmysql {
+   public \$dbuser      = 'glpi';
+   public \$dbdefault   = 'glpi';
+}
+PHP
+               ,
+            ],
+            'name'                  => 'utf8mb4',
+            'new_value'             => true,
+            'update_slave'          => true, // Will have no effect as slave not exists
+            'expected_config_files' => [
+               'config_db.php' => <<<PHP
+<?php
+class DB extends DBmysql {
+   public \$dbuser      = 'glpi';
+   public \$dbdefault   = 'glpi';
+   public \$utf8mb4 = true;
+}
+PHP
+               ,
+            ],
+         ],
+         [
+            // Add a new boolean (false) variable with slave
+            'init_config_files'     => [
+               'config_db.php' => <<<PHP
+<?php
+class DB extends DBmysql {
+   public \$dbuser      = 'glpi';
+   public \$dbdefault   = 'glpi';
+}
+PHP
+               ,
+               'config_db_slave.php' => <<<PHP
+<?php
+class DB extends DBmysql {
+   public \$dbhost      = 'slave.domain.org';
+   public \$dbuser      = 'glpi';
+   public \$dbdefault   = 'glpi';
+}
+PHP
+               ,
+            ],
+            'name'                  => 'utf8mb4',
+            'new_value'             => false,
+            'update_slave'          => true,
+            'expected_config_files' => [
+               'config_db.php' => <<<PHP
+<?php
+class DB extends DBmysql {
+   public \$dbuser      = 'glpi';
+   public \$dbdefault   = 'glpi';
+   public \$utf8mb4 = false;
+}
+PHP
+               ,
+               'config_db_slave.php' => <<<PHP
+<?php
+class DB extends DBmysql {
+   public \$dbhost      = 'slave.domain.org';
+   public \$dbuser      = 'glpi';
+   public \$dbdefault   = 'glpi';
+   public \$utf8mb4 = false;
+}
+PHP
+               ,
+            ],
+         ],
+         [
+            // Update an array variable without updating slave
+            'init_config_files'     => [
+               'config_db.php' => <<<PHP
+<?php
+class DB extends DBmysql {
+   public \$dbuser      = 'glpi';
+   public \$dbdefault   = 'glpi';
+   public \$prop        = ['first', 'second'];
+}
+PHP
+               ,
+               'config_db_slave.php' => <<<PHP
+<?php
+class DB extends DBmysql {
+   public \$dbhost      = 'slave.domain.org';
+   public \$dbuser      = 'glpi';
+   public \$dbdefault   = 'glpi';
+}
+PHP
+               ,
+            ],
+            'name'                  => 'prop',
+            'new_value'             => ['new', 'old'],
+            'update_slave'          => false,
+            'expected_config_files' => [
+               'config_db.php' => <<<PHP
+<?php
+class DB extends DBmysql {
+   public \$dbuser      = 'glpi';
+   public \$dbdefault   = 'glpi';
+   public \$prop        = array (
+  0 => 'new',
+  1 => 'old',
+);
+}
+PHP
+               ,
+               'config_db_slave.php' => <<<PHP
+<?php
+class DB extends DBmysql {
+   public \$dbhost      = 'slave.domain.org';
+   public \$dbuser      = 'glpi';
+   public \$dbdefault   = 'glpi';
+}
+PHP
+               ,
+            ],
+         ],
+         [
+            // Update a string variable
+            'init_config_files'     => [
+               'config_db.php' => <<<PHP
+<?php
+class DB extends DBmysql {
+   public \$dbuser      = 'glpi';
+   public \$dbdefault   = 'glpi';
+}
+PHP
+               ,
+            ],
+            'name'                  => 'dbdefault',
+            'new_value'             => 'glpi_b',
+            'update_slave'          => false,
+            'expected_config_files' => [
+               'config_db.php' => <<<PHP
+<?php
+class DB extends DBmysql {
+   public \$dbuser      = 'glpi';
+   public \$dbdefault   = 'glpi_b';
+}
+PHP
+               ,
+            ],
+         ],
+         [
+            // Add a float variable
+            'init_config_files'     => [
+               'config_db.php' => <<<PHP
+<?php
+class DB extends DBmysql {
+   public \$dbuser      = 'glpi';
+   public \$dbdefault   = 'glpi';
+}
+PHP
+               ,
+            ],
+            'name'                  => 'version',
+            'new_value'             => 20.3,
+            'update_slave'          => false,
+            'expected_config_files' => [
+               'config_db.php' => <<<PHP
+<?php
+class DB extends DBmysql {
+   public \$dbuser      = 'glpi';
+   public \$dbdefault   = 'glpi';
+   public \$version = 20.3;
+}
+PHP
+               ,
+            ],
+         ],
+         [
+            // Cannot update a config that not exists
+            'init_config_files'     => [],
+            'name'                  => 'version',
+            'new_value'             => 20.3,
+            'update_slave'          => false,
+            'expected_config_files' => [],
+            'expected_result'       => false,
+         ],
+      ];
+   }
+
+   /**
+    * @dataProvider configFilesProvider
+    */
+   public function testUpdateConfigProperty(
+      array $init_config_files,
+      string $name, $new_value,
+      bool $update_slave,
+      array $expected_config_files,
+      bool $expected_result = true
+   ) {
+      vfsStream::setup('config-dir', null, $init_config_files);
+
+      $result = \DBConnection::updateConfigProperty($name, $new_value, $update_slave, vfsStream::url('config-dir'));
+      $this->boolean($result)->isEqualTo($expected_result);
+
+      foreach ($expected_config_files as $filename => $contents) {
+         $path = vfsStream::url('config-dir/' . $filename);
+         $this->boolean(file_exists($path))->isTrue();
+         $this->string(file_get_contents($path))->isEqualTo($contents);
+      }
+   }
+}

--- a/tests/units/Glpi/System/Requirement/DbConfiguration.php
+++ b/tests/units/Glpi/System/Requirement/DbConfiguration.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\System\Requirement;
+
+class DbConfiguration extends \GLPITestCase {
+
+   protected function configurationProvider() {
+      return [
+         [
+            // Default variables on MySQL 5.6
+            'version'   => '5.6.50-log',
+            'variables' => [
+               'innodb_file_format'  => 'Antelope',
+               'innodb_large_prefix' => 0,
+               'innodb_page_size'    => 16384,
+            ],
+            'validated' => false,
+            'messages'  => [
+               '"innodb_file_format" must be set to "Barracuda".',
+               '"innodb_large_prefix" must be enabled.',
+            ]
+         ],
+         [
+            // Required variables on MySQL 5.6
+            'version'   => '5.6.50-log',
+            'variables' => [
+               'innodb_file_format'  => 'Barracuda',
+               'innodb_large_prefix' => 1,
+               'innodb_page_size'    => 16384,
+            ],
+            'validated' => true,
+            'messages'  => [
+               'Database configuration is OK.',
+            ]
+         ],
+         [
+            // Incompatible variables on MySQL 5.6
+            'version'   => '5.6.50-log',
+            'variables' => [
+               'innodb_file_format'  => 'Antelope',
+               'innodb_large_prefix' => 0,
+               'innodb_page_size'    => 4096,
+            ],
+            'validated' => false,
+            'messages'  => [
+               '"innodb_file_format" must be set to "Barracuda".',
+               '"innodb_large_prefix" must be enabled.',
+               '"innodb_page_size" must be >= 8KB.',
+            ]
+         ],
+         [
+            // Default variables on MySQL 5.7
+            'version'   => '5.7.34-standard',
+            'variables' => [
+               'innodb_file_format'  => 'Barracuda',
+               'innodb_large_prefix' => 1,
+               'innodb_page_size'    => 16384,
+            ],
+            'validated' => true,
+            'messages'  => [
+               'Database configuration is OK.',
+            ]
+         ],
+         [
+            // Incompatible variables on MySQL 5.7
+            'version'   => '5.7.34-standard',
+            'variables' => [
+               'innodb_file_format'  => 'Antelope', // Not a problem, will enforce Barracuda for Dynamic tables
+               'innodb_large_prefix' => 0,
+               'innodb_page_size'    => 4096,
+            ],
+            'validated' => false,
+            'messages'  => [
+               '"innodb_large_prefix" must be enabled.',
+               '"innodb_page_size" must be >= 8KB.',
+            ]
+         ],
+         [
+            // Default variables on MySQL 8.0
+            'version'   => '8.0.24-standard',
+            'variables' => [
+               'innodb_page_size'    => 16384,
+            ],
+            'validated' => true,
+            'messages'  => [
+               'Database configuration is OK.',
+            ]
+         ],
+         [
+            // "innodb_page_size=8k" config is valid too
+            'version'   => '8.0.24-standard',
+            'variables' => [
+               'innodb_page_size'    => 8192,
+            ],
+            'validated' => true,
+            'messages'  => [
+               'Database configuration is OK.',
+            ]
+         ],
+         [
+            // Incompatible variables on MySQL 8.0
+            'version'   => '8.0.24-standard',
+            'variables' => [
+               'innodb_page_size'    => 4096,
+            ],
+            'validated' => false,
+            'messages'  => [
+               '"innodb_page_size" must be >= 8KB.',
+            ]
+         ],
+         [
+            // Default variables on MariaDB 10.1
+            'version'   => '10.1.48-MariaDB',
+            'variables' => [
+               'innodb_file_format'  => 'Antelope',
+               'innodb_large_prefix' => 0,
+               'innodb_page_size'    => 16384,
+            ],
+            'validated' => false,
+            'messages'  => [
+               '"innodb_large_prefix" must be enabled.',
+            ]
+         ],
+         [
+            // Required variables on MariaDB 10.1
+            'version'   => '10.1.48-MariaDB',
+            'variables' => [
+               'innodb_file_format'  => 'Antelope',
+               'innodb_large_prefix' => 1,
+               'innodb_page_size'    => 16384,
+            ],
+            'validated' => true,
+            'messages'  => [
+               'Database configuration is OK.',
+            ]
+         ],
+         [
+            // Incompatible variables on MariaDB 10.1
+            'version'   => '10.1.48-MariaDB',
+            'variables' => [
+               'innodb_file_format'  => 'Antelope', // Not a problem, will enforce Barracuda for Dynamic tables
+               'innodb_large_prefix' => 0,
+               'innodb_page_size'    => 4096,
+            ],
+            'validated' => false,
+            'messages'  => [
+               '"innodb_large_prefix" must be enabled.',
+               '"innodb_page_size" must be >= 8KB.',
+            ]
+         ],
+         [
+            // Default variables on MariaDB 10.2
+            'version'   => '10.2.36-MariaDB',
+            'variables' => [
+               'innodb_file_format'  => 'Barracuda',
+               'innodb_large_prefix' => 1,
+               'innodb_page_size'    => 16384,
+            ],
+            'validated' => true,
+            'messages'  => [
+               'Database configuration is OK.',
+            ]
+         ],
+         [
+            // Incompatible variables on MariaDB 10.2
+            'version'   => '10.2.36-MariaDB',
+            'variables' => [
+               'innodb_file_format'  => 'Antelope', // Not a problem, will enforce Barracuda for Dynamic tables
+               'innodb_large_prefix' => 0,
+               'innodb_page_size'    => 4096,
+            ],
+            'validated' => false,
+            'messages'  => [
+               '"innodb_large_prefix" must be enabled.',
+               '"innodb_page_size" must be >= 8KB.',
+            ]
+         ],
+         [
+            // Default variables on MariaDB 10.3
+            'version'   => '10.3.27-MariaDB',
+            'variables' => [
+               'innodb_page_size'    => 16384,
+            ],
+            'validated' => true,
+            'messages'  => [
+               'Database configuration is OK.',
+            ]
+         ],
+         [
+            // Incompatible variables on MariaDB 10.3
+            'version'   => '10.3.27-MariaDB',
+            'variables' => [
+               'innodb_page_size'    => 4096,
+            ],
+            'validated' => false,
+            'messages'  => [
+               '"innodb_page_size" must be >= 8KB.',
+            ]
+         ],
+         [
+            // Default variables on MariaDB 10.4
+            'version'   => '10.4.17-MariaDB',
+            'variables' => [
+               'innodb_page_size'    => 16384,
+            ],
+            'validated' => true,
+            'messages'  => [
+               'Database configuration is OK.',
+            ]
+         ],
+         [
+            // Incompatible variables on MariaDB 10.4
+            'version'   => '10.4.17-MariaDB',
+            'variables' => [
+               'innodb_page_size'    => 4096,
+            ],
+            'validated' => false,
+            'messages'  => [
+               '"innodb_page_size" must be >= 8KB.',
+            ]
+         ],
+         [
+            // Default variables on MariaDB 10.5
+            'version'   => '10.5.8-MariaDB',
+            'variables' => [
+               'innodb_page_size'    => 16384,
+            ],
+            'validated' => true,
+            'messages'  => [
+               'Database configuration is OK.',
+            ]
+         ],
+         [
+            // Incompatible variables on MariaDB 10.5
+            'version'   => '10.5.8-MariaDB',
+            'variables' => [
+               'innodb_page_size'    => 4096,
+            ],
+            'validated' => false,
+            'messages'  => [
+               '"innodb_page_size" must be >= 8KB.',
+            ]
+         ],
+      ];
+   }
+
+   /**
+    * @dataProvider configurationProvider
+    */
+   public function testCheck(string $version, array $variables, bool $validated, array $messages) {
+
+      $that = $this;
+
+      $this->mockGenerator->orphanize('__construct');
+      $db = new \mock\DB();
+      $this->calling($db)->getVersion = $version;
+      $this->calling($db)->query = function ($query) use ($that, $variables) {
+         $matches = [];
+         if (preg_match_all('/@@GLOBAL\.`(?<name>[^`]+)`/', $query, $matches) > 0) {
+            $row = [];
+            foreach ($matches['name'] as $name) {
+               $row[$name] = $variables[$name] ?? null;
+            }
+            $that->mockGenerator->orphanize('__construct');
+            $res = new \mock\mysqli_result();
+            $that->calling($res)->fetch_assoc = $row;
+            return $res;
+         }
+         return false;
+      };
+
+      $this->newTestedInstance($db);
+      $this->boolean($this->testedInstance->isValidated())->isEqualTo($validated);
+      $this->array($this->testedInstance->getValidationMessages())
+         ->isEqualTo($messages);
+   }
+}

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -293,9 +293,10 @@ class Migration extends \GLPITestCase {
          }
       )->isIdenticalTo("Change of the database layout - change_tableTask completed.");
 
+      $collate = $DB->use_utf8mb4 ? 'utf8mb4_unicode_ci' : 'utf8_unicode_ci';
       $this->array($this->queries)->isIdenticalTo([
          "ALTER TABLE `change_table` DROP `name`  ,\n" .
-         "CHANGE `NAME` `name` VARCHAR(255) COLLATE utf8_unicode_ci DEFAULT NULL   AFTER `id` ",
+         "CHANGE `NAME` `name` VARCHAR(255) COLLATE $collate DEFAULT NULL   AFTER `id` ",
       ]);
    }
 
@@ -330,13 +331,27 @@ class Migration extends \GLPITestCase {
             'field'     => 'my_field',
             'format'    => 'string',
             'options'   => [],
-            'sql'       => "ALTER TABLE `my_table` ADD `my_field` VARCHAR(255) COLLATE utf8_unicode_ci DEFAULT NULL   "
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` VARCHAR(255) COLLATE utf8_unicode_ci DEFAULT NULL   ",
+            'utf8mb4'   => false,
+         ], [
+            'table'     => 'my_table',
+            'field'     => 'my_field',
+            'format'    => 'string',
+            'options'   => [],
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` VARCHAR(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL   ",
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'string',
             'options'   => ['value' => 'a string'],
-            'sql'       => "ALTER TABLE `my_table` ADD `my_field` VARCHAR(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'a string'   "
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` VARCHAR(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'a string'   ",
+            'utf8mb4'   => false,
+         ], [
+            'table'     => 'my_table',
+            'field'     => 'my_field',
+            'format'    => 'string',
+            'options'   => ['value' => 'a string'],
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` VARCHAR(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'a string'   ",
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
@@ -378,25 +393,53 @@ class Migration extends \GLPITestCase {
             'field'     => 'my_field',
             'format'    => 'text',
             'options'   => [],
-            'sql'       => "ALTER TABLE `my_table` ADD `my_field` TEXT COLLATE utf8_unicode_ci DEFAULT NULL   "
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` TEXT COLLATE utf8_unicode_ci DEFAULT NULL   ",
+            'utf8mb4'   => false,
+         ], [
+            'table'     => 'my_table',
+            'field'     => 'my_field',
+            'format'    => 'text',
+            'options'   => [],
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` TEXT COLLATE utf8mb4_unicode_ci DEFAULT NULL   ",
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'text',
             'options'   => ['value' => 'A text'],
-            'sql'       => "ALTER TABLE `my_table` ADD `my_field` TEXT COLLATE utf8_unicode_ci NOT NULL DEFAULT 'A text'   "
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` TEXT COLLATE utf8_unicode_ci NOT NULL DEFAULT 'A text'   ",
+            'utf8mb4'   => false,
+         ], [
+            'table'     => 'my_table',
+            'field'     => 'my_field',
+            'format'    => 'text',
+            'options'   => ['value' => 'A text'],
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` TEXT COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'A text'   ",
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'longtext',
             'options'   => [],
-            'sql'       => "ALTER TABLE `my_table` ADD `my_field` LONGTEXT COLLATE utf8_unicode_ci DEFAULT NULL   "
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` LONGTEXT COLLATE utf8_unicode_ci DEFAULT NULL   ",
+            'utf8mb4'   => false,
+         ], [
+            'table'     => 'my_table',
+            'field'     => 'my_field',
+            'format'    => 'longtext',
+            'options'   => [],
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` LONGTEXT COLLATE utf8mb4_unicode_ci DEFAULT NULL   ",
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'longtext',
             'options'   => ['value' => 'A long text'],
-            'sql'       => "ALTER TABLE `my_table` ADD `my_field` LONGTEXT COLLATE utf8_unicode_ci NOT NULL DEFAULT 'A long text'   "
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` LONGTEXT COLLATE utf8_unicode_ci NOT NULL DEFAULT 'A long text'   ",
+            'utf8mb4'   => false,
+         ], [
+            'table'     => 'my_table',
+            'field'     => 'my_field',
+            'format'    => 'longtext',
+            'options'   => ['value' => 'A long text'],
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` LONGTEXT COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'A long text'   ",
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
@@ -444,9 +487,10 @@ class Migration extends \GLPITestCase {
    /**
     * @dataProvider fieldsFormatsProvider
     */
-   public function testAddField($table, $field, $format, $options, $sql) {
+   public function testAddField($table, $field, $format, $options, $sql, bool $utf8mb4 = true) {
       global $DB;
       $DB = $this->db;
+      $DB->use_utf8mb4 = $utf8mb4;
       $this->calling($this->db)->fieldExists = false;
       $this->queries = [];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Supports emoji, and, unless I am wrong, more Han ideographs.

![image](https://user-images.githubusercontent.com/33253653/104020337-52844100-51bd-11eb-96a6-a06cb20adbc5.png)

Migration took only 15 minutes for a 1.5GB database on my developpement machine (which host DB on a HDD).

Remaining work TO DO:
 - [x] Check for `innodb_large_prefix` / `innodb_page_size` unsupported values.
 - [x] Force `ROW_FORMAT = Dynamic` in installation script / migration class.
 - [x] Check if `ROW_FORMAT` is `REDUNDANT` or `COMPACT` and block migration (or migrate to `ROW_FORMAT = Dynamic` if operation is not too risky).
 - [x] Do not use Litemoji lib when DB supports emojis.
 - [x] Test, test, and test again.