### PR TITLE
Fix some darker theme and general style issues

### DIFF
--- a/css/palettes/_darker.scss
+++ b/css/palettes/_darker.scss
@@ -436,6 +436,10 @@ body #page .mce-btn-group:not(:first-child) {
    color: #262626;
 }
 
+.timeline_history .filter_timeline {
+   opacity: 1;
+}
+
 .timeline_history .h_content.ITILFollowup,
 .timeline_history .h_content.KnowbaseItemComment {
    background-color: #686868;

--- a/css/palettes/_darker.scss
+++ b/css/palettes/_darker.scss
@@ -906,3 +906,7 @@ div.progress {
 .ui-tabs-nav li.ui-tabs-tab:focus, .ui-tabs-nav li.ui-tabs-tab a:focus {
    outline: none;
 }
+
+.boxnote {
+   background: #585957;
+}

--- a/css/palettes/_darker.scss
+++ b/css/palettes/_darker.scss
@@ -202,6 +202,12 @@ ul#menu ul.ssmenu,
    box-shadow: none;
 }
 
+#page tr.headerRow th {
+   .btn-linkstyled, a.fas, a.fa, a.far, button i {
+      color: inherit;
+   }
+}
+
 .actor_title {
    background: transparent;
 }

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -2706,6 +2706,7 @@ a.icon_nav_move {
 
 .boxnote {
    margin: 0 auto;
+   width: 950px;
    text-align: left;
    border-radius: 10px;
    background: #e7e7e2;
@@ -2728,6 +2729,10 @@ a.icon_nav_move {
    padding: 1px;
    padding: 5px 0 5px 0;
    width: 75%;
+
+   textarea {
+      max-width: 100%;
+   }
 }
 
 .boxnoteright {

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -2706,7 +2706,6 @@ a.icon_nav_move {
 
 .boxnote {
    margin: 0 auto;
-   width: 950px;
    text-align: left;
    border-radius: 10px;
    background: #e7e7e2;

--- a/inc/notepad.class.php
+++ b/inc/notepad.class.php
@@ -316,9 +316,7 @@ class Notepad extends CommonDBChild {
          echo Html::hidden('items_id', ['value' => $item->getID()]);
 
          echo "<div class='boxnotecontent'>";
-         echo "<div class='floatleft'>";
          echo "<textarea name='content' rows=5 cols=100></textarea>";
-         echo "</div>";
          echo "</div>"; // box notecontent
 
          echo "<div class='boxnoteright'><br>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8595

Fix issue where the box around the notes field could overflow the form area. Removing the static width fixes the issue.
Fixed button/icon colors in the form header like the user vCard and impersonate buttons.
Fixed issue where the timeline filter was nearly invisible unless you hovered over it.
Fixed the color of the box around the note field to better match the darker theme and not a light theme.