### PR TITLE
Fix special chars handling in massive actions; fixes #8799

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -2512,7 +2512,12 @@ JAVASCRIPT;
       if (!isset($options['specific_tags']['data-glpicore-ma-tags'])) {
          $options['specific_tags']['data-glpicore-ma-tags'] = 'common';
       }
+
+      // encode quotes and brackets to prevent maformed name attribute
+      $id = htmlspecialchars($id, ENT_QUOTES);
+      $id = str_replace(['[', ']'], ['&amp;#91;', '&amp;#93;'], $id);
       $options['name']          = "item[$itemtype][".$id."]";
+
       $options['zero_on_empty'] = false;
 
       return self::getCheckbox($options);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8799 

If id used in massive action checkbox contains quotes or square brackets, name attribute of the checkbox will be malformed. It may happen on LDAP users import.