### PR TITLE
Fix 'take into account' delay using SLM calendar; fixes #8710

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -6700,11 +6700,11 @@ class Ticket extends CommonITILObject {
    function getCalendar() {
 
       if (isset($this->fields['slas_id_ttr']) && $this->fields['slas_id_ttr'] > 0) {
-         $slm = new SLM();
-         if ($slm->getFromDB($this->fields['slas_id_ttr'])) {
+         $sla = new SLA();
+         if ($sla->getFromDB($this->fields['slas_id_ttr'])) {
             // not -1: calendar of the entity
-            if ($slm->getField('calendars_id') >= 0) {
-               return $slm->getField('calendars_id');
+            if ($sla->getField('calendars_id') >= 0) {
+               return $sla->getField('calendars_id');
             }
          }
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8710 

`Ticket::computeTakeIntoAccountDelayStat()` base its computation on result of `Ticket::getCalendar()` method.

Without this fix, used calendar is always the one configured in entity.

With this fix, used calendar will be the one defined in SLM. Indeed, `calendars_id` field of SLA/OLA objects is filled on `post_getFromDB` method, based on parent SLM `calendars_id` field. It seems like a hack to me, but is used like that at many places.