### PR TITLE
Anonymize observers if they have at least one 'central' profile

### DIFF
--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -1273,9 +1273,7 @@ JAVASCRIPT;
       if (in_array(CommonITILActor::ASSIGN, $roles)) {
          // The author is assigned -> support agent
          return true;
-      } else if (in_array(CommonITILActor::OBSERVER, $roles)
-         || in_array(CommonITILActor::REQUESTER, $roles)
-      ) {
+      } else if (in_array(CommonITILActor::OBSERVER, $roles)) {
          // The author is an observer or a requester -> can be support agent OR
          // requester depending on how GLPI is used so we must check the user's
          // profiles
@@ -1300,6 +1298,9 @@ JAVASCRIPT;
          }
 
          return $central_profiles->next()['total'] > 0;
+      } else if (in_array(CommonITILActor::REQUESTER, $roles)) {
+         // The author is a requester -> not from support agent
+         return false;
       } else {
          // The author is not an actor of the ticket -> he was most likely a
          // support agent that is no longer assigned to the ticket

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -1260,6 +1260,8 @@ JAVASCRIPT;
     * @return bool
     */
    public function isFromSupportAgent() {
+      global $DB;
+
       // Get parent item
       $commonITILObject = new $this->fields['itemtype']();
       $commonITILObject->getFromDB($this->fields['items_id']);
@@ -1274,8 +1276,30 @@ JAVASCRIPT;
       } else if (in_array(CommonITILActor::OBSERVER, $roles)
          || in_array(CommonITILActor::REQUESTER, $roles)
       ) {
-         // The author is an observer or a requester -> not a support agent
-         return false;
+         // The author is an observer or a requester -> can be support agent OR
+         // requester depending on how GLPI is used so we must check the user's
+         // profiles
+         $central_profiles = $DB->request([
+            'COUNT' => 'total',
+            'FROM' => Profile::getTable(),
+            'WHERE' => [
+               'interface' => 'central',
+               'id' => new QuerySubQuery([
+                  'SELECT' => ['profiles_id'],
+                  'FROM' => Profile_User::getTable(),
+                  'WHERE' => [
+                     'users_id' => $user_id
+                  ]
+               ])
+            ]
+         ]);
+
+         // No profiles, let's assume it is a support agent to be safe
+         if (!count($central_profiles)) {
+            return false;
+         }
+
+         return $central_profiles->next()['total'] > 0;
       } else {
          // The author is not an actor of the ticket -> he was most likely a
          // support agent that is no longer assigned to the ticket

--- a/tests/functionnal/ITILFollowup.php
+++ b/tests/functionnal/ITILFollowup.php
@@ -37,6 +37,7 @@ use \DbTestCase;
 use ITILFollowup as CoreITILFollowup;
 use Ticket;
 use Ticket_User;
+use User;
 
 /* Test for inc/itilfollowup.class.php */
 
@@ -274,21 +275,31 @@ class ITILFollowup extends DbTestCase {
          [
             // Case 1: user is not an actor of the ticket
             "roles"    => [],
+            "profile" => "Technician",
             "expected" => true,
          ],
          [
             // Case 2: user is a requester
             "roles"    => [CommonITILActor::REQUESTER],
+            "profile" => "Technician",
             "expected" => false,
          ],
          [
-            // Case 3: user is an observer
+            // Case 3: user is an observer with a central profile
             "roles"    => [CommonITILActor::OBSERVER],
+            "profile" => "Technician",
+            "expected" => true,
+         ],
+         [
+            // Case 3b: user is an observer without central profiles
+            "roles"    => [CommonITILActor::OBSERVER],
+            "profile" => "Self-Service",
             "expected" => false,
          ],
          [
             // Case 4: user is assigned
             "roles"    => [CommonITILActor::ASSIGN],
+            "profile" => "Technician",
             "expected" => true,
          ],
          [
@@ -297,6 +308,7 @@ class ITILFollowup extends DbTestCase {
                CommonITILActor::OBSERVER,
                CommonITILActor::ASSIGN,
             ],
+            "profile" => "Technician",
             "expected" => true,
          ],
       ];
@@ -307,6 +319,7 @@ class ITILFollowup extends DbTestCase {
     */
    public function testIsFromSupportAgent(
       array $roles,
+      string $profile,
       bool $expected
    ) {
       global $CFG_GLPI, $DB;
@@ -325,12 +338,23 @@ class ITILFollowup extends DbTestCase {
       ]);
       $this->integer($ticket_id);
 
+      // Create test user
+      $rand = mt_rand();
+      $user = new User();
+      $users_id = $user->add([
+         'name' => "testIsFromSupportAgent$rand",
+         'password' => 'testIsFromSupportAgent',
+         'password2' => 'testIsFromSupportAgent',
+         '_profiles_id' => getItemByTypeName('Profile', $profile, true),
+         '_entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+      ]);
+      $this->integer($users_id)->isGreaterThan(0);
+
       // Insert a followup
-      $user1 = getItemByTypeName('User', TU_USER, true);
       $fup = new CoreITILFollowup();
       $fup_id = $fup->add([
          'content'  => "testIsFromSupportAgent",
-         'users_id' => $user1,
+         'users_id' => $users_id,
          'items_id' => $ticket_id,
          'itemtype' => "Ticket",
       ]);
@@ -346,7 +370,7 @@ class ITILFollowup extends DbTestCase {
       foreach ($roles as $role) {
          $this->integer($tuser->add([
             'tickets_id' => $ticket_id,
-            'users_id'   => $user1,
+            'users_id'   => $users_id,
             'type'       => $role,
          ]));
       }


### PR DESCRIPTION
Currently observers are not anonymized as we assume that they are supposed to be 'end users' and not technicians.
However this is not the only possible use-case, some people might put a mix of technicians and end-users in the observers part.

With these changes : 
- Observer with at least one 'central' profile -> anonymized 
- Other observers -> not anonymized

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Related tickets | !21776
