### PR TITLE
fix(dashboard): fix reset criteria

### DIFF
--- a/inc/dashboard/provider.class.php
+++ b/inc/dashboard/provider.class.php
@@ -122,7 +122,7 @@ class Provider extends CommonGLPI {
 
       $url = $item::getSearchURL()."?".Toolbox::append_params([
          $search_criteria,
-         'reset'
+         'reset' => 'reset',
       ]);
 
       return [


### PR DESCRIPTION
Fix reset filter criteria

for BigNumber widget in mini dahsboard , criterias are not reset correctly

url before patch  =   &1=reset

url after patch =   &reset=reset


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 21739
