### PR TITLE
Fix cleaning of items created from Kanban

### DIFF
--- a/ajax/kanban.php
+++ b/ajax/kanban.php
@@ -41,14 +41,6 @@ Html::header_nocache();
 
 Session::checkLoginUser();
 
-if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
-   // Get AJAX input and load it into $_REQUEST
-   $input = file_get_contents('php://input');
-   parse_str($input, $_REQUEST);
-}
-
-$_REQUEST = Toolbox::clean_cross_side_scripting_deep($_REQUEST);
-
 if (!isset($_REQUEST['action'])) {
    Toolbox::logError("Missing action parameter");
    http_response_code(400);
@@ -121,7 +113,8 @@ if ($_REQUEST['action'] == 'update') {
    $item = new $itemtype();
    $inputs = [];
    parse_str($_REQUEST['inputs'], $inputs);
-   $item->add($inputs);
+
+   $item->add(Toolbox::clean_cross_side_scripting_deep($inputs));
 } else if ($_REQUEST['action'] == 'bulk_add_item') {
    $checkParams(['inputs']);
    $item = new $itemtype();
@@ -134,7 +127,7 @@ if ($_REQUEST['action'] == 'update') {
       foreach ($bulk_item_list as $item_entry) {
          $item_entry = trim($item_entry);
          if (!empty($item_entry)) {
-            $item->add($inputs + ['name' => $item_entry]);
+            $item->add(Toolbox::clean_cross_side_scripting_deep($inputs + ['name' => $item_entry]));
          }
       }
    }

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -668,7 +668,6 @@
                   itemtype: self.item.itemtype,
                   items_id: items_id
                },
-               contentType: 'application/json',
                success: function(url) {
                   window.location = url;
                }
@@ -928,7 +927,6 @@
                   column_field: self.column_field.id,
                   column_value: column_id
                },
-               contentType: 'application/json',
                error: function() {
                   $(sortable).sortable('cancel');
                   return false;
@@ -976,7 +974,6 @@
                position: position,
                kanban: self.item
             },
-            contentType: 'application/json',
             error: function() {
                if (error) {
                   error();
@@ -1004,7 +1001,6 @@
                column: column,
                kanban: self.item
             },
-            contentType: 'application/json',
             complete: function() {
                $.each(self.user_state.state, function(i, c) {
                   if (parseInt(c['column']) === parseInt(column)) {
@@ -1032,7 +1028,6 @@
                column: column,
                kanban: self.item
             },
-            contentType: 'application/json',
             complete: function() {
                $(getColumnElementFromID(column)).remove();
                $.each(self.user_state.state, function(i, c) {
@@ -1061,8 +1056,7 @@
                column: column,
                position: position,
                kanban: self.item
-            },
-            contentType: 'application/json'
+            }
          });
       };
 
@@ -1088,9 +1082,7 @@
                   data: {
                      users_id: [items_id],
                      size: self.team_image_size,
-                  },
-                  contentType: 'application/json',
-                  dataType: 'json'
+                  }
                }).done(function(data) {
                   if (data[items_id] !== undefined) {
                      user_img = data[items_id];
@@ -1169,9 +1161,7 @@
             data: {
                users_id: Object.keys(users),
                size: self.team_image_size
-            },
-            contentType: 'application/json',
-            dataType: 'json'
+            }
          }).done(function(data) {
             Object.keys(users).forEach(function(user_id) {
                var teammember = users[user_id];
@@ -1601,9 +1591,7 @@
                   itemtype: self.item.itemtype,
                   items_id: self.item.items_id,
                   column_field: self.column_field.id
-               },
-               contentType: 'application/json',
-               dataType: 'json'
+               }
             }).done(function(columns, textStatus, jqXHR) {
                preloadBadgeCache({
                   trim_cache: true
@@ -1822,8 +1810,7 @@
                action: action,
                column: getColumnIDFromElement(column_el),
                kanban: self.item
-            },
-            contentType: 'application/json'
+            }
          });
       };
 
@@ -1861,8 +1848,6 @@
          $.ajax({
             method: 'GET',
             url: (self.ajax_root + "kanban.php"),
-            contentType: 'application/json',
-            dataType: 'json',
             async: false,
             data: {
                action: "get_column",
@@ -1902,8 +1887,6 @@
          $.ajax({
             method: 'POST',
             url: (self.ajax_root + "kanban.php"),
-            contentType: 'application/json',
-            dataType: 'json',
             data: {
                action: "create_column",
                itemtype: self.item.itemtype,
@@ -1968,8 +1951,7 @@
                itemtype: self.item.itemtype,
                items_id: self.item.items_id,
                last_load: self.last_refresh
-            },
-            contentType: 'application/json'
+            }
          }).done(function(state) {
             if (state['state'] === undefined || state['state'] === null || Object.keys(state['state']).length === 0) {
                if (callback) {
@@ -2043,8 +2025,7 @@
                itemtype: self.item.itemtype,
                items_id: self.item.items_id,
                state: self.user_state.state
-            },
-            contentType: 'application/json'
+            }
          }).done(function(data, textStatus, jqXHR) {
             self.user_state.is_dirty = false;
             if (success) {
@@ -2102,7 +2083,6 @@
                      itemtype: self.item.itemtype,
                      items_id: self.item.items_id
                   },
-                  contentType: 'application/json',
                   success: function($data) {
                      var switcher = $(self.element + " .kanban-toolbar select[name='kanban-board-switcher']");
                      switcher.replaceWith($data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. AJAX input sent using POST query is already present and sanitized in `$_REQUEST` lines 44 to 51 were useless (unless I am wrong).
2. As items creation input is based on a URL encoded form value, `Toolbox::clean_cross_side_scripting_deep()` had no effect and has to be done once params are extracted from `$_REQUEST['inputs']`.

This change is required to be able to apply #9101 .