### PR TITLE
Add missing fields to anonymization process

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -4511,7 +4511,16 @@ class Ticket extends CommonITILObject {
                                  'entity' => $this->fields["entities_id"],
                                  'right'  => 'all']);
          } else {
-            echo getUserName($this->fields["users_id_recipient"], $showuserlink);
+            if (Session::getCurrentInterface() == 'helpdesk'
+               && !empty($anon_name = User::getAnonymizedName(
+                  $this->fields['users_id_recipient'],
+                  $this->getEntityID()
+               ))
+            ) {
+               echo $anon_name;
+            } else {
+               echo getUserName($this->fields["users_id_recipient"], $showuserlink);
+            }
          }
 
          echo "</td>";
@@ -4527,8 +4536,21 @@ class Ticket extends CommonITILObject {
          echo "<td width='$colsize4%' colspan='3'>";
          if ($this->fields['users_id_lastupdater'] > 0) {
             //TRANS: %1$s is the update date, %2$s is the last updater name
-            printf(__('%1$s by %2$s'), Html::convDateTime($this->fields["date_mod"]),
-                   getUserName($this->fields["users_id_lastupdater"], $showuserlink));
+            if (Session::getCurrentInterface() == 'helpdesk'
+               && !empty($anon_name = User::getAnonymizedName(
+                  $this->fields["users_id_lastupdater"],
+                  $this->getEntityID()
+               ))
+            ) {
+               $edited_by_name = $anon_name;
+            } else {
+               $edited_by_name = getUserName($this->fields["users_id_lastupdater"], $showuserlink);
+            }
+            printf(
+               __('%1$s by %2$s'),
+               Html::convDateTime($this->fields["date_mod"]),
+               $edited_by_name
+            );
          }
          echo "</td>";
       }


### PR DESCRIPTION
While testing a backport of #9060 I noticed that two fields were missing anonymization:

![image](https://user-images.githubusercontent.com/42734840/117956089-01c25780-b319-11eb-9a96-e7057d6a8ad9.png)

This PR add correct anonymization for these two fields and add this case to the functional tests.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
