### PR TITLE
Document: handle duplicate links in associated items tab

### DIFF
--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -426,13 +426,16 @@ class Document_Item extends CommonDBRelation{
             }
 
             while ($data = $iterator->next()) {
+               $linkname_extra = "";
                if ($item instanceof ITILFollowup || $item instanceof ITILSolution) {
+                  $linkname_extra = "(" . $item::getTypeName(1) . ")";
                   $itemtype = $data['itemtype'];
                   $item = new $itemtype();
                   $item->getFromDB($data['items_id']);
                   $data['id'] = $item->fields['id'];
                   $data['entity'] = $item->fields['entities_id'];
                } else if ($item instanceof CommonITILTask) {
+                  $linkname_extra = "(" . CommonITILTask::getTypeName(1) . ")";
                   $itemtype = $item->getItilObjectItemType();
                   $item = new $itemtype();
                   $item->getFromDB($data[$item->getForeignKeyField()]);
@@ -466,8 +469,9 @@ class Document_Item extends CommonDBRelation{
                      $linkname = $tmpitem->getLink();
                   }
                }
+
                $link     = $itemtype::getFormURLWithID($data['id']);
-               $name = "<a href=\"".$link."\">".$linkname."</a>";
+               $name = "<a href='$link'>$linkname $linkname_extra</a>";
 
                echo "<tr class='tab_bg_1'>";
 


### PR DESCRIPTION
The "Associated items" tab of documents may contain duplicate lines.
This is because some items like followups or tasks are shown as their parent in this tab (since we need a link and we don't have link to this kind of item yet).
This means that if you have a document linked both to a followup and to its parent ticket then the ticket will be shown twice in the list: 
![image](https://user-images.githubusercontent.com/42734840/118823779-8c76f980-b8b9-11eb-9ed9-93d319c608c4.png)


My suggestion is to add a type hint for followup, solutions and task so the users have a bit more information and are aware it isn't a duplicated line but two different links:
![image](https://user-images.githubusercontent.com/42734840/118826388-bf21f180-b8bb-11eb-943a-758b64865576.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22093
