### PR TITLE
Fix entities_id/is_recursive values of cloned childs; fixes #8598

### DIFF
--- a/inc/features/clonable.class.php
+++ b/inc/features/clonable.class.php
@@ -37,6 +37,7 @@ if (!defined('GLPI_ROOT')) {
 }
 
 use CommonDBConnexity;
+use Session;
 use Toolbox;
 
 /**
@@ -66,6 +67,11 @@ trait Clonable {
          }
 
          $override_input[$classname::getItemField($this->getType())] = $this->getID();
+
+         // Force entity / recursivity based on cloned parent, with fallback on session values
+         $override_input['entities_id'] = $this->isEntityAssign() ? $this->getEntityID() : Session::getActiveEntity();
+         $override_input['is_recursive'] = $this->maybeRecursive() ? $this->isRecursive() : Session::getIsActiveEntityRecursive();
+
          $relation_items = $classname::getItemsAssociatedTo($this->getType(), $source->getID());
          foreach ($relation_items as $relation_item) {
             $relation_item->clone($override_input, $history);

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -1558,6 +1558,17 @@ class Session {
    }
 
    /**
+    * Get recursive state of active entity selection.
+    *
+    * @since 9.5.5
+    *
+    * @return bool
+    */
+   public static function getIsActiveEntityRecursive(): bool {
+      return $_SESSION['glpiactive_entity_recursive'] ?? false;
+   }
+
+   /**
     * Start session for a given user
     *
     * @param int $users_id ID of the user


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8598

When creating an item from a template, clone process is used. In case cloned element is created in another entity, child elements must also be created in this entity.