### PR TITLE
Use correct infocom data for softwares searchoptions

### DIFF
--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -1322,9 +1322,9 @@ class Infocom extends CommonDBChild {
       switch ($itemtype) {
          case 'Software' :
             // Return the infocom linked to the license, not the template linked to the software
-            $beforejoin        = ['table'      => 'glpi_softwarelicenses',
+            $beforejoin        = ['table'      => Software::getTable(),
                                        'joinparams' => ['jointype' => 'child']];
-            $specific_itemtype = 'SoftwareLicense';
+            $specific_itemtype = 'Software';
             break;
 
          case 'CartridgeItem' :

--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -1320,13 +1320,6 @@ class Infocom extends CommonDBChild {
       $beforejoin        = [];
 
       switch ($itemtype) {
-         case 'Software' :
-            // Return the infocom linked to the license, not the template linked to the software
-            $beforejoin        = ['table'      => Software::getTable(),
-                                       'joinparams' => ['jointype' => 'child']];
-            $specific_itemtype = 'Software';
-            break;
-
          case 'CartridgeItem' :
             // Return the infocom linked to the license, not the template linked to the software
             $beforejoin        = ['table'      => 'glpi_cartridges',


### PR DESCRIPTION
As discussed today in our meeting, use the correct data when searching for software infocom data.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22034
