### PR TITLE
fix(reopen): do not check allowed status from self service

### DIFF
--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -263,13 +263,15 @@ class ITILFollowup  extends CommonDBChild {
              || ($parentitem->countSuppliers(CommonITILActor::ASSIGN) > 0)) {
 
             //check if lifecycle allowed new status
-            if ($parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::ASSIGNED)) {
+            if ($parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::ASSIGNED)
+               || Session::getCurrentInterface() == "helpdesk") {
                $needupdateparent = true;
                $update['status'] = CommonITILObject::ASSIGNED;
             }
          } else {
             //check if lifecycle allowed new status
-            if ($parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::INCOMING)) {
+            if ($parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::INCOMING) ||
+               Session::getCurrentInterface() == "helpdesk") {
                $needupdateparent = true;
                $update['status'] = CommonITILObject::INCOMING;
             }


### PR DESCRIPTION

PR https://github.com/glpi-project/glpi/pull/8668
introduce bug for self service

Which is not allowed to go from resolved to ongoing status

This PR fix this


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
