### PR TITLE
Remove massive actions icons from search results view

### DIFF
--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -646,6 +646,14 @@ class MassiveAction {
             }
          }
       }
+
+      // Remove icons as they are not displayed in list view
+      if (!$single) {
+         $actions = array_map(function($action) {
+            return strip_tags($action);
+         }, $actions);
+      }
+
       return $actions;
    }
 


### PR DESCRIPTION
Massive actions have icons that are displayed in item view:
![image](https://user-images.githubusercontent.com/42734840/110123340-120e0180-7dc1-11eb-8c1e-2c1fcdb7049f.png)

But are not displayed in the search results view: 
![image](https://user-images.githubusercontent.com/42734840/110123419-25b96800-7dc1-11eb-9305-b6d53da3ccae.png)

This was not an issue since the `<i>` tags weren't rendered.
However since 553b3dd0fa96de0226eacb2c14e5e72fd3780e6f the tags are escaped and displayed in plain text:

![image](https://user-images.githubusercontent.com/42734840/110123618-67e2a980-7dc1-11eb-9c15-c8906b3b52a4.png)

To fix this I've added a call to strip_tags for the search results view.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21680
