### PR TITLE
Fix image pasting in rich text

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -2240,7 +2240,7 @@ a.icon_nav_move {
 
 /* ################--------------- File upload  ---------------#################### */
 
-.fileupload {
+.fileupload:not(.only-uploaded-files) {
    text-align: center;
    border: 1px dashed #cccccc;
    min-height: 65px;
@@ -2250,6 +2250,9 @@ a.icon_nav_move {
    margin: .5em auto;
    padding: .5em;
    margin-top: 5px;
+}
+.fileupload.only-uploaded-files input[type=file] {
+   display:none;
 }
 
 .fileupload_info {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since #8180 , image upload is broken on rich text editors that uses the option `enable_fileupload: false` (the default value). Indeed, pasting an image in rich text now uses the `fileupload` component, but this one was not initialized when `enable_fileupload` option was not `true`.