### PR TITLE
Contract: take renewal into account when checking validity

### DIFF
--- a/inc/contract.class.php
+++ b/inc/contract.class.php
@@ -47,6 +47,9 @@ class Contract extends CommonDBTM {
    static $rightname                   = 'contract';
    protected $usenotepad               = true;
 
+   const RENEWAL_NEVER = 0;
+   const RENEWAL_TACIT = 1;
+   const RENEWAL_EXPRESS = 2;
 
    public function getCloneRelations() :array {
       return [
@@ -222,8 +225,13 @@ class Contract extends CommonDBTM {
                                              'toadd' => [0 => Dropdown::EMPTY_VALUE],
                                              'unit'  => 'month']);
       if (!empty($this->fields["begin_date"])) {
-         echo " -> ".Infocom::getWarrantyExpir($this->fields["begin_date"],
-                                               $this->fields["duration"], 0, true);
+         echo " -> " . Infocom::getWarrantyExpir(
+            $this->fields["begin_date"],
+            $this->fields["duration"],
+            0,
+            true,
+            $this->fields['renewal'] == self::RENEWAL_TACIT
+         );
       }
       echo "</td></tr>";
 
@@ -1555,15 +1563,9 @@ class Contract extends CommonDBTM {
       }
       if (!$p['expired']) {
          $WHERE[] = ['OR' => [
+            'glpi_contracts.renewal' => 1,
             new \QueryExpression('DATEDIFF(ADDDATE(' . $DB->quoteName('glpi_contracts.begin_date') . ', INTERVAL ' . $DB->quoteName('glpi_contracts.duration') . ' MONTH), CURDATE()) > 0'),
             'glpi_contracts.begin_date'   => null,
-            ['AND' => [
-               'glpi_contracts.duration'  => 0,
-               'OR' => [
-                  new \QueryExpression('DATEDIFF(' . $DB->quoteName('glpi_contracts.begin_date') . ', CURDATE() ) < 0'),
-                  'glpi_contracts.renewal' => 1
-               ]
-            ]]
          ]];
       }
 
@@ -1635,9 +1637,9 @@ class Contract extends CommonDBTM {
    static function dropdownContractRenewal($name, $value = 0, $display = true) {
 
       $values = [
-         __('Never'),
-         __('Tacit'),
-         __('Express'),
+         self::RENEWAL_NEVER => __('Never'),
+         self::RENEWAL_TACIT => __('Tacit'),
+         self::RENEWAL_EXPRESS => __('Express'),
       ];
       return Dropdown::showFromArray($name, $values, ['value'   => $value,
                                                         'display' => $display]);

--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -1958,7 +1958,7 @@ class Infocom extends CommonDBChild {
 
       $timestamp = strtotime("$from+$addwarranty month -$deletenotice month");
 
-      if ($auto_renew) {
+      if ($auto_renew && $addwarranty > 0) {
          while ($timestamp < time()) {
             $datetime = new DateTime();
             $datetime->setTimestamp($timestamp);

--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -1940,10 +1940,11 @@ class Infocom extends CommonDBChild {
     * @param integer $addwarranty   period in months
     * @param integer $deletenotice  period in months of notice (default 0)
     * @param boolean $color         if show expire date in red color (false by default)
+    * @param boolean $auto_renew
     *
     * @return string expiration date
    **/
-   static function getWarrantyExpir($from, $addwarranty, $deletenotice = 0, $color = false) {
+   static function getWarrantyExpir($from, $addwarranty, $deletenotice = 0, $color = false, $auto_renew = false) {
 
       // Life warranty
       if (($addwarranty == -1)
@@ -1955,11 +1956,20 @@ class Infocom extends CommonDBChild {
          return "";
       }
 
-      $datetime = strtotime("$from+$addwarranty month -$deletenotice month");
-      if ($color && ($datetime < time())) {
-         return "<span class='red'>".Html::convDate(date("Y-m-d", $datetime))."</span>";
+      $timestamp = strtotime("$from+$addwarranty month -$deletenotice month");
+
+      if ($auto_renew) {
+         while ($timestamp < time()) {
+            $datetime = new DateTime();
+            $datetime->setTimestamp($timestamp);
+            $timestamp = strtotime($datetime->format("Y-m-d H:i:s") . "+$addwarranty month");
+         }
       }
-      return Html::convDate(date("Y-m-d", $datetime));
+
+      if ($color && ($timestamp < time())) {
+         return "<span class='red'>".Html::convDate(date("Y-m-d", $timestamp))."</span>";
+      }
+      return Html::convDate(date("Y-m-d", $timestamp));
    }
 
 


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/42734840/119006579-cbc44980-b990-11eb-9a41-34756e17df20.png)
The contract end date appear in red (= expired) despite having an auto renewal policy.

The expired check in Contract::dropdown() doesn't seem to be better: it only take into account the tacit renewal policy if the contract has no duration defined (`'glpi_contracts.duration' => 0,`).

After:
![image](https://user-images.githubusercontent.com/42734840/119006441-aafbf400-b990-11eb-9d62-b4ad8b5e5f99.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21598
