### PR TITLE
Fix CREATE TABLE detection in db:check command

### DIFF
--- a/inc/console/database/checkcommand.class.php
+++ b/inc/console/database/checkcommand.class.php
@@ -123,7 +123,7 @@ class CheckCommand extends AbstractCommand {
       }
 
       $matches = [];
-      preg_match_all('/CREATE TABLE `(.+)`[^;]+/', $empty_sql, $matches);
+      preg_match_all('/CREATE TABLE[^`]*`(.+)`[^;]+/', $empty_sql, $matches);
       $empty_tables_names   = $matches[1];
       $empty_tables_schemas = $matches[0];
 

--- a/inc/system/diagnostic/databasechecker.class.php
+++ b/inc/system/diagnostic/databasechecker.class.php
@@ -204,7 +204,7 @@ class DatabaseChecker {
       $indexes_matches = [];
       $properties_matches = [];
       if (!preg_match_all('/^\s*(?<column>`\w+` .+?),?$/im', $structure_sql, $columns_matches)
-          || !preg_match_all('/^\s*(?<index>(CONSTRAINT|(UNIQUE |PRIMARY )?KEY) .+?),?$/im', $structure_sql, $indexes_matches)
+          || !preg_match_all('/^\s*(?<index>(CONSTRAINT|(UNIQUE |PRIMARY |FULLTEXT )?KEY) .+?),?$/im', $structure_sql, $indexes_matches)
           || !preg_match_all('/\s+((?<property>[^=]+[^\s])\s*=\s*(?<value>(\w+|\'(\\.|[^"])+\')))/i', $properties_sql, $properties_matches)) {
          return $create_table_sql;// Unable to normalize
       }

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8165,7 +8165,7 @@ CREATE TABLE `glpi_appliancetypes` (
   `comment` text,
   `externalidentifier` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY (`externalidentifier`),
+  UNIQUE KEY `externalidentifier` (`externalidentifier`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8151,7 +8151,7 @@ CREATE TABLE `glpi_appliances_items` (
   `items_id` int NOT NULL DEFAULT '0',
   `itemtype` varchar(100) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
-  UNIQUE `unicity` (`appliances_id`,`items_id`,`itemtype`),
+  UNIQUE KEY `unicity` (`appliances_id`,`items_id`,`itemtype`),
   KEY `appliances_id` (`appliances_id`),
   KEY `item` (`itemtype`,`items_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -8163,11 +8163,11 @@ CREATE TABLE `glpi_appliancetypes` (
   `is_recursive` tinyint NOT NULL DEFAULT '0',
   `name` varchar(255) NOT NULL DEFAULT '',
   `comment` text,
-  `externalidentifier` varchar(255),
+  `externalidentifier` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
+  UNIQUE KEY (`externalidentifier`),
   KEY `name` (`name`),
-  KEY `entities_id` (`entities_id`),
-  UNIQUE (`externalidentifier`)
+  KEY `entities_id` (`entities_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_applianceenvironments`;

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -2190,7 +2190,7 @@ CREATE TABLE `glpi_devicesensortypes` (
 ### Dump table glpi_devicesimcards
 
 DROP TABLE IF EXISTS `glpi_devicesimcards`;
-CREATE TABLE IF NOT EXISTS `glpi_devicesimcards` (
+CREATE TABLE `glpi_devicesimcards` (
   `id` int NOT NULL AUTO_INCREMENT,
   `designation` varchar(255) DEFAULT NULL,
   `comment` text,
@@ -2216,7 +2216,7 @@ CREATE TABLE IF NOT EXISTS `glpi_devicesimcards` (
 ### Dump table glpi_items_devicesimcards
 
 DROP TABLE IF EXISTS `glpi_items_devicesimcards`;
-CREATE TABLE IF NOT EXISTS `glpi_items_devicesimcards` (
+CREATE TABLE `glpi_items_devicesimcards` (
   `id` int NOT NULL AUTO_INCREMENT,
   `items_id` int NOT NULL DEFAULT '0' COMMENT 'RELATION to various table, according to itemtype (id)',
   `itemtype` varchar(100) NOT NULL,
@@ -2257,7 +2257,7 @@ CREATE TABLE IF NOT EXISTS `glpi_items_devicesimcards` (
 ### Dump table glpi_devicesimcardtypes
 
 DROP TABLE IF EXISTS `glpi_devicesimcardtypes`;
-CREATE TABLE IF NOT EXISTS `glpi_devicesimcardtypes` (
+CREATE TABLE `glpi_devicesimcardtypes` (
   `id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL DEFAULT '',
   `comment` text,
@@ -3755,7 +3755,7 @@ CREATE TABLE `glpi_lines` (
 ### Dump table glpi_lineoperators
 
 DROP TABLE IF EXISTS `glpi_lineoperators`;
-CREATE TABLE IF NOT EXISTS `glpi_lineoperators` (
+CREATE TABLE `glpi_lineoperators` (
   `id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL DEFAULT '',
   `comment` text,
@@ -3776,7 +3776,7 @@ CREATE TABLE IF NOT EXISTS `glpi_lineoperators` (
 
 
 DROP TABLE IF EXISTS `glpi_linetypes`;
-CREATE TABLE IF NOT EXISTS `glpi_linetypes` (
+CREATE TABLE `glpi_linetypes` (
   `id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(255) DEFAULT NULL,
   `comment` text,
@@ -8144,8 +8144,8 @@ CREATE TABLE `glpi_appliances` (
   KEY `is_helpdesk_visible` (`is_helpdesk_visible`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
-
-CREATE TABLE IF NOT EXISTS `glpi_appliances_items` (
+DROP TABLE IF EXISTS `glpi_appliances_items`;
+CREATE TABLE `glpi_appliances_items` (
   `id` int NOT NULL AUTO_INCREMENT,
   `appliances_id` int NOT NULL DEFAULT '0',
   `items_id` int NOT NULL DEFAULT '0',
@@ -8156,8 +8156,8 @@ CREATE TABLE IF NOT EXISTS `glpi_appliances_items` (
   KEY `item` (`itemtype`,`items_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
-
-CREATE TABLE IF NOT EXISTS `glpi_appliancetypes` (
+DROP TABLE IF EXISTS `glpi_appliancetypes`;
+CREATE TABLE `glpi_appliancetypes` (
   `id` int NOT NULL AUTO_INCREMENT,
   `entities_id` int NOT NULL DEFAULT '0',
   `is_recursive` tinyint NOT NULL DEFAULT '0',
@@ -8170,8 +8170,8 @@ CREATE TABLE IF NOT EXISTS `glpi_appliancetypes` (
   UNIQUE (`externalidentifier`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
-
-CREATE TABLE IF NOT EXISTS `glpi_applianceenvironments` (
+DROP TABLE IF EXISTS `glpi_applianceenvironments`;
+CREATE TABLE `glpi_applianceenvironments` (
   `id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(255) DEFAULT NULL,
   `comment` text,
@@ -8179,7 +8179,8 @@ CREATE TABLE IF NOT EXISTS `glpi_applianceenvironments` (
   KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
-CREATE TABLE IF NOT EXISTS `glpi_appliances_items_relations` (
+DROP TABLE IF EXISTS `glpi_appliances_items_relations`;
+CREATE TABLE `glpi_appliances_items_relations` (
   `id` int NOT NULL AUTO_INCREMENT,
   `appliances_items_id` int NOT NULL DEFAULT '0',
   `itemtype` varchar(100) NOT NULL,

--- a/tests/units/Glpi/System/Diagnostic/DatabaseChecker.php
+++ b/tests/units/Glpi/System/Diagnostic/DatabaseChecker.php
@@ -63,6 +63,69 @@ SQL
             'expected_diff'  => '',
          ],
 
+         // Check should detect missing keys and columns.
+         [
+            'proper_sql'     => <<<SQL
+CREATE TABLE `table` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `content` text,
+  `field` text,
+  `computers_id` tinyint NOT NULL,
+  `is_valid` tinyint NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unicity` (`computers_id`,`is_valid`),
+  UNIQUE KEY `name` (`name`),
+  FULLTEXT KEY `content` (`content`),
+  FULLTEXT KEY `field` (`field`),
+  KEY `computers_id` (`computers_id`),
+  KEY `is_valid` (`is_valid`)
+) ENGINE=InnoDB ROW_FORMAT=DYNAMIC
+SQL
+            ,
+            'effective_sql'  => <<<SQL
+CREATE TABLE `table` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `content` text,
+  `is_valid` tinyint NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`),
+  FULLTEXT KEY `content` (`content`),
+  KEY `is_valid` (`is_valid`),
+) ENGINE=InnoDB
+SQL
+            ,
+            'version_string' => '5.7.34-standard',
+            'args'           => [
+               'strict' => false,
+            ],
+            'expected_has'   => true,
+            'expected_diff'  => <<<DIFF
+--- Original
++++ New
+@@ @@
+ CREATE TABLE `table` (
+-  `computers_id` tinyint NOT NULL,
+   `content` text,
+-  `field` text,
+   `id` int NOT NULL AUTO_INCREMENT,
+   `is_valid` tinyint NOT NULL,
+   `name` varchar(255) NOT NULL,
+   FULLTEXT KEY `content` (`content`),
+-  FULLTEXT KEY `field` (`field`),
+-  KEY `computers_id` (`computers_id`),
+   KEY `is_valid` (`is_valid`),
+   PRIMARY KEY (`id`),
+-  UNIQUE KEY `name` (`name`),
+-  UNIQUE KEY `unicity` (`computers_id`,`is_valid`)
++  UNIQUE KEY `name` (`name`)
+ ) ENGINE=InnoDB
+
+DIFF
+            ,
+         ],
+
          // Non strict check does not take care of columns/indexes order and ROW_FORMAT.
          [
             'proper_sql'     => <<<SQL


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Some tables were not detected due to usage of `IF NOT EXISTS`.

I fixed some minor issues on these tables declaration, added missing `DROP TABLE` instructions, and removed these `IF NOT EXISTS`.