### PR TITLE
Fix plugin case in search hooks

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -4879,13 +4879,13 @@ JAVASCRIPT;
             // Plugin can override core definition for its type
             if ($plug = isPluginItemType($itemtype)) {
                $plugin_name   = $plug['plugin'];
-               $hook_function = 'plugin_' . $plugin_name . '_addDefaultJoin';
+               $hook_function = 'plugin_' . strtolower($plugin_name) . '_addDefaultJoin';
                $hook_closure  = function () use ($hook_function, $itemtype, $ref_table, &$already_link_tables) {
                   if (is_callable($hook_function)) {
                      return $hook_function($itemtype, $ref_table, $already_link_tables);
                   }
                };
-               $out = Plugin::doOneHook($plug['plugin'], $hook_closure);
+               $out = Plugin::doOneHook($plugin_name, $hook_closure);
                if (!empty($out)) {
                   return $out;
                }
@@ -4982,7 +4982,7 @@ JAVASCRIPT;
       // Plugin can override core definition for its type
       if ($plug = isPluginItemType($itemtype)) {
          $plugin_name   = $plug['plugin'];
-         $hook_function = 'plugin_' . $plugin_name . '_addLeftJoin';
+         $hook_function = 'plugin_' . strtolower($plugin_name) . '_addLeftJoin';
          $hook_closure  = function () use ($hook_function, $itemtype, $ref_table, $new_table, $linkfield, &$already_link_tables) {
             if (is_callable($hook_function)) {
                return $hook_function($itemtype, $ref_table, $new_table, $linkfield, $already_link_tables);
@@ -4996,7 +4996,7 @@ JAVASCRIPT;
           && preg_match("/^glpi_plugin_([a-z0-9]+)/", $new_table, $matches)) {
          if (count($matches) == 2) {
             $plugin_name   = $matches[1];
-            $hook_function = 'plugin_' . $plugin_name . '_addLeftJoin';
+            $hook_function = 'plugin_' . strtolower($plugin_name) . '_addLeftJoin';
             $hook_closure  = function () use ($hook_function, $itemtype, $ref_table, $new_table, $linkfield, &$already_link_tables) {
                if (is_callable($hook_function)) {
                   return $hook_function($itemtype, $ref_table, $new_table, $linkfield, $already_link_tables);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

PHP function declaration is case insensitive, so this change has potentially no impact. But maybe in a far future PHP will introduce case sensitivity in class / function names, so I prefer to fix it.