### PR TITLE
Fix handling of illegal chars in collected emails; see #8986

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -2146,7 +2146,11 @@ class MailCollector  extends CommonDBTM {
                $charset = preg_replace('/^WINDOWS-(\d{4})$/i', 'CP$1', $charset);
             }
 
-            if ($converted = iconv($charset, 'UTF-8//TRANSLIT', $contents)) {
+            // Try to convert using iconv with TRANSLIT, then with IGNORE.
+            // TRANSLIT may result in failure depending on system iconv implementation.
+            if ($converted = @iconv($charset, 'UTF-8//TRANSLIT', $contents)) {
+               $contents = $converted;
+            } else if ($converted = iconv($charset, 'UTF-8//IGNORE', $contents)) {
                $contents = $converted;
             }
          }

--- a/tests/emails-tests/26-illegal-char-in-body.eml
+++ b/tests/emails-tests/26-illegal-char-in-body.eml
@@ -1,0 +1,10 @@
+Date: Sun, 25 Apr 2021 03:17:07 +0000
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <1695134010.1757889.1528365951040.JavaMail.zimbra@glpi-project.org>
+Subject: 26 Illegal char in body
+MIME-Version: 1.0
+Content-Type: text/plain; charset="gb2312"
+Content-Transfer-Encoding: base64
+
+1eLKx7rcu7W1xE1pbnVzIKhDIEJsYWJsYQ0KDQoNCg0K

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -535,7 +535,8 @@ class MailCollector extends DbTestCase {
                'Mono-part HTML message',
                '24.1 Test attachment with long multibyte filename',
                '24.2 Test attachment with short multibyte filename',
-               '25 - Test attachment with invalid chars for OS'
+               '25 - Test attachment with invalid chars for OS',
+               '26 Illegal char in body',
             ]
          ],
          // Mails having "normal" user as observer (add_cc_to_observer = true)
@@ -555,6 +556,7 @@ class MailCollector extends DbTestCase {
          // HTML on multi-part email
          'Re: [GLPI #0038927] Update - Issues with new Windows 10 machine' => '&lt;p&gt;This message have reply to header, requester should be get from this header.&lt;/p&gt;',
          'Mono-part HTML message' => '&lt;p&gt;This HTML message does not use &lt;strong&gt;"multipart/alternative"&lt;/strong&gt; format.&lt;/p&gt;',
+         '26 Illegal char in body' => '这是很坏的Minus C Blabla',
       ];
 
       foreach ($actors_specs as $actor_specs) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8986

Sometimes, some chars in email body cannot be transliterated to UTF-8, and the whole body remains in base encoding.

In added test :
 - expected result: `这是很坏的Minus – Blabla`
 - result without proposed fix: `ÕâÊÇºÜ»µµÄMinus ¨C Blabla`
 - result with proposed fix: `这是很坏的Minus C Blabla`

I do not know if problem is due to an illegal char (conversion issue in the client that sent the email) or to a char that is not supported by iconv. However, I guess it is better to have some wrong chars instead of having the whole body in a wrong charset.