### PR TITLE
Add a check on database keys

### DIFF
--- a/.github/actions/test_install.sh
+++ b/.github/actions/test_install.sh
@@ -11,7 +11,8 @@ if [[ -n $(grep "Warning" install.log) ]];
 fi
 
 # Check DB
-bin/console glpi:database:check --config-dir=./tests --ansi --no-interaction --strict
+bin/console glpi:database:check_schema --config-dir=./tests --ansi --no-interaction --strict
+bin/console glpi:database:check_keys --config-dir=./tests --ansi --no-interaction --detect-useless-keys
 
 # Execute update
 ## Should do nothing.

--- a/.github/actions/test_update-from-9.5.sh
+++ b/.github/actions/test_update-from-9.5.sh
@@ -23,7 +23,7 @@ if [[ -z $(grep "No migration needed." ~/migration.log) ]];
   then echo "bin/console glpi:database:update command FAILED" && exit 1;
 fi
 ## Check DB
-bin/console glpi:database:check --config-dir=./tests --ansi --no-interaction --ignore-utf8mb4-migration
+bin/console glpi:database:check_schema --config-dir=./tests --ansi --no-interaction --ignore-utf8mb4-migration
 
 # Execute myisam_to_innodb migration
 ## First run should do nothing.
@@ -51,4 +51,4 @@ if [[ -z $(grep "No migration needed." ~/migration.log) ]];
   then echo "bin/console glpi:migration:utf8mb4 command FAILED" && exit 1;
 fi
 # Check DB
-bin/console glpi:database:check --config-dir=./tests --ansi --no-interaction
+bin/console glpi:database:check_schema --config-dir=./tests --ansi --no-interaction

--- a/.github/actions/test_update-from-older-version.sh
+++ b/.github/actions/test_update-from-older-version.sh
@@ -16,7 +16,7 @@ if [[ -z $(grep "No migration needed." ~/migration.log) ]];
   then echo "bin/console glpi:database:update command FAILED" && exit 1;
 fi
 ## Check DB
-bin/console glpi:database:check \
+bin/console glpi:database:check_schema \
   --config-dir=./tests --ansi --no-interaction \
   --ignore-innodb-migration --ignore-timestamps-migration --ignore-dynamic-row-format-migration --ignore-utf8mb4-migration
 
@@ -32,7 +32,7 @@ if [[ -z $(grep "No migration needed." ~/migration.log) ]];
   then echo "bin/console glpi:migration:myisam_to_innodb command FAILED" && exit 1;
 fi
 ## Check DB
-bin/console glpi:database:check \
+bin/console glpi:database:check_schema \
   --config-dir=./tests --ansi --no-interaction \
   --ignore-timestamps-migration --ignore-dynamic-row-format-migration --ignore-utf8mb4-migration
 
@@ -48,7 +48,7 @@ if [[ -z $(grep "No migration needed." ~/migration.log) ]];
   then echo "bin/console glpi:migration:timestamps command FAILED" && exit 1;
 fi
 ## Check DB
-bin/console glpi:database:check \
+bin/console glpi:database:check_schema \
   --config-dir=./tests --ansi --no-interaction \
   --ignore-dynamic-row-format-migration --ignore-utf8mb4-migration
 
@@ -56,7 +56,7 @@ bin/console glpi:database:check \
 ## Result will depend on DB server/version, we just expect that command will not fail.
 bin/console glpi:migration:dynamic_row_format --config-dir=./tests --ansi --no-interaction
 ## Check DB
-bin/console glpi:database:check --config-dir=./tests --ansi --no-interaction --ignore-utf8mb4-migration
+bin/console glpi:database:check_schema --config-dir=./tests --ansi --no-interaction --ignore-utf8mb4-migration
 
 # Execute utf8mb4 migration
 ## First run should do the migration (with no warnings).
@@ -70,4 +70,4 @@ if [[ -z $(grep "No migration needed." ~/migration.log) ]];
   then echo "bin/console glpi:migration:utf8mb4 command FAILED" && exit 1;
 fi
 ## Check DB
-bin/console glpi:database:check --config-dir=./tests --ansi --no-interaction
+bin/console glpi:database:check_schema --config-dir=./tests --ansi --no-interaction

--- a/inc/console/database/checkschemacommand.class.php
+++ b/inc/console/database/checkschemacommand.class.php
@@ -37,12 +37,12 @@ if (!defined('GLPI_ROOT')) {
 }
 
 use Glpi\Console\AbstractCommand;
