### PR TITLE
fix(event): fix get event for savedsearch

### DIFF
--- a/inc/notificationtargetsavedsearch_alert.class.php
+++ b/inc/notificationtargetsavedsearch_alert.class.php
@@ -60,7 +60,7 @@ class NotificationTargetSavedSearch_Alert extends NotificationTarget {
                   $search->getID()
                );
             } else {
-               $events[$row['event']] = __('Private search alert');
+               $events['alert'] = __('Private search alert');
             }
          }
       } else {

--- a/inc/notificationtargetsavedsearch_alert.class.php
+++ b/inc/notificationtargetsavedsearch_alert.class.php
@@ -59,13 +59,10 @@ class NotificationTargetSavedSearch_Alert extends NotificationTarget {
                   $search->getName(),
                   $search->getID()
                );
-            } else {
-               $events['alert'] = __('Private search alert');
             }
          }
-      } else {
-         $events['alert'] = __('Private search alert');
       }
+      $events['alert'] = __('Private search alert');
 
       return $events;
    }


### PR DESCRIPTION
If the 'private search alerts' event is inadvertently removed, it is no longer possible to select it.

![image](https://user-images.githubusercontent.com/7335054/106572259-7fb3dd00-6538-11eb-8126-bac2366dd23b.png)

This PR fix this



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Internal 21447
