### PR TITLE
Handle chevrons and quotes in custom CSS; fixes #8397

### DIFF
--- a/front/entity.form.php
+++ b/front/entity.form.php
@@ -40,4 +40,8 @@ if (isset($_GET['id']) && ($_GET['id'] == 0)) {
                     'candel'  => false];
 }
 
+if (array_key_exists('custom_css_code', $_POST)) {
+   $_POST['custom_css_code'] = $_UPOST['custom_css_code'];
+}
+
 include (GLPI_ROOT . "/front/dropdown.common.form.php");

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -2302,7 +2302,7 @@ class Entity extends CommonTreeDropdown {
          return '';
       }
 
-      return '<style>' . Html::entities_deep($custom_css_code) . '</style>';
+      return '<style>' . strip_tags($custom_css_code) . '</style>';
    }
 
    /**

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -402,10 +402,10 @@ class Entity extends DbTestCase {
             // Output custom CSS from parent
             'entity_id'               => $child_id,
             'root_enable_custom_css'  => 1,
-            'root_custom_css_code'    => 'body { color:blue; }',
+            'root_custom_css_code'    => '.link::before { content: "test"; }',
             'child_enable_custom_css' => \Entity::CONFIG_PARENT,
             'child_custom_css_code'   => '',
-            'expected'                => '<style>body { color:blue; }</style>',
+            'expected'                => '<style>.link::before { content: "test"; }</style>',
          ],
          [
             // Do not output custom CSS from entity itself if disabled
@@ -431,8 +431,17 @@ class Entity extends DbTestCase {
             'root_enable_custom_css'  => 0,
             'root_custom_css_code'    => '',
             'child_enable_custom_css' => 1,
-            'child_custom_css_code'   => 'body { color:blue; }',
-            'expected'                => '<style>body { color:blue; }</style>',
+            'child_custom_css_code'   => 'body > a { color:blue; }',
+            'expected'                => '<style>body > a { color:blue; }</style>',
+         ],
+         [
+            // Output cleaned custom CSS
+            'entity_id'               => $child_id,
+            'root_enable_custom_css'  => 0,
+            'root_custom_css_code'    => '',
+            'child_enable_custom_css' => 1,
+            'child_custom_css_code'   => '</style><script>alert(1);</script>',
+            'expected'                => '<style>alert(1);</style>',
          ],
       ];
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8397 

Alternative proposal to #8576 .

The idea is to store raw input, and then :
 - display it with encoded entities in entity form, to display what was really set (this was already done like that, but was so twice encoded);
 - strip tags before using the value in the `<style>` header tag, in order to prevent security issue without encoding or removing `<`, `>`, `'` and `"`.

![image](https://user-images.githubusercontent.com/33253653/106006416-7c8e9c00-60b5-11eb-9b49-52a1c18ef13e.png)
