### PR TITLE
Fix URL validation

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3488,8 +3488,9 @@ HTML;
       // Verify absence of known disallowed characters.
       // It is still possible to have false positives, but a fireproof check would be too complex
       // (or would require usage of a dedicated lib).
+      // return filter_var($url, FILTER_VALIDATE_URL) !== false;
       return (preg_match(
-         "/^(?:http[s]?:\/\/(?:[^\s`!()\[\]{};'\",<>?«»“”‘’+]+|[^\s`!()\[\]{};:'\".,<>?«»“”‘’+]))$/iu",
+         "/^(?:http[s]?:\/\/(?:[^\s`!()\[\]{};'\",<>«»“”‘’+]+|[^\s`!()\[\]{};:'\".,<>?«»“”‘’+]))$/iu",
          $url
       ) === 1);
    }

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3488,7 +3488,6 @@ HTML;
       // Verify absence of known disallowed characters.
       // It is still possible to have false positives, but a fireproof check would be too complex
       // (or would require usage of a dedicated lib).
-      // return filter_var($url, FILTER_VALIDATE_URL) !== false;
       return (preg_match(
          "/^(?:http[s]?:\/\/(?:[^\s`!()\[\]{};'\",<>«»“”‘’+]+|[^\s`!()\[\]{};:'\".,<>?«»“”‘’+]))$/iu",
          $url

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -1046,6 +1046,8 @@ class Toolbox extends \GLPITestCase {
          ['https://localhost<', false],
          ['https://localhost"', false],
          ['https://localhost\'', false],
+         ['https://localhost?test=true', true],
+         ['https://localhost?test=true&othertest=false', true],
       ];
    }
 


### PR DESCRIPTION
New regex introduced in #7733 is a bit too strict: URL containing "?" are considered to be not valid (so any URL with a query string would be marked as invalid).
 
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
