### PR TITLE
Fix XSS clean/unclean process

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -1151,6 +1151,11 @@ class MailCollector  extends CommonDBTM {
                                                            $this->tags);
       }
 
+      if (!$DB->use_utf8mb4) {
+         // Replace emojis by their shortcode
+         $tkt['content'] = LitEmoji::encodeShortcode($tkt['content']);
+      }
+
       // Clean mail content
       $tkt['content'] = $this->cleanContent($tkt['content']);
 
@@ -1202,10 +1207,6 @@ class MailCollector  extends CommonDBTM {
          }
       }
 
-      if (!$DB->use_utf8mb4) {
-         $tkt['content'] = LitEmoji::encodeShortcode($tkt['content']);
-      }
-
       $tkt = Toolbox::addslashes_deep($tkt);
       return $tkt;
    }
@@ -1252,9 +1253,6 @@ class MailCollector  extends CommonDBTM {
       }
 
       $string = str_replace($br_marker, "<br />", $string);
-
-      // Double encoding for > and < char to avoid misinterpretations
-      $string = str_replace(['&lt;', '&gt;'], ['&amp;lt;', '&amp;gt;'], $string);
 
       // Prevent XSS
       $string = Toolbox::clean_cross_side_scripting_deep($string);

--- a/tests/functionnal/ITILFollowup.php
+++ b/tests/functionnal/ITILFollowup.php
@@ -396,7 +396,7 @@ class ITILFollowup extends DbTestCase {
 
       $instance->add($input);
       $this->boolean($instance->isNewItem())->isFalse();
-      $expected = 'a href=&quot;/front/document.send.php?docid=';
+      $expected = 'a href="/front/document.send.php?docid=';
       $this->string($instance->fields['content'])->contains($expected);
 
       // Test uploads for item update
@@ -418,7 +418,7 @@ class ITILFollowup extends DbTestCase {
          ]
       ]);
       $this->boolean($success)->isTrue();
-      $expected = 'a href=&quot;/front/document.send.php?docid=';
+      $expected = 'a href="/front/document.send.php?docid=';
       $this->string($instance->fields['content'])->contains($expected);
    }
 

--- a/tests/functionnal/ITILSolution.php
+++ b/tests/functionnal/ITILSolution.php
@@ -334,7 +334,7 @@ class ITILSolution extends DbTestCase {
 
       $instance->add($input);
       $this->boolean($instance->isNewItem())->isFalse();
-      $expected = 'a href=&quot;/front/document.send.php?docid=';
+      $expected = 'a href="/front/document.send.php?docid=';
       $this->string($instance->fields['content'])->contains($expected);
 
       // Test uploads for item update
@@ -356,7 +356,7 @@ class ITILSolution extends DbTestCase {
          ]
       ]);
       $this->boolean($success)->isTrue();
-      $expected = 'a href=&quot;/front/document.send.php?docid=';
+      $expected = 'a href="/front/document.send.php?docid=';
       $this->string($instance->fields['content'])->contains($expected);
    }
 

--- a/tests/functionnal/KnowbaseItem.php
+++ b/tests/functionnal/KnowbaseItem.php
@@ -205,7 +205,7 @@ class KnowbaseItem extends DbTestCase {
       copy(__DIR__ . '/../fixtures/uploads/foo.png', GLPI_TMP_DIR . '/' . $filename);
       $instance->add($input);
       $this->boolean($instance->isNewItem())->isFalse();
-      $expected = 'a href=&quot;/front/document.send.php?docid=';
+      $expected = 'a href="/front/document.send.php?docid=';
       $this->string($instance->fields['answer'])->contains($expected);
 
       // Test uploads for item update
@@ -229,7 +229,7 @@ class KnowbaseItem extends DbTestCase {
       ]);
       $this->boolean($success)->isTrue();
       // Ensure there is an anchor to the uploaded document
-      $expected = 'a href=&quot;/front/document.send.php?docid=';
+      $expected = 'a href="/front/document.send.php?docid=';
       $this->string($instance->fields['answer'])->contains($expected);
    }
 

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -3083,7 +3083,7 @@ class Ticket extends DbTestCase {
       ];
       copy(__DIR__ . '/../fixtures/uploads/foo.png', GLPI_TMP_DIR . '/' . $filename);
       $instance->add($input);
-      $expected = 'a href=&quot;/front/document.send.php?docid=';
+      $expected = 'a href="/front/document.send.php?docid=';
       $this->string($instance->fields['content'])->contains($expected);
 
       // Test uploads for item update
@@ -3104,7 +3104,7 @@ class Ticket extends DbTestCase {
             '5e5e92ffd9bd91.44444444',
          ]
       ]);
