### PR TITLE
fix(core): always restore default language

### DIFF
--- a/inc/notificationtemplate.class.php
+++ b/inc/notificationtemplate.class.php
@@ -307,18 +307,18 @@ class NotificationTemplate extends CommonDBTM {
                                 $data)."\n\n-- \n".$this->signature.
                                       "\n".Html::entity_decode_deep($generated_by))."\n\n".$add_footer;
             $this->templates_by_languages[$tid] = $lang;
+         }
 
-            // Restore default language
-            $_SESSION["glpilanguage"] = $bak_language;
-            Session::loadLanguage();
-            if ($bak_dropdowntranslations !== null) {
-               $_SESSION['glpi_dropdowntranslations'] = $bak_dropdowntranslations;
-            } else {
-               unset($_SESSION['glpi_dropdowntranslations']);
-            }
-            if ($plug = isPluginItemType(get_class($target->obj))) {
-               Plugin::loadLang(strtolower($plug['plugin']));
-            }
+         // Restore default language
+         $_SESSION["glpilanguage"] = $bak_language;
+         Session::loadLanguage();
+         if ($bak_dropdowntranslations !== null) {
+            $_SESSION['glpi_dropdowntranslations'] = $bak_dropdowntranslations;
+         } else {
+            unset($_SESSION['glpi_dropdowntranslations']);
+         }
+         if ($plug = isPluginItemType(get_class($target->obj))) {
+            Plugin::loadLang(strtolower($plug['plugin']));
          }
       }
       if (isset($this->templates_by_languages[$tid])) {

--- a/inc/notificationtemplatetranslation.class.php
+++ b/inc/notificationtemplatetranslation.class.php
@@ -130,9 +130,10 @@ class NotificationTemplateTranslation extends CommonDBChild {
             unset($used[$this->getField('language')]);
          }
       }
-      Dropdown::showLanguages("language", ['display_emptychoice' => true,
-                                                'value'               => $this->fields['language'],
-                                                'used'                => $used]);
+      Dropdown::showLanguages("language", ['display_emptychoice'  => true,
+                                             'value'              => $this->fields['language'],
+                                             'emptylabel'         => __('Default translation'),
+                                          ]);
       echo "</td></tr>";
 
       echo "<tr class='tab_bg_1'><td>" . __('Subject') . "</td>";


### PR DESCRIPTION
When GLPI try to find translations from notification template for user language (or default language),
if it not found, GLPI do not restore the default language.

This PR fix this.

To avoid mistake, add empty label ```Default translation```  instead of ```---``` to language dropdown of ```NotificationTemplateTranslation```
 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22101
