### PR TITLE
Add scripts to locally run test suite on CI docker containers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,8 @@
         "/public/lib/*",
         "/public/build/*",
         "/tests/config/*",
-        "/vendor/*"
+        "/vendor/*",
+        "**/*.min.js"
     ],
     "env": {
         "browser": true,

--- a/.github/actions/init_containers-start.sh
+++ b/.github/actions/init_containers-start.sh
@@ -1,10 +1,5 @@
 #!/bin/bash -e
 
-# Import variables from .env file if it exists
-if [[ -f .env ]]; then
-  . .env
-fi
-
 echo "Init app container home"
 mkdir -p $APP_CONTAINER_HOME
 
@@ -15,7 +10,7 @@ docker-compose start
 
 if [[ "$UPDATE_FILES_ACL" = true ]]; then
   echo "Change files rights to give write access to app container user"
-  sudo apt-get install acl
+  sudo apt-get install --assume-yes --no-install-recommends --quiet acl
   setfacl --recursive --modify u:1000:rwx $APPLICATION_ROOT
   setfacl --recursive --modify u:1000:rwx $APP_CONTAINER_HOME
 fi

--- a/.github/actions/init_initialize-imap-fixtures.sh
+++ b/.github/actions/init_initialize-imap-fixtures.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+ROOT_DIR=$(readlink -f "$(dirname $0)/../..")
+
+echo "Initialize email fixtures"
+docker-compose exec -T --user root dovecot doveadm expunge -u glpi mailbox 'INBOX' all
+docker-compose exec -T --user root dovecot doveadm purge -u glpi
+for f in `ls $ROOT_DIR/tests/emails-tests/*.eml`; do
+  cat $f | docker-compose exec -T --user glpi dovecot getmail_maildir /home/glpi/Maildir/
+done

--- a/.github/actions/init_initialize-ldap-fixtures.sh
+++ b/.github/actions/init_initialize-ldap-fixtures.sh
@@ -12,10 +12,3 @@ done
 for f in `ls $ROOT_DIR/tests/LDAP/ldif/*.ldif`; do
   cat $f | docker-compose exec -T openldap ldapadd -x -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure
 done
-
-echo "Initialize email fixtures"
-docker-compose exec -T --user root dovecot doveadm expunge -u glpi mailbox 'INBOX' all
-docker-compose exec -T --user root dovecot doveadm purge -u glpi
-for f in `ls $ROOT_DIR/tests/emails-tests/*.eml`; do
-  cat $f | docker-compose exec -T --user glpi dovecot getmail_maildir /home/glpi/Maildir/
-done

--- a/.github/actions/lint_php-lint.sh
+++ b/.github/actions/lint_php-lint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -e
 
 ROOT_DIR=$(readlink -f "$(dirname $0)/../..")
-echo $ROOT_DIR
 
 echo "Check for syntax errors"
 vendor/bin/parallel-lint \

--- a/.github/actions/test_install.sh
+++ b/.github/actions/test_install.sh
@@ -1,13 +1,16 @@
 #!/bin/bash -e
 
+LOG_FILE="./tests/files/_log/install.log"
+mkdir -p $(dirname "$LOG_FILE")
+
 # Execute install
 bin/console glpi:database:install \
-  --config-dir=./tests --ansi --no-interaction \
-  --reconfigure --db-name=glpi --db-host=db --db-user=root
+  --config-dir=./tests/config --ansi --no-interaction \
+  --reconfigure --db-name=glpi --db-host=db --db-user=root --force
 
 # Execute update
 ## Should do nothing.
-bin/console glpi:database:update --config-dir=./tests --ansi --no-interaction | tee migration.log
-if [[ -z $(grep "No migration needed." migration.log) ]];
+bin/console glpi:database:update --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "glpi:database:update command FAILED" && exit 1;
 fi

--- a/.github/actions/test_update-from-older-version.sh
+++ b/.github/actions/test_update-from-older-version.sh
@@ -1,48 +1,52 @@
 #!/bin/bash -e
 
+LOG_FILE="./tests/files/_log/migration.log"
+mkdir -p $(dirname "$LOG_FILE")
+
+# Reconfigure DB
 bin/console glpi:database:configure \
-  --config-dir=./tests --ansi --no-interaction \
+  --config-dir=./tests/config --ansi --no-interaction \
   --reconfigure --db-name=glpitest0723 --db-host=db --db-user=root
 
 # Execute update
 ## First run should do the migration.
-bin/console glpi:database:update --config-dir=./tests --ansi --no-interaction --allow-unstable | tee ~/migration.log
-if [[ -n $(grep "No migration needed." ~/migration.log) ]];
+bin/console glpi:database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
+if [[ -n $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:database:update command FAILED" && exit 1;
 fi
 ## Second run should do nothing.
-bin/console glpi:database:update --config-dir=./tests --ansi --no-interaction --allow-unstable | tee ~/migration.log
-if [[ -z $(grep "No migration needed." ~/migration.log) ]];
+bin/console glpi:database:update --config-dir=./tests/config --ansi --no-interaction --allow-unstable | tee $LOG_FILE
+if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:database:update command FAILED" && exit 1;
 fi
 
 # Execute myisam_to_innodb migration
 ## First run should do the migration.
-bin/console glpi:migration:myisam_to_innodb --config-dir=./tests --ansi --no-interaction | tee ~/migration.log
-if [[ -n $(grep "No migration needed." ~/migration.log) ]];
+bin/console glpi:migration:myisam_to_innodb --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+if [[ -n $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:myisam_to_innodb command FAILED" && exit 1;
 fi
 ## Second run should do nothing.
-bin/console glpi:migration:myisam_to_innodb --config-dir=./tests --ansi --no-interaction | tee ~/migration.log
-if [[ -z $(grep "No migration needed." ~/migration.log) ]];
+bin/console glpi:migration:myisam_to_innodb --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:myisam_to_innodb command FAILED" && exit 1;
 fi
 
 # Execute timestamps migration
 ## First run should do the migration.
-bin/console glpi:migration:timestamps --config-dir=./tests --ansi --no-interaction | tee ~/migration.log
-if [[ -n $(grep "No migration needed." ~/migration.log) ]];
+bin/console glpi:migration:timestamps --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+if [[ -n $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:timestamps command FAILED" && exit 1;
 fi
 ## Second run should do nothing.
-bin/console glpi:migration:timestamps --config-dir=./tests --ansi --no-interaction | tee ~/migration.log
-if [[ -z $(grep "No migration needed." ~/migration.log) ]];
+bin/console glpi:migration:timestamps --config-dir=./tests/config --ansi --no-interaction | tee $LOG_FILE
+if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:timestamps command FAILED" && exit 1;
 fi
 
 # Test that updated DB has same schema as newly installed DB
 bin/console glpi:database:configure \
-  --config-dir=./tests --no-interaction \
+  --config-dir=./tests/config --no-interaction \
   --reconfigure --db-name=glpi --db-host=db --db-user=root
 vendor/bin/atoum \
   -p 'php -d memory_limit=512M' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,11 +157,6 @@ jobs:
         if: env.skip != 'true'
         run: |
           .github/actions/init_show-versions.sh
-      - name: "Initialize fixtures"
-        if: env.skip != 'true'
-        run: |
-          .github/actions/init_initialize-old-dbs.sh
-          .github/actions/init_initialize-services-fixtures.sh
       - name: "Install dependencies"
         if: env.skip != 'true'
         run: |
@@ -173,6 +168,7 @@ jobs:
       - name: "Update DB tests"
         if: env.skip != 'true'
         run: |
+          .github/actions/init_initialize-old-dbs.sh
           docker-compose exec -T app .github/actions/test_update-from-older-version.sh
       - name: "Unit tests"
         if: env.skip != 'true'
@@ -185,10 +181,12 @@ jobs:
       - name: "LDAP tests"
         if: env.skip != 'true'
         run: |
+          .github/actions/init_initialize-ldap-fixtures.sh
           docker-compose exec -T app .github/actions/test_tests-ldap.sh
       - name: "IMAP tests"
         if: env.skip != 'true'
         run: |
+          .github/actions/init_initialize-imap-fixtures.sh
           docker-compose exec -T app .github/actions/test_tests-imap.sh
       - name: "WEB tests"
         if: env.skip != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ phpunit.xml
 /tests/code-coverage/
 /tests/coverage-*/
 /tests/files/
+/tests/.env
 /tests/glpicrypt.key
 /config/based_config.php
 /config/config.php

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,17 +22,17 @@ Creating a dedicated database
 -----------------------------
 
 Use the **glpi:database:install** CLI command to create a new database,
-only used for the test suite, using the `--config-dir=./tests` option:
+only used for the test suite, using the `--config-dir=./tests/config` option:
 
 ```bash
-$ bin/console glpi:database:install --config-dir=./tests --db-name=glpitests --db-user=root --db-password=xxxx
+$ bin/console glpi:database:install --config-dir=./tests/config --db-name=glpitests --db-user=root --db-password=xxxx
 Creating the database...
 Saving configuration file...
 Loading default schema...
 Installation done.
 ```
 
-The configuration file is saved as `tests/config_db.php`.
+The configuration file is saved as `tests/config/config_db.php`.
 
 The database is created using the default schema for current version.
 
@@ -43,14 +43,17 @@ If you need to recreate the database (e.g. for a new schema), you need to run
 Changing database configuration
 -------------------------------
 
-Using the same database than the web application is not recommended. Use the `tests/config_db.php` file to adjust connection settings.
+Using the same database than the web application is not recommended. Use the `tests/config/config_db.php` file to adjust connection settings.
 
-Running the test suite
-----------------------
+Running the test suite on developpement env
+-------------------------------------------
 
-There are two directories for tests:
-- `tests/units` for main core tests;
-- `tests/api` for API tests.
+There are multiple directories for tests:
+- `tests/units` for unit tests;
+- `tests/functionnal` for functionnal tests;
+- `tests/imap` for Mail collector tests;
+- `tests/LDAP` for LDAP connection tests;
+- `tests/web` for API tests.
 
 You can choose to run tests on a whole directory, on any file, or on any \<class::method>. You have to specify a bootstrap file each time:
 
@@ -85,3 +88,10 @@ Note that if you do not use the `-ncc` switch; coverage will be generated in the
 On first run, additional data are loaded into the test database. On following run, this step is skipped. Note that if the test dataset version changes; you'll have to reset your database using the **CliInstall** script again.
 
 Note: you may see a skipped tests regarding missing extension `event`; this is expected ;)
+
+Running the test suite on containerized env
+-------------------------------------------
+
+If you want to execute tests in an environment similar to what is done by CI, you can use the `tests/run_tests.sh`.
+This scripts requires both "docker" and "docker-compose" utilities to be installed.
+Run `tests/run_tests.sh --help` for more information about its usage.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,7 +34,7 @@ ini_set('display_errors', 'On');
 error_reporting(E_ALL);
 
 define('GLPI_ROOT', __DIR__ . '/../');
-define('GLPI_CONFIG_DIR', __DIR__);
+define('GLPI_CONFIG_DIR', __DIR__ . '/config');
 define('GLPI_VAR_DIR', __DIR__ . '/files');
 define('GLPI_URI', (getenv('GLPI_URI') ?: 'http://localhost:8088'));
 
@@ -54,7 +54,7 @@ global $CFG_GLPI, $GLPI_CACHE;
 include (GLPI_ROOT . "/inc/based_config.php");
 
 if (!file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {
-   die("\nConfiguration file for tests not found\n\nrun: bin/console glpi:database:install --config-dir=./tests ...\n\n");
+   die("\nConfiguration file for tests not found\n\nrun: bin/console glpi:database:install --config-dir=./tests/config ...\n\n");
 }
 
 // Create subdirectories of GLPI_VAR_DIR based on defined constants

--- a/tests/config/.gitignore
+++ b/tests/config/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/router.php
+++ b/tests/router.php
@@ -30,7 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
-define('GLPI_CONFIG_DIR', __DIR__);
+define('GLPI_CONFIG_DIR', __DIR__ . '/config');
 define('GLPI_PICTURE_DIR', __DIR__ . '/files/_pictures');
 
 define(

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,211 @@
+#!/bin/bash -e
+# /**
+#  * ---------------------------------------------------------------------
+#  * GLPI - Gestionnaire Libre de Parc Informatique
+#  * Copyright (C) 2015-2021 Teclib' and contributors.
+#  *
+#  * http://glpi-project.org
+#  *
+#  * based on GLPI - Gestionnaire Libre de Parc Informatique
+#  * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+#  *
+#  * ---------------------------------------------------------------------
+#  *
+#  * LICENSE
+#  *
+#  * This file is part of GLPI.
+#  *
+#  * GLPI is free software; you can redistribute it and/or modify
+#  * it under the terms of the GNU General Public License as published by
+#  * the Free Software Foundation; either version 2 of the License, or
+#  * (at your option) any later version.
+#  *
+#  * GLPI is distributed in the hope that it will be useful,
+#  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  * GNU General Public License for more details.
+#  *
+#  * You should have received a copy of the GNU General Public License
+#  * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+#  * ---------------------------------------------------------------------
+# */
+
+WORKING_DIR=$(readlink -f "$(dirname $0)")
+
+# Declaration order in $TESTS_SUITES corresponds to the execution order
+TESTS_SUITES=(
+  "lint"
+  "install"
+  "update"
+  "units"
+  "functionnal"
+  "ldap"
+  "imap"
+  "web"
+)
+
+# Extract named options
+while [[ $# -gt 0 ]]; do
+  if [[ $1 == "--"* ]]; then
+    ## Remove -- prefix, replace - by _ and uppercase all
+    declare $(echo $1 | sed -e 's/^--//g' | sed -e 's/-/_/g' -e 's/\(.*\)/\U\1/')=true
+    shift
+  else
+    break
+  fi
+done
+
+# Extract list of tests suites to run
+TESTS_TO_RUN=()
+if [[ $# -gt 0 ]]; then
+  ARGS=("$@")
+
+  for KEY in "${ARGS[@]}"; do
+    INDEX=0
+    for VALID_KEY in "${TESTS_SUITES[@]}"; do
+      if [[ "$VALID_KEY" == "$KEY" ]]; then
+        TESTS_TO_RUN[$INDEX]=$KEY
+        continue 2 # Go to next arg
+      fi
+      INDEX+=1
+    done
+    echo -e "\e[1;30;43m/!\ Invalid \"$KEY\" test suite \e[0m"
+  done
+
+  # Ensure install test is executed if something else than "lint" is executed
+  # This is mandatory as database is initialized by this test suite
+  if [[ !${#TESTS_TO_RUN[@]} -eq 0 && "${TESTS_TO_RUN[@]}" != "lint" && ! "${TESTS_TO_RUN[@]}" =~ "install" ]]; then
+    TESTS_TO_RUN=("install" "${TESTS_TO_RUN[@]}")
+  fi
+elif [[ "$ALL" = true ]]; then
+  TESTS_TO_RUN=("${TESTS_SUITES[@]}")
+fi
+
+# Display help if user asks for it, or if it does not provide which test suite has to be executed
+if [[ "$HELP" = true || ${#TESTS_TO_RUN[@]} -eq 0 ]]; then
+  cat << EOF
+This command runs the tests in an environment similar to what is done by CI.
+
+Usage: run_tests.sh [options] [tests-suites]
+
+Examples:
+ - run_tests.sh --all
+ - run_tests.sh --build ldap imap
+ - run_tests.sh lint
+
+Available options:
+ --all      run all tests suites
+ --build    build dependencies and translation files before running test suites
+
+Available tests suites:
+ - lint
+ - install
+ - update
+ - units
+ - functionnal
+ - ldap
+ - imap
+ - web
+EOF
+
+  exit 0
+fi
+
+# Check for system dependencies
+if [[ ! -x "$(command -v docker)" || ! -x "$(command -v docker-compose)" ]]; then
+  echo "This scripts requires both \"docker\" and \"docker-compose\" utilities to be installed"
+  exit 1
+fi
+
+# Import variables from .env file this file exists
+if [[ -f "$WORKING_DIR/.env" ]]; then
+  source $WORKING_DIR/.env
+fi
+
+# Define variables (some may be defined in .env file)
+APPLICATION_ROOT=$(readlink -f "$WORKING_DIR/..")
+[[ ! -z "$APP_CONTAINER_HOME" ]] || APP_CONTAINER_HOME=$(mktemp -d -t glpi-tests-home-XXXXXXXXXX)
+[[ ! -z "$DB_IMAGE" ]] || DB_IMAGE=githubactions-mysql:8.0
+[[ ! -z "$PHP_IMAGE" ]] || PHP_IMAGE=githubactions-php:7.2
+
+# Backup configuration files
+BACKUP_DIR=$(mktemp -d -t glpi-tests-backup-XXXXXXXXXX)
+find "$APPLICATION_ROOT/tests/config" -mindepth 1 ! -iname ".gitignore" -exec mv {} $BACKUP_DIR \;
+
+# Export variables to env (required for docker-compose) and start containers
+export COMPOSE_FILE="$APPLICATION_ROOT/.github/actions/docker-compose-app.yml"
+[[ "${TESTS_TO_RUN[@]}" == "lint" ]] || export COMPOSE_FILE="$COMPOSE_FILE:$APPLICATION_ROOT/.github/actions/docker-compose-services.yml"
+export APPLICATION_ROOT
+export APP_CONTAINER_HOME
+export DB_IMAGE
+export PHP_IMAGE
+cd $WORKING_DIR # Ensure docker-compose will look for .env in current directory
+$APPLICATION_ROOT/.github/actions/init_containers-start.sh
+$APPLICATION_ROOT/.github/actions/init_show-versions.sh
+
+# Install dependencies if required
+[[ -z "$BUILD" ]] || docker-compose exec -T app .github/actions/init_install-dependencies.sh
+
+# Run tests
+for TEST_SUITE in "${TESTS_TO_RUN[@]}";
+do
+  echo -e "\n\e[1;30;43m Running \"$TEST_SUITE\" test suite \e[0m"
+  LAST_EXIT_CODE=0
+  case $TEST_SUITE in
+    "lint")
+      # Misc lint (locales and SCSS) is not executed here as their output is not configurable yet
+      # and it would be a pain to handle rolling back of their changes.
+      # TODO Add ability to simulate locales extact and SCSS compilation without actually modifying locale files.
+         docker-compose exec -T app .github/actions/lint_php-lint.sh \
+      && docker-compose exec -T app .github/actions/lint_js-lint.sh \
+      || LAST_EXIT_CODE=$?
+      ;;
+    "install")
+         docker-compose exec -T app .github/actions/test_install.sh \
+      || LAST_EXIT_CODE=$?
+      ;;
+    "update")
+         $APPLICATION_ROOT/.github/actions/init_initialize-old-dbs.sh \
+      && docker-compose exec -T app .github/actions/test_update-from-older-version.sh \
+      || LAST_EXIT_CODE=$?
+      ;;
+    "units")
+         docker-compose exec -T app .github/actions/test_tests-units.sh \
+      || LAST_EXIT_CODE=$?
+      ;;
+    "functionnal")
+         docker-compose exec -T app .github/actions/test_tests-functionnal.sh \
+      || LAST_EXIT_CODE=$?
+      ;;
+    "ldap")
+         $APPLICATION_ROOT/.github/actions/init_initialize-ldap-fixtures.sh \
+      && docker-compose exec -T app .github/actions/test_tests-ldap.sh \
+      || LAST_EXIT_CODE=$?
+      ;;
+    "imap")
+         $APPLICATION_ROOT/.github/actions/init_initialize-imap-fixtures.sh \
+      && docker-compose exec -T app .github/actions/test_tests-imap.sh \
+      || LAST_EXIT_CODE=$?
+      ;;
+    "web")
+         docker-compose exec -T app .github/actions/test_tests-web.sh \
+      || LAST_EXIT_CODE=$?
+      ;;
+  esac
+
+  if [[ $LAST_EXIT_CODE -ne 0 ]]; then
+    echo -e "\e[1;39;41m Tests \"$TEST_SUITE\" failed \e[0m\n"
+    break
+  else
+    echo -e "\e[1;30;42m Tests \"$TEST_SUITE\" passed \e[0m\n"
+  fi
+done
+
+# Restore configuration files
+rm -f $APPLICATION_ROOT/tests/config/*
+find "$BACKUP_DIR" -mindepth 1 -exec mv -f {} $APPLICATION_ROOT/tests/config \;
+
+# Stop containers
+$APPLICATION_ROOT/.github/actions/teardown_containers-cleanup.sh
+
+exit $LAST_EXIT_CODE


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Example with install test suite
![image](https://user-images.githubusercontent.com/33253653/122377783-a9105b00-cf65-11eb-964b-b29658bbc779.png)

TODO
- [x] Create a script for complete `lint` suite.
- [x] Create a script for `update` tests.
- [x] Create a script for `unit` tests.
- [x] Create a script for `functionnal` tests.
- [x] Create a script for `ldap` tests.
- [x] Create a script for `imap` tests.
- [x] Create a script for `web` tests.
- [x] Create a script for complete `test` suite.
- [x] Update test `tests/README.md`.
- [x] Add a parameter to build dependencies and locales (optionnal to save time).