### PR TITLE
Check for criteria conflicts (inside and outside "WHERE" key); see #8670

### DIFF
--- a/inc/dbmysqliterator.class.php
+++ b/inc/dbmysqliterator.class.php
@@ -285,6 +285,12 @@ class DBmysqlIterator implements Iterator, Countable {
          // WHERE criteria list
          if (!empty($crit)) {
             $this->sql .= " WHERE ".$this->analyseCrit($crit);
+            if ($where) {
+               trigger_error(
+                  'Criteria found both inside and outside "WHERE" key. Some of them will be ignored',
+                  E_USER_WARNING
+               );
+            }
          } else if ($where) {
             $this->sql .= " WHERE ".$this->analyseCrit($where);
          }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

DB iterator allow criteria to be placed both inside or outside "WHERE" key. If criteria are present on both place, thoose in "WHERE" key will be ignored.
I propose to add a warning, in order to prevent potential issues.