### PR TITLE
fix(core): list to front/rack.php

### DIFF
--- a/front/pdu_rack.form.php
+++ b/front/pdu_rack.form.php
@@ -66,6 +66,9 @@ if (isset($_GET['id'])) {
       'racks_id'     => $_GET['racks_id'],
    ];
 }
+
+$_SESSION['glpilisturl'][PDU_Rack::getType()] = $rack->getSearchURL();
+
 $ajax = isset($_REQUEST['ajax']) ? true : false;
 
 if (!$ajax) {


### PR DESCRIPTION

URL to redirect to list is wrong from ```PDU_Rack``` form

![image](https://user-images.githubusercontent.com/7335054/117413272-0d2b1280-af16-11eb-9da9-1d6a9327b952.png)

Now URL redirec to Rack list

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 22058
