### PR TITLE
Fix webcal export rights check

### DIFF
--- a/front/planning.php
+++ b/front/planning.php
@@ -128,8 +128,9 @@ if (isset($_GET['checkavailability'])) {
             }
          }
 
-         if ($ismine || $canview) {
+         if (($ismine || $canview) && Session::startImpersonating($_GET["uID"], true)) {
             Planning::generateIcal($_GET["uID"], $_GET["gID"], $_GET["limititemtype"]);
+            Session::destroy();
          }
       }
    }

--- a/front/planning.php
+++ b/front/planning.php
@@ -63,11 +63,9 @@ if (isset($_GET['checkavailability'])) {
 } else if (isset($_GET['genical'])) {
    if (isset($_GET['token'])) {
       // Check user token
-      $user = new User();
-      if ($user->getFromDBByToken($_GET['token'])) {
+      $user = Session::authWithToken($_GET['token'], 'personal_token', $_GET['entities_id'], $_GET['is_recursive']);
+      if ($user) {
          if (isset($_GET['entities_id']) && isset($_GET['is_recursive'])) {
-            $user->loadMinimalSession($_GET['entities_id'], $_GET['is_recursive']);
-
             // load entities & profiles
             // needed to pass canViewItem() in populatePlanning functions in case of ical export
             $_SESSION["glpidefault_entity"]  = $user->fields['entities_id'];
@@ -128,7 +126,7 @@ if (isset($_GET['checkavailability'])) {
             }
          }
 
-         if (($ismine || $canview) && Session::initForUser($_GET["uID"])) {
+         if ($ismine || $canview) {
             Planning::generateIcal($_GET["uID"], $_GET["gID"], $_GET["limititemtype"]);
             Session::destroy();
          }

--- a/front/planning.php
+++ b/front/planning.php
@@ -128,7 +128,7 @@ if (isset($_GET['checkavailability'])) {
             }
          }
 
-         if (($ismine || $canview) && Session::startImpersonating($_GET["uID"], true)) {
+         if (($ismine || $canview) && Session::initForUser($_GET["uID"])) {
             Planning::generateIcal($_GET["uID"], $_GET["gID"], $_GET["limititemtype"]);
             Session::destroy();
          }

--- a/front/planning.php
+++ b/front/planning.php
@@ -63,7 +63,12 @@ if (isset($_GET['checkavailability'])) {
 } else if (isset($_GET['genical'])) {
    if (isset($_GET['token'])) {
       // Check user token
-      $user = Session::authWithToken($_GET['token'], 'personal_token', $_GET['entities_id'], $_GET['is_recursive']);
+      $user = Session::authWithToken(
+         $_GET['token'],
+         'personal_token',
+         $_GET['entities_id'] ?? null,
+         $_GET['is_recursive'] ?? null
+      );
       if ($user) {
          if (isset($_GET['entities_id']) && isset($_GET['is_recursive'])) {
             // load entities & profiles

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -1430,12 +1430,13 @@ class Session {
     * Impersonate user having given id.
     *
     * @param integer $user_id
+    * @param bool    $force   Bypass "canImpersonate" check
     *
     * @return boolean
     */
-   static function startImpersonating($user_id) {
+   static function startImpersonating($user_id, $force = false) {
 
-      if (!self::canImpersonate($user_id)) {
+      if (!$force && !self::canImpersonate($user_id)) {
          return false;
       }
 

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -1430,13 +1430,12 @@ class Session {
     * Impersonate user having given id.
     *
     * @param integer $user_id
-    * @param bool    $force   Bypass "canImpersonate" check
     *
     * @return boolean
     */
-   static function startImpersonating($user_id, $force = false) {
+   static function startImpersonating($user_id) {
 
-      if (!$force && !self::canImpersonate($user_id)) {
+      if (!self::canImpersonate($user_id)) {
          return false;
       }
 
@@ -1529,5 +1528,25 @@ class Session {
     */
    public static function getActiveEntity() {
       return $_SESSION['glpiactive_entity'] ?? 0;
+   }
+
+   /**
+    * Start session for a given user
+    *
+    * @param int $users_id ID of the user
+    *
+    * @return bool
+    */
+   public static function initForUser(int $users_id): bool {
+      $user = new User();
+      if (!$user->getFromDB($users_id)) {
+         return false;
+      }
+
+      $auth = new Auth();
+      $auth->auth_succeded = true;
+      $auth->user = $user;
+      Session::init($auth);
+      return true;
    }
 }

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -1556,17 +1556,29 @@ class Session {
       Session::init($auth);
 
       if (!is_null($entities_id) && !is_null($is_recursive)) {
-         $_SESSION["glpiactive_entity"]           = $entities_id;
-         $_SESSION["glpiactive_entity_recursive"] = $is_recursive;
-         if ($is_recursive) {
-            $entities = getSonsOf("glpi_entities", $entities_id);
-         } else {
-            $entities = [$entities_id];
-         }
-         $_SESSION['glpiactiveentities']        = $entities;
-         $_SESSION['glpiactiveentities_string'] = "'".implode("', '", $entities)."'";
+         self::loadEntity($entities_id, $is_recursive);
       }
 
       return $user;
+   }
+
+   /**
+    * Load given entity.
+    *
+    * @param integer $entities_id  Entity to use
+    * @param boolean $is_recursive Whether to load entities recursivly or not
+    *
+    * @return void
+    */
+   public static function loadEntity($entities_id, $is_recursive): void {
+      $_SESSION["glpiactive_entity"]           = $entities_id;
+      $_SESSION["glpiactive_entity_recursive"] = $is_recursive;
+      if ($is_recursive) {
+         $entities = getSonsOf("glpi_entities", $entities_id);
+      } else {
+         $entities = [$entities_id];
+      }
+      $_SESSION['glpiactiveentities']        = $entities;
+      $_SESSION['glpiactiveentities_string'] = "'".implode("', '", $entities)."'";
    }
 }

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -192,15 +192,7 @@ class User extends CommonDBTM {
          Session::start();
          $_SESSION["glpiID"]                      = $this->fields['id'];
          $_SESSION["glpi_use_mode"]               = Session::NORMAL_MODE;
-         $_SESSION["glpiactive_entity"]           = $entities_id;
-         $_SESSION["glpiactive_entity_recursive"] = $is_recursive;
-         if ($is_recursive) {
-            $entities = getSonsOf("glpi_entities", $entities_id);
-         } else {
-            $entities = [$entities_id];
-         }
-         $_SESSION['glpiactiveentities']        = $entities;
-         $_SESSION['glpiactiveentities_string'] = "'".implode("', '", $entities)."'";
+         Session::loadEntity($entities_id, $is_recursive);
          $this->computePreferences();
          foreach ($CFG_GLPI['user_pref_field'] as $field) {
             if (isset($this->fields[$field])) {


### PR DESCRIPTION
WebCal export isn't working due to rights checks added in ba0f81603e5677c34397397329837a4637012248.   
External tools call front/planning.php with no session so all rights check done in Planning::generateIcal() will never work.

Fixed it by loading the calendar owner session.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21503
