### PR TITLE
Fix SO tests on MySQL 5.6/5.7

### DIFF
--- a/inc/item_devicebattery.class.php
+++ b/inc/item_devicebattery.class.php
@@ -55,6 +55,7 @@ class Item_DeviceBattery extends Item_Devices {
             'long name' => __('Manufacturing date'),
             'short name' => _n('Date', 'Dates', 1),
             'size'       => 10,
+            'datatype'   => 'date',
             'id'         => 20,
             'autocomplete' => true,
          ]

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -580,7 +580,8 @@ class Search extends DbTestCase {
             $val = date('Y-m-d');
             break;
          case 'datetime':
-            $val = date('Y-m-d H:i:s');
+            // Search class expects seconds to be ":00".
+            $val = date('Y-m-d H:i:00');
             break;
          case 'right':
             $val = READ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Part of #8610.

Fixes following errors:
```
=> tests\units\Search::testSearchAllMeta():
==> An exception has been thrown in file /var/glpi/tests/functionnal/Search.php on line 539:
==> RuntimeException: DBmysql::query() in /var/glpi/inc/dbmysql.class.php line 363
==>   *** MySQL query warnings:
==>   SQL: SELECT DISTINCT `glpi_computers`.`id` AS id, '_test_user' AS currentuser,
==>                         `glpi_computers`.`entities_id`, `glpi_computers`.`is_recursive`,  `glpi_computers`.`name` AS `ITEM_Computer_1`,
==>                         `glpi_computers`.`id` AS `ITEM_Computer_1_id`,
==>                         `glpi_entities`.`completename` AS `ITEM_Computer_80`,  `glpi_states`.`completename` AS `ITEM_Computer_31`,  `glpi_manufacturers`.`name` AS `ITEM_Computer_23`,  `glpi_computers`.`serial` AS `ITEM_Computer_5`,  `glpi_computertypes`.`name` AS `ITEM_Computer_4`,  `glpi_computermodels`.`name` AS `ITEM_Computer_40`,  `glpi_operatingsystems_9719987b154aaf3b42c3db32aef59090`.`name` AS `ITEM_Computer_45`,  `glpi_locations`.`completename` AS `ITEM_Computer_3`,  `glpi_computers`.`date_mod` AS `ITEM_Computer_19`,   GROUP_CONCAT(DISTINCT CONCAT(IFNULL(`glpi_deviceprocessors_7083fb7d2b7a8b8abd619678acc5b604`.`designation`, '__NULL__'),
==>                                                '$#$',`glpi_deviceprocessors_7083fb7d2b7a8b8abd619678acc5b604`.`id`) ORDER BY `glpi_deviceprocessors_7083fb7d2b7a8b8abd619678acc5b604`.`id` SEPARATOR '$$##$$')
==>                               AS `ITEM_Computer_17`,
==>                   
==>                    GROUP_CONCAT(DISTINCT CONCAT(IFNULL(`glpi_monitors`.`date_mod`, '__NULL__'),
==>                                                '$#$',`glpi_monitors`.`id`) ORDER BY `glpi_monitors`.`id` SEPARATOR '$$##$$')
==>                               AS `ITEM_Monitor_19` FROM `glpi_computers`LEFT JOIN `glpi_entities` 
==>                                           ON (`glpi_computers`.`entities_id` = `glpi_entities`.`id`
==>                                               )LEFT JOIN `glpi_states` 
==>                                           ON (`glpi_computers`.`states_id` = `glpi_states`.`id`
==>                                               )LEFT JOIN `glpi_manufacturers` 
==>                                           ON (`glpi_computers`.`manufacturers_id` = `glpi_manufacturers`.`id`
==>                                               )LEFT JOIN `glpi_computertypes` 
==>                                           ON (`glpi_computers`.`computertypes_id` = `glpi_computertypes`.`id`
==>                                               )LEFT JOIN `glpi_computermodels` 
==>                                           ON (`glpi_computers`.`computermodels_id` = `glpi_computermodels`.`id`
==>                                               ) LEFT JOIN `glpi_items_operatingsystems` 
==>                                           ON (`glpi_computers`.`id` = `glpi_items_operatingsystems`.`items_id`
==>                                               AND `glpi_items_operatingsystems`.`itemtype` = 'Computer'
==>                                               ) LEFT JOIN `glpi_operatingsystems`  AS `glpi_operatingsystems_9719987b154aaf3b42c3db32aef59090`
==>                                           ON (`glpi_items_operatingsystems`.`operatingsystems_id` = `glpi_operatingsystems_9719987b154aaf3b42c3db32aef59090`.`id`
==>                                               )LEFT JOIN `glpi_locations` 
==>                                           ON (`glpi_computers`.`locations_id` = `glpi_locations`.`id`
==>                                               ) LEFT JOIN `glpi_items_deviceprocessors` 
==>                                           ON (`glpi_computers`.`id` = `glpi_items_deviceprocessors`.`items_id`
==>                                               AND `glpi_items_deviceprocessors`.`itemtype` = 'Computer'
==>                                               ) LEFT JOIN `glpi_deviceprocessors`  AS `glpi_deviceprocessors_7083fb7d2b7a8b8abd619678acc5b604`
==>                                           ON (`glpi_items_deviceprocessors`.`deviceprocessors_id` = `glpi_deviceprocessors_7083fb7d2b7a8b8abd619678acc5b604`.`id`
==>                                               )  LEFT JOIN  `glpi_computers_items` AS `glpi_computers_items_Monitor`
==>                               ON (`glpi_computers_items_Monitor`.`computers_id`
==>                                        = `glpi_computers`.`id`
==>                                   AND `glpi_computers_items_Monitor`.`itemtype` = 'Monitor'
==>                                   AND `glpi_computers_items_Monitor`.`is_deleted` = 0)
==>                             LEFT JOIN  `glpi_monitors`
==>                               ON (`glpi_computers_items_Monitor`.`items_id` = `glpi_monitors`.`id`)  WHERE  `glpi_computers`.`is_deleted` = 0  AND `glpi_computers`.`is_template` = 0  AND  ( `glpi_computers`.`entities_id` IN ('1', '2', '3')  OR (`glpi_computers`.`is_recursive`='1' AND `glpi_computers`.`entities_id` IN (0)) )  AND (    (`glpi_monitors`.`date_mod`  LIKE '2021-02-01 11:17:57%'  ) ) GROUP BY `glpi_computers`.`id` ORDER BY `ITEM_Computer_1` ASC 
==>   Warnings: 
==> 1292: Incorrect datetime value: '2021-02-01 11:17:57%' for column 'date_mod' at row 1
```

```
=> tests\units\Search::testSearchOptions():
==> An exception has been thrown in file /var/glpi/tests/functionnal/Search.php on line 471:
==> RuntimeException: DBmysql::query() in /var/glpi/inc/dbmysql.class.php line 363
==>   *** MySQL query warnings:
==>   SQL: SELECT DISTINCT `glpi_items_devicebatteries`.`id` AS id, '_test_user' AS currentuser,
==>                         `glpi_items_devicebatteries`.`entities_id`, `glpi_items_devicebatteries`.`is_recursive`,  `glpi_items_devicebatteries`.`id` AS `ITEM_Item_DeviceBattery_1`,
==>                         `glpi_items_devicebatteries`.`id` AS `ITEM_Item_DeviceBattery_1_id`,
==>                         `glpi_entities`.`completename` AS `ITEM_Item_DeviceBattery_80`,  `glpi_items_devicebatteries`.`manufacturing_date` AS `ITEM_Item_DeviceBattery_20` FROM `glpi_items_devicebatteries`LEFT JOIN `glpi_entities` 
==>                                           ON (`glpi_items_devicebatteries`.`entities_id` = `glpi_entities`.`id`
==>                                               ) WHERE  `glpi_items_devicebatteries`.`is_deleted` = 0  AND  ( `glpi_items_devicebatteries`.`entities_id` IN ('1', '2', '3')  OR (`glpi_items_devicebatteries`.`is_recursive`='1' AND `glpi_items_devicebatteries`.`entities_id` IN (0)) )  AND (    (`glpi_items_devicebatteries`.`manufacturing_date`  LIKE '%val%'  ) ) ORDER BY `ITEM_Item_DeviceBattery_1` ASC 
==>   Warnings: 
==> 1292: Incorrect date value: '%val%' for column 'manufacturing_date' at row 1
```