### PR TITLE
set minimal height for textarea

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3889,6 +3889,7 @@ JS;
             skin_url: '".$CFG_GLPI['root_doc']."/css/tiny_mce/skins/light',
             content_css: '$darker_css,".$CFG_GLPI['root_doc']."/css/tiny_mce_custom.css',
             cache_suffix: '?v=".GLPI_VERSION."',
+            min_height: '148px',
             setup: function(editor) {
                if ($('#$name').attr('required') == 'required') {
                   $('#$name').closest('form').find('input[type=submit]').click(function() {

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3889,7 +3889,7 @@ JS;
             skin_url: '".$CFG_GLPI['root_doc']."/css/tiny_mce/skins/light',
             content_css: '$darker_css,".$CFG_GLPI['root_doc']."/css/tiny_mce_custom.css',
             cache_suffix: '?v=".GLPI_VERSION."',
-            min_height: '148px',
+            min_height: '150px',
             setup: function(editor) {
                if ($('#$name').attr('required') == 'required') {
                   $('#$name').closest('form').find('input[type=submit]').click(function() {


### PR DESCRIPTION
In some cases, a textarea may be dosplayed with  a height of 0. This can occur in Formcreator, very likely when a textarea is hidden and displayed by javascript.

It appears that setting a minimum height to the textarea solves the issue. Internal ref: 21355

The minimal height set here is similar to the height usually observed in GLPI, i.e. a new ticket.