### PR TITLE
Drop PHP 7.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {php-version: "7.2"} # Lint on lower PHP version to detected too early usage of new syntaxes
+          - {php-version: "7.3"} # Lint on lower PHP version to detected too early usage of new syntaxes
           - {php-version: "8.0"} # Lint on higher PHP version to detected deprecated elements usage
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml"
@@ -101,7 +101,6 @@ jobs:
           - {php-version: "8.0", db-image: "mariadb:10.5", always: true}
           - {php-version: "8.0", db-image: "mysql:8.0", always: true}
           # test other PHP versions
-          - {php-version: "7.2", db-image: "mariadb:10.5", always: false}
           - {php-version: "7.3", db-image: "mariadb:10.5", always: false}
           - {php-version: "7.4", db-image: "mariadb:10.5", always: false}
           # test other DB servers/versions

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It is distributed under the GNU GENERAL PUBLIC LICENSE Version 2 - please consul
 
 * A web server (Apache, Nginx, IIS, etc.)
 * MariaDB >= 10.0 or MySQL >= 5.6
-* PHP 7.2 or higher
+* PHP 7.3 or higher
 * Mandatory PHP extensions:
     - ctype
     - curl

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "docs": "https://github.com/glpi-project/doc"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.3",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-fileinfo": "*",
@@ -81,7 +81,7 @@
     "config": {
         "optimize-autoloader": true,
         "platform": {
-            "php": "7.2.5"
+            "php": "7.3.0"
         },
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2c0a02a0c10dc0f0660c8ad2c2f87ce",
+    "content-hash": "4d71d084c6131a2e565dd25a08dd7b67",
     "packages": [
         {
             "name": "blueimp/jquery-file-upload",
@@ -6800,7 +6800,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2",
+        "php": ">=7.3",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-fileinfo": "*",
@@ -6817,7 +6817,7 @@
         "ext-xml": "*"
     },
     "platform-overrides": {
-        "php": "7.2.5"
+        "php": "7.3.0"
     },
     "plugin-api-version": "2.0.0"
 }

--- a/inc/define.php
+++ b/inc/define.php
@@ -43,7 +43,7 @@ if (substr(GLPI_VERSION, -4) === '-dev') {
    //for stable version
    define("GLPI_SCHEMA_VERSION", '9.5.4');
 }
-define('GLPI_MIN_PHP', '7.2.5'); // Must also be changed in top of index.php
+define('GLPI_MIN_PHP', '7.3.0'); // Must also be changed in top of index.php
 define('GLPI_YEAR', '2021');
 
 //Define a global recipient address for email notifications

--- a/index.php
+++ b/index.php
@@ -32,8 +32,8 @@
 
 // Check PHP version not to have trouble
 // Need to be the very fist step before any include
-if (version_compare(PHP_VERSION, '7.2.5') < 0) {
-   die('PHP >= 7.2.5 required');
+if (version_compare(PHP_VERSION, '7.3.0') < 0) {
+   die('PHP >= 7.3.0 required');
 }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

PHP 7.2 is not supported since November 30, and some packages (laminas for instance) already dropped support of PHP 7.2 in their composer.json file, meaning that dependabot will not inform us about new releases of these packages as they are considered as incompatible.

For information, here is the current version oh PHP in main linux distributions
| Distribution | Release date | PHP Version
| --------------- | ------------------ | -----------------
| RHEL 8.3 | October 29, 2020 | PHP 7.4
| Debian Buster | July 6, 2019 | PHP 7.3
| Ubuntu 20.04 | April 23, 2020 | PHP 7.4
| openSUSE Leap 15.2 | July 2, 2020 | PHP 7.4
