### PR TITLE
fix(apppliance): prevent duplicated infocom creation

### DIFF
--- a/inc/console/migration/appliancesplugintocorecommand.class.php
+++ b/inc/console/migration/appliancesplugintocorecommand.class.php
@@ -275,7 +275,14 @@ class AppliancesPluginToCoreCommand extends AbstractCommand {
     * @return bool
     */
    private  function migratePlugin(): bool {
+      global $CFG_GLPI;
+
+      //prevent infocom creation from general setup
+      if (isset($CFG_GLPI["auto_create_infocoms"]) && $CFG_GLPI["auto_create_infocoms"]) {
+         $CFG_GLPI['auto_create_infocoms'] = false;
+      }
       $this->cleanCoreTables();
+
 
       return $this->createApplianceTypes()
          && $this->createApplianceEnvironments()

--- a/inc/console/migration/appliancesplugintocorecommand.class.php
+++ b/inc/console/migration/appliancesplugintocorecommand.class.php
@@ -283,7 +283,6 @@ class AppliancesPluginToCoreCommand extends AbstractCommand {
       }
       $this->cleanCoreTables();
 
-
       return $this->createApplianceTypes()
          && $this->createApplianceEnvironments()
          && $this->createApplianceRelations()


### PR DESCRIPTION
If option "Enable the financial and administrative information by default" is enabled

![image](https://user-images.githubusercontent.com/7335054/107009550-7ffce400-6795-11eb-99a5-0d4ea7d16f3a.png)


Appliance migration thrown error for infocom step

![image](https://user-images.githubusercontent.com/7335054/107009496-6eb3d780-6795-11eb-885f-c05b2fff8004.png)

Because, infocom already exist with good itemtype (due to option)

This PR fix this problem

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 21322
