### PR TITLE
Fix monitor asset handling in inventory

### DIFF
--- a/inc/inventory/asset/monitor.class.php
+++ b/inc/inventory/asset/monitor.class.php
@@ -151,7 +151,7 @@ class Monitor extends InventoryAsset
          ],
          'WHERE'     => [
             'itemtype'                          => 'Monitor',
-            'computers_id'                      => $this->item->getType(),
+            'computers_id'                      => $this->item->getID(),
             'entities_id'                       => $entities_id,
             'glpi_computers_items.is_dynamic'   => 1,
             'glpi_monitors.is_global'           => 0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

```
*** MySQL query warnings:
SQL: SELECT `glpi_monitors`.`id`, `glpi_computers_items`.`id` AS `link_id` FROM `glpi_computers_items` LEFT JOIN `glpi_monitors` ON (`glpi_monitors`.`id` = `glpi_computers_items`.`items_id`) WHERE `itemtype` = 'Monitor' AND `computers_id` = 'Computer' AND `entities_id` = '0' AND `glpi_computers_items`.`is_dynamic` = '1' AND `glpi_monitors`.`is_global` = '0'
Warnings: 
1292: Truncated incorrect DOUBLE value: 'Computer'
Backtrace :
/var/glpi/inc/dbmysqliterator.class.php:95         
/var/glpi/inc/dbmysql.class.php:806                DBmysqlIterator->execute()
.../glpi/inc/inventory/asset/monitor.class.php:157 DBmysql->request()
...lpi/inc/inventory/asset/mainasset.class.php:634 Glpi\Inventory\Asset\Monitor->handle()
...lpi/inc/inventory/asset/mainasset.class.php:573 Glpi\Inventory\Asset\MainAsset->handleAssets()
/var/glpi/inc/ruleimportasset.class.php:930        Glpi\Inventory\Asset\MainAsset->rulepassed()
```