### PR TITLE
Filter service and change format in HTTP Status endpoint

### DIFF
--- a/status.php
+++ b/status.php
@@ -53,7 +53,7 @@ if ($_SERVER['HTTP_ACCEPT'] === 'text/plain') {
 header('Content-type: ' . $_SERVER['HTTP_ACCEPT']);
 
 if ($_SERVER['HTTP_ACCEPT'] === 'application/json') {
-   echo json_encode(StatusChecker::getServiceStatus(null, true, true));
+   echo json_encode(StatusChecker::getServiceStatus($_REQUEST['service'] ?? null, true, true));
 } else {
-   echo StatusChecker::getServiceStatus(null, true, false);
+   echo StatusChecker::getServiceStatus($_REQUEST['service'] ?? null, true, false);
 }

--- a/status.php
+++ b/status.php
@@ -47,12 +47,25 @@ $fallback_response_type = 'text/plain';
 if (!isset($_SERVER['HTTP_ACCEPT']) || !in_array($_SERVER['HTTP_ACCEPT'], $valid_response_types, true)) {
    $_SERVER['HTTP_ACCEPT'] = $fallback_response_type;
 }
-if ($_SERVER['HTTP_ACCEPT'] === 'text/plain') {
+
+$format = $_SERVER['HTTP_ACCEPT'];
+if (isset($_REQUEST['format'])) {
+   switch ($_REQUEST['format']) {
+      case 'json':
+         $format = 'application/json';
+         break;
+      case 'plain':
+         $format = 'text/plain';
+         break;
+   }
+}
+
+if ($format === 'text/plain') {
    Toolbox::deprecated('Plain-text status output is deprecated please use the JSON format instead by specifically setting the Accept header to "application/json". In the future, JSON output will be the default.');
 }
-header('Content-type: ' . $_SERVER['HTTP_ACCEPT']);
+header('Content-type: ' . $format);
 
-if ($_SERVER['HTTP_ACCEPT'] === 'application/json') {
+if ($format === 'application/json') {
    echo json_encode(StatusChecker::getServiceStatus($_REQUEST['service'] ?? null, true, true));
 } else {
    echo StatusChecker::getServiceStatus($_REQUEST['service'] ?? null, true, false);


### PR DESCRIPTION
Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I missed adding the ability to filter by service through the HTTP endpoint. Service names are the same as shown in the CLI by running the `system:service:list` command. I also added the ability to change the output format using a query parameter for when you cannot change the `Accept` header.

Sample calls:
/status.php?service=db
/status.php?service=db&format=plain
/status.php?service=db&format=json