### PR TITLE
Set tab number in session before loading content

### DIFF
--- a/ajax/common.tabs.php
+++ b/ajax/common.tabs.php
@@ -87,6 +87,11 @@ if (isset($_GET['_target'])) {
    $_GET['_target'] = Toolbox::cleanTarget($_GET['_target']);
 }
 
+$tabs = Toolbox::getAvailablesTabs($_UGET['_itemtype'], $_GET['id'] ?? null);
+if (isset($tabs[$_GET['_glpi_tab']])) {
+   Session::setActiveTab($_UGET['_itemtype'], $_GET['_glpi_tab']);
+}
+
 $notvalidoptions = ['_glpi_tab', '_itemtype', 'sort', 'order', 'withtemplate', 'formoptions'];
 $options         = $_GET;
 foreach ($notvalidoptions as $key) {

--- a/ajax/updatecurrenttab.php
+++ b/ajax/updatecurrenttab.php
@@ -38,28 +38,17 @@ if (!basename($_SERVER['SCRIPT_NAME']) == "helpdesk.faq.php") {
 
 // Manage tabs
 if (isset($_GET['tab']) && isset($_GET['itemtype'])) {
-   if ($item = getItemForItemtype($_UGET['itemtype'])) {
-      if (isset($_GET['id']) && !$item->isNewID($_GET['id'])) {
-         $item->getFromDB($_GET['id']);
-      }
 
-      $tabs         = $item->defineAllTabs();
-      if (isset($tabs['no_all_tab'])) {
-         unset($tabs['no_all_tab']);
+   $tabs = Toolbox::getAvailablesTabs($_UGET['itemtype'], $_GET['id'] ?? null);
+   $selected_tab = '';
+   $current      = 0;
+   foreach (array_keys($tabs) as $key) {
+      if ($current == $_GET['tab']) {
+         $selected_tab = $key;
       }
-      // Add all tab
-      $tabs[-1]     = 'All';
-      $selected_tab = '';
-      $current      = 0;
-      foreach (array_keys($tabs) as $key) {
-         if ($current == $_GET['tab']) {
-            $selected_tab = $key;
-         }
-         $current++;
-      }
-      if (!empty($selected_tab)) {
-         Session::setActiveTab($_UGET['itemtype'], $selected_tab);
-      }
-
+      $current++;
+   }
+   if (!empty($selected_tab)) {
+      Session::setActiveTab($_UGET['itemtype'], $selected_tab);
    }
 }

--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -409,9 +409,12 @@ class Ajax {
             active: $selected_tab,
             // Loading indicator
             beforeLoad: function (event, ui) {
+               var event_prevented = false;
+
                if ($(ui.panel).html()
                    && !forceReload$rand) {
                   event.preventDefault();
+                  event_prevented = true;
                } else {
                   forceReload$rand = false;
                   var _loader = $('<div id=\'loadingtabs\'><div class=\'loadingindicator\'>" . addslashes(__('Loading...')) . "</div></div>');
@@ -433,14 +436,16 @@ class Ajax {
                      }
                   });
                }
-
-               var tabs = ui.tab.parent().children();
-               if (tabs.length > 1) {
-                  var newIndex = tabs.index(ui.tab);
-                  $.get(
-                     '".$CFG_GLPI['root_doc']."/ajax/updatecurrenttab.php',
-                     { itemtype: '".addslashes($type)."', id: '$ID', tab: newIndex }
-                  );
+               // We need to manually set the current tab if the main event was prevented
+               if (event_prevented) {
+                  var tabs = ui.tab.parent().children();
+                  if (tabs.length > 1) {
+                     var newIndex = tabs.index(ui.tab);
+                     $.get(
+                        '".$CFG_GLPI['root_doc']."/ajax/updatecurrenttab.php',
+                        { itemtype: '".addslashes($type)."', id: '$ID', tab: newIndex }
+                     );
+                  }
                }
             },
             load: function(event) {

--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -436,7 +436,7 @@ class Ajax {
                }
                // We need to manually set the current tab if the main event was prevented.
                // It happens when user switch between tabs and then select a tab that was already shown before.
-               // It is displayed without having to beeing reloaded.
+               // It is displayed without having to be reloaded.
                if (event.isDefaultPrevented()) {
                   var tabs = ui.tab.parent().children();
                   if (tabs.length > 1) {

--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -434,7 +434,9 @@ class Ajax {
                      }
                   });
                }
-               // We need to manually set the current tab if the main event was prevented
+               // We need to manually set the current tab if the main event was prevented.
+               // It happens when user switch between tabs and then select a tab that was already shown before.
+               // It is displayed without having to beeing reloaded.
                if (event.isDefaultPrevented()) {
                   var tabs = ui.tab.parent().children();
                   if (tabs.length > 1) {

--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -409,12 +409,10 @@ class Ajax {
             active: $selected_tab,
             // Loading indicator
             beforeLoad: function (event, ui) {
-               var event_prevented = false;
 
                if ($(ui.panel).html()
                    && !forceReload$rand) {
                   event.preventDefault();
-                  event_prevented = true;
                } else {
                   forceReload$rand = false;
                   var _loader = $('<div id=\'loadingtabs\'><div class=\'loadingindicator\'>" . addslashes(__('Loading...')) . "</div></div>');
@@ -437,7 +435,7 @@ class Ajax {
                   });
                }
                // We need to manually set the current tab if the main event was prevented
-               if (event_prevented) {
+               if (event.isDefaultPrevented()) {
                   var tabs = ui.tab.parent().children();
                   if (tabs.length > 1) {
                      var newIndex = tabs.index(ui.tab);

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3559,4 +3559,33 @@ HTML;
 
       return '';
    }
+
+   /**
+    * Get available tabs for a given item
+    *
+    * @param string   $itemtype Type of the item
+    * @param int|null $itemtype Id the item, optional
+    *
+    * @return array
+    */
+   public static function getAvailablesTabs(string $itemtype, ?int $id = null): array {
+      $item = getItemForItemtype($itemtype);
+
+      if (!$item) {
+         return [];
+      }
+
+      if (isset($_GET['id']) && !$item->isNewID($_GET['id'])) {
+         $item->getFromDB($_GET['id']);
+      }
+
+      $tabs = $item->defineAllTabs();
+      if (isset($tabs['no_all_tab'])) {
+         unset($tabs['no_all_tab']);
+      }
+      // Add all tab
+      $tabs[-1] = 'All';
+
+      return $tabs;
+   }
 }


### PR DESCRIPTION
GLPI use two ajax endpoint to handle tab loading.

If the tab was not loaded yet:
- `ajax/updatecurrenttab.php` set the current tab id in the session
- `ajax/common.tabs.php` load the tab content

If the tab was already loaded:
- `ajax/updatecurrenttab.php` set the current tab id in the session

The 'not loaded' case can lead to non deterministic issues as the request are sent asynchronously and can complete in different orders.
One clear example of this is that if the second request is completed first then the fields plugin would consider the user to still be on the previous tab (since the session data is not yet updated) and return incorrect data.

---

To fix this, I've changed the logic to this:

If the tab was not loaded yet:
- `ajax/common.tabs.php` set the current tab id in the session AND load the tab content

If the tab was already loaded:
- `ajax/updatecurrenttab.php` set the current tab id in the session

---

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !20911
