### PR TITLE
add action button in user synchronization tab to clear ldap sync field

### DIFF
--- a/front/user.form.php
+++ b/front/user.form.php
@@ -100,6 +100,13 @@ if (isset($_GET['getvcard'])) {
    AuthLDAP::forceOneUserSynchronization($user);
    Html::back();
 
+} else if (isset($_POST["clean_ldap_fields"])) {
+   Session::checkRight('user', User::UPDATEAUTHENT);
+
+   $user->getFromDB($_POST["id"]);
+   AuthLDAP::forceOneUserSynchronization($user, true);
+   Html::back();
+
 } else if (isset($_POST["update"])) {
    $user->check($_POST['id'], UPDATE);
    $user->update($_POST);

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -1379,10 +1379,11 @@ class Auth extends CommonGLPI {
                      'name' => 'force_ldap_resynch'
                   ]);
 
-                  if (strlen($authldap->fields['sync_field']) > 0)
-                  echo Html::submit("<i class='fas fa-broom'></i><span>".__s('Clean ldap fields and force synchronisation')."</span>", [
-                     'name' => 'clean_ldap_fields'
-                  ]);
+                  if (strlen($authldap->fields['sync_field']) > 0) {
+                     echo Html::submit("<i class='fas fa-broom'></i><span>".__s('Clean ldap fields and force synchronisation')."</span>", [
+                        'name' => 'clean_ldap_fields'
+                     ]);
+                  }
                }
                break;
 

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -1380,7 +1380,7 @@ class Auth extends CommonGLPI {
                   ]);
 
                   if (strlen($authldap->fields['sync_field']) > 0) {
-                     echo Html::submit("<i class='fas fa-broom'></i><span>".__s('Clean ldap fields and force synchronisation')."</span>", [
+                     echo Html::submit("<i class='fas fa-broom'></i><span>".__s('Clean LDAP fields and force synchronisation')."</span>", [
                         'name' => 'clean_ldap_fields'
                      ]);
                   }

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -39,7 +39,7 @@ if (!defined('GLPI_ROOT')) {
 /**
  *  Identification class used to login
  */
-class Auth {
+class Auth extends CommonGLPI {
 
    /** @var array Array of errors */
    private $errors = [];
@@ -1361,6 +1361,7 @@ class Auth {
       if (Session::haveRight("user", User::UPDATEAUTHENT)) {
          echo "<form method='post' action='".Toolbox::getItemTypeFormURL('User')."'>";
          echo "<div class='firstbloc'>";
+         echo "<input type='hidden' name='id' value='".$user->getID()."'>";
 
          switch ($user->getField('authtype')) {
             case self::CAS :
@@ -1369,19 +1370,19 @@ class Auth {
             case self::LDAP :
                //Look it the auth server still exists !
                // <- Bad idea : id not exists unable to change anything
-               // SQL query
-               $result = $DB->request([
-                   'SELECT' => 'name',
-                   'FROM' => 'glpi_authldaps',
-                   'WHERE' => ['id' => $user->getField('auths_id'), 'is_active' => 1],
-               ]);
+               $authldap = new AuthLDAP;
+               if ($authldap->getFromDBByCrit([
+                  'id'        => $user->getField('auths_id'),
+                  'is_active' => 1,
+               ])) {
+                  echo Html::submit("<i class='fas fa-sync-alt'></i><span>".__s('Force synchronization')."</span>", [
+                     'name' => 'force_ldap_resynch'
+                  ]);
 
-               if ($result->numrows() > 0) {
-                  echo "<table class='tab_cadre'><tr class='tab_bg_2'><td>";
-                  echo "<input type='hidden' name='id' value='".$user->getID()."'>";
-                  echo "<input class=submit type='submit' name='force_ldap_resynch' value='" .
-                         __s('Force synchronization') . "'>";
-                  echo "</td></tr></table>";
+                  if (strlen($authldap->fields['sync_field']) > 0)
+                  echo Html::submit("<i class='fas fa-broom'></i><span>".__s('Clean ldap fields and force synchronisation')."</span>", [
+                     'name' => 'clean_ldap_fields'
+                  ]);
                }
                break;
 
@@ -1389,21 +1390,18 @@ class Auth {
             case self::MAIL :
                break;
          }
+
          echo "</div>";
 
          echo "<div class='spaced'>";
-         echo "<table class='tab_cadre'>";
-         echo "<tr><th>".__('Change of the authentication method')."</th></tr>";
-         echo "<tr class='tab_bg_2'><td class='center'>";
+         echo "<h3>".__('Change of the authentication method')."</h3>";
          $rand             = self::dropdown(['name' => 'authtype']);
          $paramsmassaction = ['authtype' => '__VALUE__',
                                    'name'     => 'change_auth_method'];
          Ajax::updateItemOnSelectEvent("dropdown_authtype$rand", "show_massiveaction_field",
                                        $CFG_GLPI["root_doc"]."/ajax/dropdownMassiveActionAuthMethods.php",
                                        $paramsmassaction);
-         echo "<input type='hidden' name='id' value='" . $user->getID() . "'>";
          echo "<span id='show_massiveaction_field'></span>";
-         echo "</td></tr></table>";
          echo "</div>";
          Html::closeForm();
       }

--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -2454,16 +2454,26 @@ class AuthLDAP extends CommonDBTM {
    /**
     * Force synchronization for one user
     *
-    * @param User    $user    User to synchronize
-    * @param boolean $display Display message information on redirect (true by default)
+    * @param User    $user              User to synchronize
+    * @param boolean $clean_ldap_fields empty user_dn and sync_field before import user again
+    * @param boolean $display           Display message information on redirect (true by default)
     *
     * @return array|boolean  with state, else false
     */
-   static function forceOneUserSynchronization(User $user, $display = true) {
+   static function forceOneUserSynchronization(User $user, $clean_ldap_fields = false, $display = true) {
       $authldap = new AuthLDAP();
 
       //Get the LDAP server from which the user has been imported
       if ($authldap->getFromDB($user->fields['auths_id'])) {
+         // clean ldap fields if asked by admin
+         if ($clean_ldap_fields) {
+            $user->update([
+               'id'         => $user->fields['id'],
+               'user_dn'    => '',
+               'sync_field' => '',
+            ]);
+         }
+
          $user_field = 'name';
          $id_field = $authldap->fields['login_field'];
          if ($authldap->isSyncFieldEnabled() && !empty($user->fields['sync_field'])) {

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -3056,7 +3056,7 @@ JAVASCRIPT;
                if ($item->can($id, UPDATE)) {
                   if (($item->fields["authtype"] == Auth::LDAP)
                       || ($item->fields["authtype"] == Auth::EXTERNAL)) {
-                     if (AuthLDAP::forceOneUserSynchronization($item, false)) {
+                     if (AuthLDAP::forceOneUserSynchronization($item, false, false)) {
                         $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
                      } else {
                         $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -959,6 +959,7 @@ class AuthLDAP extends DbTestCase {
          ->string['phone']->isIdenticalTo('034596780')
          ->string['user_dn']->isIdenticalTo('uid=ecuador0,ou=people,ou=ldap3,dc=glpi,dc=org');
 
+      // update the user in ldap (change phone number)
       $this->boolean(
          ldap_modify(
             $ldap->connect(),
@@ -983,12 +984,14 @@ class AuthLDAP extends DbTestCase {
          ->integer['action']->isIdenticalTo(\AuthLDAP::USER_SYNCHRONIZED)
          ->variable['id']->isEqualTo($user->getID());
 
+      // check phone number has been synced
       $this->boolean($user->getFromDB($user->getID()))->isTrue();
       $this->array($user->fields)
          ->string['name']->isIdenticalTo('ecuador0')
          ->string['phone']->isIdenticalTo('+33101010101')
          ->string['user_dn']->isIdenticalTo('uid=ecuador0,ou=people,ou=ldap3,dc=glpi,dc=org');
 
+      // update sync field of user
       $this->boolean(
          $ldap->update([
             'id'           => $ldap->getID(),
@@ -998,6 +1001,7 @@ class AuthLDAP extends DbTestCase {
 
       $this->boolean($ldap->isSyncFieldEnabled())->isTrue();
 
+      // add sync field attribute in ldap user
       $this->boolean(
          ldap_mod_add(
             $ldap->connect(),
@@ -1016,6 +1020,7 @@ class AuthLDAP extends DbTestCase {
 
       $this->variable($user->fields['sync_field'])->isEqualTo(42);
 
+      // rename the user (uid change, syncfield keep its value)
       $this->boolean(
          ldap_rename(
             $ldap->connect(),
@@ -1047,6 +1052,7 @@ class AuthLDAP extends DbTestCase {
          )
       )->isTrue();
 
+      // check the `name` field (corresponding to the uid) has been updated for the user
       $this->boolean($user->getFromDB($user->getID()))->isTrue();
       $this->array($synchro)
          ->hasSize(2)
@@ -1055,6 +1061,66 @@ class AuthLDAP extends DbTestCase {
 
       $this->variable($user->fields['sync_field'])->isEqualTo(42);
       $this->string($user->fields['name'])->isIdenticalTo('testecuador');
+
+      // ## test we can sync the when the syncfield is different but after we reset it manually
+      $this->boolean(
+         ldap_mod_add(
+            $ldap->connect(),
+            'uid=ecuador0,ou=people,ou=ldap3,dc=glpi,dc=org',
+            ['employeeNumber' => '42']
+         )
+      )->isTrue();
+
+      $synchro = $ldap->forceOneUserSynchronization($user);
+
+      $this->boolean($user->getFromDB($user->getID()))->isTrue();
+      $this->array($synchro)
+         ->hasSize(2)
+         ->integer['action']->isIdenticalTo(\AuthLDAP::USER_SYNCHRONIZED)
+         ->variable['id']->isEqualTo($user->getID());
+
+      $this->variable($user->fields['sync_field'])->isEqualTo(42);
+
+      $this->boolean(
+         ldap_mod_replace(
+            $ldap->connect(),
+            'uid=ecuador0,ou=people,ou=ldap3,dc=glpi,dc=org',
+            ['employeeNumber' => '43']
+         )
+      )->isTrue();
+
+      // do a simple sync
+      $synchro = $ldap->forceOneUserSynchronization($user);
+      $this->boolean($user->getFromDB($user->getID()))->isTrue();
+
+      // the sync field should have been kept
+      // but the user should now be in non synchronized state
+      $this->variable($user->fields['sync_field'])->isEqualTo(42);
+      $this->array($synchro)
+         ->hasSize(2)
+         ->integer['action']->isIdenticalTo(\AuthLDAP::USER_DELETED_LDAP)
+         ->variable['id']->isEqualTo($user->getID());
+
+      // sync after emptying the sync field
+      $synchro2 = $ldap->forceOneUserSynchronization($user, true);
+      $this->boolean($user->getFromDB($user->getID()))->isTrue();
+
+      // the sync field should have changed
+      // and the user is now synchronized again
+      $this->variable($user->fields['sync_field'])->isEqualTo(43);
+      $this->array($synchro2)
+         ->hasSize(2)
+         ->integer['action']->isIdenticalTo(\AuthLDAP::USER_SYNCHRONIZED)
+         ->variable['id']->isEqualTo($user->getID());
+
+      // reset attribute
+      $this->boolean(
+         ldap_mod_del(
+            $ldap->connect(),
+            'uid=ecuador0,ou=people,ou=ldap3,dc=glpi,dc=org',
+            ['employeeNumber' => 43]
+         )
+      )->isTrue();
 
       global $DB;
       $DB->updateOrDie(

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -1062,7 +1062,7 @@ class AuthLDAP extends DbTestCase {
       $this->variable($user->fields['sync_field'])->isEqualTo(42);
       $this->string($user->fields['name'])->isIdenticalTo('testecuador');
 
-      // ## test we can sync the when the syncfield is different but after we reset it manually
+      // ## test we can sync the user when the syncfield is different but after we reset it manually
       $this->boolean(
          ldap_mod_add(
             $ldap->connect(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal ref !20695

ldap fields match:
- user.name -> sameaccountname
- user.sync_field -> guid

Scenario:
- A user was created in glpi with ldap entry: [sameaccountname = user1, guid = 1]
- The user was deleted from ldap ands kept in GLPI (for history)
- The user is recreated with the same login but another guid [sameaccountname = user1, guid = 2]
- The user cannot login because the glpi entry is locked on the previous sync_field value.

I propose a new action in synchronization tab to clear the sync_field (and force a sync) to fix the last step of the scenarion.
It requires a manual action because the purpose of sync_field is exactly done to sync a user despite login changes in ldap server.