### PR TITLE
Allow multiple custom locales files

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -360,17 +360,32 @@ class Plugin extends CommonDBTM {
          );
       }
 
-      $mofile = str_replace($locales_dir, GLPI_LOCAL_I18N_DIR . '/'.$plugin_key . '/', $mofile);
-      $phpfile = str_replace('.mo', '.php', $mofile);
+      $plugin_folders = scandir(GLPI_LOCAL_I18N_DIR);
+      $plugin_folders = array_filter($plugin_folders, function($dir) use ($plugin_key) {
+         if (!is_dir(GLPI_LOCAL_I18N_DIR . "/$dir")) {
+            return false;
+         }
 
-      // Load local PHP file if it exists
-      if (file_exists($phpfile)) {
-         $TRANSLATE->addTranslationFile('phparray', $phpfile, $plugin_key, $coretrytoload);
-      }
+         if ($dir == $plugin_key) {
+            return true;
+         }
 
-      // Load local MO file if it exists -- keep last so it gets precedence
-      if (file_exists($mofile)) {
-         $TRANSLATE->addTranslationFile('gettext', $mofile, $plugin_key, $coretrytoload);
+         return strpos($dir, $plugin_key . '_') !== false;
+      });
+
+      foreach ($plugin_folders as $plugin_folder) {
+         $mofile = str_replace($locales_dir, GLPI_LOCAL_I18N_DIR . '/'. $plugin_folder . '/', $mofile);
+         $phpfile = str_replace('.mo', '.php', $mofile);
+
+         // Load local PHP file if it exists
+         if (file_exists($phpfile)) {
+            $TRANSLATE->addTranslationFile('phparray', $phpfile, $plugin_key, $coretrytoload);
+         }
+
+         // Load local MO file if it exists -- keep last so it gets precedence
+         if (file_exists($mofile)) {
+            $TRANSLATE->addTranslationFile('gettext', $mofile, $plugin_key, $coretrytoload);
+         }
       }
    }
 

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -370,7 +370,7 @@ class Plugin extends CommonDBTM {
             return true;
          }
 
-         return strpos($dir, $plugin_key . '_') !== false;
+         return Toolbox::startsWith($dir, $plugin_key . '_');
       });
 
       foreach ($plugin_folders as $plugin_folder) {

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -647,7 +647,7 @@ class Session {
             return true;
          }
 
-         return strpos($dir, 'core_') !== false;
+         return Toolbox::startsWith($dir, 'core_');
       });
 
       foreach ($core_folders as $core_folder) {

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -637,17 +637,32 @@ class Session {
 
       $TRANSLATE->addTranslationFile('gettext', GLPI_I18N_DIR.$newfile, 'glpi', $trytoload);
 
-      $mofile = GLPI_LOCAL_I18N_DIR . '/core/' . $newfile;
-      $phpfile = str_replace('.mo', '.php', $mofile);
+      $core_folders = scandir(GLPI_LOCAL_I18N_DIR);
+      $core_folders = array_filter($core_folders, function($dir) {
+         if (!is_dir(GLPI_LOCAL_I18N_DIR . "/$dir")) {
+            return false;
+         }
 
-      // Load local PHP file if it exists
-      if (file_exists($phpfile)) {
-         $TRANSLATE->addTranslationFile('phparray', $phpfile, 'glpi', $trytoload);
-      }
+         if ($dir == 'core') {
+            return true;
+         }
 
-      // Load local MO file if it exists -- keep last so it gets precedence
-      if (file_exists($mofile)) {
-         $TRANSLATE->addTranslationFile('gettext', $mofile, 'glpi', $trytoload);
+         return strpos($dir, 'core_') !== false;
+      });
+
+      foreach ($core_folders as $core_folder) {
+         $mofile = GLPI_LOCAL_I18N_DIR . "/$core_folder/" . $newfile;
+         $phpfile = str_replace('.mo', '.php', $mofile);
+
+         // Load local PHP file if it exists
+         if (file_exists($phpfile)) {
+            $TRANSLATE->addTranslationFile('phparray', $phpfile, 'glpi', $trytoload);
+         }
+
+         // Load local MO file if it exists -- keep last so it gets precedence
+         if (file_exists($mofile)) {
+            $TRANSLATE->addTranslationFile('gettext', $mofile, 'glpi', $trytoload);
+         }
       }
 
       // Load plugin dicts


### PR DESCRIPTION
GLPI allow custom locales in `files/_locales`.
Locale for core are placed in `files/_locales/core` and for a given plugin in `files/_locales/given_plugin_name`.

The main issue with this system is that it only allows one folder per locale "namespace".

To improve this I've modified this behavior to look for `files/_locales/core`  AND `files/_locales/core_*`  files.
This means that two  `core_feature1` and a `core_feature2` folders can coexist and add their own locales without having to be merged in one folder.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
