### PR TITLE
Fix charset used in search

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -4557,7 +4557,8 @@ JAVASCRIPT;
                   $date_computation = $tocompute;
                }
                if (in_array($searchtype, ["contains", "notcontains"])) {
-                  $date_computation = "CONVERT($date_computation USING utf8)";
+                  $default_charset = DBConnection::getDefaultCharset();
+                  $date_computation = "CONVERT($date_computation USING {$default_charset})";
                }
                $search_unit = ' MONTH ';
                if (isset($searchopt[$ID]['searchunit'])) {

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -410,6 +410,8 @@ class Search extends DbTestCase {
             ->array['sql']
                ->hasKey('search');
 
+      $default_charset = DBConnection::getDefaultCharset();
+
       $this->string($data['sql']['search'])
          ->contains("`glpi_computers`.`is_deleted` = 0")
          ->contains("AND `glpi_computers`.`is_template` = 0")
@@ -424,7 +426,7 @@ class Search extends DbTestCase {
          ->matches("/OR\s*\(`glpi_computertypes`\.`name`\s*LIKE '%test%'\s*\)/")
          ->matches("/OR\s*\(`glpi_computermodels`\.`name`\s*LIKE '%test%'\s*\)/")
          ->matches("/OR\s*\(`glpi_locations`\.`completename`\s*LIKE '%test%'\s*\)/")
-         ->matches("/OR\s*\(CONVERT\(`glpi_computers`\.`date_mod` USING utf8\)\s*LIKE '%test%'\s*\)\)/");
+         ->matches("/OR\s*\(CONVERT\(`glpi_computers`\.`date_mod` USING {$default_charset}\)\s*LIKE '%test%'\s*\)\)/");
    }
 
    public function testSearchOnRelationTable() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Charset must match the one used in tables.