### PR TITLE
Fix NOT search; fixes #8671

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -7831,7 +7831,7 @@ JAVASCRIPT;
          // Remove trailing `$`
          $val = rtrim(preg_replace('/\$$/', '', $val));
       } else {
-         // Add % wildcard before searched string if not ending by a `$`
+         // Add % wildcard after searched string if not ending by a `$`
          $val = $val . '%';
       }
 

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -7808,6 +7808,8 @@ JAVASCRIPT;
          return null;
       }
 
+      $val = trim($val);
+
       if ($val === '^') {
          // Special case, searching "^" or "$" means we are searching for a non empty/null field
          return '%';
@@ -7819,7 +7821,7 @@ JAVASCRIPT;
 
       if (preg_match('/^\^/', $val)) {
          // Remove leading `^`
-         $val = preg_replace('/^\^/', '', $val);
+         $val = ltrim(preg_replace('/^\^/', '', $val));
       } else {
          // Add % wildcard before searched string if not begining by a `^`
          $val = '%' . $val;
@@ -7827,7 +7829,7 @@ JAVASCRIPT;
 
       if (preg_match('/\$$/', $val)) {
          // Remove trailing `$`
-         $val = preg_replace('/\$$/', '', $val);
+         $val = rtrim(preg_replace('/\$$/', '', $val));
       } else {
          // Add % wildcard before searched string if not ending by a `$`
          $val = $val . '%';

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -975,7 +975,12 @@ class Search {
 
             if (isset($criterion['link'])
                   && in_array($criterion['link'], array_keys(self::getLogicalOperators()))) {
-               $tmplink = " ".$criterion['link'];
+               if (strstr($criterion['link'], "NOT")) {
+                  $tmplink = " ".str_replace(" NOT", "", $criterion['link']);
+                  $NOT     = 1;
+               } else {
+                  $tmplink = " ".$criterion['link'];
+               }
             } else {
                $tmplink = " AND ";
             }
@@ -983,8 +988,6 @@ class Search {
             // Manage Link if not first item
             if (!empty($sql)) {
                $LINK = $tmplink;
-            } else if (strstr($tmplink, "NOT")) {
-               $NOT = 1;
             }
 
             if (isset($criterion['criteria']) && count($criterion['criteria'])) {

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -7811,7 +7811,7 @@ JAVASCRIPT;
       $val = trim($val);
 
       if ($val === '^') {
-         // Special case, searching "^" or "$" means we are searching for a non empty/null field
+         // Special case, searching "^" means we are searching for a non empty/null field
          return '%';
       }
 

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1221,6 +1221,10 @@ class Search extends DbTestCase {
          ['a ^ in the middle$', '%a ^ in the middle'],
          ['^and $ not at the end', 'and $ not at the end%'],
          ['45$^ab5', '%45$^ab5%'],
+         ['^ ltrim', 'ltrim%'],
+         ['rtim this   $', '%rtim this'],
+         ['  extra spaces ', '%extra spaces%'],
+         ['^ exactval $', 'exactval'],
       ];
    }
 

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1207,14 +1207,20 @@ class Search extends DbTestCase {
 
    protected function makeTextSearchValueProvider() {
       return [
+         ['NULL', null],
+         ['null', null],
          ['', ''],
          ['^', '%'],
          ['$', ''],
          ['^$', ''],
+         ['$^', '%$^%'], // inverted ^ and $
          ['looking for', '%looking for%'],
          ['^starts with', 'starts with%'],
          ['ends with$', '%ends with'],
-         ['^exact string$', 'exact string']
+         ['^exact string$', 'exact string'],
+         ['a ^ in the middle$', '%a ^ in the middle'],
+         ['^and $ not at the end', 'and $ not at the end%'],
+         ['45$^ab5', '%45$^ab5%'],
       ];
    }
 
@@ -1222,7 +1228,7 @@ class Search extends DbTestCase {
     * @dataProvider makeTextSearchValueProvider
     */
    public function testMakeTextSearchValue($value, $expected) {
-      $this->string(\Search::makeTextSearchValue($value))->isIdenticalTo($expected);
+      $this->variable(\Search::makeTextSearchValue($value))->isIdenticalTo($expected);
    }
 
    public function providerAddWhere() {

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -109,7 +109,7 @@ class Search extends DbTestCase {
             . '\)/im');
    }
 
-   public function testSoftwareLinkedToNoComputer() {
+   public function testSoftwareLinkedToAnyComputer() {
       $search_params = [
          'is_deleted'   => 0,
          'start'        => 0,
@@ -126,7 +126,7 @@ class Search extends DbTestCase {
                'itemtype'   => 'Computer',
                'field'      => 2,
                'searchtype' => 'contains',
-               'value'      => '$^',
+               'value'      => '^$', // search for "null" id
             ],
          ],
       ];
@@ -134,7 +134,7 @@ class Search extends DbTestCase {
       $data = $this->doSearch('Software', $search_params);
 
       $this->string($data['sql']['search'])
-         ->matches("/HAVING\s*\(`ITEM_Computer_2`\s+IS\s+NULL\s*\)/");
+         ->matches("/HAVING\s*\(`ITEM_Computer_2`\s+IS\s+NOT\s+NULL\s*\)/");
    }
 
    public function testMetaComputerUser() {

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -109,6 +109,34 @@ class Search extends DbTestCase {
             . '\)/im');
    }
 
+   public function testSoftwareLinkedToNoComputer() {
+      $search_params = [
+         'is_deleted'   => 0,
+         'start'        => 0,
+         'criteria'     => [
+            [
+               'field'      => 'view',
+               'searchtype' => 'contains',
+               'value'      => '',
+            ],
+         ],
+         'metacriteria' => [
+            [
+               'link'       => 'AND NOT',
+               'itemtype'   => 'Computer',
+               'field'      => 2,
+               'searchtype' => 'contains',
+               'value'      => '$^',
+            ],
+         ],
+      ];
+
+      $data = $this->doSearch('Software', $search_params);
+
+      $this->string($data['sql']['search'])
+         ->matches("/HAVING\s*\(`ITEM_Computer_2`\s+IS\s+NULL\s*\)/");
+   }
+
    public function testMetaComputerUser() {
       $search_params = ['is_deleted'   => 0,
                         'start'        => 0,
@@ -339,7 +367,7 @@ class Search extends DbTestCase {
          ->contains("(`glpi_users`.`id` = '2')")
          ->contains("OR (`glpi_users`.`id` = '3')")
          // match having
-         ->matches("/HAVING\s*\(`ITEM_Budget_2`\s+<>\s+5\)\s+AND NOT\s+\(`ITEM_Printer_1`\s+LIKE\s+'%HP%'\s*\)/");
+         ->matches("/HAVING\s*\(`ITEM_Budget_2`\s+<>\s+5\)\s+AND\s+\(\(`ITEM_Printer_1`\s+NOT LIKE\s+'%HP%'\s+OR\s+`ITEM_Printer_1`\s+IS NULL\)\s*\)/");
    }
 
    function testViewCriterion() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8671 

#8311 introduced a bug when using the `AND NOT` operator outside meta context.

I reverted #8311 and added a test case related to !21081.

I do not even know if my test is correct (it reproduces the query obtained with #8311 patch), but I guess we should find a way to make it pass.