### PR TITLE
fix(core): use CommonDBTM instead of CommonDropdown

### DIFF
--- a/inc/line.class.php
+++ b/inc/line.class.php
@@ -38,7 +38,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
-class Line extends CommonDropdown {
+class Line extends CommonDBTM {
    // From CommonDBTM
    public $dohistory                   = true;
 

--- a/inc/line.class.php
+++ b/inc/line.class.php
@@ -180,11 +180,37 @@ class Line extends CommonDBTM {
       $tab = array_merge($tab, Location::rawSearchOptionsToAdd());
 
       $tab[] = [
+            'id'                 => '2',
+            'table'              => $this->getTable(),
+            'field'              => 'id',
+            'name'               => __('ID'),
+            'massiveaction'      => false,
+            'datatype'           => 'number'
+      ];
+
+      $tab[] = [
             'id'                 => '4',
             'table'              => 'glpi_linetypes',
             'field'              => 'name',
             'name'               => LineType::getTypeName(1),
             'datatype'           => 'dropdown',
+      ];
+
+      $tab[] = [
+            'id'                 => '16',
+            'table'              => $this->getTable(),
+            'field'              => 'comment',
+            'name'               => __('Comments'),
+            'datatype'           => 'text'
+      ];
+
+      $tab[] = [
+            'id'                 => '19',
+            'table'              => $this->getTable(),
+            'field'              => 'date_mod',
+            'name'               => __('Last update'),
+            'datatype'           => 'datetime',
+            'massiveaction'      => false
       ];
 
       $tab[] = [
@@ -212,6 +238,24 @@ class Line extends CommonDBTM {
             'name'               => Group::getTypeName(1),
             'condition'          => ['is_itemgroup' => 1],
             'datatype'           => 'dropdown'
+      ];
+
+      $tab[] = [
+            'id'                 => '80',
+            'table'              => 'glpi_entities',
+            'field'              => 'completename',
+            'name'               => __('Entity'),
+            'massiveaction'      => false,
+            'datatype'           => 'dropdown'
+      ];
+
+      $tab[] = [
+            'id'                 => '121',
+            'table'              => $this->getTable(),
+            'field'              => 'date_creation',
+            'name'               => __('Creation date'),
+            'datatype'           => 'datetime',
+            'massiveaction'      => false
       ];
 
       $tab[] = [


### PR DESCRIPTION
Original problem :

When creating a line with location, the line takes the entity of the location unlike certificates, for example

The inheritance of the class "line" has changed from ```CommonDBTM``` to ```CommonDropDown``` (I don't know why)


This PR revert commit https://github.com/glpi-project/glpi/commit/8052033582dc58eb6f90b256db4c436d3104f4e7#diff-7d3f7c2f1bdbb4c5a110fffc4d89bd93fd223c1cdad4d0b9698aae74344cda83R41

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 21479
