### PR TITLE
Store search criteria toggle state in client

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2425,12 +2425,23 @@ JAVASCRIPT;
       if ($p['mainform']) {
          $JS .= <<<JAVASCRIPT
          $('.fold-search').on('click', function(event) {
+            var search_criteria =  $('#searchcriteria ul li:not(:first-child)');
             event.preventDefault();
             $(this)
                .toggleClass('fa-angle-double-up')
                .toggleClass('fa-angle-double-down');
-            $('#searchcriteria ul li:not(:first-child)').toggle();
+            search_criteria.toggle();
+            window.localStorage.setItem(
+               'show_full_searchcriteria',
+               search_criteria.first().is(':visible')
+            );
          });
+
+         // Init search_criteria state
+         var search_criteria_visibility = window.localStorage.getItem('show_full_searchcriteria');
+         if (search_criteria_visibility !== undefined && search_criteria_visibility == 'false') {
+            $('.fold-search').click();
+         }
 
          $(document).on("click", ".remove-search-criteria", function() {
             var rowID = $(this).data('rowid');


### PR DESCRIPTION
The search UI allow to expand or reduce search criteria like this:
![image](https://user-images.githubusercontent.com/42734840/110336969-af696f80-8025-11eb-8bbb-2da89280bced.png)
![image](https://user-images.githubusercontent.com/42734840/110337001-b7291400-8025-11eb-9f39-444855930419.png)

However this setting is lost on reload which make it a lot less useful.
I propose to store it in the client and reapply it on load if needed.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21701
