### PR TITLE
Fix dropdown using 0 as a concrete value; see #8681

### DIFF
--- a/inc/dashboard/filter.class.php
+++ b/inc/dashboard/filter.class.php
@@ -133,37 +133,37 @@ JAVASCRIPT;
    }
 
 
-   static function itilcategory(string $value = "0"): string {
+   static function itilcategory(string $value = ""): string {
       return self::dropdown($value, 'itilcategory', ItilCategory::class);
    }
 
-   static function requesttype(string $value = "0"): string {
+   static function requesttype(string $value = ""): string {
       return self::dropdown($value, 'requesttype', RequestType::class);
    }
 
-   static function location(string $value = "0"): string {
+   static function location(string $value = ""): string {
       return self::dropdown($value, 'location', Location::class);
    }
 
-   static function manufacturer(string $value = "0"): string {
+   static function manufacturer(string $value = ""): string {
       return self::dropdown($value, 'manufacturer', Manufacturer::class);
    }
 
-   static function group_tech(string $value = "0"): string {
+   static function group_tech(string $value = ""): string {
       return self::dropdown($value, 'group_tech', Group::class, ['toadd' => [-1 => __("My groups")]]);
    }
 
-   static function user_tech(string $value = "0"): string {
+   static function user_tech(string $value = ""): string {
       return self::dropdown($value, 'user_tech', User::class, ['right' => 'own_ticket']);
    }
 
    static function dropdown(
-      string $value = "0",
+      string $value = "",
       string $fieldname = "",
       string $itemtype = "",
       array $add_params = []
    ): string {
-      $value     = (int) $value;
+      $value     = !empty($value) ? (int) $value : null;
       $rand      = mt_rand();
       $label     = self::getAll()[$fieldname];
       $field     = $itemtype::dropdown([

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -120,8 +120,9 @@ class Dropdown {
       $name         = $params['emptylabel'];
       $comment      = "";
 
-      // Check default value for dropdown : need to be a numeric
-      if ((strlen($params['value']) == 0) || !is_numeric($params['value']) && $params['value'] != 'mygroups') {
+      // Check default value for dropdown : need to be a numeric (or null)
+      if ($params['value'] !== null
+          && ((strlen($params['value']) == 0) || !is_numeric($params['value']) && $params['value'] != 'mygroups')) {
          $params['value'] = 0;
       }
 

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -4762,14 +4762,11 @@ JS;
    static function jsAjaxDropdown($name, $field_id, $url, $params = []) {
       global $CFG_GLPI;
 
-      if (!isset($params['value'])) {
+      if (!array_key_exists('value', $params)) {
          $value = 0;
-      } else {
-         $value = $params['value'];
-      }
-      if (!isset($params['value'])) {
          $valuename = Dropdown::EMPTY_VALUE;
       } else {
+         $value = $params['value'];
          $valuename = $params['valuename'];
       }
       $on_change = '';
@@ -4815,9 +4812,7 @@ JS;
          $values = [];
 
          // simple select (multiple = no)
-         if ((isset($params['display_emptychoice']) && $params['display_emptychoice'])
-             || isset($params['toadd'][$value])
-             || $value > 0) {
+         if ($value !== null) {
             $values = ["$value" => $valuename];
          }
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In commit 984ae321eca4cf516a0f07a205d5e39c12fc2edf, dropdown values were filtered to handle the case where we want to display a dropdown without preselecting a value and without displaying the empty value. It intoduced bugs on dropdown that needs to display values <= 0.

#8255 was a first fix, to handle values <= 0 that was part of `toadd` option, but a bug was still existing for numeric dropdown when the 0 value was the selected value (blank value was displayed).

This PR introduced ability to explicitely pass `null` as a dropdown value.