### PR TITLE
Pending reasons

### DIFF
--- a/ajax/pendingreason.php
+++ b/ajax/pendingreason.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+// Direct access to file
+include ('../inc/includes.php');
+header("Content-Type: application/json; charset=UTF-8");
+
+Session::checkLoginUser();
+
+// Tech only
+if (Session::getCurrentInterface() !== "central") {
+    http_response_code(403);
+    die;
+}
+
+// Read parameter and load pending reason
+$pending_reason = PendingReason::getById($_REQUEST['pendingreasons_id'] ?? null);
+if (!$pending_reason) {
+    http_response_code(400);
+    die;
+}
+
+echo json_encode([
+    'followup_frequency'          => $pending_reason->fields['followup_frequency'],
+    'followups_before_resolution' => $pending_reason->fields['followups_before_resolution'],
+]);

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -7231,3 +7231,16 @@ div.progress {
    height: 24px;
    width: 24px;
 }
+
+.mr10px {
+   margin-right: 10px !important
+}
+
+.pending_detail{
+   margin-top: 6px;
+   margin-left: 2px;
+
+   .fas {
+      margin-left: 5px;
+   }
+}

--- a/front/pendingreason.form.php
+++ b/front/pendingreason.form.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+include ('../inc/includes.php');
+
+$dropdown = new PendingReason();
+include (GLPI_ROOT . "/front/dropdown.common.form.php");

--- a/front/pendingreason.php
+++ b/front/pendingreason.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+include ('../inc/includes.php');
+$dropdown = new PendingReason();
+include (GLPI_ROOT . "/front/dropdown.common.php");

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -961,6 +961,7 @@ class Change extends CommonITILObject {
             echo "&nbsp;<a class='vsubmit' href='$link'>". __('Reopen')."</a>";
          }
       }
+      PendingReason_Item::displayStatusTooltip($this);
       echo $tt->getEndHiddenFieldValue('status', $this);
 
       echo "</td>";
@@ -1662,5 +1663,9 @@ class Change extends CommonITILObject {
          default:
             return parent::getStatusKey($status);
       }
