### PR TITLE
[Modern UI] Some plugin compatibility

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -7309,6 +7309,9 @@ CSS;
     * @return string
     */
    static function time2str($ts) {
+      if ($ts === null) {
+         return __('Never');
+      }
       if (!ctype_digit($ts)) {
          $ts = strtotime($ts);
       }

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1607,7 +1607,7 @@ class Html {
     * @param $keepDB boolean, closeDBConnections if false (false by default)
    **/
    static function footer($keepDB = false) {
-      global $CFG_GLPI, $FOOTER_LOADED, $TIMER_DEBUG;
+      global $CFG_GLPI, $FOOTER_LOADED, $TIMER_DEBUG, $PLUGIN_HOOKS;
 
       // If in modal : display popFooter
       if (isset($_REQUEST['_in_modal']) && $_REQUEST['_in_modal']) {
@@ -1655,7 +1655,46 @@ class Html {
       $tpl_vars['js_files'][] = 'js/misc.js';
 
       // TODO Add Ajax notifications script block
-      // TODO Add plugins scripts
+      if (isset($PLUGIN_HOOKS['add_javascript']) && count($PLUGIN_HOOKS['add_javascript'])) {
+         foreach ($PLUGIN_HOOKS["add_javascript"] as $plugin => $files) {
+            if (!Plugin::isPluginActive($plugin)) {
+               continue;
+            }
+            $plugin_root_dir = Plugin::getPhpDir($plugin, true);
+            $plugin_web_dir  = Plugin::getWebDir($plugin, false);
+
+            if (!is_array($files)) {
+               $files = [$files];
+            }
+            foreach ($files as $file) {
+               if (file_exists($plugin_root_dir."/{$file}")) {
+                  $tpl_vars['js_files'][] = $plugin_web_dir."/{$file}";
+               } else {
+                  Toolbox::logWarning("{$file} file not found from plugin $plugin!");
+               }
+            }
+         }
+      }
+      if (isset($PLUGIN_HOOKS['add_javascript_module']) && count($PLUGIN_HOOKS['add_javascript_module'])) {
+         foreach ($PLUGIN_HOOKS["add_javascript_module"] as $plugin => $files) {
+            if (!Plugin::isPluginActive($plugin)) {
+               continue;
+            }
+            $plugin_root_dir = Plugin::getPhpDir($plugin, true);
+            $plugin_web_dir  = Plugin::getWebDir($plugin, false);
+
+            if (!is_array($files)) {
+               $files = [$files];
+            }
+            foreach ($files as $file) {
+               if (file_exists($plugin_root_dir."/{$file}")) {
+                  $tpl_vars['js_modules'][] = $plugin_web_dir."/{$file}";
+               } else {
+                  Toolbox::logWarning("{$file} file not found from plugin $plugin!");
+               }
+            }
+         }
+      }
 
       TemplateRenderer::getInstance()->display('layout/parts/page_footer.html.twig', $tpl_vars);
 
@@ -5233,6 +5272,9 @@ JAVASCRIPT;
          unset($options['version']);
       }
 
+      $type = (isset($options['type']) && $options['type'] === 'module') ||
+         preg_match('/^js\/modules\//', $url) === 1 ? 'module' : 'text/javascript';
+
       if ($minify === true) {
          $url = self::getMiniFile($url);
       }
@@ -5243,7 +5285,7 @@ JAVASCRIPT;
          $url .= '?v=' . $version;
       }
 
-      return sprintf('<script type="text/javascript" src="%1$s"></script>', $url);
+      return sprintf('<script type="%s" src="%s"></script>', $type, $url);
    }
 
 
@@ -6274,20 +6316,47 @@ JAVASCRIPT;
       // Add specific javascript for plugins
       if (isset($PLUGIN_HOOKS['add_javascript']) && count($PLUGIN_HOOKS['add_javascript'])) {
          foreach ($PLUGIN_HOOKS["add_javascript"] as $plugin => $files) {
-            $plugin_root_dir = Plugin::getPhpDir($plugin, true);
-            $plugin_web_dir  = Plugin::getWebDir($plugin, false);
             if (!Plugin::isPluginActive($plugin)) {
                continue;
             }
+            $plugin_root_dir = Plugin::getPhpDir($plugin, true);
+            $plugin_web_dir  = Plugin::getWebDir($plugin, false);
             $version = Plugin::getInfo($plugin, 'version');
             if (!is_array($files)) {
                $files = [$files];
             }
             foreach ($files as $file) {
-               if (file_exists($plugin_root_dir."/$file")) {
-                  echo Html::script("$plugin_web_dir/$file", ['version' => $version]);
+               if (file_exists($plugin_root_dir."/{$file}")) {
+                  echo Html::script("$plugin_web_dir/{$file}", [
+                     'version'   => $version,
+                     'type'      => 'text/javascript'
+                  ]);
                } else {
-                  Toolbox::logWarning("$file file not found from plugin $plugin!");
+                  Toolbox::logWarning("{$file} file not found from plugin {$plugin}!");
+               }
+            }
+         }
+      }
+
+      if (isset($PLUGIN_HOOKS['add_javascript_module']) && count($PLUGIN_HOOKS['add_javascript_module'])) {
+         foreach ($PLUGIN_HOOKS["add_javascript_module"] as $plugin => $files) {
+            if (!Plugin::isPluginActive($plugin)) {
+               continue;
+            }
+            $plugin_root_dir = Plugin::getPhpDir($plugin, true);
+            $plugin_web_dir  = Plugin::getWebDir($plugin, false);
+            $version = Plugin::getInfo($plugin, 'version');
+            if (!is_array($files)) {
+               $files = [$files];
+            }
+            foreach ($files as $file) {
+               if (file_exists($plugin_root_dir."/{$file}")) {
+                  echo self::script("$plugin_web_dir/{$file}", [
+                     'version'   => $version,
+                     'type'      => 'module'
+                  ]);
+               } else {
+                  Toolbox::logWarning("{$file} file not found from plugin {$plugin}!");
                }
             }
          }

--- a/templates/layout/parts/page_footer.html.twig
+++ b/templates/layout/parts/page_footer.html.twig
@@ -52,5 +52,9 @@
       <script type="text/javascript" src="{{ js_path(js_file) }}"></script>
    {% endfor %}
 
+   {% for js_file in js_modules %}
+      <script type="module" src="{{ js_path(js_file) }}"></script>
+   {% endfor %}
+
 </body>
 </html>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While testing a plugin, I made a few commits to allow it to function with the new UI.
- Load Javascript files from plugins
- Support loading core and plugin JS files as modules
- Show 'Never' instead of the start of Unix time when passing a null value to `Html::time2str`
  The plugin has a "Last check" field and was showing December 1969 when no checks had been done yet. It was previously using its own method for building relative time strings, but I switched it to use what was provided by GLPI.