### PR TITLE
Fix handling of plugins namespaces on crontask

### DIFF
--- a/tests/functionnal/CronTask.php
+++ b/tests/functionnal/CronTask.php
@@ -38,42 +38,160 @@ use DbTestCase;
 
 class CronTask extends DbTestCase {
 
-   public function registerProvider() {
+   protected function registerProvider() {
       return [
-         ['CoreNonExistent', 'CoreTest1', 30, [], false], // Non-existent core class
-         ['CronTask', 'CoreTest2', 30, [], true], // Existing core class
-         ['PluginTestItemtype', 'PluginTest1', 30, [], true] // Plugin class. Existence not checked.
+         [
+            'itemtype'        => 'CoreNonExistent',
+            'name'            => 'CoreTest1',
+            'should_register' => false, // Non-existent core class
+         ],
+         [
+            'itemtype'        => 'CronTask',
+            'name'            => 'CoreTest2',
+            'should_register' => true, // Existing core class
+         ],
+         [
+            'itemtype'        => 'Glpi\Marketplace\Controller',
+            'name'            => 'CoreTest3',
+            'should_register' => true, // Existing core namespaced class
+         ],
+         [
+            'itemtype'        => 'PluginTestItemtype',
+            'name'            => 'PluginTest1',
+            'should_register' => true, // Plugin class. Existence not checked.
+         ],
+         [
+            'itemtype'        => 'GlpiPlugin\\Tester\\TestItemtype',
+            'name'            => 'NamespacedPluginTest1',
+            'should_register' => true, // Plugin class with namespace. Existence not checked.
+         ],
       ];
    }
 
    /**
     * @dataProvider registerProvider
     */
-   public function testRegister($itemtype, $name, $frequency, $options, $expect_pass) {
-      $result = \CronTask::register($itemtype, $name, $frequency, $options);
-      if ($expect_pass) {
+   public function testRegister(string $itemtype, string $name, bool $should_register) {
+      $result = \CronTask::register($itemtype, $name, 30);
+      if ($should_register) {
          $this->variable($result)->isNotEqualTo(false);
       } else {
          $this->variable($result)->isEqualTo(false);
       }
    }
 
-   public function testUnregister() {
+   protected function unregisterProvider() {
+      // Only plugins are supported with the unregister method.
+      return [
+         [
+            'plugin_name'       => 'Test',
+            'itemtype'          => 'PluginTestItemtype',
+            'name'              => 'PluginTest1',
+            'should_unregister' => true,
+         ],
+         [
+            'plugin_name'       => 'Tester',
+            'itemtype'          => 'GlpiPlugin\\Tester\\TestItemtype',
+            'name'              => 'NamespacedPluginTest1',
+            'should_unregister' => true,
+         ],
+         [
+            'plugin_name'       => 'Tester',
+            'itemtype'          => 'GlpiPlugin\\TesterNg\\TestItemtype',
+            'name'              => 'NamespacedPluginTest2',
+            'should_unregister' => false, // plugin name does not match class namespace
+         ],
+      ];
+   }
+
+   /**
+    * @dataProvider unregisterProvider
+    */
+   public function testUnregister(string $plugin_name, string $itemtype, string $name, bool $should_unregister) {
       global $DB;
 
-      // Register task for any plugin class. Only plugins are supported with the unregister method.
-      $plugin_task = \CronTask::register('PluginTestItemtype', 'PluginTest1', 30, []);
+      // Register task .
+      $plugin_task = \CronTask::register($itemtype, $name, 30, []);
       $this->variable($plugin_task)->isNotEqualTo(false);
 
+      // Check the task has been created in DB
+      $iterator = $DB->request([
+         'SELECT' => ['id'],
+         'FROM'   => \CronTask::getTable(),
+         'WHERE'  => ['itemtype' => addslashes($itemtype), 'name' => $name]
+      ]);
+      $this->integer($iterator->count())->isEqualTo(1);
+
       // Try un-registering the task
-      $result = \CronTask::unregister('Test');
+      $result = \CronTask::unregister($plugin_name);
       $this->boolean($result)->isTrue();
+
       // Check the delete actually worked
       $iterator = $DB->request([
          'SELECT' => ['id'],
          'FROM'   => \CronTask::getTable(),
-         'WHERE'  => ['itemtype' => 'PluginTestItemtype']
+         'WHERE'  => ['itemtype' => addslashes($itemtype), 'name' => $name]
       ]);
-      $this->integer($iterator->count())->isEqualTo(0);
+      $this->integer($iterator->count())->isEqualTo($should_unregister ? 0 : 1);
+   }
+
+   protected function getNeedToRunProvider() {
+      return [
+         [
+            'itemtype'    => 'CronTask',
+            'name'        => 'CoreTest1',
+            'should_run'  => true,
+         ],
+         [
+            'itemtype'    => 'Glpi\Marketplace\Controller',
+            'name'        => 'CoreTest2',
+            'should_run'  => true,
+         ],
+         [
+            'itemtype'    => 'PluginTestItemtype',
+            'name'        => 'PluginTest1',
+            'should_run'  => false, // Inactive plugin
+         ],
+         [
+            'itemtype'    => 'PluginTesterItemtype',
+            'name'        => 'PluginTest2',
+            'should_run'  => true,
+         ],
+         [
+            'itemtype'    => 'GlpiPlugin\\Tester\\TestItemtype',
+            'name'        => 'NamespacedPluginTest',
+            'should_run'  => true,
+         ],
+      ];
+   }
+
+   /**
+    * @dataProvider getNeedToRunProvider
+    */
+   public function testGetNeedToRun(string $itemtype, string $name, bool $should_run) {
+      global $DB;
+
+      // Deactivate all registered tasks
+      $crontask = new \CronTask();
+      $DB->update(\CronTask::getTable(), ['state' => \CronTask::STATE_DISABLE], [1]);
+      $this->boolean($crontask->getNeedToRun())->isFalse();
+
+      // Register task for active plugin.
+      $plugin_task = \CronTask::register(
+         $itemtype,
+         $name,
+         30,
+         [
+            'state'   => \CronTask::STATE_WAITING,
+            'hourmin' => 0,
+            'hourmax' => 24,
+         ]
+      );
+      $this->variable($plugin_task)->isNotEqualTo(false);
+      $this->boolean($crontask->getNeedToRun())->isEqualTo($should_run);
+      if ($should_run) {
+         $this->variable($crontask->fields['itemtype'])->isEqualTo($itemtype);
+         $this->variable($crontask->fields['name'])->isEqualTo($name);
+      }
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes following issues:
1. If a plugin has registered a cron task that uses namespaced itemtype, then this cron task will be always executed, whenever the plugin is disabled.
2. If a plugin has registered a cron task that uses namespaced itemtype, then this cron task will not be removed by `CronTask::unregister()`.