### PR TITLE
WIP fix(css): date label disposition

### DIFF
--- a/css/dashboard.scss
+++ b/css/dashboard.scss
@@ -1002,7 +1002,7 @@ $break_tablet: 1400px;
 
       .ct-chart-line {
          .ct-label.ct-horizontal.ct-end {
-            transform: translateX(-40%);
+            transform: translateX(-22%);
          }
       }
 


### PR DESCRIPTION
Fix date label disposition from dashboard 

Before (date not centred on the y-axis)
![image](https://user-images.githubusercontent.com/7335054/117414752-cb9b6700-af17-11eb-8112-e1c878202a3e.png)

After 
![image](https://user-images.githubusercontent.com/7335054/117414775-d0601b00-af17-11eb-81ba-b8835eaa7d32.png)



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 22067
