### PR TITLE
Drop MySQL 5.6 and MariaDB 10.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,9 +108,9 @@ jobs:
           - {php-version: "7.3", db-image: "mariadb:10.5", always: false}
           - {php-version: "7.4", db-image: "mariadb:10.5", always: false}
           # test other DB servers/versions
-          - {php-version: "8.0", db-image: "mariadb:10.1", always: false}
-          - {php-version: "8.0", db-image: "mysql:5.6", always: false}
-          - {php-version: "8.0", db-image: "percona:5.6", always: false}
+          - {php-version: "8.0", db-image: "mariadb:10.2", always: false}
+          - {php-version: "8.0", db-image: "mysql:5.7", always: false}
+          - {php-version: "8.0", db-image: "percona:5.7", always: false}
           - {php-version: "8.0", db-image: "percona:8.0", always: false}
     env:
       # Skip jobs that should not be always run on pull requests or on push on tier repository (to limit workers usage).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It is distributed under the GNU GENERAL PUBLIC LICENSE Version 2 - please consul
 ## Prerequisites
 
 * A web server (Apache, Nginx, IIS, etc.)
-* MariaDB >= 10.0 or MySQL >= 5.6
+* MariaDB >= 10.2 or MySQL >= 5.7
 * PHP 7.3 or higher
 * Mandatory PHP extensions:
     - ctype

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2409,18 +2409,20 @@ class Config extends CommonDBTM {
     * @return boolean
    **/
    static function checkDbEngine($raw = null) {
-      // MySQL >= 5.6 || MariaDB >= 10
       if ($raw === null) {
          global $DB;
          $raw = $DB->getVersion();
       }
 
-      /** @var array $found */
-      preg_match('/(\d+(\.)?)+/', $raw, $found);
-      $version = $found[0];
+      $server  = preg_match('/-MariaDB/', $raw) ? 'MariaDB': 'MySQL';
+      $version = preg_replace('/^((\d+\.?)+).*$/', '$1', $raw);
 
-      $db_ver = version_compare($version, '5.6', '>=');
-      return [$version => $db_ver];
+      // MySQL >= 5.7 || MariaDB >= 10.2
+      $is_supported = $server === 'MariaDB'
+         ? version_compare($version, '10.2', '>=')
+         : version_compare($version, '5.7', '>=');
+
+      return [$version => $is_supported];
    }
 
 

--- a/inc/console/migration/dynamicrowformatcommand.class.php
+++ b/inc/console/migration/dynamicrowformatcommand.class.php
@@ -57,13 +57,6 @@ class DynamicRowFormatCommand extends AbstractCommand {
     */
    const ERROR_INNODB_REQUIRED = 2;
 
-   /**
-    * Error code returned if DB configuration is not compatible with large indexes.
-    *
-    * @var integer
-    */
-   const ERROR_INCOMPATIBLE_DB_CONFIG = 3;
-
    protected $requires_db_up_to_date = false;
 
    protected function configure() {
@@ -86,26 +79,6 @@ class DynamicRowFormatCommand extends AbstractCommand {
     * @return void
     */
    private function checkForPrerequisites(): void {
-      // Check that DB configuration is compatible
-      $version = preg_replace('/^((\d+\.?)+).*$/', '$1', $this->db->getVersion());
-      if (version_compare($version, '5.7', '<')) {
-         // On MySQL 5.6, "ROW_FORMAT = DYNAMIC" fallbacks to "ROW_FORMAT = COMPACT"
-         // if "innodb_file_format" is not set to "Barracuda".
-         // This variable has been removed in MySQL 8.0 and in MariaDB 10.3.
-         $query = 'SELECT @@GLOBAL.' . $this->db->quoteName('innodb_file_format as innodb_file_format');
-
-         if (($db_config_res = $this->db->query($query)) === false) {
-            $msg = '<error>' . __('Unable to validate database configuration variables.') . '</error>';
-            throw new \Glpi\Console\Exception\EarlyExitException($msg, self::ERROR_INCOMPATIBLE_DB_CONFIG);
-         }
-
-         $db_config = $db_config_res->fetch_assoc();
-         if ($db_config['innodb_file_format'] !== 'Barracuda') {
-            $msg = '<error>' . __('Database configuration is not compatible with "Dynamic" row format usage.') . '</error>'
-                 . "\n" . '<error> - ' . __('"innodb_file_format" must be set to "Barracuda".') . '</error>';
-            throw new \Glpi\Console\Exception\EarlyExitException($msg, self::ERROR_INCOMPATIBLE_DB_CONFIG);
-         }
-      }
 
       // Check that all tables are using InnoDB engine
       if (($myisam_count = $this->db->getMyIsamTables()->count()) > 0) {

--- a/inc/system/requirement/dbengine.class.php
+++ b/inc/system/requirement/dbengine.class.php
@@ -54,9 +54,16 @@ class DbEngine extends AbstractRequirement {
    }
 
    protected function check() {
-      $version = preg_replace('/^((\d+\.?)+).*$/', '$1', $this->db->getVersion());
+      $version_string = $this->db->getVersion();
 
-      if (version_compare($version, '5.6', '>=')) {
+      $server  = preg_match('/-MariaDB/', $version_string) ? 'MariaDB': 'MySQL';
+      $version = preg_replace('/^((\d+\.?)+).*$/', '$1', $version_string);
+
+      $is_supported = $server === 'MariaDB'
+         ? version_compare($version, '10.2', '>=')
+         : version_compare($version, '5.7', '>=');
+
+      if ($is_supported) {
          $this->validated = true;
          $this->validation_messages[] = sprintf(
             __('Database version seems correct (%s) - Perfect!'),

--- a/tests/functionnal/Config.php
+++ b/tests/functionnal/Config.php
@@ -443,30 +443,38 @@ class Config extends DbTestCase {
    protected function dbEngineProvider() {
       return [
          [
+            'raw'       => '10.1.48-MariaDB',
+            'version'   => '10.1.48',
+            'compat'    => false
+         ], [
             'raw'       => '10.2.14-MariaDB',
             'version'   => '10.2.14',
             'compat'    => true
          ], [
-            'raw'       => '5.5.10-MariaDB',
-            'version'   => '5.5.10',
-            'compat'    => false
+            'raw'       => '10.3.28-MariaDB',
+            'version'   => '10.3.28',
+            'compat'    => true
+         ], [
+            'raw'       => '10.4.8-MariaDB-1:10.4.8+maria~bionic',
+            'version'   => '10.4.8',
+            'compat'    => true
+         ], [
+            'raw'       => '10.5.9-MariaDB',
+            'version'   => '10.5.9',
+            'compat'    => true
          ], [
             'raw'       => '5.6.38-log',
             'version'   => '5.6.38',
-            'compat'    => true
-         ], [
-            'raw'       => '5-5-57',
-            'version'   => '5',
             'compat'    => false
-         ], [
-            'raw'       => '5-6-31',
-            'version'   => '5',
-            'compat'    => false // since version is 5, this is not compat.
-         ], [
-            'raw'       => '10-2-35',
-            'version'   => '10',
+         ],  [
+            'raw'       => '5.7.50-log',
+            'version'   => '5.7.50',
             'compat'    => true
-         ]
+         ], [
+            'raw'       => '8.0.23-standard',
+            'version'   => '8.0.23',
+            'compat'    => true
+         ],
       ];
    }
 

--- a/tests/units/Glpi/System/Diagnostic/DatabaseSchemaChecker.php
+++ b/tests/units/Glpi/System/Diagnostic/DatabaseSchemaChecker.php
@@ -56,7 +56,7 @@ CREATE TABLE `table` (
 ) ENGINE=InnoDB AUTO_INCREMENT=15
 SQL
             ,
-            'version_string' => '5.6.50-log',
+            'version_string' => '5.7.50-log',
             'args'           => [
             ],
             'expected_has'   => false,
@@ -321,7 +321,7 @@ CREATE TABLE `table` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci
 SQL
             ,
-            'version_string' => '10.1.48-MariaDB',
+            'version_string' => '10.2.36-MariaDB',
             'args'           => [
                'use_utf8mb4' => false,
                'ignore_utf8mb4_migration' => true,
@@ -351,7 +351,7 @@ CREATE TABLE `table` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci
 SQL
             ,
-            'version_string' => '10.1.48-MariaDB',
+            'version_string' => '10.2.36-MariaDB',
             'args'           => [
                'use_utf8mb4' => false,
                'ignore_utf8mb4_migration' => false,
@@ -395,7 +395,7 @@ CREATE TABLE `table` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci
 SQL
             ,
-            'version_string' => '10.1.48-MariaDB',
+            'version_string' => '10.2.36-MariaDB',
             'args'           => [
                'use_utf8mb4' => false,
                'ignore_utf8mb4_migration' => true,
@@ -437,7 +437,7 @@ CREATE TABLE `table` (
 ) ENGINE=InnoDB
 SQL
             ,
-            'version_string' => '10.1.48-MariaDB',
+            'version_string' => '10.2.36-MariaDB',
             'args'           => [
                'ignore_timestamps_migration' => true,
             ],
@@ -465,7 +465,7 @@ CREATE TABLE `table` (
 ) ENGINE=InnoDB
 SQL
             ,
-            'version_string' => '10.1.48-MariaDB',
+            'version_string' => '10.2.36-MariaDB',
             'args'           => [
                'ignore_timestamps_migration' => false,
             ],

--- a/tests/units/Glpi/System/Requirement/DbConfiguration.php
+++ b/tests/units/Glpi/System/Requirement/DbConfiguration.php
@@ -37,48 +37,6 @@ class DbConfiguration extends \GLPITestCase {
    protected function configurationProvider() {
       return [
          [
-            // Default variables on MySQL 5.6
-            'version'   => '5.6.50-log',
-            'variables' => [
-               'innodb_file_format'  => 'Antelope',
-               'innodb_large_prefix' => 0,
-               'innodb_page_size'    => 16384,
-            ],
-            'validated' => false,
-            'messages'  => [
-               '"innodb_file_format" must be set to "Barracuda".',
-               '"innodb_large_prefix" must be enabled.',
-            ]
-         ],
-         [
-            // Required variables on MySQL 5.6
-            'version'   => '5.6.50-log',
-            'variables' => [
-               'innodb_file_format'  => 'Barracuda',
-               'innodb_large_prefix' => 1,
-               'innodb_page_size'    => 16384,
-            ],
-            'validated' => true,
-            'messages'  => [
-               'Database configuration is OK.',
-            ]
-         ],
-         [
-            // Incompatible variables on MySQL 5.6
-            'version'   => '5.6.50-log',
-            'variables' => [
-               'innodb_file_format'  => 'Antelope',
-               'innodb_large_prefix' => 0,
-               'innodb_page_size'    => 4096,
-            ],
-            'validated' => false,
-            'messages'  => [
-               '"innodb_file_format" must be set to "Barracuda".',
-               '"innodb_large_prefix" must be enabled.',
-               '"innodb_page_size" must be >= 8KB.',
-            ]
-         ],
-         [
             // Default variables on MySQL 5.7
             'version'   => '5.7.34-standard',
             'variables' => [

--- a/tests/units/Glpi/System/Requirement/DbEngine.php
+++ b/tests/units/Glpi/System/Requirement/DbEngine.php
@@ -37,19 +37,49 @@ class DbEngine extends \GLPITestCase {
    protected function versionProvider() {
       return [
          [
+            'version'   => '5.5.38-0ubuntu0.14.04.1',
+            'validated' => false,
+            'messages'  => ['Your database engine version seems too old: 5.5.38.'],
+         ],
+         [
             'version'   => '5.6.46-log',
+            'validated' => false,
+            'messages'  => ['Your database engine version seems too old: 5.6.46.'],
+         ],
+         [
+            'version'   => '5.7.50-log',
             'validated' => true,
-            'messages'  => ['Database version seems correct (5.6.46) - Perfect!']
+            'messages'  => ['Database version seems correct (5.7.50) - Perfect!'],
+         ],
+         [
+            'version'   => '8.0.23-standard',
+            'validated' => true,
+            'messages'  => ['Database version seems correct (8.0.23) - Perfect!'],
+         ],
+         [
+            'version'   => '10.1.48-MariaDB',
+            'validated' => false,
+            'messages'  => ['Your database engine version seems too old: 10.1.48.'],
+         ],
+         [
+            'version'   => '10.2.36-MariaDB',
+            'validated' => true,
+            'messages'  => ['Database version seems correct (10.2.36) - Perfect!'],
+         ],
+         [
+            'version'   => '10.3.28-MariaDB',
+            'validated' => true,
+            'messages'  => ['Database version seems correct (10.3.28) - Perfect!'],
          ],
          [
             'version'   => '10.4.8-MariaDB-1:10.4.8+maria~bionic',
             'validated' => true,
-            'messages'  => ['Database version seems correct (10.4.8) - Perfect!']
+            'messages'  => ['Database version seems correct (10.4.8) - Perfect!'],
          ],
          [
-            'version'   => '5.5.38-0ubuntu0.14.04.1',
-            'validated' => false,
-            'messages'  => ['Your database engine version seems too old: 5.5.38.']
+            'version'   => '10.5.9-MariaDB',
+            'validated' => true,
+            'messages'  => ['Database version seems correct (10.5.9) - Perfect!'],
          ],
       ];
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

MySQL 5.6 active support ended on February 5, 2021.
MariaDB 10.1 active support ended on October 17, 2020.