### PR TITLE
Fix meta left join through *_items when target is main item; fixes #8765

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5418,7 +5418,7 @@ JAVASCRIPT;
          if (!in_array($to_table, $already_link_tables2)) {
             array_push($already_link_tables2, $to_table);
             $JOIN .= "$LINK `$to_table`
-                         ON (`$items_table_alias`.`$to_fk` = `$from_table`.`id`
+                         ON (`$items_table_alias`.`$to_fk` = `$to_table`.`id`
                              $to_entity_restrict) ";
          }
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8765 

```diff
LEFT JOIN `glpi_computers_items` AS `glpi_computers_items_Computer` ON (`glpi_computers_items_Computer`.`items_id` = `glpi_monitors`.`id` AND `glpi_computers_items_Computer`.`itemtype` = 'Monitor' AND `glpi_computers_items_Computer`.`is_deleted` = 0)
-LEFT JOIN `glpi_computers` ON (`glpi_computers_items_Computer`.`computers_id` = `glpi_monitors`.`id` )
+LEFT JOIN `glpi_computers` ON (`glpi_computers_items_Computer`.`computers_id` = `glpi_computers`.`id` )
```
