### PR TITLE
Fix fetching of images width/height on notifications; fixes #9075

### DIFF
--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -218,16 +218,12 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
 
                         //find width
                         $width = null;
-                        if (preg_match("/width=[\"|'](\d*(\.\d*)?)[\"|']/", $matches[0][$pos], $wmatches)) {
-                           if (isset($wmatches[1])) {
-                              $width = round($wmatches[1]);
-                           }
+                        if (preg_match("/width=[\"|'](\d+)(\.\d+)?[\"|']/", $matches[0][$pos], $wmatches)) {
+                           $width = intval($wmatches[1]);
                         }
                         $height = null;
-                        if (preg_match("/height=[\"|'](\d*(\.\d*)?)[\"|']/", $matches[0][$pos], $hmatches)) {
-                           if (isset($wmatches[1])) {
-                              $height = round($hmatches[1]);
-                           }
+                        if (preg_match("/height=[\"|'](\d+)(\.\d+)?[\"|']/", $matches[0][$pos], $hmatches)) {
+                           $height = intval($hmatches[1]);
                         }
 
                         $image_path = Document::getImage(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #9075

If `width` or `height` of an img tag is empty, an error is triggered on PHP8. Changing regex to prevent matching when width/height is empty fixes this issue. Also, there is no need to round anymore, as we only extract integer values.
