### PR TITLE
Fix images handling in dropdown and massive actions

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -4909,11 +4909,22 @@ class CommonDBTM extends CommonGLPI {
                return Html::autocompletionTextField($this, $name, $options);
 
             case "text" :
-               $out = '';
-               if (isset($searchoptions['htmltext']) && $searchoptions['htmltext']) {
-                  $out = Html::initEditorSystem($name, '', false);
-               }
-               return $out."<textarea cols='45' rows='5' name='$name'>$value</textarea>";
+               return Html::textarea(
+                  [
+                     'display'           => false,
+                     'name'              => $name,
+                     'value'             => $value,
+                     'enable_fileupload' => false,
+                     'enable_richtext'   => isset($searchoptions['htmltext']) && $searchoptions['htmltext'],
+                     // For now, this textarea is displayed only in the "update" massive action form, for fields
+                     // corresponding to a search option having "htmltext" property.
+                     // Uploaded images processing is not able to handle multiple use of same uploaded file, so until this is fixed,
+                     // it is preferable to disable image pasting in rich text inside massive actions.
+                     'enable_images'     => false,
+                     'cols'              => 45,
+                     'rows'              => 5,
+                  ]
+               );
 
             case "bool" :
                return Dropdown::showYesNo($name, $value, -1, $options);

--- a/inc/commondropdown.class.php
+++ b/inc/commondropdown.class.php
@@ -233,6 +233,43 @@ abstract class CommonDropdown extends CommonDBTM {
       return self::prepareInputForAdd($input);
    }
 
+   function post_addItem() {
+      $this->addFilesFromRichText();
+
+      parent::post_addItem();
+   }
+
+   function post_updateItem($history = 1) {
+      $this->addFilesFromRichText();
+
+      parent::post_updateItem($history);
+   }
+
+   /**
+    * Add files from rich text fields.
+    *
+    * @return void
+    */
+   private function addFilesFromRichText(): void {
+
+      $fields = $this->getAdditionalFields();
+      foreach ($fields as $field) {
+         $type           = $field['type'] ?? '';
+         $disable_images = $field['disable_images'] ?? false;
+         if ($type === 'tinymce' && !$disable_images) {
+            // Add files from inline images
+            $this->input = $this->addFiles(
+               $this->input,
+               [
+                  'force_update'  => true,
+                  'name'          => $field['name'],
+                  'content_field' => $field['name'],
+               ]
+            );
+         }
+      }
+   }
+
 
    function showForm($ID, $options = []) {
       global $CFG_GLPI;
@@ -438,6 +475,7 @@ abstract class CommonDropdown extends CommonDBTM {
                   'name'            => $field['name'],
                   'value'           => $this->fields[$field['name']],
                   'enable_richtext' => true,
+                  'enable_images'   => !($field['disable_images'] ?? false),
                ]);
                break;
 

--- a/inc/itilfollowuptemplate.class.php
+++ b/inc/itilfollowuptemplate.class.php
@@ -53,9 +53,15 @@ class ITILFollowupTemplate extends CommonDropdown {
    function getAdditionalFields() {
       return [
          [
-            'name'  => 'content',
-            'label' => __('Content'),
-            'type'  => 'tinymce',
+            'name'           => 'content',
+            'label'          => __('Content'),
+            'type'           => 'tinymce',
+            // As content copying from template is not using the image pasting process, these images
+            // are not correctly processed. Indeed, document item corresponding to the destination item is not created and
+            // image src is not containing the ITIL item foreign key, so image will not be visible for helpdesk profiles.
+            // As fixing it is really complex (requires lot of refactoring in images handling, both on JS and PHP side),
+            // it is preferable to disable usage of images in templates.
+            'disable_images' => true,
          ], [
             'name'  => 'requesttypes_id',
             'label' => __('Source of followup'),

--- a/inc/solutiontemplate.class.php
+++ b/inc/solutiontemplate.class.php
@@ -54,13 +54,25 @@ class SolutionTemplate extends CommonDropdown {
 
    function getAdditionalFields() {
 
-      return [['name'  => 'solutiontypes_id',
-                         'label' => SolutionType::getTypeName(1),
-                         'type'  => 'dropdownValue',
-                         'list'  => true],
-                   ['name'  => 'content',
-                         'label' => __('Content'),
-                         'type'  => 'tinymce']];
+      return [
+         [
+            'name'  => 'solutiontypes_id',
+            'label' => SolutionType::getTypeName(1),
+            'type'  => 'dropdownValue',
+            'list'  => true,
+         ],
+         [
+            'name'           => 'content',
+            'label'          => __('Content'),
+            'type'           => 'tinymce',
+            // As content copying from template is not using the image pasting process, these images
+            // are not correctly processed. Indeed, document item corresponding to the destination item is not created and
+            // image src is not containing the ITIL item foreign key, so image will not be visible for helpdesk profiles.
+            // As fixing it is really complex (requires lot of refactoring in images handling, both on JS and PHP side),
+            // it is preferable to disable usage of images in templates.
+            'disable_images' => true,
+         ]
+      ];
    }
 
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2608,6 +2608,9 @@ JAVASCRIPT;
                             'editor_id'         => $content_id,
                             'enable_fileupload' => false,
                             'enable_richtext'   => true,
+                            // Uploaded images processing is not able to handle multiple use of same uploaded file, so until this is fixed,
+                            // it is preferable to disable image pasting in rich text inside massive actions.
+                            'enable_images'     => false,
                             'cols'              => 12,
                             'rows'              => 80]);
             echo '</div>'; // .form-row


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Fix display of rich text input in "update" massive action (for followup and solution templates for instance).

2. Disable images pasting in rich text in massive action context (GLPI uploaded images handling does ot permit to reuse multiple times the same uploaded image, as uploaded file is moved once the first document is created).

3. Fix uploaded images handling in CommonDropdown.