### PR TITLE
fix(data-track-change): do not track on license add form

### DIFF
--- a/front/softwarelicense.form.php
+++ b/front/softwarelicense.form.php
@@ -96,6 +96,6 @@ if (isset($_POST["add"])) {
 } else {
    Html::header(SoftwareLicense::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'],
                 "management", "softwarelicense");
-   $license->display($_REQUEST + ['formoptions' => "data-track-changes=true"]);
+   $license->display($_REQUEST);
    Html::footer();
 }


### PR DESCRIPTION
do not track changes on license add form

Because of software dropdown wich reload page
if user change some input before, browser say "this page is asking you to confirm that you want to leave - data you have entered may not be saved"

this PR prevent this (same behavior for ticket.form.php


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Internal 21586
