### PR TITLE
Anonymized helpdesk: add nicknames

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7041,7 +7041,6 @@ abstract class CommonITILObject extends CommonDBTM {
                echo "</div>";
 
                echo "<span class='h_user_name'>";
-               $userdata = getUserName($item_i['users_id'], 2);
                if (Session::getCurrentInterface() == 'helpdesk'
                   && (
                      $item['type'] == "Solution"
@@ -7062,6 +7061,7 @@ abstract class CommonITILObject extends CommonDBTM {
                ) {
                   echo $anon_name;
                } else {
+                  $userdata = getUserName($item_i['users_id'], 2);
                   echo $user->getLink()."&nbsp;";
                   echo Html::showToolTip(
                      $userdata["comment"],

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -61,6 +61,13 @@ class Entity extends CommonTreeDropdown {
    const AUTO_ASSIGN_HARDWARE_CATEGORY  = 1;
    const AUTO_ASSIGN_CATEGORY_HARDWARE  = 2;
 
+   /**
+    * Possible values for "anonymize_support_agents" setting
+    */
+   const ANONYMIZE_DISABLED     = 0;
+   const ANONYMIZE_USE_GENERIC  = 1;
+   const ANONYMIZE_USE_NICKNAME = 2;
+
    // Array of "right required to update" => array of fields allowed
    // Missing field here couldn't be update (no right)
    private static $field_right = [
@@ -2610,26 +2617,26 @@ class Entity extends CommonTreeDropdown {
 
       echo "<tr class='tab_bg_1'><td  colspan='2'>".__('Anonymize support agents')."</td>";
       echo "<td colspan='2'>";
-      $anonymizeValues = self::getAnonymizeSupportAgentsValues();
-      $currentAnonymizeValue = $entity->fields['anonymize_support_agents'];
+      $anonymize_values = self::getAnonymizeSupportAgentsValues();
+      $current_anonymize_value = $entity->fields['anonymize_support_agents'];
 
       if ($ID == 0) { // Remove parent option for root entity
-         unset($anonymizeValues[self::CONFIG_PARENT]);
+         unset($anonymize_values[self::CONFIG_PARENT]);
       }
 
       Dropdown::showFromArray(
          'anonymize_support_agents',
-         $anonymizeValues,
-         ['value' => $currentAnonymizeValue]
+         $anonymize_values,
+         ['value' => $current_anonymize_value]
       );
 
       // If the entity is using it's parent value, print it
-      if ($currentAnonymizeValue == self::CONFIG_PARENT && $ID != 0) {
-         $parentHelpdeskValue = self::getUsedConfig(
+      if ($current_anonymize_value == self::CONFIG_PARENT && $ID != 0) {
+         $parent_helpdesk_value = self::getUsedConfig(
             'anonymize_support_agents',
             $entity->fields['entities_id']
          );
-         self::inheritedValue($anonymizeValues[$parentHelpdeskValue], true);
+         self::inheritedValue($anonymize_values[$parent_helpdesk_value], true);
       }
       echo "</td></tr>";
 
@@ -3038,8 +3045,9 @@ class Entity extends CommonTreeDropdown {
 
       return [
          self::CONFIG_PARENT => __('Inheritance of the parent entity'),
-         0 => __('No'),
-         1 => __('Yes'),
+         self::ANONYMIZE_DISABLED => __('Disabled'),
+         self::ANONYMIZE_USE_GENERIC => __("Replace the agent's name with a generic name"),
+         self::ANONYMIZE_USE_NICKNAME => __("Replace the agent's name with a customisable nickname"),
       ];
    }
 
@@ -3405,5 +3413,9 @@ class Entity extends CommonTreeDropdown {
 
    static function getIcon() {
       return "fas fa-layer-group";
+   }
+
+   public static function getAnonymizeConfig(?int $entities_id = null) {
+      return Entity::getUsedConfig('anonymize_support_agents', $entities_id);
    }
 }

--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -952,6 +952,17 @@ class Group extends CommonTreeDropdown {
       ) > 0;
    }
 
+   public static function getAnonymizedName(?int $entities_id = null): string {
+      switch (Entity::getAnonymizeConfig($entities_id)) {
+         default:
+         case Entity::ANONYMIZE_DISABLED:
+            return "";
+
+         case Entity::ANONYMIZE_USE_GENERIC:
+         case Entity::ANONYMIZE_USE_NICKNAME:
+            return __("Helpdesk group");
+      }
+   }
 
    static function getIcon() {
       return "fas fa-users";

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1268,10 +1268,14 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
             $tmp['##followup.isprivate##']   = Dropdown::getYesNo($followup['is_private']);
 
             // Check if the author need to be anonymized
-            if (Entity::getUsedConfig('anonymize_support_agents', $item->getField('entities_id'))
-               && ITILFollowup::getById($followup['id'])->isFromSupportAgent()
+            if (ITILFollowup::getById($followup['id'])->isFromSupportAgent()
+               && Session::getCurrentInterface() == 'helpdesk'
+               && !empty($anon_name = User::getAnonymizedName(
+                  $followup['users_id'],
+                  $item->getField('entities_id')
+               ))
             ) {
-               $tmp['##followup.author##'] = __("Helpdesk");
+               $tmp['##followup.author##'] = $anon_name;
             } else {
                $tmp['##followup.author##'] = Html::clean(getUserName($followup['users_id']));
             }

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1247,10 +1247,10 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
 
       // Complex mode
       if (!$simple) {
+         $show_private = $options['additionnaloption']['show_private'] ?? false;
          $followup_restrict = [];
          $followup_restrict['items_id'] = $item->getField('id');
-         if (!isset($options['additionnaloption']['show_private'])
-             || !$options['additionnaloption']['show_private']) {
+         if (!$show_private) {
             $followup_restrict['is_private'] = 0;
          }
          $followup_restrict['itemtype'] = $objettype;
@@ -1269,7 +1269,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
 
             // Check if the author need to be anonymized
             if (ITILFollowup::getById($followup['id'])->isFromSupportAgent()
-               && isset($followup_restrict['is_private'])
+               && !$show_private
                && !empty($anon_name = User::getAnonymizedName(
                   $followup['users_id'],
                   $item->getField('entities_id')

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1269,7 +1269,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
 
             // Check if the author need to be anonymized
             if (ITILFollowup::getById($followup['id'])->isFromSupportAgent()
-               && Session::getCurrentInterface() == 'helpdesk'
+               && isset($followup_restrict['is_private'])
                && !empty($anon_name = User::getAnonymizedName(
                   $followup['users_id'],
                   $item->getField('entities_id')

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5610,7 +5610,7 @@ JAVASCRIPT;
                               if (Session::getCurrentInterface() == 'helpdesk'
                                  && $orig_id == 5 // -> Assigned user
                                  && !empty($anon_name = User::getAnonymizedName(
-                                    2,
+                                    $data[$ID][$k]['name'],
                                     $itemtype::getById($data['id'])->getEntityId()
                                  ))
                               ) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -830,9 +830,8 @@ class Ticket extends CommonITILObject {
       $this->addStandardTab('Problem_Ticket', $ong, $options);
       $this->addStandardTab('Change_Ticket', $ong, $options);
 
-      $entity = $this->getEntityID();
-      if (!(Entity::getUsedConfig('anonymize_support_agents', $entity)
-         && Session::getCurrentInterface() == 'helpdesk')
+      if (Entity::getAnonymizeConfig($this->getEntityID()) == Entity::ANONYMIZE_DISABLED
+         || Session::getCurrentInterface() == 'central'
       ) {
          $this->addStandardTab('Log', $ong, $options);
       }

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -2413,6 +2413,23 @@ JAVASCRIPT;
             echo "</td></tr>";
          }
 
+         if (Entity::getAnonymizeConfig() == Entity::ANONYMIZE_USE_NICKNAME
+            && Session::getCurrentInterface() == "central"
+         ) {
+            echo "<tr class='tab_bg_1'>";
+            echo "<td><label for='nickname$rand'> " . __('Nickname') . "</label></td>";
+            echo "<td>";
+            if ($this->can($ID, UPDATE)) {
+               echo Html::input('nickname', [
+                  'value' => $this->fields['nickname']
+                  ]);
+            } else {
+               echo $this->fields['nickname'];
+            }
+            echo "</td>";
+            echo "</tr>";
+         }
+
          if ($this->can($ID, UPDATE)) {
             echo "<tr class='tab_bg_1'><th colspan='4'>". __('Remote access keys') ."</th></tr>";
 
@@ -2817,6 +2834,23 @@ JAVASCRIPT;
             echo "<td colspan='2'>&nbsp;";
          }
          echo "</td></tr>";
+
+         if (Entity::getAnonymizeConfig() == Entity::ANONYMIZE_USE_NICKNAME
+            && Session::getCurrentInterface() == "central"
+         ) {
+            echo "<tr class='tab_bg_1'>";
+            echo "<td><label for='nickname$rand'> " . __('Nickname') . "</label></td>";
+            echo "<td>";
+            if ($this->can($ID, UPDATE)) {
+               echo Html::input('nickname', [
+                  'value' => $this->fields['nickname']
+               ]);
+            } else {
+               echo $this->fields['nickname'];
+            }
+            echo "</td>";
+            echo "</tr>";
+         }
 
          echo "<tr class='tab_bg_1'><th colspan='4'>". __('Remote access keys') ."</th></tr>";
 
@@ -5684,6 +5718,25 @@ JAVASCRIPT;
             $group_user->add($data);
          }
 
+      }
+   }
+
+   public static function getAnonymizedName(int $users_id, ?int $entities_id = null): ?string {
+      switch (Entity::getAnonymizeConfig($entities_id)) {
+         default:
+         case Entity::ANONYMIZE_DISABLED:
+            return "";
+
+         case Entity::ANONYMIZE_USE_GENERIC:
+            return __("Helpdesk");
+
+         case Entity::ANONYMIZE_USE_NICKNAME:
+            $user = new User();
+            if (!$user->getFromDB($users_id)) {
+               return "";
+            }
+
+            return $user->fields['nickname'];
       }
    }
 }

--- a/install/migrations/update_9.5.x_to_10.0.0/nicknames.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/nicknames.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+if (!$DB->fieldExists("glpi_users", "nickname")) {
+   $migration->addField("glpi_users", "nickname", "string");
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -7332,6 +7332,7 @@ CREATE TABLE `glpi_users` (
   `default_dashboard_helpdesk` varchar(100) DEFAULT NULL,
   `default_dashboard_mini_ticket` varchar(100) DEFAULT NULL,
   `default_central_tab` tinyint DEFAULT '0',
+  `nickname` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicityloginauth` (`name`,`authtype`,`auths_id`),
   KEY `firstname` (`firstname`),

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -37,12 +37,9 @@ use DbTestCase;
 use ITILFollowup;
 use ITILSolution;
 use NotificationTarget;
-use NotificationTargetCommonITILObject;
 use NotificationTargetTicket;
 use Profile_User;
-use Search;
 use Ticket;
-use User;
 
 /* Test for inc/entity.class.php */
 
@@ -695,7 +692,7 @@ class Entity extends DbTestCase {
             'usertype' => NotificationTarget::GLPI_USER
          ]
       ]);
-      foreach($notif_data['followups'] as $n_fup) {
+      foreach ($notif_data['followups'] as $n_fup) {
          foreach ($possible_values as $value) {
             if ($value == $expected) {
                $this->string($n_fup['##followup.author##'])->contains($value);

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -690,7 +690,9 @@ class Entity extends DbTestCase {
       $notif_data = $notification->getDataForObject($ticket, [
          'additionnaloption' => [
             'usertype' => NotificationTarget::GLPI_USER,
-            'show_private' => $interface == 'central', // Workaround to "simulate" different notification target and test this part more easily
+            // Workaround to "simulate" different notification target and test
+            // this part more easily
+            'is_self_service' => $interface == 'helpdesk',
          ]
       ]);
       foreach ($notif_data['followups'] as $n_fup) {

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -689,7 +689,8 @@ class Entity extends DbTestCase {
       $notification = new NotificationTargetTicket();
       $notif_data = $notification->getDataForObject($ticket, [
          'additionnaloption' => [
-            'usertype' => NotificationTarget::GLPI_USER
+            'usertype' => NotificationTarget::GLPI_USER,
+            'show_private' => $interface == 'central', // Workaround to "simulate" different notification target and test this part more easily
          ]
       ]);
       foreach ($notif_data['followups'] as $n_fup) {


### PR DESCRIPTION
Add a new entity config regarding anonymized helpdesk:
![image](https://user-images.githubusercontent.com/42734840/117621021-6c389380-b171-11eb-9eac-66a7eabc74c8.png)

This setting allow tech user to define a nickname in their preferences.
If a nickname is defined for a given user, it will be used instead of his name in the self-service interface.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21776
