### PR TITLE
Fix utf8 migration checks on MySQL 8.0

### DIFF
--- a/inc/system/diagnostic/databaseschemachecker.class.php
+++ b/inc/system/diagnostic/databaseschemachecker.class.php
@@ -237,6 +237,8 @@ class DatabaseSchemaChecker {
       if ($this->ignore_timestamps_migration) {
          $column_replacements['/ timestamp( NULL)?/i'] = ' datetime';
       }
+      // Normalize utf8mb3 to utf8
+      $column_replacements['/utf8mb3/i'] = 'utf8';
       if ($this->ignore_utf8mb4_migration) {
          $column_replacements['/( CHARACTER SET (utf8|utf8mb4))? COLLATE (utf8_unicode_ci|utf8mb4_unicode_ci)/i'] = '';
       }
@@ -273,6 +275,13 @@ class DatabaseSchemaChecker {
       }
       if ($this->ignore_innodb_migration) {
          unset($properties['ENGINE']);
+      }
+      // Normalize utf8mb3 to utf8
+      if (array_key_exists('DEFAULT CHARSET', $properties)) {
+         $properties['DEFAULT CHARSET'] = str_replace('utf8mb3', 'utf8', $properties['DEFAULT CHARSET']);
+      }
+      if (array_key_exists('COLLATE', $properties)) {
+         $properties['COLLATE'] = str_replace('utf8mb3', 'utf8', $properties['COLLATE']);
       }
       if ($this->ignore_utf8mb4_migration) {
          // Remove non specific character set / collate


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Change made in [MySQL 8.0.24](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-24.html) (released last week) :
> Client applications and test suite plugins now report utf8mb3 rather than utf8 when writing character set names. (Bug #32164079, Bug #32164125)
