### PR TITLE
Fix images handling in dropdown and massive actions

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -4909,11 +4909,17 @@ class CommonDBTM extends CommonGLPI {
                return Html::autocompletionTextField($this, $name, $options);
 
             case "text" :
-               $out = '';
-               if (isset($searchoptions['htmltext']) && $searchoptions['htmltext']) {
-                  $out = Html::initEditorSystem($name, '', false);
-               }
-               return $out."<textarea cols='45' rows='5' name='$name'>$value</textarea>";
+               return Html::textarea(
+                  [
+                     'display'           => false,
+                     'name'              => $name,
+                     'value'             => $value,
+                     'enable_fileupload' => false,
+                     'enable_richtext'   => isset($searchoptions['htmltext']) && $searchoptions['htmltext'],
+                     'cols'              => 45,
+                     'rows'              => 5,
+                  ]
+               );
 
             case "bool" :
                return Dropdown::showYesNo($name, $value, -1, $options);

--- a/inc/commondropdown.class.php
+++ b/inc/commondropdown.class.php
@@ -233,6 +233,42 @@ abstract class CommonDropdown extends CommonDBTM {
       return self::prepareInputForAdd($input);
    }
 
+   function post_addItem() {
+      $this->addFilesFromRichText();
+
+      parent::post_addItem();
+   }
+
+   function post_updateItem($history = 1) {
+      $this->addFilesFromRichText();
+
+      parent::post_updateItem($history);
+   }
+
+   /**
+    * Add files from rich text fields.
+    *
+    * @return void
+    */
+   private function addFilesFromRichText(): void {
+
+      $fields = $this->getAdditionalFields();
+      foreach ($fields as $field) {
+         $type = $field['type'] ?? '';
+         if ($type === 'tinymce') {
+            // Add files from inline images
+            $this->input = $this->addFiles(
+               $this->input,
+               [
+                  'force_update'  => true,
+                  'name'          => $field['name'],
+                  'content_field' => $field['name'],
+               ]
+            );
+         }
+      }
+   }
+
 
    function showForm($ID, $options = []) {
       global $CFG_GLPI;

--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -1290,8 +1290,25 @@ class MassiveAction {
                                                     $input[$input["field"]])) {
                         if ((count($link_entity_type) == 0)
                             || in_array($item->fields["entities_id"], $link_entity_type)) {
-                           if ($item->update(['id'            => $key,
-                                                   $input["field"] => $input[$input["field"]]])) {
+                           $field = $input['field'];
+                           $update_input = [
+                              'id'   => $key,
+                              $field => $input[$field],
+                           ];
+                           // Add fields related to uploaded images from rich text
+                           $_field        = sprintf('_%s', $field);
+                           $_tag_field    = sprintf('_tag_%s', $field);
+                           $_prefix_field = sprintf('_prefix_%s', $field);
+                           if (array_key_exists($_field, $input)
+                               && array_key_exists($_tag_field, $input)
+                               && array_key_exists($_prefix_field, $input)) {
+                              $update_input += [
+                                 $_field        => $input[$_field],
+                                 $_tag_field    => $input[$_tag_field],
+                                 $_prefix_field => $input[$_prefix_field],
+                              ];
+                           }
+                           if ($item->update($update_input)) {
                               $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
                            } else {
                               $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Fix handling of images pasted in a `tinymce` field of a `CommonDropdown` item.
2. Fix handling of images pasted in rich text using update massive action.

These features are only available on Followup and Solution templates right now. 