### PR TITLE
More reliable way to detect sortable/not sortable tab

### DIFF
--- a/inc/rulecollection.class.php
+++ b/inc/rulecollection.class.php
@@ -265,8 +265,8 @@ class RuleCollection extends CommonDBTM {
 
          if (count($iterator)) {
             $this->RuleList->list = [];
-            $current_tab = str_replace($this->getType().'$', '', Session::getActiveTab($this->getType()));
-            $tabs = $this->getTabNameForItem($this);
+            $active_tab = Session::getActiveTab($this->getType());
+            $can_sort = !(Toolbox::startsWith($this->getType() . '$', $active_tab));
 
             while ($rule = $iterator->next()) {
                //For each rule, get a Rule object with all the criterias and actions
@@ -275,9 +275,7 @@ class RuleCollection extends CommonDBTM {
                if ($tempRule->getRuleWithCriteriasAndActions($rule["id"], $retrieve_criteria,
                                                              $retrieve_action)) {
 
-                  if (!isset($tabs[$current_tab])) {
-                     $tempRule->can_sort = false;
-                  }
+                  $tempRule->can_sort = $can_sort;
 
                   //Add the object to the list of rules
                   $this->RuleList->list[] = $tempRule;

--- a/inc/rulecollection.class.php
+++ b/inc/rulecollection.class.php
@@ -223,18 +223,14 @@ class RuleCollection extends CommonDBTM {
 
       $iterator   = $DB->request($criteria);
 
-      $current_tab = str_replace($this->getType().'$', '', Session::getActiveTab($this->getType()));
-      $tabs = $this->getTabNameForItem($this);
+      $active_tab = Session::getActiveTab($this->getType());
+      $can_sort = !(Toolbox::startsWith($this->getType() . '$', $active_tab));
 
       while ($data = $iterator->next()) {
          //For each rule, get a Rule object with all the criterias and actions
          $tempRule               = $this->getRuleClass();
          $tempRule->fields       = $data;
-
-         if (isset($tabs[$current_tab])) {
-            //in a subtab disable sorting
-            $tempRule->can_sort = false;
-         }
+         $tempRule->can_sort = $can_sort;
 
          $this->RuleList->list[] = $tempRule;
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Hope this fix sortable buttons missing/present when then should/not appears.
