### PR TITLE
Ensure plugin state is up to date before activate/install it

### DIFF
--- a/inc/console/plugin/activatecommand.class.php
+++ b/inc/console/plugin/activatecommand.class.php
@@ -63,12 +63,13 @@ class ActivateCommand extends AbstractPluginCommand {
             OutputInterface::VERBOSITY_NORMAL
          );
 
+         $plugin = new Plugin();
+         $plugin->checkPluginState($directory); // Be sure that plugin informations are up to date in DB
+
          if (!$this->canRunActivateMethod($directory)) {
             continue;
          }
 
-         $plugin = new Plugin();
-         $plugin->checkPluginState($directory); // Be sure that plugin informations are up to date in DB
          if (!$plugin->getFromDBByCrit(['directory' => $directory])) {
             $this->output->writeln(
                '<error>' . sprintf(__('Unable to load plugin "%s" informations.'), $directory) . '</error>',

--- a/inc/console/plugin/deactivatecommand.class.php
+++ b/inc/console/plugin/deactivatecommand.class.php
@@ -63,12 +63,13 @@ class DeactivateCommand extends AbstractPluginCommand {
             OutputInterface::VERBOSITY_NORMAL
          );
 
+         $plugin = new Plugin();
+         $plugin->checkPluginState($directory); // Be sure that plugin informations are up to date in DB
+
          if (!$this->canRunDeactivateMethod($directory)) {
             continue;
          }
 
-         $plugin = new Plugin();
-         $plugin->checkPluginState($directory); // Be sure that plugin informations are up to date in DB
          if (!$plugin->getFromDBByCrit(['directory' => $directory])) {
             $this->output->writeln(
                '<error>' . sprintf(__('Unable to load plugin "%s" informations.'), $directory) . '</error>',

--- a/inc/console/plugin/installcommand.class.php
+++ b/inc/console/plugin/installcommand.class.php
@@ -117,12 +117,13 @@ class InstallCommand extends AbstractPluginCommand {
             OutputInterface::VERBOSITY_NORMAL
          );
 
+         $plugin = new Plugin();
+         $plugin->checkPluginState($directory); // Be sure that plugin informations are up to date in DB
+
          if (!$this->canRunInstallMethod($directory, $force)) {
             continue;
          }
 
-         $plugin = new Plugin();
-         $plugin->checkPluginState($directory); // Be sure that plugin informations are up to date in DB
          if (!$plugin->getFromDBByCrit(['directory' => $directory])) {
             $this->output->writeln(
                '<error>' . sprintf(__('Unable to load plugin "%s" informations.'), $directory) . '</error>',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This will prevent ability to activate, from CLI command, an inactive plugin which have a version different from its last installed version.

To reproduce the bug:
 - deactivate an active plugin using `bin/console plugin:deactivate` command
 - update its code source
 - reactivate it using `bin/console plugin:activate` command

Without this fix, plugin will be reactivated but its `install` hook will not be trigerred.

With this fix, activation will be blocked.
![image](https://user-images.githubusercontent.com/33253653/114179530-661b8100-993f-11eb-8b86-d29d533a092b.png)
