### PR TITLE
Improved Status Checking

### DIFF
--- a/inc/console/system/checkstatuscommand.class.php
+++ b/inc/console/system/checkstatuscommand.class.php
@@ -41,6 +41,7 @@ use Glpi\System\Status\StatusChecker;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Toolbox;
 
 class CheckStatusCommand extends AbstractCommand {
 
@@ -66,6 +67,7 @@ class CheckStatusCommand extends AbstractCommand {
       if ($format === 'json') {
          $output->writeln(json_encode($status, JSON_PRETTY_PRINT));
       } else {
+         Toolbox::deprecated('Plain-text status output is deprecated please use the JSON format instead by specifically using the "--format json" parameter. In the future, JSON output will be the default.');
          $output->writeln($status);
       }
 

--- a/inc/console/system/listservicecommand.class.php
+++ b/inc/console/system/listservicecommand.class.php
@@ -60,7 +60,6 @@ class ListServiceCommand extends AbstractCommand {
 
       $services = array_keys(StatusChecker::getServices());
 
-
       if ($format === 'json') {
          $output->writeln(json_encode($services, JSON_PRETTY_PRINT));
       } else {

--- a/inc/console/system/listservicecommand.class.php
+++ b/inc/console/system/listservicecommand.class.php
@@ -51,7 +51,7 @@ class ListServicesCommand extends AbstractCommand {
       $this->setAliases(['system:list_services']);
       $this->setDescription(__('List system services'));
       $this->addOption('format', 'f', InputOption::VALUE_OPTIONAL,
-         'Output format [plain or json]', 'plain');
+         'Output format [json]', 'plain');
    }
 
    protected function execute(InputInterface $input, OutputInterface $output) {

--- a/inc/console/system/listservicecommand.class.php
+++ b/inc/console/system/listservicecommand.class.php
@@ -58,9 +58,7 @@ class ListServiceCommand extends AbstractCommand {
 
       $format = strtolower($input->getOption('format'));
 
-      $services = [
-         'db', 'cas', 'ldap', 'imap', 'mail_collectors', 'crontasks', 'filesystem', 'glpi', 'plugins'
-      ];
+      $services = array_keys(StatusChecker::getServices());
 
 
       if ($format === 'json') {

--- a/inc/console/system/listservicecommand.class.php
+++ b/inc/console/system/listservicecommand.class.php
@@ -42,13 +42,13 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ListServiceCommand extends AbstractCommand {
+class ListServicesCommand extends AbstractCommand {
 
    protected function configure() {
       parent::configure();
 
-      $this->setName('glpi:system:service:list');
-      $this->setAliases(['system:service:list']);
+      $this->setName('glpi:system:list_services');
+      $this->setAliases(['system:list_services']);
       $this->setDescription(__('List system services'));
       $this->addOption('format', 'f', InputOption::VALUE_OPTIONAL,
          'Output format [plain or json]', 'plain');

--- a/inc/console/system/listservicecommand.class.php
+++ b/inc/console/system/listservicecommand.class.php
@@ -42,31 +42,33 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CheckStatusCommand extends AbstractCommand {
+class ListServiceCommand extends AbstractCommand {
 
    protected function configure() {
       parent::configure();
 
-      $this->setName('glpi:system:status');
-      $this->setAliases(['system:status']);
-      $this->setDescription(__('Check system status'));
+      $this->setName('glpi:system:service:list');
+      $this->setAliases(['system:service:list']);
+      $this->setDescription(__('List system services'));
       $this->addOption('format', 'f', InputOption::VALUE_OPTIONAL,
          'Output format [plain or json]', 'plain');
-      $this->addOption('private', 'p', InputOption::VALUE_NONE,
-         'Status information publicity. Private status information may contain potentially sensitive information such as version information.');
-      $this->addOption('service', 's', InputOption::VALUE_OPTIONAL,
-         'The service to check or all', 'all');
    }
 
    protected function execute(InputInterface $input, OutputInterface $output) {
 
       $format = strtolower($input->getOption('format'));
-      $status = StatusChecker::getServiceStatus($input->getOption('service'), !$input->getOption('private'), $format === 'json');
+
+      $services = [
+         'db', 'cas', 'ldap', 'imap', 'mail_collectors', 'crontasks', 'filesystem', 'glpi', 'plugins'
+      ];
+
 
       if ($format === 'json') {
-         $output->writeln(json_encode($status, JSON_PRETTY_PRINT));
+         $output->writeln(json_encode($services, JSON_PRETTY_PRINT));
       } else {
-         $output->writeln($status);
+         foreach ($services as $service) {
+            $output->writeln($service);
+         }
       }
 
       return 0; // Success

--- a/inc/console/system/listservicescommand.class.php
+++ b/inc/console/system/listservicescommand.class.php
@@ -50,23 +50,11 @@ class ListServicesCommand extends AbstractCommand {
       $this->setName('glpi:system:list_services');
       $this->setAliases(['system:list_services']);
       $this->setDescription(__('List system services'));
-      $this->addOption('format', 'f', InputOption::VALUE_OPTIONAL,
-         'Output format [json]', 'plain');
    }
 
    protected function execute(InputInterface $input, OutputInterface $output) {
-
-      $format = strtolower($input->getOption('format'));
-
       $services = array_keys(StatusChecker::getServices());
-
-      if ($format === 'json') {
-         $output->writeln(json_encode($services, JSON_PRETTY_PRINT));
-      } else {
-         foreach ($services as $service) {
-            $output->writeln($service);
-         }
-      }
+      $output->writeln(json_encode($services, JSON_PRETTY_PRINT));
 
       return 0; // Success
    }

--- a/inc/console/system/listservicescommand.class.php
+++ b/inc/console/system/listservicescommand.class.php
@@ -39,7 +39,6 @@ if (!defined('GLPI_ROOT')) {
 use Glpi\Console\AbstractCommand;
 use Glpi\System\Status\StatusChecker;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListServicesCommand extends AbstractCommand {

--- a/inc/system/status/statuschecker.class.php
+++ b/inc/system/status/statuschecker.class.php
@@ -71,6 +71,12 @@ final class StatusChecker {
     */
    public const STATUS_NO_DATA = 'NO_DATA';
 
+   /**
+    * Get all registered services
+    * @return array Array of services keyed by name.
+    *    The value for each service is expected to be an array containing a class name and a method name relating to the method that will do the check.
+    * @since x.x.x
+    */
    public static function getServices(): array {
       return [
          'db'              => [self::class, 'getDBStatus'],
@@ -84,6 +90,13 @@ final class StatusChecker {
       ];
    }
 
+   /**
+    * Calculate the overall GLPI status or the overall service status based on all child status checks
+    * @param array $status The status array for all services or a specific service check.
+    * @return string The calculated status.
+    *    One of {@link STATUS_NO_DATA}, {@link STATUS_OK}, {@link STATUS_WARNING}, or {@link STATUS_PROBLEM}.
+    * @since x.x.x
+    */
    public static function calculateGlobalStatus(array $status)
    {
       $statuses = array_column($status, 'status');
@@ -96,6 +109,16 @@ final class StatusChecker {
       return $global_status;
    }
 
+   /**
+    * Get a service's status
+    *
+    * @param string|null $service The name of the service or if null/'all' all services will be checked
+    * @param bool $public_only True if only public information should be available in the status check.
+    *    If true, assume the data is being viewed by an anonymous user.
+    * @param bool $as_array True if the service check result should be returned as an array instead of a plain-text string.
+    * @return array|string An array or string with the result based on the $as_array parameter value.
+    * @since x.x.x
+    */
    public static function getServiceStatus(?string $service, $public_only = true, $as_array = true) {
       $services = self::getServices();
       if ($service === 'all' || $service === null) {
@@ -507,6 +530,7 @@ final class StatusChecker {
    }
 
    /**
+    * Format the given full service status result as a plain-text output compatible with previous versions of GLPI.
     * @param array $status
     * @return string
     * @deprecated x.x.x

--- a/inc/system/status/statuschecker.class.php
+++ b/inc/system/status/statuschecker.class.php
@@ -55,6 +55,11 @@ final class StatusChecker {
    public const STATUS_OK = 'OK';
 
    /**
+    * The plugin or service is working but may have some issues
+    */
+   public const STATUS_WARNING = 'WARNING';
+
+   /**
     * The plugin or service is reachable but not working as expected.
     */
    public const STATUS_PROBLEM = 'PROBLEM';
@@ -496,8 +501,13 @@ final class StatusChecker {
          ];
          // Compute GLPI status from top-level services
          $statuses = array_column($status, 'status');
-         $all_ok = !in_array(self::STATUS_PROBLEM, $statuses, true);
-         $status['glpi']['status'] = $all_ok ? self::STATUS_OK : self::STATUS_PROBLEM;
+         $global_status = self::STATUS_OK;
+         if (in_array(self::STATUS_PROBLEM, $statuses, true)) {
+            $global_status = self::STATUS_PROBLEM;
+         } else if (in_array(self::STATUS_WARNING, $statuses, true)) {
+            $global_status = self::STATUS_WARNING;
+         }
+         $status['glpi']['status'] = $global_status ? self::STATUS_OK : self::STATUS_PROBLEM;
       }
 
       // Only show overall core status for public

--- a/inc/system/status/statuschecker.class.php
+++ b/inc/system/status/statuschecker.class.php
@@ -446,11 +446,15 @@ final class StatusChecker {
 
          foreach ($plugins as $plugin) {
             // Old-style plugin status hook which only modified the global OK status.
-            $param = ['ok' => true];
+            $param = [
+               'ok' => true,
+               '_public_only' => $public_only
+            ];
             $plugin_status = Plugin::doOneHook($plugin, 'status', $param);
             if ($plugin_status === null) {
                continue;
             }
+            unset($plugin_status['_public_only']);
             if (isset($plugin_status['ok']) && count(array_keys($plugin_status)) === 1) {
                $status[$plugin] = [
                   'status'    => $plugin_status['ok'] ? self::STATUS_OK : self::STATUS_PROBLEM,

--- a/inc/system/status/statuschecker.class.php
+++ b/inc/system/status/statuschecker.class.php
@@ -97,8 +97,7 @@ final class StatusChecker {
     *    One of {@link STATUS_NO_DATA}, {@link STATUS_OK}, {@link STATUS_WARNING}, or {@link STATUS_PROBLEM}.
     * @since x.x.x
     */
-   public static function calculateGlobalStatus(array $status)
-   {
+   public static function calculateGlobalStatus(array $status) {
       $statuses = array_column($status, 'status');
       $global_status = self::STATUS_OK;
       if (in_array(self::STATUS_PROBLEM, $statuses, true)) {
@@ -535,8 +534,7 @@ final class StatusChecker {
     * @return string
     * @deprecated x.x.x
     */
-   private static function getPlaintextOutput(array $status): string
-   {
+   private static function getPlaintextOutput(array $status): string {
       // Deprecated notices are done on the /status.php endpoint and CLI commands to give better migration hints
       $output = '';
       // Plain-text output

--- a/inc/system/status/statuschecker.class.php
+++ b/inc/system/status/statuschecker.class.php
@@ -84,7 +84,7 @@ final class StatusChecker {
       ];
    }
 
-   private static function calculateGlobalStatus(array $status)
+   public static function calculateGlobalStatus(array $status)
    {
       $statuses = array_column($status, 'status');
       $global_status = self::STATUS_OK;
@@ -502,7 +502,7 @@ final class StatusChecker {
     * @deprecated x.x.x Use {@link self::getServiceStatus} instead
     */
    public static function getFullStatus($public_only = true, $as_array = true) {
-      //Toolbox::deprecated('Use StatusChecker::getServiceStatus for service checks instead');
+      Toolbox::deprecated('Use StatusChecker::getServiceStatus for service checks instead');
       return self::getServiceStatus(null, $public_only, $as_array);
    }
 

--- a/inc/system/status/statuschecker.class.php
+++ b/inc/system/status/statuschecker.class.php
@@ -103,7 +103,6 @@ final class StatusChecker {
          }
       }
 
-
       if (!array_key_exists($service, $services)) {
          return $as_array ? [] : '';
       }

--- a/status.php
+++ b/status.php
@@ -47,10 +47,13 @@ $fallback_response_type = 'text/plain';
 if (!isset($_SERVER['HTTP_ACCEPT']) || !in_array($_SERVER['HTTP_ACCEPT'], $valid_response_types, true)) {
    $_SERVER['HTTP_ACCEPT'] = $fallback_response_type;
 }
+if ($_SERVER['HTTP_ACCEPT'] === 'text/plain') {
+   Toolbox::deprecated('Plain-text status output is deprecated please use the JSON format instead by specifically setting the Accept header to "application/json". In the future, JSON output will be the default.');
+}
 header('Content-type: ' . $_SERVER['HTTP_ACCEPT']);
 
 if ($_SERVER['HTTP_ACCEPT'] === 'application/json') {
-   echo json_encode(StatusChecker::getFullStatus(true, true));
+   echo json_encode(StatusChecker::getServiceStatus(null, true, true));
 } else {
-   echo StatusChecker::getFullStatus(true, false);
+   echo StatusChecker::getServiceStatus(null, true, false);
 }

--- a/tests/functionnal/Glpi/System/Status/StatusChecker.php
+++ b/tests/functionnal/Glpi/System/Status/StatusChecker.php
@@ -166,8 +166,7 @@ class StatusChecker extends DbTestCase {
       // afterTestMethod will rollback the DB changes for us
    }
 
-   protected function getCalculatedGlobalStatusProvider()
-   {
+   protected function getCalculatedGlobalStatusProvider() {
       return [
          [
             [
@@ -216,13 +215,11 @@ class StatusChecker extends DbTestCase {
     * @dataProvider getCalculatedGlobalStatusProvider
     * @param $status
     */
-   public function testGetCalculateGlobalStatus($status, $expected)
-   {
+   public function testGetCalculateGlobalStatus($status, $expected) {
       $this->string(GlpiStatusChecker::calculateGlobalStatus($status))->isEqualTo($expected);
    }
 
-   public function testGetServiceStatus()
-   {
+   public function testGetServiceStatus() {
       $services = GlpiStatusChecker::getServices();
       $this->boolean(is_array($services))->isTrue();
 

--- a/tests/functionnal/Glpi/System/Status/StatusChecker.php
+++ b/tests/functionnal/Glpi/System/Status/StatusChecker.php
@@ -41,15 +41,15 @@ use Glpi\System\Status\StatusChecker as GlpiStatusChecker;
 class StatusChecker extends DbTestCase {
 
    public function testStatusFormats() {
-      $status = GlpiStatusChecker::getFullStatus(true);
+      $status = GlpiStatusChecker::getServiceStatus(null, true);
       $this->boolean(is_array($status))->isTrue();
 
-      $status = GlpiStatusChecker::getFullStatus(true, false);
+      $status = GlpiStatusChecker::getServiceStatus(null, true, false);
       $this->boolean(is_string($status))->isTrue();
    }
 
    public function testDefaultStatus() {
-      $status = GlpiStatusChecker::getFullStatus(true);
+      $status = GlpiStatusChecker::getServiceStatus(null, true);
 
       $known_services = ['db', 'cas', 'ldap', 'imap', 'mail_collectors', 'crontasks', 'filesystem', 'glpi', 'plugins'];
       // Check we are getting all of the expected services
@@ -144,7 +144,7 @@ class StatusChecker extends DbTestCase {
          'state'        => \CronTask::STATE_RUNNING,
       ]);
 
-      $status = GlpiStatusChecker::getFullStatus(true);
+      $status = GlpiStatusChecker::getServiceStatus(null, true, true);
 
       // Test overall status is PROBLEM
       $this->string($status['glpi']['status'])->isEqualTo(GlpiStatusChecker::STATUS_PROBLEM);
@@ -164,5 +164,90 @@ class StatusChecker extends DbTestCase {
       $this->array($status['crontasks']['stuck'])->size->isEqualTo(2);
 
       // afterTestMethod will rollback the DB changes for us
+   }
+
+   protected function getCalculatedGlobalStatusProvider()
+   {
+      return [
+         [
+            [
+               'db'  => ['status' => GlpiStatusChecker::STATUS_OK],
+               'cas'  => ['status' => GlpiStatusChecker::STATUS_OK],
+               'ldap'  => ['status' => GlpiStatusChecker::STATUS_OK]
+            ],
+            GlpiStatusChecker::STATUS_OK
+         ],
+         [
+            [
+               'db'  => ['status' => GlpiStatusChecker::STATUS_OK],
+               'cas'  => ['status' => GlpiStatusChecker::STATUS_WARNING],
+               'ldap'  => ['status' => GlpiStatusChecker::STATUS_OK]
+            ],
+            GlpiStatusChecker::STATUS_WARNING
+         ],
+         [
+            [
+               'db'  => ['status' => GlpiStatusChecker::STATUS_OK],
+               'cas'  => ['status' => GlpiStatusChecker::STATUS_OK],
+               'ldap'  => ['status' => GlpiStatusChecker::STATUS_PROBLEM]
+            ],
+            GlpiStatusChecker::STATUS_PROBLEM
+         ],
+         [
+            [
+               'db'  => ['status' => GlpiStatusChecker::STATUS_NO_DATA],
+               'cas'  => ['status' => GlpiStatusChecker::STATUS_OK],
+               'ldap'  => ['status' => GlpiStatusChecker::STATUS_OK]
+            ],
+            GlpiStatusChecker::STATUS_OK
+         ],
+         [
+            [
+               'db'  => ['status' => GlpiStatusChecker::STATUS_NO_DATA],
+               'cas'  => ['status' => GlpiStatusChecker::STATUS_WARNING],
+               'ldap'  => ['status' => GlpiStatusChecker::STATUS_PROBLEM]
+            ],
+            GlpiStatusChecker::STATUS_PROBLEM
+         ]
+      ];
+   }
+
+   /**
+    * @dataProvider getCalculatedGlobalStatusProvider
+    * @param $status
+    */
+   public function testGetCalculateGlobalStatus($status, $expected)
+   {
+      $this->string(GlpiStatusChecker::calculateGlobalStatus($status))->isEqualTo($expected);
+   }
+
+   public function testGetServiceStatus()
+   {
+      $services = GlpiStatusChecker::getServices();
+      $this->boolean(is_array($services))->isTrue();
+
+      foreach ($services as $name => $callback) {
+         $this->boolean(is_string($name))->isTrue();
+
+         $this->boolean(is_array($callback))->isTrue();
+         $this->integer(count($callback))->isEqualTo(2);
+         $this->boolean(method_exists($callback[0], $callback[1]))->isTrue();
+
+         $status = GlpiStatusChecker::getServiceStatus($name, true);
+         $this->boolean(is_array($status))->isTrue();
+         $this->array($status)->hasKey('status');
+
+         $status = GlpiStatusChecker::getServiceStatus($name, false);
+         $this->boolean(is_array($status))->isTrue();
+         $this->array($status)->hasKey('status');
+
+         $status = GlpiStatusChecker::getServiceStatus($name, true, false);
+         $this->boolean(is_string($status))->isTrue();
+         $this->string($status)->isNotEmpty();
+
+         $status = GlpiStatusChecker::getServiceStatus($name, false, false);
+         $this->boolean(is_string($status))->isTrue();
+         $this->string($status)->isNotEmpty();
+      }
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

As GLPI and plugins become more complex and reliant on external services/systems it becomes more likely that a configuration or connectivity issue (In GLPI or the external service) could partially or completely break GLPI or the plugins, and it becomes more necessary to monitor and alert on these issues.
The goal of this PR is to make it easier to monitor GLPI. In some monitoring software, it may be inconvenient to do that with the previous implementation because all status checks were done together and returned as a single result which is slow and inefficient if you only want to check one or two things. The goal is to have the option to break up these checks and allow each "service" to be monitored at differing intervals, under separate services in the monitoring software, skipped completely, etc.

- [x] Break up the different status checks into different "services" (DB, Email, Automatic Actions, etc) which can be checked individually instead of all at once to allow administrators to more easily monitor each one more efficiently. Leaving out the service name or using the name "all" will check everything as before.
- [x] Add command to list all available services
- [x] Add warning level in addition to the existing OK and Problem statuses which can be used to describe a service that works, at least partially, but may not be working as best as it should. There is nothing in the core that uses it now, but it is taken into account for the overall system status calculation in case it is used in the future or if a plugin uses it.
- [x] Pass a parameter to the plugin hook so plugins can add more or less information based on if only public information is requested (using public status endpoint instead of the console with -p flag) or not.

- [x] Provide compatible output for previous full status check with a plain-text format. JSON output should already be the same.

New Commands Examples:
```
$ bin/console system:service:list
db
cas
ldap
imap
mail_collectors
crontasks
filesystem
plugins
```
```
$ bin/console system:status -service db
DB_OK
```
```
$ bin/console system:status -s db -f json
{
    "status": "OK",
    "master": {
        "status": "OK"
    },
    "slaves": {
        "status": "NO_DATA",
        "servers": []
    }
}
```