-      $expected = 'a href=&quot;/front/document.send.php?docid=';
+      $expected = 'a href="/front/document.send.php?docid=';
       $this->string($instance->fields['content'])->contains($expected);
    }
 

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -85,7 +85,7 @@ class MailCollector extends DbTestCase {
             'expected'  => "With a \ncarriage return"
          ], [
             'raw'       => 'We have a problem, <strong>URGENT</strong>',
-            'expected'  => 'We have a problem, &lt;strong&gt;URGENT&lt;/strong&gt;'
+            'expected'  => 'We have a problem, &#60;strong&#62;URGENT&#60;/strong&#62;'
          ], [ //dunno why...
             'raw'       => 'Subject with =20 character',
             'expected'  => "Subject with \n character"
@@ -659,10 +659,10 @@ class MailCollector extends DbTestCase {
       // Tickets on which content should be checked (key is ticket name)
       $tickets_contents = [
          // Plain text on mono-part email
-         'PHP fatal error' => 'On some cases, doing the following:&lt;br /&gt;# blahblah&lt;br /&gt;&lt;br /&gt;Will cause a PHP fatal error:&lt;br /&gt;# blahblah&lt;br /&gt;&lt;br /&gt;Best regards,',
+         'PHP fatal error' => 'On some cases, doing the following:<br /># blahblah<br /><br />Will cause a PHP fatal error:<br /># blahblah<br /><br />Best regards,',
          // HTML on multi-part email
-         'Re: [GLPI #0038927] Update - Issues with new Windows 10 machine' => '&lt;p&gt;This message have reply to header, requester should be get from this header.&lt;/p&gt;',
-         'Mono-part HTML message' => '&lt;p&gt;This HTML message does not use &lt;strong&gt;"multipart/alternative"&lt;/strong&gt; format.&lt;/p&gt;',
+         'Re: [GLPI #0038927] Update - Issues with new Windows 10 machine' => '<p>This message have reply to header, requester should be get from this header.</p>',
+         'Mono-part HTML message' => '<p>This HTML message does not use <strong>"multipart/alternative"</strong> format.</p>',
          '26 Illegal char in body' => '这是很坏的Minus C Blabla',
       ];
 
@@ -691,7 +691,7 @@ class MailCollector extends DbTestCase {
             $name = $data['name'];
 
             if (array_key_exists($name, $tickets_contents)) {
-               $this->string($data['content'])->isEqualTo($tickets_contents[$name]);
+               $this->string(\Toolbox::getHtmlToDisplay($data['content']))->isEqualTo($tickets_contents[$name]);
             }
 
             $this->string($data['content'])->notContains('cid:'); // check that image were correctly imported
@@ -751,27 +751,27 @@ class MailCollector extends DbTestCase {
          [
             'items_id' => 100,
             'users_id' => $tuid,
-            'content'  => 'This is a reply that references Ticket 100 in In-Reply-To header (old format).&lt;br /&gt;It should be added as followup.',
+            'content'  => 'This is a reply that references Ticket 100 in In-Reply-To header (old format).&#60;br /&#62;It should be added as followup.',
          ],
          [
             'items_id' => 100,
             'users_id' => $tuid,
-            'content'  => 'This is a reply that references Ticket 100 in References header (old format).&lt;br /&gt;It should be added as followup.',
+            'content'  => 'This is a reply that references Ticket 100 in References header (old format).&#60;br /&#62;It should be added as followup.',
          ],
          [
             'items_id' => 101,
             'users_id' => $tuid,
-            'content'  => 'This is a reply that references Ticket 101 in its subject.&lt;br /&gt;It should be added as followup.',
+            'content'  => 'This is a reply that references Ticket 101 in its subject.&#60;br /&#62;It should be added as followup.',
          ],
          [
             'items_id' => 100,
             'users_id' => $tuid,
-            'content'  => 'This is a reply that references Ticket 100 in In-Reply-To header (new format).&lt;br /&gt;It should be added as followup.',
+            'content'  => 'This is a reply that references Ticket 100 in In-Reply-To header (new format).&#60;br /&#62;It should be added as followup.',
          ],
          [
             'items_id' => 100,
             'users_id' => $tuid,
-            'content'  => 'This is a reply that references Ticket 100 in References header (new format).&lt;br /&gt;It should be added as followup.',
+            'content'  => 'This is a reply that references Ticket 100 in References header (new format).&#60;br /&#62;It should be added as followup.',
          ],
       ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | part of #140

Currently, `<` and `>` chars are not correctly handled in rich test due to the way `Toolbox::clean_cross_side_scripting_deep()` and `Toolbox::unclean_cross_side_scripting_deep()` are working.
A short example:
 - user types `time <5ms` in TinyMCE, and submit its ticket;
 - `content` received will be `<p>time &lt;5ms</p>`, which is correct;
 - `Toolbox::sanitize()` transforms it to `&lt;p&gt;time &lt;5ms&lt;/p&gt;`, and starting to this point we cannot differenciate anymore what was a `<` and what was a `&lt;`;
 - when value is displayed, `Toolbox::unclean_cross_side_scripting_deep()` transforms it into `<p>time <5ms</p>`.

Solution was to also encode `&` in the XSS clean/unclean process, like proposed in #6111, but the problem was that the proposed solution may have a negative impact on existing content, and a migration was not an accepted option.

I finally found a way to differenciate unclean process for content that was cleaned with old logic and for content using the new logic: using alternative notation for encoded html entities (i.e. using `&#60;` for `<` and `&#62;` for `>`). Only existing content that may be impacted is content containing `&#38;`, `&#60;` or `&#62;`, which is really an edge case (we could propose a migration in this case).


With some more work, it permits use the codesample plugin from TinyMCE:
![image](https://user-images.githubusercontent.com/33253653/110101830-55a64280-7da4-11eb-8630-0cdba7983b2e.png)


It will help to fix #140 , but it will not be sufficient, as, in many places, more entity decoding than required are done.