### PR TITLE
Don't redirect to AJAX URLs

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -536,15 +536,18 @@ class Html {
     * @return void
    **/
    static function redirectToLogin($params = '') {
-      global $CFG_GLPI;
+      global $CFG_GLPI, $AJAX_INCLUDE;
 
       $dest     = $CFG_GLPI["root_doc"] . "/index.php";
-      $url_dest = preg_replace(
-         '/^' . preg_quote($CFG_GLPI["root_doc"], '/') . '/',
-         '',
-         $_SERVER['REQUEST_URI']
-      );
-      $dest    .= "?redirect=".rawurlencode($url_dest);
+
+      if (!isset($AJAX_INCLUDE)) {
+         $url_dest = preg_replace(
+            '/^' . preg_quote($CFG_GLPI["root_doc"], '/') . '/',
+            '',
+            $_SERVER['REQUEST_URI']
+         );
+         $dest .= "?redirect=" . rawurlencode($url_dest);
+      }
 
       if (!empty($params)) {
          $dest .= '&'.$params;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I don't full understand how it happened, but on a modern UI branch I tried logging out while the dashboard was still loading and it redirected me to the login screen with a dashboard AJAX URL set as the redirect. I guess in this edge case, the user should just get redirect to the home page since we cannot tell where they actually came from.