### PR TITLE
Fix entity import rule actions

### DIFF
--- a/inc/ruleimportentity.class.php
+++ b/inc/ruleimportentity.class.php
@@ -346,7 +346,7 @@ class RuleImportEntity extends Rule {
          '_affect_entity_by_tag' => [
             'name' => __('Entity from TAG'),
             'type' => 'text',
-            'force_actions' => 'regex_result',
+            'force_actions' => ['regex_result'],
          ],
          '_ignore_import' => [
             'name' => __('Refuse import'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes following error:
```
glpiphplog.CRITICAL:   *** Uncaught Exception TypeError: in_array(): Argument #2 ($haystack) must be of type array, string given in /var/www/glpi/inc/rule.class.php at line 1007
  Backtrace :
  inc/rule.class.php:1007                            in_array()
  inc/rule.class.php:1058                            Rule->getTitleAction()
  inc/rule.class.php:3185                            Rule->showActionsList()
  inc/commonglpi.class.php:656                       Rule::displayTabContentForItem()
  ajax/common.tabs.php:106                           CommonGLPI::displayStandardTab()
```