### PR TITLE
Fix invalid return for Central group view

### DIFF
--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1829,7 +1829,8 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
          if (isset($_SESSION['glpigroups']) && count($_SESSION['glpigroups'])) {
             $prep_req['WHERE'][self::getTable() . '.groups_id_tech'] = $_SESSION['glpigroups'];
          } else {
-            return false;
+            // Return empty iterator result
+            return new DBmysqlIterator($DB);
          }
       } else {
          $prep_req['WHERE'][self::getTable() . '.users_id_tech'] = $_SESSION['glpiID'];

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1830,7 +1830,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             $prep_req['WHERE'][self::getTable() . '.groups_id_tech'] = $_SESSION['glpigroups'];
          } else {
             // Return empty iterator result
-            return new DBmysqlIterator($DB);
+            $prep_req['WHERE'][] = 0;
          }
       } else {
          $prep_req['WHERE'][self::getTable() . '.users_id_tech'] = $_SESSION['glpiID'];

--- a/tests/functionnal/TicketTask.php
+++ b/tests/functionnal/TicketTask.php
@@ -217,7 +217,7 @@ class TicketTask extends DbTestCase {
       $this->integer(count($iterator))->isIdenticalTo(3);
 
       $iterator = $task::getTaskList('todo', true);
-      $this->boolean($iterator)->isFalse();
+      $this->integer(count($iterator))->isIdenticalTo(0);
 
       $_SESSION['glpigroups'] = [42, 1337];
       $iterator = $task::getTaskList('todo', true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8407 

Currently, `CommonITILTask::getTaskList` must return a `DBmysqlIterator` instance even if there are no results or it is an invalid query. If group tickets are requested and the current user has no groups, we must return an "empty" iterator instead of false.