### PR TITLE
fix(api): manage mainitems_id foreignkey

### DIFF
--- a/inc/api/api.class.php
+++ b/inc/api/api.class.php
@@ -2475,6 +2475,10 @@ abstract class API extends CommonGLPI {
             if ($key == "default_requesttypes_id") {
                $key = "requesttypes_id";
             }
+            // mainitems_id mainitemtype
+            if ($key == "mainitems_id" && isset($fields['mainitemtype'])) {
+               $key = getForeignKeyFieldForItemType($fields['mainitemtype']);
+            }
 
             if (!empty($value)
                 || $key == 'entities_id' && $value >= 0) {


### PR DESCRIPTION
through GLPI API, when searching for ```IPAddress``` itemtype,

```mainitems_id``` is always empty.

```json
[
    {
        "id": 508,
        "entities_id": "Root entity",
        "items_id": "",
        "itemtype": "NetworkName",
        "version": 4,
        "name": "192.168.139.246",
        "binary_0": 0,
        "binary_1": 0,
        "binary_2": 65535,
        "binary_3": 3232271350,
        "is_deleted": 0,
        "is_dynamic": 0,
        "mainitems_id": "",
        "mainitemtype": "Computer"
    }
]
```

This foreign key need a specific transformation to be "understood" by API

This PR fix this


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Internal 21367
