### PR TITLE
Use trigger_error() to be able to get trace in logs

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7947,7 +7947,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
             default:
                $field = '';
-               Toolbox::logError('Missing type for Ticket template!');
+               trigger_error('Missing type for Ticket template!', E_USER_WARNING);
                break;
          }
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I see lot of occurences of `Missing type for Ticket template!` in logs provided in issues, but as it is logged using `Toolbox::logError()`, the backtrace is not available.

Using `trigger_error()` will permit to have the full trace. I use `E_USER_WARNING` as it is not a blocking error according to code, and `E_USER_ERROR` level will trigger a fatal error.
Exemple of trace we would get (I triggered it on a valid case):
```
[2021-03-19 09:58:04] glpiphplog.WARNING:   *** PHP User Warning (512): Missing type for Ticket template! in /var/www/glpi/inc/commonitilobject.class.php at line 7934
  Backtrace :
  inc/commonitilobject.class.php:7934                trigger_error()
  inc/commonitilobject.class.php:7870                CommonITILObject->getTemplateFieldName()
  inc/ticket.class.php:4281                          CommonITILObject->getITILTemplateToUse()
  inc/commonglpi.class.php:627                       Ticket->showForm()
  ajax/common.tabs.php:106                           CommonGLPI::displayStandardTab()
```

I think this change should be done at many places, but I have no time right now. 