### PR TITLE
Remove check on logs file web access; see #8693

### DIFF
--- a/inc/central.class.php
+++ b/inc/central.class.php
@@ -31,8 +31,6 @@
  */
 
 use Glpi\Event;
-use Glpi\System\Requirement\ProtectedWebAccess;
-use Glpi\System\Variables;
 
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
@@ -315,11 +313,6 @@ class Central extends CommonGLPI {
             }
             $warnings[] = sprintf(__('For security reasons, please change the password for the default users: %s'),
                                implode(" ", $accounts));
-         }
-
-         $protected_web_access = new ProtectedWebAccess(Variables::getDataDirectories());
-         if (!$protected_web_access->isValidated()) {
-            $warnings[] = implode(' ', $protected_web_access->getValidationMessages());
          }
 
          if (file_exists(GLPI_ROOT . "/install/install.php")) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

As seen on #8693 , checking web access is so easy. We should remove this new check since we do not have a better solution.