### PR TITLE
Fix lint

### DIFF
--- a/tests/functionnal/IPAddress.php
+++ b/tests/functionnal/IPAddress.php
@@ -32,8 +32,7 @@
 
 namespace tests\units;
 
-use \DbTestCase;
-use NetworkName;
+use DbTestCase;
 
 /* Test for inc/networkport.class.php */
 


### PR DESCRIPTION
Lint seems broken since https://github.com/glpi-project/glpi/pull/9139.

Tests were successful in #9139 but are failing in #9145:
![image](https://user-images.githubusercontent.com/42734840/121205039-a338bc80-c877-11eb-9ab9-0fa0640c8e23.png)

Why didn't the tests fail for #9139 ?


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
