### PR TITLE
Do not filter unavailable plugins in marketplace

### DIFF
--- a/css/marketplace.scss
+++ b/css/marketplace.scss
@@ -295,10 +295,14 @@ $break_s_screen: 1400px;
                      }
                   }
 
-                  .plugin-error {
-                     color: red;
+                  > .fa-exclamation-triangle {
+                     color: #8f5a0a;
                      margin: 1px;
                      padding: 3px 5px;
+
+                     &.plugin-error {
+                        color: red;
+                     }
                   }
                }
             }
@@ -460,6 +464,11 @@ $break_s_screen: 1400px;
                .buttons {
                   width: 26px;
                   padding: 4px 5px;
+
+                  .plugin-unavailable {
+                     // Do not display unavailability on marketplace in installed view
+                     display: none;
+                  }
                }
             }
 

--- a/inc/marketplace/api/plugins.class.php
+++ b/inc/marketplace/api/plugins.class.php
@@ -181,12 +181,11 @@ class Plugins {
    ) {
       global $GLPI_CACHE;
 
-      $plugins_colct = [];
-      if (!$force_refresh && $GLPI_CACHE->has('marketplace_all_plugins')) {
-         $plugins_colct = $GLPI_CACHE->get('marketplace_all_plugins');
-      }
+      $plugins_colct = !$force_refresh
+         ? $GLPI_CACHE->get('marketplace_all_plugins', null)
+         : null;
 
-      if (!count($plugins_colct)) {
+      if ($plugins_colct === null) {
          $plugins = $this->getPaginatedCollection('plugins');
 
          // replace keys indexes by system names
@@ -226,14 +225,6 @@ class Plugins {
          }
       }
       self::$plugins = $plugins_colct;
-
-      // Remove plugins with no versions for current config (i.e. only unstable versions that are not proposed).
-      $plugins_colct = array_filter(
-         $plugins_colct,
-         function($plugin) {
-            return count($plugin['versions']) > 0;
-         }
-      );
 
       if (strlen($tag_filter) > 0) {
          $tagged_plugins = array_column($this->getPluginsForTag($tag_filter), 'key');

--- a/inc/marketplace/controller.class.php
+++ b/inc/marketplace/controller.class.php
@@ -357,6 +357,17 @@ class Controller extends CommonGLPI {
    }
 
    /**
+    * Check if a given plugin has available versions for current GLPI instance.
+    *
+    * @return bool
+    */
+   public function isAvailable() {
+      $api          = self::getAPI();
+      $api_plugin   = $api->getPlugin($this->plugin_key);
+      return count($api_plugin['versions'] ?? []) > 0;
+   }
+
+   /**
     * Check if plugin is eligible inside an higher offer.
     *
     * @return bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Displays plugins in discover page even if plugin is not available for their GLPI version. For instance, on current master branch, no plugins are available, so page is empty.

![image](https://user-images.githubusercontent.com/33253653/120618309-3e3a2c80-c45b-11eb-91db-316046f41092.png)

I put this change on 9.5/bugfixes branch, as I think it could be usefull to be able to promote future new plugins in GLPI 9.5 even if they are only compatible with a newer GLPI version.