### PR TITLE
Fix map display on 'All' tab; fixes #9072

### DIFF
--- a/inc/mapgeolocation.class.php
+++ b/inc/mapgeolocation.class.php
@@ -43,7 +43,9 @@ trait MapGeolocation {
     * get openstreetmap
     */
    public function showMap() {
-      echo "<div id='setlocation_container'></div>";
+      $rand = mt_rand();
+
+      echo "<div id='setlocation_container_{$rand}'></div>";
       $js = "var map_elt, _marker;
       var _setLocation = function(lat, lng) {
          if (_marker) {
@@ -83,7 +85,7 @@ trait MapGeolocation {
       }
 
       $(function(){
-         map_elt = initMap($('#setlocation_container'), 'setlocation', '200px');
+         map_elt = initMap($('#setlocation_container_{$rand}'), 'setlocation_{$rand}', '200px');
 
          var osmGeocoder = new L.Control.OSMGeocoder({
             collapsed: false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #9072 

When the "All" tab is displayed just after the main form tab has been displayed, map init does not work due to a conflict on map container and map elements HTML id (they have the same id on both tabs).
Using a randomized id fixes this.