### PR TITLE
feat(networkname): find ipnetwork from IP for networkname

### DIFF
--- a/inc/ipaddress.class.php
+++ b/inc/ipaddress.class.php
@@ -422,10 +422,10 @@ class IPAddress extends CommonDBChild {
       if (!isset($array[$textualField])) {
          return false;
       }
-      if (!isset($array[$binaryField."_0"])
-          || !isset($array[$binaryField."_1"])
-          || !isset($array[$binaryField."_2"])
-          || !isset($array[$binaryField."_3"])) {
+      if ((!isset($array[$binaryField."_0"]) || !is_numeric($array[$binaryField."_0"]))
+         || (!isset($array[$binaryField."_1"]) || !is_numeric($array[$binaryField."_0"]))
+         || (!isset($array[$binaryField."_2"]) || !is_numeric($array[$binaryField."_0"]))
+         || (!isset($array[$binaryField."_3"]) || !is_numeric($array[$binaryField."_0"]))) {
          return false;
       }
 

--- a/inc/ipnetwork.class.php
+++ b/inc/ipnetwork.class.php
@@ -996,12 +996,13 @@ class IPNetwork extends CommonImplicitTreeDropdown {
     * @param $entities_id  entity of the IPNetworks (-1 for all entities)
     *                      (default -1)
    **/
-   static function showIPNetworkProperties($entities_id = -1) {
+   static function showIPNetworkProperties($entities_id = -1, $value = 0) {
       global $CFG_GLPI;
 
       $rand = mt_rand();
       self::dropdown(['entity' => $entities_id,
-                           'rand'   => $rand]);
+                           'rand'   => $rand,
+                           'value' => $value]);
 
       $params = ['ipnetworks_id' => '__VALUE__'];
 
@@ -1010,6 +1011,13 @@ class IPNetwork extends CommonImplicitTreeDropdown {
                                     $params);
 
       echo "<span id='show_ipnetwork_$rand'>&nbsp;</span>\n";
+
+      if ($value > 0) {
+         $params = ["ipnetworks_id" => $value];
+         Ajax::updateItem("show_ipnetwork_$rand",
+                           $CFG_GLPI["root_doc"]. "/ajax/dropdownShowIPNetwork.php",
+                           $params);
+      }
    }
 
 

--- a/inc/networkname.class.php
+++ b/inc/networkname.class.php
@@ -149,7 +149,7 @@ class NetworkName extends FQDNLabel {
       echo __('IP network is not included in the database. However, you can see current available networks.');
       echo "</td></tr>";
       echo "<tr class='tab_bg_1'><td>&nbsp;</td><td>";
-      IPNetwork::showIPNetworkProperties($this->getEntityID());
+      IPNetwork::showIPNetworkProperties($this->getEntityID(), $this->fields['ipnetworks_id']);
       echo "</td></tr>\n";
 
       $this->showFormButtons($options);

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -350,8 +350,9 @@ class NetworkPort extends CommonDBChild {
          } else {
 
             if (!$empty_networkName) { // Only create a NetworkName if it is not empty
-               $this->input_for_NetworkName['itemtype'] = 'NetworkPort';
-               $this->input_for_NetworkName['items_id'] = $this->getID();
+               $this->input_for_NetworkName['itemtype']    = 'NetworkPort';
+               $this->input_for_NetworkName['items_id']    = $this->getID();
+               $this->input_for_NetworkName['entities_id'] = $this->fields['entities_id'];
                $network_name->add($this->input_for_NetworkName, [], $history);
             }
          }

--- a/install/migrations/update_9.5.x_to_10.0.0/networknames.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/networknames.php
@@ -30,31 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
-include ('../inc/includes.php');
-
-header("Content-Type: text/html; charset=UTF-8");
-Html::header_nocache();
-
-$network = new IPNetwork();
-
-if ($_POST['ipnetworks_id'] && $network->can($_POST['ipnetworks_id'], READ)) {
-   echo "<br>\n";
-   echo "<a href='".$network->getLinkURL()."'>".$network->fields['completename']."</a><br>\n";
-
-   $address = $network->getAddress()->getTextual();
-   $netmask = $network->getNetmask()->getTextual();
-   $gateway = $network->getGateway()->getTextual();
-
-   $start   = new IPAddress();
-   $end     = new IPAddress();
-
-   $network->computeNetworkRange($start, $end);
-
-   //TRANS: %1$s is address, %2$s is netmask
-   printf(__('IP network: %1$s/%2$s')."<br>\n", $address, $netmask);
-   printf(__('First/last addresses: %1$s/%2$s'), $start->getTextual(), $end->getTextual());
-   if (!empty($gateway)) {
-      echo "<br>\n";
-      printf(__('Gateway: %s')."\n", $gateway);
-   }
-}
+$migration->addField('glpi_networknames', 'ipnetworks_id', 'int', [
+   'after' => 'fqdns_id'
+]);
+$migration->addKey('glpi_networknames', 'ipnetworks_id', 'ipnetworks_id');

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -4509,6 +4509,7 @@ CREATE TABLE `glpi_networknames` (
   `name` varchar(255) DEFAULT NULL,
   `comment` text,
   `fqdns_id` int NOT NULL DEFAULT '0',
+  `ipnetworks_id` int NOT NULL DEFAULT '0',
   `is_deleted` tinyint NOT NULL DEFAULT '0',
   `is_dynamic` tinyint NOT NULL DEFAULT '0',
   `date_mod` timestamp NULL DEFAULT NULL,
@@ -4521,7 +4522,8 @@ CREATE TABLE `glpi_networknames` (
   KEY `is_dynamic` (`is_dynamic`),
   KEY `item` (`itemtype`,`items_id`,`is_deleted`),
   KEY `date_mod` (`date_mod`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date_creation` (`date_creation`),
+  KEY `ipnetworks_id` (`ipnetworks_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 

--- a/tests/functionnal/NetworkName.php
+++ b/tests/functionnal/NetworkName.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+
+/* Test for inc/networkport.class.php */
+
+class NetworkName extends DbTestCase
+{
+
+   public function testAddSimpleNetworkName() {
+      $this->login();
+
+      //First add IPNetwork
+      $IPNetwork = new \IPNetwork();
+      $ipnetwork_id = $IPNetwork->add([
+         'name'               => "test",
+         'network'            => '1.1.1.0 / 255.255.255.0',
+         'gateway'            => '1.1.1.254',
+         'entites_id'         => 0,
+         'is_recursive'       => 1,
+         'addressable'        => 0,
+      ]);
+
+      $this->integer((int)$ipnetwork_id)->isGreaterThan(0);
+      $this->boolean($IPNetwork->getFromDB($ipnetwork_id))->isTrue();
+      $current_ipnetwork = $IPNetwork->fields;
+
+      unset($current_ipnetwork['id']);
+      unset($current_ipnetwork['date_mod']);
+      unset($current_ipnetwork['date_creation']);
+      unset($current_ipnetwork['level']);
+      unset($current_ipnetwork["ancestors_cache"]);
+      unset($current_ipnetwork["sons_cache"]);
+
+      $expected = [
+         "entities_id"   => 0,
+         "is_recursive"  => 1,
+         "ipnetworks_id" => 0,
+         "completename"  => "test",
+         "addressable"   => 0,
+         "version"       => 4,
+         "name"          => "test",
+         "address"       => "1.1.1.0",
+         "address_0"     => 0,
+         "address_1"     => 0,
+         "address_2"     => 65535,
+         "address_3"     => 16843008,
+         "netmask"       => "255.255.255.0",
+         "netmask_0"     => 4294967295,
+         "netmask_1"     => 4294967295,
+         "netmask_2"     => 4294967295,
+         "netmask_3"     => 4294967040,
+         "gateway"       => "1.1.1.254",
+         "gateway_0"     => 0,
+         "gateway_1"     => 0,
+         "gateway_2"     => 65535,
+         "gateway_3"     => 16843262,
+         "comment"       => null,
+         "network"       => "1.1.1.0 / 255.255.255.0",
+      ];
+      $this->array($current_ipnetwork)->isIdenticalTo($expected);
+
+      //Second add NetworkName
+      $Networkname = new \NetworkName();
+      $networkname_id = $Networkname->add([
+         'name'          => "test",
+         '_ipaddresses'  => [-1 => '1.1.1.24'],
+         'entities_id'    => 0,
+         'items_id'      => 0,
+         'itemtype'      => '',
+         'fqdns_id'      => 0,
+         'comment'       => '',
+         'ipnetworks_id' => 0
+      ]);
+
+      $this->integer((int)$networkname_id)->isGreaterThan(0);
+      $this->boolean($Networkname->getFromDB($networkname_id))->isTrue();
+      $current_networkname = $Networkname->fields;
+
+      unset($current_networkname['id']);
+      unset($current_networkname['date_mod']);
+      unset($current_networkname['date_creation']);
+
+      $expected = [
+         "entities_id"   => 0,
+         "items_id"      => 0,
+         "itemtype"      => "",
+         "name"          => "test",
+         "comment"       => "",
+         "fqdns_id"      => 0,
+         "ipnetworks_id" => $ipnetwork_id, //check the automatic recovery of IPNetwork previsouly created
+         "is_deleted"    => 0,
+         "is_dynamic"    => 0,
+      ];
+      $this->array($current_networkname)->isIdenticalTo($expected);
+   }
+
+}

--- a/tests/functionnal/NetworkPort.php
+++ b/tests/functionnal/NetworkPort.php
@@ -169,14 +169,15 @@ class NetworkPort extends DbTestCase {
       unset($networkname['date_mod']);
       unset($networkname['date_creation']);
       $expected = [
-          'entities_id' => $computer1->fields['entities_id'],
-          'items_id'    => $new_id,
-          'itemtype'    => 'NetworkPort',
-          'name'        => 'test1',
-          'comment'     => 'test1 comment',
-          'fqdns_id'    => 0,
-          'is_deleted'  => 0,
-          'is_dynamic'  => 0,
+          'entities_id'   => $computer1->fields['entities_id'],
+          'items_id'      => $new_id,
+          'itemtype'      => 'NetworkPort',
+          'name'          => 'test1',
+          'comment'       => 'test1 comment',
+          'fqdns_id'      => 0,
+          'ipnetworks_id' => 0,
+          'is_deleted'    => 0,
+          'is_dynamic'    => 0,
       ];
       $this->array($networkname)->isIdenticalTo($expected);
 


### PR DESCRIPTION
From dynamic or manual inventory, 

When we add an IPNetwork, 
![image](https://user-images.githubusercontent.com/7335054/117139464-91618680-adac-11eb-8d97-25b76c095c67.png)

GLPI add automatically IPaddress which correpond to IPNetwork -> OK
![image](https://user-images.githubusercontent.com/7335054/117139505-9b838500-adac-11eb-889d-c01b49c0be43.png)

But from NetworkName (attached to the IPAddress), GLPI does not find the correct ```IPNetwork``` (automatically)
![image](https://user-images.githubusercontent.com/7335054/117139594-b8b85380-adac-11eb-91c4-91c478b66b1d.png)

This PR solves several problems

From database ```glpi_networknames``` has no column ```ipnetworks_id``` (Strange, because we have its graphical representation)

If you select manually an ```IPNetwork``` from ```NetworkName```
some informations are added

![image](https://user-images.githubusercontent.com/7335054/117139971-1c428100-adad-11eb-9354-f5f3eebe17d5.png)

But if you select empty choice, some warning are displayed
![image](https://user-images.githubusercontent.com/7335054/117140018-2c5a6080-adad-11eb-9c1a-1e9dd278c103.png)

On ```NetworkName``` create / update, GLPI automatically adds the corresponding ```IPNetwork``` if it found

 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 22051 
