### PR TITLE
Fix meta criteria from plugin objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,16 @@
 The present file will list all changes made to the project; according to the
 [Keep a Changelog](http://keepachangelog.com/) project.
 
-## [9.5.4] unreleased
+## [9.5.5] unreleased
+
+### API changes
+
+#### Changed
+
+- Remove deprecation of `Search::getMetaReferenceItemtype()`
+
+
+## [9.5.4] 2021-03-02
 
 ### Changed
 

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2148,6 +2148,8 @@ class Search {
    static function getMetaItemtypeAvailable($itemtype) {
       global $CFG_GLPI;
 
+      $itemtype = self::getMetaReferenceItemtype($itemtype);
+
       if (!(($item = getItemForItemtype($itemtype)) instanceof CommonDBTM)) {
          return [];
       }
@@ -2205,13 +2207,14 @@ class Search {
     * @since 0.85
     *
     * @param $itemtype
-    *
-    * @deprecated 9.5.4
    **/
-   static function getMetaReferenceItemtype ($itemtype) {
+   static function getMetaReferenceItemtype($itemtype) {
 
-      Toolbox::deprecated();
+      if (!isPluginItemType($itemtype)) {
+         return $itemtype;
+      }
 
+      // Use reference type if given itemtype extends a reference type.
       $types = [
          'Computer',
          'Problem',
@@ -2228,6 +2231,7 @@ class Search {
             return $type;
          }
       }
+
       return false;
    }
 
@@ -5203,6 +5207,9 @@ JAVASCRIPT;
    static function addMetaLeftJoin($from_type, $to_type, array &$already_link_tables2,
                                    $joinparams = []) {
       global $CFG_GLPI;
+
+      $from_referencetype = self::getMetaReferenceItemtype($from_type);
+
       $LINK = " LEFT JOIN ";
 
       $from_table = $from_type::getTable();
@@ -5219,7 +5226,7 @@ JAVASCRIPT;
       $JOIN = "";
 
       // Specific JOIN
-      if ($from_type === 'Software' && in_array($to_type, $CFG_GLPI['software_types'])) {
+      if ($from_referencetype === 'Software' && in_array($to_type, $CFG_GLPI['software_types'])) {
          // From Software to software_types
          $softwareversions_table = "glpi_softwareversions{$alias_suffix}";
          if (!in_array($softwareversions_table, $already_link_tables2)) {
@@ -5245,7 +5252,7 @@ JAVASCRIPT;
          return $JOIN;
       }
 
-      if ($to_type === 'Software' && in_array($from_type, $CFG_GLPI['software_types'])) {
+      if ($to_type === 'Software' && in_array($from_referencetype, $CFG_GLPI['software_types'])) {
          // From software_types to Software
          $items_softwareversions_table = "glpi_items_softwareversions{$alias_suffix}";
          if (!in_array($items_softwareversions_table, $already_link_tables2)) {
@@ -5276,7 +5283,7 @@ JAVASCRIPT;
          return $JOIN;
       }
 
-      if ($from_type === 'Budget' && in_array($to_type, $CFG_GLPI['infocom_types'])) {
+      if ($from_referencetype === 'Budget' && in_array($to_type, $CFG_GLPI['infocom_types'])) {
          // From Budget to infocom_types
          $infocom_alias = "glpi_infocoms{$alias_suffix}";
          if (!in_array($infocom_alias, $already_link_tables2)) {
@@ -5294,7 +5301,7 @@ JAVASCRIPT;
          return $JOIN;
       }
 
-      if ($to_type === 'Budget' && in_array($from_type, $CFG_GLPI['infocom_types'])) {
+      if ($to_type === 'Budget' && in_array($from_referencetype, $CFG_GLPI['infocom_types'])) {
          // From infocom_types to Budget
          $infocom_alias = "glpi_infocoms{$alias_suffix}";
          if (!in_array($infocom_alias, $already_link_tables2)) {
@@ -5312,7 +5319,7 @@ JAVASCRIPT;
          return $JOIN;
       }
 
-      if ($from_type === 'Reservation' && in_array($to_type, $CFG_GLPI['reservation_types'])) {
+      if ($from_referencetype === 'Reservation' && in_array($to_type, $CFG_GLPI['reservation_types'])) {
          // From Reservation to reservation_types
          $reservationitems_alias = "glpi_reservationitems{$alias_suffix}";
          if (!in_array($reservationitems_alias, $already_link_tables2)) {
@@ -5330,7 +5337,7 @@ JAVASCRIPT;
          return $JOIN;
       }
 
-      if ($to_type === 'Reservation' && in_array($from_type, $CFG_GLPI['reservation_types'])) {
+      if ($to_type === 'Reservation' && in_array($from_referencetype, $CFG_GLPI['reservation_types'])) {
          // From reservation_types to Reservation
          $reservationitems_alias = "glpi_reservationitems{$alias_suffix}";
          if (!in_array($infocom_alias, $already_link_tables2)) {
@@ -5349,11 +5356,11 @@ JAVASCRIPT;
       }
 
       // Generic JOIN
-      $from_obj      = getItemForItemtype($from_type);
+      $from_obj      = getItemForItemtype($from_referencetype);
       $to_obj        = getItemForItemtype($to_type);
-      $from_item_obj = getItemForItemtype($from_type . '_Item');
+      $from_item_obj = getItemForItemtype($from_referencetype . '_Item');
       if (!$from_item_obj) {
-         $from_item_obj = getItemForItemtype('Item_' . $from_type);
+         $from_item_obj = getItemForItemtype('Item_' . $from_referencetype);
       }
       $to_item_obj   = getItemForItemtype($to_type . '_Item');
       if (!$to_item_obj) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

#8629 breaks meta search in plugins itemtypes that are extending GLPI core itemtypes.

This PR puts back previous behaviour on plugin itemtypes.