### PR TITLE
Allow preformatted numbers

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3317,8 +3317,16 @@ class Toolbox {
     * @return string shortened number
     */
    static function shortenNumber($number = 0, $precision = 1, bool $html = true): string {
+
+      $formatted = "";
       $suffix = "";
-      if ($number < 900) {
+      if (!is_numeric($number)) {
+         // Already formatted number
+         if (preg_match("/^([0-9\.]+)(.*)/", $number, $matches)) {
+            $formatted = $matches[1];
+            $suffix = $matches[2];
+         }
+      } else if ($number < 900) {
          $formatted = number_format($number);
       } else if ($number < 900000) {
          $formatted = number_format($number / 1000, $precision);

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -909,6 +909,10 @@ class Toolbox extends \GLPITestCase {
             'number'    => 1600000000000,
             'precision' => 1,
             'expected'  => '1.6T',
+         ], [
+            'number'    => "14%",
+            'precision' => 1,
+            'expected'  => '14%',
          ],
       ];
    }
@@ -916,7 +920,7 @@ class Toolbox extends \GLPITestCase {
    /**
     * @dataProvider shortenNumbers
     */
-   public function testShortenNumber(int $number, int $precision, string $expected) {
+   public function testShortenNumber($number, int $precision, string $expected) {
       $this->string(\Toolbox::shortenNumber($number, $precision, false))
          ->isEqualTo($expected);
    }


### PR DESCRIPTION
User may define a "pre formatted" number using the advanced dashboard plugin and the CONCAT mysql function (e.g. to display a percentage with a "%" suffix after).

These changes make sure we don't auto format these special cases keep the existing suffix.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21911
