### PR TITLE
Fix default entity in CommonDBRelation

### DIFF
--- a/inc/commondbrelation.class.php
+++ b/inc/commondbrelation.class.php
@@ -637,7 +637,7 @@ abstract class CommonDBRelation extends CommonDBConnexity {
 
          } else {
             // No entity link : set default values
-            $input['entities_id']  = 0;
+            $input['entities_id']  = Session::getActiveEntity();
             $input['is_recursive'] = 0;
          }
       }

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -1527,6 +1527,6 @@ class Session {
     * @return int
     */
    public static function getActiveEntity() {
-      return $_SESSION['glpiactive_entity'];
+      return $_SESSION['glpiactive_entity'] ?? 0;
    }
 }


### PR DESCRIPTION
Some items were hardcoded to be created on the default entity instead of the current one (Item_DeviceSimcard for example).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21363
