### PR TITLE
Flatpickr: Set start of week to Monday for UK

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -2866,7 +2866,7 @@ HTML;
             dateFormat: 'Y-m-d',
             wrap: true, // permits to have controls in addition to input (like clear or open date buttons
             weekNumbers: true,
-            locale: "{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][3]}",
+            locale: getFlatPickerLocale("{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][0]}", "{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][3]}"),
             {$min_attr}
             {$max_attr}
             {$multiple_attr}
@@ -3036,7 +3036,7 @@ HTML;
          ? "maxDate: '{$p['max']}',"
          : "";
 
-      $js = <<<JS
+$js = <<<JS
       $(function() {
          $("#showdate{$p['rand']}").flatpickr({
             altInput: true, // Show the user a readable date (as per altFormat), but return something totally different to the server.
@@ -3046,7 +3046,7 @@ HTML;
             enableTime: true,
             enableSeconds: true,
             weekNumbers: true,
-            locale: "{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][3]}",
+            locale: getFlatPickerLocale("{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][0]}", "{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][3]}"),
             minuteIncrement: "{$p['timestep']}",
             {$min_attr}
             {$max_attr}
@@ -3165,7 +3165,7 @@ HTML;
             enableTime: true,
             noCalendar: true, // only time picker
             enableSeconds: true,
-            locale: "{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][3]}",
+            locale: getFlatPickerLocale("{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][0]}", "{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][3]}"),
             minuteIncrement: "{$p['timestep']}",
             onChange: function(selectedDates, dateStr, instance) {
                {$p['on_change']}

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -2857,6 +2857,7 @@ HTML;
          ? json_encode($p['value'])
          : "'{$p['value']}'";
 
+      $locale = Locale::parseLocale($_SESSION['glpilanguage']);
       $js = <<<JS
       $(function() {
          $("#showdate{$p['rand']}").flatpickr({
@@ -2866,7 +2867,7 @@ HTML;
             dateFormat: 'Y-m-d',
             wrap: true, // permits to have controls in addition to input (like clear or open date buttons
             weekNumbers: true,
-            locale: getFlatPickerLocale("{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][0]}", "{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][3]}"),
+            locale: getFlatPickerLocale("{$locale['language']}", "{$locale['region']}"),
             {$min_attr}
             {$max_attr}
             {$multiple_attr}
@@ -3036,7 +3037,8 @@ HTML;
          ? "maxDate: '{$p['max']}',"
          : "";
 
-$js = <<<JS
+      $locale = Locale::parseLocale($_SESSION['glpilanguage']);
+      $js = <<<JS
       $(function() {
          $("#showdate{$p['rand']}").flatpickr({
             altInput: true, // Show the user a readable date (as per altFormat), but return something totally different to the server.
@@ -3046,7 +3048,7 @@ $js = <<<JS
             enableTime: true,
             enableSeconds: true,
             weekNumbers: true,
-            locale: getFlatPickerLocale("{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][0]}", "{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][3]}"),
+            locale: getFlatPickerLocale("{$locale['language']}", "{$locale['region']}"),
             minuteIncrement: "{$p['timestep']}",
             {$min_attr}
             {$max_attr}
@@ -3156,7 +3158,7 @@ JS;
             $clear
          </div>
 HTML;
-
+      $locale = Locale::parseLocale($_SESSION['glpilanguage']);
       $js = <<<JS
       $(function() {
          $("#showtime{$p['rand']}").flatpickr({
@@ -3165,7 +3167,7 @@ HTML;
             enableTime: true,
             noCalendar: true, // only time picker
             enableSeconds: true,
-            locale: getFlatPickerLocale("{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][0]}", "{$CFG_GLPI['languages'][$_SESSION['glpilanguage']][3]}"),
+            locale: getFlatPickerLocale("{$locale['language']}", "{$locale['region']}"),
             minuteIncrement: "{$p['timestep']}",
             onChange: function(selectedDates, dateStr, instance) {
                {$p['on_change']}

--- a/js/common.js
+++ b/js/common.js
@@ -1193,3 +1193,22 @@ function relativeDate(str) {
                            : (tmp = Math.round(y)) === 1 ? __('a year ago')
                               : '%s years ago'.replace('%s', tmp);
 }
+
+/**
+ * Special case as both "English" and "English (US)" use the same locale for
+ * flatpickr but should have different first day of week.
+ * We must manually set firstDayOfWeek for "English"
+ *
+ * @param {String} locale_label
+ * @param {String} locale_code
+ * @returns
+ */
+function getFlatPickerLocale(locale_label, locale_code) {
+   if (locale_label == "English") {
+      return {
+         firstDayOfWeek: 1 // No need to specify locale code, default is english
+      };
+   } else {
+      return locale_code;
+   }
+}

--- a/js/common.js
+++ b/js/common.js
@@ -1199,16 +1199,16 @@ function relativeDate(str) {
  * flatpickr but should have different first day of week.
  * We must manually set firstDayOfWeek for "English"
  *
- * @param {String} locale_label
- * @param {String} locale_code
+ * @param {String} language
+ * @param {String} region
  * @returns
  */
-function getFlatPickerLocale(locale_label, locale_code) {
-   if (locale_label == "English") {
+function getFlatPickerLocale(language, region) {
+   if (language == "en" && region == "GB") {
       return {
          firstDayOfWeek: 1 // No need to specify locale code, default is english
       };
    } else {
-      return locale_code;
+      return language;
    }
 }


### PR DESCRIPTION
Flatpickr use the selected locale to define the start of the weeks.
The issue is that the US and the UK share one "english" locale config but should have different start of week (US -> sunday, UK -> monday).

Only way to fix this is to set the `firstDayOfWeek` param manually for this specific case.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21789
