### PR TITLE
feat(dsahboard): change function visibility to be call by plugins

### DIFF
--- a/inc/dashboard/provider.class.php
+++ b/inc/dashboard/provider.class.php
@@ -1271,7 +1271,7 @@ class Provider extends CommonGLPI {
       return array_search($name."-".$tableToSearch, $sort);
    }
 
-   public static function getSearchFiltersCriteria(string $table = "", array $apply_filters = []) {
+   final public static function getSearchFiltersCriteria(string $table = "", array $apply_filters = []) {
       $DB = DBConnection::getReadConnection();
       $s_criteria = [];
 

--- a/inc/dashboard/provider.class.php
+++ b/inc/dashboard/provider.class.php
@@ -1271,7 +1271,7 @@ class Provider extends CommonGLPI {
       return array_search($name."-".$tableToSearch, $sort);
    }
 
-   private static function getSearchFiltersCriteria(string $table = "", array $apply_filters = []) {
+   public static function getSearchFiltersCriteria(string $table = "", array $apply_filters = []) {
       $DB = DBConnection::getReadConnection();
       $s_criteria = [];
 


### PR DESCRIPTION

Allow ```getSearchFiltersCriteria``` to be call outside ```Provider``` 

Usefull for plugins (advancedashboard) who would like to manage the criteria on the dashboard

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
