### PR TITLE
make notification email/name from entity inheritables

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -172,6 +172,24 @@ sup {
    background-color: #cf9b9b;
 }
 
+.inherited {
+   color: rgb(34, 77, 194);
+   padding: 5px;
+   margin: 3px 0;
+   border: 1px solidt transparent;
+   border-radius: 2px;
+   background-color: rgba(34, 77, 194, .1);
+   white-space: nowrap;
+   font-style: italic;
+   display: table;
+
+   i.fas {
+      margin-right: 2px;
+      font-size: 0.7em;
+   }
+}
+
+
 .separ {
    clear: both;
    visibility: hidden;

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -183,6 +183,10 @@ sup {
    font-style: italic;
    display: table;
 
+   &.inline {
+      display: inline-block;
+   }
+
    i.fas {
       margin-right: 2px;
       font-size: 0.7em;

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -176,7 +176,7 @@ sup {
    color: rgb(34, 77, 194);
    padding: 5px;
    margin: 3px 0;
-   border: 1px solidt transparent;
+   border: 1px solid transparent;
    border-radius: 2px;
    background-color: rgba(34, 77, 194, .1);
    white-space: nowrap;

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -1794,7 +1794,7 @@ class Entity extends CommonTreeDropdown {
       echo "<td>" . __('Administrator name') . "</td><td>";
       // we inherit only if email inherit also
       Html::autocompletionTextField($entity, "admin_email");
-      if (strlen($entity->fields['admin_email_name']) == 0) {
+      if (strlen($entity->fields['admin_email']) == 0) {
          self::inheritedValue(self::getUsedConfig('admin_email_name', $ID, '', ''));
       }
       echo "</td></tr>";

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -1761,28 +1761,51 @@ class Entity extends CommonTreeDropdown {
 
       echo "<tr><th colspan='4'>".__('Notification options')."</th></tr>";
 
+      if ($ID > 0) {
+         echo "<tr><td colspan='4' class='warning'>".
+            "<div>".__('All options below inherit from parent entities if not set (even if not explicitly indicated).')."</div>".
+            "<div>".__('The inherited values will be displayed in green')."</div>".
+         "</td></tr>";
+      }
+
       echo "<tr class='tab_bg_1'>";
       echo "<td>".__('Administrator email')."</td>";
       echo "<td>";
       Html::autocompletionTextField($entity, "admin_email");
+      if (strlen($entity->fields['admin_email']) == 0) {
+         echo "<div class='green'>".self::getUsedConfig('admin_email', $ID, '', '')."</div>";
+      }
       echo "</td>";
       echo "<td>" . __('Administrator name') . "</td><td>";
-      Html::autocompletionTextField($entity, "admin_email_name");
+      // we inherit only if email inherit also
+      Html::autocompletionTextField($entity, "admin_email");
+      if (strlen($entity->fields['admin_email_name']) == 0) {
+         echo "<div class='green'>".self::getUsedConfig('admin_email_name', $ID, '', '')."</div>";
+      }
       echo "</td></tr>";
 
       echo "<tr class='tab_bg_1'>";
       echo "<td>".__('Administrator reply-to email (if needed)')."</td>";
       echo "<td>";
       Html::autocompletionTextField($entity, "admin_reply");
+      if (strlen($entity->fields['admin_reply']) == 0) {
+         echo "<div class='green'>".self::getUsedConfig('admin_reply', $ID, '', '')."</div>";
+      }
       echo "</td>";
       echo "<td>" . __('Response address (if needed)') . "</td><td>";
       Html::autocompletionTextField($entity, "admin_reply_name");
+      if (strlen($entity->fields['admin_reply']) == 0) {
+         echo "<div class='green'>".self::getUsedConfig('admin_reply_name', $ID, '', '')."</div>";
+      }
       echo "</td></tr>";
 
       echo "<tr class='tab_bg_1'>";
       echo "<td>".__('Prefix for notifications')."</td>";
       echo "<td>";
       Html::autocompletionTextField($entity, "notification_subject_tag");
+      if (strlen($entity->fields['notification_subject_tag']) == 0) {
+         echo "<div class='green'>".self::getUsedConfig('notification_subject_tag', $ID, '', '')."</div>";
+      }
       echo "</td>";
       echo "<td>".__('Delay to send email notifications')."</td>";
       echo "<td>";
@@ -1798,9 +1821,9 @@ class Entity extends CommonTreeDropdown {
 
       if ($entity->fields['delay_send_emails'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('delay_send_emails', $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo $entity->getValueToDisplay('delay_send_emails', $tid, ['html' => true]);
-         echo "</font>";
+         echo "</div>";
       }
       echo "</td></tr>";
 
@@ -1814,9 +1837,9 @@ class Entity extends CommonTreeDropdown {
 
       if ($entity->fields['is_notif_enable_default'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('is_notif_enable_default', $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('is_notif_enable_default', $tid);
-         echo "</font>";
+         echo "</div>";
       }
       echo "</td>";
       echo "<td colspan='2'>&nbsp;</td>";
@@ -1828,6 +1851,9 @@ class Entity extends CommonTreeDropdown {
       echo "<td colspan='3'>";
       echo "<textarea cols='60' rows='5' name='mailing_signature'>".
              $entity->fields["mailing_signature"]."</textarea>";
+      if (strlen($entity->fields['mailing_signature']) == 0) {
+         echo "<div class='green'>".self::getUsedConfig('mailing_signature', $ID, '', '')."</div>";
+      }
       echo "</td></tr>";
       echo "</table>";
 
@@ -1846,9 +1872,9 @@ class Entity extends CommonTreeDropdown {
 
       if ($entity->fields['cartridges_alert_repeat'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('cartridges_alert_repeat', $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('cartridges_alert_repeat', $tid);
-         echo "</font>";
+         echo "</div>";
       }
 
       echo "</td></tr>";
@@ -1868,9 +1894,9 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['default_cartridges_alarm_threshold'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('default_cartridges_alarm_threshold',
                                     $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('default_cartridges_alarm_threshold', $tid);
-         echo "</font>";
+         echo "</div>";
       }
       echo "</td></tr>";
 
@@ -1886,9 +1912,9 @@ class Entity extends CommonTreeDropdown {
                             'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['consumables_alert_repeat'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('consumables_alert_repeat', $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('consumables_alert_repeat', $tid);
-         echo "</font>";
+         echo "</div>";
       }
       echo "</td></tr>";
 
@@ -1908,9 +1934,9 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['default_consumables_alarm_threshold'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('default_consumables_alarm_threshold',
                                     $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('default_consumables_alarm_threshold', $tid);
-         echo "</font>";
+         echo "</div>";
 
       }
       echo "</td></tr>";
@@ -1926,9 +1952,9 @@ class Entity extends CommonTreeDropdown {
                                  'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_contracts_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_contracts_alert', $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('use_contracts_alert', $tid);
-         echo "</font>";
+         echo "</div>";
       }
       echo "</td></tr>";
 
@@ -1954,9 +1980,9 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['send_contracts_alert_before_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('send_contracts_alert_before_delay',
                                     $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('send_contracts_alert_before_delay', $tid);
-         echo "</font>";
+         echo "</div>";
       }
       echo "</td></tr>";
 
@@ -1971,9 +1997,9 @@ class Entity extends CommonTreeDropdown {
                                  'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_infocoms_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_infocoms_alert', $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('use_infocoms_alert', $tid);
-         echo "</font>";
+         echo "</div>";
       }
 
       echo "</td></tr>";
@@ -1983,9 +2009,9 @@ class Entity extends CommonTreeDropdown {
                                    'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['default_infocom_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('default_infocom_alert', $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('default_infocom_alert', $tid);
-         echo "</font>";
+         echo "</div>";
       }
 
       echo "</td></tr>";
@@ -2000,9 +2026,9 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['send_infocoms_alert_before_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('send_infocoms_alert_before_delay',
                                     $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('send_infocoms_alert_before_delay', $tid);
-         echo "</font>";
+         echo "</div>";
       }
       echo "</td></tr>";
 
@@ -2017,9 +2043,9 @@ class Entity extends CommonTreeDropdown {
                                  'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_licenses_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_licenses_alert', $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('use_licenses_alert', $tid);
-         echo "</font>";
+         echo "</div>";
       }
       echo "</td></tr>";
       echo "<tr class='tab_bg_1'><td>" . __('Send license alarms before')."</td><td>";
@@ -2032,9 +2058,9 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['send_licenses_alert_before_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('send_licenses_alert_before_delay',
                                     $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('send_licenses_alert_before_delay', $tid);
-         echo "</font>";
+         echo "</div>";
       }
 
       echo "</td></tr>";
@@ -2050,9 +2076,9 @@ class Entity extends CommonTreeDropdown {
                             'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_certificates_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_certificates_alert', $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('use_certificates_alert', $tid);
-         echo "</font>";
+         echo "</div>";
       }
       echo "</td></tr>";
       echo "<tr class='tab_bg_1'><td>" . __('Send certificates alarms before')."</td><td>";
@@ -2065,9 +2091,9 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['send_certificates_alert_before_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('send_certificates_alert_before_delay',
                                     $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('send_certificates_alert_before_delay', $tid);
-         echo "</font>";
+         echo "</div>";
       }
 
       echo "</td></tr>";
@@ -2084,9 +2110,9 @@ class Entity extends CommonTreeDropdown {
                                         'unit'           => 'hour']);
       if ($entity->fields['use_reservations_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_reservations_alert', $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('use_reservations_alert', $tid);
-         echo "</font>";
+         echo "</div>";
       }
       echo "</td></tr>";
 
@@ -2101,9 +2127,9 @@ class Entity extends CommonTreeDropdown {
                                         'unit'           => 'day']);
       if ($entity->fields['notclosed_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('notclosed_delay', $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('notclosed_delay', $tid);
-         echo "</font>";
+         echo "</div>";
       }
       echo "</td></tr>";
 
@@ -2118,9 +2144,9 @@ class Entity extends CommonTreeDropdown {
                                  'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_domains_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_domains_alert', $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
+         echo "<div class='green'>";
          echo self::getSpecificValueToDisplay('use_domains_alert', $tid);
-         echo "</font>";
+         echo "</div>";
       }
       echo "</td></tr>";
       echo "<tr class='tab_bg_1'>";

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -1794,6 +1794,7 @@ class Entity extends CommonTreeDropdown {
       echo "<td>" . __('Administrator name') . "</td><td>";
       // we inherit only if email inherit also
       Html::autocompletionTextField($entity, "admin_email_name");
+      // warning, we rely on email field to inherit name field
       if (strlen($entity->fields['admin_email']) == 0) {
          self::inheritedValue(self::getUsedConfig('admin_email_name', $ID, '', ''));
       }
@@ -1809,6 +1810,7 @@ class Entity extends CommonTreeDropdown {
       echo "</td>";
       echo "<td>" . __('Response address (if needed)') . "</td><td>";
       Html::autocompletionTextField($entity, "admin_reply_name");
+      // warning, we rely on email field to inherit name field
       if (strlen($entity->fields['admin_reply']) == 0) {
          self::inheritedValue(self::getUsedConfig('admin_reply_name', $ID, '', ''));
       }

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -1764,7 +1764,7 @@ class Entity extends CommonTreeDropdown {
       if ($ID > 0) {
          echo "<tr><td colspan='4' class='warning'>".
             "<div>".__('All options below inherit from parent entities if not set (even if not explicitly indicated).')."</div>".
-            "<div>".__('The inherited values will be displayed in green')."</div>".
+            "<div>".__('The inherited values will be displayed below the corresponding empty field')."</div>".
          "</td></tr>";
       }
 
@@ -1773,14 +1773,14 @@ class Entity extends CommonTreeDropdown {
       echo "<td>";
       Html::autocompletionTextField($entity, "admin_email");
       if (strlen($entity->fields['admin_email']) == 0) {
-         echo "<div class='green'>".self::getUsedConfig('admin_email', $ID, '', '')."</div>";
+         self::getInheritedValue(self::getUsedConfig('admin_email', $ID, '', ''));
       }
       echo "</td>";
       echo "<td>" . __('Administrator name') . "</td><td>";
       // we inherit only if email inherit also
       Html::autocompletionTextField($entity, "admin_email");
       if (strlen($entity->fields['admin_email_name']) == 0) {
-         echo "<div class='green'>".self::getUsedConfig('admin_email_name', $ID, '', '')."</div>";
+         self::getInheritedValue(self::getUsedConfig('admin_email_name', $ID, '', ''));
       }
       echo "</td></tr>";
 
@@ -1789,13 +1789,13 @@ class Entity extends CommonTreeDropdown {
       echo "<td>";
       Html::autocompletionTextField($entity, "admin_reply");
       if (strlen($entity->fields['admin_reply']) == 0) {
-         echo "<div class='green'>".self::getUsedConfig('admin_reply', $ID, '', '')."</div>";
+         self::getInheritedValue(self::getUsedConfig('admin_reply', $ID, '', ''));
       }
       echo "</td>";
       echo "<td>" . __('Response address (if needed)') . "</td><td>";
       Html::autocompletionTextField($entity, "admin_reply_name");
       if (strlen($entity->fields['admin_reply']) == 0) {
-         echo "<div class='green'>".self::getUsedConfig('admin_reply_name', $ID, '', '')."</div>";
+         self::getInheritedValue(self::getUsedConfig('admin_reply_name', $ID, '', ''));
       }
       echo "</td></tr>";
 
@@ -1804,7 +1804,7 @@ class Entity extends CommonTreeDropdown {
       echo "<td>";
       Html::autocompletionTextField($entity, "notification_subject_tag");
       if (strlen($entity->fields['notification_subject_tag']) == 0) {
-         echo "<div class='green'>".self::getUsedConfig('notification_subject_tag', $ID, '', '')."</div>";
+         self::getInheritedValue(self::getUsedConfig('notification_subject_tag', $ID, '', ''));
       }
       echo "</td>";
       echo "<td>".__('Delay to send email notifications')."</td>";
@@ -1821,9 +1821,7 @@ class Entity extends CommonTreeDropdown {
 
       if ($entity->fields['delay_send_emails'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('delay_send_emails', $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo $entity->getValueToDisplay('delay_send_emails', $tid, ['html' => true]);
-         echo "</div>";
+         self::getInheritedValue($entity->getValueToDisplay('delay_send_emails', $tid, ['html' => true]));
       }
       echo "</td></tr>";
 
@@ -1837,9 +1835,7 @@ class Entity extends CommonTreeDropdown {
 
       if ($entity->fields['is_notif_enable_default'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('is_notif_enable_default', $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('is_notif_enable_default', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('is_notif_enable_default', $tid));
       }
       echo "</td>";
       echo "<td colspan='2'>&nbsp;</td>";
@@ -1852,7 +1848,7 @@ class Entity extends CommonTreeDropdown {
       echo "<textarea cols='60' rows='5' name='mailing_signature'>".
              $entity->fields["mailing_signature"]."</textarea>";
       if (strlen($entity->fields['mailing_signature']) == 0) {
-         echo "<div class='green'>".self::getUsedConfig('mailing_signature', $ID, '', '')."</div>";
+         self::getInheritedValue(self::getUsedConfig('mailing_signature', $ID, '', ''));
       }
       echo "</td></tr>";
       echo "</table>";
@@ -1872,9 +1868,7 @@ class Entity extends CommonTreeDropdown {
 
       if ($entity->fields['cartridges_alert_repeat'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('cartridges_alert_repeat', $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('cartridges_alert_repeat', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('cartridges_alert_repeat', $tid));
       }
 
       echo "</td></tr>";
@@ -1894,9 +1888,7 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['default_cartridges_alarm_threshold'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('default_cartridges_alarm_threshold',
                                     $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('default_cartridges_alarm_threshold', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('default_cartridges_alarm_threshold', $tid));
       }
       echo "</td></tr>";
 
@@ -1912,9 +1904,7 @@ class Entity extends CommonTreeDropdown {
                             'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['consumables_alert_repeat'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('consumables_alert_repeat', $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('consumables_alert_repeat', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('consumables_alert_repeat', $tid));
       }
       echo "</td></tr>";
 
@@ -1934,9 +1924,7 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['default_consumables_alarm_threshold'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('default_consumables_alarm_threshold',
                                     $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('default_consumables_alarm_threshold', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('default_consumables_alarm_threshold', $tid));
 
       }
       echo "</td></tr>";
@@ -1952,9 +1940,7 @@ class Entity extends CommonTreeDropdown {
                                  'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_contracts_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_contracts_alert', $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('use_contracts_alert', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('use_contracts_alert', $tid));
       }
       echo "</td></tr>";
 
@@ -1964,9 +1950,7 @@ class Entity extends CommonTreeDropdown {
                                     'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['default_contract_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('default_contract_alert', $entity->getField('entities_id'));
-         echo "<font class='green'><br>";
-         echo self::getSpecificValueToDisplay('default_contract_alert', $tid);
-         echo "</font>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('default_contract_alert', $tid));
       }
 
       echo "</td></tr>";
@@ -1980,9 +1964,7 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['send_contracts_alert_before_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('send_contracts_alert_before_delay',
                                     $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('send_contracts_alert_before_delay', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('send_contracts_alert_before_delay', $tid));
       }
       echo "</td></tr>";
 
@@ -1997,9 +1979,7 @@ class Entity extends CommonTreeDropdown {
                                  'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_infocoms_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_infocoms_alert', $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('use_infocoms_alert', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('use_infocoms_alert', $tid));
       }
 
       echo "</td></tr>";
@@ -2009,9 +1989,7 @@ class Entity extends CommonTreeDropdown {
                                    'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['default_infocom_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('default_infocom_alert', $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('default_infocom_alert', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('default_infocom_alert', $tid));
       }
 
       echo "</td></tr>";
@@ -2026,9 +2004,7 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['send_infocoms_alert_before_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('send_infocoms_alert_before_delay',
                                     $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('send_infocoms_alert_before_delay', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('send_infocoms_alert_before_delay', $tid));
       }
       echo "</td></tr>";
 
@@ -2043,9 +2019,7 @@ class Entity extends CommonTreeDropdown {
                                  'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_licenses_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_licenses_alert', $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('use_licenses_alert', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('use_licenses_alert', $tid));
       }
       echo "</td></tr>";
       echo "<tr class='tab_bg_1'><td>" . __('Send license alarms before')."</td><td>";
@@ -2058,9 +2032,7 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['send_licenses_alert_before_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('send_licenses_alert_before_delay',
                                     $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('send_licenses_alert_before_delay', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('send_licenses_alert_before_delay', $tid));
       }
 
       echo "</td></tr>";
@@ -2076,9 +2048,7 @@ class Entity extends CommonTreeDropdown {
                             'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_certificates_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_certificates_alert', $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('use_certificates_alert', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('use_certificates_alert', $tid));;
       }
       echo "</td></tr>";
       echo "<tr class='tab_bg_1'><td>" . __('Send certificates alarms before')."</td><td>";
@@ -2091,9 +2061,7 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['send_certificates_alert_before_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('send_certificates_alert_before_delay',
                                     $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('send_certificates_alert_before_delay', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('send_certificates_alert_before_delay', $tid));
       }
 
       echo "</td></tr>";
@@ -2110,9 +2078,7 @@ class Entity extends CommonTreeDropdown {
                                         'unit'           => 'hour']);
       if ($entity->fields['use_reservations_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_reservations_alert', $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('use_reservations_alert', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('use_reservations_alert', $tid));
       }
       echo "</td></tr>";
 
@@ -2127,9 +2093,7 @@ class Entity extends CommonTreeDropdown {
                                         'unit'           => 'day']);
       if ($entity->fields['notclosed_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('notclosed_delay', $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('notclosed_delay', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('notclosed_delay', $tid));
       }
       echo "</td></tr>";
 
@@ -2144,9 +2108,7 @@ class Entity extends CommonTreeDropdown {
                                  'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_domains_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_domains_alert', $entity->getField('entities_id'));
-         echo "<div class='green'>";
-         echo self::getSpecificValueToDisplay('use_domains_alert', $tid);
-         echo "</div>";
+         self::getInheritedValue(self::getSpecificValueToDisplay('use_domains_alert', $tid));
       }
       echo "</td></tr>";
       echo "<tr class='tab_bg_1'>";
@@ -3383,6 +3345,20 @@ class Entity extends CommonTreeDropdown {
          default:
             throw new \RuntimeException("Unknown {$field['type']}");
       }
+   }
+
+   static function getInheritedValue($value = "", bool $display = true): string {
+      $out = "<div class='inherited' title='".__("Value inherited from a parent entity")."'>
+         <i class='fas fa-level-down-alt'></i>
+         $value
+      </div>";
+
+      if ($display) {
+         echo $out;
+         return "";
+      }
+
+      return $out;
    }
 
    static function getIcon() {

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -1793,7 +1793,7 @@ class Entity extends CommonTreeDropdown {
       echo "</td>";
       echo "<td>" . __('Administrator name') . "</td><td>";
       // we inherit only if email inherit also
-      Html::autocompletionTextField($entity, "admin_email");
+      Html::autocompletionTextField($entity, "admin_email_name");
       if (strlen($entity->fields['admin_email']) == 0) {
          self::inheritedValue(self::getUsedConfig('admin_email_name', $ID, '', ''));
       }

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -1621,8 +1621,8 @@ class Entity extends CommonTreeDropdown {
       Dropdown::showFromArray('autofill_buy_date', $options,
                               ['value' => $entity->getField('autofill_buy_date')]);
       if ($entity->fields['autofill_buy_date'] == self::CONFIG_PARENT) {
-         $tid = self::getUsedConfig('autofill_buy_date', $entity->getField('entities_id'));
-         self::inheritedValue(self::getSpecificValueToDisplay('autofill_buy_date', $tid));
+         $inherited_value = self::getUsedConfig('autofill_buy_date', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('autofill_buy_date', $inherited_value));
       }
       echo "</td>";
 
@@ -1633,8 +1633,8 @@ class Entity extends CommonTreeDropdown {
       Dropdown::showFromArray('autofill_order_date', $options,
                               ['value' => $entity->getField('autofill_order_date')]);
       if ($entity->fields['autofill_order_date'] == self::CONFIG_PARENT) {
-         $tid = self::getUsedConfig('autofill_order_date', $entity->getField('entities_id'));
-         self::inheritedValue(self::getSpecificValueToDisplay('autofill_order_date', $tid));
+         $inherited_value = self::getUsedConfig('autofill_order_date', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('autofill_order_date', $inherited_value));
       }
       echo "</td></tr>";
 
@@ -1646,8 +1646,8 @@ class Entity extends CommonTreeDropdown {
       Dropdown::showFromArray('autofill_delivery_date', $options,
                               ['value' => $entity->getField('autofill_delivery_date')]);
       if ($entity->fields['autofill_delivery_date'] == self::CONFIG_PARENT) {
-         $tid = self::getUsedConfig('autofill_delivery_date', $entity->getField('entities_id'));
-         self::inheritedValue(self::getSpecificValueToDisplay('autofill_delivery_date', $tid));
+         $inherited_value = self::getUsedConfig('autofill_delivery_date', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('autofill_delivery_date', $inherited_value));
       }
       echo "</td>";
 
@@ -1658,8 +1658,8 @@ class Entity extends CommonTreeDropdown {
       Dropdown::showFromArray('autofill_use_date', $options,
                               ['value' => $entity->getField('autofill_use_date')]);
       if ($entity->fields['autofill_use_date'] == self::CONFIG_PARENT) {
-         $tid = self::getUsedConfig('autofill_use_date', $entity->getField('entities_id'));
-         self::inheritedValue(self::getSpecificValueToDisplay('autofill_use_date', $tid));
+         $inherited_value = self::getUsedConfig('autofill_use_date', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('autofill_use_date', $inherited_value));
       }
       echo "</td></tr>";
 
@@ -1678,8 +1678,8 @@ class Entity extends CommonTreeDropdown {
       Dropdown::showFromArray('autofill_warranty_date', $options,
                               ['value' => $entity->getField('autofill_warranty_date')]);
       if ($entity->fields['autofill_warranty_date'] == self::CONFIG_PARENT) {
-         $tid = self::getUsedConfig('autofill_warranty_date', $entity->getField('entities_id'));
-         self::inheritedValue(self::getSpecificValueToDisplay('autofill_warranty_date', $tid));
+         $inherited_value = self::getUsedConfig('autofill_warranty_date', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('autofill_warranty_date', $inherited_value));
       }
       echo "</td>";
 
@@ -1705,8 +1705,8 @@ class Entity extends CommonTreeDropdown {
                               ['value' => $entity->getField('autofill_decommission_date')]);
 
       if ($entity->fields['autofill_decommission_date'] == self::CONFIG_PARENT) {
-         $tid = self::getUsedConfig('autofill_decommission_date', $entity->getField('entities_id'));
-         self::inheritedValue(self::getSpecificValueToDisplay('autofill_decommission_date', $tid));
+         $inherited_value = self::getUsedConfig('autofill_decommission_date', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('autofill_decommission_date', $inherited_value));
       }
       echo "</td></tr>";
 
@@ -1733,8 +1733,8 @@ class Entity extends CommonTreeDropdown {
                            'comments' => false]);
 
       if ($entity->fields['entities_id_software'] == self::CONFIG_PARENT) {
-         $tid = self::getUsedConfig('entities_id_software', $entity->getField('entities_id'));
-         self::inheritedValue(self::getSpecificValueToDisplay('entities_id_software', $tid));
+         $inherited_value = self::getUsedConfig('entities_id_software', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('entities_id_software', $inherited_value));
       }
       echo "</td><td colspan='2'></td></tr>";
 
@@ -2736,10 +2736,10 @@ class Entity extends CommonTreeDropdown {
             $inqconf = self::getUsedConfig('inquest_config', $entity->fields['entities_id'],
                                            'inquest_delay');
 
-            sprintf(_n('%d day', '%d days', $inqconf), $inqconf);
+            $inherit.= sprintf(_n('%d day', '%d days', $inqconf), $inqconf);
             $inherit.= "<br>";
             //TRANS: %d is the percentage. %% to display %
-            sprintf(__('%d%%'), $inquestrate);
+            $inherit.= sprintf(__('%d%%'), $inquestrate);
 
             if ($inquestconfig == 2) {
                $inherit.= "<br>";

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -1620,6 +1620,10 @@ class Entity extends CommonTreeDropdown {
       echo "<td>";
       Dropdown::showFromArray('autofill_buy_date', $options,
                               ['value' => $entity->getField('autofill_buy_date')]);
+      if ($entity->fields['autofill_buy_date'] == self::CONFIG_PARENT) {
+         $tid = self::getUsedConfig('autofill_buy_date', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('autofill_buy_date', $tid));
+      }
       echo "</td>";
 
       //Order date
@@ -1628,6 +1632,10 @@ class Entity extends CommonTreeDropdown {
       $options[Infocom::COPY_BUY_DATE] = __('Copy the date of purchase');
       Dropdown::showFromArray('autofill_order_date', $options,
                               ['value' => $entity->getField('autofill_order_date')]);
+      if ($entity->fields['autofill_order_date'] == self::CONFIG_PARENT) {
+         $tid = self::getUsedConfig('autofill_order_date', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('autofill_order_date', $tid));
+      }
       echo "</td></tr>";
 
       //Delivery date
@@ -1637,6 +1645,10 @@ class Entity extends CommonTreeDropdown {
       $options[Infocom::COPY_ORDER_DATE] = __('Copy the order date');
       Dropdown::showFromArray('autofill_delivery_date', $options,
                               ['value' => $entity->getField('autofill_delivery_date')]);
+      if ($entity->fields['autofill_delivery_date'] == self::CONFIG_PARENT) {
+         $tid = self::getUsedConfig('autofill_delivery_date', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('autofill_delivery_date', $tid));
+      }
       echo "</td>";
 
       //Use date
@@ -1645,6 +1657,10 @@ class Entity extends CommonTreeDropdown {
       $options[Infocom::COPY_DELIVERY_DATE] = __('Copy the delivery date');
       Dropdown::showFromArray('autofill_use_date', $options,
                               ['value' => $entity->getField('autofill_use_date')]);
+      if ($entity->fields['autofill_use_date'] == self::CONFIG_PARENT) {
+         $tid = self::getUsedConfig('autofill_use_date', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('autofill_use_date', $tid));
+      }
       echo "</td></tr>";
 
       //Warranty date
@@ -1661,6 +1677,10 @@ class Entity extends CommonTreeDropdown {
 
       Dropdown::showFromArray('autofill_warranty_date', $options,
                               ['value' => $entity->getField('autofill_warranty_date')]);
+      if ($entity->fields['autofill_warranty_date'] == self::CONFIG_PARENT) {
+         $tid = self::getUsedConfig('autofill_warranty_date', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('autofill_warranty_date', $tid));
+      }
       echo "</td>";
 
       //Decommission date
@@ -1684,6 +1704,10 @@ class Entity extends CommonTreeDropdown {
       Dropdown::showFromArray('autofill_decommission_date', $options,
                               ['value' => $entity->getField('autofill_decommission_date')]);
 
+      if ($entity->fields['autofill_decommission_date'] == self::CONFIG_PARENT) {
+         $tid = self::getUsedConfig('autofill_decommission_date', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('autofill_decommission_date', $tid));
+      }
       echo "</td></tr>";
 
       echo "<tr><th colspan='4'>"._n('Software', 'Software', Session::getPluralNumber())."</th></tr>";
@@ -1710,9 +1734,7 @@ class Entity extends CommonTreeDropdown {
 
       if ($entity->fields['entities_id_software'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('entities_id_software', $entity->getField('entities_id'));
-         echo "<font class='green'>&nbsp;&nbsp;";
-         echo self::getSpecificValueToDisplay('entities_id_software', $tid);
-         echo "</font>";
+         self::inheritedValue(self::getSpecificValueToDisplay('entities_id_software', $tid));
       }
       echo "</td><td colspan='2'></td></tr>";
 
@@ -1761,26 +1783,19 @@ class Entity extends CommonTreeDropdown {
 
       echo "<tr><th colspan='4'>".__('Notification options')."</th></tr>";
 
-      if ($ID > 0) {
-         echo "<tr><td colspan='4' class='warning'>".
-            "<div>".__('All options below inherit from parent entities if not set (even if not explicitly indicated).')."</div>".
-            "<div>".__('The inherited values will be displayed below the corresponding empty field')."</div>".
-         "</td></tr>";
-      }
-
       echo "<tr class='tab_bg_1'>";
       echo "<td>".__('Administrator email')."</td>";
       echo "<td>";
       Html::autocompletionTextField($entity, "admin_email");
       if (strlen($entity->fields['admin_email']) == 0) {
-         self::getInheritedValue(self::getUsedConfig('admin_email', $ID, '', ''));
+         self::inheritedValue(self::getUsedConfig('admin_email', $ID, '', ''));
       }
       echo "</td>";
       echo "<td>" . __('Administrator name') . "</td><td>";
       // we inherit only if email inherit also
       Html::autocompletionTextField($entity, "admin_email");
       if (strlen($entity->fields['admin_email_name']) == 0) {
-         self::getInheritedValue(self::getUsedConfig('admin_email_name', $ID, '', ''));
+         self::inheritedValue(self::getUsedConfig('admin_email_name', $ID, '', ''));
       }
       echo "</td></tr>";
 
@@ -1789,13 +1804,13 @@ class Entity extends CommonTreeDropdown {
       echo "<td>";
       Html::autocompletionTextField($entity, "admin_reply");
       if (strlen($entity->fields['admin_reply']) == 0) {
-         self::getInheritedValue(self::getUsedConfig('admin_reply', $ID, '', ''));
+         self::inheritedValue(self::getUsedConfig('admin_reply', $ID, '', ''));
       }
       echo "</td>";
       echo "<td>" . __('Response address (if needed)') . "</td><td>";
       Html::autocompletionTextField($entity, "admin_reply_name");
       if (strlen($entity->fields['admin_reply']) == 0) {
-         self::getInheritedValue(self::getUsedConfig('admin_reply_name', $ID, '', ''));
+         self::inheritedValue(self::getUsedConfig('admin_reply_name', $ID, '', ''));
       }
       echo "</td></tr>";
 
@@ -1804,7 +1819,7 @@ class Entity extends CommonTreeDropdown {
       echo "<td>";
       Html::autocompletionTextField($entity, "notification_subject_tag");
       if (strlen($entity->fields['notification_subject_tag']) == 0) {
-         self::getInheritedValue(self::getUsedConfig('notification_subject_tag', $ID, '', ''));
+         self::inheritedValue(self::getUsedConfig('notification_subject_tag', $ID, '', ''));
       }
       echo "</td>";
       echo "<td>".__('Delay to send email notifications')."</td>";
@@ -1821,7 +1836,7 @@ class Entity extends CommonTreeDropdown {
 
       if ($entity->fields['delay_send_emails'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('delay_send_emails', $entity->getField('entities_id'));
-         self::getInheritedValue($entity->getValueToDisplay('delay_send_emails', $tid, ['html' => true]));
+         self::inheritedValue($entity->getValueToDisplay('delay_send_emails', $tid, ['html' => true]));
       }
       echo "</td></tr>";
 
@@ -1835,7 +1850,7 @@ class Entity extends CommonTreeDropdown {
 
       if ($entity->fields['is_notif_enable_default'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('is_notif_enable_default', $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('is_notif_enable_default', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('is_notif_enable_default', $tid));
       }
       echo "</td>";
       echo "<td colspan='2'>&nbsp;</td>";
@@ -1848,7 +1863,7 @@ class Entity extends CommonTreeDropdown {
       echo "<textarea cols='60' rows='5' name='mailing_signature'>".
              $entity->fields["mailing_signature"]."</textarea>";
       if (strlen($entity->fields['mailing_signature']) == 0) {
-         self::getInheritedValue(self::getUsedConfig('mailing_signature', $ID, '', ''));
+         self::inheritedValue(self::getUsedConfig('mailing_signature', $ID, '', ''));
       }
       echo "</td></tr>";
       echo "</table>";
@@ -1868,7 +1883,7 @@ class Entity extends CommonTreeDropdown {
 
       if ($entity->fields['cartridges_alert_repeat'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('cartridges_alert_repeat', $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('cartridges_alert_repeat', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('cartridges_alert_repeat', $tid), true);
       }
 
       echo "</td></tr>";
@@ -1888,7 +1903,7 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['default_cartridges_alarm_threshold'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('default_cartridges_alarm_threshold',
                                     $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('default_cartridges_alarm_threshold', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('default_cartridges_alarm_threshold', $tid), true);
       }
       echo "</td></tr>";
 
@@ -1904,7 +1919,7 @@ class Entity extends CommonTreeDropdown {
                             'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['consumables_alert_repeat'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('consumables_alert_repeat', $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('consumables_alert_repeat', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('consumables_alert_repeat', $tid), true);
       }
       echo "</td></tr>";
 
@@ -1924,7 +1939,7 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['default_consumables_alarm_threshold'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('default_consumables_alarm_threshold',
                                     $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('default_consumables_alarm_threshold', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('default_consumables_alarm_threshold', $tid), true);
 
       }
       echo "</td></tr>";
@@ -1940,7 +1955,7 @@ class Entity extends CommonTreeDropdown {
                                  'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_contracts_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_contracts_alert', $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('use_contracts_alert', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('use_contracts_alert', $tid), true);
       }
       echo "</td></tr>";
 
@@ -1950,7 +1965,7 @@ class Entity extends CommonTreeDropdown {
                                     'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['default_contract_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('default_contract_alert', $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('default_contract_alert', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('default_contract_alert', $tid), true);
       }
 
       echo "</td></tr>";
@@ -1964,7 +1979,7 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['send_contracts_alert_before_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('send_contracts_alert_before_delay',
                                     $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('send_contracts_alert_before_delay', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('send_contracts_alert_before_delay', $tid), true);
       }
       echo "</td></tr>";
 
@@ -1979,7 +1994,7 @@ class Entity extends CommonTreeDropdown {
                                  'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_infocoms_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_infocoms_alert', $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('use_infocoms_alert', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('use_infocoms_alert', $tid), true);
       }
 
       echo "</td></tr>";
@@ -1989,7 +2004,7 @@ class Entity extends CommonTreeDropdown {
                                    'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['default_infocom_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('default_infocom_alert', $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('default_infocom_alert', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('default_infocom_alert', $tid), true);
       }
 
       echo "</td></tr>";
@@ -2004,7 +2019,7 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['send_infocoms_alert_before_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('send_infocoms_alert_before_delay',
                                     $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('send_infocoms_alert_before_delay', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('send_infocoms_alert_before_delay', $tid), true);
       }
       echo "</td></tr>";
 
@@ -2019,7 +2034,7 @@ class Entity extends CommonTreeDropdown {
                                  'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_licenses_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_licenses_alert', $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('use_licenses_alert', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('use_licenses_alert', $tid), true);
       }
       echo "</td></tr>";
       echo "<tr class='tab_bg_1'><td>" . __('Send license alarms before')."</td><td>";
@@ -2032,7 +2047,7 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['send_licenses_alert_before_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('send_licenses_alert_before_delay',
                                     $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('send_licenses_alert_before_delay', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('send_licenses_alert_before_delay', $tid), true);
       }
 
       echo "</td></tr>";
@@ -2048,7 +2063,7 @@ class Entity extends CommonTreeDropdown {
                             'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_certificates_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_certificates_alert', $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('use_certificates_alert', $tid));;
+         self::inheritedValue(self::getSpecificValueToDisplay('use_certificates_alert', $tid), true);
       }
       echo "</td></tr>";
       echo "<tr class='tab_bg_1'><td>" . __('Send certificates alarms before')."</td><td>";
@@ -2061,7 +2076,7 @@ class Entity extends CommonTreeDropdown {
       if ($entity->fields['send_certificates_alert_before_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('send_certificates_alert_before_delay',
                                     $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('send_certificates_alert_before_delay', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('send_certificates_alert_before_delay', $tid), true);
       }
 
       echo "</td></tr>";
@@ -2078,7 +2093,7 @@ class Entity extends CommonTreeDropdown {
                                         'unit'           => 'hour']);
       if ($entity->fields['use_reservations_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_reservations_alert', $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('use_reservations_alert', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('use_reservations_alert', $tid), true);
       }
       echo "</td></tr>";
 
@@ -2093,7 +2108,7 @@ class Entity extends CommonTreeDropdown {
                                         'unit'           => 'day']);
       if ($entity->fields['notclosed_delay'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('notclosed_delay', $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('notclosed_delay', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('notclosed_delay', $tid), true);
       }
       echo "</td></tr>";
 
@@ -2108,7 +2123,7 @@ class Entity extends CommonTreeDropdown {
                                  'inherit_parent' => (($ID > 0) ? 1 : 0)]);
       if ($entity->fields['use_domains_alert'] == self::CONFIG_PARENT) {
          $tid = self::getUsedConfig('use_domains_alert', $entity->getField('entities_id'));
-         self::getInheritedValue(self::getSpecificValueToDisplay('use_domains_alert', $tid));
+         self::inheritedValue(self::getSpecificValueToDisplay('use_domains_alert', $tid), true);
       }
       echo "</td></tr>";
       echo "<tr class='tab_bg_1'>";
@@ -2123,6 +2138,10 @@ class Entity extends CommonTreeDropdown {
             'unit'           => 'day'
          ]
       );
+      if ($entity->fields['send_domains_alert_close_expiries_delay'] == self::CONFIG_PARENT) {
+         $tid = self::getUsedConfig('send_domains_alert_close_expiries_delay', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('send_domains_alert_close_expiries_delay', $tid), true);
+      }
       echo "</td></tr>";
       echo "<tr class='tab_bg_1'>";
       echo "<td>" . __('Domains expired') . "</td><td>";
@@ -2135,6 +2154,10 @@ class Entity extends CommonTreeDropdown {
             'unit'           => 'day'
          ]
       );
+      if ($entity->fields['send_domains_alert_expired_delay'] == self::CONFIG_PARENT) {
+         $tid = self::getUsedConfig('send_domains_alert_expired_delay', $entity->getField('entities_id'));
+         self::inheritedValue(self::getSpecificValueToDisplay('send_domains_alert_expired_delay', $tid), true);
+      }
       echo "</td></tr>";
 
       Plugin::doHook("post_item_form", ['item' => $entity, 'options' => &$options]);
@@ -2410,16 +2433,13 @@ class Entity extends CommonTreeDropdown {
 
       if (($entity->fields["tickettemplates_id"] == self::CONFIG_PARENT)
           && ($ID != 0)) {
-         echo "<font class='green'>&nbsp;&nbsp;";
-
          $tt  = new TicketTemplate();
          $tid = self::getUsedConfig('tickettemplates_id', $ID, '', 0);
          if (!$tid) {
-            echo Dropdown::EMPTY_VALUE;
+            self::inheritedValue(Dropdown::EMPTY_VALUE, true);
          } else if ($tt->getFromDB($tid)) {
-            echo $tt->getLink();
+            self::inheritedValue($tt->getLink(), true);
          }
-         echo "</font>";
       }
       echo "</td></tr>";
 
@@ -2439,16 +2459,14 @@ class Entity extends CommonTreeDropdown {
 
       if (($entity->fields["changetemplates_id"] == self::CONFIG_PARENT)
           && ($ID != 0)) {
-         echo "<font class='green'>&nbsp;&nbsp;";
 
          $tt  = new ChangeTemplate();
          $tid = self::getUsedConfig('changetemplates_id', $ID, '', 0);
          if (!$tid) {
-            echo Dropdown::EMPTY_VALUE;
+            self::inheritedValue(Dropdown::EMPTY_VALUE, true);
          } else if ($tt->getFromDB($tid)) {
-            echo $tt->getLink();
+            self::inheritedValue($tt->getLink(), true);
          }
-         echo "</font>";
       }
       echo "</td></tr>";
 
@@ -2468,16 +2486,14 @@ class Entity extends CommonTreeDropdown {
 
       if (($entity->fields["problemtemplates_id"] == self::CONFIG_PARENT)
           && ($ID != 0)) {
-         echo "<font class='green'>&nbsp;&nbsp;";
 
          $tt  = new ProblemTemplate();
          $tid = self::getUsedConfig('problemtemplates_id', $ID, '', 0);
          if (!$tid) {
-            echo Dropdown::EMPTY_VALUE;
+            self::inheritedValue(Dropdown::EMPTY_VALUE, true);
          } else if ($tt->getFromDB($tid)) {
-            echo $tt->getLink();
+            self::inheritedValue($tt->getLink(), true);
          }
-         echo "</font>";
       }
       echo "</td></tr>";
 
@@ -2495,15 +2511,13 @@ class Entity extends CommonTreeDropdown {
 
       if (($entity->fields["calendars_id"] == self::CONFIG_PARENT)
           && ($ID != 0)) {
-         echo "<font class='green'>&nbsp;&nbsp;";
          $calendar = new Calendar();
          $cid = self::getUsedConfig('calendars_id', $ID, '', 0);
          if (!$cid) {
-            echo __('24/7');
+            self::inheritedValue(__('24/7'), true);
          } else if ($calendar->getFromDB($cid)) {
-            echo $calendar->getLink();
+            self::inheritedValue($calendar->getLink(), true);
          }
-         echo "</font>";
       }
       echo "</td></tr>";
 
@@ -2518,10 +2532,8 @@ class Entity extends CommonTreeDropdown {
 
       if (($entity->fields['tickettype'] == self::CONFIG_PARENT)
           && ($ID != 0)) {
-         echo "<font class='green'>&nbsp;&nbsp;";
-         echo Ticket::getTicketTypeName(self::getUsedConfig('tickettype', $ID, '',
-                                                            Ticket::INCIDENT_TYPE));
-         echo "</font>";
+            self::inheritedValue(Ticket::getTicketTypeName(self::getUsedConfig('tickettype', $ID, '',
+                                                                               Ticket::INCIDENT_TYPE)), true);
       }
       echo "</td></tr>";
 
@@ -2539,9 +2551,7 @@ class Entity extends CommonTreeDropdown {
       if (($entity->fields['auto_assign_mode'] == self::CONFIG_PARENT)
           && ($ID != 0)) {
          $auto_assign_mode = self::getUsedConfig('auto_assign_mode', $entity->fields['entities_id']);
-         echo "<font class='green'>&nbsp;&nbsp;";
-         echo $autoassign[$auto_assign_mode];
-         echo "</font>";
+         self::inheritedValue($autoassign[$auto_assign_mode], true);
       }
       echo "</td></tr>";
 
@@ -2566,9 +2576,7 @@ class Entity extends CommonTreeDropdown {
             'suppliers_as_private',
             $entity->fields['entities_id']
          );
-         echo "<font class='green'>&nbsp;&nbsp;";
-         echo $supplierValues[$parentSupplierValue];
-         echo "</font>";
+         self::inheritedValue($supplierValues[$parentSupplierValue], true);
       }
       echo "</td></tr>";
 
@@ -2593,9 +2601,7 @@ class Entity extends CommonTreeDropdown {
             'anonymize_support_agents',
             $entity->fields['entities_id']
          );
-         echo "<font class='green'>&nbsp;&nbsp;";
-         echo $anonymizeValues[$parentHelpdeskValue];
-         echo "</font>";
+         self::inheritedValue($anonymizeValues[$parentHelpdeskValue], true);
       }
       echo "</td></tr>";
 
@@ -2637,13 +2643,11 @@ class Entity extends CommonTreeDropdown {
          $autoclose_mode = self::getUsedConfig('autoclose_delay', $entity->fields['entities_id'],
                                                '', self::CONFIG_NEVER);
 
-         echo "<br><font class='green'>&nbsp;&nbsp;";
          if ($autoclose_mode >= 0) {
-            printf(_n('%d day', '%d days', $autoclose_mode), $autoclose_mode);
+            self::inheritedValue(sprintf(_n('%d day', '%d days', $autoclose_mode), $autoclose_mode), true);
          } else {
-            echo $autoclose[$autoclose_mode];
+            self::inheritedValue($autoclose[$autoclose_mode], true);
          }
-         echo "</font>";
       }
       echo "<td>".__('Automatic purge of closed tickets after');
 
@@ -2686,13 +2690,11 @@ class Entity extends CommonTreeDropdown {
             self::CONFIG_NEVER
           );
 
-         echo "<br><font class='green'>&nbsp;&nbsp;";
          if ($autopurge_mode >= 0) {
-            printf(_n('%d day', '%d days', $autopurge_mode), $autopurge_mode);
+            self::inheritedValue(sprintf(_n('%d day', '%d days', $autopurge_mode), $autopurge_mode), true);
          } else {
-            echo $autopurge[$autopurge_mode];
+            self::inheritedValue($autopurge[$autopurge_mode], true);
          }
-         echo "</font>";
       }
       echo "</td></tr>";
 
@@ -2724,27 +2726,29 @@ class Entity extends CommonTreeDropdown {
          $inquestconfig = self::getUsedConfig('inquest_config', $entity->fields['entities_id']);
          $inquestrate   = self::getUsedConfig('inquest_config', $entity->fields['entities_id'],
                                               'inquest_rate');
-         echo "<tr class='tab_bg_1'><td colspan='4' class='green center'>";
+         echo "<tr class='tab_bg_1'><td colspan='4'>";
 
+         $inherit = "";
          if ($inquestrate == 0) {
-            echo __('Disabled');
+            $inherit.= __('Disabled');
          } else {
-            echo $typeinquest[$inquestconfig].'<br>';
+            $inherit.= $typeinquest[$inquestconfig].'<br>';
             $inqconf = self::getUsedConfig('inquest_config', $entity->fields['entities_id'],
                                            'inquest_delay');
 
-            printf(_n('%d day', '%d days', $inqconf), $inqconf);
-            echo "<br>";
+            sprintf(_n('%d day', '%d days', $inqconf), $inqconf);
+            $inherit.= "<br>";
             //TRANS: %d is the percentage. %% to display %
-            printf(__('%d%%'), $inquestrate);
+            sprintf(__('%d%%'), $inquestrate);
 
             if ($inquestconfig == 2) {
-               echo "<br>";
-               echo self::getUsedConfig('inquest_config', $entity->fields['entities_id'],
+               $inherit.= "<br>";
+               $inherit.= self::getUsedConfig('inquest_config', $entity->fields['entities_id'],
                                         'inquest_URL');
             }
          }
-         echo "</td></tr>\n";
+         self::inheritedValue($inherit, true);
+         echo "</td></tr>";
       }
 
       echo "<tr class='tab_bg_1'><td colspan='4'>";
@@ -3047,6 +3051,7 @@ class Entity extends CommonTreeDropdown {
          case 'use_licenses_alert' :
          case 'use_certificates_alert' :
          case 'use_contracts_alert' :
+         case 'use_domains_alert' :
          case 'use_infocoms_alert' :
          case 'is_notif_enable_default' :
             if ($values[$field] == self::CONFIG_PARENT) {
@@ -3079,6 +3084,8 @@ class Entity extends CommonTreeDropdown {
          case 'send_infocoms_alert_before_delay' :
          case 'send_licenses_alert_before_delay' :
          case 'send_certificates_alert_before_delay' :
+         case 'send_domains_alert_close_expiries_delay' :
+         case 'send_domains_alert_expired_delay' :
             switch ($values[$field]) {
                case self::CONFIG_PARENT :
                   return __('Inheritance of the parent entity');
@@ -3347,8 +3354,13 @@ class Entity extends CommonTreeDropdown {
       }
    }
 
-   static function getInheritedValue($value = "", bool $display = true): string {
-      $out = "<div class='inherited' title='".__("Value inherited from a parent entity")."'>
+   static function inheritedValue($value = "", bool $inline = false, bool $display = true): string {
+      if (trim($value) == "") {
+         return "";
+      }
+
+      $out = "<div class='inherited ".($inline ? "inline" : "")."'
+                   title='".__("Value inherited from a parent entity")."'>
          <i class='fas fa-level-down-alt'></i>
          $value
       </div>";

--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -584,13 +584,13 @@ class Notification extends CommonDBTM {
     * @param $entity
    **/
    static function getMailingSignature($entity) {
-      global $DB, $CFG_GLPI;
+      global $CFG_GLPI;
 
-      foreach ($DB->request('glpi_entities', ['id' => $entity]) as $data) {
-         if (!empty($data['mailing_signature'])) {
-            return $data['mailing_signature'];
-         }
+      $signature = trim(Entity::getUsedConfig('mailing_signature', $entity, '', ''));
+      if (strlen($signature) > 0) {
+         return $signature;
       }
+
       return $CFG_GLPI['mailing_signature'];
    }
 

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -1078,7 +1078,7 @@ class NotificationTarget extends CommonDBChild {
     * @return the reply to address
    **/
    public function getReplyTo($options = []) {
-      global $DB, $CFG_GLPI;
+      global $CFG_GLPI;
 
       //If the entity administrator's address is defined, return it
       $admin_reply      = trim(Entity::getUsedConfig('admin_reply', $this->getEntity(), '', ''));

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -1081,7 +1081,7 @@ class NotificationTarget extends CommonDBChild {
       global $DB, $CFG_GLPI;
 
       //If the entity administrator's address is defined, return it
-      $admin_reply      = trim(Entity::getUsedConfig('admin_replyl', $this->getEntity(), '', ''));
+      $admin_reply      = trim(Entity::getUsedConfig('admin_reply', $this->getEntity(), '', ''));
       $admin_reply_name = trim(Entity::getUsedConfig('admin_reply_name', $this->getEntity(), '', ''));
 
       if (NotificationMailing::isUserAddressValid($admin_reply)) {

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -1037,13 +1037,13 @@ class NotificationTarget extends CommonDBChild {
          $sender['email'] = $CFG_GLPI['from_email'];
          $sender['name']  = $CFG_GLPI['from_email_name'];
       } else {
-         $entity = new \Entity();
-         $entity->getFromDB($this->getEntity());
+         $admin_email      = trim(Entity::getUsedConfig('admin_email', $this->getEntity(), '', ''));
+         $admin_email_name = trim(Entity::getUsedConfig('admin_email_name', $this->getEntity(), '', ''));
 
-         if (NotificationMailing::isUserAddressValid($entity->fields['admin_email'])) {
+         if (NotificationMailing::isUserAddressValid($admin_email)) {
             //If the entity administrator's address is defined, return it
-            $sender['email'] = $entity->fields['admin_email'];
-            $sender['name']  = $entity->fields['admin_email_name'];
+            $sender['email'] = $admin_email;
+            $sender['name']  = $admin_email_name;
          } else {
             //Entity admin is not defined, return the global admin's address
             $sender['email'] = $CFG_GLPI['admin_email'];
@@ -1081,17 +1081,21 @@ class NotificationTarget extends CommonDBChild {
       global $DB, $CFG_GLPI;
 
       //If the entity administrator's address is defined, return it
-      foreach ($DB->request('glpi_entities',
-               ['id' => $this->getEntity()]) as $data) {
+      $admin_reply      = trim(Entity::getUsedConfig('admin_replyl', $this->getEntity(), '', ''));
+      $admin_reply_name = trim(Entity::getUsedConfig('admin_reply_name', $this->getEntity(), '', ''));
 
-         if (NotificationMailing::isUserAddressValid($data['admin_reply'])) {
-            return ['email' => $data['admin_reply'],
-                    'name'  => $data['admin_reply_name']];
-         }
+      if (NotificationMailing::isUserAddressValid($admin_reply)) {
+         return [
+            'email' => $admin_reply,
+            'name'  => $admin_reply_name,
+         ];
       }
+
       //Entity admin is not defined, return the global admin's address
-      return ['email' => $CFG_GLPI['admin_reply'],
-              'name'  => $CFG_GLPI['admin_reply_name']];
+      return [
+         'email' => $CFG_GLPI['admin_reply'],
+         'name'  => $CFG_GLPI['admin_reply_name']
+      ];
    }
 
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -110,6 +110,9 @@ function loadDataset() {
          ], [
             'name'        => '_test_child_2',
             'entities_id' => '_test_root_entity',
+         ], [
+            'name'        => '_test_child_3',
+            'entities_id' => '_test_child_2',
          ]
       ], 'Computer' => [
          [
@@ -664,7 +667,7 @@ function loadDataset() {
  * @param string  $type
  * @param string  $name
  * @param boolean $onlyid
- * @return CommonGLPI|false the item, or its id
+ * @return CommonDBTM|false the item, or its id
  */
 function getItemByTypeName($type, $name, $onlyid = false) {
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -110,9 +110,6 @@ function loadDataset() {
          ], [
             'name'        => '_test_child_2',
             'entities_id' => '_test_root_entity',
-         ], [
-            'name'        => '_test_child_3',
-            'entities_id' => '_test_child_2',
          ]
       ], 'Computer' => [
          [

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -290,9 +290,9 @@ class Entity extends DbTestCase {
    protected function inheritanceProvider() {
       return [
          ['admin_email', "username+admin@domain.tld"],
-         ['admin_email_name', "Username admin replay"],
+         ['admin_email_name', "Username admin"],
          ['admin_reply', "username+admin+reply@domain.tld"],
-         ['admin_reply_name', "Username admin replay"],
+         ['admin_reply_name', "Username admin reply"],
       ];
    }
 

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -286,4 +286,61 @@ class Entity extends DbTestCase {
       // Profile_User has been deleted when entity has been deleted
       $this->boolean($profile_user->getFromDB($profile_user_id))->isFalse();
    }
+
+   protected function inheritanceProvider() {
+      return [
+         ['admin_email', "username+admin@domain.tld"],
+         ['admin_email_name', "Username admin replay"],
+         ['admin_reply', "username+admin+reply@domain.tld"],
+         ['admin_reply_name', "Username admin replay"],
+      ];
+   }
+
+   /**
+    * @dataProvider inheritanceProvider
+    */
+   public function testGetUsedConfig(string $field, $value) {
+      $this->login();
+
+      $root    = getItemByTypeName('Entity', 'Root entity', true);
+      $child_1 = getItemByTypeName('Entity', '_test_child_1', true);
+      $child_2 = getItemByTypeName('Entity', '_test_child_2', true);
+      $child_3 = getItemByTypeName('Entity', '_test_child_3', true);
+
+      $entity = new \Entity;
+      $this->boolean($entity->update([
+         'id'   => $root,
+         $field => $value."_root",
+      ]));
+
+      $this->string(\Entity::getUsedConfig($field, $child_1))->isEqualTo($value."_root");
+      $this->string(\Entity::getUsedConfig($field, $child_2))->isEqualTo($value."_root");
+      $this->string(\Entity::getUsedConfig($field, $child_3))->isEqualTo($value."_root");
+
+      $this->boolean($entity->update([
+         'id'   => $child_1,
+         $field => $value."_child_1",
+      ]));
+
+      $this->string(\Entity::getUsedConfig($field, $child_1))->isEqualTo($value."_child_1");
+      $this->string(\Entity::getUsedConfig($field, $child_2))->isEqualTo($value."_root");
+
+      $this->boolean($entity->update([
+         'id'   => $child_2,
+         $field => $value."_child_2",
+      ]));
+
+      $this->string(\Entity::getUsedConfig($field, $child_1))->isEqualTo($value."_child_1");
+      $this->string(\Entity::getUsedConfig($field, $child_2))->isEqualTo($value."_child_2");
+      $this->string(\Entity::getUsedConfig($field, $child_3))->isEqualTo($value."_child_2");
+
+      $this->boolean($entity->update([
+         'id'   => $child_3,
+         $field => $value."_child_3",
+      ]));
+
+      $this->string(\Entity::getUsedConfig($field, $child_1))->isEqualTo($value."_child_1");
+      $this->string(\Entity::getUsedConfig($field, $child_2))->isEqualTo($value."_child_2");
+      $this->string(\Entity::getUsedConfig($field, $child_3))->isEqualTo($value."_child_3");
+   }
 }

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -303,9 +303,9 @@ class Entity extends DbTestCase {
       $this->login();
 
       $root    = getItemByTypeName('Entity', 'Root entity', true);
+      $parent  = getItemByTypeName('Entity', '_test_root_entity', true);
       $child_1 = getItemByTypeName('Entity', '_test_child_1', true);
       $child_2 = getItemByTypeName('Entity', '_test_child_2', true);
-      $child_3 = getItemByTypeName('Entity', '_test_child_3', true);
 
       $entity = new \Entity;
       $this->boolean($entity->update([
@@ -313,34 +313,36 @@ class Entity extends DbTestCase {
          $field => $value."_root",
       ]));
 
+      $this->string(\Entity::getUsedConfig($field, $parent))->isEqualTo($value."_root");
       $this->string(\Entity::getUsedConfig($field, $child_1))->isEqualTo($value."_root");
       $this->string(\Entity::getUsedConfig($field, $child_2))->isEqualTo($value."_root");
-      $this->string(\Entity::getUsedConfig($field, $child_3))->isEqualTo($value."_root");
+
+      $this->boolean($entity->update([
+         'id'   => $parent,
+         $field => $value."_parent",
+      ]));
+
+      $this->string(\Entity::getUsedConfig($field, $parent))->isEqualTo($value."_parent");
+      $this->string(\Entity::getUsedConfig($field, $child_1))->isEqualTo($value."_parent");
+      $this->string(\Entity::getUsedConfig($field, $child_2))->isEqualTo($value."_parent");
 
       $this->boolean($entity->update([
          'id'   => $child_1,
          $field => $value."_child_1",
       ]));
 
+      $this->string(\Entity::getUsedConfig($field, $parent))->isEqualTo($value."_parent");
       $this->string(\Entity::getUsedConfig($field, $child_1))->isEqualTo($value."_child_1");
-      $this->string(\Entity::getUsedConfig($field, $child_2))->isEqualTo($value."_root");
+      $this->string(\Entity::getUsedConfig($field, $child_2))->isEqualTo($value."_parent");
 
       $this->boolean($entity->update([
          'id'   => $child_2,
          $field => $value."_child_2",
       ]));
 
+      $this->string(\Entity::getUsedConfig($field, $parent))->isEqualTo($value."_parent");
       $this->string(\Entity::getUsedConfig($field, $child_1))->isEqualTo($value."_child_1");
       $this->string(\Entity::getUsedConfig($field, $child_2))->isEqualTo($value."_child_2");
-      $this->string(\Entity::getUsedConfig($field, $child_3))->isEqualTo($value."_child_2");
 
-      $this->boolean($entity->update([
-         'id'   => $child_3,
-         $field => $value."_child_3",
-      ]));
-
-      $this->string(\Entity::getUsedConfig($field, $child_1))->isEqualTo($value."_child_1");
-      $this->string(\Entity::getUsedConfig($field, $child_2))->isEqualTo($value."_child_2");
-      $this->string(\Entity::getUsedConfig($field, $child_3))->isEqualTo($value."_child_3");
    }
 }

--- a/tests/functionnal/Notification.php
+++ b/tests/functionnal/Notification.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use \DbTestCase;
+
+/* Test for inc/notification.class.php */
+
+class Notification extends DbTestCase {
+
+   public function testGetMailingSignature() {
+      global $CFG_GLPI;
+
+      $this->login();
+
+      $root    = getItemByTypeName('Entity', 'Root entity', true);
+      $child_1 = getItemByTypeName('Entity', '_test_child_1', true);
+      $child_2 = getItemByTypeName('Entity', '_test_child_2', true);
+      $child_3 = getItemByTypeName('Entity', '_test_child_3', true);
+
+      $CFG_GLPI['mailing_signature'] = 'global_signature';
+
+      $this->string(\Notification::getMailingSignature($child_1))->isEqualTo("global_signature");
+      $this->string(\Notification::getMailingSignature($child_2))->isEqualTo("global_signature");
+      $this->string(\Notification::getMailingSignature($child_3))->isEqualTo("global_signature");
+
+      $entity = new \Entity;
+      $this->boolean($entity->update([
+         'id'                => $root,
+         'mailing_signature' => "signature_root",
+      ]))->isTrue();
+
+      $this->string(\Notification::getMailingSignature($child_1))->isEqualTo("signature_root");
+      $this->string(\Notification::getMailingSignature($child_2))->isEqualTo("signature_root");
+      $this->string(\Notification::getMailingSignature($child_3))->isEqualTo("signature_root");
+
+      $this->boolean($entity->update([
+         'id'                => $child_1,
+         'mailing_signature' => "signature_child_1",
+      ]))->isTrue();
+
+      $this->string(\Notification::getMailingSignature($child_1))->isEqualTo("signature_child_1");
+      $this->string(\Notification::getMailingSignature($child_2))->isEqualTo("signature_root");
+      $this->string(\Notification::getMailingSignature($child_3))->isEqualTo("signature_root");
+
+      $this->boolean($entity->update([
+         'id'                => $child_2,
+         'mailing_signature' => "signature_child_2",
+      ]))->isTrue();
+
+      $this->string(\Notification::getMailingSignature($child_1))->isEqualTo("signature_child_1");
+      $this->string(\Notification::getMailingSignature($child_2))->isEqualTo("signature_child_2");
+      $this->string(\Notification::getMailingSignature($child_3))->isEqualTo("signature_child_2");
+
+      $this->boolean($entity->update([
+         'id'                => $child_3,
+         'mailing_signature' => "signature_child_3",
+      ]))->isTrue();
+
+      $this->string(\Notification::getMailingSignature($child_1))->isEqualTo("signature_child_1");
+      $this->string(\Notification::getMailingSignature($child_2))->isEqualTo("signature_child_2");
+      $this->string(\Notification::getMailingSignature($child_3))->isEqualTo("signature_child_3");
+   }
+}

--- a/tests/functionnal/Notification.php
+++ b/tests/functionnal/Notification.php
@@ -44,15 +44,15 @@ class Notification extends DbTestCase {
       $this->login();
 
       $root    = getItemByTypeName('Entity', 'Root entity', true);
+      $parent  = getItemByTypeName('Entity', '_test_root_entity', true);
       $child_1 = getItemByTypeName('Entity', '_test_child_1', true);
       $child_2 = getItemByTypeName('Entity', '_test_child_2', true);
-      $child_3 = getItemByTypeName('Entity', '_test_child_3', true);
 
       $CFG_GLPI['mailing_signature'] = 'global_signature';
 
+      $this->string(\Notification::getMailingSignature($parent))->isEqualTo("global_signature");
       $this->string(\Notification::getMailingSignature($child_1))->isEqualTo("global_signature");
       $this->string(\Notification::getMailingSignature($child_2))->isEqualTo("global_signature");
-      $this->string(\Notification::getMailingSignature($child_3))->isEqualTo("global_signature");
 
       $entity = new \Entity;
       $this->boolean($entity->update([
@@ -60,35 +60,35 @@ class Notification extends DbTestCase {
          'mailing_signature' => "signature_root",
       ]))->isTrue();
 
+      $this->string(\Notification::getMailingSignature($parent))->isEqualTo("signature_root");
       $this->string(\Notification::getMailingSignature($child_1))->isEqualTo("signature_root");
       $this->string(\Notification::getMailingSignature($child_2))->isEqualTo("signature_root");
-      $this->string(\Notification::getMailingSignature($child_3))->isEqualTo("signature_root");
+
+      $this->boolean($entity->update([
+         'id'                => $parent,
+         'mailing_signature' => "signature_parent",
+      ]))->isTrue();
+
+      $this->string(\Notification::getMailingSignature($parent))->isEqualTo("signature_parent");
+      $this->string(\Notification::getMailingSignature($child_1))->isEqualTo("signature_parent");
+      $this->string(\Notification::getMailingSignature($child_2))->isEqualTo("signature_parent");
 
       $this->boolean($entity->update([
          'id'                => $child_1,
          'mailing_signature' => "signature_child_1",
       ]))->isTrue();
 
+      $this->string(\Notification::getMailingSignature($parent))->isEqualTo("signature_parent");
       $this->string(\Notification::getMailingSignature($child_1))->isEqualTo("signature_child_1");
-      $this->string(\Notification::getMailingSignature($child_2))->isEqualTo("signature_root");
-      $this->string(\Notification::getMailingSignature($child_3))->isEqualTo("signature_root");
+      $this->string(\Notification::getMailingSignature($child_2))->isEqualTo("signature_parent");
 
       $this->boolean($entity->update([
          'id'                => $child_2,
          'mailing_signature' => "signature_child_2",
       ]))->isTrue();
 
+      $this->string(\Notification::getMailingSignature($parent))->isEqualTo("signature_parent");
       $this->string(\Notification::getMailingSignature($child_1))->isEqualTo("signature_child_1");
       $this->string(\Notification::getMailingSignature($child_2))->isEqualTo("signature_child_2");
-      $this->string(\Notification::getMailingSignature($child_3))->isEqualTo("signature_child_2");
-
-      $this->boolean($entity->update([
-         'id'                => $child_3,
-         'mailing_signature' => "signature_child_3",
-      ]))->isTrue();
-
-      $this->string(\Notification::getMailingSignature($child_1))->isEqualTo("signature_child_1");
-      $this->string(\Notification::getMailingSignature($child_2))->isEqualTo("signature_child_2");
-      $this->string(\Notification::getMailingSignature($child_3))->isEqualTo("signature_child_3");
    }
 }

--- a/tests/functionnal/NotificationTarget.php
+++ b/tests/functionnal/NotificationTarget.php
@@ -91,4 +91,119 @@ class NotificationTarget extends DbTestCase {
       $this->string($ntarget_child_1->getSubjectPrefix())->isEqualTo("[prefix_child_1] ");
       $this->string($ntarget_child_2->getSubjectPrefix())->isEqualTo("[prefix_child_2] ");
    }
+
+   public function testGetReplyTo() {
+      global $CFG_GLPI;
+
+      $this->login();
+
+      $root    = getItemByTypeName('Entity', 'Root entity', true);
+      $parent  = getItemByTypeName('Entity', '_test_root_entity', true);
+      $child_1 = getItemByTypeName('Entity', '_test_child_1', true);
+      $child_2 = getItemByTypeName('Entity', '_test_child_2', true);
+
+      $ntarget_parent  = new \NotificationTarget($parent);
+      $ntarget_child_1 = new \NotificationTarget($child_1);
+      $ntarget_child_2 = new \NotificationTarget($child_2);
+
+      // test global settings
+      $CFG_GLPI['admin_reply'] = 'test@global.tld';
+      $CFG_GLPI['admin_reply_name'] = 'test global';
+      $CFG_GLPI['from_email'] = '';
+
+      $this->array($ntarget_parent->getReplyTo())->isEqualTo([
+         'email' => 'test@global.tld',
+         'name'  => 'test global'
+      ]);
+      $this->array($ntarget_child_1->getReplyTo())->isEqualTo([
+         'email' => 'test@global.tld',
+         'name'  => 'test global'
+      ]);
+      $this->array($ntarget_child_2->getReplyTo())->isEqualTo([
+         'email' => 'test@global.tld',
+         'name'  => 'test global'
+      ]);
+
+      // test root entity settings
+      $entity  = new \Entity;
+      $this->boolean($entity->update([
+         'id'               => $root,
+         'admin_reply'      => "test@root.tld",
+         'admin_reply_name' => "test root",
+      ]))->isTrue();
+
+      $this->array($ntarget_parent->getReplyTo())->isEqualTo([
+         'email' => 'test@root.tld',
+         'name'  => 'test root'
+      ]);
+      $this->array($ntarget_child_1->getReplyTo())->isEqualTo([
+         'email' => 'test@root.tld',
+         'name'  => 'test root'
+      ]);
+      $this->array($ntarget_child_2->getReplyTo())->isEqualTo([
+         'email' => 'test@root.tld',
+         'name'  => 'test root'
+      ]);
+
+      // test parent entity settings
+      $this->boolean($entity->update([
+         'id'               => $parent,
+         'admin_reply'      => "test@parent.tld",
+         'admin_reply_name' => "test parent",
+      ]))->isTrue();
+
+      $this->array($ntarget_parent->getReplyTo())->isEqualTo([
+         'email' => 'test@parent.tld',
+         'name'  => 'test parent'
+      ]);
+      $this->array($ntarget_child_1->getReplyTo())->isEqualTo([
+         'email' => 'test@parent.tld',
+         'name'  => 'test parent'
+      ]);
+      $this->array($ntarget_child_2->getReplyTo())->isEqualTo([
+         'email' => 'test@parent.tld',
+         'name'  => 'test parent'
+      ]);
+
+      // test child_1 entity settings
+      $this->boolean($entity->update([
+         'id'               => $child_1,
+         'admin_reply'      => "test@child1.tld",
+         'admin_reply_name' => "test child1",
+      ]))->isTrue();
+
+      $this->array($ntarget_parent->getReplyTo())->isEqualTo([
+         'email' => 'test@parent.tld',
+         'name'  => 'test parent'
+      ]);
+      $this->array($ntarget_child_1->getReplyTo())->isEqualTo([
+         'email' => 'test@child1.tld',
+         'name'  => 'test child1'
+      ]);
+      $this->array($ntarget_child_2->getReplyTo())->isEqualTo([
+         'email' => 'test@parent.tld',
+         'name'  => 'test parent'
+      ]);
+
+      // test child_2 entity settings
+      $this->boolean($entity->update([
+         'id'               => $child_2,
+         'admin_reply'      => "test@child2.tld",
+         'admin_reply_name' => "test child2",
+      ]))->isTrue();
+
+      $this->array($ntarget_parent->getReplyTo())->isEqualTo([
+         'email' => 'test@parent.tld',
+         'name'  => 'test parent'
+      ]);
+      $this->array($ntarget_child_1->getReplyTo())->isEqualTo([
+         'email' => 'test@child1.tld',
+         'name'  => 'test child1'
+      ]);
+      $this->array($ntarget_child_2->getReplyTo())->isEqualTo([
+         'email' => 'test@child2.tld',
+         'name'  => 'test child2'
+      ]);
+
+   }
 }

--- a/tests/functionnal/NotificationTarget.php
+++ b/tests/functionnal/NotificationTarget.php
@@ -42,17 +42,17 @@ class NotificationTarget extends DbTestCase {
       $this->login();
 
       $root    = getItemByTypeName('Entity', 'Root entity', true);
+      $parent  = getItemByTypeName('Entity', '_test_root_entity', true);
       $child_1 = getItemByTypeName('Entity', '_test_child_1', true);
       $child_2 = getItemByTypeName('Entity', '_test_child_2', true);
-      $child_3 = getItemByTypeName('Entity', '_test_child_3', true);
 
+      $ntarget_parent  = new \NotificationTarget($parent);
       $ntarget_child_1 = new \NotificationTarget($child_1);
       $ntarget_child_2 = new \NotificationTarget($child_2);
-      $ntarget_child_3 = new \NotificationTarget($child_3);
 
+      $this->string($ntarget_parent->getSubjectPrefix())->isEqualTo("[GLPI] ");
       $this->string($ntarget_child_1->getSubjectPrefix())->isEqualTo("[GLPI] ");
       $this->string($ntarget_child_2->getSubjectPrefix())->isEqualTo("[GLPI] ");
-      $this->string($ntarget_child_3->getSubjectPrefix())->isEqualTo("[GLPI] ");
 
       $entity  = new \Entity;
       $this->boolean($entity->update([
@@ -60,35 +60,35 @@ class NotificationTarget extends DbTestCase {
          'notification_subject_tag' => "prefix_root",
       ]))->isTrue();
 
+      $this->string($ntarget_parent->getSubjectPrefix())->isEqualTo("[prefix_root] ");
       $this->string($ntarget_child_1->getSubjectPrefix())->isEqualTo("[prefix_root] ");
       $this->string($ntarget_child_2->getSubjectPrefix())->isEqualTo("[prefix_root] ");
-      $this->string($ntarget_child_3->getSubjectPrefix())->isEqualTo("[prefix_root] ");
+
+      $this->boolean($entity->update([
+         'id'                       => $parent,
+         'notification_subject_tag' => "prefix_parent",
+      ]))->isTrue();
+
+      $this->string($ntarget_parent->getSubjectPrefix())->isEqualTo("[prefix_parent] ");
+      $this->string($ntarget_child_1->getSubjectPrefix())->isEqualTo("[prefix_parent] ");
+      $this->string($ntarget_child_2->getSubjectPrefix())->isEqualTo("[prefix_parent] ");
 
       $this->boolean($entity->update([
          'id'                       => $child_1,
          'notification_subject_tag' => "prefix_child_1",
       ]))->isTrue();
 
+      $this->string($ntarget_parent->getSubjectPrefix())->isEqualTo("[prefix_parent] ");
       $this->string($ntarget_child_1->getSubjectPrefix())->isEqualTo("[prefix_child_1] ");
-      $this->string($ntarget_child_2->getSubjectPrefix())->isEqualTo("[prefix_root] ");
-      $this->string($ntarget_child_3->getSubjectPrefix())->isEqualTo("[prefix_root] ");
+      $this->string($ntarget_child_2->getSubjectPrefix())->isEqualTo("[prefix_parent] ");
 
       $this->boolean($entity->update([
          'id'                       => $child_2,
          'notification_subject_tag' => "prefix_child_2",
       ]))->isTrue();
 
+      $this->string($ntarget_parent->getSubjectPrefix())->isEqualTo("[prefix_parent] ");
       $this->string($ntarget_child_1->getSubjectPrefix())->isEqualTo("[prefix_child_1] ");
       $this->string($ntarget_child_2->getSubjectPrefix())->isEqualTo("[prefix_child_2] ");
-      $this->string($ntarget_child_3->getSubjectPrefix())->isEqualTo("[prefix_child_2] ");
-
-      $this->boolean($entity->update([
-         'id'                       => $child_3,
-         'notification_subject_tag' => "prefix_child_3",
-      ]))->isTrue();
-
-      $this->string($ntarget_child_1->getSubjectPrefix())->isEqualTo("[prefix_child_1] ");
-      $this->string($ntarget_child_2->getSubjectPrefix())->isEqualTo("[prefix_child_2] ");
-      $this->string($ntarget_child_3->getSubjectPrefix())->isEqualTo("[prefix_child_3] ");
    }
 }

--- a/tests/functionnal/NotificationTarget.php
+++ b/tests/functionnal/NotificationTarget.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use \DbTestCase;
+
+/* Test for inc/notificationtarget.class.php */
+
+class NotificationTarget extends DbTestCase {
+
+   public function testGetSubjectPrefix() {
+      $this->login();
+
+      $root    = getItemByTypeName('Entity', 'Root entity', true);
+      $child_1 = getItemByTypeName('Entity', '_test_child_1', true);
+      $child_2 = getItemByTypeName('Entity', '_test_child_2', true);
+      $child_3 = getItemByTypeName('Entity', '_test_child_3', true);
+
+      $ntarget_child_1 = new \NotificationTarget($child_1);
+      $ntarget_child_2 = new \NotificationTarget($child_2);
+      $ntarget_child_3 = new \NotificationTarget($child_3);
+
+      $this->string($ntarget_child_1->getSubjectPrefix())->isEqualTo("[GLPI] ");
+      $this->string($ntarget_child_2->getSubjectPrefix())->isEqualTo("[GLPI] ");
+      $this->string($ntarget_child_3->getSubjectPrefix())->isEqualTo("[GLPI] ");
+
+      $entity  = new \Entity;
+      $this->boolean($entity->update([
+         'id'                       => $root,
+         'notification_subject_tag' => "prefix_root",
+      ]))->isTrue();
+
+      $this->string($ntarget_child_1->getSubjectPrefix())->isEqualTo("[prefix_root] ");
+      $this->string($ntarget_child_2->getSubjectPrefix())->isEqualTo("[prefix_root] ");
+      $this->string($ntarget_child_3->getSubjectPrefix())->isEqualTo("[prefix_root] ");
+
+      $this->boolean($entity->update([
+         'id'                       => $child_1,
+         'notification_subject_tag' => "prefix_child_1",
+      ]))->isTrue();
+
+      $this->string($ntarget_child_1->getSubjectPrefix())->isEqualTo("[prefix_child_1] ");
+      $this->string($ntarget_child_2->getSubjectPrefix())->isEqualTo("[prefix_root] ");
+      $this->string($ntarget_child_3->getSubjectPrefix())->isEqualTo("[prefix_root] ");
+
+      $this->boolean($entity->update([
+         'id'                       => $child_2,
+         'notification_subject_tag' => "prefix_child_2",
+      ]))->isTrue();
+
+      $this->string($ntarget_child_1->getSubjectPrefix())->isEqualTo("[prefix_child_1] ");
+      $this->string($ntarget_child_2->getSubjectPrefix())->isEqualTo("[prefix_child_2] ");
+      $this->string($ntarget_child_3->getSubjectPrefix())->isEqualTo("[prefix_child_2] ");
+
+      $this->boolean($entity->update([
+         'id'                       => $child_3,
+         'notification_subject_tag' => "prefix_child_3",
+      ]))->isTrue();
+
+      $this->string($ntarget_child_1->getSubjectPrefix())->isEqualTo("[prefix_child_1] ");
+      $this->string($ntarget_child_2->getSubjectPrefix())->isEqualTo("[prefix_child_2] ");
+      $this->string($ntarget_child_3->getSubjectPrefix())->isEqualTo("[prefix_child_3] ");
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | maybe #6944, and internal ref !21352

The purpose of this pr is to make easier configuration for large entity tree
All fields in the notification tabs of entities are curently inheritable except mails and names (ex prefix or signatures are inheritable despite no inline documentation).

I took the opportunity to extends inline documentation for inheritance on missing fields (and remove \<font\> balise deprecated in 1999 😬 )

I still have a concern by the way, we may change existing malformed setup in existing instances.
And some may have emails changes (before if no value defined in the direct entity, the system took the global configuration).
It's difficult to say if it's a big impact but i dont' have solution to ease this transiftion, any ideas ?

![image](https://user-images.githubusercontent.com/418844/105330978-3330df00-5bd3-11eb-8da7-09bbf0d0c2eb.png)

