### PR TITLE
Ensure release process will exit on error

### DIFF
--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # /**
 #  * ---------------------------------------------------------------------
 #  * GLPI - Gestionnaire Libre de Parc Informatique

--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # /**
 #  * ---------------------------------------------------------------------
 #  * GLPI - Gestionnaire Libre de Parc Informatique


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While trying to build GLPI 9.5.x on PHP 8, I saw that failure of minification command (used version of Robo in 9.5 branch is not PHP 8 compliant), was not stopping the build process. Usage of `-e` flag should ensure that process is exit when a subcommand fails.