### PR TITLE
Do not update tickets date on inline images fixing

### DIFF
--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -185,7 +185,7 @@ class Document_Item extends CommonDBRelation{
 
    function post_addItem() {
 
-      if ($this->fields['itemtype'] == 'Ticket' && $input['_do_update_ticket'] ?? true) {
+      if ($this->fields['itemtype'] == 'Ticket' && $this->input['_do_update_ticket'] ?? true) {
          $ticket = new Ticket();
          $input  = [
             'id'              => $this->fields['items_id'],

--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -185,7 +185,7 @@ class Document_Item extends CommonDBRelation{
 
    function post_addItem() {
 
-      if ($this->fields['itemtype'] == 'Ticket') {
+      if ($this->fields['itemtype'] == 'Ticket' && $input['_do_update_ticket'] ?? true) {
          $ticket = new Ticket();
          $input  = [
             'id'              => $this->fields['items_id'],

--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -185,7 +185,7 @@ class Document_Item extends CommonDBRelation{
 
    function post_addItem() {
 
-      if ($this->fields['itemtype'] == 'Ticket' && $this->input['_do_update_ticket'] ?? true) {
+      if ($this->fields['itemtype'] == 'Ticket' && ($this->input['_do_update_ticket'] ?? true)) {
          $ticket = new Ticket();
          $input  = [
             'id'              => $this->fields['items_id'],

--- a/install/update_951_952.php
+++ b/install/update_951_952.php
@@ -88,6 +88,7 @@ function update951to952() {
                'timeline_position'  => CommonITILObject::NO_TIMELINE,
                'users_id'           => $data[$user_field],
                '_disablenotif'      => true, // prevent parent object "update" notification
+               '_do_update_ticket'  => false
             ];
          }
       }

--- a/tests/functionnal/Document_Item.php
+++ b/tests/functionnal/Document_Item.php
@@ -164,4 +164,68 @@ class Document_Item extends DbTestCase {
       ];
       $this->array(\Document_Item::getDistinctTypesParams(1, $extra_where))->isIdenticalTo($expected);
    }
+
+
+   public function testPostAddItem() {
+      $uid = getItemByTypeName('User', TU_USER, true);
+
+      $ticket = new \Ticket();
+      $tickets_id = $ticket->add([
+         'name' => '',
+         'content' => 'Test modification date not updated from Document_Item',
+         'date_mod' => '2020-01-01'
+      ]);
+
+      $this->integer($tickets_id)->isGreaterThan(0);
+
+      // Document and Document_Item
+      $doc = new \Document();
+      $this->integer(
+         (int)$doc->add([
+            'users_id'     => $uid,
+            'tickets_id'   => $tickets_id,
+            'name'         => 'A simple document object'
+         ])
+      )->isGreaterThan(0);
+
+      //do not change ticket modification date
+      $doc_item = new \Document_Item();
+      $this->integer(
+         (int)$doc_item->add([
+            'users_id'      => $uid,
+            'items_id'      => $tickets_id,
+            'itemtype'      => 'Ticket',
+            'documents_id'  => $doc->getID(),
+            '_do_update_ticket' => false
+         ])
+      )->isGreaterThan(0);
+
+      $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
+      $this->string($ticket->fields['date_mod'])->isIdenticalTo('2020-01-01 00:00:00');
+
+      //do change ticket modification date
+      $_SESSION["glpi_currenttime"] = '2021-01-01 00:00:01';
+      $doc = new \Document();
+      $this->integer(
+         (int)$doc->add([
+            'users_id'     => $uid,
+            'tickets_id'   => $tickets_id,
+            'name'         => 'A simple document object'
+         ])
+      )->isGreaterThan(0);
+
+      $doc_item = new \Document_Item();
+      $this->integer(
+         (int)$doc_item->add([
+            'users_id'      => $uid,
+            'items_id'      => $tickets_id,
+            'itemtype'      => 'Ticket',
+            'documents_id'  => $doc->getID(),
+         ])
+      )->isGreaterThan(0);
+
+      $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
+      $this->string($ticket->fields['date_mod'])->isNotEqualTo('2021-01-01 00:00:01');
+
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Tickets modification date were all updated when "Building inline images" migration part was played.
