### PR TITLE
Fix images upload validation

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -5686,7 +5686,7 @@ JAVASCRIPT;
                               ? "$('#{$p['dropZone']}')"
                               : "false").",
                acceptFileTypes: ".($p['onlyimages']
-                                    ? "'/(\.|\/)(gif|jpe?g|png)$/i'"
+                                    ? "/(\.|\/)(gif|jpe?g|png)$/i"
                                     : "undefined").",
                progressall: function(event, data) {
                   var progress = parseInt(data.loaded / data.total * 100, 10);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

RegEx in JS are not surrounding by quotes.
This option is not used in 9.5 so bug only affects master, but as code is present on 9.5, I fix it on 9.5/bugfixes branch.