### PR TITLE
Init active tab on display

### DIFF
--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -1195,7 +1195,12 @@ class CommonGLPI {
 
       // Init active tab to main if not defined
       if (!isset($_SESSION['glpi_tabs'][self::getType()])) {
-         Session::setActiveTab(self::getType(), self::getType().'$main');
+         // TODO: use array_key_first when php 7.3 is supported
+         $tabs = array_keys($this->defineTabs());
+         $first_tab = array_shift($tabs);
+         if ($first_tab) {
+            Session::setActiveTab(self::getType(), $first_tab);
+         }
       }
 
       if (isset($options['id'])

--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -1193,6 +1193,11 @@ class CommonGLPI {
    function display($options = []) {
       global $CFG_GLPI;
 
+      // Init active tab to main if not defined
+      if (!isset($_SESSION['glpi_tabs'][self::getType()])) {
+         Session::setActiveTab(self::getType(), self::getType().'$main');
+      }
+
       if (isset($options['id'])
           && !$this->isNewID($options['id'])) {
          if (!$this->getFromDB($options['id'])) {


### PR DESCRIPTION
The fields plugin use the `$_SESSION['glpi_tabs']` array to check whether or not it must load some additional fields.

If you login to GLPI, you start with the following `$_SESSION['glpi_tabs']` content:
```
Array
  (
      [central] => Central$0
  )
```

If you then go, for example, to the ticket creation form then there will NOT be any additional fields added by the plugin.
These fields will only be displayed after you have loaded an individual ticket and thus got a 'ticket' key in your `$_SESSION['glpi_tabs']` like this:
```
Array
  (
      [central] => Central$0
      [ticket]  => Ticket$main
  )
```

This fix prevent this issue by initializing the current `$_SESSION['glpi_tabs']` itemtype when you go on a form page.

While this fix seems to be a good short term solution, maybe we could also open an issue on the fields plugin repository's to see if the `PluginFieldsField::showForTab()` method can be cleaned up to not rely on session tabs data (and not rely on `debug_backtrace()` aswell...) unless there is some technical constraint preventing it.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21319
