### PR TITLE
Do no delete default profiles if no rules were applied

### DIFF
--- a/inc/profile_user.class.php
+++ b/inc/profile_user.class.php
@@ -100,12 +100,6 @@ class Profile_User extends CommonDBRelation {
          return false;
       }
 
-      if (isset($input['profiles_id']) && !empty($input['profiles_id'])) {
-         if ($input['profiles_id'] == Profile::getDefault()) {
-            $input['is_default_profile'] = true;
-         }
-      }
-
       return parent::prepareInputForAdd($input);
    }
 

--- a/inc/profile_user.class.php
+++ b/inc/profile_user.class.php
@@ -99,6 +99,13 @@ class Profile_User extends CommonDBRelation {
                                           false, ERROR);
          return false;
       }
+
+      if (isset($input['profiles_id']) && !empty($input['profiles_id'])) {
+         if ($input['profiles_id'] == Profile::getDefault()) {
+            $input['is_default_profile'] = true;
+         }
+      }
+
       return parent::prepareInputForAdd($input);
    }
 

--- a/inc/update.class.php
+++ b/inc/update.class.php
@@ -488,6 +488,11 @@ class Update extends CommonGLPI {
             update953to954();
             break;
 
+         case "9.5.3":
+            include_once "{$updir}update_953_954.php";
+            update953to954();
+            break;
+
          case GLPI_VERSION:
          case GLPI_SCHEMA_VERSION:
             break;

--- a/inc/update.class.php
+++ b/inc/update.class.php
@@ -488,11 +488,6 @@ class Update extends CommonGLPI {
             update953to954();
             break;
 
-         case "9.5.3":
-            include_once "{$updir}update_953_954.php";
-            update953to954();
-            break;
-
          case GLPI_VERSION:
          case GLPI_SCHEMA_VERSION:
             break;

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -679,6 +679,7 @@ class User extends CommonDBTM {
             $profile                   = Profile::getDefault();
             // Default right as dynamic. If dynamic rights are set it will disappear.
             $affectation['is_dynamic'] = 1;
+            $affectation['is_default_profile'] = 1;
          }
 
          if ($profile) {
@@ -1052,10 +1053,12 @@ class User extends CommonDBTM {
             $return = true;
          } else if (count($dynamic_profiles) == 1) {
             $dynamic_profile = reset($dynamic_profiles);
-            $default_profile = Profile::getDefault();
+
             // If no rule applied and only one dynamic profile found, check if
             // it is the default profile
             if ($dynamic_profile['is_default_profile'] == true) {
+               $default_profile = Profile::getDefault();
+
                // Remove from to be deleted list
                $dynamic_profiles = [];
 

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -1050,6 +1050,25 @@ class User extends CommonDBTM {
             unset($this->input["_ldap_rules"]);
 
             $return = true;
+         } else if (count($dynamic_profiles) == 1) {
+            $dynamic_profile = reset($dynamic_profiles);
+            $default_profile = Profile::getDefault();
+            // If no rule applied and only one dynamic profile found, check if
+            // it is the default profile
+            if ($dynamic_profile['is_default_profile'] == true) {
+               // Remove from to be deleted list
+               $dynamic_profiles = [];
+
+               // Update profile if need to match the current default profile
+               if ($dynamic_profile['profiles_id'] !== $default_profile) {
+                  $pu = new Profile_User();
+                  $dynamic_profile['profiles_id'] = $default_profile;
+                  $pu->add($dynamic_profile);
+                  $pu->delete([
+                     'id' => $dynamic_profile['id']
+                  ]);
+               }
+            }
          }
 
          // Delete old dynamic profiles

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -5277,6 +5277,7 @@ CREATE TABLE `glpi_profiles_users` (
   `entities_id` int(11) NOT NULL DEFAULT '0',
   `is_recursive` tinyint(1) NOT NULL DEFAULT '1',
   `is_dynamic` tinyint(1) NOT NULL DEFAULT '0',
+  `is_default_profile` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `entities_id` (`entities_id`),
   KEY `profiles_id` (`profiles_id`),

--- a/install/update_953_954.php
+++ b/install/update_953_954.php
@@ -38,7 +38,7 @@
 function update953to954() {
    global $DB, $migration;
 
-   $updateresult     = true;
+   $updateresult = true;
 
    //TRANS: %s is the number of new version
    $migration->displayTitle(sprintf(__('Update to %s'), '9.5.4'));
@@ -47,6 +47,10 @@ function update953to954() {
    /* Remove invalid Profile SO */
    $DB->delete('glpi_displaypreferences', ['itemtype' => 'Profile', 'num' => 62]);
    /* /Remove invalid Profile SO */
+
+   /* Add is_default_profile */
+   $migration->addField("glpi_profiles_users", "is_default_profile", "bool");
+   /* /Add is_default_profile */
 
    // ************ Keep it at the end **************
    $migration->executeMigration();

--- a/tests/units/RuleRight.php
+++ b/tests/units/RuleRight.php
@@ -161,6 +161,7 @@ class RuleRight extends DbTestCase {
       ];
 
       $user = new \User();
+      $this->login();
       $users_id = $user->add($testuser);
       $this->integer($users_id)->isGreaterThan(0);
 
@@ -182,9 +183,7 @@ class RuleRight extends DbTestCase {
       $right2 = array_pop($pu);
       $this->array($right2)->isEqualTo($right);
 
-      $_SESSION['glpiactiveprofile']['user'] = 7327;
-      $_SESSION['glpiactiveprofile']['profile'] = 23;
-
+      $this->login();
       // Change the $right profile, since this is the default profile it should
       // be fixed on next login
       $pu = new \Profile_User();
@@ -197,7 +196,6 @@ class RuleRight extends DbTestCase {
       $this->integer($pu->fields['is_default_profile'])->isEqualTo(1);
       $this->integer($pu->fields['is_dynamic'])->isEqualTo(1);
 
-      $this->login(TU_USER, TU_PASS, false);
       $this->login($testuser['name'], $testuser['password'], false);
       $pu = \Profile_User::getForUser($users_id, true);
       $this->array($pu)->hasSize(1);
@@ -209,6 +207,6 @@ class RuleRight extends DbTestCase {
       $this->array($right3)->isEqualTo($right);
 
       // Clean session
-      $this->login(TU_USER, TU_PASS, false);
+      $this->login();
    }
 }

--- a/tests/units/RuleRight.php
+++ b/tests/units/RuleRight.php
@@ -152,4 +152,63 @@ class RuleRight extends DbTestCase {
       }
       $this->boolean($found)->isFalse();
    }
+
+   public function testLocalAccountNoRules() {
+      $testuser = [
+         'name'      => 'testuser',
+         'password'  => 'test',
+         'password2' => 'test',
+      ];
+
+      $user = new \User();
+      $users_id = $user->add($testuser);
+      $this->integer($users_id)->isGreaterThan(0);
+
+      // Get rights
+      $pu = \Profile_User::getForUser($users_id, true);
+
+      // User should have a single dynamic right
+      $this->array($pu)->hasSize(1);
+      $right = array_pop($pu);
+      $this->integer($right['is_dynamic'])->isEqualTo(1);
+      $this->integer($right['is_default_profile'])->isEqualTo(1);
+
+      // Log in to force rules right processing
+      $this->login($testuser['name'], $testuser['password'], false);
+
+      // Get rights again, should not have changed
+      $pu = \Profile_User::getForUser($users_id, true);
+      $this->array($pu)->hasSize(1);
+      $right2 = array_pop($pu);
+      $this->array($right2)->isEqualTo($right);
+
+      $_SESSION['glpiactiveprofile']['user'] = 7327;
+      $_SESSION['glpiactiveprofile']['profile'] = 23;
+
+      // Change the $right profile, since this is the default profile it should
+      // be fixed on next login
+      $pu = new \Profile_User();
+      $res = $pu->update([
+         'id' => $right2['id'],
+         'profiles_id' => 2
+      ]);
+      $this->boolean($res)->isTrue();
+      $this->boolean($pu->getFromDB($right2['id']))->isTrue();
+      $this->integer($pu->fields['is_default_profile'])->isEqualTo(1);
+      $this->integer($pu->fields['is_dynamic'])->isEqualTo(1);
+
+      $this->login(TU_USER, TU_PASS, false);
+      $this->login($testuser['name'], $testuser['password'], false);
+      $pu = \Profile_User::getForUser($users_id, true);
+      $this->array($pu)->hasSize(1);
+      $right3 = array_pop($pu);
+
+      // Compare without id which changed
+      unset($right['id']);
+      unset($right3['id']);
+      $this->array($right3)->isEqualTo($right);
+
+      // Clean session
+      $this->login(TU_USER, TU_PASS, false);
+   }
 }


### PR DESCRIPTION
When users have only one dynamic profiles that match the default profile of GLPI, this profile should not be deleted by the right rules engine if no rules match this user.

Concrete example (!21527) :  
- An user is created through the API
- The default profile is auto affected as dyamic
- There is no right rules targeting this user
-> When this user log in, he should keep the current profile (currently the profile is removed and he can't login).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