+   }
+
+   public static function getTaskClass() {
+      return ChangeTask::class;
    }
 }

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -5675,7 +5675,11 @@ class CommonDBTM extends CommonGLPI {
     *
     * @return static|boolean false on failure
    */
-   public static function getById(int $id) {
+   public static function getById(?int $id) {
+      if (is_null($id)) {
+         return false;
+      }
+
       $item = new static();
 
       if (!$item->getFromDB($id)) {

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7264,7 +7264,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
                   $resolve = $pending_reason_item_parent->getAutoResolvedate();
                   if ($resolve) {
-                     echo __("Automatic resolution scheduled on ") . Html::convDate($resolve) . ".<br>";
+                     echo sprintf(__("Automatic resolution scheduled on %s"), Html::convDate($resolve)) . ".<br>";
                   }
                }
             }

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -847,6 +847,7 @@ class Dropdown {
                  'ProjectTaskTemplate' => null,
                  'PlanningExternalEventTemplate' => null,
                  'PlanningEventCategory' => null,
+                 'PendingReason' => null,
              ],
 
              _n('Type', 'Types', Session::getPluralNumber()) => [

--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -281,7 +281,9 @@ JAVASCRIPT;
    }
 
    function prepareInputForAdd($input) {
-      $input['users_id'] = Session::getLoginUserID();
+      if (!isset($input['users_id']) && (Session::isCron() || strpos($_SERVER['REQUEST_URI'], 'crontask.form.php') !== false)) {
+         $input['users_id'] = Session::getLoginUserID();
+      }
 
       if ($this->item == null
          || (isset($input['itemtype']) && isset($input['items_id']))

--- a/inc/pendingreason.class.php
+++ b/inc/pendingreason.class.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ * ITILCategory class
+**/
+class PendingReason extends CommonDropdown
+{
+   // From CommonDBTM
+   public $dohistory = true;
+
+   // From CommonDBTM
+   public $can_be_translated = true;
+
+   // Rights managment
+   public static $rightname = 'pendingreason';
+
+   public static function getTypeName($nb = 0) {
+      return _n('Pending reason', 'Pending reasons', $nb);
+   }
+
+   public function getAdditionalFields() {
+      return [
+         [
+            'name'  => 'followup_frequency',
+            'label' => __('Automatic follow-up frequency'),
+            'type'  => '',
+            'list'  => true
+         ],
+         [
+            'name'      => 'itilfollowuptemplates_id',
+            'label'     => ITILFollowupTemplate::getTypeName(1),
+            'type'      => 'dropdownValue',
+            'list'      => true
+         ],
+         [
+            'name'  => 'followups_before_resolution',
+            'label' => __('Follow-ups before automatic resolution'),
+            'type'  => '',
+            'list'  => true
+         ],
+         [
+            'name'      => 'solutiontemplates_id',
+            'label'     => SolutionTemplate::getTypeName(1),
+            'type'      => 'dropdownValue',
+            'list'      => true
+         ],
+      ];
+   }
+
+   public function rawSearchOptions() {
+      $tab = parent::rawSearchOptions();
+
+      $tab[] = [
+         'id'                 => '200',
+         'table'              => $this->getTable(),
+         'field'              => 'followup_frequency',
+         'name'               => __('Automatic follow-up frequency'),
+         'searchtype'         => ['equals', 'notequals'],
+         'datatype'           => 'specific'
+      ];
+
+      $tab[] = [
+         'id'                 => '201',
+         'table'              => $this->getTable(),
+         'field'              => 'followups_before_resolution',
+         'name'               => __('Follow-ups before automatic resolution'),
+         'searchtype'         => ['equals', 'notequals'],
+         'datatype'           => 'specific'
+      ];
+
+      $tab[] = [
+         'id'                 => '202',
+         'table'              => ITILFollowupTemplate::getTable(),
+         'field'              => 'name',
+         'linkfield'          => ITILFollowupTemplate::getForeignKeyField(),
+         'name'               => __('Follow-up template'),
+         'massiveaction'      => false,
+         'searchtype'         => ['equals', 'notequals'],
+         'datatype'           => 'dropdown',
+      ];
+
+      $tab[] = [
+         'id'                 => '203',
+         'table'              => SolutionTemplate::getTable(),
+         'field'              => 'name',
+         'linkfield'          => SolutionTemplate::getForeignKeyField(),
+         'name'               => SolutionTemplate::getTypeName(1),
+         'massiveaction'      => false,
+         'searchtype'         => ['equals', 'notequals'],
+         'datatype'           => 'dropdown',
+      ];
+
+      return $tab;
+   }
+
+   /**
+    * Display specific "followup_frequency" field
+    *
+    * @param $value
+    * @param $name
+    * @param $options
+    * @param $long_label If false give less details in the default label
+    */
+   public static function displayFollowupFrequencyfield(
+      $value = null,
+      $name = "",
+      $options = [],
+      $long_label = true
+   ) {
+      $values = self::getFollowupFrequencyValues();
+
+      // Short label for forms with input labels
+      $label = __("Disabled");
+
+      if ($long_label) {
+         // Long default value label for forms with icons instead of labels
+         $label = __("Automatic follow-up disabled");
+      }
+
+      if ($value) {
+         if (!isset($values[$value])) {
+            $value = null;
+         }
+      }
+
+      $options['value'] = $value;
+      $options['emptylabel'] = $label;
+      $options['display_emptychoice'] = true;
+      $options['display'] = false;
+
+      if (empty($name)) {
+         $name = "followup_frequency";
+      }
+
+      return Dropdown::showFromArray($name, $values, $options);
+   }
+
+   /**
+    * Get possibles followup frequency values for pending reasons
+    * @return array timestamp before each bump => label
+    */
+   public static function getFollowupFrequencyValues(): array {
+      return [
+         WEEK_TIMESTAMP     => __("Every week"),
+         2 * WEEK_TIMESTAMP => __("Every two weeks"),
+         3 * WEEK_TIMESTAMP => __("Every three weeks"),
+         4 * WEEK_TIMESTAMP => __("Every four weeks"),
+      ];
+   }
+
+   /**
+    * Display specific "followups_before_resolution" field
+    *
+    * @param $value
+    * @param $name
+    * @param $options
+    * @param $long_label If false give less details in the default label
+    */
+   public static function displayFollowupsNumberBeforeResolutionField(
+      $value = null,
+      $name = "",
+      $options = [],
+      $long_label = true
+   ) {
+      $values = self::getFollowupsBeforeResolutionValues();
+
+      // Short label for forms with input labels
+      $label = __("Disabled");
+
+      if ($long_label) {
+         // Long default value label for forms with icons instead of labels
+         $label = __("Automatic resolution disabled");
+      }
+
+      if ($value) {
+         if (!isset($values[$value])) {
+            $value = null;
+         }
+      }
+
+      if (empty($name)) {
+         $name = "followups_before_resolution";
+      }
+
+      $options['value'] = $value;
+      $options['emptylabel'] = $label;
+      $options['display_emptychoice'] = true;
+      $options['display'] = false;
+
+      return Dropdown::showFromArray($name, $values, $options);
+   }
+
+   /**
+    * Get possibles values for 'followups_before_resolution' field of pending reasons
+    * @return array number of bump before resolution => label
+    */
+   public static function getFollowupsBeforeResolutionValues(): array {
+      return [
+         1 => __("After one follow-up"),
+         2 => __("After two follow-ups"),
+         3 => __("After three follow-ups"),
+      ];
+   }
+
+   public function displaySpecificTypeField($ID, $field = []) {
+
+      if ($field['name'] == 'followup_frequency') {
+         echo self::displayFollowupFrequencyfield($this->fields['followup_frequency'], "", [], false);
+      } else if ($field['name'] == 'followups_before_resolution') {
+         echo self::displayFollowupsNumberBeforeResolutionField($this->fields['followups_before_resolution'], "", [], false);
+      }
+   }
+
+   public static function getSpecificValueToDisplay($field, $values, array $options = []) {
+      if ($field == 'followup_frequency') {
+         if ($values[$field] == 0) {
+            return __("Disabled");
+         }
+         return self::getFollowupFrequencyValues()[$values[$field]];
+      } else if ($field == 'followups_before_resolution') {
+         if ($values[$field] == 0) {
+            return __("Disabled");
+         }
+         return self::getFollowupsBeforeResolutionValues()[$values[$field]];
+      }
+
+      return parent::getSpecificValueToDisplay($field, $values, $options);
+   }
+
+   public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = []) {
+
+      if ($field == 'followup_frequency') {
+         return self::displayFollowupFrequencyfield($values[$field], $name, $options, false);
+      } else if ($field == 'followups_before_resolution') {
+         return self::displayFollowupsNumberBeforeResolutionField($values[$field], $name, $options, false);
+      }
+
+      return parent::getSpecificValueToSelect($field, $name, $values, $options);
+   }
+
+}

--- a/inc/pendingreason_item.class.php
+++ b/inc/pendingreason_item.class.php
@@ -1,0 +1,575 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+class PendingReason_Item extends CommonDBRelation
+{
+   public static $itemtype_1 = 'PendingReason';
+   public static $items_id_1 = 'pendingreasons_id';
+   public static $take_entity_1 = false;
+
+   public static $itemtype_2 = 'itemtype';
+   public static $items_id_2 = 'items_id';
+   public static $take_entity_2 = true;
+
+   public static function getTypeName($nb = 0) {
+      return _n('Item', 'Items', $nb);
+   }
+
+   public static function getForItem(CommonDBTM $item) {
+      $em = new self();
+      $find = $em->find([
+         'itemtype' => $item::getType(),
+         'items_id' => $item->getID(),
+      ]);
+
+      if (!count($find)) {
+         return false;
+      }
+
+      $row_found = array_pop($find);
+      return self::getById($row_found['id']);
+   }
+
+   /**
+    * Create a pendingreason_item for a given item
+    *
+    * @param CommonDBTM $item
+    * @param array      $fields field to insert (pendingreasons_id, followup_frequency
+    *                           and followups_before_resolution)
+    * @return bool true on success
+    */
+   public static function createForItem(CommonDBTM $item, array $fields): bool {
+      $em = new self();
+      $find = $em->find([
+         'itemtype' => $item::getType(),
+         'items_id' => $item->getID(),
+      ]);
+
+      if (count($find)) {
+         // Clean existing entry
+         $to_delete = array_pop($find);
+         $fields['id'] = $to_delete['id'];
+         $em->delete(['id' => $fields['id']]);
+         unset($fields['id']);
+         $em = new self();
+      }
+
+      $fields['itemtype'] = $item::getType();
+      $fields['items_id'] = $item->getID();
+      $fields['last_bump_date'] = $_SESSION['glpi_currenttime'];
+      $success = $em->add($fields);
+      if (!$success) {
+         trigger_error("Failed to create PendingReason_Item", E_USER_WARNING);
+      }
+
+      return $success;
+   }
+
+   /**
+    * Update a pendingreason_item for a given item
+    *
+    * @param CommonDBTM $item
+    * @param array      $fields fields to update
+    * @return bool true on success
+    */
+   public static function updateForItem(CommonDBTM $item, array $fields): bool {
+      $em = new self();
+      $find = $em->find([
+         'itemtype' => $item::getType(),
+         'items_id' => $item->getID(),
+      ]);
+
+      if (!count($find)) {
+         trigger_error("Failed to update PendingReason_Item, no item found", E_USER_WARNING);
+         return false;
+      }
+
+      $to_update = array_pop($find);
+      $fields['id'] = $to_update['id'];
+      $success = $em->update($fields);
+      if (!$success) {
+         trigger_error("Failed to update PendingReason_Item", E_USER_WARNING);
+      }
+
+      return $success;
+   }
+
+   /**
+    * Delete a pendingreason_item for a given item
+    *
+    * @param CommonDBTM $item
+    * @return bool true on success
+    */
+   public static function deleteForItem(CommonDBTM $item): bool {
+      $em = new self();
+      $find = $em->find([
+         'itemtype' => $item::getType(),
+         'items_id' => $item->getID(),
+      ]);
+
+      if (!count($find)) {
+         // Nothing to delete
+         return true;
+      }
+
+      $to_delete = array_pop($find);
+      $success = $em->delete([
+         'id' => $to_delete['id']
+      ]);
+
+      if (!$success) {
+         trigger_error("Failed to delete PendingReason_Item", E_USER_WARNING);
+      }
+
+      return $success;
+   }
+
+   /**
+    * Get auto resolve date
+    *
+    * @return string|bool date (Y-m-d H:i:s) or false
+    */
+   public function getNextFollowupDate() {
+      if (empty($this->fields['followup_frequency'])) {
+         return false;
+      }
+
+      if ($this->fields['followups_before_resolution'] > 0 && $this->fields['followups_before_resolution'] <= $this->fields['bump_count']) {
+         return false;
+      }
+
+      $date = new DateTime($this->fields['last_bump_date']);
+      $date->setTimestamp($date->getTimestamp() + $this->fields['followup_frequency']);
+      return $date->format("Y-m-d H:i:s");
+   }
+
+   /**
+    * Get auto resolve date
+    *
+    * @return string|bool date (Y-m-d H:i:s) or false
+    */
+   public function getAutoResolvedate() {
+      if (empty($this->fields['followup_frequency']) || empty($this->fields['followups_before_resolution'])) {
+         return false;
+      }
+
+      // If there was a bump, calculate from last_bump_date
+      $date = new DateTime($this->fields['last_bump_date']);
+      $date->setTimestamp($date->getTimestamp() + $this->fields['followup_frequency'] * ($this->fields['followups_before_resolution'] + 1 - $this->fields['bump_count']));
+
+      return $date->format("Y-m-d H:i:s");
+   }
+
+   /**
+    * Display the "pending" mini form for a given timeline item
+    *
+    * @param CommonDBTM $item
+    * @param int $rand
+    */
+   public static function showFormForTimelineItem(CommonDBTM $item, int $rand): void {
+      global $CFG_GLPI;
+
+      // Only show pending form if creating a new followup or editing one with a pending reason
+      $pending_item = self::getForItem($item);
+      if ($item->isNewItem() || $pending_item || self::isLastTimelineItem($item)) {
+         if (!$pending_item) {
+            $pending_item = new self();
+            $pending_item->getEmpty();
+         }
+
+         echo "<tr><td colspan='4'>";
+
+         // Display "pending" switch
+         echo "<div class='fa-label'>";
+         echo "<i class='fas fa-pause fa-fw' title='".__('Pending')."'></i>";
+         echo "<span class='switch pager_controls'>";
+         echo "<label for='pendingswitch$rand' title='".__('Pending')."'>";
+         $pending_checked = !$pending_item->isNewItem() ? "checked='checked'" : "";
+         echo "<input type='checkbox' id='pendingswitch$rand' name='pending' value='1' $pending_checked>";
+         echo "<span class='lever'></span>";
+         echo "</label>";
+         echo "</span>";
+         echo "</div>";
+
+         // Display pending reason field
+         $display_pending_reason = $pending_checked ? "" : "starthidden";
+         echo "<div id='pending_reason_dropdown$rand' class='$display_pending_reason fa-label'>";
+         echo "<i class='fas fa-tag fa-fw mr10px' title='". PendingReason::getTypeName(1) ."'></i>";
+         PendingReason::dropdown([
+            'emptylabel'          => __("No pending reason"),
+            'display_emptychoice' => true,
+            'rand'                => $rand,
+            'value'               => $pending_item->fields["pendingreasons_id"],
+         ]);
+         echo "</div>";
+
+         // Display auto bump field
+         $display_pending_reason_extra = $pending_item->fields["pendingreasons_id"] > 0 ? "" : "starthidden";
+         echo "<div id='pending_reason_followup_frequency_dropdown$rand' class='$display_pending_reason_extra fa-label'>";
+         echo "<i class='fas fa-redo fa-fw mr10px' title='".__('Automatic follow-up')."'></i>";
+         echo PendingReason::displayFollowupFrequencyfield($pending_item->fields["followup_frequency"]);
+         echo "</div>";
+
+         // Display auto solve field
+         echo "<div id='pending_reason_followups_before_resolution_dropdown$rand' class='$display_pending_reason_extra fa-label'>";
+         echo "<i class='fas fa-check fa-fw mr10px' title='".__('Automatic resolution')."'></i>";
+         echo PendingReason::displayFollowupsNumberBeforeResolutionField($pending_item->fields["followups_before_resolution"]);
+         echo "</div>";
+
+         // JS handling visiblity and values of the previous fields
+         $pending_ajax_url = $CFG_GLPI["root_doc"]."/ajax/pendingreason.php";
+         echo Html::scriptBlock("
+            $('#pendingswitch$rand').change(function() {
+               if ($('#pendingswitch$rand').prop('checked')) {
+                  $('#pending_reason_dropdown$rand').show();
+                  if ($('#dropdown_pendingreasons_id$rand').val() > 0) {
+                     $('#pending_reason_followup_frequency_dropdown$rand').show();
+                     $('#pending_reason_followups_before_resolution_dropdown$rand').show();
+                  }
+               } else {
+                  $('#pending_reason_dropdown$rand').hide();
+                  $('#pending_reason_followup_frequency_dropdown$rand').hide();
+                  $('#pending_reason_followups_before_resolution_dropdown$rand').hide();
+               }
+            });
+
+            var pending_reasons_cache = [];
+            $('#dropdown_pendingreasons_id$rand').change(function() {
+               var pending_val = $('#dropdown_pendingreasons_id$rand').val();
+
+               if (pending_val > 0) {
+                  if (pending_reasons_cache[pending_val] == undefined) {
+                     $.ajax({
+                        url: '{$pending_ajax_url}',
+                        type: 'POST',
+                        data: {
+                           pendingreasons_id: pending_val
+                        }
+                     }).done(function(data) {
+                        $('#pending_reason_followup_frequency_dropdown$rand').show();
+                        $('#pending_reason_followups_before_resolution_dropdown$rand').show();
+                        $('#pending_reason_followup_frequency_dropdown$rand select').val(data.followup_frequency);
+                        $('#pending_reason_followups_before_resolution_dropdown$rand select').val(data.followups_before_resolution);
+                        $('#pending_reason_followup_frequency_dropdown$rand select').trigger('change');
+                        $('#pending_reason_followups_before_resolution_dropdown$rand select').trigger('change');
+
+                        pending_reasons_cache[pending_val] = data;
+                     });
+                  } else {
+                     $('#pending_reason_followup_frequency_dropdown$rand').show();
+                     $('#pending_reason_followups_before_resolution_dropdown$rand').show();
+                  }
+               } else {
+                  $('#pending_reason_followup_frequency_dropdown$rand').hide();
+                  $('#pending_reason_followups_before_resolution_dropdown$rand').hide();
+               }
+            });
+         ");
+
+         echo "</td></tr>";
+      }
+   }
+
+   /**
+    * Display pending informations in the main tab of a given CommonITILObject
+    *
+    * @param CommonITILObject $item
+    */
+   public static function displayStatusTooltip(CommonITILObject $item): void {
+      $pending_item = self::getForItem($item);
+      if ($pending_item) {
+         $pending_reason = PendingReason::getById($pending_item->fields['pendingreasons_id']);
+
+         if (!$pending_reason) {
+            return;
+         }
+
+         echo '<div class="pending_detail">' . $pending_reason->getLink();
+         $tooltip = "";
+
+         $next_bump = $pending_item->getNextFollowupDate();
+         if ($next_bump) {
+            $tooltip .= sprintf(__("Next automatic follow-up scheduled on %s"), Html::convDate($next_bump)) . ".<br>";
+         }
+
+         $resolve = $pending_item->getAutoResolvedate();
+         if ($resolve) {
+            $tooltip .= sprintf(__("Automatic resolution scheduled on %s"), Html::convDate($resolve)) . ".<br>";
+         }
+
+         if (!empty($tooltip)) {
+            Html::showToolTip($tooltip);
+         }
+
+         echo "</div>";
+      }
+   }
+
+   /**
+    * Check that the given timeline event is the lastest "pending" action for
+    * the given item
+    *
+    * @param CommonITILObject $item
+    * @param CommonDBTM       $timeline_item
+    * @return boolean
+    */
+   public static function isLastPendingForItem(
+      CommonITILObject $item,
+      CommonDBTM $timeline_item
+   ): bool {
+      global $DB;
+
+      $task_class = $item::getTaskClass();
+
+      $data = $DB->request([
+         'SELECT' => ['MAX' => 'id AS max_id'],
+         'FROM'  => PendingReason_Item::getTable(),
+         'WHERE' => [
+            'OR' => [
+               [
+                  'itemtype' => ITILFollowup::getType(),
+                  'items_id' => new QuerySubQuery([
+                     'SELECT' => 'id',
+                     'FROM'   => ITILFollowup::getTable(),
+                     'WHERE'  => [
+                        'itemtype' => $item::getType(),
+                        'items_id' => $item->getID(),
+                     ]
+                  ])
+               ],
+               [
+                  'itemtype' => $task_class::getType(),
+                  'items_id' => new QuerySubQuery([
+                     'SELECT' => 'id',
+                     'FROM'   => $task_class::getTable(),
+                     'WHERE'  => [
+                        $item::getForeignKeyField() => $item->getID(),
+                     ]
+                  ])
+               ],
+            ]
+         ]
+      ]);
+
+      if (!count($data)) {
+         return false;
+      }
+
+      $row = $data->next();
+      $pending_item = self::getById($row['max_id']);
+
+      return $pending_item->fields['items_id'] == $timeline_item->fields['id'] && $pending_item->fields['itemtype'] == $timeline_item::getType();
+   }
+
+   /**
+    * Check that the given timeline_item is the last one added in it's
+    * parent timeline
+    *
+    * @param CommonDBTM $timeline_item
+    * @return boolean
+    */
+   public static function isLastTimelineItem(CommonDBTM $timeline_item): bool {
+      global $DB;
+
+      if ($timeline_item instanceof ITILFollowup) {
+         $parent_itemtype = $timeline_item->fields['itemtype'];
+         $parent_items_id = $timeline_item->fields['items_id'];
+         $task_class = $parent_itemtype::getTaskClass();
+      } else if ($timeline_item instanceof TicketTask) {
+         $parent_itemtype = Ticket::class;
+         $parent_items_id = $timeline_item->fields[Ticket::getForeignKeyField()];
+         $task_class = TicketTask::class;
+      } else if ($timeline_item instanceof ProblemTask) {
+         $parent_itemtype = Problem::class;
+         $parent_items_id = $timeline_item->fields[Problem::getForeignKeyField()];
+         $task_class = ProblemTask::class;
+      } else if ($timeline_item instanceof ChangeTask) {
+         $parent_itemtype = Change::class;
+         $parent_items_id = $timeline_item->fields[Change::getForeignKeyField()];
+         $task_class = ChangeTask::class;
+      } else {
+         return false;
+      }
+
+      $followups_query = new QuerySubQuery([
+         'SELECT'    => ['date_creation'],
+         'FROM'      => ITILFollowup::getTable(),
+         'WHERE'     => [
+            "itemtype" => $parent_itemtype,
+            "items_id" => $parent_items_id,
+         ]
+      ]);
+
+      $tasks_query = new QuerySubQuery([
+         'SELECT'    => ['date_creation'],
+         'FROM'      => $task_class::getTable(),
+         'WHERE'     => [
+            $parent_itemtype::getForeignKeyField() => $parent_items_id,
+         ]
+      ]);
+
+      $union = new \QueryUnion([$followups_query, $tasks_query], false, 'timelinevents');
+      $data = $DB->request([
+         'SELECT' => ['MAX' => 'date_creation AS max_date_creation'],
+         'FROM'   => $union
+      ]);
+
+      if (!count($data)) {
+         return false;
+      }
+
+      $row = $data->next();
+
+      return $row['max_date_creation'] == $timeline_item->fields['date_creation'];
+   }
+
+   /**
+    * Handle edit on a "pending action" from an item the timeline
+    *
+    * @param CommonDBTM $timeline_item
+    * @return array
+    */
+   public static function handleTimelineEdits(CommonDBTM $timeline_item): array {
+
+      if (self::getForItem($timeline_item)) {
+         // Event was already marked as pending
+
+         if ($timeline_item->input['pending'] ?? 0) {
+            // Still pending, check for update
+            $pending_updates = [];
+            if (isset($timeline_item->input['pendingreasons_id'])) {
+               $pending_updates['pendingreasons_id'] = $timeline_item->input['pendingreasons_id'];
+            }
+            if (isset($timeline_item->input['followup_frequency'])) {
+               $pending_updates['followup_frequency'] = $timeline_item->input['followup_frequency'];
+            }
+            if (isset($timeline_item->input['followups_before_resolution'])) {
+               $pending_updates['followups_before_resolution'] = $timeline_item->input['followups_before_resolution'];
+            }
+
+            if (count($pending_updates) > 0) {
+               self::updateForItem($timeline_item, $pending_updates);
+
+               if ($timeline_item->input['_job']->fields['status'] == CommonITILObject::WAITING
+                  && self::isLastPendingForItem($timeline_item->input['_job'], $timeline_item)) {
+                  // Update parent if needed
+                  self::updateForItem($timeline_item->input['_job'], $pending_updates);
+               }
+            }
+         } else if (!$timeline_item->input['pending'] ?? 1) {
+            // No longer pending, remove pending data
+            self::deleteForItem($timeline_item->input["_job"]);
+            self::deleteForItem($timeline_item);
+
+            // Change status of parent if needed
+            if ($timeline_item->input["_job"]->fields['status'] == CommonITILObject::WAITING) {
+               $timeline_item->input['_status'] = CommonITILObject::ASSIGNED;
+            }
+         }
+      } else {
+         // Not pending yet; did it change ?
+         if ($timeline_item->input['pending'] ?? 0) {
+            // Set parent status
+            $timeline_item->input['_status'] = CommonITILObject::WAITING;
+
+            // Create pending_item data for event and parent
+            self::createForItem($timeline_item->input["_job"], [
+               'pendingreasons_id' => $timeline_item->input['pendingreasons_id'],
+               'followup_frequency'         => $timeline_item->input['followup_frequency'] ?? 0,
+               'followups_before_resolution'        => $timeline_item->input['followups_before_resolution'] ?? 0,
+            ]);
+            self::createForItem($timeline_item, [
+               'pendingreasons_id' => $timeline_item->input['pendingreasons_id'],
+               'followup_frequency'         => $timeline_item->input['followup_frequency'] ?? 0,
+               'followups_before_resolution'        => $timeline_item->input['followups_before_resolution'] ?? 0,
+            ]);
+         }
+      }
+
+      return $timeline_item->input;
+   }
+
+   public static function canCreate() {
+      return ITILFollowup::canUpdate() || TicketTask::canUpdate() || ChangeTask::canUpdate() || ProblemTask::canUpdate();
+   }
+
+   public static function canView() {
+      return ITILFollowup::canView() || TicketTask::canView() || ChangeTask::canView() || ProblemTask::canView();
+   }
+
+   public static function canUpdate() {
+      return ITILFollowup::canUpdate() || TicketTask::canUpdate() || ChangeTask::canUpdate() || ProblemTask::canUpdate();
+   }
+
+   public static function canDelete() {
+      return ITILFollowup::canUpdate() || TicketTask::canUpdate() || ChangeTask::canUpdate() || ProblemTask::canUpdate();
+   }
+
+   public static function canPurge() {
+      return ITILFollowup::canUpdate() || TicketTask::canUpdate() || ChangeTask::canUpdate() || ProblemTask::canUpdate();
+   }
+
+   public function canCreateItem() {
+      $itemtype = $this->fields['itemtype'];
+      $item = $itemtype::getById($this->fields['items_id']);
+      return $item->canUpdateItem();
+   }
+
+   public function canViewItem() {
+      $itemtype = $this->fields['itemtype'];
+      $item = $itemtype::getById($this->fields['items_id']);
+      return $item->canViewItem();
+   }
+
+   public function canUpdateItem() {
+      $itemtype = $this->fields['itemtype'];
+      $item = $itemtype::getById($this->fields['items_id']);
+      return $item->canUpdateItem();
+   }
+
+   public function canDeleteItem() {
+      $itemtype = $this->fields['itemtype'];
+      $item = $itemtype::getById($this->fields['items_id']);
+      return $item->canUpdateItem();
+   }
+
+   public function canPurgeItem() {
+      $itemtype = $this->fields['itemtype'];
+      $item = $itemtype::getById($this->fields['items_id']);
+      return $item->canUpdateItem();
+   }
+
+}

--- a/inc/pendingreasoncron.class.php
+++ b/inc/pendingreasoncron.class.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ * @since 10.0.0
+ */
+class PendingReasonCron extends CommonDBTM
+{
+   const TASK_NAME = 'pendingreason_autobump_autosolve';
+
+   /**
+    * Get task description
+    *
+    * @return string
+    */
+   public static function getTaskDescription(): string {
+      return __("Send automated follow-ups on pending tickets and solve them if necessary");
+   }
+
+   public static function cronInfo($name) {
+      return [
+         'description' => self::getTaskDescription(),
+      ];
+   }
+
+   /**
+    * Run from cronTask
+    *
+    * @param CronTask $task
+    */
+   public static function cronPendingreason_autobump_autosolve(CronTask $task) {
+      global $DB;
+
+      $config = Config::getConfigurationValues('core', ['system_user']);
+
+      if (empty($config['system_user'])) {
+         trigger_error("Mising system_user config", E_USER_WARNING);
+         return 0;
+      }
+
+      $user = User::getById($config['system_user']);
+      if (!$user) {
+         trigger_error("Mising system_user user", E_USER_WARNING);
+         return 0;
+      }
+
+      $targets = [
+         Ticket::getType(),
+         Change::getType(),
+         Problem::getType(),
+      ];
+
+      $now = date("Y-m-d H:i:s");
+
+      $data = $DB->request([
+         'SELECT' => 'id',
+         'FROM'   => PendingReason_Item::getTable(),
+         'WHERE'  => [
+            'pendingreasons_id'  => ['>', 0],
+            'followup_frequency' => ['>', 0],
+            'itemtype'           => $targets
+         ]
+      ]);
+
+      foreach ($data as $row) {
+         $pending_item = PendingReason_Item::getById($row['id']);
+         $itemtype = $pending_item->fields['itemtype'];
+         $item = $itemtype::getById($pending_item->fields['items_id']);
+         if (!$item) {
+            trigger_error("Failed to load item", E_USER_WARNING);
+            continue;
+         }
+
+         if ($item->fields['status'] != CommonITILObject::WAITING) {
+            trigger_error("Status is not pending", E_USER_WARNING);
+            continue;
+         }
+
+         $next_bump = $pending_item->getNextFollowupDate();
+         $resolve = $pending_item->getAutoResolvedate();
+
+         if ($next_bump && $now > $next_bump) {
+            // Load pending reason
+            $pending_reason = PendingReason::getById($pending_item->fields['pendingreasons_id']);
+            if (!$pending_reason) {
+               trigger_error("Failed to load PendingReason", E_USER_WARNING);
+               continue;
+            }
+
+            // Load followup template
+            $fup_template = ITILFollowupTemplate::getById($pending_reason->fields['itilfollowuptemplates_id']);
+            if (!$fup_template) {
+               trigger_error("Failed to load ITILFollowupTemplate::{$pending_reason->fields['itilfollowuptemplates_id']}", E_USER_WARNING);
+               continue;
+            }
+
+            $success = $pending_item->update([
+               'id'             => $pending_item->getID(),
+               'bump_count'     => $pending_item->fields['bump_count'] + 1,
+               'last_bump_date' => date("Y-m-d H:i:s"),
+            ]);
+
+            if (!$success) {
+               trigger_error("Can't bump, unable to update pending item", E_USER_WARNING);
+               continue;
+            }
+
+            // Add bump (new followup from template)
+            $fup = new ITILFollowup();
+            $fup->add([
+               'itemtype' => $item::getType(),
+               'items_id' => $item->getID(),
+               'users_id' => $config['system_user'],
+               'content' => addslashes($fup_template->fields['content']),
+               'is_private' => $fup_template->fields['is_private'],
+               'requesttypes_id' => $fup_template->fields['requesttypes_id'],
+               'timeline_position' => CommonITILObject::TIMELINE_RIGHT,
+            ]);
+            $task->addVolume(1);
+         } else if ($resolve && $now > $resolve) {
+            // Load pending reason
+            $pending_reason = PendingReason::getById($pending_item->fields['pendingreasons_id']);
+            if (!$pending_reason) {
+               trigger_error("Failed to load PendingReason", E_USER_WARNING);
+               continue;
+            }
+
+            // Load solution template
+            $solution_template = SolutionTemplate::getById($pending_reason->fields['solutiontemplates_id']);
+            if (!$solution_template) {
+               trigger_error("Failed to load SolutionTemplate::{$pending_reason->fields['solutiontemplates_id']}", E_USER_WARNING);
+               continue;
+            }
+
+            // Add solution
+            $solution = new ITILSolution();
+            $solution->add([
+               'itemtype'         => $item::getType(),
+               'items_id'         => $item->getID(),
+               'solutiontypes_id' => $solution_template->fields['solutiontypes_id'],
+               'content'          => addslashes($solution_template->fields['content']),
+               'users_id'         => $config['system_user'],
+            ]);
+            $task->addVolume(1);
+         }
+      }
+
+      return 1;
+   }
+
+   /**
+    * Return the localized name of the current Type
+    * Should be overloaded in each new class
+    *
+    * @param integer $nb Number of items
+    *
+    * @return string
+   **/
+   public static function getTypeName($nb = 0) {
+      return __('Automatic followups / resolution');
+   }
+}

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -1477,6 +1477,7 @@ class Problem extends CommonITILObject {
             echo "&nbsp;<a class='vsubmit' href='$link'>". __('Reopen')."</a>";
          }
       }
+      PendingReason_Item::displayStatusTooltip($this);
       echo $tt->getEndHiddenFieldValue('status', $this);
 
       echo "</td>";
@@ -2032,5 +2033,9 @@ class Problem extends CommonITILObject {
 
    public static function getItemLinkClass(): string {
       return Item_Problem::class;
+   }
+
+   public static function getTaskClass() {
+      return ProblemTask::class;
    }
 }

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -1132,9 +1132,18 @@ class Profile extends CommonDBTM {
       $matrix_options = ['canedit'       => $canedit,
                               'default_class' => 'tab_bg_2'];
 
-      $rights = [['itemtype'  => 'TicketTemplate',
-                            'label'     => _n('Template', 'Templates', Session::getPluralNumber()),
-                            'field'     => 'itiltemplate']];
+      $rights = [
+         [
+            'itemtype'  => 'TicketTemplate',
+            'label'     => _n('Template', 'Templates', Session::getPluralNumber()),
+            'field'     => 'itiltemplate'
+         ],
+         [
+            'itemtype'  => 'PendingReason',
+            'label'     => PendingReason::getTypeName(0),
+            'field'     => 'pendingreason'
+         ],
+      ];
       $matrix_options['title'] = _n('ITIL object', 'ITIL objects', Session::getPluralNumber());
       $this->displayRightsChoiceMatrix($rights, $matrix_options);
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -4907,6 +4907,9 @@ JAVASCRIPT;
             echo "&nbsp;<a class='vsubmit' href='$link'>". __('Reopen')."</a>";
          }
       }
+
+      // If ticket have a pending reason, display the detail in a tooltip
+      PendingReason_Item::displayStatusTooltip($this);
       echo $tt->getEndHiddenFieldValue('status', $this);
 
       echo "</td>";
@@ -6964,49 +6967,6 @@ JAVASCRIPT;
 
    }
 
-
-   /**
-    * @since 0.90
-    *
-    * @param integer $tickets_id
-    * @param string  $action      (default 'add')
-   **/
-   static function getSplittedSubmitButtonHtml($tickets_id, $action = "add") {
-
-      $locale = _sx('button', 'Add');
-      if ($action == 'update') {
-         $locale = _x('button', 'Save');
-      }
-      $ticket       = new self();
-      $ticket->getFromDB($tickets_id);
-      $all_status   = Ticket::getAllowedStatusArray($ticket->fields['status']);
-      $rand = mt_rand();
-
-      $html = "<div class='x-split-button' id='x-split-button'>
-               <input type='submit' value='$locale' name='$action' class='x-button x-button-main'>
-               <span class='x-button x-button-drop'>&nbsp;</span>
-               <ul class='x-button-drop-menu'>";
-      foreach ($all_status as $status_key => $status_label) {
-         $checked = "";
-         if ($status_key == $ticket->fields['status']) {
-            $checked = "checked='checked'";
-         }
-         $html .= "<li data-status='".self::getStatusKey($status_key)."'>";
-         $html .= "<input type='radio' id='status_radio_$status_key$rand' name='_status'
-                    $checked value='$status_key'>";
-         $html .= "<label for='status_radio_$status_key$rand'>";
-         $html .= Ticket::getStatusIcon($status_key) . "&nbsp;";
-         $html .= $status_label;
-         $html .= "</label>";
-         $html .= "</li>";
-      }
-      $html .= "</ul></div>";
-
-      $html.= "<script type='text/javascript'>$(function() {split_button();});</script>";
-      return $html;
-   }
-
-
    /**
     * Get correct Calendar: Entity or Sla
     *
@@ -7732,5 +7692,9 @@ JAVASCRIPT;
 
    public static function getItemLinkClass(): string {
       return Item_Ticket::class;
+   }
+
+   public static function getTaskClass() {
+      return TicketTask::class;
    }
 }

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -688,6 +688,16 @@ $tables['glpi_crontasks'] = [
       'lastrun'       => null,
       'logs_lifetime' => 30,
    ], [
+      'id'            => 42,
+      'itemtype'      => PendingReasonCron::getType(),
+      'name'          => PendingReasonCron::TASK_NAME,
+      'frequency'     => 30 * MINUTE_TIMESTAMP,
+      'param'         => null,
+      'state'         => 1,
+      'mode'          => 2,
+      'lastrun'       => null,
+      'logs_lifetime' => 60,
+   ], [
       'id'            => 40,
       'itemtype'      => 'Glpi\Inventory\Inventory',
       'name'          => 'cleantemp',
@@ -7511,6 +7521,38 @@ $tables['glpi_profilerights'] = [
       'profiles_id' => '8',
       'name'        => 'inventory',
       'rights'      => 0,
+   ], [
+      'profiles_id' => '1',
+      'name'        => 'pendingreason',
+      'rights'      => 0,
+   ], [
+      'profiles_id' => '2',
+      'name'        => 'pendingreason',
+      'rights'      => 0,
+   ], [
+      'profiles_id' => '3',
+      'name'        => 'pendingreason',
+      'rights'      => 31,
+   ], [
+      'profiles_id' => '4',
+      'name'        => 'pendingreason',
+      'rights'      => 31,
+   ], [
+      'profiles_id' => '5',
+      'name'        => 'pendingreason',
+      'rights'      => 1,
+   ], [
+      'profiles_id' => '6',
+      'name'        => 'pendingreason',
+      'rights'      => 1,
+   ], [
+      'profiles_id' => '7',
+      'name'        => 'pendingreason',
+      'rights'      => 1,
+   ], [
+      'profiles_id' => '8',
+      'name'        => 'pendingreason',
+      'rights'      => 1,
    ],
 ];
 

--- a/install/migrations/update_9.5.x_to_10.0.0/pendingreason.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/pendingreason.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+$default_charset = DBConnection::getDefaultCharset();
+$default_collation = DBConnection::getDefaultCollation();
+
+// Add pending reason table
+if (!$DB->tableExists('glpi_pendingreasons')) {
+   $query = "CREATE TABLE `glpi_pendingreasons` (
+         `id` int NOT NULL AUTO_INCREMENT,
+         `entities_id` int NOT NULL DEFAULT '0',
+         `is_recursive` tinyint NOT NULL DEFAULT '0',
+         `name` varchar(255) DEFAULT NULL,
+         `followup_frequency` int NOT NULL DEFAULT '0',
+         `followups_before_resolution` int NOT NULL DEFAULT '0',
+         `itilfollowuptemplates_id` int NOT NULL DEFAULT '0',
+         `solutiontemplates_id` int NOT NULL DEFAULT '0',
+         `comment` text,
+         PRIMARY KEY (`id`),
+         KEY `name` (`name`),
+         KEY `itilfollowuptemplates_id` (`itilfollowuptemplates_id`),
+         KEY `entities_id` (`entities_id`),
+         KEY `is_recursive` (`is_recursive`),
+         KEY `solutiontemplates_id` (`solutiontemplates_id`)
+      ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = $default_charset COLLATE = $default_collation;";
+   $DB->queryOrDie($query, "x.x add table glpi_pendingreasons");
+}
+
+// Add pending reason items table
+if (!$DB->tableExists('glpi_pendingreasons_items')) {
+   $query = "CREATE TABLE `glpi_pendingreasons_items` (
+         `id` int NOT NULL AUTO_INCREMENT,
+         `pendingreasons_id` int NOT NULL DEFAULT '0',
+         `items_id` int NOT NULL DEFAULT '0',
+         `itemtype` varchar(100) NOT NULL DEFAULT '',
+         `followup_frequency` int NOT NULL DEFAULT '0',
+         `followups_before_resolution` int NOT NULL DEFAULT '0',
+         `bump_count` int NOT NULL DEFAULT '0',
+         `last_bump_date` timestamp NULL DEFAULT NULL,
+         PRIMARY KEY (`id`),
+         UNIQUE KEY `unicity` (`items_id`,`itemtype`),
+         KEY `pendingreasons_id` (`pendingreasons_id`),
+         KEY `item` (`itemtype`,`items_id`)
+      ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = $default_charset COLLATE = $default_collation;";
+   $DB->queryOrDie($query, "x.x add table glpi_pendingreasons_items");
+}
+
+// Add pendingreason right
+$migration->addRight('pendingreason', ALLSTANDARDRIGHT, ['itiltemplate' => UPDATE]);
+
+// Add user for automatic bump and followup
+$migration->addConfig('system_user', 'core');
+
+$config = Config::getConfigurationValues('core');
+if (empty($config['system_user'])) {
+   $user = new User();
+
+   $id = $user->add([
+      'name'     => 'glpi-system-' . Toolbox::getRandomString(8),
+      'realname' => 'Support',
+   ]);
+
+   if (!$id) {
+      die("Can't add 'glpi-system' user");
+   }
+
+   Config::setConfigurationValues('core', ['system_user' => $id]);
+}
+
+// Add crontask for auto bump and auto solve
+$crontask = new CronTask();
+if (empty($crontask->find(['itemtype' => 'PendingReasonCron']))) {
+   $cron_added = CronTask::register(
+      'PendingReasonCron',
+      'pendingreason_autobump_autosolve',
+      30 * MINUTE_TIMESTAMP,
+      [
+         'state'         => 1,
+         'mode'          => 2,
+         'allowmode'     => 3,
+         'logs_lifetime' => 60,
+      ]
+   );
+
+   if (!$cron_added) {
+      die("Can't add PendingReasonCron");
+   }
+}
+
+// Name change, might be needed for a few user who used the feature before release
+if ($DB->fieldExists('glpi_pendingreasons_items', 'auto_bump')) {
+   $migration->changeField('glpi_pendingreasons_items', 'auto_bump', 'followup_frequency', 'int');
+}
+
+if ($DB->fieldExists('glpi_pendingreasons_items', 'auto_solve')) {
+   $migration->changeField('glpi_pendingreasons_items', 'auto_solve', 'followups_before_resolution', 'int');
+}
+
+if ($DB->fieldExists('glpi_pendingreasons', 'auto_bump')) {
+   $migration->changeField('glpi_pendingreasons', 'auto_bump', 'followup_frequency', 'int');
+}
+
+if ($DB->fieldExists('glpi_pendingreasons', 'auto_solve')) {
+   $migration->changeField('glpi_pendingreasons', 'auto_solve', 'followups_before_resolution', 'int');
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8690,6 +8690,41 @@ CREATE TABLE `glpi_items_remotemanagements` (
   KEY `item` (`itemtype`,`items_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
+DROP TABLE IF EXISTS `glpi_pendingreasons`;
+CREATE TABLE `glpi_pendingreasons` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `entities_id` int NOT NULL DEFAULT '0',
+  `is_recursive` tinyint NOT NULL DEFAULT '0',
+  `name` varchar(255) DEFAULT NULL,
+  `followup_frequency` int NOT NULL DEFAULT '0',
+  `followups_before_resolution` int NOT NULL DEFAULT '0',
+  `itilfollowuptemplates_id` int NOT NULL DEFAULT '0',
+  `solutiontemplates_id` int NOT NULL DEFAULT '0',
+  `comment` text,
+  PRIMARY KEY (`id`),
+  KEY `name` (`name`),
+  KEY `itilfollowuptemplates_id` (`itilfollowuptemplates_id`),
+  KEY `entities_id` (`entities_id`),
+  KEY `is_recursive` (`is_recursive`),
+  KEY `solutiontemplates_id` (`solutiontemplates_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
+DROP TABLE IF EXISTS `glpi_pendingreasons_items`;
+CREATE TABLE `glpi_pendingreasons_items` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `pendingreasons_id` int NOT NULL DEFAULT '0',
+  `items_id` int NOT NULL DEFAULT '0',
+  `itemtype` varchar(100) NOT NULL DEFAULT '',
+  `followup_frequency` int NOT NULL DEFAULT '0',
+  `followups_before_resolution` int NOT NULL DEFAULT '0',
+  `bump_count` int NOT NULL DEFAULT '0',
+  `last_bump_date` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unicity` (`items_id`,`itemtype`),
+  KEY `pendingreasons_id` (`pendingreasons_id`),
+  KEY `item` (`itemtype`,`items_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
 DROP TABLE IF EXISTS `glpi_manuallinks`;
 CREATE TABLE `glpi_manuallinks` (
   `id` int NOT NULL AUTO_INCREMENT,

--- a/tests/functionnal/PendingReason.class.php
+++ b/tests/functionnal/PendingReason.class.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Change;
+use ChangeTask;
+use CommonITILObject;
+use DbTestCase;
+use ITILFollowup;
+use PendingReason_Item;
+use Problem;
+use ProblemTask;
+use Ticket;
+use TicketTask;
+
+class PendingReason extends DbTestCase {
+
+   protected function testGetNextFollowupDateProvider() {
+      return [
+         [
+            // Case 1: no auto bump
+            'fields' => [
+               'followup_frequency'          => 0,
+            ],
+            'expected' => false
+         ],
+         [
+            // Case 2: max bump reached
+            'fields' => [
+               'followup_frequency'          => 60,
+               'followups_before_resolution' => 2,
+               'bump_count'                  => 2,
+            ],
+            'expected' => false
+         ],
+         [
+            // Case 3: first bump
+            'fields' => [
+               'followup_frequency'          => 60,
+               'followups_before_resolution' => 2,
+               'bump_count'                  => 0,
+               'last_bump_date'              => '2021-02-25 12:00:00',
+            ],
+            'expected' => date('2021-02-25 12:01:00')
+         ],
+         [
+            // Case 4: second or more bump
+            'fields' => [
+               'followup_frequency'          => 60,
+               'followups_before_resolution' => 7,
+               'bump_count'                  => 5,
+               'last_bump_date'              => '2021-02-25 13:00:00',
+            ],
+            'expected' => '2021-02-25 13:01:00'
+         ],
+      ];
+   }
+
+   /**
+    * @dataprovider testGetNextFollowupDateProvider
+    */
+   public function testGetNextFollowupDate(array $fields, $expected) {
+      $pending_reason_item = new \PendingReason_Item();
+      $pending_reason_item->fields = $fields;
+
+      $this->variable($expected)->isEqualTo($pending_reason_item->getNextFollowupDate());
+   }
+
+   protected function testGetAutoResolvedateProvider() {
+      return [
+         [
+            // Case 1: no auto bump
+            'fields' => [
+               'followup_frequency'          => 0,
+               'followups_before_resolution' => 2,
+            ],
+            'expected' => false
+         ],
+         [
+            // Case 2: no auto solve
+            'fields' => [
+               'followup_frequency'          => 60,
+               'followups_before_resolution' => 0,
+            ],
+            'expected' => false
+         ],
+         [
+            // Case 3: 0/5 bump occured yet
+            'fields' => [
+               'followup_frequency'          => 60,
+               'followups_before_resolution' => 5,
+               'bump_count'                  => 0,
+               'last_bump_date'              => '2021-02-25 14:00:00',
+            ],
+            'expected' => '2021-02-25 14:06:00'
+         ],
+         [
+            // Case 4: 1/5 bump occured
+            'fields' => [
+               'followup_frequency'          => 60,
+               'followups_before_resolution' => 5,
+               'bump_count'                  => 1,
+               'last_bump_date'              => '2021-02-25 15:00:00',
+            ],
+            'expected' => '2021-02-25 15:05:00'
+         ],
+         [
+            // Case 5: 2/5 bump occured
+            'fields' => [
+               'followup_frequency'          => 60,
+               'followups_before_resolution' => 5,
+               'bump_count'                  => 2,
+               'last_bump_date'              => '2021-02-25 16:00:00',
+            ],
+            'expected' => '2021-02-25 16:04:00'
+         ],
+         [
+            // Case 5: 3/5 bump occured
+            'fields' => [
+               'followup_frequency'          => 60,
+               'followups_before_resolution' => 5,
+               'bump_count'                  => 3,
+               'last_bump_date'              => '2021-02-25 17:00:00',
+            ],
+            'expected' => '2021-02-25 17:03:00'
+         ],
+         [
+            // Case 5: 4/5 bump occured
+            'fields' => [
+               'followup_frequency'          => 60,
+               'followups_before_resolution' => 5,
+               'bump_count'                  => 4,
+               'last_bump_date'              => '2021-02-25 18:00:00',
+            ],
+            'expected' => '2021-02-25 18:02:00'
+         ],
+         [
+            // Case 5: 5/5 bump occured
+            'fields' => [
+               'followup_frequency'          => 60,
+               'followups_before_resolution' => 5,
+               'bump_count'                  => 5,
+               'last_bump_date'              => '2021-02-25 19:00:00',
+            ],
+            'expected' => '2021-02-25 19:01:00'
+         ],
+      ];
+   }
+
+   /**
+    * @dataprovider testGetAutoResolvedateProvider
+    */
+   public function testGetAutoResolvedate(array $fields, $expected) {
+      $pending_reason_item = new \PendingReason_Item();
+      $pending_reason_item->fields = $fields;
+
+      $this->variable($expected)->isEqualTo($pending_reason_item->getAutoResolvedate());
+   }
+
+
+   protected function itemtypeProvider(): array {
+      return [
+         ['itemtype' => Ticket::class],
+         ['itemtype' => Change::class],
+         ['itemtype' => Problem::class],
+      ];
+   }
+
+   protected function itemtypeAndActionProvider(): array {
+      $array = [];
+      $itemtypes = [Ticket::class, Change::class, Problem::class];
+      foreach ($itemtypes as $itemtype) {
+         $array[] = [
+            'itemtype' => $itemtype,
+            'action_itemtype' => ITILFollowup::class,
+         ];
+         $array[] = [
+            'itemtype' => $itemtype,
+            'action_itemtype' => $itemtype::getTaskClass(),
+         ];
+      }
+
+      return $array;
+   }
+
+   protected static function getBaseActionAddInput($action_item, $item) {
+      if ($action_item instanceof ITILFollowup) {
+         return [
+            'items_id' => $item->getID(),
+            'itemtype' => $item::getType(),
+         ];
+      } else if ($action_item instanceof TicketTask) {
+         return ['tickets_id' => $item->getID()];
+      } else if ($action_item instanceof ChangeTask) {
+         return ['changes_id' => $item->getID()];
+      } else if ($action_item instanceof ProblemTask) {
+         return ['problems_id' => $item->getID()];
+      }
+
+      return [];
+   }
+
+   /**
+    * Test that a PendingReason_Item object is created when an item is marked as
+    * pending
+    *
+    * @dataprovider itemtypeAndActionProvider
+    */
+   public function testPendingItemCreation($itemtype, $action_itemtype) {
+      $this->login();
+
+      $item = new $itemtype();
+      $action_item = new $action_itemtype();
+
+      // Create test item
+      $items_id = $item->add([
+         'name'    => 'test',
+         'content' => 'test',
+      ]);
+      $this->integer($items_id)->isGreaterThan(0);
+      $this->boolean($item->getFromDB($items_id))->isTrue();
+
+      // Check that no pending item exist
+      $this->boolean(PendingReason_Item::getForItem($item))->isFalse();
+
+      // Add a new action with the "pending" flag set
+      $actions_id = $action_item->add([
+         'content' => 'test',
+         'pending' => true,
+         'pendingreasons_id' => 0,
+      ] + self::getBaseActionAddInput($action_item, $item));
+      $this->integer($actions_id)->isGreaterThan(0);
+
+      // Check that pending item have been created
+      $this->variable(PendingReason_Item::getForItem($item))->isNotFalse();
+
+      // Check that parent item status was set to pending
+      $this->boolean($item->getFromDB($items_id))->isTrue();
+      $this->integer($item->fields['status'])->isEqualTo(CommonITILObject::WAITING);
+   }
+
+   /**
+    * A status change from pending to any other should delete any linked
+    * PendingReason_Item objects
+    *
+    * @dataprovider itemtypeProvider
+    */
+   public function testStatusChangeNoLongerPending($itemtype) {
+      $this->login();
+
+      $item = new $itemtype();
+
+      // Create test item
+      $items_id = $item->add([
+         'name'    => 'test',
+         'content' => 'test',
+         'status'  => CommonITILObject::WAITING,
+      ]);
+      $this->integer($items_id)->isGreaterThan(0);
+      $this->boolean($item->getFromDB($items_id))->isTrue();
+
+      // Check item is pending
+      $this->integer($item->fields['status'])->isEqualTo(CommonITILObject::WAITING);
+
+      // Attach pending item
+      $this->boolean(PendingReason_Item::createForItem($item, []))->isTrue();
+
+      // Check pending item
+      $this->variable(PendingReason_Item::getForItem($item))->isNotFalse();
+
+      // Change ticket status
+      $success = $item->update([
+         'id' => $items_id,
+         'status' => CommonITILObject::ASSIGNED,
+      ]);
+      $this->boolean($success)->isTrue();
+
+      // Check pending item again
+      $this->boolean(PendingReason_Item::getForItem($item))->isFalse();
+   }
+}

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1460,6 +1460,7 @@ class Search extends DbTestCase {
             'NetworkPortInstantiation', // Should be abstract (or have $notable = true)
             'NetworkPortMigration', // Tables only exists in specific cases
             'NotificationSettingConfig', // Stores its data in glpi_configs, does not acts as a CommonDBTM
+            'PendingReasonCron'
          ]
       );
       $searchable_classes = [];

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -3635,4 +3635,5 @@ class Ticket extends DbTestCase {
       $this->login('post-only', 'postonly');
       $this->boolean((boolean)$ticket->canAddFollowups())->isTrue();
    }
