### PR TITLE
Fix notification when image has a missing width/height; fixes #8795

### DIFF
--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -1520,15 +1520,15 @@ class Document extends CommonDBTM {
     * @return string Image path on disk
     */
    public static function getImage($path, $context, $mwidth = null, $mheight = null) {
-      if ($mwidth === null && $mheight === null) {
+      if ($mwidth === null || $mheight === null) {
          switch ($context) {
             case 'mail':
-               $mwidth = 400;
-               $mheight = 300;
+               $mwidth  = $mwidth ?? 400;
+               $mheight = $mheight ?? 300;
                break;
             case 'timeline':
-               $mwidth = 100;
-               $mheight = 100;
+               $mwidth  = $mwidth ?? 100;
+               $mheight = $mheight ?? 100;
                break;
             default:
                throw new \RuntimeException("Unknown context $context!");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8795 

When trying to reproduce the initial issue, I ended up with a followup where image had no height property. No sure how it happens, but result is that `Document::getImage()` was called with a width but no height.
