### PR TITLE
Add unit tests for Html::getGenericDateTimeSearchItems

### DIFF
--- a/tests/units/Html.php
+++ b/tests/units/Html.php
@@ -1003,6 +1003,7 @@ SCSS
                '-4HOUR'    => "- 4 hours",
                '-14MINUTE' => "- 14 minutes",
             ],
+            'unwanted' => ['0', '4DAY', 'LASTMONDAY'],
          ],
          [
             'options' => [
@@ -1018,6 +1019,7 @@ SCSS
                '5DAY'      => "+ 5 days",
                '11HOUR'    => "+ 11 hours",
             ],
+            'unwanted' => ['0', 'LASTMONDAY'],
          ],
          [
             'options' => [
@@ -1031,6 +1033,7 @@ SCSS
                '4DAY'      => "+ 4 days",
                '-3DAY'      => "- 3 days",
             ],
+            'unwanted' => ['0', 'LASTMONDAY', '-3MINUTE'],
          ],
          [
             'options' => [
@@ -1048,6 +1051,7 @@ SCSS
                'BEGINMONTH' => "Beginning of the month",
                'BEGINYEAR'  => "Beginning of the year",
             ],
+            'unwanted' => ['0', '+2DAY',],
          ],
          [
             'options' => [
@@ -1057,8 +1061,9 @@ SCSS
                'with_specific_date' => true,
             ],
             'check_values' => [
-               '0'        => "Specify a date",
+               '0' => "Specify a date",
             ],
+            'unwanted' => ['+2DAY', 'LASTMONDAY', '-3MINUTE'],
          ],
       ];
    }
@@ -1068,12 +1073,18 @@ SCSS
     */
    public function testGetGenericDateTimeSearchItems(
       array $options,
-      array $check_values
+      array $check_values,
+      array $unwanted
    ) {
       $values = \Html::getGenericDateTimeSearchItems($options);
+
       foreach ($check_values as $key => $value) {
          $this->array($values)->hasKey($key);
          $this->string($values[$key])->isEqualTo($value);
+      }
+
+      foreach ($unwanted as $key) {
+         $this->array($values)->notHasKey($key);
       }
    }
 }

--- a/tests/units/Html.php
+++ b/tests/units/Html.php
@@ -987,4 +987,93 @@ SCSS
       $this->string(\Html::getScssFileHash(vfsStream::url('glpi/css/another.scss')))
          ->isEqualTo($files_md5['another.scss']);
    }
+
+
+   protected function testGetGenericDateTimeSearchItemsProvider(): array {
+      return [
+         [
+            'options' => [
+               'with_time'          => true,
+               'with_future'        => false,
+               'with_days'          => false,
+               'with_specific_date' => false,
+            ],
+            'check_values' => [
+               'NOW'       => "Now",
+               '-4HOUR'    => "- 4 hours",
+               '-14MINUTE' => "- 14 minutes",
+            ],
+         ],
+         [
+            'options' => [
+               'with_time'          => true,
+               'with_future'        => true,
+               'with_days'          => false,
+               'with_specific_date' => false,
+            ],
+            'check_values' => [
+               'NOW'       => "Now",
+               '-4HOUR'    => "- 4 hours",
+               '-14MINUTE' => "- 14 minutes",
+               '5DAY'      => "+ 5 days",
+               '11HOUR'    => "+ 11 hours",
+            ],
+         ],
+         [
+            'options' => [
+               'with_time'          => false,
+               'with_future'        => true,
+               'with_days'          => false,
+               'with_specific_date' => false,
+            ],
+            'check_values' => [
+               'NOW'       => "Today",
+               '4DAY'      => "+ 4 days",
+               '-3DAY'      => "- 3 days",
+            ],
+         ],
+         [
+            'options' => [
+               'with_time'          => true,
+               'with_future'        => false,
+               'with_days'          => true,
+               'with_specific_date' => false,
+            ],
+            'check_values' => [
+               'NOW'        => "Now",
+               'TODAY'      => "Today",
+               '-4HOUR'     => "- 4 hours",
+               '-14MINUTE'  => "- 14 minutes",
+               'LASTMONDAY' => "last Monday",
+               'BEGINMONTH' => "Beginning of the month",
+               'BEGINYEAR'  => "Beginning of the year",
+            ],
+         ],
+         [
+            'options' => [
+               'with_time'          => false,
+               'with_future'        => false,
+               'with_days'          => false,
+               'with_specific_date' => true,
+            ],
+            'check_values' => [
+               '0'        => "Specify a date",
+            ],
+         ],
+      ];
+   }
+
+   /**
+    * @dataProvider testGetGenericDateTimeSearchItemsProvider
+    */
+   public function testGetGenericDateTimeSearchItems(
+      array $options,
+      array $check_values
+   ) {
+      $values = \Html::getGenericDateTimeSearchItems($options);
+      foreach ($check_values as $key => $value) {
+         $this->array($values)->hasKey($key);
+         $this->string($values[$key])->isEqualTo($value);
+      }
+   }
 }


### PR DESCRIPTION
Following #8985, added some unit test for Html::getGenericDateTimeSearchItems.
The `maybefuture` option mentioned in #8985 is used as `with_future` in this function.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
