### PR TITLE
Take extra fields into account when executing a RuleRight

### DIFF
--- a/inc/ruleright.class.php
+++ b/inc/ruleright.class.php
@@ -138,6 +138,10 @@ class RuleRight extends Rule {
                         $output_src["_stop_import"] = true;
                         break;
 
+                     default:
+                        $output[$action->fields["field"]] = $action->fields["value"];
+                        break;
+
                   } // switch (field)
                   break;
 


### PR DESCRIPTION
You can add new actions for rule through plugins with the `plugin_XXXXX_getRuleActions` hook.
The `executeAction` method for `RuleRight` use only specifics switch/cases values so the extra fields were never taken into account.

To fix this I've added a generic default case.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
