### PR TITLE
fix(ldap_sync): check if link already exist before add

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -5640,10 +5640,16 @@ JAVASCRIPT;
       $group_ids = array_unique($this->input["_ldap_rules"]['groups_id']);
       foreach ($group_ids as $group_id) {
          $group_user = new Group_User();
-         $group_user->add([
+
+         $data = [
             'groups_id' => $group_id,
             'users_id'  => $this->getId()
-         ]);
+         ];
+
+         if (!$group_user->getFromDBByCrit($data)) {
+            $group_user->add($data);
+         }
+
       }
    }
 }


### PR DESCRIPTION
During LDAP synchronization 
GLPI does not check if the user already has the group.

![image](https://user-images.githubusercontent.com/7335054/108971900-1597df00-7683-11eb-8db1-4118a80aedd3.png)

This Pr prevent this


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
