### PR TITLE
Deleted excess quote in generated HTML

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7503,7 +7503,7 @@ abstract class CommonITILObject extends CommonDBTM {
       $rand = mt_rand();
 
       if (!isset($options['template_preview']) || !$options['template_preview']) {
-         $output = "<form method='post' name='form_ticket' enctype='multipart/form-data' action='".static::getFormURL()."''";
+         $output = "<form method='post' name='form_ticket' enctype='multipart/form-data' action='".static::getFormURL()."'";
          if ($ID) {
             $output .= " data-track-changes='true'";
          }


### PR DESCRIPTION
Hello,
There was a two single quotes to end the action attribute of the form HTML tag.
Delete one in order to keep HTML clean.
Thank you
Regards
Tomolimo


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
