### PR TITLE
a search uses DISTINCT, counting its results shall contain it as well

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -726,11 +726,7 @@ class Search {
          $LIMIT = " LIMIT ".(int)$data['search']['start'].", ".(int)$data['search']['list_limit'];
 
          // Force group by for all the type -> need to count only on table ID
-         if (!isset($searchopt[1]['forcegroupby'])) {
-            $count = "count(*)";
-         } else {
-            $count = "count(DISTINCT `$itemtable`.`id`)";
-         }
+         $count = "count(DISTINCT `$itemtable`.`id`)";
          // request currentuser for SQL supervision, not displayed
          $query_num = "SELECT $count,
                               '".Toolbox::addslashes_deep($_SESSION['glpiname'])."' AS currentuser

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -725,7 +725,6 @@ class Search {
       if ($data['search']['no_search']) {
          $LIMIT = " LIMIT ".(int)$data['search']['start'].", ".(int)$data['search']['list_limit'];
 
-         // Force group by for all the type -> need to count only on table ID
          $count = "count(DISTINCT `$itemtable`.`id`)";
          // request currentuser for SQL supervision, not displayed
          $query_num = "SELECT $count,


### PR DESCRIPTION
related to #4219

All searches use SELECT DISTINCT, then the extra SQL query to count the results shall do it as well.

Issue found on the Formanswers tab on form itemtype, and the issues list on the service catalog. I think the bug is new, and appeared after creating search options with a subquery of the following form:

LEFT JOIN foo ON (foo.id = bar.foos_id AND (SELECT ... FROM ...))

Forcegroupby is enabled for those search options, and those search options are force-enabled for all searches on the itemtypes with a plugin_foo_addDefaultJoin() function