### PR TITLE
fix(check): prevent warning with SSO

### DIFF
--- a/inc/system/requirement/protectedwebaccess.class.php
+++ b/inc/system/requirement/protectedwebaccess.class.php
@@ -113,13 +113,15 @@ class ProtectedWebAccess extends AbstractRequirement {
             $this->validation_messages[] = __('Web access to files directory is protected');
          }
       } else {
-         $this->validated = false;
-         $this->validation_messages[] = __('Web access to the files directory should not be allowed but this cannot be checked automatically on this instance.');
-         $this->validation_messages[] = sprintf(
-            __('Make sure access to %s (%s) is forbidden; otherwise review .htaccess file and web server configuration.'),
-            __('error log file'),
-            $CFG_GLPI['root_doc'] . '/files/_log/php-errors.log'
-         );
+         if(!$CFG_GLPI["ssovariables_id"] > 0){
+            $this->validated = false;
+            $this->validation_messages[] = __('Web access to the files directory should not be allowed but this cannot be checked automatically on this instance.');
+            $this->validation_messages[] = sprintf(
+               __('Make sure access to %s (%s) is forbidden; otherwise review .htaccess file and web server configuration.'),
+               __('error log file'),
+               $CFG_GLPI['root_doc'] . '/files/_log/php-errors.log'
+            );
+         }
       }
 
       error_reporting($oldlevel);


### PR DESCRIPTION
In case of SSO, 

GLPI check for web acces to the files directory is wrong

Result : warning is always displayed

![image](https://user-images.githubusercontent.com/7335054/109014942-e69a6100-76b4-11eb-871e-30c9c345ad49.png)


I don't know if this is the right way to do it.


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
