### PR TITLE
Fix encoding for "message/rfc822" attachments

### DIFF
--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -362,7 +362,7 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
          $mime = mime_content_type($path);
          if ($mime == "message/rfc822") {
             // messages/rfc822 can't be encoded in base64 according to RFC2046
-            // https://datatracker.ietf.org/doc/html/rfc2046)
+            // https://datatracker.ietf.org/doc/html/rfc2046
             $encoding = PHPMailer::ENCODING_8BIT;
          }
 

--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use PHPMailer\PHPMailer\PHPMailer;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -355,9 +357,19 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                'mail'
             );
          }
+
+         $encoding = PHPMailer::ENCODING_BASE64;
+         $mime = mime_content_type($path);
+         if ($mime == "message/rfc822") {
+            // messages/rfc822 can't be encoded in base64 according to RFC2046
+            // https://datatracker.ietf.org/doc/html/rfc2046)
+            $encoding = PHPMailer::ENCODING_8BIT;
+         }
+
          $mmail->addAttachment(
             $path,
-            $document->fields['filename']
+            $document->fields['filename'],
+            $encoding
          );
       }
    }


### PR DESCRIPTION
GLPI use `PHPMailer::addAttachment()` to add attachments to emails notifications .
The default encoding used by `PHPMailer::addAttachment()` is base64, this means that every attachments sent by GLPI is base64 encoded.

This is a problem for `message/rfc822 (.eml)` files as they are not allowed to be encoded in base64 according to [RFC2046](https://datatracker.ietf.org/doc/html/rfc2046):
>No encoding other than "7bit", "8bit", or "binary" is permitted for
   the body of a "message/rfc822" entity.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22174
