### PR TITLE
Add missing method to Inventory cron

### DIFF
--- a/inc/inventory/inventory.class.php
+++ b/inc/inventory/inventory.class.php
@@ -809,4 +809,7 @@ class Inventory
       return $cron_status;
    }
 
+   public static function getTypeName($nb = 0) {
+      return __("Inventory");
+   }
 }


### PR DESCRIPTION
Fix fatal error on front/crontask.php: 
```
[2021-02-25 11:23:50] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Call to undefined method Glpi\Inventory\Inventory::getTypeName() in /home/adrie/localhost/gmaster/inc/search.class.php at line 6469
  Backtrace :
  inc/search.class.php:1448                          Search::giveItem()
  inc/search.class.php:320                           Search::constructData()
  inc/search.class.php:95                            Search::getDatas()
  inc/search.class.php:80                            Search::showList()
  front/crontask.php:62                              Search::show()
```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
