### PR TITLE
fix(validation: compute global status even if it is not waitting for approval

### DIFF
--- a/inc/commonitilvalidation.class.php
+++ b/inc/commonitilvalidation.class.php
@@ -363,10 +363,8 @@ abstract class CommonITILValidation  extends CommonDBChild {
             NotificationEvent::raiseEvent('validation_answer', $item, $options);
          }
 
-          //Set global validation to accepted to define one
-         if (($item->fields['global_validation'] == self::WAITING)
-             && in_array("status", $this->updates)) {
-
+         //if status is updated, update global approval status
+         if (in_array("status", $this->updates)) {
             $input = [
                'id'                => $this->fields[static::$items_id],
                'global_validation' => self::computeValidationStatus($item),


### PR DESCRIPTION

If an approver changes their response, global approval status is not recalculated



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 21725
