### PR TITLE
Fix multiple ITIL rich text issues

### DIFF
--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -841,7 +841,7 @@ class CommonGLPI {
          if (isset($cleaned_options['stock_image'])) {
             unset($cleaned_options['stock_image']);
          }
-         if ($this->getType() == 'Ticket') {
+         if ($this instanceof CommonITILObject) {
             $this->input = $cleaned_options;
             $this->saveInput();
             // $extraparamhtml can be tool long in case of ticket with content

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -4876,10 +4876,10 @@ class Ticket extends CommonITILObject {
             'value'           => $content,
             'uploads'         => $uploads,
          ]);
-         echo "</div>";
       } else {
          echo Toolbox::getHtmlToDisplay($content);
       }
+      echo "</div>";
       echo $tt->getEndHiddenFieldValue('content', $this);
 
       echo "</td>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Fix restoration of input on Change and Problem
When changing category on creation form, content and images were lost.

2. Fix images saving on Change and Problem update
During update, inline images were not transformed into documents

3. Fix missing ending `</div>` on readonly Ticket form
