### PR TITLE
Timestamp migration should care only about glpi_% tables

### DIFF
--- a/inc/console/migration/timestampscommand.class.php
+++ b/inc/console/migration/timestampscommand.class.php
@@ -71,6 +71,7 @@ class TimestampsCommand extends AbstractCommand {
          ],
          'WHERE'       => [
             'information_schema.columns.table_schema' => $this->db->dbdefault,
+            'information_schema.columns.table_name'   => ['LIKE', 'glpi_%'],
             'information_schema.columns.data_type'    => 'datetime'
          ],
          'ORDER'       => [

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -1634,8 +1634,9 @@ class DBmysql {
            'COUNT'       => 'cpt',
            'FROM'        => 'information_schema.columns',
            'WHERE'       => [
-              'information_schema.columns.table_schema'  => $DB->dbdefault,
-              'information_schema.columns.data_type'     => ['datetime']
+              'information_schema.columns.table_schema' => $DB->dbdefault,
+              'information_schema.columns.table_name'   => ['LIKE', 'glpi_%'],
+              'information_schema.columns.data_type'    => ['datetime']
            ]
        ])->next();
        return (int)$result['cpt'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
