### PR TITLE
Add missing 'echo' statement

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7545,7 +7545,7 @@ abstract class CommonITILObject extends CommonDBTM {
          echo $text;
       } else {
          if ($ismultientities) {
-            sprintf(
+            echo sprintf(
                //TRANS first parameter is the type name, second the entity name
                __('%1$s will be added in entity %2$s'),
                static::getTypeName(1),


### PR DESCRIPTION
Introduced in #8960, missing an `echo` statement after the change from `printf` to `sprintf`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
