### PR TITLE
Clarify mailcollector name function

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -973,10 +973,8 @@ class MailCollector  extends CommonDBTM {
 
       // manage blacklist
       $blacklisted_emails   = Blacklist::getEmails();
-      if (GLPIMailer::ValidateAddress($this->fields['name'])) {
-         // Add name of the mailcollector as blacklisted
-         $blacklisted_emails[] = $this->fields['name'];
-      }
+      // Add name of the mailcollector as blacklisted
+      $blacklisted_emails[] = $this->fields['name'];
       if (Toolbox::inArrayCaseCompare($headers['from'], $blacklisted_emails)) {
          $tkt['_blacklisted'] = true;
          return $tkt;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This is not really a bug fix nor a new feature.

Currently, when a user creates/updates a mail collector with a name that is not an email address, an error message is displayed (`Invalid email address`), but input is saved anyway.
During collect process, name is added to blacklisted emails even if it is not a valid email address.

I added a tooltip to explain how this name is used, and removed the error message during input saving.