### PR TITLE
Use 403 for API errors on missing rights

### DIFF
--- a/inc/api/api.class.php
+++ b/inc/api/api.class.php
@@ -2662,7 +2662,7 @@ abstract class API extends CommonGLPI {
    public function messageRightError($return_error = true) {
 
       $this->returnError(__("You don't have permission to perform this action."),
-                         401,
+                         403,
                          "ERROR_RIGHT_MISSING",
                          false,
                          $return_error);

--- a/tests/APIBaseClass.php
+++ b/tests/APIBaseClass.php
@@ -915,7 +915,7 @@ abstract class APIBaseClass extends atoum {
                     'id'       => $tickets_id,
                     'headers'  => [
                         'Session-Token' => $data['session_token']]],
-                   401,
+                   403,
                    'ERROR_RIGHT_MISSING');
 
       // try to access ticket list (we should get empty return)


### PR DESCRIPTION
The `API->messageRightError()` method currently use a 401 (Unauthorized) returns code.

401 should be used when users are trying to access resources whitout being loged in:

> The 401 (Unauthorized) status code indicates that the request has not
   been applied because it lacks valid authentication credentials for
   the target resource 
https://tools.ietf.org/html/rfc7235#section-3.1.

In this case our user is logged in but doesn't have enough rights so 403 is more appropriate:
> The 403 (Forbidden) status code indicates that the server understood
   the request but refuses to authorize it
https://tools.ietf.org/html/rfc7231#section-6.5.3

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
