### PR TITLE
Fix CI 'Show version' step

### DIFF
--- a/.github/actions/init_show-versions.sh
+++ b/.github/actions/init_show-versions.sh
@@ -5,4 +5,4 @@ docker exec app php -r 'echo(sprintf("PHP extensions: %s\n", implode(", ", get_l
 docker exec app composer --version
 docker exec app sh -c 'echo "node $(node --version)"'
 docker exec app sh -c 'echo "npm $(npm --version)"'
-[ ! "$(docker ps -a | grep db)" ] || docker exec db mysql --version
+[ ! "$(docker ps -q -f name=db)" ] || docker exec db mysql --version


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Using a `grep db` on docker container list may return entries that are not related to the container having the name `db`.
Example:
![image](https://user-images.githubusercontent.com/33253653/107535500-13348000-6bc1-11eb-979c-7388ff9b43e4.png)

1. It is safer to rely on the `name=db` filter.
2. The `-a` option is useless as we should test ionly running containers (not all).
3. The `-q` option removes the headers to be sure to have an empty string if no cotnainer matches given name.

Prevents this error:
![image](https://user-images.githubusercontent.com/33253653/107536334-f3518c00-6bc1-11eb-9268-0d4e382c84b2.png)
