### PR TITLE
Do not require rights to update nickname in user settings

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -2841,13 +2841,9 @@ JAVASCRIPT;
             echo "<tr class='tab_bg_1'>";
             echo "<td><label for='nickname$rand'> " . __('Nickname') . "</label></td>";
             echo "<td>";
-            if ($this->can($ID, UPDATE)) {
-               echo Html::input('nickname', [
-                  'value' => $this->fields['nickname']
-               ]);
-            } else {
-               echo $this->fields['nickname'];
-            }
+            echo Html::input('nickname', [
+               'value' => $this->fields['nickname']
+            ]);
             echo "</td>";
             echo "</tr>";
          }


### PR DESCRIPTION
Users should always be able to update their nicknames, current check on rights was a mistake.

This fix target master and not 9.5/bf as it is a feature introduced in GLPI 10.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !21776
