### PR TITLE
feat(marketplace): add capability to disable plugin update from marketplace

### DIFF
--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -78,6 +78,7 @@ include_once (GLPI_ROOT . "/inc/autoload.function.php");
       'GLPI_USE_IDOR_CHECK'            => '1',
       'GLPI_IDOR_EXPIRES'              => '7200',
       'GLPI_ALLOW_IFRAME_IN_RICH_TEXT' => false,
+      'GLPI_ALLOW_UPDATE_MARKETPLACE'  => true,
 
       // Constants related to GLPI Project / GLPI Network external services
       'GLPI_TELEMETRY_URI'                => 'https://telemetry.glpi-project.org', // Telemetry project URL

--- a/inc/marketplace/view.class.php
+++ b/inc/marketplace/view.class.php
@@ -665,7 +665,7 @@ HTML;
                                 title='".__s("Download")."'>
                <i class='fas fa-cloud-download-alt'></i>
             </button>";
-         } else if ($can_be_updated) {
+         } else if ($can_be_updated && GLPI_ALLOW_UPDATE_MARKETPLACE) {
             $update_title = sprintf(
                __s("A new version (%s) is available, update ?", 'marketplace'),
                $web_update_version


### PR DESCRIPTION
Add capability to disable plugin update from marketplace
useful for internal usage (TGU) and for community if needed

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