+
 }

--- a/tests/functionnal/Transfer.php
+++ b/tests/functionnal/Transfer.php
@@ -97,7 +97,8 @@ class Transfer extends DbTestCase {
             'Printer_CartridgeInfo',
             'PrinterLog',
             'USBVendor',
-            'PCIVendor'
+            'PCIVendor',
+            'PendingReasonCron',
          ]
       );
 


### PR DESCRIPTION
## Pending reasons

New dropdown:
![image](https://user-images.githubusercontent.com/42734840/109317781-5d6a6200-784d-11eb-8447-fdd024920d80.png)

You can define the following fields:
![image](https://user-images.githubusercontent.com/42734840/109317840-71ae5f00-784d-11eb-8cd4-bf99b1e98250.png)

## Rights

New right added for managing pending reasons:
![image](https://user-images.githubusercontent.com/42734840/109318069-b20ddd00-784d-11eb-9582-721c4dd3010e.png)

## Adding a followup

When adding a new followup to a ticket, there is a new "pause" toggle:
![image](https://user-images.githubusercontent.com/42734840/109318399-0a44df00-784e-11eb-991e-65b2fe8bafc5.png)

Enabling this toggle will set the ticket status to pending and allow you to select a pending reason:
![image](https://user-images.githubusercontent.com/42734840/109318634-4c6e2080-784e-11eb-8961-61cdfa7e54fc.png)

Selecting a reason will display two additional fields: the auto bump and resolve parameters.
Their values will be set to the data defined in the pending reason object but can be modified.
![image](https://user-images.githubusercontent.com/42734840/109318809-7e7f8280-784e-11eb-99cf-13d42c93fe55.png)

## Info in ticket details and timeline

After submitting the previous form, information regarding the pending reason can be found in two places :

1) In the ticket details:
![image](https://user-images.githubusercontent.com/42734840/109319779-8c81d300-784f-11eb-803f-ffe1c9a0ff3b.png)

2) In the timeline
![image](https://user-images.githubusercontent.com/42734840/109319831-9acfef00-784f-11eb-9b71-ae1f63728716.png)

## Auto bump / auto resolve task

Auto bump and auto resolve are handled by a new task:
![image](https://user-images.githubusercontent.com/42734840/109320230-15007380-7850-11eb-9267-55bf1902ad09.png)

Followup and solutions are added using a new special user.
This user is added during the migration and can't be deleted.
Only a few fields are displayed and editable on his details:
![image](https://user-images.githubusercontent.com/42734840/109320440-4ed17a00-7850-11eb-977a-65037da1e9dc.png)


## Split button
When adding a followup, the "split" submit button has been removed.
The most common use case for this button was to add a followup and set the ticket status to pending in one action.
This is no longer needed thanks to the new "pause" switch.
If you really need the split button you can re enable it with a plugin by setting `$CFG_GLPI["enable_split_button"]` to `true`.
If we have no feedback on people needing it then maybe we can completely delete in the following version ?


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Internal ref | !21251
