### PR TITLE
Avoid conflicting sql aliases

### DIFF
--- a/inc/dashboard/provider.class.php
+++ b/inc/dashboard/provider.class.php
@@ -1538,20 +1538,20 @@ class Provider extends CommonGLPI {
             $itemtype  = getItemTypeForTable($table);
             $main_item = getItemForItemtype($itemtype);
             $userlink  = $main_item->userlinkclass;
-            $gl_table  = $userlink::getTable();
+            $ul_table  = $userlink::getTable();
             $fk        = $main_item->getForeignKeyField();
 
             $join += [
-               "$gl_table as gl" => [
+               "$ul_table as ul" => [
                   'ON' => [
-                     'gl'   => $fk,
+                     'ul'   => $fk,
                      $table => 'id',
                   ]
                ]
             ];
             $where += [
-               "gl.type"     => \CommonITILActor::ASSIGN,
-               "gl.users_id" => (int) $apply_filters['user_tech']
+               "ul.type"     => \CommonITILActor::ASSIGN,
+               "ul.users_id" => (int) $apply_filters['user_tech']
             ];
          }
       }


### PR DESCRIPTION
When using at the same time the filters
- technician
- technician group

the resulting SQL query contains 2 tables with the same alias "gl".

I guess this is a code copy / paste problem, and despite these filter will unlikely used together, this PR prevents an empty / erroneous card.