### PR TITLE
Minor CI fixes

### DIFF
--- a/.github/actions/docker-compose-app.yml
+++ b/.github/actions/docker-compose-app.yml
@@ -4,9 +4,11 @@ services:
   app:
     container_name: "app"
     image: "ghcr.io/glpi-project/${PHP_IMAGE:-githubactions-php}"
+    environment:
+      IGNORE_LOCK_FILES: "${IGNORE_LOCK_FILES:-false}"
     volumes: 
       - type: "bind"
-        source: "${APPLICATION_ROOT:-..}"
+        source: "${APPLICATION_ROOT}"
         target: "/var/glpi"
       - type: "bind"
         source: "${APP_CONTAINER_HOME}"

--- a/.github/actions/docker-compose-app.yml
+++ b/.github/actions/docker-compose-app.yml
@@ -5,6 +5,7 @@ services:
     container_name: "app"
     image: "ghcr.io/glpi-project/${PHP_IMAGE:-githubactions-php}"
     environment:
+      CODE_COVERAGE: "${CODE_COVERAGE:-false}"
       IGNORE_LOCK_FILES: "${IGNORE_LOCK_FILES:-false}"
     volumes: 
       - type: "bind"

--- a/.github/actions/lint_php-lint.sh
+++ b/.github/actions/lint_php-lint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+ROOT_DIR=$(readlink -f "$(dirname $0)/../..")
+echo $ROOT_DIR
+
 echo "Check for syntax errors"
 vendor/bin/parallel-lint \
   --exclude ./files/ \
@@ -18,12 +21,12 @@ php -d memory_limit=1G \
   check --config-file=.composer-require-checker.config.json
 
 echo "Check for coding standards violations"
-touch /home/glpi/phpcs.cache
+touch ~/phpcs.cache
 vendor/bin/phpcs \
-  --cache /home/glpi/phpcs.cache \
+  --cache ~/phpcs.cache \
   -d memory_limit=512M \
   -p \
   --extensions=php \
   --standard=vendor/glpi-project/coding-standard/GlpiStandard/ \
-  --ignore="/.git/,^/var/glpi/(config|files|lib|marketplace|node_modules|plugins|tests/config|vendor)/" \
+  --ignore="/.git/,^$ROOT_DIR/(config|files|lib|marketplace|node_modules|plugins|tests/config|vendor)/" \
   .

--- a/.github/actions/test_tests-functionnal.sh
+++ b/.github/actions/test_tests-functionnal.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -e
 
 ATOUM_ADDITIONNAL_OPTIONS=""
-if [[ -z "$COVERAGE_DIR" ]];
-  then ATOUM_ADDITIONNAL_OPTIONS="--no-code-coverage";
+if [[ "$CODE_COVERAGE" = true ]]; then
+  export COVERAGE_DIR="coverage-functionnal"
+else
+  ATOUM_ADDITIONNAL_OPTIONS="--no-code-coverage";
 fi
 
 vendor/bin/atoum \
@@ -15,3 +17,5 @@ vendor/bin/atoum \
   $ATOUM_ADDITIONNAL_OPTIONS \
   --max-children-number 1 \
   -d tests/functionnal
+
+unset COVERAGE_DIR

--- a/.github/actions/test_tests-imap.sh
+++ b/.github/actions/test_tests-imap.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -e
 
 ATOUM_ADDITIONNAL_OPTIONS=""
-if [[ -z "$COVERAGE_DIR" ]];
-  then ATOUM_ADDITIONNAL_OPTIONS="--no-code-coverage";
+if [[ "$CODE_COVERAGE" = true ]]; then
+  export COVERAGE_DIR="coverage-imap"
+else
+  ATOUM_ADDITIONNAL_OPTIONS="--no-code-coverage";
 fi
 
 vendor/bin/atoum \
@@ -15,3 +17,5 @@ vendor/bin/atoum \
   $ATOUM_ADDITIONNAL_OPTIONS \
   --max-children-number 1 \
   -d tests/imap
+
+unset COVERAGE_DIR

--- a/.github/actions/test_tests-ldap.sh
+++ b/.github/actions/test_tests-ldap.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -e
 
 ATOUM_ADDITIONNAL_OPTIONS=""
-if [[ -z "$COVERAGE_DIR" ]];
-  then ATOUM_ADDITIONNAL_OPTIONS="--no-code-coverage";
+if [[ "$CODE_COVERAGE" = true ]]; then
+  export COVERAGE_DIR="coverage-ldap"
+else
+  ATOUM_ADDITIONNAL_OPTIONS="--no-code-coverage";
 fi
 
 vendor/bin/atoum \
@@ -15,3 +17,5 @@ vendor/bin/atoum \
   $ATOUM_ADDITIONNAL_OPTIONS \
   --max-children-number 1 \
   -d tests/LDAP
+
+unset COVERAGE_DIR

--- a/.github/actions/test_tests-units.sh
+++ b/.github/actions/test_tests-units.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -e
 
 ATOUM_ADDITIONNAL_OPTIONS=""
-if [[ -z "$COVERAGE_DIR" ]];
-  then ATOUM_ADDITIONNAL_OPTIONS="--no-code-coverage";
+if [[ "$CODE_COVERAGE" = true ]]; then
+  export COVERAGE_DIR="coverage-unit"
+else
+  ATOUM_ADDITIONNAL_OPTIONS="--no-code-coverage";
 fi
 
 vendor/bin/atoum \
