### PR TITLE
Ticket rules: add 'global_valdiation' action

### DIFF
--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -2474,6 +2474,9 @@ class Rule extends CommonDBTM {
             case "dropdown_management" :
                return Dropdown::getGlobalSwitch($value);
 
+            case "dropdown_validation_status":
+               return TicketValidation::getStatus($value);
+
             default :
                return $this->displayAdditionRuleActionValue($value);
          }

--- a/inc/ruleaction.class.php
+++ b/inc/ruleaction.class.php
@@ -632,6 +632,14 @@ class RuleAction extends CommonDBChild {
                      $display       = true;
                      break;
 
+                  case "dropdown_validation_status":
+                     TicketValidation::dropdownStatus('value', [
+                        'global' => true,
+                        'value' => $param['value'],
+                     ]);
+                     $display = true;
+                     break;
+
                   default :
                      if ($rule = getItemForItemtype($options["sub_type"])) {
                         $display = $rule->displayAdditionalRuleAction($actions[$options["field"]], $param['value']);

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -796,6 +796,9 @@ class RuleTicket extends Rule {
       $actions['task_template']['table']                     = TaskTemplate::getTable();
       $actions['task_template']['force_actions']             = ['assign'];
 
+      $actions['global_validation']['name']                  = _n('Validation', 'Validations', 1);
+      $actions['global_validation']['type']                  = 'dropdown_validation_status';
+
       return $actions;
    }
 

--- a/tests/functionnal/Rule.php
+++ b/tests/functionnal/Rule.php
@@ -241,7 +241,7 @@ class Rule extends DbTestCase {
       $this->integer($rule->maxActionsCount())->isIdenticalTo(0);
 
       $rule = new \RuleTicket();
-      $this->integer($rule->maxActionsCount())->isIdenticalTo(30);
+      $this->integer($rule->maxActionsCount())->isIdenticalTo(31);
 
       $rule = new \RuleDictionnarySoftware();
       $this->integer($rule->maxActionsCount())->isIdenticalTo(4);

--- a/tests/functionnal/RuleTicket.php
+++ b/tests/functionnal/RuleTicket.php
@@ -867,7 +867,7 @@ class RuleTicket extends DbTestCase {
       ]);
       $this->checkInput($rulecrit, $crit_id, $crit_input);
 
-      // Create action to put impact to very low
+      // Create action to set validation to "refused"
       $action_value = CommonITILValidation::REFUSED;
       $action_id = $ruleaction->add($action_input = [
          'rules_id'    => $ruletid,


### PR DESCRIPTION
Following #9052, let's also add the 'global_valdiation' field to the possibles actions.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21937