-use Glpi\System\Diagnostic\DatabaseChecker;
+use Glpi\System\Diagnostic\DatabaseSchemaChecker;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CheckCommand extends AbstractCommand {
+class CheckSchemaCommand extends AbstractCommand {
 
    /**
     * Error code returned when failed to read empty SQL file.
@@ -52,7 +52,7 @@ class CheckCommand extends AbstractCommand {
    const ERROR_UNABLE_TO_READ_EMPTYSQL = 1;
 
    /**
-    * Error code returned differences were found.
+    * Error code returned when differences are found.
     *
     * @var integer
     */
@@ -61,8 +61,14 @@ class CheckCommand extends AbstractCommand {
    protected function configure() {
       parent::configure();
 
-      $this->setName('glpi:database:check');
-      $this->setAliases(['db:check']);
+      $this->setName('glpi:database:check_schema');
+      $this->setAliases(
+         [
+            'db:check_schema',
+            'glpi:database:check', // old name
+            'db:check', // old alias
+         ]
+      );
       $this->setDescription(__('Check for schema differences between current database and installation file.'));
 
       $this->addOption(
@@ -103,7 +109,7 @@ class CheckCommand extends AbstractCommand {
 
    protected function execute(InputInterface $input, OutputInterface $output) {
 
-      $checker = new DatabaseChecker(
+      $checker = new DatabaseSchemaChecker(
          $this->db,
          $input->getOption('strict'),
          $input->getOption('ignore-innodb-migration'),

--- a/inc/system/diagnostic/databasekeyschecker.class.php
+++ b/inc/system/diagnostic/databasekeyschecker.class.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\System\Diagnostic;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use DBmysql;
+
+/**
+ * @since x.x.x
+ */
+class DatabaseKeysChecker {
+
+   /**
+    * DB instance.
+    *
+    * @var DBmysql
+    */
+   protected $db;
+
+   /**
+    * Local cache for tables columns.
+    *
+    * @var array
+    */
+   private $columns = [];
+
+   /**
+    * Local cache for tables indexes.
+    *
+    * @var array
+    */
+   private $indexes = [];
+
+   /**
+    * @param DBmysql $db   DB instance.
+    */
+   public function __construct(DBmysql $db) {
+      $this->db = $db;
+   }
+
+   /**
+    * Get list of missing keys, basing detection on column names.
+    *
+    * Array keys are expected key names, and array values are fields that should be contained in these keys.
+    *
+    * @param string $table_name
+    *
+    * @return array
+    */
+   public function getMissingKeys(string $table_name): array {
+      $missing_keys = [];
+
+      $misnamed_keys = $this->getMisnamedKeys($table_name);
+
+      $columns = $this->getColumnsNames($table_name);
+      foreach ($columns as $column_name) {
+         $column_name_matches = [];
+         if (preg_match('/^items_id(?<suffix>_.+)?/', $column_name, $column_name_matches)) {
+            $suffix = $column_name_matches['suffix'] ?? '';
+            $expected_key = 'item' . $suffix;
+            if (in_array('itemtype' . $suffix, $columns)
+               && !in_array($expected_key, $misnamed_keys)
+               && !$this->areFieldsCorrecltyIndexed($table_name, ['itemtype' . $suffix, 'items_id' . $suffix], $expected_key)) {
+               // Expect a key named item for itemtype/items_id polymorphic foreign keys
+               $missing_keys[$expected_key] = ['itemtype' . $suffix, 'items_id' . $suffix];
+            }
+         } else if (isForeignKeyField($column_name)
+                    || preg_match('/^date(_(mod|creation))$/', $column_name)
+                    || preg_match('/^is_(active|deleted|dynamic|recursive|template)$/', $column_name)) {
+            $ignored_fields = [
+               'glpi_ipaddresses.mainitems_id', // FIXME Should be renamed to glpi_ipaddresses.items_id_main to fit naming conventions.
+               'glpi_networkportaggregates.networkports_id_list', // FIXME Should be replaced by a relation table.
+               'glpi_planningexternalevents.users_id_guests', // FIXME Should be replaced by a relation table.
+               'glpi_dashboards_items.card_id', // FIXME This is not a foreign key.
+               'glpi_dashboards_items.gridstack_id', // FIXME This is not a foreign key.
+            ];
+            if (in_array("$table_name.$column_name", $ignored_fields)) {
+               continue;
+            }
+            $expected_key = $column_name;
+            if (!in_array($expected_key, $misnamed_keys) && !$this->areFieldsCorrecltyIndexed($table_name, [$column_name], $expected_key)) {
+               // Expect a key with same name as field or a key that contains multiple fields including current one.
+               $missing_keys[$expected_key] = [$column_name];
+            }
+         }
+      }
+
+      return $missing_keys;
+   }
+
+   /**
+    * Get list of keys having a name that mismatch conventions.
+    *
+    * Array keys are misnamed key names, and array values are expected key names.
+    *
+    * @param string $table_name
+    *
+    * @return array
+    */
+   public function getMisnamedKeys(string $table_name): array {
+      $misnamed_keys = [];
+
+      $index = $this->getIndex($table_name);
+      foreach ($index as $key => $fields) {
+         if ($key === 'PRIMARY' || $key === 'unicity') {
+            continue; // PRIMARY and 'unicity' cannot be misnamed.
+         }
+
+         if (count($fields) === 1 && $key !== reset($fields)) {
+            // A key corresponding to a unique field should be named like this field.
+            $misnamed_keys[$key] = reset($fields);
+         } else if (count($fields) === 2 && count($matching_fields = preg_grep('/^items_id(_.+)?/', $fields)) === 1) {
+            $items_id_field = reset($matching_fields);
+            $suffix = str_replace('items_id', '', $items_id_field);
+            $expected_key = 'item' . $suffix;
+            if (in_array('itemtype' . $suffix, $fields) && $key !== $expected_key) {
+               $misnamed_keys[$key] = $expected_key;
+            }
+         }
+      }
+
+      return $misnamed_keys;
+   }
+
+   /**
+    * Get list of keys that are included in larger keys.
+    *
+    * Array keys are useless key names, and array values are expected larger key names.
+    *
+    * @param string $table_name
+    *
+    * @return array
+    */
+   public function getUselessKeys(string $table_name): array {
+      $useless_keys = [];
+
+      $index = $this->getIndex($table_name);
+      foreach ($index as $checked_key => $checked_fields) {
+         if ($checked_key === 'PRIMARY' || $checked_key === 'unicity') {
+            continue; // PRIMARY and 'unicity' cannot be useless.
+         }
+
+         foreach ($index as $other_key => $other_fields) {
+            if ($checked_key === $other_key) {
+               continue; // This is not another key.
+            }
+            if (count($checked_fields) >= count($other_fields)) {
+               continue; // Other key does not contains more that expected fields, it is not a larger key.
+            }
+
+            foreach ($checked_fields as $i => $checked_field) {
+               if (!array_key_exists($i, $other_fields) || $other_fields[$i] !== $checked_field) {
+                  break;
+               }
+               // Fields are considered as part of a larger index only if they are located at the beginning of
+               // this larger index. Otherwise, MySQL will not be able to use the index if preceding fields
+               // are not tested in the query.
+               $useless_keys[$checked_key] = $other_key;
+            }
+
+         }
+      }
+
+      return $useless_keys;
+   }
+
+   /**
+    * Return list of column names for given table.
+    *
+    * @param string $table_name
+    *
+    * @return array
+    */
+   private function getColumnsNames(string $table_name): array {
+      if (!array_key_exists($table_name, $this->columns)) {
+         if (($columns_res = $this->db->query('SHOW COLUMNS FROM ' . $this->db->quoteName($table_name))) === false) {
+            throw new \Exception(sprintf('Unable to get table "%s" columns', $table_name));
+         }
+
+         $this->columns[$table_name] = array_column($columns_res->fetch_all(MYSQLI_ASSOC), 'Field');
+      }
+
+      return $this->columns[$table_name];
+   }
+
+   /**
+    * Return index for given table.
+    * Array keys are index key, and values are fields related to this key.
+    *
+    * @param string $table_name
+    *
+    * @return array
+    */
+   private function getIndex(string $table_name): array {
+      if (!array_key_exists($table_name, $this->indexes)) {
+         if (($keys_res = $this->db->query('SHOW INDEX FROM ' . $this->db->quoteName($table_name))) === false) {
+            throw new \Exception(sprintf('Unable to get table "%s" index', $table_name));
+         }
+
+         $index = [];
+         while ($key_specs = $keys_res->fetch_assoc()) {
+            if ($key_specs['Index_type'] === 'FULLTEXT') {
+               continue; // Ignore FULLTEXT keys
+            }
+            $key_name = $key_specs['Key_name'];
+            if (!array_key_exists($key_name, $index)) {
+               $index[$key_name] = [];
+            }
+            $index[$key_name][$key_specs['Seq_in_index'] - 1] = $key_specs['Column_name'];
+         }
+
+         $this->indexes[$table_name] = $index;
+      }
+
+      return $this->indexes[$table_name];
+   }
+
+   /**
+    * Check if fields are correctly indexed.
+    *
+    * @param string $table_name
+    * @param array $fields
+    * @param string $expected_key
+    *
+    * @return bool
+    */
+   private function areFieldsCorrecltyIndexed(string $table_name, array $fields, string $expected_key): bool {
+      $index = $this->getIndex($table_name);
+
+      // Check if expected key exists and matches given fields.
+      if (array_key_exists($expected_key, $index) && $index[$expected_key] === $fields) {
+         return true;
+      }
+
+      // Check if unicity key exists and matches given fields.
+      if (array_key_exists('unicity', $index) && $index['unicity'] === $fields) {
+         return true;
+      }
+
+      // Check if a larger key exists and contains given fields.
+      foreach ($index as $key_fields) {
+         if (count($fields) >= count($key_fields)) {
+            continue; // Key does not contains more that expected fields, it is not a larger key.
+         }
+         foreach ($fields as $i => $field) {
+            if (!array_key_exists($i, $key_fields) || $key_fields[$i] !== $field) {
+               break;
+            }
+            // Fields are considered as part of a larger index only if they are located at the beginning of
+            // this larger index. Otherwise, MySQL will not be able to use the index if preceding fields
+            // are not tested in the query.
+            return true;
+         }
+      }
+
+      return false;
+   }
+}

--- a/inc/system/diagnostic/databaseschemachecker.class.php
+++ b/inc/system/diagnostic/databaseschemachecker.class.php
@@ -42,7 +42,7 @@ use SebastianBergmann\Diff\Differ;
 /**
  * @since x.x.x
  */
-class DatabaseChecker {
+class DatabaseSchemaChecker {
 
    /**
     * DB instance.

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -155,7 +155,9 @@ CREATE TABLE `glpi_apiclients` (
   `comment` text,
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
-  KEY `is_active` (`is_active`)
+  KEY `is_active` (`is_active`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -341,7 +343,9 @@ CREATE TABLE `glpi_businesscriticities` (
   UNIQUE KEY `unicity` (`businesscriticities_id`,`name`),
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -392,7 +396,9 @@ CREATE TABLE `glpi_calendarsegments` (
   `end` time DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `calendars_id` (`calendars_id`),
-  KEY `day` (`day`)
+  KEY `day` (`day`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -418,6 +424,7 @@ CREATE TABLE `glpi_cartridgeitems` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `manufacturers_id` (`manufacturers_id`),
   KEY `locations_id` (`locations_id`),
   KEY `users_id_tech` (`users_id_tech`),
@@ -531,6 +538,7 @@ CREATE TABLE `glpi_certificates` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `is_template` (`is_template`),
   KEY `is_deleted` (`is_deleted`),
   KEY `certificatetypes_id` (`certificatetypes_id`),
@@ -558,7 +566,6 @@ CREATE TABLE `glpi_certificates_items` (
   `date_mod` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`certificates_id`,`itemtype`,`items_id`),
-  KEY `device` (`items_id`,`itemtype`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`)
@@ -854,7 +861,8 @@ CREATE TABLE `glpi_computerantiviruses` (
   KEY `computers_id` (`computers_id`),
   KEY `date_expiration` (`date_expiration`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `manufacturers_id` (`manufacturers_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -886,8 +894,6 @@ CREATE TABLE `glpi_items_disks` (
   KEY `mountpoint` (`mountpoint`),
   KEY `totalsize` (`totalsize`),
   KEY `freesize` (`freesize`),
-  KEY `itemtype` (`itemtype`),
-  KEY `items_id` (`items_id`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `filesystems_id` (`filesystems_id`),
   KEY `entities_id` (`entities_id`),
@@ -1012,8 +1018,6 @@ CREATE TABLE `glpi_items_softwarelicenses` (
   `is_deleted` tinyint NOT NULL DEFAULT '0',
   `is_dynamic` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `items_id` (`items_id`),
-  KEY `itemtype` (`itemtype`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `softwarelicenses_id` (`softwarelicenses_id`),
   KEY `is_deleted` (`is_deleted`),
@@ -1037,14 +1041,12 @@ CREATE TABLE `glpi_items_softwareversions` (
   `date_install` date DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`itemtype`,`items_id`,`softwareversions_id`),
-  KEY `items_id` (`items_id`),
-  KEY `itemtype` (`itemtype`),
-  KEY `item` (`itemtype`,`items_id`),
   KEY `softwareversions_id` (`softwareversions_id`),
   KEY `computers_info` (`entities_id`,`is_template_item`,`is_deleted_item`),
-  KEY `is_template` (`is_template_item`),
-  KEY `is_deleted` (`is_deleted_item`),
+  KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
+  KEY `is_deleted_item` (`is_deleted_item`),
+  KEY `is_template_item` (`is_template_item`),
   KEY `date_install` (`date_install`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
@@ -1096,7 +1098,8 @@ CREATE TABLE `glpi_computervirtualmachines` (
   KEY `is_dynamic` (`is_dynamic`),
   KEY `uuid` (`uuid`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `virtualmachinetypes_id` (`virtualmachinetypes_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -1123,7 +1126,6 @@ CREATE TABLE `glpi_items_operatingsystems` (
   `is_recursive` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`items_id`,`itemtype`,`operatingsystems_id`,`operatingsystemarchitectures_id`),
-  KEY `items_id` (`items_id`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `operatingsystems_id` (`operatingsystems_id`),
   KEY `operatingsystemservicepacks_id` (`operatingsystemservicepacks_id`),
@@ -1134,7 +1136,9 @@ CREATE TABLE `glpi_items_operatingsystems` (
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
   KEY `entities_id` (`entities_id`),
-  KEY `is_recursive` (`is_recursive`)
+  KEY `is_recursive` (`is_recursive`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -1148,7 +1152,9 @@ CREATE TABLE `glpi_operatingsystemkernels` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `name` (`name`)
+  KEY `name` (`name`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -1164,7 +1170,9 @@ CREATE TABLE `glpi_operatingsystemkernelversions` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
-  KEY `operatingsystemkernels_id` (`operatingsystemkernels_id`)
+  KEY `operatingsystemkernels_id` (`operatingsystemkernels_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_operatingsystemeditions
@@ -1177,7 +1185,9 @@ CREATE TABLE `glpi_operatingsystemeditions` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `name` (`name`)
+  KEY `name` (`name`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_configs
@@ -1203,7 +1213,6 @@ CREATE TABLE `glpi_impactrelations` (
   `items_id_impacted` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`itemtype_source`,`items_id_source`,`itemtype_impacted`,`items_id_impacted`),
-  KEY `source_asset` (`itemtype_source`,`items_id_source`),
   KEY `impacted_asset` (`itemtype_impacted`,`items_id_impacted`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
@@ -1277,6 +1286,7 @@ CREATE TABLE `glpi_consumableitems` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `manufacturers_id` (`manufacturers_id`),
   KEY `locations_id` (`locations_id`),
   KEY `users_id_tech` (`users_id_tech`),
@@ -1358,6 +1368,7 @@ CREATE TABLE `glpi_contacts` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `contacttypes_id` (`contacttypes_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `usertitles_id` (`usertitles_id`),
@@ -1459,7 +1470,9 @@ CREATE TABLE `glpi_contracts` (
   KEY `name` (`name`),
   KEY `contracttypes_id` (`contracttypes_id`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `is_deleted` (`is_deleted`),
+  KEY `is_template` (`is_template`),
   KEY `use_monday` (`use_monday`),
   KEY `use_saturday` (`use_saturday`),
   KEY `alert` (`alert`),
@@ -1479,7 +1492,6 @@ CREATE TABLE `glpi_contracts_items` (
   `itemtype` varchar(100) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`contracts_id`,`itemtype`,`items_id`),
-  KEY `FK_device` (`items_id`,`itemtype`),
   KEY `item` (`itemtype`,`items_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
@@ -1598,7 +1610,7 @@ CREATE TABLE `glpi_dashboards_rights` (
   `items_id` int NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`dashboards_dashboards_id`,`itemtype`,`items_id`),
-  KEY `dashboards_dashboards_id` (`dashboards_dashboards_id`)
+  KEY `item` (`itemtype`,`items_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_devicecasemodels
@@ -2157,7 +2169,8 @@ CREATE TABLE `glpi_devicesensors` (
   KEY `locations_id` (`locations_id`),
   KEY `states_id` (`states_id`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `devicesensormodels_id` (`devicesensormodels_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -2374,6 +2387,7 @@ CREATE TABLE `glpi_documents` (
   KEY `date_mod` (`date_mod`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `tickets_id` (`tickets_id`),
   KEY `users_id` (`users_id`),
   KEY `documentcategories_id` (`documentcategories_id`),
@@ -2402,7 +2416,10 @@ CREATE TABLE `glpi_documents_items` (
   UNIQUE KEY `unicity` (`documents_id`,`itemtype`,`items_id`,`timeline_position`),
   KEY `item` (`itemtype`,`items_id`,`entities_id`,`is_recursive`),
   KEY `users_id` (`users_id`),
-  KEY `date_creation` (`date_creation`)
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -2450,6 +2467,7 @@ CREATE TABLE `glpi_domains` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `domaintypes_id` (`domaintypes_id`),
   KEY `users_id_tech` (`users_id_tech`),
   KEY `groups_id_tech` (`groups_id_tech`),
@@ -2474,7 +2492,6 @@ CREATE TABLE `glpi_dropdowntranslations` (
   `value` text,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`itemtype`,`items_id`,`language`,`field`),
-  KEY `typeid` (`itemtype`,`items_id`),
   KEY `language` (`language`),
   KEY `field` (`field`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -2566,13 +2583,15 @@ CREATE TABLE `glpi_entities` (
   `transfers_id` int NOT NULL DEFAULT '-2',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`entities_id`,`name`),
-  KEY `entities_id` (`entities_id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `tickettemplates_id` (`tickettemplates_id`),
   KEY `changetemplates_id` (`changetemplates_id`),
   KEY `problemtemplates_id` (`problemtemplates_id`),
-  KEY `transfers_id` (`transfers_id`)
+  KEY `transfers_id` (`transfers_id`),
+  KEY `authldaps_id` (`authldaps_id`),
+  KEY `calendars_id` (`calendars_id`),
+  KEY `entities_id_software` (`entities_id_software`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -2655,6 +2674,8 @@ CREATE TABLE `glpi_fieldblacklists` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -2677,6 +2698,9 @@ CREATE TABLE `glpi_fieldunicities` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
+  KEY `is_active` (`is_active`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC COMMENT='Stores field unicity criterias';
@@ -2751,6 +2775,7 @@ CREATE TABLE `glpi_groups` (
   KEY `name` (`name`),
   KEY `ldap_field` (`ldap_field`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `ldap_value` (`ldap_value`(200)),
   KEY `ldap_group_dn` (`ldap_group_dn`(200)),
@@ -2858,6 +2883,7 @@ CREATE TABLE `glpi_groups_users` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`users_id`,`groups_id`),
   KEY `groups_id` (`groups_id`),
+  KEY `is_dynamic` (`is_dynamic`),
   KEY `is_manager` (`is_manager`),
   KEY `is_userdelegate` (`is_userdelegate`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -2879,6 +2905,8 @@ CREATE TABLE `glpi_holidays` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `begin_date` (`begin_date`),
   KEY `end_date` (`end_date`),
   KEY `is_perpetual` (`is_perpetual`),
@@ -2989,8 +3017,7 @@ CREATE TABLE `glpi_ipaddresses_ipnetworks` (
   `ipnetworks_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`ipaddresses_id`,`ipnetworks_id`),
-  KEY `ipnetworks_id` (`ipnetworks_id`),
-  KEY `ipaddresses_id` (`ipaddresses_id`)
+  KEY `ipnetworks_id` (`ipnetworks_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -3028,13 +3055,15 @@ CREATE TABLE `glpi_ipnetworks` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `network_definition` (`entities_id`,`address`,`netmask`),
   KEY `address` (`address_0`,`address_1`,`address_2`,`address_3`),
   KEY `netmask` (`netmask_0`,`netmask_1`,`netmask_2`,`netmask_3`),
   KEY `gateway` (`gateway_0`,`gateway_1`,`gateway_2`,`gateway_3`),
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `ipnetworks_id` (`ipnetworks_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -3046,7 +3075,8 @@ CREATE TABLE `glpi_ipnetworks_vlans` (
   `ipnetworks_id` int NOT NULL DEFAULT '0',
   `vlans_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `link` (`ipnetworks_id`,`vlans_id`)
+  UNIQUE KEY `link` (`ipnetworks_id`,`vlans_id`),
+  KEY `vlans_id` (`vlans_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -3067,7 +3097,6 @@ CREATE TABLE `glpi_items_devicecases` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `devicecases_id` (`devicecases_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
@@ -3099,7 +3128,6 @@ CREATE TABLE `glpi_items_devicecontrols` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `devicecontrols_id` (`devicecontrols_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
@@ -3132,7 +3160,6 @@ CREATE TABLE `glpi_items_devicedrives` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `devicedrives_id` (`devicedrives_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
@@ -3164,7 +3191,6 @@ CREATE TABLE `glpi_items_devicegenerics` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `devicegenerics_id` (`devicegenerics_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
@@ -3172,7 +3198,9 @@ CREATE TABLE `glpi_items_devicegenerics` (
   KEY `is_recursive` (`is_recursive`),
   KEY `serial` (`serial`),
   KEY `item` (`itemtype`,`items_id`),
-  KEY `otherserial` (`otherserial`)
+  KEY `otherserial` (`otherserial`),
+  KEY `locations_id` (`locations_id`),
+  KEY `states_id` (`states_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -3195,7 +3223,6 @@ CREATE TABLE `glpi_items_devicegraphiccards` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `devicegraphiccards_id` (`devicegraphiccards_id`),
   KEY `specificity` (`memory`),
   KEY `is_deleted` (`is_deleted`),
@@ -3230,7 +3257,6 @@ CREATE TABLE `glpi_items_deviceharddrives` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `deviceharddrives_id` (`deviceharddrives_id`),
   KEY `specificity` (`capacity`),
   KEY `is_deleted` (`is_deleted`),
@@ -3265,7 +3291,6 @@ CREATE TABLE `glpi_items_devicememories` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `devicememories_id` (`devicememories_id`),
   KEY `specificity` (`size`),
   KEY `is_deleted` (`is_deleted`),
@@ -3298,7 +3323,6 @@ CREATE TABLE `glpi_items_devicemotherboards` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `devicemotherboards_id` (`devicemotherboards_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
@@ -3331,7 +3355,6 @@ CREATE TABLE `glpi_items_devicenetworkcards` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `devicenetworkcards_id` (`devicenetworkcards_id`),
   KEY `specificity` (`mac`),
   KEY `is_deleted` (`is_deleted`),
@@ -3365,7 +3388,6 @@ CREATE TABLE `glpi_items_devicepcis` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `devicepcis_id` (`devicepcis_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
@@ -3397,7 +3419,6 @@ CREATE TABLE `glpi_items_devicepowersupplies` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `devicepowersupplies_id` (`devicepowersupplies_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
@@ -3432,7 +3453,6 @@ CREATE TABLE `glpi_items_deviceprocessors` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `deviceprocessors_id` (`deviceprocessors_id`),
   KEY `specificity` (`frequency`),
   KEY `is_deleted` (`is_deleted`),
@@ -3467,7 +3487,6 @@ CREATE TABLE `glpi_items_devicesensors` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `devicesensors_id` (`devicesensors_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
@@ -3475,7 +3494,9 @@ CREATE TABLE `glpi_items_devicesensors` (
   KEY `is_recursive` (`is_recursive`),
   KEY `serial` (`serial`),
   KEY `item` (`itemtype`,`items_id`),
-  KEY `otherserial` (`otherserial`)
+  KEY `otherserial` (`otherserial`),
+  KEY `locations_id` (`locations_id`),
+  KEY `states_id` (`states_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -3497,7 +3518,6 @@ CREATE TABLE `glpi_items_devicesoundcards` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `devicesoundcards_id` (`devicesoundcards_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
@@ -3638,10 +3658,10 @@ CREATE TABLE `glpi_knowbaseitemcategories` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`entities_id`,`knowbaseitemcategories_id`,`name`),
   KEY `name` (`name`),
-  KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `knowbaseitemcategories_id` (`knowbaseitemcategories_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -3718,6 +3738,8 @@ CREATE TABLE `glpi_knowbaseitemtranslations` (
   PRIMARY KEY (`id`),
   KEY `item` (`knowbaseitems_id`,`language`),
   KEY `users_id` (`users_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`),
   FULLTEXT KEY `fulltext` (`name`,`answer`),
   FULLTEXT KEY `name` (`name`),
   FULLTEXT KEY `answer` (`answer`)
@@ -3747,8 +3769,15 @@ CREATE TABLE `glpi_lines` (
   PRIMARY KEY (`id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
+  KEY `is_deleted` (`is_deleted`),
   KEY `users_id` (`users_id`),
-  KEY `lineoperators_id` (`lineoperators_id`)
+  KEY `lineoperators_id` (`lineoperators_id`),
+  KEY `groups_id` (`groups_id`),
+  KEY `linetypes_id` (`linetypes_id`),
+  KEY `locations_id` (`locations_id`),
+  KEY `states_id` (`states_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -3803,6 +3832,7 @@ CREATE TABLE `glpi_links` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -4009,7 +4039,8 @@ CREATE TABLE `glpi_monitors` (
   KEY `otherserial` (`otherserial`),
   KEY `uuid` (`uuid`),
   KEY `date_creation` (`date_creation`),
-  KEY `is_recursive` (`is_recursive`)
+  KEY `is_recursive` (`is_recursive`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -4062,7 +4093,8 @@ CREATE TABLE `glpi_networkaliases` (
   PRIMARY KEY (`id`),
   KEY `entities_id` (`entities_id`),
   KEY `name` (`name`),
-  KEY `networknames_id` (`networknames_id`)
+  KEY `networknames_id` (`networknames_id`),
+  KEY `fqdns_id` (`fqdns_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -4130,6 +4162,7 @@ CREATE TABLE `glpi_networkequipments` (
   KEY `name` (`name`),
   KEY `is_template` (`is_template`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `manufacturers_id` (`manufacturers_id`),
   KEY `groups_id` (`groups_id`),
   KEY `users_id` (`users_id`),
@@ -4197,7 +4230,6 @@ CREATE TABLE `glpi_networknames` (
   PRIMARY KEY (`id`),
   KEY `entities_id` (`entities_id`),
   KEY `FQDN` (`name`,`fqdns_id`),
-  KEY `name` (`name`),
   KEY `fqdns_id` (`fqdns_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
@@ -4348,7 +4380,6 @@ CREATE TABLE `glpi_networkports` (
   `trunk` tinyint NOT NULL DEFAULT '0',
   `lastup` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `on_device` (`items_id`,`itemtype`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
@@ -4407,7 +4438,8 @@ CREATE TABLE `glpi_networkportwifis` (
   KEY `version` (`version`),
   KEY `mode` (`mode`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `networkportwifis_id` (`networkportwifis_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -4485,7 +4517,6 @@ CREATE TABLE `glpi_notifications_notificationtemplates` (
   `notificationtemplates_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`notifications_id`,`mode`,`notificationtemplates_id`),
-  KEY `notifications_id` (`notifications_id`),
   KEY `notificationtemplates_id` (`notificationtemplates_id`),
   KEY `mode` (`mode`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -4569,7 +4600,9 @@ CREATE TABLE `glpi_objectlocks` (
   `users_id` int NOT NULL COMMENT 'id of the locker',
   `date_mod` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp of the lock',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `item` (`itemtype`,`items_id`)
+  UNIQUE KEY `item` (`itemtype`,`items_id`),
+  KEY `users_id` (`users_id`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -4671,7 +4704,9 @@ CREATE TABLE `glpi_passivedcequipments` (
   KEY `is_template` (`is_template`),
   KEY `is_deleted` (`is_deleted`),
   KEY `states_id` (`states_id`),
-  KEY `manufacturers_id` (`manufacturers_id`)
+  KEY `manufacturers_id` (`manufacturers_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -5028,6 +5063,7 @@ CREATE TABLE `glpi_printers` (
   KEY `is_template` (`is_template`),
   KEY `is_global` (`is_global`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `manufacturers_id` (`manufacturers_id`),
   KEY `groups_id` (`groups_id`),
   KEY `users_id` (`users_id`),
@@ -5388,6 +5424,7 @@ CREATE TABLE `glpi_projects` (
   KEY `code` (`code`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
+  KEY `is_deleted` (`is_deleted`),
   KEY `projects_id` (`projects_id`),
   KEY `projectstates_id` (`projectstates_id`),
   KEY `projecttypes_id` (`projecttypes_id`),
@@ -5633,7 +5670,8 @@ CREATE TABLE `glpi_queuednotifications` (
   KEY `create_time` (`create_time`),
   KEY `send_time` (`send_time`),
   KEY `sent_time` (`sent_time`),
-  KEY `mode` (`mode`)
+  KEY `mode` (`mode`),
+  KEY `notificationtemplates_id` (`notificationtemplates_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -5648,7 +5686,7 @@ CREATE TABLE `glpi_registeredids` (
   `device_type` varchar(100) NOT NULL COMMENT 'USB, PCI ...',
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
-  KEY `item` (`items_id`,`itemtype`),
+  KEY `item` (`itemtype`,`items_id`),
   KEY `device_type` (`device_type`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
@@ -5697,7 +5735,9 @@ CREATE TABLE `glpi_remindertranslations` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `item` (`reminders_id`,`language`),
-  KEY `users_id` (`users_id`)
+  KEY `users_id` (`users_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_reminders_users
@@ -5777,7 +5817,6 @@ CREATE TABLE `glpi_reservations` (
   PRIMARY KEY (`id`),
   KEY `begin` (`begin`),
   KEY `end` (`end`),
-  KEY `reservationitems_id` (`reservationitems_id`),
   KEY `users_id` (`users_id`),
   KEY `resagroup` (`reservationitems_id`,`group`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -5940,6 +5979,8 @@ CREATE TABLE `glpi_slalevels` (
   `uuid` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `is_active` (`is_active`),
   KEY `slas_id` (`slas_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -5955,7 +5996,6 @@ CREATE TABLE `glpi_slalevels_tickets` (
   `date` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`tickets_id`,`slalevels_id`),
-  KEY `tickets_id` (`tickets_id`),
   KEY `slalevels_id` (`slalevels_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
@@ -6003,6 +6043,8 @@ CREATE TABLE `glpi_olalevels` (
   `uuid` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `is_active` (`is_active`),
   KEY `olas_id` (`olas_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -6018,7 +6060,6 @@ CREATE TABLE `glpi_olalevels_tickets` (
   `date` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`tickets_id`,`olalevels_id`),
-  KEY `tickets_id` (`tickets_id`),
   KEY `olalevels_id` (`olalevels_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
@@ -6062,6 +6103,8 @@ CREATE TABLE `glpi_slas` (
   `slms_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `calendars_id` (`calendars_id`),
@@ -6087,6 +6130,8 @@ CREATE TABLE `glpi_olas` (
   `slms_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `calendars_id` (`calendars_id`),
@@ -6155,6 +6200,7 @@ CREATE TABLE `glpi_softwarelicenses` (
   KEY `expire` (`expire`),
   KEY `softwareversions_id_buy` (`softwareversions_id_buy`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `softwarelicensetypes_id` (`softwarelicensetypes_id`),
   KEY `softwareversions_id_use` (`softwareversions_id_use`),
   KEY `date_mod` (`date_mod`),
@@ -6169,7 +6215,8 @@ CREATE TABLE `glpi_softwarelicenses` (
   KEY `date_creation` (`date_creation`),
   KEY `manufacturers_id` (`manufacturers_id`),
   KEY `states_id` (`states_id`),
-  KEY `allow_overquota` (`allow_overquota`)
+  KEY `allow_overquota` (`allow_overquota`),
+  KEY `softwarelicenses_id` (`softwarelicenses_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -6191,6 +6238,8 @@ CREATE TABLE `glpi_softwarelicensetypes` (
   `completename` text,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `softwarelicensetypes_id` (`softwarelicensetypes_id`)
@@ -6230,6 +6279,7 @@ CREATE TABLE `glpi_softwares` (
   KEY `is_update` (`is_update`),
   KEY `softwarecategories_id` (`softwarecategories_id`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `manufacturers_id` (`manufacturers_id`),
   KEY `groups_id` (`groups_id`),
   KEY `users_id` (`users_id`),
@@ -6332,15 +6382,15 @@ CREATE TABLE `glpi_itilsolutions` (
   `status` int NOT NULL DEFAULT '1',
   `itilfollowups_id` int DEFAULT NULL COMMENT 'Followup reference on reject or approve a solution',
   PRIMARY KEY (`id`),
-  KEY `itemtype` (`itemtype`),
-  KEY `item_id` (`items_id`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `solutiontypes_id` (`solutiontypes_id`),
   KEY `users_id` (`users_id`),
   KEY `users_id_editor` (`users_id_editor`),
   KEY `users_id_approval` (`users_id_approval`),
   KEY `status` (`status`),
-  KEY `itilfollowups_id` (`itilfollowups_id`)
+  KEY `itilfollowups_id` (`itilfollowups_id`),
+  KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -6395,6 +6445,8 @@ CREATE TABLE `glpi_states` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`states_id`,`name`),
   KEY `name` (`name`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `is_visible_computer` (`is_visible_computer`),
   KEY `is_visible_monitor` (`is_visible_monitor`),
   KEY `is_visible_networkequipment` (`is_visible_networkequipment`),
@@ -6443,6 +6495,7 @@ CREATE TABLE `glpi_suppliers` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `suppliertypes_id` (`suppliertypes_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `date_mod` (`date_mod`),
@@ -6594,7 +6647,8 @@ CREATE TABLE `glpi_ticketrecurrents` (
   KEY `is_recursive` (`is_recursive`),
   KEY `is_active` (`is_active`),
   KEY `tickettemplates_id` (`tickettemplates_id`),
-  KEY `next_creation_date` (`next_creation_date`)
+  KEY `next_creation_date` (`next_creation_date`),
+  KEY `calendars_id` (`calendars_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -6620,7 +6674,8 @@ CREATE TABLE `glpi_recurrentchanges` (
   KEY `is_recursive` (`is_recursive`),
   KEY `is_active` (`is_active`),
   KEY `changetemplates_id` (`changetemplates_id`),
-  KEY `next_creation_date` (`next_creation_date`)
+  KEY `next_creation_date` (`next_creation_date`),
+  KEY `calendars_id` (`calendars_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_tickets
@@ -6711,7 +6766,8 @@ CREATE TABLE `glpi_tickets_tickets` (
   `tickets_id_2` int NOT NULL DEFAULT '0',
   `link` int NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unicity` (`tickets_id_1`,`tickets_id_2`)
+  UNIQUE KEY `unicity` (`tickets_id_1`,`tickets_id_2`),
+  KEY `tickets_id_2` (`tickets_id_2`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -6799,8 +6855,7 @@ CREATE TABLE `glpi_tickettemplatehiddenfields` (
   `tickettemplates_id` int NOT NULL DEFAULT '0',
   `num` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unicity` (`tickettemplates_id`,`num`),
-  KEY `tickettemplates_id` (`tickettemplates_id`)
+  UNIQUE KEY `unicity` (`tickettemplates_id`,`num`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_changeemplatehiddenfields
@@ -6811,8 +6866,7 @@ CREATE TABLE `glpi_changetemplatehiddenfields` (
   `changetemplates_id` int NOT NULL DEFAULT '0',
   `num` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unicity` (`changetemplates_id`,`num`),
-  KEY `changetemplates_id` (`changetemplates_id`)
+  UNIQUE KEY `unicity` (`changetemplates_id`,`num`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_problemtemplatehiddenfields
@@ -6823,8 +6877,7 @@ CREATE TABLE `glpi_problemtemplatehiddenfields` (
   `problemtemplates_id` int NOT NULL DEFAULT '0',
   `num` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unicity` (`problemtemplates_id`,`num`),
-  KEY `problemtemplates_id` (`problemtemplates_id`)
+  UNIQUE KEY `unicity` (`problemtemplates_id`,`num`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_tickettemplatemandatoryfields
@@ -6835,8 +6888,7 @@ CREATE TABLE `glpi_tickettemplatemandatoryfields` (
   `tickettemplates_id` int NOT NULL DEFAULT '0',
   `num` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unicity` (`tickettemplates_id`,`num`),
-  KEY `tickettemplates_id` (`tickettemplates_id`)
+  UNIQUE KEY `unicity` (`tickettemplates_id`,`num`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -6848,8 +6900,7 @@ CREATE TABLE `glpi_changetemplatemandatoryfields` (
   `changetemplates_id` int NOT NULL DEFAULT '0',
   `num` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unicity` (`changetemplates_id`,`num`),
-  KEY `changetemplates_id` (`changetemplates_id`)
+  UNIQUE KEY `unicity` (`changetemplates_id`,`num`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_problemtemplatemandatoryfields
@@ -6860,8 +6911,7 @@ CREATE TABLE `glpi_problemtemplatemandatoryfields` (
   `problemtemplates_id` int NOT NULL DEFAULT '0',
   `num` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unicity` (`problemtemplates_id`,`num`),
-  KEY `problemtemplates_id` (`problemtemplates_id`)
+  UNIQUE KEY `unicity` (`problemtemplates_id`,`num`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_tickettemplatepredefinedfields
@@ -7161,7 +7211,9 @@ CREATE TABLE `glpi_users` (
   KEY `end_date` (`end_date`),
   KEY `sync_field` (`sync_field`),
   KEY `groups_id` (`groups_id`),
-  KEY `users_id_supervisor` (`users_id_supervisor`)
+  KEY `users_id_supervisor` (`users_id_supervisor`),
+  KEY `auths_id` (`auths_id`),
+  KEY `default_requesttypes_id` (`default_requesttypes_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -7241,6 +7293,7 @@ CREATE TABLE `glpi_vlans` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `tag` (`tag`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
@@ -7262,6 +7315,7 @@ CREATE TABLE `glpi_wifinetworks` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `essid` (`essid`),
   KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
@@ -7280,9 +7334,9 @@ CREATE TABLE `glpi_knowbaseitems_items` (
   `date_mod` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`itemtype`,`items_id`,`knowbaseitems_id`),
-  KEY `itemtype` (`itemtype`),
-  KEY `item_id` (`items_id`),
-  KEY `item` (`itemtype`,`items_id`)
+  KEY `knowbaseitems_id` (`knowbaseitems_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_knowbaseitems_revisions
@@ -7299,7 +7353,9 @@ CREATE TABLE `glpi_knowbaseitems_revisions` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`knowbaseitems_id`,`revision`,`language`),
-  KEY `revision` (`revision`)
+  KEY `revision` (`revision`),
+  KEY `users_id` (`users_id`),
+  KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_knowbaseitems_comments
@@ -7314,7 +7370,12 @@ CREATE TABLE `glpi_knowbaseitems_comments` (
   `parent_comment_id` int DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   `date_mod` timestamp NULL DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `knowbaseitems_id` (`knowbaseitems_id`),
+  KEY `parent_comment_id` (`parent_comment_id`),
+  KEY `users_id` (`users_id`),
+  KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_devicebatterymodels
@@ -7376,7 +7437,6 @@ CREATE TABLE `glpi_items_devicebatteries` (
   `states_id` int NOT NULL DEFAULT '0',
   `real_capacity` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `devicebatteries_id` (`devicebatteries_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
@@ -7384,7 +7444,9 @@ CREATE TABLE `glpi_items_devicebatteries` (
   KEY `is_recursive` (`is_recursive`),
   KEY `serial` (`serial`),
   KEY `item` (`itemtype`,`items_id`),
-  KEY `otherserial` (`otherserial`)
+  KEY `otherserial` (`otherserial`),
+  KEY `locations_id` (`locations_id`),
+  KEY `states_id` (`states_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_devicebatterytypes`;
@@ -7457,7 +7519,6 @@ CREATE TABLE `glpi_items_devicefirmwares` (
   `locations_id` int NOT NULL DEFAULT '0',
   `states_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `computers_id` (`items_id`),
   KEY `devicefirmwares_id` (`devicefirmwares_id`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
@@ -7465,7 +7526,9 @@ CREATE TABLE `glpi_items_devicefirmwares` (
   KEY `is_recursive` (`is_recursive`),
   KEY `serial` (`serial`),
   KEY `item` (`itemtype`,`items_id`),
-  KEY `otherserial` (`otherserial`)
+  KEY `otherserial` (`otherserial`),
+  KEY `locations_id` (`locations_id`),
+  KEY `states_id` (`states_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_devicefirmwaretypes`;
@@ -7498,7 +7561,9 @@ CREATE TABLE `glpi_datacenters` (
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `locations_id` (`locations_id`),
-  KEY `is_deleted` (`is_deleted`)
+  KEY `is_deleted` (`is_deleted`),
+  KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_dcrooms`;
@@ -7520,7 +7585,9 @@ CREATE TABLE `glpi_dcrooms` (
   KEY `is_recursive` (`is_recursive`),
   KEY `locations_id` (`locations_id`),
   KEY `datacenters_id` (`datacenters_id`),
-  KEY `is_deleted` (`is_deleted`)
+  KEY `is_deleted` (`is_deleted`),
+  KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_rackmodels`;
@@ -7533,7 +7600,9 @@ CREATE TABLE `glpi_rackmodels` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
-  KEY `product_number` (`product_number`)
+  KEY `product_number` (`product_number`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_racktypes`;
@@ -7597,7 +7666,9 @@ CREATE TABLE `glpi_racks` (
   KEY `group_id_tech` (`groups_id_tech`),
   KEY `is_template` (`is_template`),
   KEY `is_deleted` (`is_deleted`),
-  KEY `dcrooms_id` (`dcrooms_id`)
+  KEY `dcrooms_id` (`dcrooms_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_items_racks`;
@@ -7671,7 +7742,9 @@ CREATE TABLE `glpi_enclosures` (
   KEY `is_template` (`is_template`),
   KEY `is_deleted` (`is_deleted`),
   KEY `states_id` (`states_id`),
-  KEY `manufacturers_id` (`manufacturers_id`)
+  KEY `manufacturers_id` (`manufacturers_id`),
+  KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_items_enclosures`;
@@ -7706,7 +7779,9 @@ CREATE TABLE `glpi_pdumodels` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `is_rackable` (`is_rackable`),
-  KEY `product_number` (`product_number`)
+  KEY `product_number` (`product_number`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_pdutypes`;
@@ -7759,7 +7834,9 @@ CREATE TABLE `glpi_pdus` (
   KEY `is_deleted` (`is_deleted`),
   KEY `states_id` (`states_id`),
   KEY `manufacturers_id` (`manufacturers_id`),
-  KEY `pdutypes_id` (`pdutypes_id`)
+  KEY `pdutypes_id` (`pdutypes_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_plugs`;
@@ -7785,7 +7862,9 @@ CREATE TABLE `glpi_pdus_plugs` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `plugs_id` (`plugs_id`),
-  KEY `pdus_id` (`pdus_id`)
+  KEY `pdus_id` (`pdus_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_pdus_racks`;
@@ -7800,7 +7879,9 @@ CREATE TABLE `glpi_pdus_racks` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `racks_id` (`racks_id`),
-  KEY `pdus_id` (`pdus_id`)
+  KEY `pdus_id` (`pdus_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 -- /Datacenters
 
@@ -7843,8 +7924,6 @@ CREATE TABLE `glpi_itilfollowups` (
   `sourceitems_id` int NOT NULL DEFAULT '0',
   `sourceof_items_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `itemtype` (`itemtype`),
-  KEY `item_id` (`items_id`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `date` (`date`),
   KEY `date_mod` (`date_mod`),
@@ -7899,7 +7978,9 @@ CREATE TABLE `glpi_clusters` (
   KEY `clustertypes_id` (`clustertypes_id`),
   KEY `autoupdatesystems_id` (`autoupdatesystems_id`),
   KEY `entities_id` (`entities_id`),
-  KEY `is_recursive` (`is_recursive`)
+  KEY `is_recursive` (`is_recursive`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_items_clusters`;
@@ -8005,7 +8086,10 @@ CREATE TABLE `glpi_items_kanbans` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unicity` (`itemtype`,`items_id`,`users_id`)
+  UNIQUE KEY `unicity` (`itemtype`,`items_id`,`users_id`),
+  KEY `users_id` (`users_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_vobjects
@@ -8033,7 +8117,9 @@ CREATE TABLE `glpi_domaintypes` (
   `is_recursive` tinyint NOT NULL DEFAULT '0',
   `comment` text,
   PRIMARY KEY (`id`),
-  KEY `name` (`name`)
+  KEY `name` (`name`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_domainrelations`;
@@ -8044,7 +8130,9 @@ CREATE TABLE `glpi_domainrelations` (
   `is_recursive` tinyint NOT NULL DEFAULT '0',
   `comment` text,
   PRIMARY KEY (`id`),
-  KEY `name` (`name`)
+  KEY `name` (`name`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_domains_items`;
@@ -8056,9 +8144,7 @@ CREATE TABLE `glpi_domains_items` (
   `domainrelations_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`domains_id`,`itemtype`,`items_id`),
-  KEY `domains_id` (`domains_id`),
   KEY `domainrelations_id` (`domainrelations_id`),
-  KEY `FK_device` (`items_id`,`itemtype`),
   KEY `item` (`itemtype`,`items_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
@@ -8071,7 +8157,9 @@ CREATE TABLE `glpi_domainrecordtypes` (
   `is_recursive` tinyint NOT NULL DEFAULT '0',
   `comment` text,
   PRIMARY KEY (`id`),
-  KEY `name` (`name`)
+  KEY `name` (`name`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_domainrecords`;
@@ -8094,6 +8182,7 @@ CREATE TABLE `glpi_domainrecords` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `domains_id` (`domains_id`),
   KEY `domainrecordtypes_id` (`domainrecordtypes_id`),
   KEY `users_id_tech` (`users_id_tech`),
@@ -8128,6 +8217,7 @@ CREATE TABLE `glpi_appliances` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`externalidentifier`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `name` (`name`),
   KEY `is_deleted` (`is_deleted`),
   KEY `appliancetypes_id` (`appliancetypes_id`),
@@ -8141,7 +8231,8 @@ CREATE TABLE `glpi_appliances` (
   KEY `states_id` (`states_id`),
   KEY `serial` (`serial`),
   KEY `otherserial` (`otherserial`),
-  KEY `is_helpdesk_visible` (`is_helpdesk_visible`)
+  KEY `is_helpdesk_visible` (`is_helpdesk_visible`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_appliances_items`;
@@ -8152,7 +8243,6 @@ CREATE TABLE `glpi_appliances_items` (
   `itemtype` varchar(100) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`appliances_id`,`items_id`,`itemtype`),
-  KEY `appliances_id` (`appliances_id`),
   KEY `item` (`itemtype`,`items_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
@@ -8167,7 +8257,8 @@ CREATE TABLE `glpi_appliancetypes` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `externalidentifier` (`externalidentifier`),
   KEY `name` (`name`),
-  KEY `entities_id` (`entities_id`)
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_applianceenvironments`;
@@ -8187,8 +8278,6 @@ CREATE TABLE `glpi_appliances_items_relations` (
   `items_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `appliances_items_id` (`appliances_items_id`),
-  KEY `itemtype` (`itemtype`),
-  KEY `items_id` (`items_id`),
   KEY `item` (`itemtype`,`items_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
@@ -8219,10 +8308,11 @@ CREATE TABLE `glpi_agents` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `deviceid` (`deviceid`),
   KEY `name` (`name`),
-  KEY `items_id` (`items_id`),
-  KEY `itemtype` (`itemtype`),
-  KEY `glpi_agents_fk_agenttypes_id` (`agenttypes_id`),
-  CONSTRAINT `glpi_agents_fk_agenttypes_id` FOREIGN KEY (`agenttypes_id`) REFERENCES `glpi_agenttypes` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  KEY `agenttypes_id` (`agenttypes_id`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
+  KEY `item` (`itemtype`,`items_id`),
+  CONSTRAINT `agenttypes_id` FOREIGN KEY (`agenttypes_id`) REFERENCES `glpi_agenttypes` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_rulematchedlogs`;
@@ -8235,7 +8325,9 @@ CREATE TABLE `glpi_rulematchedlogs` (
   `agents_id` int NOT NULL DEFAULT '0',
   `method` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `item` (`itemtype`,`items_id`)
+  KEY `agents_id` (`agents_id`),
+  KEY `item` (`itemtype`,`items_id`),
+  KEY `rules_id` (`rules_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_lockedfields`;
@@ -8248,7 +8340,7 @@ CREATE TABLE `glpi_lockedfields` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`itemtype`,`items_id`,`field`),
-  KEY `item` (`itemtype`,`items_id`)
+  KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_unmanageds`;
@@ -8283,6 +8375,7 @@ CREATE TABLE `glpi_unmanageds` (
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `manufacturers_id` (`manufacturers_id`),
   KEY `groups_id` (`groups_id`),
   KEY `users_id` (`users_id`),
@@ -8316,6 +8409,7 @@ CREATE TABLE `glpi_networkporttypes` (
   KEY `value_decimal` (`value_decimal`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `is_importable` (`is_importable`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
@@ -8340,7 +8434,8 @@ CREATE TABLE `glpi_printerlogs` (
   `faxed` int NOT NULL DEFAULT '0',
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `printers_id` (`printers_id`)
+  KEY `printers_id` (`printers_id`),
+  KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -8352,7 +8447,9 @@ CREATE TABLE `glpi_networkportconnectionlogs` (
   `networkports_id_source` int NOT NULL DEFAULT '0',
   `networkports_id_destination` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `networkports_id_source` (`networkports_id_source`),
+  KEY `networkports_id_destination` (`networkports_id_destination`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -8385,7 +8482,12 @@ CREATE TABLE `glpi_refusedequipments` (
   `agents_id` int NOT NULL DEFAULT '0',
   `date_creation` timestamp NULL DEFAULT NULL,
   `date_mod` timestamp NULL DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `entities_id` (`entities_id`),
+  KEY `agents_id` (`agents_id`),
+  KEY `rules_id` (`rules_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_usbvendors`;
@@ -8401,10 +8503,10 @@ CREATE TABLE `glpi_usbvendors` (
   `date_mod` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`vendorid`,`deviceid`),
-  KEY `vendorid` (`vendorid`),
   KEY `deviceid` (`deviceid`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -8422,10 +8524,10 @@ CREATE TABLE `glpi_pcivendors` (
   `date_mod` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`vendorid`,`deviceid`),
-  KEY `vendorid` (`vendorid`),
   KEY `deviceid` (`deviceid`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;

--- a/install/update_95_xx/schema_fixes.php
+++ b/install/update_95_xx/schema_fixes.php
@@ -74,3 +74,501 @@ $migration->addPreQuery(
 );
 // Put back `subject` type to text (charset convertion changed it from text to mediumtext)
 $migration->changeField('glpi_notimportedemails', 'subject', 'subject', 'text', ['nodefault' => true]);
+
+// Drop malformed keys
+$malformed_keys = [
+   'glpi_items_softwareversions' => [
+      'is_deleted',
+      'is_template',
+   ],
+   'glpi_registeredids' => [
+      'item',
+   ],
+];
+foreach ($malformed_keys as $table => $keys) {
+   foreach ($keys as $key) {
+      $migration->dropKey($table, $key);
+      $migration->migrationOneTable($table);
+   }
+}
+
+// Drop useless keys
+$useless_keys = [
+   'glpi_appliances_items' => [
+      'appliances_id',
+   ],
+   'glpi_appliances_items_relations' => [
+      'itemtype',
+      'items_id',
+   ],
+   'glpi_certificates_items' => [
+      'device',
+   ],
+   'glpi_changetemplatehiddenfields' => [
+      'changetemplates_id',
+   ],
+   'glpi_changetemplatemandatoryfields' => [
+      'changetemplates_id',
+   ],
+   'glpi_contracts_items' => [
+      'FK_device',
+   ],
+   'glpi_dashboards_rights' => [
+      'dashboards_dashboards_id',
+   ],
+   'glpi_domains_items' => [
+      'domains_id',
+      'FK_device',
+   ],
+   'glpi_dropdowntranslations' => [
+      'typeid'
+   ],
+   'glpi_entities' => [
+      'entities_id',
+   ],
+   'glpi_impactrelations' => [
+      'source_asset',
+   ],
+   'glpi_ipaddresses_ipnetworks' => [
+      'ipaddresses_id',
+   ],
+   'glpi_items_devicebatteries' => [
+      'computers_id',
+   ],
+   'glpi_items_devicecases' => [
+      'computers_id',
+   ],
+   'glpi_items_devicecontrols' => [
+      'computers_id',
+   ],
+   'glpi_items_devicedrives' => [
+      'computers_id',
+   ],
+   'glpi_items_devicefirmwares' => [
+      'computers_id',
+   ],
+   'glpi_items_devicegenerics' => [
+      'computers_id',
+   ],
+   'glpi_items_devicegraphiccards' => [
+      'computers_id',
+   ],
+   'glpi_items_deviceharddrives' => [
+      'computers_id',
+   ],
+   'glpi_items_devicememories' => [
+      'computers_id',
+   ],
+   'glpi_items_devicemotherboards' => [
+      'computers_id',
+   ],
+   'glpi_items_devicenetworkcards' => [
+      'computers_id',
+   ],
+   'glpi_items_devicepcis' => [
+      'computers_id',
+   ],
+   'glpi_items_devicepowersupplies' => [
+      'computers_id',
+   ],
+   'glpi_items_deviceprocessors' => [
+      'computers_id',
+   ],
+   'glpi_items_devicesensors' => [
+      'computers_id',
+   ],
+   'glpi_items_devicesoundcards' => [
+      'computers_id',
+   ],
+   'glpi_items_disks' => [
+      'itemtype',
+      'items_id',
+   ],
+   'glpi_items_operatingsystems' => [
+      'items_id',
+   ],
+   'glpi_items_softwarelicenses' => [
+      'itemtype',
+      'items_id',
+   ],
+   'glpi_items_softwareversions' => [
+      'item',
+      'itemtype',
+      'items_id',
+   ],
+   'glpi_itilfollowups' => [
+      'itemtype',
+      'item_id',
+   ],
+   'glpi_itilsolutions' => [
+      'itemtype',
+      'item_id',
+   ],
+   'glpi_knowbaseitemcategories' => [
+      'entities_id',
+   ],
+   'glpi_knowbaseitems_items' => [
+      'item',
+      'itemtype',
+      'item_id',
+   ],
+   'glpi_networknames' => [
+      'name',
+   ],
+   'glpi_networkports' => [
+      'on_device',
+   ],
+   'glpi_notifications_notificationtemplates' => [
+      'notifications_id',
+   ],
+   'glpi_olalevels_tickets' => [
+      'tickets_id',
+   ],
+   'glpi_problemtemplatehiddenfields' => [
+      'problemtemplates_id',
+   ],
+   'glpi_problemtemplatemandatoryfields' => [
+      'problemtemplates_id',
+   ],
+   'glpi_reservations' => [
+      'reservationitems_id',
+   ],
+   'glpi_slalevels_tickets' => [
+      'tickets_id',
+   ],
+   'glpi_tickettemplatehiddenfields' => [
+      'tickettemplates_id',
+   ],
+   'glpi_tickettemplatemandatoryfields' => [
+      'tickettemplates_id',
+   ],
+];
+foreach ($useless_keys as $table => $keys) {
+   foreach ($keys as $key) {
+      $migration->dropKey($table, $key);
+      $migration->migrationOneTable($table);
+   }
+}
+
+// Add missing keys (based on glpi:database:check_keys detection)
+$missing_keys = [
+   'glpi_apiclients' => [
+      'entities_id',
+      'is_recursive',
+   ],
+   'glpi_appliances' => [
+      'date_mod',
+      'is_recursive',
+   ],
+   'glpi_appliancetypes' => [
+      'is_recursive',
+   ],
+   'glpi_businesscriticities' => [
+      'entities_id',
+      'is_recursive',
+   ],
+   'glpi_calendarsegments' => [
+      'entities_id',
+      'is_recursive',
+   ],
+   'glpi_cartridgeitems' => [
+      'is_recursive',
+   ],
+   'glpi_certificates' => [
+      'is_recursive',
+   ],
+   'glpi_clusters' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_computerantiviruses' => [
+      'manufacturers_id',
+   ],
+   'glpi_computervirtualmachines' => [
+      'virtualmachinetypes_id',
+   ],
+   'glpi_consumableitems' => [
+      'is_recursive',
+   ],
+   'glpi_contacts' => [
+      'is_recursive',
+   ],
+   'glpi_contracts' => [
+      'is_recursive',
+      'is_template',
+   ],
+   'glpi_dashboards_rights' => [
+      'item' => ['itemtype', 'items_id'],
+   ],
+   'glpi_datacenters' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_dcrooms' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_devicesensors' => [
+      'devicesensormodels_id',
+   ],
+   'glpi_documents' => [
+      'is_recursive',
+   ],
+   'glpi_documents_items' => [
+      'entities_id',
+      'is_recursive',
+      'date_mod',
+   ],
+   'glpi_domainrecords' => [
+      'is_recursive',
+   ],
+   'glpi_domainrecordtypes' => [
+      'entities_id',
+      'is_recursive',
+   ],
+   'glpi_domainrelations' => [
+      'entities_id',
+      'is_recursive',
+   ],
+   'glpi_domains' => [
+      'is_recursive',
+   ],
+   'glpi_domaintypes' => [
+      'entities_id',
+      'is_recursive',
+   ],
+   'glpi_enclosures' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_entities' => [
+      'authldaps_id',
+      'calendars_id',
+      'entities_id_software',
+   ],
+   'glpi_fieldblacklists' => [
+      'entities_id',
+      'is_recursive',
+   ],
+   'glpi_fieldunicities' => [
+      'entities_id',
+      'is_active',
+      'is_recursive',
+   ],
+   'glpi_groups' => [
+      'is_recursive',
+   ],
+   'glpi_groups_users' => [
+      'is_dynamic',
+   ],
+   'glpi_holidays' => [
+      'entities_id',
+      'is_recursive',
+   ],
+   'glpi_ipnetworks' => [
+      'ipnetworks_id',
+      'is_recursive',
+   ],
+   'glpi_ipnetworks_vlans' => [
+      'vlans_id',
+   ],
+   'glpi_items_devicebatteries' => [
+      'locations_id',
+      'states_id',
+   ],
+   'glpi_items_devicefirmwares' => [
+      'locations_id',
+      'states_id',
+   ],
+   'glpi_items_devicegenerics' => [
+      'locations_id',
+      'states_id',
+   ],
+   'glpi_items_devicesensors' => [
+      'locations_id',
+      'states_id',
+   ],
+   'glpi_items_kanbans' => [
+      'users_id',
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_items_operatingsystems' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_items_softwareversions' => [
+      'is_deleted',
+      'is_deleted_item',
+      'is_template_item',
+   ],
+   'glpi_itilsolutions' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_knowbaseitemcategories' => [
+      'knowbaseitemcategories_id',
+   ],
+   'glpi_knowbaseitems_comments' => [
+      'knowbaseitems_id',
+      'parent_comment_id',
+      'users_id',
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_knowbaseitems_items' => [
+      'knowbaseitems_id',
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_knowbaseitems_revisions' => [
+      'users_id',
+      'date_creation',
+   ],
+   'glpi_knowbaseitemtranslations' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_lines' => [
+      'is_deleted',
+      'groups_id',
+      'linetypes_id',
+      'locations_id',
+      'states_id',
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_links' => [
+      'is_recursive',
+   ],
+   'glpi_monitors' => [
+      'date_mod',
+   ],
+   'glpi_networkaliases' => [
+      'fqdns_id',
+   ],
+   'glpi_networkequipments' => [
+      'is_recursive',
+   ],
+   'glpi_networkportwifis' => [
+      'networkportwifis_id',
+   ],
+   'glpi_objectlocks' => [
+      'users_id',
+      'date_mod',
+   ],
+   'glpi_olalevels' => [
+      'entities_id',
+      'is_recursive',
+   ],
+   'glpi_olas' => [
+      'entities_id',
+      'is_recursive',
+   ],
+   'glpi_operatingsystemeditions' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_operatingsystemkernels' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_operatingsystemkernelversions' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_passivedcequipments' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_pdumodels' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_pdus' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_pdus_plugs' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_pdus_racks' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_printers' => [
+      'is_recursive',
+   ],
+   'glpi_projects' => [
+      'is_deleted',
+   ],
+   'glpi_queuednotifications' => [
+      'notificationtemplates_id',
+   ],
+   'glpi_rackmodels' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_racks' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_recurrentchanges' => [
+      'calendars_id',
+   ],
+   'glpi_registeredids' => [
+      'item' => ['itemtype', 'items_id'],
+   ],
+   'glpi_remindertranslations' => [
+      'date_creation',
+      'date_mod',
+   ],
+   'glpi_softwarelicenses' => [
+      'is_recursive',
+      'softwarelicenses_id',
+   ],
+   'glpi_softwarelicensetypes' => [
+      'entities_id',
+      'is_recursive',
+   ],
+   'glpi_softwares' => [
+      'is_recursive',
+   ],
+   'glpi_slalevels' => [
+      'entities_id',
+      'is_recursive',
+   ],
+   'glpi_slas' => [
+      'entities_id',
+      'is_recursive',
+   ],
+   'glpi_states' => [
+      'entities_id',
+      'is_recursive',
+   ],
+   'glpi_suppliers' => [
+      'is_recursive',
+   ],
+   'glpi_ticketrecurrents' => [
+      'calendars_id',
+   ],
+   'glpi_tickets_tickets' => [
+      'tickets_id_2',
+   ],
+   'glpi_users' => [
+      'auths_id',
+      'default_requesttypes_id',
+   ],
+   'glpi_vlans' => [
+      'is_recursive',
+   ],
+   'glpi_wifinetworks' => [
+      'is_recursive',
+   ],
+];
+foreach ($missing_keys as $table => $fields) {
+   foreach ($fields as $key => $field) {
+      $migration->addKey($table, $field, is_numeric($key) ? '' : $key);
+   }
+}

--- a/tests/units/Glpi/System/Diagnostic/DatabaseKeysChecker.php
+++ b/tests/units/Glpi/System/Diagnostic/DatabaseKeysChecker.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\System\Diagnostic;
+
+class DatabaseKeysChecker extends \GLPITestCase {
+
+   protected function sqlProvider() {
+      return [
+         [
+            // Uncommon is_ flags and dates may have no entry in index
+            'create_table_sql'   => <<<SQL
+CREATE TABLE `%s` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `content` text NOT NULL,
+  `externalid` int NOT NULL,
+  `is_something` tinyint NOT NULL,
+  `date_of_stuff` tinyint NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB
+SQL
+            ,
+            'expected_missing'   => [],
+            'expected_misnamed'  => [],
+            'expected_useless'   => [],
+         ],
+         [
+            // All these fields (except name) have NOT expected corresponding key
+            'create_table_sql'   => <<<SQL
+CREATE TABLE `%s` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `entities_id` int NOT NULL,
+  `is_recursive` tinyint NOT NULL,
+  `items_id` int NOT NULL DEFAULT '0',
+  `itemtype` varchar(100) NOT NULL,
+  `is_active` tinyint NOT NULL,
+  `is_deleted` tinyint NOT NULL,
+  `is_dynamic` tinyint NOT NULL,
+  `is_template` tinyint NOT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
+  `date_mod` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB
+SQL
+            ,
+            'expected_missing'   => [
+               'entities_id'   => ['entities_id'],
+               'is_recursive'  => ['is_recursive'],
+               'item'          => ['itemtype', 'items_id'],
+               'is_active'     => ['is_active'],
+               'is_deleted'    => ['is_deleted'],
+               'is_dynamic'    => ['is_dynamic'],
+               'is_template'   => ['is_template'],
+               'date_creation' => ['date_creation'],
+               'date_mod'      => ['date_mod'],
+            ],
+            'expected_misnamed'  => [],
+            'expected_useless'   => [],
+         ],
+         [
+            // All these fields (except name) have expected corresponding key
+            'create_table_sql'   => <<<SQL
+CREATE TABLE `%s` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `entities_id` int NOT NULL,
+  `is_recursive` tinyint NOT NULL,
+  `items_id` int NOT NULL DEFAULT '0',
+  `itemtype` varchar(100) NOT NULL,
+  `is_active` tinyint NOT NULL,
+  `is_deleted` tinyint NOT NULL,
+  `is_dynamic` tinyint NOT NULL,
+  `is_template` tinyint NOT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
+  `date_mod` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
+  KEY `item` (`itemtype`,`items_id`),
+  KEY `is_active` (`is_active`),
+  KEY `is_deleted` (`is_deleted`),
+  KEY `is_dynamic` (`is_dynamic`),
+  KEY `is_template` (`is_template`),
+  KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`)
+) ENGINE=InnoDB
+SQL
+            ,
+            'expected_missing'   => [],
+            'expected_misnamed'  => [],
+            'expected_useless'   => [],
+         ],
+         [
+            // Fields be indexed in a key that contains other keys, but only if they are at first position
+            'create_table_sql'   => <<<SQL
+CREATE TABLE `%s` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `computers_id` int NOT NULL,
+  `items_id_1` int NOT NULL DEFAULT '0',
+  `itemtype_1` varchar(100) NOT NULL,
+  `items_id_2` int NOT NULL DEFAULT '0',
+  `itemtype_2` varchar(100) NOT NULL,
+  `is_active` int NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unicity` (`computers_id`,`is_active`),
+  KEY `some_key` (`itemtype_1`,`items_id_1`,`itemtype_2`,`items_id_2`)
+) ENGINE=InnoDB
+SQL
+            ,
+            'expected_missing'   => [
+               'is_active' => ['is_active'], // Included in `unicity`, but not at first position
+               'item_2' => ['itemtype_2', 'items_id_2'], // Included in `some_key`, but not at first positions
+            ],
+            'expected_misnamed'  => [],
+            'expected_useless'   => [],
+         ],
+         [
+            // Key should match field name when key corresponds to a unique field
+            'create_table_sql'   => <<<SQL
+CREATE TABLE `%s` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `computers_id` int NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `some_key` (`computers_id`)
+) ENGINE=InnoDB
+SQL
+            ,
+            'expected_missing'   => [],
+            'expected_misnamed'  => [
+               'some_key' => 'computers_id',
+            ],
+            'expected_useless'   => [],
+         ],
+         [
+            // Key should match `item(_suffix)?` pattern when key corresponds to a itemtype/items_id couple
+            'create_table_sql'   => <<<SQL
+CREATE TABLE `%s` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `items_id` int NOT NULL DEFAULT '0',
+  `itemtype` varchar(100) NOT NULL,
+  `items_id_blablabla` int NOT NULL DEFAULT '0',
+  `itemtype_blablabla` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `mainitem` (`itemtype`, `items_id`),
+  KEY `some_key` (`itemtype_blablabla`, `items_id_blablabla`)
+) ENGINE=InnoDB
+SQL
+            ,
+            'expected_missing'   => [],
+            'expected_misnamed'  => [
+               'mainitem' => 'item',
+               'some_key' => 'item_blablabla',
+            ],
+            'expected_useless'   => [],
+         ],
+         [
+            // Keys are useless if included in larger keys
+            'create_table_sql'   => <<<SQL
+CREATE TABLE `%s` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `computers_id` int NOT NULL,
+  `items_id` int NOT NULL DEFAULT '0',
+  `itemtype` varchar(100) NOT NULL,
+  `items_linktype` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unicity` (`computers_id`,`itemtype`),
+  KEY `computers_id` (`computers_id`),
+  KEY `item_link` (`itemtype`,`items_id`,`items_linktype`),
+  KEY `item` (`itemtype`,`items_id`)
+) ENGINE=InnoDB
+SQL
+            ,
+            'expected_missing'   => [],
+            'expected_misnamed'  => [],
+            'expected_useless'   => [
+               'computers_id' => 'unicity',
+               'item'         => 'item_link',
+            ],
+         ],
+         [
+            // Keys are NOT useless if included in FULLTEXT larger keys
+            'create_table_sql'   => <<<SQL
+CREATE TABLE `%s` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `content` text,
+  PRIMARY KEY (`id`),
+  KEY `name` (`name`),
+  FULLTEXT KEY `fulltext` (`name`,`content`)
+) ENGINE=InnoDB
+SQL
+            ,
+            'expected_missing'   => [],
+            'expected_misnamed'  => [],
+            'expected_useless'   => [],
+         ],
+      ];
+   }
+
+   /**
+    * @dataProvider sqlProvider
+    */
+   public function testMissingMisnamedUseless(
+      string $create_table_sql,
+      array $expected_missing,
+      array $expected_misnamed,
+      array $expected_useless
+   ) {
+
+      global $DB;
+
+      $table_name = sprintf('glpitests_%s', uniqid());
+
+      $this->newTestedInstance($DB);
+      $DB->query(sprintf($create_table_sql, $table_name));
+      $missing_keys  = $this->testedInstance->getMissingKeys($table_name);
+      $misnamed_keys = $this->testedInstance->getMisnamedKeys($table_name);
+      $useless_keys = $this->testedInstance->getUselessKeys($table_name);
+      $DB->query(sprintf('DROP TABLE `%s`', $table_name));
+
+      $this->array($missing_keys)->isEqualTo($expected_missing);
+      $this->array($misnamed_keys)->isEqualTo($expected_misnamed);
+      $this->array($useless_keys)->isEqualTo($expected_useless);
+   }
+}

--- a/tests/units/Glpi/System/Diagnostic/DatabaseSchemaChecker.php
+++ b/tests/units/Glpi/System/Diagnostic/DatabaseSchemaChecker.php
@@ -32,7 +32,7 @@
 
 namespace tests\units\Glpi\System\Diagnostic;
 
-class DatabaseChecker extends \GLPITestCase {
+class DatabaseSchemaChecker extends \GLPITestCase {
 
    protected function sqlProvider() {
       return [

--- a/tools/checkkeyscommand.class.php
+++ b/tools/checkkeyscommand.class.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use Glpi\Console\AbstractCommand;
+use Glpi\System\Diagnostic\DatabaseKeysChecker;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CheckKeysCommand extends AbstractCommand {
+
+   /**
+    * Error code returned when missing keys found.
+    *
+    * @var integer
+    */
+   const ERROR_FOUND_MISSING_KEYS = 1;
+
+   /**
+    * Error code returned when misnamed keys found.
+    *
+    * @var integer
+    */
+   const ERROR_FOUND_MISNAMED_KEYS = 2;
+
+   /**
+    * Error code returned when useless keys found.
+    *
+    * @var integer
+    */
+   const ERROR_FOUND_USELESS_KEYS = 3;
+
+   protected function configure() {
+      parent::configure();
+
+      $this->setName('glpi:database:check_keys');
+      $this->setAliases(['db:check_keys']);
+      $this->setDescription(__('Check database for missing and errounous keys.'));
+
+      $this->addOption(
+         'detect-misnamed-keys',
+         null,
+         InputOption::VALUE_NONE,
+         __('Detect misnamed keys')
+      );
+
+      $this->addOption(
+         'detect-useless-keys',
+         null,
+         InputOption::VALUE_NONE,
+         __('Detect misnamed keys')
+      );
+   }
+
+   protected function execute(InputInterface $input, OutputInterface $output) {
+
+      $checker = new DatabaseKeysChecker($this->db);
+
+      $has_missing_keys  = false;
+      $has_misnamed_keys = false;
+      $has_useless_keys  = false;
+
+      $table_iterator = $this->db->listTables('glpi\_%', ['NOT' => ['table_name' => ['LIKE', 'glpi\_plugin\_%']]]);
+      foreach ($table_iterator as $table_data) {
+         $table_name = $table_data['TABLE_NAME'];
+
+         $missing_keys  = $checker->getMissingKeys($table_name);
+         if (count($missing_keys) > 0) {
+            ksort($missing_keys);
+            $has_missing_keys = true;
+            $message = '<error>' . sprintf(__('Table "%s" has missing keys:'), $table_name) . '</error>';
+            foreach ($missing_keys as $key => $fields) {
+               $message .= sprintf("\n    <comment>KEY `%s` (`%s`)</comment>", $key, implode('`,`', $fields));
+            }
+            $output->writeln($message, OutputInterface::VERBOSITY_QUIET);
+         }
+
+         if ($input->getOption('detect-misnamed-keys')) {
+            $misnamed_keys = $checker->getMisnamedKeys($table_name);
+            if (count($misnamed_keys) > 0) {
+               ksort($misnamed_keys);
+               $has_misnamed_keys = true;
+               $message = '<info>' . sprintf(__('Table "%s" has misnamed keys:'), $table_name) . '</info>';
+               foreach ($misnamed_keys as $current_key_name => $expected_key_name) {
+                  $message .= sprintf("\n    KEY `%s` should be `%s`", $current_key_name, $expected_key_name);
+               }
+               $output->writeln($message, OutputInterface::VERBOSITY_QUIET);
+            }
+         }
+
+         if ($input->getOption('detect-useless-keys')) {
+            $useless_keys = $checker->getUselessKeys($table_name);
+            if (count($useless_keys) > 0) {
+               ksort($useless_keys);
+               $has_useless_keys = true;
+               $message = '<info>' . sprintf(__('Table "%s" has useless keys:'), $table_name) . '</info>';
+               foreach ($useless_keys as $current_key_name => $larger_key_name) {
+                  $message .= sprintf("\n    KEY `%s` is included in `%s`", $current_key_name, $larger_key_name);
+               }
+               $output->writeln($message, OutputInterface::VERBOSITY_QUIET);
+            }
+         }
+      }
+
+      if ($has_missing_keys) {
+         return self::ERROR_FOUND_MISSING_KEYS;
+      }
+      if ($has_misnamed_keys) {
+         return self::ERROR_FOUND_MISNAMED_KEYS;
+      }
+      if ($has_useless_keys) {
+         return self::ERROR_FOUND_USELESS_KEYS;
+      }
+
+      $output->writeln('<info>' . __('Database has no missing keys.') . '</info>');
+
+      return 0; // Success
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While analysing performances issues on meta criteria tests, I noticed that some fields in database corresponding to "foreign keys" were not in tables index.
This PR introduces a system that detects missing keys, based on column names. This system is called on tests suite and triggers a failure when a missing key is found.

Exemple of failure:
![image](https://user-images.githubusercontent.com/33253653/107216513-2acb0780-6a0d-11eb-8cce-9b806dc96ee0.png)

At first, I thought about putting this command into glpi-project/tools, but it would need to implement a way to configure DB connection for these tools and also to add CI checks. Maybe it could be done later, when I would have time to do it.