### PR TITLE
Fix planning timezone

### DIFF
--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -1710,8 +1710,9 @@ class Planning extends CommonGLPI {
          }
       }
 
-      $time_begin = strtotime($param['start']);
-      $time_end   = strtotime($param['end']);
+      $timezone = new DateTimeZone(date_default_timezone_get());
+      $time_begin = strtotime($param['start']) - $timezone->getOffset(new DateTime($param['start']));
+      $time_end   = strtotime($param['end']) - $timezone->getOffset(new DateTime($param['end']));
 
       // if the dates range is greater than a certain amount, and we're not on a list view
       // we certainly are on this view (as our biggest view apart list is month one).


### PR DESCRIPTION
There is some timezone issues that affect the planning start date.

For example, if you tried to set a full day event on the first day on the week it would not display correctly:
![image](https://user-images.githubusercontent.com/42734840/118946275-7f5c1800-b956-11eb-8c45-5c3a1c7f68b0.png)

As you can see on the image it works for the others days in this week view but if I switch to the "day" view it not longer works since the selected day is now at the start date of the view:
![image](https://user-images.githubusercontent.com/42734840/118946479-b6cac480-b956-11eb-9279-6933737a29ed.png)

It seems the issue is that some dates sent from the client are in UTC while my server is in "Europe/Berlin".
The date received from the client are then casted to an "unix timestamp" with `strtotime` and compared with others dates retrieved by the server using it's own timestamp.
This is an issue as the "unix timestamp" format lose the timezone information so any calculation using dates with a different timestamp will be incorrect.

To fix this I've manually added the timezone offset to the `strtotime` results so the timestamp match the server timezone and gives expected results in later calculations.

After fix:
![image](https://user-images.githubusercontent.com/42734840/118947625-cf87aa00-b957-11eb-98e9-b199fd5677c7.png)
![image](https://user-images.githubusercontent.com/42734840/118947663-d9a9a880-b957-11eb-9450-4abac50d2900.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22092
