### PR TITLE
Support larger impact graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The present file will list all changes made to the project; according to the
 #### Changes
 - Format of `Message-Id` header sent in Tickets notifications changed to match format used by other items.
 - Added `DB::truncate()` to replace raw SQL queries
+- Impact context `positions` field type changed from `TEXT` to `MEDIUMTEXT`
 
 #### Deprecated
 - Usage of `GLPI_FORCE_EMPTY_SQL_MODE` constant

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -317,7 +317,7 @@ class Migration {
          case 'text' :
          case 'mediumtext' :
          case 'longtext' :
-            $format = sprintf('%s collate %s', strtoupper($type), $collate);
+            $format = sprintf('%s COLLATE %s', strtoupper($type), $collate);
             if (!$nodefault) {
                if (is_null($default_value)) {
                   $format .= " DEFAULT NULL";

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -315,23 +315,18 @@ class Migration {
             break;
 
          case 'text' :
-            $format = "TEXT COLLATE $collate";
-            if (!$nodefault) {
-               if (is_null($default_value)) {
-                  $format.= " DEFAULT NULL";
-               } else {
-                  $format.= " NOT NULL DEFAULT '$default_value'";
-               }
-            }
-            break;
-
+         case 'mediumtext' :
          case 'longtext' :
-            $format = "LONGTEXT COLLATE $collate";
+            $format = sprintf('%s collate %s', strtoupper($type), $collate);
             if (!$nodefault) {
                if (is_null($default_value)) {
                   $format .= " DEFAULT NULL";
                } else {
-                  $format .= " NOT NULL DEFAULT '$default_value'";
+                  if (empty($default_value)) {
+                     $format .= " NOT NULL";
+                  } else {
+                     $format .= " NOT NULL DEFAULT '$default_value'";
+                  }
                }
             }
             break;
@@ -429,7 +424,7 @@ class Migration {
     * @param string $newfield New name of the field
     * @param string $type     Field type, @see Migration::fieldFormat()
     * @param array  $options  Options:
-    *                         - default_value new field's default value, if a specific default value needs to be used
+    *                         - value     : new field's default value, if a specific default value needs to be used
     *                         - first     : add the new field at first column
     *                         - after     : where adding the new field
     *                         - null      : value could be NULL (default false)

--- a/inc/system/diagnostic/databaseschemachecker.class.php
+++ b/inc/system/diagnostic/databaseschemachecker.class.php
@@ -154,8 +154,8 @@ class DatabaseSchemaChecker {
 
       $differ = new Differ();
       return $differ->diff(
-         $this->getNomalizedSql($proper_create_table_sql),
-         $this->getNomalizedSql($effective_create_table_sql)
+         $proper_create_table_sql,
+         $effective_create_table_sql
       );
    }
 
@@ -245,8 +245,10 @@ class DatabaseSchemaChecker {
       if ($this->db->use_utf8mb4) {
          // Remove default charset / collate
          $column_replacements['/( CHARACTER SET utf8mb4)? COLLATE utf8mb4_unicode_ci/i'] = '';
-         // text were replaced by mediumtext during utf8mb4 migration
-         $column_replacements['/mediumtext/i'] = 'text';
+         // "text" fields were replaced by larger type during utf8mb4 migration.
+         // As is it not really possible to know if checked database has been modified by utf8mb4 migration
+         // or not, we normalize "mediumtext" and "longtext" fields to "text".
+         $column_replacements['/(medium|long)text/i'] = 'text';
       } else {
          // Remove default charset / collate
          $column_replacements['/( CHARACTER SET utf8)? COLLATE utf8_unicode_ci/i'] = '';

--- a/install/migrations/update_9.5.x_to_10.0.0/impact.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/impact.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+/** Impact Relations improvements */
+
+$migration->changeField('glpi_impactcontexts', 'positions', 'positions', 'mediumtext', [
+   'after' => 'id',
+   'value' => '',
+]);

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -1255,7 +1255,7 @@ CREATE TABLE `glpi_impactitems` (
 DROP TABLE IF EXISTS `glpi_impactcontexts`;
 CREATE TABLE `glpi_impactcontexts` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `positions` text NOT NULL,
+  `positions` mediumtext NOT NULL,
   `zoom` float NOT NULL DEFAULT '0',
   `pan_x` float NOT NULL DEFAULT '0',
   `pan_y` float NOT NULL DEFAULT '0',

--- a/tests/units/Glpi/System/Diagnostic/DatabaseSchemaChecker.php
+++ b/tests/units/Glpi/System/Diagnostic/DatabaseSchemaChecker.php
@@ -239,12 +239,14 @@ SQL
          // - should accept missing default charset/collate on columns if matching utf8mb4;
          // - should not accept non utf8mb4 charset;
          // - should accept 'mediumtext' instead of 'text'.
+         // - should accept 'longtext' instead of 'mediumtext'.
          [
             'proper_sql'     => <<<SQL
 CREATE TABLE `table` (
   `id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   `content` text,
+  `description` mediumtext,
   `bis` varchar(100),
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
@@ -255,6 +257,7 @@ CREATE TABLE `table` (
   `id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL CHARACTER SET utf8 COLLATE utf8_unicode_ci,
   `content` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `description` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `bis` varchar(100) CHARSET latin1,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
@@ -274,6 +277,7 @@ SQL
 -  `name` varchar(255) NOT NULL,
 +  `name` varchar(255) NOT NULL CHARACTER SET utf8 COLLATE utf8_unicode_ci,
    `content` text,
+   `description` text,
 -  `bis` varchar(100),
 +  `bis` varchar(100) CHARSET latin1,
    PRIMARY KEY (`id`)
@@ -287,12 +291,14 @@ DIFF
          // - should accept missing default charset/collate on columns if matching utf8;
          // - should not accept non utf8 charset;
          // - should not accept 'mediumtext' instead of 'text'.
+         // - should not accept 'longtext' instead of 'mediumtext'.
          [
             'proper_sql'     => <<<SQL
 CREATE TABLE `table` (
   `id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   `content` text,
+  `description` mediumtext,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci
 SQL
@@ -302,6 +308,7 @@ CREATE TABLE `table` (
   `id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `content` mediumtext CHARACTER SET utf8 COLLATE utf8_unicode_ci,
+  `description` longtext CHARACTER SET utf8 COLLATE utf8_unicode_ci,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci
 SQL
@@ -319,8 +326,10 @@ SQL
    `id` int NOT NULL AUTO_INCREMENT,
 -  `name` varchar(255) NOT NULL,
 -  `content` text,
+-  `description` mediumtext,
 +  `name` varchar(255) NOT NULL CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
 +  `content` mediumtext,
++  `description` longtext,
    PRIMARY KEY (`id`)
  ) COLLATE=utf8_unicode_ci DEFAULT CHARSET=utf8 ENGINE=InnoDB
 

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -417,6 +417,32 @@ class Migration extends \GLPITestCase {
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
+            'format'    => 'mediumtext',
+            'options'   => [],
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` MEDIUMTEXT COLLATE utf8_unicode_ci DEFAULT NULL   ",
+            'utf8mb4'   => false,
+         ], [
+            'table'     => 'my_table',
+            'field'     => 'my_field',
+            'format'    => 'mediumtext',
+            'options'   => [],
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` MEDIUMTEXT COLLATE utf8mb4_unicode_ci DEFAULT NULL   ",
+         ], [
+            'table'     => 'my_table',
+            'field'     => 'my_field',
+            'format'    => 'mediumtext',
+            'options'   => ['value' => 'A medium text'],
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` MEDIUMTEXT COLLATE utf8_unicode_ci NOT NULL DEFAULT 'A medium text'   ",
+            'utf8mb4'   => false,
+         ], [
+            'table'     => 'my_table',
+            'field'     => 'my_field',
+            'format'    => 'mediumtext',
+            'options'   => ['value' => 'A medium text'],
+            'sql'       => "ALTER TABLE `my_table` ADD `my_field` MEDIUMTEXT COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'A medium text'   ",
+         ], [
+            'table'     => 'my_table',
+            'field'     => 'my_field',
             'format'    => 'longtext',
             'options'   => [],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` LONGTEXT COLLATE utf8_unicode_ci DEFAULT NULL   ",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Currently, the `positions` field in `glpi_impactcontexts` uses TEXT which can store around 16,383 4-byte characters and each item on the graph seems to take around 60 characters in the JSON (mostly from using 13 decimal places for each coordinate value), leaving room for around 270 items total. In large/complex environments, it may be desired to view more devices all in the same graph.
MEDIUMTEXT would support around 69,905 items in each graph.