@@ -15,3 +17,5 @@ vendor/bin/atoum \
   $ATOUM_ADDITIONNAL_OPTIONS \
   --max-children-number 10 \
   -d tests/units
+
+unset COVERAGE_DIR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
           - {php-version: "8.0"} # Lint on higher PHP version to detected deprecated elements usage
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml"
-      APP_CONTAINER_HOME: "${{ github.workspace }}/../app_home"
       APPLICATION_ROOT: "${{ github.workspace }}"
       PHP_IMAGE: "githubactions-php:${{ matrix.php-version }}"
       UPDATE_FILES_ACL: true
@@ -46,6 +45,7 @@ jobs:
           access_token: "${{ github.token }}"
       - name: "Clean workspace"
         run: |
+          echo "APP_CONTAINER_HOME=${{ runner.temp }}/app_home" >> $GITHUB_ENV
           rm -rf "${{ env.APPLICATION_ROOT }}/*"
           rm -rf "${{ env.APP_CONTAINER_HOME }}/*"
       - name: "Checkout"
@@ -119,7 +119,6 @@ jobs:
       skip: ${{ matrix.always == false && (github.event_name == 'pull_request' || github.repository != 'glpi-project/glpi' || !(github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' || endsWith(github.ref, '/bugfixes') || startsWith(github.ref, 'refs/tags'))) }}
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"
       APPLICATION_ROOT: "${{ github.workspace }}"
-      APP_CONTAINER_HOME: "${{ github.workspace }}/../app_home"
       DB_IMAGE: "githubactions-${{ matrix.db-image }}"
       PHP_IMAGE: "githubactions-php:${{ matrix.php-version }}"
       IGNORE_LOCK_FILES: true
@@ -133,6 +132,7 @@ jobs:
       - name: "Clean workspace"
         if: env.skip != 'true'
         run: |
+          echo "APP_CONTAINER_HOME=${{ runner.temp }}/app_home" >> $GITHUB_ENV
           rm -rf "${{ env.APPLICATION_ROOT }}/*"
           rm -rf "${{ env.APP_CONTAINER_HOME }}/*"
       - name: "Checkout"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,6 @@ jobs:
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"
       APPLICATION_ROOT: "${{ github.workspace }}"
-      APP_CONTAINER_HOME: "${{ github.workspace }}/../app_home"
       DB_IMAGE: "githubactions-${{ matrix.db-image }}"
       PHP_IMAGE: "githubactions-php-coverage:${{ matrix.php-version }}"
       UPDATE_FILES_ACL: true
@@ -34,6 +33,7 @@ jobs:
       - name: "Clean workspace"
         if: env.skip != 'true'
         run: |
+          echo "APP_CONTAINER_HOME=${{ runner.temp }}/app_home" >> $GITHUB_ENV
           rm -rf "${{ env.APPLICATION_ROOT }}/*"
           rm -rf "${{ env.APP_CONTAINER_HOME }}/*"
       - name: "Checkout"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,6 +29,7 @@ jobs:
       PHP_IMAGE: "githubactions-php-coverage:${{ matrix.php-version }}"
       UPDATE_FILES_ACL: true
       IGNORE_LOCK_FILES: true
+      CODE_COVERAGE: true
     steps:
       - name: "Clean workspace"
         if: env.skip != 'true'
@@ -68,16 +69,16 @@ jobs:
           docker-compose exec -T app .github/actions/test_install.sh
       - name: "Unit tests"
         run: |
-          docker-compose exec -T app sh -c "COVERAGE_DIR=coverage-unit .github/actions/test_tests-units.sh"
+          docker-compose exec -T app .github/actions/test_tests-units.sh
       - name: "Functionnal tests"
         run: |
-          docker-compose exec -T app sh -c "COVERAGE_DIR=coverage-functionnal .github/actions/test_tests-functionnal.sh"
+          docker-compose exec -T app .github/actions/test_tests-functionnal.sh
       - name: "LDAP tests"
         run: |
-          docker-compose exec -T app sh -c "COVERAGE_DIR=coverage-ldap .github/actions/test_tests-ldap.sh"
+          docker-compose exec -T app .github/actions/test_tests-ldap.sh
       - name: "IMAP tests"
         run: |
-          docker-compose exec -T app sh -c "COVERAGE_DIR=coverage-imap .github/actions/test_tests-imap.sh"
+          docker-compose exec -T app .github/actions/test_tests-imap.sh
       - name: "Codecov"
         uses: "codecov/codecov-action@v1"
         with:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Fix composer.lock removal in CI. Was not working as `IGNORE_LOCK_FILES` env was not passed to app container.
2. Fix CI cache. Was not working du tu usage of relative path (`${{ github.workspace }}/../app_home`). I put back old value, but, as `${{ runner.temp }}` is not accessiblle in job env declaration, I had to move `APP_CONTAINER_HOME` env declaration in a job step.
3. Fix PHP lint script for execution on dev machine. Hardcoded path for cache file and in ignore pattern was preventing this script to be usable on dev machine.
4. Use unique env var for code coverage (`CODE_COVERAGE`), to simplify usage of test scripts (may be chained like this: `CODE_COVERAGE=true .github/actions/test_tests-units.sh && .github/actions/test_tests-functionnal.sh`)