### PR TITLE
Fix kanban

### DIFF
--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -2385,7 +2385,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
                ],
                'entities_id' => [
                   'type'   => 'hidden',
-                  'value'  => $_SESSION['glpiactive_entity']
+                  'value'  => $project->getField("entities_id"),
                ],
                'is_recursive' => [
                   'type'   => 'hidden',
@@ -2420,7 +2420,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
                ],
                'entities_id' => [
                   'type'   => 'hidden',
-                  'value'  => $_SESSION['glpiactive_entity']
+                  'value'  => $project->getField("entities_id"),
                ],
                'is_recursive' => [
                   'type'   => 'hidden',

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -2385,7 +2385,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
                ],
                'entities_id' => [
                   'type'   => 'hidden',
-                  'value'  => isset($project->fields["entities_id"]) ? $project->fields["entities_id"] : 0, //undefined in global kanban but manage by 'supported_itemtypes'
+                  'value'  => $ID > 0 ? $project->fields["entities_id"] : $_SESSION['glpiactive_entity'],
                ],
                'is_recursive' => [
                   'type'   => 'hidden',
@@ -2420,7 +2420,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
                ],
                'entities_id' => [
                   'type'   => 'hidden',
-                  'value'  => isset($project->fields["entities_id"]) ? $project->fields["entities_id"] : 0, //undefined in global kanban but manage by 'supported_itemtypes'
+                  'value'  => $ID > 0 ? $project->fields["entities_id"] : $_SESSION['glpiactive_entity'],
                ],
                'is_recursive' => [
                   'type'   => 'hidden',
@@ -2448,7 +2448,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
 
       echo "<div id='kanban' class='kanban'></div>";
       $darkmode = ($_SESSION['glpipalette'] === 'darker') ? 'true' : 'false';
-      $canadd_item = json_encode($project->canEdit($ID) && $project->can($ID, UPDATE));
+      $canadd_item = json_encode($ID > 0 ? $project->canEdit($ID) && $project->can($ID, UPDATE) : self::canCreate() || ProjectTask::canCreate());
       $canmodify_view = json_encode(($ID == 0 || $project->canModifyGlobalState()));
       $cancreate_column = json_encode((bool)ProjectState::canCreate());
       $limit_addcard_columns = $canmodify_view !== 'false' ? '[]' : json_encode([0]);

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -2448,7 +2448,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
 
       echo "<div id='kanban' class='kanban'></div>";
       $darkmode = ($_SESSION['glpipalette'] === 'darker') ? 'true' : 'false';
-      $canadd_item = json_encode(self::canCreate() || ProjectTask::canCreate());
+      $canadd_item = json_encode($project->canEdit($ID) && $project->can($ID, UPDATE));
       $canmodify_view = json_encode(($ID == 0 || $project->canModifyGlobalState()));
       $cancreate_column = json_encode((bool)ProjectState::canCreate());
       $limit_addcard_columns = $canmodify_view !== 'false' ? '[]' : json_encode([0]);

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -2385,7 +2385,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
                ],
                'entities_id' => [
                   'type'   => 'hidden',
-                  'value'  => $project->getField("entities_id"),
+                  'value'  => isset($project->fields["entities_id"]) ? $project->fields["entities_id"] : 0, //undefined in global kanban but manage by 'supported_itemtypes'
                ],
                'is_recursive' => [
                   'type'   => 'hidden',
@@ -2420,7 +2420,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
                ],
                'entities_id' => [
                   'type'   => 'hidden',
-                  'value'  => $project->getField("entities_id"),
+                  'value'  => isset($project->fields["entities_id"]) ? $project->fields["entities_id"] : 0, //undefined in global kanban but manage by 'supported_itemtypes'
                ],
                'is_recursive' => [
                   'type'   => 'hidden',

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -1469,7 +1469,6 @@
          add_form += form_header;
 
          add_form += "<div class='kanban-item-content'>";
-         add_form += "<textarea name='bulk_item_list'></textarea>";
          $.each(self.supported_itemtypes[itemtype]['fields'], function(name, options) {
             var input_type = options['type'] !== undefined ? options['type'] : 'text';
             var value = options['value'] !== undefined ? options['value'] : '';
@@ -1481,8 +1480,11 @@
                   add_form += " value='" + value + "'";
                }
                add_form += "/>";
+            } else if (input_type.toLowerCase() === 'raw') {
+               add_form += value;
             }
          });
+         add_form += "<textarea name='bulk_item_list'></textarea>";
          add_form += "</div>";
 
          var column_id_elements = column_el.prop('id').split('-');

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -371,7 +371,7 @@
          self.temp_forms = {};
          var columns = $(self.element + " .kanban-column");
          $.each(columns, function(i, column) {
-            var forms = $(column).find('.kanban-add-form').find('.kanban-bulk-add-form');
+            var forms = $(column).find('.kanban-add-form');
             if (forms.length > 0) {
                self.temp_forms[column.id] = [];
                $.each(forms, function(i2, form) {
@@ -704,7 +704,7 @@
             );
          }
 
-         $(self.element + ' .kanban-container').on('submit', '.kanban-add-form', function(e) {
+         $(self.element + ' .kanban-container').on('submit', '.kanban-add-form:not(.kanban-bulk-add-form)', function(e) {
             e.preventDefault();
             var form = $(e.target);
             var data = {};
@@ -1461,7 +1461,7 @@
 
          var uniqueID = Math.floor(Math.random() * 999999);
          var formID = "form_add_" + itemtype + "_" + uniqueID;
-         var add_form = "<form id='" + formID + "' class='kanban-bulk-add-form kanban-form no-track'>";
+         var add_form = "<form id='" + formID + "' class='kanban-add-form kanban-bulk-add-form kanban-form no-track'>";
          var form_header = "<div class='kanban-item-header'>";
          form_header += "<span class='kanban-item-title'>"+self.supported_itemtypes[itemtype]['name']+"</span>";
          form_header += "<i class='fas fa-times' title='Close' onclick='$(this).parent().parent().remove()'></i>";

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -371,7 +371,7 @@
          self.temp_forms = {};
          var columns = $(self.element + " .kanban-column");
          $.each(columns, function(i, column) {
-            var forms = $(column).find('.kanban-add-form');
+            var forms = $(column).find('.kanban-add-form').find('.kanban-bulk-add-form');
             if (forms.length > 0) {
                self.temp_forms[column.id] = [];
                $.each(forms, function(i2, form) {

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -1461,7 +1461,7 @@
 
          var uniqueID = Math.floor(Math.random() * 999999);
          var formID = "form_add_" + itemtype + "_" + uniqueID;
-         var add_form = "<form id='" + formID + "' class='kanban-add-form kanban-form no-track'>";
+         var add_form = "<form id='" + formID + "' class='kanban-bulk-add-form kanban-form no-track'>";
          var form_header = "<div class='kanban-item-header'>";
          form_header += "<span class='kanban-item-title'>"+self.supported_itemtypes[itemtype]['name']+"</span>";
          form_header += "<i class='fas fa-times' title='Close' onclick='$(this).parent().parent().remove()'></i>";


### PR DESCRIPTION
First problem

The bulk and individual add form uses the same css class ```kanban-add-form```
and the javascript code that add only one task is triggered during bulk add

Second problem
add task or sub project project from kanban view, use current active entity, rather than the problem entity

This PR fix this

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 21417
