### PR TITLE
Newlines are removed in preformatted text

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -1232,7 +1232,7 @@ class MailCollector  extends CommonDBTM {
       // Replace plain text line breaks to marker if content is not html
       // and rich text mode is enabled (otherwise remove them)
       $string = str_replace(
-         ["\r\n", "\n", "\r"],
+         ["\r\n", "\n\n", "\r"],
          $this->body_is_html ? ' ' : $br_marker,
          $string
       );


### PR DESCRIPTION
Email signatures are in text format (15 perfect lines). They appear on the same line in the follow-ups making it impossible to read the follow-up!
Since the transition to rich text, it is no longer possible to modify the content and description of the notificationtargetcommonitilobject.class file because the effects on the operation of GLPI are significant.

I did the following tests with a signature of 15 lines! :

- ticket creation by mail tool -> the signature is displayed as a block, it's ok all the same
- follow-up by email -> ok now signature ok follow-up with the follow-up before that is displayed