### PR TITLE
Fix search options tests

### DIFF
--- a/inc/unmanaged.class.php
+++ b/inc/unmanaged.class.php
@@ -230,7 +230,7 @@ class Unmanaged extends CommonDBTM {
       $tab[] = [
          'id'        => '13',
          'table'     => $this->getTable(),
-         'field'     => 'item_type',
+         'field'     => 'itemtype',
          'name'      => _n('Type', 'Types', 1),
          'datatype'  => 'dropdown',
       ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes warnings on SO tests.
This PR targets master as MySQL warnings are not showned on 9.5/bugfixes branch, but I guess first 2 commits should be applied to 9.5 branch.
```
=> tests\units\Search::testSearchOptions():
==> An exception has been thrown in file /var/glpi/tests/functionnal/Search.php on line 471:
==> RuntimeException: DBmysql::query() in /var/glpi/inc/dbmysql.class.php line 363
==>   *** MySQL query warnings:
==>   SQL: SELECT DISTINCT `glpi_entities_knowbaseitems`.`id` AS id, '_test_user' AS currentuser,
==>                         `glpi_entities_knowbaseitems`.`entities_id`, `glpi_entities_knowbaseitems`.`is_recursive`, `glpi_entities`.`id` AS `ITEM_Entity_KnowbaseItem_4` FROM `glpi_entities_knowbaseitems`LEFT JOIN `glpi_entities` 
==>                                           ON (`glpi_entities_knowbaseitems`.`entities_id` = `glpi_entities`.`id`
==>                                               ) WHERE   ( `glpi_entities_knowbaseitems`.`entities_id` IN ('1', '2', '3')  OR (`glpi_entities_knowbaseitems`.`is_recursive`='1' AND `glpi_entities_knowbaseitems`.`entities_id` IN (0)) )  AND (    (`glpi_entities`.`id` = 'val') ) ORDER BY `id` 
==>   Warnings: 
==> 1292: Truncated incorrect DOUBLE value: 'val'
```