### PR TITLE
Fix projects visibility in Kanban; fixes #8574

### DIFF
--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -1985,10 +1985,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
             ]
          ];
       }
-      $restrict = getEntitiesRestrictCriteria(self::getTable(), '', '', 'auto');;
-      if (!empty($restrict)) {
-         $criteria += $restrict;
-      }
+      $criteria += getEntitiesRestrictCriteria(self::getTable(), '', '', 'auto');
       $iterator = $DB->request(array_merge_recursive([
          'SELECT'   => [
             'glpi_projects.id',
@@ -2052,10 +2049,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
       $projectteam = new ProjectTeam();
       $project = new Project();
       $project_visibility = self::getVisibilityCriteria();
-      $restrict = getEntitiesRestrictCriteria(self::getTable(), '', '', 'auto');;
-      if (!empty($restrict)) {
-         $project_visibility['WHERE'] += $restrict;
-      }
+      $project_visibility['WHERE'] += getEntitiesRestrictCriteria(self::getTable(), '', '', 'auto');
       $request = [
          'SELECT' => [
             'glpi_projects.*',

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -1985,6 +1985,10 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
             ]
          ];
       }
+      $restrict = getEntitiesRestrictCriteria(self::getTable(), '', '', 'auto');;
+      if (!empty($restrict)) {
+         $criteria += $restrict;
+      }
       $iterator = $DB->request(array_merge_recursive([
          'SELECT'   => [
             'glpi_projects.id',
@@ -2048,6 +2052,10 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
       $projectteam = new ProjectTeam();
       $project = new Project();
       $project_visibility = self::getVisibilityCriteria();
+      $restrict = getEntitiesRestrictCriteria(self::getTable(), '', '', 'auto');;
+      if (!empty($restrict)) {
+         $project_visibility['WHERE'] += $restrict;
+      }
       $request = [
          'SELECT' => [
             'glpi_projects.*',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8574 

1. Show only projects related to active entities in the Global Kanban.
2. Show only projects related to active entities in the Project switch of the Kanban view.