### PR TITLE
Fix timezone used for cron task execution hours

### DIFF
--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -355,7 +355,7 @@ class CronTask extends CommonDBTM{
    function getNeedToRun($mode = 0, $name = '') {
       global $DB;
 
-      $hour = date('H');
+      $hour_criteria = new QueryExpression('hour(curtime())');
       // First core ones
       $WHERE = ['NOT' => ['itemtype' => ['LIKE', 'Plugin%']]];
 
@@ -398,14 +398,14 @@ class CronTask extends CommonDBTM{
          $WHERE[] = ['OR' => [
             ['AND' => [
                ['hourmin'   => ['<', new QueryExpression($DB->quoteName('hourmax'))]],
-               'hourmin'   => ['<=', $hour],
-               'hourmax'   => ['>', $hour]
+               'hourmin'   => ['<=', $hour_criteria],
+               'hourmax'   => ['>', $hour_criteria]
             ]],
             ['AND' => [
                'hourmin'   => ['>', new QueryExpression($DB->quoteName('hourmax'))],
                'OR'        => [
-                  'hourmin'   => ['<=', $hour],
-                  'hourmax'   => ['>', $hour]
+                  'hourmin'   => ['<=', $hour_criteria],
+                  'hourmax'   => ['>', $hour_criteria]
                ]
             ]]
          ]];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Crontask scheduling is based on dates computed on MySQL side (`lastrun` is using `DATE_FORMAT(NOW(),\'%Y-%m-%d %H:%i:00\')` and is the compared to `NOW()`).

Using PHP side hour may result in having tasks marked as executed outside their run period due to timezone offset between PHP and MySQL.

Example:
 - Current hour is 05:00:00 UTC,
 - PHP TZ is UTC+4,
 - MySQL TZ is UTC+2,
 - Run period is 8 -> 17;
-> PHP hour is so 09:00:00, within the run period. Task is executed and `lastrun` is updated to 07:00:00 (the MySQL time), wich is outside the run period.