### PR TITLE
feat(searchoption): add software date install to metacriteria

### DIFF
--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -581,6 +581,25 @@ class Software extends CommonDBTM {
       }
       $tab[] = $newtab;
 
+      $tab[] = [
+         'id'                 => '73',
+         'table'              => 'glpi_items_softwareversions',
+         'field'              => 'date_install',
+         'name'               => __('Installation date'),
+         'datatype'           => 'date',
+         'massiveaction'      => false,
+         'joinparams'         => [
+            'jointype'   => 'child',
+            'beforejoin' => [
+               'table'      => 'glpi_softwareversions',
+               'joinparams' => ['jointype' => 'child'],
+            ],
+            'condition'  => "AND NEWTABLE.`is_deleted_item` = 0
+                             AND NEWTABLE.`is_deleted` = 0
+                             AND NEWTABLE.`is_template_item` = 0",
+         ]
+      ];
+
       $tab = array_merge($tab, SoftwareLicense::rawSearchOptionsToAdd());
 
       $name = _n('Version', 'Versions', Session::getPluralNumber());

--- a/tests/functionnal/Software.php
+++ b/tests/functionnal/Software.php
@@ -414,10 +414,10 @@ class Software extends DbTestCase {
    public function testGetSearchOptionsNew() {
       $software = new \Software();
       $result   = $software->rawSearchOptions();
-      $this->array($result)->hasSize(40);
+      $this->array($result)->hasSize(41);
 
       $this->login();
       $result   = $software->rawSearchOptions();
-      $this->array($result)->hasSize(49);
+      $this->array($result)->hasSize(50);
    }
 }


### PR DESCRIPTION
Add new searchoption 'date install' to Software metacriteria

![image](https://user-images.githubusercontent.com/7335054/106259184-2a698a00-621f-11eb-805f-2775c29c222e.png)

depends on #8596 

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 21362