### PR TITLE
Prevent plugin reload on crontask execution

### DIFF
--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -830,9 +830,6 @@ class CronTask extends CommonDBTM{
             if ($crontask->getNeedToRun($mode, $name)) {
                $_SESSION["glpicronuserrunning"] = "cron_".$crontask->fields['name'];
 
-               if ($plug = isPluginItemType($crontask->fields['itemtype'])) {
-                  Plugin::load($plug['plugin'], true);
-               }
                $fonction = [$crontask->fields['itemtype'],
                                  'cron' . $crontask->fields['name']];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8701

During cronstask execution:
1. Active plugins are loaded.
2. A loop is done using `$crontask->getNeedToRun()` to get next task to execute (it fetches only tasks for core and ACTIVE plugins).
3. Task callable is executed.

So plugin should already be loaded, and there is no neet to load it again.

On case sensitive filesystems (almost all now), plugin is not reloaded as `Plugin::load()` is called with an plugin name using camel case (first letter is uppercased). Directory is not found, so nothing is done.

On case insensitive systems (FAT ?), plugin is reloaded, and it produces an error, see #8701.