### PR TITLE
Handle errors on crontasks

### DIFF
--- a/inc/crontasklog.class.php
+++ b/inc/crontasklog.class.php
@@ -43,6 +43,7 @@ class CronTaskLog extends CommonDBTM{
    const STATE_START = 0;
    const STATE_RUN   = 1;
    const STATE_STOP  = 2;
+   const STATE_ERROR = 3;
 
 
    /**

--- a/inc/notificationtargetcrontask.class.php
+++ b/inc/notificationtargetcrontask.class.php
@@ -90,7 +90,7 @@ class NotificationTargetCrontask extends NotificationTarget {
       }
 
       $this->addTagToList(['tag'     => 'crontasks',
-                                'label'   => __('Device list'),
+                                'label'   => __('Automatic actions list'),
                                 'value'   => false,
                                 'foreach' => true]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Here is a simple solution to prevent cron tasks to be marked as running when an error occured. Recoverable errors will be catched and so the task execution will be considered as aborted.
Consequences are:
 - task will be reexecuted on next scheduled date,
 - scripts will not exit due to error, so following tasks on the loop will be executed.

A better solution would be to add the error trace in the `glpi_crontasklogs` table, but it would require to add a new field in DB, much new strings and some UI changes, so it cannot be done on a bugfixes branch.

I forced an error on mailgate, for the example.

Cron log:
```
2021-03-26 09:26:01 [@69509cfe24fe]
External #1: Launch mailgate
2021-03-26 09:26:02 [@69509cfe24fe]
External #1: Error during mailgate execution. Check in "/var/www/glpi/files/_log/php-errors.log" for more details.
2021-03-26 09:26:02 [@69509cfe24fe]
External #2: Launch slaticket
2021-03-26 09:26:03 [@69509cfe24fe]
External #3: Launch planningrecall
2021-03-26 09:26:03 [@69509cfe24fe]
External #4: Launch queuednotification
2021-03-26 09:26:03 [@69509cfe24fe]
External #5: Launch olaticket
```

PHP errors log:
```
[2021-03-26 09:26:02] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Call to a member function next() on null in /var/www/glpi/inc/mailcollector.class.php at line 1738
  Backtrace :
  inc/crontask.class.php:848                         MailCollector::cronMailgate()
  front/cron.php:83                                  CronTask::launch()
```

Cron task log:
![image](https://user-images.githubusercontent.com/33253653/112611223-d7c2dd80-8e1d-11eb-818d-c7cc4fe4448b.png)
