### PR TITLE
Fix for #8566  - Revert fix margin for p tag in timeline solution

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -4073,10 +4073,6 @@ a.copyright {
       }
    }
 
-   .right .h_content p {
-      margin: 2px 0 0;
-   }
-
    .left .h_content.timeline_active {
       border-right: 8px solid #3C5874;
    }


### PR DESCRIPTION
Revert fix margin for p tag in timeline solution as exposed in #8566

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8566 
