### PR TITLE
fix(savedsearch): determine if path contains marketplace or plugins

### DIFF
--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -281,7 +281,12 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria {
 
       $taburl = parse_url(rawurldecode($input['url']));
 
-      $index  = strpos($taburl["path"], "plugins");
+      $key = "plugins";
+      if (preg_match('/marketplace/i', $taburl["path"])) {
+         $key = "marketplace";
+      }
+
+      $index  = strpos($taburl["path"], $key);
       if (!$index) {
          $index = strpos($taburl["path"], "front");
       }


### PR DESCRIPTION
When GLPI savedsearch parse URL, we ened to check if it from plugins or marketplace folder



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Internal 22080