### PR TITLE
Fix multiple solution form issues

### DIFF
--- a/ajax/solution.php
+++ b/ajax/solution.php
@@ -33,28 +33,19 @@
 $AJAX_INCLUDE = 1;
 
 include ('../inc/includes.php');
-header("Content-Type: text/html; charset=UTF-8");
+header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
 Session::checkLoginUser();
 
-$rand = mt_rand();
-
-Html::initEditorSystem("content$rand");
-
-if (isset($_POST['value']) && ($_POST['value'] > 0)) {
+if (isset($_POST['solutiontemplates_id']) && $_POST['solutiontemplates_id'] > 0) {
    $template = new SolutionTemplate();
+   $template->getFromDB($_POST['solutiontemplates_id']);
 
-   if ($template->getFromDB($_POST['value'])) {
-      echo "<textarea id='content$rand' name='content' rows='12' cols='80'>";
-      echo $template->getField('content');
-      echo "</textarea>\n";
-      echo "<script type='text/javascript'>".
-               Html::jsSetDropdownValue($_POST["type_id"],
-                                        $template->getField('solutiontypes_id')).
-           "</script>";
-   }
-
-} else {
-      echo "<textarea id='content$rand' name='content' rows='12' cols='80'></textarea>";
+   echo json_encode(
+      [
+         'content'          => Toolbox::unclean_cross_side_scripting_deep($template->fields['content']),
+         'solutiontypes_id' => $template->fields['solutiontypes_id'],
+      ]
+   );
 }

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -2589,7 +2589,8 @@ JAVASCRIPT;
          $name = 'massaction_'.mt_rand();
       }
       return  "<form name='$name' id='$name' method='post'
-               action='".$CFG_GLPI["root_doc"]."/front/massiveaction.php'>";
+               action='".$CFG_GLPI["root_doc"]."/front/massiveaction.php'
+               enctype='multipart/form-data'>";
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. When selecting a template, the whole `textarea` was replaced, so the TinyMCE instance was reinit and user mention feature was not working anymore. I reused a similar logic as for followup form to fix this.
2. When an inline image was present in solution added from massive action, some errors were triggered, du to the missing `enctype="multipart/form-data"`.