### PR TITLE
fix(rule): add _groups_id_of_requester to changes only if users change

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -2090,7 +2090,6 @@ abstract class CommonITILObject extends CommonDBTM {
       // Additional groups actors
       if (!is_null($groupactors)) {
          $group_input = [
-            $groupactors->getItilObjectForeignKey() => $this->fields['id'],
             '_do_not_compute_takeintoaccount'       => $do_not_compute_takeintoaccount,
             '_from_object'                          => true,
          ];
@@ -2101,12 +2100,17 @@ abstract class CommonITILObject extends CommonDBTM {
              && count($input['_additional_groups_requesters'])) {
             foreach ($input['_additional_groups_requesters'] as $tmp) {
                if ($tmp > 0) {
-                  $groupactors->add(
-                     [
-                        'type'      => CommonITILActor::REQUESTER,
-                        'groups_id' => $tmp,
-                     ] + $group_input
-                  );
+
+                  $crit = [
+                     $groupactors->getItilObjectForeignKey() => $this->fields['id'],
+                     'type'      => CommonITILActor::REQUESTER,
+                     'groups_id' => $tmp,
+                  ];
+
+                  if (!$groupactors->getFromDBByCrit($crit)) {
+                     $groupactors->add($crit + $group_input);
+                  }
+
                }
             }
          }
@@ -2117,12 +2121,15 @@ abstract class CommonITILObject extends CommonDBTM {
              && count($input['_additional_groups_observers'])) {
             foreach ($input['_additional_groups_observers'] as $tmp) {
                if ($tmp > 0) {
-                  $groupactors->add(
-                     [
-                        'type'      => CommonITILActor::OBSERVER,
-                        'groups_id' => $tmp,
-                     ] + $group_input
-                  );
+                  $crit = [
+                     $groupactors->getItilObjectForeignKey() => $this->fields['id'],
+                     'type'      => CommonITILActor::OBSERVER,
+                     'groups_id' => $tmp,
+                  ];
+
+                  if (!$groupactors->getFromDBByCrit($crit)) {
+                     $groupactors->add($crit + $group_input);
+                  }
                }
             }
          }
@@ -2133,12 +2140,15 @@ abstract class CommonITILObject extends CommonDBTM {
              && count($input['_additional_groups_assigns'])) {
             foreach ($input['_additional_groups_assigns'] as $tmp) {
                if ($tmp > 0) {
-                  $groupactors->add(
-                     [
-                        'type'      => CommonITILActor::ASSIGN,
-                        'groups_id' => $tmp,
-                     ] + $group_input
-                  );
+                  $crit = [
+                     $groupactors->getItilObjectForeignKey() => $this->fields['id'],
+                     'type'      => CommonITILActor::ASSIGN,
+                     'groups_id' => $tmp,
+                  ];
+
+                  if (!$groupactors->getFromDBByCrit($crit)) {
+                     $groupactors->add($crit + $group_input);
+                  }
                }
             }
          }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1123,12 +1123,7 @@ class Ticket extends CommonITILObject {
             $input['_locations_id_of_requester']   = $user->fields['locations_id'];
             $input['users_default_groups']         = $user->fields['groups_id'];
             $changes[]                             = '_locations_id_of_requester';
-
-            //add _groups_id_of_requester to changes only if users change
-            if (in_array('_users_id_requester', $changes)) {
-               $changes[] = '_groups_id_of_requester';
-            }
-
+            $changes[] = '_groups_id_of_requester';
          }
 
          $input = $rules->processAllRules($input,

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1123,7 +1123,7 @@ class Ticket extends CommonITILObject {
             $input['_locations_id_of_requester']   = $user->fields['locations_id'];
             $input['users_default_groups']         = $user->fields['groups_id'];
             $changes[]                             = '_locations_id_of_requester';
-            $changes[] = '_groups_id_of_requester';
+            $changes[]                             = '_groups_id_of_requester';
          }
 
          $input = $rules->processAllRules($input,

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1123,7 +1123,12 @@ class Ticket extends CommonITILObject {
             $input['_locations_id_of_requester']   = $user->fields['locations_id'];
             $input['users_default_groups']         = $user->fields['groups_id'];
             $changes[]                             = '_locations_id_of_requester';
-            $changes[]                             = '_groups_id_of_requester';
+
+            //add _groups_id_of_requester to changes only if users change
+            if (in_array('_users_id_requester', $changes)) {
+               $changes[] = '_groups_id_of_requester';
+            }
+
          }
 
          $input = $rules->processAllRules($input,

--- a/tests/functionnal/RuleTicket.php
+++ b/tests/functionnal/RuleTicket.php
@@ -787,7 +787,7 @@ class RuleTicket extends DbTestCase {
       $this->string($task_data['content'])->isEqualTo('test content');
    }
 
-   public function testGroupRequesterAssignFromUserGroupsAndRegex() {
+   public function testGroupRequesterAssignFromUserGroupsAndRegexOnAdd() {
       $this->login();
 
       // Create rule
@@ -890,6 +890,154 @@ class RuleTicket extends DbTestCase {
             'type'               => \CommonITILActor::REQUESTER
          ])
       )->isTrue();
+   }
+
+   public function testGroupRequesterAssignFromUserGroupsAndRegexOnUpdate() {
+      $this->login();
+
+      // Create rule
+      $ruleticket = new \RuleTicket();
+      $rulecrit   = new \RuleCriteria();
+      $ruleaction = new \RuleAction();
+
+      $ruletid = $ruleticket->add($ruletinput = [
+         'name'         => 'test regex group requester criterion',
+         'match'        => 'AND',
+         'is_active'    => 1,
+         'sub_type'     => 'RuleTicket',
+         'condition'    => \RuleTicket::ONUPDATE,
+         'is_recursive' => 0,
+      ]);
+      $this->checkInput($ruleticket, $ruletid, $ruletinput);
+
+      //create criteria to check if group requester match regex
+      $crit_id = $rulecrit->add($crit_input = [
+         'rules_id'  => $ruletid,
+         'criteria'  => '_groups_id_of_requester',
+         'condition' => \Rule::REGEX_MATCH,
+         'pattern'   => Toolbox::addslashes_deep('/(.+\([^()]*\))/'),   //retrieve groupe with '(' and ')'
+      ]);
+      //change value because of addslashes
+      $crit_input['pattern'] = '/(.+\([^()]*\))/';
+      $this->checkInput($rulecrit, $crit_id, $crit_input);
+
+      //create action to put  group matching on criteria
+      $action_id = $ruleaction->add($action_input = [
+         'rules_id'    => $ruletid,
+         'action_type' => 'regex_result',
+         'field'       => '_groups_id_requester',
+         'value'       => '#0',
+      ]);
+      $this->checkInput($ruleaction, $action_id, $action_input);
+
+      //create 2 new group
+      $group = new \Group();
+      $group_id1 = $group->add($group_input = [
+         "name"         => "group1 (5215)",
+         "is_requester" => true
+      ]);
+      $this->checkInput($group, $group_id1, $group_input);
+
+      //create new group
+      $group_id2 = $group->add($group_input = [
+         "name"         => "group2 (13)",
+         "is_requester" => true
+      ]);
+      $this->checkInput($group, $group_id2, $group_input);
+
+      //Load user post_only
+      $userPostOnly = new \User();
+      $userPostOnly->getFromDB(getItemByTypeName('User', 'post-only', true));
+
+      //Load user normal
+      $userNormal = new \User();
+      $userNormal->getFromDB(getItemByTypeName('User', 'normal', true));
+
+      //add user to groups
+      $group_user = new Group_User();
+      $group_user_id1 = $group_user->add($group_user_input = [
+         "groups_id" => $group_id1,
+         "users_id"  => $userNormal->fields['id']
+      ]);
+      $this->checkInput($group_user, $group_user_id1, $group_user_input);
+
+      $group_user = new Group_User();
+      $group_user_id2 = $group_user->add($group_user_input = [
+         "groups_id" => $group_id2,
+         "users_id"  => $userNormal->fields['id']
+      ]);
+      $this->checkInput($group_user, $group_user_id2, $group_user_input);
+
+      // create ticket that trigger rule on creation
+      $ticket = new \Ticket();
+      $ticket->getEmpty();
+      $tickets_id = $ticket->add($ticket_input = [
+         'name'                  => 'Add group requester',
+         'id'                    => 0, //pass id = 0 because in IHM it's passed as POST
+         'content'               => 'test',
+         '_users_id_requester'   => $userPostOnly->fields['id']
+      ]);
+      unset($ticket_input['_users_id_requester']);
+      $ticket_input['id'] = $tickets_id; //force id to $input
+      $this->checkInput($ticket, $tickets_id, $ticket_input);
+
+      //link between groupe1 and ticket will not exist
+      $ticketGroup = new \Group_Ticket();
+      $this->boolean(
+         $ticketGroup->getFromDBByCrit([
+            'tickets_id'         => $tickets_id,
+            'groups_id'          => $group_id1,
+            'type'               => \CommonITILActor::REQUESTER
+         ])
+      )->isFalse();
+
+      //link between groupe2 and ticket will not exist
+      $this->boolean(
+         $ticketGroup->getFromDBByCrit([
+            'tickets_id'         => $tickets_id,
+            'groups_id'          => $group_id2,
+            'type'               => \CommonITILActor::REQUESTER
+         ])
+      )->isFalse();
+
+      //remove old user manually because from IHM is done before update ticket
+      $ticket_user = new \Ticket_User();
+      $ticket_user->deleteByCriteria([
+         "users_id" => $userPostOnly->fields['id'],
+         "tickets_id" => $tickets_id
+      ]);
+
+
+      //update ticket and change requester
+      $ticket->update($ticket_input = [
+         'name'                  => 'Add group requester',
+         'id'                    => $tickets_id,
+         'content'               => 'test',
+         '_itil_requester'   => ["_type" => "user",
+                                 "users_id" => $userNormal->fields['id']]
+      ]);
+      unset($ticket_input['_itil_requester']);
+      $this->checkInput($ticket, $tickets_id, $ticket_input);
+
+      //link between groupe1 and ticket will exist
+      $ticketGroup = new \Group_Ticket();
+      $this->boolean(
+         $ticketGroup->getFromDBByCrit([
+            'tickets_id'         => $tickets_id,
+            'groups_id'          => $group_id1,
+            'type'               => \CommonITILActor::REQUESTER
+         ])
+      )->isTrue();
+
+      //link between groupe2 and ticket will not exist
+      $this->boolean(
+         $ticketGroup->getFromDBByCrit([
+            'tickets_id'         => $tickets_id,
+            'groups_id'          => $group_id2,
+            'type'               => \CommonITILActor::REQUESTER
+         ])
+      )->isTrue();
+
    }
 
    public function testValidationCriteria() {

--- a/tests/functionnal/RuleTicket.php
+++ b/tests/functionnal/RuleTicket.php
@@ -858,10 +858,9 @@ class RuleTicket extends DbTestCase {
          '_users_id_requester'   => $user->fields['id']
       ]);
       unset($ticket_input['_users_id_requester']);
-      unset($ticket_input['id']);
       $this->checkInput($ticket, $tickets_id, $ticket_input);
 
-      //link between groupe1 and ticket will not exist
+      //link between group1 and ticket will not exist
       $ticketGroup = new \Group_Ticket();
       $this->boolean(
          $ticketGroup->getFromDBByCrit([
@@ -871,7 +870,7 @@ class RuleTicket extends DbTestCase {
          ])
       )->isFalse();
 
-      //link between groupe2 and ticket will not exist
+      //link between group2 and ticket will not exist
       $this->boolean(
          $ticketGroup->getFromDBByCrit([
             'tickets_id'         => $tickets_id,
@@ -880,7 +879,7 @@ class RuleTicket extends DbTestCase {
          ])
       )->isFalse();
 
-      //link between groupe3 and ticket will not exist
+      //link between group3 and ticket will not exist
       $this->boolean(
          $ticketGroup->getFromDBByCrit([
             'tickets_id'         => $tickets_id,
@@ -1042,7 +1041,6 @@ class RuleTicket extends DbTestCase {
          '_users_id_requester'   => $user->fields['id']
       ]);
       unset($ticket_input['_users_id_requester']);
-      unset($ticket_input['id']);
       $this->checkInput($ticket, $tickets_id, $ticket_input);
 
       //link between group1 and ticket will exist
@@ -1171,10 +1169,9 @@ class RuleTicket extends DbTestCase {
          '_users_id_requester'   => $userPostOnly->fields['id']
       ]);
       unset($ticket_input['_users_id_requester']);
-      unset($ticket_input['id']);
       $this->checkInput($ticket, $tickets_id, $ticket_input);
 
-      //link between groupe1 and ticket will not exist
+      //link between group1 and ticket will not exist
       $ticketGroup = new \Group_Ticket();
       $this->boolean(
          $ticketGroup->getFromDBByCrit([
@@ -1184,7 +1181,7 @@ class RuleTicket extends DbTestCase {
          ])
       )->isFalse();
 
-      //link between groupe2 and ticket will not exist
+      //link between group2 and ticket will not exist
       $this->boolean(
          $ticketGroup->getFromDBByCrit([
             'tickets_id'         => $tickets_id,
@@ -1193,7 +1190,7 @@ class RuleTicket extends DbTestCase {
          ])
       )->isFalse();
 
-      //link between groupe2 and ticket will not exist
+      //link between group2 and ticket will not exist
       $this->boolean(
          $ticketGroup->getFromDBByCrit([
             'tickets_id'         => $tickets_id,

--- a/tests/functionnal/RuleTicket.php
+++ b/tests/functionnal/RuleTicket.php
@@ -787,6 +787,138 @@ class RuleTicket extends DbTestCase {
       $this->string($task_data['content'])->isEqualTo('test content');
    }
 
+   public function testGroupRequesterAssignFromUserGroupsAndRegexOnUpdateTicketContent() {
+      $this->login();
+
+      // Create rule
+      $ruleticket = new \RuleTicket();
+      $rulecrit   = new \RuleCriteria();
+      $ruleaction = new \RuleAction();
+
+      $ruletid = $ruleticket->add($ruletinput = [
+         'name'         => 'test regex group requester criterion',
+         'match'        => 'AND',
+         'is_active'    => 1,
+         'sub_type'     => 'RuleTicket',
+         'condition'    => \RuleTicket::ONUPDATE,
+         'is_recursive' => 0,
+      ]);
+      $this->checkInput($ruleticket, $ruletid, $ruletinput);
+
+      //create criteria to check if group requester match regex
+      $crit_id = $rulecrit->add($crit_input = [
+         'rules_id'  => $ruletid,
+         'criteria'  => '_groups_id_of_requester',
+         'condition' => \Rule::REGEX_MATCH,
+         'pattern'   => Toolbox::addslashes_deep('/(.+\([^()]*\))/'),   //retrieve groupe with '(' and ')'
+      ]);
+      //change value because of addslashes
+      $crit_input['pattern'] = '/(.+\([^()]*\))/';
+      $this->checkInput($rulecrit, $crit_id, $crit_input);
+
+      //create action to put  group matching on criteria
+      $action_id = $ruleaction->add($action_input = [
+         'rules_id'    => $ruletid,
+         'action_type' => 'regex_result',
+         'field'       => '_groups_id_requester',
+         'value'       => '#0',
+      ]);
+      $this->checkInput($ruleaction, $action_id, $action_input);
+
+      //Load user post_only
+      $user = new \User();
+      $user->getFromDB(getItemByTypeName('User', 'post-only', true));
+
+      //create 2 new group
+      $group = new \Group();
+      $group_id1 = $group->add($group_input = [
+         "name"         => "group1 (5215)",
+         "is_requester" => true
+      ]);
+      $this->checkInput($group, $group_id1, $group_input);
+
+      //create new group
+      $group_id2 = $group->add($group_input = [
+         "name"         => "group2 (13)",
+         "is_requester" => true
+      ]);
+      $this->checkInput($group, $group_id2, $group_input);
+
+      // create ticket that trigger rule on creation
+      $ticket = new \Ticket();
+      $ticket->getEmpty();
+      $tickets_id = $ticket->add($ticket_input = [
+         'name'                  => 'Add group requester',
+         'id'                    => 0, //pass id = 0 because in IHM it's passed as POST
+         'content'               => 'test',
+         '_users_id_requester'   => $user->fields['id']
+      ]);
+      unset($ticket_input['_users_id_requester']);
+      $ticket_input['id'] = $tickets_id; //force id to $input
+      $this->checkInput($ticket, $tickets_id, $ticket_input);
+
+      //link between groupe1 and ticket will exist
+      $ticketGroup = new \Group_Ticket();
+      $this->boolean(
+         $ticketGroup->getFromDBByCrit([
+            'tickets_id'         => $tickets_id,
+            'groups_id'          => $group_id1,
+            'type'               => \CommonITILActor::REQUESTER
+         ])
+      )->isFalse();
+
+      //link between groupe2 and ticket will not exist
+      $this->boolean(
+         $ticketGroup->getFromDBByCrit([
+            'tickets_id'         => $tickets_id,
+            'groups_id'          => $group_id2,
+            'type'               => \CommonITILActor::REQUESTER
+         ])
+      )->isFalse();
+
+      //add user to groups
+      $group_user = new Group_User();
+      $group_user_id1 = $group_user->add($group_user_input = [
+         "groups_id" => $group_id1,
+         "users_id"  => $user->fields['id']
+      ]);
+      $this->checkInput($group_user, $group_user_id1, $group_user_input);
+
+      $group_user = new Group_User();
+      $group_user_id2 = $group_user->add($group_user_input = [
+         "groups_id" => $group_id2,
+         "users_id"  => $user->fields['id']
+      ]);
+      $this->checkInput($group_user, $group_user_id2, $group_user_input);
+
+      //update ticket and update only content
+      $ticket->update($ticket_input = [
+         'id'                    => $tickets_id,
+         'content'               => 'testupdated',
+      ]);
+      $this->checkInput($ticket, $tickets_id, $ticket_input);
+
+      //link between groupe1 and ticket will exist
+      $ticketGroup = new \Group_Ticket();
+      $this->boolean(
+         $ticketGroup->getFromDBByCrit([
+            'tickets_id'         => $tickets_id,
+            'groups_id'          => $group_id1,
+            'type'               => \CommonITILActor::REQUESTER
+         ])
+      )->isTrue();
+
+      //link between groupe2 and ticket will not exist
+      $this->boolean(
+         $ticketGroup->getFromDBByCrit([
+            'tickets_id'         => $tickets_id,
+            'groups_id'          => $group_id2,
+            'type'               => \CommonITILActor::REQUESTER
+         ])
+      )->isTrue();
+
+   }
+
    public function testGroupRequesterAssignFromUserGroupsAndRegexOnAdd() {
       $this->login();
 
@@ -1006,7 +1138,6 @@ class RuleTicket extends DbTestCase {
          "users_id" => $userPostOnly->fields['id'],
          "tickets_id" => $tickets_id
       ]);
-
 
       //update ticket and change requester
       $ticket->update($ticket_input = [


### PR DESCRIPTION
Master TU are broken

Several elements are involved

- Always prepare user data for rule on update only if we have some changes on ticket
https://github.com/glpi-project/glpi/blob/65df212e2fb8faff3a214a38399a0a3468e56465/inc/ticket.class.php#L1111-L1135
- Capability to use regex to add groups with ```_additional_groups_requesters```
https://github.com/glpi-project/glpi/blob/65df212e2fb8faff3a214a38399a0a3468e56465/inc/ruleticket.class.php#L369-L379

Description :
- Create ```Ticket```
- RuleTicket  add groups to ```_additional_groups_requesters```
- On ``post_addItem``` process ```CommonItilObject ``` add  ```_additional_groups_requesters```  (```addAdditionalActors```)
- Then GLPI try to update ```date_mod``` from main item (```Ticket```)
```prepareInputForUpdate``` detect two key (```[_contract_types] => Array (),[_date_creation_calendars_id]```) for changes  even if there are no ```real``` changes.
https://github.com/glpi-project/glpi/blob/65df212e2fb8faff3a214a38399a0a3468e56465/inc/ticket.class.php#L1085-L1093
- Changes are detected so prepare user data for rule on update
- RuleTicket  add groups to ```_additional_groups_requesters```
- ```CommonItilObject ``` add  ```_additional_groups_requesters```  but groups already exist -> SQL error
``` 
*** MySQL query error:
==>   SQL: INSERT INTO `glpi_groups_tickets` (`tickets_id`, `type`, `groups_id`) VALUES ('190', '1', '141')
==>   Error: Duplicate entry '190-1-141' for key 'glpi_groups_tickets.unicity'
```

Stacktrace :
```
2021-06-09 09:07:24 [2@Desktop]
  Backtrace :
  inc/commonitilobject.class.php:2092                Toolbox::backtrace()
  inc/commonitilobject.class.php:1067                CommonITILObject->addAdditionalActors()
  inc/ticket.class.php:1194                          CommonITILObject->prepareInputForUpdate()
  inc/commondbtm.class.php:1520                      Ticket->prepareInputForUpdate()
  inc/ticket.class.php:2320                          CommonDBTM->update()
  inc/commonitilactor.class.php:382                  Ticket->updateDateMod()
  inc/ticket_user.class.php:59                       CommonITILActor->post_addItem()
  inc/commondbtm.class.php:1192                      Ticket_User->post_addItem()
  inc/commonitilobject.class.php:1917                CommonDBTM->add()
  inc/ticket.class.php:1912                          CommonITILObject->post_addItem()
  inc/commondbtm.class.php:1192                      Ticket->post_addItem()
  front/ticket.form.php:63                           CommonDBTM->add()
2021-06-09 09:07:24 [2@Desktop]
  Backtrace :
  inc/commonitilobject.class.php:2092                Toolbox::backtrace()
  inc/commonitilobject.class.php:2034                CommonITILObject->addAdditionalActors()
  inc/ticket.class.php:1912                          CommonITILObject->post_addItem()
  inc/commondbtm.class.php:1192                      Ticket->post_addItem()
  front/ticket.form.php:63                           CommonDBTM->add()
```

To prevent error, adding check to knwo if group requester is already added.

This check is still mandatory, because at each update the groups are recalculated and GLPI try to add theme each time.

Only for group requester because is the only 'type' which have capability to use ```regex``` and ```_additional_groups_requesters``` from ```Ruleticket``` 

| Q             | A
| ------------- | ---
| Bug fix?      | yes| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
