### PR TITLE
Drop phpCAS extension check on install

### DIFF
--- a/inc/system/requirementsmanager.class.php
+++ b/inc/system/requirementsmanager.class.php
@@ -86,7 +86,6 @@ class RequirementsManager {
       $requirements[] = new Extension('apcu', true); // to enhance perfs
       $requirements[] = new Extension('Zend OPcache', true); // to enhance perfs
       $requirements[] = new Extension('xmlrpc', true); // for XMLRPC API
-      $requirements[] = new ExtensionClass('CAS', 'phpCAS', true); // for CAS lib
       $requirements[] = new Extension('exif', true); // for security reasons (images checks)
       $requirements[] = new Extension('zip', true); // to handle zip packages on marketplace
       $requirements[] = new Extension('bz2', true); // to handle bz2 packages on marketplace


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

People who do not use CAS do not understand why it is a requirement, and people who want to use it will still be warned when lib cannot be loaded by GLPI in the CAS configuration form.
![image](https://user-images.githubusercontent.com/33253653/116407296-ed1e9380-a831-11eb-8b69-7e53f5d874b9.png)
