### PR TITLE
Add ticket rule action : add task template

### DIFF
--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -238,6 +238,25 @@ class RuleTicket extends Rule {
                      }
                   }
 
+                  // special case of task template
+                  if ($action->fields["field"] == 'task_template') {
+                     //load template
+                     $template = new TaskTemplate();
+                     if ($template->getFromDB($action->fields["value"]) && $output['id'] != null) {
+                        $task = new TicketTask();
+                        $task->add([
+                                      "taskcategories_id" => $template->getField("taskcategories_id"),
+                                      "users_id_tech"     => $template->getField("users_id_tech"),
+                                      "groups_id_tech"    => $template->getField("groups_id_tech"),
+                                      "tasktemplates_id"  => $template->getField("id"),
+                                      "state"             => $template->getField("state"),
+                                      "is_private"        => $template->getField("is_private"),
+                                      "actiontime"        => $template->getField("actiontime"),
+                                      "content"           => Toolbox::addslashes_deep($template->getField('content')),
+                                      "tickets_id"        => $output['id']]);
+                     }
+                  }
+
                   break;
 
                case "append" :
@@ -767,6 +786,11 @@ class RuleTicket extends Rule {
       $actions['solution_template']['type']                  = 'dropdown';
       $actions['solution_template']['table']                 = 'glpi_solutiontemplates';
       $actions['solution_template']['force_actions']         = ['assign'];
+
+      $actions['task_template']['name']                  = _n('Task template', 'Task templates', 1);
+      $actions['task_template']['type']                  = 'dropdown';
+      $actions['task_template']['table']                 = 'glpi_tasktemplates';
+      $actions['task_template']['force_actions']         = ['assign'];
 
       return $actions;
    }

--- a/tests/functionnal/RuleTicket.php
+++ b/tests/functionnal/RuleTicket.php
@@ -484,12 +484,12 @@ class RuleTicket extends DbTestCase {
 
    }
 
-   public function testTicketTasknAssignFromRule() {
+   public function testTicketTaskAssignFromRule() {
       $this->login();
 
-      // Create solution template
+      // Create task template
       $taskTemplate = new \TaskTemplate();
-      $taskTemplate_id = $taskTemplate->add($solutionInput = [
+      $taskTemplate_id = $taskTemplate->add($taskInput = [
          'content' => Toolbox::addslashes_deep("content of task template  white ' quote")
       ]);
       $this->integer((int)$taskTemplate_id)->isGreaterThan(0);

--- a/tests/functionnal/RuleTicket.php
+++ b/tests/functionnal/RuleTicket.php
@@ -544,7 +544,7 @@ class RuleTicket extends DbTestCase {
       $ticketTask = new \TicketTask();
       $this->boolean($ticketTask->getFromDBByCrit(['items_id'            => $tickets_id,
                                                    'itemtype'              => 'Ticket',
-                                                   'content'               => Toolbox::addslashes_deep("content of solution template  white ' quote")]))->isTrue();
+                                                   'content'               => Toolbox::addslashes_deep("content of task template  white ' quote")]))->isTrue();
 
       $this->integer((int)$ticketTask->getID())->isGreaterThan(0);
 


### PR DESCRIPTION
This is a new feature for ticket rules. It adds a new action for adding task templates.
I couldn't pass the tests because there was an error on the composer install with the master.
logs error : 
> @php -r "file_put_contents('.composer.hash', sha1_file('composer.lock'));"
> patch -f -p1 -d vendor/tecnickcom/tcpdf/ < tools/tcpdf-php8-compat.patch || echo 'Error applying patch, deprecation warnings related to TCPDF lib may pollute logs'
(Stripping trailing CRs from patch; use --binary to disable.)
patching file include/tcpdf_fonts.php
Hunk #1 FAILED at 1995.
Hunk #2 FAILED at 2021.
Hunk #3 FAILED at 2037.
Hunk #4 FAILED at 2057.
Hunk #5 FAILED at 2074.
Hunk #6 FAILED at 2090.
6 out of 6 hunks FAILED -- saving rejects to file include/tcpdf_fonts.php.rej


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ?
