### PR TITLE
fix(dashboard): add saerch filter criteria for widget by year

### DIFF
--- a/inc/dashboard/provider.class.php
+++ b/inc/dashboard/provider.class.php
@@ -715,7 +715,7 @@ class Provider extends CommonGLPI {
                      'field'      => 15, // creation date
                      'searchtype' => 'lessthan',
                      'value'      => null
-                  ]
+                  ],self::getSearchFiltersCriteria($t_table, $params['apply_filters']),
                ],
                'reset' => 'reset'
             ]
@@ -734,7 +734,7 @@ class Provider extends CommonGLPI {
                      'field'      => 17, // solve date
                      'searchtype' => 'lessthan',
                      'value'      => null
-                  ]
+                  ],self::getSearchFiltersCriteria($t_table, $params['apply_filters']),
                ],
                'reset' => 'reset'
             ]
@@ -758,7 +758,7 @@ class Provider extends CommonGLPI {
                      'field'      => 82, // time_to_resolve exceed solve date
                      'searchtype' => 'equals',
                      'value'      => 1
-                  ]
+                  ],self::getSearchFiltersCriteria($t_table, $params['apply_filters']),
                ],
                'reset' => 'reset'
             ]
@@ -777,7 +777,7 @@ class Provider extends CommonGLPI {
                      'field'      => 16, // close date
                      'searchtype' => 'lessthan',
                      'value'      => null
-                  ]
+                  ],self::getSearchFiltersCriteria($t_table, $params['apply_filters']),
                ],
                'reset' => 'reset'
             ]


### PR DESCRIPTION
When you click on a point in the widget to search for tickets, the filters are not used.

![image](https://user-images.githubusercontent.com/7335054/106782994-1c669f80-664b-11eb-829a-858f4f9fa2cc.png)


This PR fix this


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 21250
