### PR TITLE
Give ability to tickets observers to add followups

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -209,6 +209,8 @@ abstract class CommonITILObject extends CommonDBTM {
                && ($this->isUser(CommonITILActor::REQUESTER, Session::getLoginUserID())
                    || (isset($this->fields["users_id_recipient"])
                         && ($this->fields["users_id_recipient"] == Session::getLoginUserID()))))
+              || (Session::haveRight("followup", ITILFollowup::ADD_AS_OBSERVER)
+                  && $this->isUser(CommonITILActor::OBSERVER, Session::getLoginUserID()))
               || Session::haveRight('followup', ITILFollowup::ADDALLTICKET)
               || (Session::haveRight('followup', ITILFollowup::ADDGROUPTICKET)
                   && isset($_SESSION["glpigroups"])

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -57,6 +57,12 @@ class ITILFollowup  extends CommonDBChild {
    const ADDALLTICKET    = 4096;
    const SEEPRIVATE      = 8192;
 
+   /**
+    * Right allowing the user to add a follow-up as soon as he is an observer of an ITIL object.
+    * @var integer
+    */
+   const ADD_AS_OBSERVER = 16384;
+
    static public $itemtype = 'itemtype';
    static public $items_id = 'items_id';
 
@@ -1090,6 +1096,8 @@ JAVASCRIPT;
       $values[self::UPDATEMY]    = __('Update followups (author)');
       $values[self::ADDMYTICKET] = ['short' => __('Add followup (requester)'),
                                          'long'  => __('Add a followup to tickets (requester)')];
+      $values[self::ADD_AS_OBSERVER] = ['short' => __('Add followup (watcher)'),
+                                         'long'  => __('Add a followup to tickets (watcher)')];
       $values[self::SEEPUBLIC]   = __('See public ones');
 
       if ($interface == 'helpdesk') {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2338,6 +2338,10 @@ class Ticket extends CommonITILObject {
                )
             )
          )
+         || (
+            Profile::haveUserRight($user_id, $rightname, ITILFollowup::ADD_AS_OBSERVER, $entity_id)
+            && $this->isUser(CommonITILActor::OBSERVER, $user_id)
+         )
          || Profile::haveUserRight($user_id, $rightname, ITILFollowup::ADDALLTICKET, $entity_id)
          || (
             Profile::haveUserRight($user_id, $rightname, ITILFollowup::ADDGROUPTICKET, $entity_id)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21953

Includes #8991, as it is mandatory to make new test case pass.