### PR TITLE
Fix external links

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -6175,22 +6175,17 @@ JAVASCRIPT;
                $link = new Link();
                if (($item = getItemForItemtype($itemtype))
                    && $item->getFromDB($data['id'])
-                   && $link->getfromDB($data[$ID][0]['id'])
-                   && ($item->fields['entities_id'] == $link->fields['entities_id'])) {
-                  if (count($data[$ID])) {
-                     $count_display = 0;
-                     foreach ($data[$ID] as$val) {
-
-                        if (is_array($val)) {
-                           $links = Link::getAllLinksFor($item, $val);
-                           foreach ($links as $link) {
-                              if ($count_display) {
-                                 $out .=  self::LBBR;
-                              }
-                              $out .= $link;
-                              $count_display++;
-                           }
+               ) {
+                  $data = Link::getLinksDataForItem($item);
+                  $count_display = 0;
+                  foreach ($data as $val) {
+                     $links = Link::getAllLinksFor($item, $val);
+                     foreach ($links as $link) {
+                        if ($count_display) {
+                           $out .=  self::LBBR;
                         }
+                        $out .= $link;
+                        $count_display++;
                      }
                   }
                }


### PR DESCRIPTION
Two data were wrong for external links:
 * Tab count display
 * Search results

The issue with links is that you need to load the links matching the entity of a given item, not the active entity from the session.

Tab count were easy to fix, I could apply the same code that was already working for the tab content.

Search results were a lot harder as I'm not sure it is possible to do it in the search options.
I've tried a few SQL request inserted in `$newtab['joinparams']['condition']` but I wasn't sure it would work for everything given that we have specific case for recursives items and/or users.

In the end I've done the work on the `Search::giveItem` method instead (the search options does not do anything).
This was we can call the trusted code that we already use for displaying the tab data.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21652
