### PR TITLE
Fixed custom css entity with quotes

### DIFF
--- a/ajax/entityCustomCssCode.php
+++ b/ajax/entityCustomCssCode.php
@@ -62,7 +62,7 @@ if (isset($_POST['enable_custom_css']) && isset($_POST['entities_id'])) {
       echo 'disabled';
    }
    echo '>';
-   echo Html::entity_decode_deep($custom_css_code);
+   echo Html::clean($custom_css_code);
    echo '</textarea>';
 
    $editor_options = [

--- a/ajax/entityCustomCssCode.php
+++ b/ajax/entityCustomCssCode.php
@@ -62,7 +62,7 @@ if (isset($_POST['enable_custom_css']) && isset($_POST['entities_id'])) {
       echo 'disabled';
    }
    echo '>';
-   echo Html::entities_deep($custom_css_code);
+   echo Html::entity_decode_deep($custom_css_code);
    echo '</textarea>';
 
    $editor_options = [

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -2302,7 +2302,7 @@ class Entity extends CommonTreeDropdown {
          return '';
       }
 
-      return '<style>' . Html::entities_deep($custom_css_code) . '</style>';
+      return '<style>' . Html::entity_decode_deep($custom_css_code) . '</style>';
    }
 
    /**

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -2302,7 +2302,13 @@ class Entity extends CommonTreeDropdown {
          return '';
       }
 
-      return '<style>' . Html::entity_decode_deep($custom_css_code) . '</style>';
+      // Remove all html tags
+      $custom_css_code = Html::clean($custom_css_code);
+
+      // Fix child combinator
+      $custom_css_code = str_replace('&gt;', '>', $custom_css_code);
+
+      return '<style>' . $custom_css_code . '</style>';
    }
 
    /**


### PR DESCRIPTION
Currenty, the caracters `quote` and `greater than (>)` are converted to `&quote;` and `&gt;`

This PR decode it to back and preveting XSS

The `less than (<)` is not part of CSS selectors

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8397 #8587
