### PR TITLE
Fix ticket dashboard criteria; fixes #8746

### DIFF
--- a/inc/dashboard/provider.class.php
+++ b/inc/dashboard/provider.class.php
@@ -277,8 +277,8 @@ class Provider extends CommonGLPI {
                   ]
                ]
             ]);
-            $query_criteria['WHERE']+= [
-               "$table.status" => Ticket::getNotSolvedStatusArray(),
+            $query_criteria['WHERE']["$table.status"] = Ticket::getNotSolvedStatusArray();
+            $query_criteria['WHERE'][] = [
                'OR' => [
                   CommonITILObject::generateSLAOLAComputation('time_to_resolve', 'glpi_tickets'),
                   CommonITILObject::generateSLAOLAComputation('internal_time_to_resolve', 'glpi_tickets'),

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -7460,7 +7460,7 @@ class Ticket extends CommonITILObject {
 
       $criteria = [];
       if (count($where_profile)) {
-         $criteria['WHERE'] = ['OR' => $where_profile];
+         $criteria['WHERE'] = [['OR' => $where_profile]];
       }
       if (count($join_profile)) {
          $criteria['LEFT JOIN'] = $join_profile;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8746

`+` operator on array ignore already existing keys.

1. `OR` key was already existing for profiles that does ot have read rights on all tickets (set in `Ticket::getCriteriaFromProfile()`). I encapsulate `OR` clauses in an array to prevent conflicting.
2. I remove usage of `+` operator as it was still not working due to presence of same numeric key in both arrays.