### PR TITLE
Dashboard/TicketSummary: don't filter waiting_validation on current user

### DIFF
--- a/inc/dashboard/grid.class.php
+++ b/inc/dashboard/grid.class.php
@@ -1286,6 +1286,9 @@ HTML;
             'provider'   => "Glpi\\Dashboard\\Provider::nbTicketsGeneric",
             'args'       => [
                'case' => $case,
+               'params' => [
+                  'validation_check_user' => true,
+               ]
             ],
             'cache'      => false,
             'filters'    => [
@@ -1302,6 +1305,7 @@ HTML;
             'provider'   => "Glpi\\Dashboard\\Provider::nbTicketsGeneric",
             'args'       => [
                'case' => $case,
+               'validation_check_user' => true,
             ],
             'filters'    => [
                'dates', 'dates_mod', 'itilcategory',

--- a/inc/dashboard/grid.class.php
+++ b/inc/dashboard/grid.class.php
@@ -1309,7 +1309,6 @@ HTML;
                   'validation_check_user' => true,
                ]
             ],
-            ],
             'filters'    => [
                'dates', 'dates_mod', 'itilcategory',
                'group_tech', 'user_tech', 'requesttype', 'location'

--- a/inc/dashboard/grid.class.php
+++ b/inc/dashboard/grid.class.php
@@ -1305,7 +1305,10 @@ HTML;
             'provider'   => "Glpi\\Dashboard\\Provider::nbTicketsGeneric",
             'args'       => [
                'case' => $case,
-               'validation_check_user' => true,
+               'params' => [
+                  'validation_check_user' => true,
+               ]
+            ],
             ],
             'filters'    => [
                'dates', 'dates_mod', 'itilcategory',

--- a/inc/dashboard/provider.class.php
+++ b/inc/dashboard/provider.class.php
@@ -207,9 +207,10 @@ class Provider extends CommonGLPI {
       $DBread = DBConnection::getReadConnection();
 
       $default_params = [
-         'label'         => "",
-         'icon'          => Ticket::getIcon(),
-         'apply_filters' => [],
+         'label'                 => "",
+         'icon'                  => Ticket::getIcon(),
+         'apply_filters'         => [],
+         'validation_check_user' => false,
       ];
       $params = array_merge($default_params, $params);
 
@@ -300,6 +301,24 @@ class Provider extends CommonGLPI {
                   'value'      => CommonITILValidation::WAITING,
                ]
             ];
+
+            if ($params['validation_check_user']) {
+               $search_criteria[] = [
+                  'link'       => 'AND',
+                  'field'      => 59,
+                  'searchtype' => 'equals',
+                  'value'      => Session::getLoginUserID(),
+               ];
+            }
+
+            $where = [
+               'glpi_ticketvalidations.status' => CommonITILValidation::WAITING,
+            ];
+
+            if ($params['validation_check_user']) {
+               $where['glpi_ticketvalidations.users_id_validate'] = Session::getLoginUserID();
+            }
+
             $query_criteria = array_merge_recursive($query_criteria, [
                'LEFT JOIN' => [
                   'glpi_ticketvalidations' => [
@@ -309,9 +328,7 @@ class Provider extends CommonGLPI {
                      ]
                   ]
                ],
-               'WHERE' => [
-                  'glpi_ticketvalidations.status' => CommonITILValidation::WAITING,
-               ]
+               'WHERE' => $where,
             ]);
             break;
 

--- a/inc/dashboard/provider.class.php
+++ b/inc/dashboard/provider.class.php
@@ -292,7 +292,7 @@ class Provider extends CommonGLPI {
 
          case 'waiting_validation':
             $params['icon']  = "far fa-eye";
-            $params['label'] = __("Tickets waiting your validation");
+            $params['label'] = __("Tickets waiting for validation");
             $search_criteria = [
                [
                   'field'      => 55,

--- a/inc/dashboard/provider.class.php
+++ b/inc/dashboard/provider.class.php
@@ -298,11 +298,6 @@ class Provider extends CommonGLPI {
                   'field'      => 55,
                   'searchtype' => 'equals',
                   'value'      => CommonITILValidation::WAITING,
-               ],  [
-                  'link'       => 'AND',
-                  'field'      => 59,
-                  'searchtype' => 'equals',
-                  'value'      => Session::getLoginUserID(),
                ]
             ];
             $query_criteria = array_merge_recursive($query_criteria, [
@@ -315,8 +310,7 @@ class Provider extends CommonGLPI {
                   ]
                ],
                'WHERE' => [
-                  'glpi_ticketvalidations.status'            => CommonITILValidation::WAITING,
-                  'glpi_ticketvalidations.users_id_validate' => Session::getLoginUserID()
+                  'glpi_ticketvalidations.status' => CommonITILValidation::WAITING,
                ]
             ]);
             break;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/42734840/119155716-c0862200-ba53-11eb-9dc1-d24b420edce5.png)

On the "Ticket summary" card that you can see above, the "To validate" column is filtered on the current logged in user.
This doesn't make sense as the other four columns only filter on status.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22124
