### PR TITLE
Fix notifications encoding when sent from massive actions

### DIFF
--- a/inc/queuednotification.class.php
+++ b/inc/queuednotification.class.php
@@ -436,6 +436,8 @@ class QueuedNotification extends CommonDBTM {
     */
    public function sendById($ID) {
       if ($this->getFromDB($ID)) {
+         $this->fields = Toolbox::unclean_cross_side_scripting_deep($this->fields);
+
          $mode = $this->getField('mode');
          $eventclass = 'NotificationEvent' . ucfirst($mode);
          $conf = Notification_NotificationTemplate::getMode($mode);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since #9011, queued notifications are stored sanitized in DB (https://github.com/glpi-project/glpi/pull/9011/files#diff-6b16f570d485c16ee727417cde892f2f6ae2f43f7ee2ac370c5bdfe15c3beed8R159). Sending from massive actions was not updated to handle that. This PR fixes it.