### PR TITLE
Add WiFi ac and ax versions

### DIFF
--- a/inc/wifinetwork.class.php
+++ b/inc/wifinetwork.class.php
@@ -50,13 +50,16 @@ class WifiNetwork extends CommonDropdown {
    }
 
    static function getWifiCardVersion() {
-
-      return [''          => '',
-                   'a'         => 'a',
-                   'a/b'       => 'a/b',
-                   'a/b/g'     => 'a/b/g',
-                   'a/b/g/n'   => 'a/b/g/n',
-                   'a/b/g/n/y' => 'a/b/g/n/y'];
+      return [
+         ''          => '',
+         'a'         => 'a',
+         'a/b'       => 'a/b',
+         'a/b/g'     => 'a/b/g',
+         'a/b/g/n'   => 'a/b/g/n',
+         'a/b/g/n/y' => 'a/b/g/n/y',
+         'ac'        => 'ac',
+         'ax'        => 'ax',
+      ];
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add the options for 802.11ac and 802.11ax for the protocol version field on WiFi ports.
