### PR TITLE
Add on-demand branch build workflow

### DIFF
--- a/.github/workflows/branch_build.yml
+++ b/.github/workflows/branch_build.yml
@@ -1,0 +1,43 @@
+name: "GLPI branch build"
+
+on:
+  workflow_dispatch:
+    inputs:
+      php-version:
+        description: "PHP version"
+        required: true
+        default: "7.4"
+
+jobs:
+  build:
+    name: "Build GLPI"
+    runs-on: "ubuntu-latest"
+    services:
+      app:
+        image: "ghcr.io/glpi-project/githubactions-php:${{ github.event.inputs.php-version }}"
+        options: >-
+          --volume /glpi:/var/glpi
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+      - name: "Deploy source into app container"
+        run: |
+          sudo cp --no-target-directory --preserve --recursive `pwd` /glpi
+          sudo chown -R 1000:1000 /glpi
+      - name: "Install dependencies"
+        run: |
+          docker exec ${{ job.services.app.id }} composer install --optimize-autoloader --prefer-dist --no-interaction --no-progress --no-suggest
+      - name: "Define release name"
+        run: |
+          REF_NAME=$(echo ${{ matrix.branch }} | sed -E 's|/|-|')
+          SHA=$(git rev-parse --short HEAD)
+          echo "release_name=$REF_NAME.$SHA" >> $GITHUB_ENV
+      - name: "Build"
+        run: |
+          echo "Y" | docker exec --interactive ${{ job.services.app.id }} tools/make_release.sh . ${{ env.release_name }}
+          docker cp ${{ job.services.app.id }}:/tmp/glpi-${{ env.release_name }}.tgz ${{ github.workspace }}/${{ env.release_name }}.tar.gz
+      - name: "Store archive"
+        uses: actions/upload-artifact@v2
+        with:
+            name: ${{ env.release_name }}.tar.gz
+            path: ${{ github.workspace }}/${{ env.release_name }}.tar.gz


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Almost the same workflow as the nightly build, but:
 - branch have to be selected manually,
 - PHP version can be selected manually (as compatible PHP version it may depend on target branch).