### PR TITLE
Use correct entity when splitting tickets

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -4212,6 +4212,13 @@ class Ticket extends CommonITILObject {
                   'link'         => Ticket_Ticket::SON_OF,
                   'tickets_id_2' => $fup->fields['items_id']
                ];
+
+               // Set entity from parent
+               $parent_itemtype = $fup->getField('itemtype');
+               $parent = new $parent_itemtype();
+               if ($parent->getFromDB($fup->getField('items_id'))) {
+                  $options['entities_id'] = $parent->getField('entities_id');
+               }
             }
             //Allow overriding the default values
             $options['_skip_promoted_fields'] = true;


### PR DESCRIPTION
When we split a ticket (Entity A) while using another entity (Root entity) :
![image](https://user-images.githubusercontent.com/42734840/121484997-105f6580-c9d0-11eb-9623-1b6240f96b3b.png)

The newly created ticket will be in Root entity instead of Entity A:
![image](https://user-images.githubusercontent.com/42734840/121485146-3553d880-c9d0-11eb-8174-67395ae19d88.png)

This is because we don't specify any entity when splitting so GLPI just use the current entity which may differ from the one in the original ticket.

The fix is simply to pass the correct entity to the creation form.

After:
![image](https://user-images.githubusercontent.com/42734840/121485462-7cda6480-c9d0-11eb-8f34-b1786f9d9531.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22234
