### PR TITLE
Fix software count on computer; fixes #8670

### DIFF
--- a/inc/item_softwareversion.class.php
+++ b/inc/item_softwareversion.class.php
@@ -1568,7 +1568,7 @@ class Item_SoftwareVersion extends CommonDBRelation {
          $table.'.is_deleted' => 0
       ];
       if ($noent === false) {
-         $params = array_merge($params, getEntitiesRestrictCriteria($table, '', '', 'auto'));
+         $params['WHERE'] += getEntitiesRestrictCriteria($table, '', '', 'auto');
       }
       return $params;
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8670 

Entities restrict criteria were pushed outside the `WHERE` key. When criteria exists outside `WHERE` key, they are ignored during query building.