### PR TITLE
Remove useless usage of Html::setRichTextContent()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The present file will list all changes made to the project; according to the
 - `CommonDBTM::clone()`
 - `CommonDBTM::prepareInputForClone()`
 - `CommonDBTM::post_clone()`
+- `Html::setRichTextContent()`
 - `RuleImportComputer` class
 - `RuleImportComputerCollection` class
 

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -1170,12 +1170,7 @@ class Change extends CommonITILObject {
          $content = Html::cleanPostForTextArea($content);
       }
 
-      $content = Html::setRichTextContent(
-         $content_id,
-         $content,
-         $rand,
-         !$canupdate
-      );
+      $content = Toolbox::getHtmlToDisplay($content);
 
       echo "<div id='content$rand_text'>";
       if ($canupdate) {
@@ -1191,11 +1186,11 @@ class Change extends CommonITILObject {
             'required'        => $tt->isMandatoryField('content'),
             'rows'            => $rows,
             'enable_richtext' => true,
-            'value'           => $content,
+            'value'           => Html::entities_deep($content), // Re-encode entities for textarea
             'uploads'         => $uploads,
          ]);
       } else {
-         echo Toolbox::getHtmlToDisplay($content);
+         echo $content;
       }
       echo "</div>";
 

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7164,9 +7164,8 @@ abstract class CommonITILObject extends CommonDBTM {
             echo "</p>";
 
             echo "<div class='rich_text_container'>";
-            $richtext = Html::setRichTextContent('', $content, '', true);
-            $richtext = Html::replaceImagesByGallery($richtext);
-            echo $richtext;
+            $content = Html::replaceImagesByGallery($content);
+            echo $content;
             echo "</div>";
 
             if (!empty($long_text)) {
@@ -7446,9 +7445,9 @@ abstract class CommonITILObject extends CommonDBTM {
       echo "</div>";
 
       echo "<div class='rich_text_container'>";
-      $richtext = Html::setRichTextContent('', $this->fields['content'], '', true);
-      $richtext = Html::replaceImagesByGallery($richtext);
-      echo $richtext;
+      $content = Toolbox::getHtmlToDisplay($this->fields['content']);
+      $content = Html::replaceImagesByGallery($content);
+      echo $content;
       echo "</div>";
 
       echo "</div>"; // h_content ITILContent

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -4023,8 +4023,12 @@ JS;
     * @param boolean $readonly true will set editor in readonly mode
     *
     * @return $content
+    *
+    * @deprecated x.x.x
    **/
    static function setRichTextContent($name, $content, $rand, $readonly = false) {
+
+      Toolbox::deprecated();
 
       // Init html editor (if name of textarea is provided)
       if (!empty($name)) {

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -1634,12 +1634,7 @@ class Problem extends CommonITILObject {
          $content = Html::cleanPostForTextArea($content);
       }
 
-      $content = Html::setRichTextContent(
-         $content_id,
-         $content,
-         $rand,
-         !$canupdate
-      );
+      $content = Toolbox::getHtmlToDisplay($content);
 
       echo "<div id='content$rand_text'>";
       if ($canupdate) {
@@ -1655,11 +1650,11 @@ class Problem extends CommonITILObject {
             'required'        => $tt->isMandatoryField('content'),
             'rows'            => $rows,
             'enable_richtext' => true,
-            'value'           => $content,
+            'value'           => Html::entities_deep($content), // Re-encode entities for textarea
             'uploads'         => $uploads,
          ]);
       } else {
-         echo Toolbox::getHtmlToDisplay($content);
+         echo $content;
       }
       echo "</div>";
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -4027,7 +4027,6 @@ class Ticket extends CommonITILObject {
          if (!$ticket_template) {
             $content = Html::cleanPostForTextArea($options['content']);
          }
-         $content = Html::setRichTextContent($content_id, $content, $rand);
 
          echo "<div id='content$rand_text'>";
          $uploads = [];
@@ -4950,12 +4949,7 @@ class Ticket extends CommonITILObject {
          $content = Html::cleanPostForTextArea($content);
       }
 
-      $content = Html::setRichTextContent(
-         $content_id,
-         $content,
-         $rand,
-         !$canupdate
-      );
+      $content = Toolbox::getHtmlToDisplay($content);
 
       echo "<div id='content$rand_text'>";
       if ($canupdate || $can_requester) {
@@ -4971,11 +4965,11 @@ class Ticket extends CommonITILObject {
             'required'        => $tt->isMandatoryField('content'),
             'rows'            => $rows,
             'enable_richtext' => true,
-            'value'           => $content,
+            'value'           => Html::entities_deep($content), // Re-encode entities for textarea
             'uploads'         => $uploads,
          ]);
       } else {
-         echo Toolbox::getHtmlToDisplay($content);
+         echo $content;
       }
       echo "</div>";
       echo $tt->getEndHiddenFieldValue('content', $this);

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2999,11 +2999,17 @@ class Toolbox {
     */
    public static function getHtmlToDisplay($content) {
       $content = Toolbox::unclean_cross_side_scripting_deep(
-         Html::entity_decode_deep(
-            $content
-         )
+         $content
       );
-      $content = nl2br(Html::clean($content, false, 1));
+
+      $content = Html::clean($content, false, 1);
+
+      // If content does not contain <br> or <p> html tag, use nl2br
+      // Required to correctly render linebreaks from "simple text mode" from GLPI prior to 9.4.0.
+      if (!preg_match('/<br\s?\/?>/', $content) && !preg_match('/<p>/', $content)) {
+         $content = nl2br($content);
+      }
+
       return $content;
    }
 

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -3056,7 +3056,7 @@ class Ticket extends DbTestCase {
             $instance = new \Ticket();
             $instance->showForm('-1');
          }
-      )->contains('src="data:image/png;base64,' . $base64Image . '"');
+      )->contains('src=&quot;data:image/png;base64,' . $base64Image . '&quot;');
    }
 
    public function testScreenshotConvertedIntoDocument() {
@@ -3189,7 +3189,7 @@ class Ticket extends DbTestCase {
             $instance->showForm('0');
             $_SESSION['glpiactiveprofile']['tickettemplates_id'] = $session_tpl_id_back;
          }
-      )->contains('src="data:image/png;base64,' . $base64Image . '"');
+      )->contains('src=&quot;data:image/png;base64,' . $base64Image . '&quot;');
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. On ITIL forms, TinyMCE is already initialized by `Html::textarea()`, so using `Html::setRichTextContent()` was initializing it twice.
2. On ITIL timeline, timeline items (except main item description), were already transformed by `Toolbox::getHtmlToDisplay()`, so using `Html::setRichTextContent()` had no effect, except that an extra entity decoding was done by the second call to `Html::clean()`.
3. On ITIL timeline, usage of `Toolbox::getHtmlToDisplay()` was more appropriate as `Html::setRichTextContent()` for main item description.
4. `Toolbox::getHtmlToDisplay()` was doing a `Html::entity_decode_deep()` that should not be done. Indeed, all content passed to this method comes from database or browser query, and is not transformed by `Html::entities_deep()`.