### PR TITLE
Do not show ancestors on entity search results

### DIFF
--- a/inc/api/api.class.php
+++ b/inc/api/api.class.php
@@ -1299,7 +1299,9 @@ abstract class API extends CommonGLPI {
       }
 
       // filter with entity
-      if ($item->isEntityAssign()
+      if ($item->getType() == 'Entity') {
+         $where.= " AND (" . getEntitiesRestrictRequest("", $itemtype::getTable()) . ")";
+      } else if ($item->isEntityAssign()
           // some CommonDBChild classes may not have entities_id fields and isEntityAssign still return true (like ITILTemplateMandatoryField)
           && array_key_exists('entities_id', $item->fields)) {
          $where.= " AND (". getEntitiesRestrictRequest("",

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -657,7 +657,7 @@ class Search {
          }
 
          if ($data['itemtype'] == 'Entity') {
-            $COMMONWHERE .= getEntitiesRestrictRequest($LINK, $itemtable, 'id', '', true);
+            $COMMONWHERE .= getEntitiesRestrictRequest($LINK, $itemtable);
 
          } else if (isset($CFG_GLPI["union_search_type"][$data['itemtype']])) {
             // Will be replace below in Union/Recursivity Hack


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In entity search results, when a user have access to only a subset of entities, their ancestor are shown, regardless user rights.
![image](https://user-images.githubusercontent.com/33253653/112131033-625ecf00-8bc9-11eb-9bae-ae0dc2131f9c.png)

Removing the `$is_recursive:true` fixes this.

Nota:
`getEntitiesRestrictRequest()` and `getEntitiesRestrictCriteria()` have a special case to handle the `$is_recursive` for `glpi_entities` table, which looks weird to me. I did not see any occurence that uses this in the code, except for the case fixed by this PR.