### PR TITLE
Fix dbversion when migration from < 9.2 fails

### DIFF
--- a/install/update_91_92.php
+++ b/install/update_91_92.php
@@ -1417,7 +1417,7 @@ Regards,',
    }
 
    //add db version
-   $migration->addConfig(['dbversion' => GLPI_SCHEMA_VERSION]);
+   $migration->addConfig(['dbversion' => '9.1.3']);
 
    // Add certificates management
    if (!$DB->tableExists('glpi_certificates')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Migration from 9.1 to 9.2 adds the `dbversion` config and initializes it with GLPI_SCHEMA_VERSION. Problem is that if migration fails after this point, it will not be possible to replay it.

`9.1.3` was the latest value of `GLPI_SCHEMA_VERSION` in 9.1 version (see https://github.com/glpi-project/glpi/blob/9.1/bugfixes/config/define.php#L40 ).

![image](https://user-images.githubusercontent.com/33253653/120494146-da145b80-c3bb-11eb-866e-d5bd936c04e1.png)
