### PR TITLE
Improved input file when setted only images

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -5666,7 +5666,9 @@ JAVASCRIPT;
          $display .= "<input id='fileupload{$p['rand']}' type='file' name='".$p['name']."[]'
                          data-url='".$CFG_GLPI["root_doc"]."/ajax/fileupload.php'
                          data-form-data='{\"name\": \"".$p['name']."\",
-                                          \"showfilesize\": \"".$p['showfilesize']."\"}'".($p['multiple']?" multiple='multiple'":"").">";
+                                          \"showfilesize\": \"".$p['showfilesize']."\"}'"
+                         .($p['multiple']?" multiple='multiple'":"")
+                         .($p['onlyimages']?" accept='.gif,.png,.jpg,.jpeg'":"").">";
          $display .= "<div id='progress{$p['rand']}' style='display:none'>".
                  "<div class='uploadbar' style='width: 0%;'></div></div>";
          $display .= "</div>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

This pull request add a filter for input files when `onlyimages` is setted when you click and open the window dialog.

Example: 
Before:
![image](https://user-images.githubusercontent.com/1530997/104391297-5fd35f80-551e-11eb-859f-c88af7ea8a31.png)

After: `Custom files: *.gif, *.png, *.jpg, *.jpeg`
![image](https://user-images.githubusercontent.com/1530997/104391818-8219ad00-551f-11eb-99d1-9e0bfb2c272b.png)
