### PR TITLE
Rule action appliance

### DIFF
--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -383,6 +383,25 @@ class RuleTicket extends Rule {
                         }
                      }
                   }
+
+                  if ($action->fields["field"] == "assign_appliance") {
+                     if (isset($this->regex_results[0])) {
+                        $regexvalue = RuleAction::getRegexResultById($action->fields["value"],
+                                                                     $this->regex_results[0]);
+                     } else {
+                        $regexvalue = $action->fields["value"];
+                     }
+
+                     if (!is_null($regexvalue)) {
+                        $appliances = new Appliance();
+                        $target_appliances = $appliances->find(["name" => $regexvalue, "is_helpdesk_visible" => true]);
+                        $output["items_id"] = [];
+                        foreach ($target_appliances as $key) {
+                           $output["items_id"][Appliance::getType()][] = $key;
+                        }
+                     }
+
+                  }
                   break;
             }
          }
@@ -718,7 +737,8 @@ class RuleTicket extends Rule {
       $actions['assign_appliance']['name']                  = _n('Associated element', 'Associated elements', Session::getPluralNumber())." : ".Appliance::getTypeName(1);
       $actions['assign_appliance']['type']                  = 'dropdown';
       $actions['assign_appliance']['table']                 = 'glpi_appliances';
-      $actions['assign_appliance']['force_actions']         = ['assign'];
+      $actions['assign_appliance']['force_actions']         = ['assign','regex_result','append'];
+      $actions['assign_appliance']['permitseveral']         = ['append'];
 
       $actions['slas_id_ttr']['table']                      = 'glpi_slas';
       $actions['slas_id_ttr']['field']                      = 'name';

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -400,7 +400,6 @@ class RuleTicket extends Rule {
                            $output["items_id"] = [];
                         }
 
-                        //var_dump($target_appliances);
                         foreach ($target_appliances as $value) {
                            $output["items_id"][Appliance::getType()][] = $value['id'];
                         }

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -749,6 +749,7 @@ class RuleTicket extends Rule {
       $actions['assign_appliance']['name']                  = _n('Associated element', 'Associated elements', Session::getPluralNumber())." : ".Appliance::getTypeName(1);
       $actions['assign_appliance']['type']                  = 'dropdown';
       $actions['assign_appliance']['table']                 = 'glpi_appliances';
+      $actions['assign_appliance']['condition']             = ['is_helpdesk_visible' => 1];
       $actions['assign_appliance']['permitseveral']         = ['append'];
       $actions['assign_appliance']['force_actions']         = ['assign','regex_result', 'append'];
       $actions['assign_appliance']['appendto']              = 'items_id';

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -248,6 +248,12 @@ class RuleTicket extends Rule {
                      }
                   }
 
+                  // special case of appliance
+                  if ($action->fields["field"] == "assign_appliance") {
+                     $output["items_id"] = [];
+                     $output["items_id"][Appliance::getType()][] = $action->fields["value"];
+                  }
+
                   break;
 
                case "append" :
@@ -708,6 +714,11 @@ class RuleTicket extends Rule {
       $actions['affectobject']['type']                      = 'text';
       $actions['affectobject']['force_actions']             = ['affectbyip', 'affectbyfqdn',
                                                                     'affectbymac'];
+
+      $actions['assign_appliance']['name']                  = _n('Associated element', 'Associated elements', Session::getPluralNumber())." : ".Appliance::getTypeName(1);
+      $actions['assign_appliance']['type']                  = 'dropdown';
+      $actions['assign_appliance']['table']                 = 'glpi_appliances';
+      $actions['assign_appliance']['force_actions']         = ['assign'];
 
       $actions['slas_id_ttr']['table']                      = 'glpi_slas';
       $actions['slas_id_ttr']['field']                      = 'name';

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -250,12 +250,11 @@ class RuleTicket extends Rule {
 
                   // special case of appliance
                   if ($action->fields["field"] == "assign_appliance") {
-                     if (!array_key_exists("items_id", $output)) {
+                     if (!array_key_exists("items_id", $output) || $output['items_id'] == '0') {
                         $output["items_id"] = [];
                      }
                      $output["items_id"][Appliance::getType()][] = $action->fields["value"];
                   }
-
                   break;
 
                case "append" :
@@ -270,8 +269,7 @@ class RuleTicket extends Rule {
 
                   // special case of appliance
                   if ($action->fields["field"] === "assign_appliance") {
-                     if (!array_key_exists("items_id", $output)
-                        || (array_key_exists("items_id", $output) && !is_array($output['items_id']))) {
+                     if (!array_key_exists("items_id", $output) || $output['items_id'] == '0') {
                         $output["items_id"] = [];
                      }
                      $output["items_id"][Appliance::getType()][] = $value;
@@ -407,7 +405,7 @@ class RuleTicket extends Rule {
                         $appliances = new Appliance();
                         $target_appliances = $appliances->find(["name" => $regexvalue, "is_helpdesk_visible" => true]);
 
-                        if (!array_key_exists("items_id", $output) && count($target_appliances) > 0) {
+                        if ((!array_key_exists("items_id", $output) || $output['items_id'] == '0') && count($target_appliances) > 0) {
                            $output["items_id"] = [];
                         }
 

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -250,7 +250,9 @@ class RuleTicket extends Rule {
 
                   // special case of appliance
                   if ($action->fields["field"] == "assign_appliance") {
-                     $output["items_id"] = [];
+                     if (!array_key_exists("items_id", $output)) {
+                        $output["items_id"] = [];
+                     }
                      $output["items_id"][Appliance::getType()][] = $action->fields["value"];
                   }
 
@@ -265,7 +267,17 @@ class RuleTicket extends Rule {
                      $value[$actions[$action->fields["field"]]["appendtoarrayfield"]]
                             = $action->fields["value"];
                   }
-                  $output[$actions[$action->fields["field"]]["appendto"]][] = $value;
+
+                  // special case of appliance
+                  if ($action->fields["field"] === "assign_appliance") {
+                     if (!array_key_exists("items_id", $output)
+                        || (array_key_exists("items_id", $output) && !is_array($output['items_id']))) {
+                        $output["items_id"] = [];
+                     }
+                     $output["items_id"][Appliance::getType()][] = $value;
+                  } else {
+                     $output[$actions[$action->fields["field"]]["appendto"]][] = $value;
+                  }
 
                   // Special case of users_id_requester
                   if ($action->fields["field"] === '_users_id_requester') {
@@ -395,7 +407,7 @@ class RuleTicket extends Rule {
                         $appliances = new Appliance();
                         $target_appliances = $appliances->find(["name" => $regexvalue, "is_helpdesk_visible" => true]);
 
-                        if (count($target_appliances) > 0) {
+                        if (!array_key_exists("items_id", $output) && count($target_appliances) > 0) {
                            $output["items_id"] = [];
                         }
 
@@ -739,7 +751,9 @@ class RuleTicket extends Rule {
       $actions['assign_appliance']['name']                  = _n('Associated element', 'Associated elements', Session::getPluralNumber())." : ".Appliance::getTypeName(1);
       $actions['assign_appliance']['type']                  = 'dropdown';
       $actions['assign_appliance']['table']                 = 'glpi_appliances';
-      $actions['assign_appliance']['force_actions']         = ['assign','regex_result'];
+      $actions['assign_appliance']['permitseveral']         = ['append'];
+      $actions['assign_appliance']['force_actions']         = ['assign','regex_result', 'append'];
+      $actions['assign_appliance']['appendto']              = 'items_id';
 
       $actions['slas_id_ttr']['table']                      = 'glpi_slas';
       $actions['slas_id_ttr']['field']                      = 'name';

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -395,12 +395,16 @@ class RuleTicket extends Rule {
                      if (!is_null($regexvalue)) {
                         $appliances = new Appliance();
                         $target_appliances = $appliances->find(["name" => $regexvalue, "is_helpdesk_visible" => true]);
-                        $output["items_id"] = [];
-                        foreach ($target_appliances as $key) {
-                           $output["items_id"][Appliance::getType()][] = $key;
+
+                        if (count($target_appliances) > 0) {
+                           $output["items_id"] = [];
+                        }
+
+                        //var_dump($target_appliances);
+                        foreach ($target_appliances as $value) {
+                           $output["items_id"][Appliance::getType()][] = $value['id'];
                         }
                      }
-
                   }
                   break;
             }

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -277,7 +277,6 @@ class RuleTicket extends Rule {
                         $output['_groups_id_of_requester'][$g['id']] = $g['id'];
                      }
                   }
-
                   break;
 
                case 'fromuser' :
@@ -740,8 +739,7 @@ class RuleTicket extends Rule {
       $actions['assign_appliance']['name']                  = _n('Associated element', 'Associated elements', Session::getPluralNumber())." : ".Appliance::getTypeName(1);
       $actions['assign_appliance']['type']                  = 'dropdown';
       $actions['assign_appliance']['table']                 = 'glpi_appliances';
-      $actions['assign_appliance']['force_actions']         = ['assign','regex_result','append'];
-      $actions['assign_appliance']['permitseveral']         = ['append'];
+      $actions['assign_appliance']['force_actions']         = ['assign','regex_result'];
 
       $actions['slas_id_ttr']['table']                      = 'glpi_slas';
       $actions['slas_id_ttr']['field']                      = 'name';

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1434,6 +1434,9 @@ class Ticket extends CommonITILObject {
    function post_updateItem($history = 1) {
       global $CFG_GLPI;
 
+      //for items added from rule
+      $this->handleItemsIdInput();
+
       parent::post_updateItem($history);
 
       //Action for send_validation rule : do validation before clean

--- a/tests/functionnal/Rule.php
+++ b/tests/functionnal/Rule.php
@@ -241,7 +241,7 @@ class Rule extends DbTestCase {
       $this->integer($rule->maxActionsCount())->isIdenticalTo(0);
 
       $rule = new \RuleTicket();
-      $this->integer($rule->maxActionsCount())->isIdenticalTo(31);
+      $this->integer($rule->maxActionsCount())->isIdenticalTo(32);
 
       $rule = new \RuleDictionnarySoftware();
       $this->integer($rule->maxActionsCount())->isIdenticalTo(4);


### PR DESCRIPTION
Add capability to aassign appliance from rule (on associated element)
Action : assign,  regex

![image](https://user-images.githubusercontent.com/7335054/117799785-c52c2880-b252-11eb-9164-d685ae7e9444.png)



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 21617
