### PR TITLE
Fix stacked refused equipments

### DIFF
--- a/ajax/comments.php
+++ b/ajax/comments.php
@@ -93,7 +93,12 @@ if (isset($_POST["itemtype"])
                exit();
             }
 
-            $table = getTableForItemType($_POST['itemtype']);
+            $itemtype = $_POST['itemtype'];
+            if (is_subclass_of($itemtype, 'Rule')) {
+               $table = Rule::getTable();
+            } else {
+               $table = getTableForItemType($_POST['itemtype']);
+            }
             $tmpname = Dropdown::getDropdownName($table, $_POST["value"], 1);
             if (is_array($tmpname) && isset($tmpname["comment"])) {
                 echo $tmpname["comment"];

--- a/inc/inventory/asset/mainasset.class.php
+++ b/inc/inventory/asset/mainasset.class.php
@@ -35,6 +35,7 @@ namespace Glpi\Inventory\Asset;
 use Auth;
 use CommonDBTM;
 use Glpi\Inventory\Conf;
+use RefusedEquipment;
 use RuleImportAssetCollection;
 use RuleImportEntityCollection;
 use RuleMatchedLog;
@@ -570,11 +571,12 @@ abstract class MainAsset extends InventoryAsset
          }
       }
 
-      $this->handleAssets();
-
       $input = (array)$val;
-
       $this->item->update(Toolbox::addslashes_deep($input), $this->withHistory());
+
+      if (!($this->item instanceof RefusedEquipment)) {
+         $this->handleAssets();
+      }
 
       $rulesmatched = new RuleMatchedLog();
       $inputrulelog = [

--- a/inc/refusedequipment.class.php
+++ b/inc/refusedequipment.class.php
@@ -234,4 +234,8 @@ class RefusedEquipment extends CommonDBTM {
    public function isDynamic() {
       return true;
    }
+
+   static function canPurge() {
+      return static::canUpdate();
+   }
 }

--- a/inc/rulecollection.class.php
+++ b/inc/rulecollection.class.php
@@ -827,7 +827,7 @@ class RuleCollection extends CommonDBTM {
             'FROM'   => 'glpi_rules',
             'WHERE'  => [
                'sub_type'  => $this->getRuleClassName(),
-               ['ranking'  => ['=>', $rank]],
+               ['ranking'  => ['>=', $rank]],
                ['ranking'  => ['<', $old_rank]]
             ]
          ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Only the first stacked entry had an itemtype correctly set and corresponding rules_id in refused logs; and only the last one had the inventory file.

For those equipments, there is currently no "stack" notion we could rely on, so inventory file is available for every stack part like it is an entire equipment.