### PR TITLE
Fix entity creation form

### DIFF
--- a/ajax/common.tabs.php
+++ b/ajax/common.tabs.php
@@ -62,7 +62,7 @@ if (!isset($_GET["withtemplate"])) {
    $_GET["withtemplate"] = "";
 }
 
-if (isset($_GET['id'])) {
+if (isset($_GET['id']) && !empty($_GET['id'])) {
    $_GET['id'] = (int)$_GET['id'];
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a creation form is displayed, `ajax/common.tabs.php` is called with an empty value for `id` param, which was transformed into `0` by int casting. In case of entity creation form, this is a problem, as `0` is the id of the root entity.