### PR TITLE
Set build date in table for nightly builds

### DIFF
--- a/tools/github-nightly-description.sh
+++ b/tools/github-nightly-description.sh
@@ -36,8 +36,6 @@ layout: default
 title: GLPI Nightly Builds
 ---
 
-Built on $( date -u +'%F %H:%M:%S UTC' )
-
 HEADER
 
 for file in $*
@@ -45,12 +43,18 @@ do
     NAME="${file#glpi/}"
     BRANCH="${NAME%.*.tar.gz}"
     SIZE=$( stat -c %s "$file" )
+    read DATE TIME TZ <<<$(git log -n1 --pretty=%ci -- $file)
+    [ "$TZ" == "+0000" ] && TZ="UTC"
     cat <<DESCRIPTION
 ## $BRANCH
 
-Archive|Size
----|---
-[$NAME]($NAME)|$SIZE
+Date|Archive|Size
+---|---|---
+$DATE $TIME $TZ|[$NAME]($NAME)|$SIZE
 
 DESCRIPTION
 done
+
+cat <<FOOTER
+<font size="1">Page generated on $( date -u +'%F %H:%M:%S UTC' )</font>
+FOOTER

--- a/tools/github-nightly-description.sh
+++ b/tools/github-nightly-description.sh
@@ -36,6 +36,8 @@ layout: default
 title: GLPI Nightly Builds
 ---
 
+Version|Archive|Build date|Size
+---|---|---|---
 HEADER
 
 for file in $*
@@ -46,15 +48,11 @@ do
     read DATE TIME TZ <<<$(git log -n1 --pretty=%ci -- $file)
     [ "$TZ" == "+0000" ] && TZ="UTC"
     cat <<DESCRIPTION
-## $BRANCH
-
-Date|Archive|Size
----|---|---
-$DATE $TIME $TZ|[$NAME]($NAME)|$SIZE
-
+$BRANCH|[$NAME]($NAME)|$DATE $TIME $TZ|$SIZE
 DESCRIPTION
 done
 
 cat <<FOOTER
+
 <font size="1">Page generated on $( date -u +'%F %H:%M:%S UTC' )</font>
 FOOTER


### PR DESCRIPTION
Update the nightly description to have something like:

## 9.5-bugfixes

Date|Archive|Size
---|---|---
2021-06-17 00:11:20 UTC|[9.5-bugfixes.ae81ac8.tar.gz](9.5-bugfixes.ae81ac8.tar.gz)|45727045

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
