### PR TITLE
Fix API errors on deprecation checks

### DIFF
--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -87,7 +87,7 @@ function isAPI() {
 function isPluginItemType($classname) {
 
    /** @var array $matches */
-   if (preg_match("/Plugin([A-Z][a-z0-9]+)([A-Z]\w+)/", $classname, $matches)) {
+   if (preg_match("/^Plugin([A-Z][a-z0-9]+)([A-Z]\w+)$/", $classname, $matches)) {
       $plug           = [];
       $plug['plugin'] = $matches[1];
       $plug['class']  = $matches[2];

--- a/tests/units/Autoload.php
+++ b/tests/units/Autoload.php
@@ -42,11 +42,14 @@ class Autoload extends DbTestCase {
 
    public function dataItemType() {
       return [
-         ['Computer',                   false, false],
-         ['Glpi\\Event',                false, false],
-         ['PluginFooBar',               'Foo', 'Bar'],
-         ['GlpiPlugin\\Foo\\Bar',       'Foo', 'Bar'],
-         ['GlpiPlugin\\Foo\\Bar\\More', 'Foo', 'Bar\\More'],
+         ['Computer',                         false, false],
+         ['Glpi\\Event',                      false, false],
+         ['PluginFooBar',                     'Foo', 'Bar'],
+         ['GlpiPlugin\\Foo\\Bar',             'Foo', 'Bar'],
+         ['GlpiPlugin\\Foo\\Bar\\More',       'Foo', 'Bar\\More'],
+         ['PluginFooBar\Invalid',             false, false],
+         ['Glpi\Api\Deprecated\PluginFooBar', false, false],
+         ['Invalid\GlpiPlugin\Foo\Bar',       false, false],
       ];
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/pluginsGLPI/genericobject/issues/290

Due to missing `^` and `$` in regex used in `isPluginItemType()`, `Glpi\Api\Deprecated\PluginGenericobjectTest` was considered as `{"plugin": "Genericobject", "class": "Test"}`, and API deprecation check was so loading the `PluginGenericobjectTest` which was also loaded by `genericobject` plugin.