### PR TITLE
Fix inconsistency on date fields and add index on name fields

### DIFF
--- a/.github/actions/test_install.sh
+++ b/.github/actions/test_install.sh
@@ -17,6 +17,7 @@ fi
 # Check DB
 bin/console glpi:database:check_schema_integrity --config-dir=./tests/config --ansi --no-interaction --strict
 bin/console glpi:tools:check_database_keys --config-dir=./tests/config --ansi --no-interaction --detect-useless-keys
+bin/console glpi:tools:check_database_schema_consistency --config-dir=./tests/config --ansi --no-interaction
 
 # Execute update
 ## Should do nothing.

--- a/.github/actions/test_install.sh
+++ b/.github/actions/test_install.sh
@@ -15,8 +15,8 @@ if [[ -n $(grep "Warning" $LOG_FILE) ]];
 fi
 
 # Check DB
-bin/console glpi:database:check_schema --config-dir=./tests/config --ansi --no-interaction --strict
-bin/console glpi:database:check_keys --config-dir=./tests/config --ansi --no-interaction --detect-useless-keys
+bin/console glpi:database:check_schema_integrity --config-dir=./tests/config --ansi --no-interaction --strict
+bin/console glpi:tools:check_database_keys --config-dir=./tests/config --ansi --no-interaction --detect-useless-keys
 
 # Execute update
 ## Should do nothing.

--- a/.github/actions/test_update-from-9.5.sh
+++ b/.github/actions/test_update-from-9.5.sh
@@ -26,7 +26,7 @@ if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:database:update command FAILED" && exit 1;
 fi
 ## Check DB
-bin/console glpi:database:check_schema --config-dir=./tests/config --ansi --no-interaction --ignore-utf8mb4-migration
+bin/console glpi:database:check_schema_integrity --config-dir=./tests/config --ansi --no-interaction --ignore-utf8mb4-migration
 
 # Execute myisam_to_innodb migration
 ## First run should do nothing.
@@ -54,7 +54,7 @@ if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:utf8mb4 command FAILED" && exit 1;
 fi
 # Check DB
-bin/console glpi:database:check_schema --config-dir=./tests/config --ansi --no-interaction
+bin/console glpi:database:check_schema_integrity --config-dir=./tests/config --ansi --no-interaction
 
 # Check updated data
 bin/console glpi:database:configure \

--- a/.github/actions/test_update-from-older-version.sh
+++ b/.github/actions/test_update-from-older-version.sh
@@ -20,7 +20,7 @@ if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:database:update command FAILED" && exit 1;
 fi
 ## Check DB
-bin/console glpi:database:check_schema \
+bin/console glpi:database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --ignore-innodb-migration --ignore-timestamps-migration --ignore-dynamic-row-format-migration --ignore-utf8mb4-migration
 
@@ -36,7 +36,7 @@ if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:myisam_to_innodb command FAILED" && exit 1;
 fi
 ## Check DB
-bin/console glpi:database:check_schema \
+bin/console glpi:database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --ignore-timestamps-migration --ignore-dynamic-row-format-migration --ignore-utf8mb4-migration
 
@@ -52,7 +52,7 @@ if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:timestamps command FAILED" && exit 1;
 fi
 ## Check DB
-bin/console glpi:database:check_schema \
+bin/console glpi:database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
   --ignore-dynamic-row-format-migration --ignore-utf8mb4-migration
 
@@ -60,7 +60,7 @@ bin/console glpi:database:check_schema \
 ## Result will depend on DB server/version, we just expect that command will not fail.
 bin/console glpi:migration:dynamic_row_format --config-dir=./tests/config --ansi --no-interaction
 ## Check DB
-bin/console glpi:database:check_schema --config-dir=./tests/config --ansi --no-interaction --ignore-utf8mb4-migration
+bin/console glpi:database:check_schema_integrity --config-dir=./tests/config --ansi --no-interaction --ignore-utf8mb4-migration
 
 # Execute utf8mb4 migration
 ## First run should do the migration (with no warnings).
@@ -74,7 +74,7 @@ if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:utf8mb4 command FAILED" && exit 1;
 fi
 ## Check DB
-bin/console glpi:database:check_schema --config-dir=./tests/config --ansi --no-interaction
+bin/console glpi:database:check_schema_integrity --config-dir=./tests/config --ansi --no-interaction
 
 # Check updated data
 bin/console glpi:database:configure \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,12 @@ The present file will list all changes made to the project; according to the
 - Added `DB::truncate()` to replace raw SQL queries
 - Impact context `positions` field type changed from `TEXT` to `MEDIUMTEXT`
 - Field `date` of KnowbaseItem has been renamed to `date_creation`.
+- Field `date_creation` of KnowbaseItem_Revision has been renamed to `date`.
+- Field `date_creation` of NetworkPortConnectionLog has been renamed to `date`.
+- Field `date_creation` of NetworkPortMetrics has been renamed to `date`.
 - Field `date` of Notepad has been renamed to `date_creation`.
+- Field `date_mod` of ObjectLock has been renamed to `date`.
+- Field `date_creation` of PrinterLog has been renamed to `date`.
 - Field `date` of ProjectTask has been renamed to `date_creation`.
 
 #### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The present file will list all changes made to the project; according to the
 - Format of `Message-Id` header sent in Tickets notifications changed to match format used by other items.
 - Added `DB::truncate()` to replace raw SQL queries
 - Impact context `positions` field type changed from `TEXT` to `MEDIUMTEXT`
+- Field `date` of KnowbaseItem has been renamed to `date_creation`.
+- Field `date` of Notepad has been renamed to `date_creation`.
+- Field `date` of ProjectTask has been renamed to `date_creation`.
 
 #### Deprecated
 - Usage of `GLPI_FORCE_EMPTY_SQL_MODE` constant

--- a/inc/console/database/checkschemaintegritycommand.class.php
+++ b/inc/console/database/checkschemaintegritycommand.class.php
@@ -37,12 +37,12 @@ if (!defined('GLPI_ROOT')) {
 }
 
 use Glpi\Console\AbstractCommand;
-use Glpi\System\Diagnostic\DatabaseSchemaChecker;
+use Glpi\System\Diagnostic\DatabaseSchemaIntegrityChecker;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CheckSchemaCommand extends AbstractCommand {
+class CheckSchemaIntegrityCommand extends AbstractCommand {
 
    /**
     * Error code returned when failed to read empty SQL file.
@@ -61,10 +61,10 @@ class CheckSchemaCommand extends AbstractCommand {
    protected function configure() {
       parent::configure();
 
-      $this->setName('glpi:database:check_schema');
+      $this->setName('glpi:database:check_schema_integrity');
       $this->setAliases(
          [
-            'db:check_schema',
+            'db:check_schema_integrity',
             'glpi:database:check', // old name
             'db:check', // old alias
          ]
@@ -109,7 +109,7 @@ class CheckSchemaCommand extends AbstractCommand {
 
    protected function execute(InputInterface $input, OutputInterface $output) {
 
-      $checker = new DatabaseSchemaChecker(
+      $checker = new DatabaseSchemaIntegrityChecker(
          $this->db,
          $input->getOption('strict'),
          $input->getOption('ignore-innodb-migration'),

--- a/inc/inventory/asset/printer.class.php
+++ b/inc/inventory/asset/printer.class.php
@@ -282,6 +282,7 @@ class Printer extends NetworkEquipment
       $metrics = new PrinterLog();
       $input = (array)$this->counters;
       $input['printers_id'] = $this->item->fields['id'];
+      $input['date'] = $_SESSION['glpi_currenttime'];
       $metrics->add($input, [], false);
    }
 }

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -623,12 +623,6 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
 
    function prepareInputForAdd($input) {
 
-      // set new date if not exists
-      if (!isset($input["date"]) || empty($input["date"])) {
-         $input["date"] = $_SESSION["glpi_currenttime"];
-      }
-      // set users_id
-
       // set title for question if empty
       if (isset($input["name"]) && empty($input["name"])) {
          $input["name"] = __('New item');
@@ -735,9 +729,9 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
       KnowbaseItemCategory::dropdown(['value' => $this->fields["knowbaseitemcategories_id"]]);
       echo "</td>";
       echo "<td>";
-      if ($this->fields["date"]) {
+      if ($this->fields["date_creation"]) {
          //TRANS: %s is the datetime of insertion
-         printf(__('Created on %s'), Html::convDateTime($this->fields["date"]));
+         printf(__('Created on %s'), Html::convDateTime($this->fields["date_creation"]));
       }
       echo "</td><td>";
       if ($this->fields["date_mod"]) {
@@ -1021,9 +1015,9 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
          $out.= "<br>";
       }
 
-      if ($this->fields["date"]) {
+      if ($this->fields["date_creation"]) {
          //TRANS: %s is the datetime of update
-         $out.= sprintf(__('Created on %s'), Html::convDateTime($this->fields["date"]));
+         $out.= sprintf(__('Created on %s'), Html::convDateTime($this->fields["date_creation"]));
          $out.= "<br>";
       }
       if ($this->fields["date_mod"]) {
@@ -1860,15 +1854,6 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
       ];
 
       $tab[] = [
-         'id'                 => '5',
-         'table'              => $this->getTable(),
-         'field'              => 'date',
-         'name'               => _n('Date', 'Dates', 1),
-         'datatype'           => 'datetime',
-         'massiveaction'      => false
-      ];
-
-      $tab[] = [
          'id'                 => '6',
          'table'              => $this->getTable(),
          'field'              => 'name',
@@ -1923,6 +1908,15 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
          'table'              => $this->getTable(),
          'field'              => 'date_mod',
          'name'               => __('Last update'),
+         'datatype'           => 'datetime',
+         'massiveaction'      => false
+      ];
+
+      $tab[] = [
+         'id'                 => '121',
+         'table'              => $this->getTable(),
+         'field'              => 'date_creation',
+         'name'               => __('Creation date'),
          'datatype'           => 'datetime',
          'massiveaction'      => false
       ];

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -1731,7 +1731,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
       ];
 
       if ($type == "recent") {
-         $criteria['ORDERBY'] = 'date DESC';
+         $criteria['ORDERBY'] = 'date_creation DESC';
          $title   = __('Recent entries');
       } else if ($type == 'lastupdate') {
          $criteria['ORDERBY'] = 'date_mod DESC';

--- a/inc/knowbaseitem_revision.class.php
+++ b/inc/knowbaseitem_revision.class.php
@@ -172,7 +172,7 @@ class KnowbaseItem_Revision extends CommonDBTM {
          echo "/> <input type='radio' name='diff' value='{$revision['id']}'/></td>";
 
          echo "<td>" . ($hasRevUser ? $user->getLink() : __('Unknown user')) . "</td>".
-             "<td class='tab_date'>". $revision['date_creation'] . "</td>";
+             "<td class='tab_date'>". $revision['date'] . "</td>";
 
          $form = null;
          if ($item->getType() == KnowbaseItem::getType()) {
@@ -299,7 +299,7 @@ class KnowbaseItem_Revision extends CommonDBTM {
       $this->fields['knowbaseitems_id'] = $item->fields['id'];
       $this->fields['name'] = Toolbox::addslashes_deep($item->fields['name']);
       $this->fields['answer'] = Toolbox::addslashes_deep($item->fields['answer']);
-      $this->fields['date_creation'] = $item->fields['date_mod'];
+      $this->fields['date'] = $item->fields['date_mod'];
       $this->fields['revision'] = $this->getNewRevision();
       $this->fields['users_id'] = $item->fields['users_id'];
       $this->addToDB();
@@ -318,7 +318,7 @@ class KnowbaseItem_Revision extends CommonDBTM {
       $this->fields['knowbaseitems_id'] = $item->fields['knowbaseitems_id'];
       $this->fields['name'] = Toolbox::addslashes_deep($item->fields['name']);
       $this->fields['answer'] = Toolbox::addslashes_deep($item->fields['answer']);
-      $this->fields['date_creation'] = $item->fields['date_mod'];
+      $this->fields['date'] = $item->fields['date_mod'];
       $this->fields['language'] = $item->fields['language'];
       $this->fields['revision'] = $this->getNewRevision();
       $this->fields['users_id'] = $item->fields['users_id'];

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -379,6 +379,7 @@ class NetworkPort extends CommonDBChild {
          'ifoutbytes'      => $this->fields['ifoutbytes'] ?? 0,
          'ifinerrors'      => $this->fields['ifinerrors'] ?? 0,
          'ifouterrors'     => $this->fields['ifouterrors'] ?? 0,
+         'date'            => $_SESSION['glpi_currenttime'],
       ], [], false);
    }
 

--- a/inc/networkport_networkport.class.php
+++ b/inc/networkport_networkport.class.php
@@ -312,7 +312,8 @@ class NetworkPort_NetworkPort extends CommonDBRelation {
       $input = [
          'networkports_id_source'      => $netports_id,
          'networkports_id_destination' => $opposite_port,
-         'connected'                   => ($action === 'add')
+         'connected'                   => ($action === 'add'),
+         'date'                        => $_SESSION['glpi_currenttime'],
       ];
 
       $log->add($input);

--- a/inc/networkportconnectionlog.class.php
+++ b/inc/networkportconnectionlog.class.php
@@ -133,7 +133,7 @@ class NetworkPortConnectionLog extends CommonDBChild {
          }
          echo "<i class='fas $co_class' title='$title'></i> <span class='sr-only'>$title</span>";
          echo "</td>";
-         echo "<td>" . $row['date_creation']  . "</td>";
+         echo "<td>" . $row['date']  . "</td>";
          echo "<td>";
 
          $is_source = $netport->fields['id'] == $row['networkports_id_source'];

--- a/inc/networkportmetrics.class.php
+++ b/inc/networkportmetrics.class.php
@@ -106,7 +106,7 @@ class NetworkPortMetrics extends CommonDBChild {
       $bdate = new DateTime();
       $bdate->sub(new DateInterval('P1Y'));
       $filters = [
-         'date_creation' => ['>', $bdate->format('Y-m-d')]
+         'date' => ['>', $bdate->format('Y-m-d')]
       ];
       $filters = array_merge($filters, $user_filters);
 
@@ -140,9 +140,9 @@ class NetworkPortMetrics extends CommonDBChild {
       $labels = [];
       $i = 0;
       foreach ($raw_metrics as $metrics) {
-         $date = new \DateTime($metrics['date_creation']);
+         $date = new \DateTime($metrics['date']);
          $labels[] = $date->format(__('Y-m-d'));
-         unset($metrics['id'], $metrics['date_creation'], $metrics[static::$items_id]);
+         unset($metrics['id'], $metrics['date'], $metrics[static::$items_id]);
 
          $bytes_metrics = $metrics;
          unset($bytes_metrics['ifinerrors'], $bytes_metrics['ifouterrors']);

--- a/inc/notepad.class.php
+++ b/inc/notepad.class.php
@@ -84,7 +84,6 @@ class Notepad extends CommonDBChild {
 
       $input['users_id']             = Session::getLoginUserID();
       $input['users_id_lastupdater'] = Session::getLoginUserID();
-      $input['date']                 = $_SESSION['glpi_currenttime'];
       return $input;
    }
 
@@ -325,7 +324,7 @@ class Notepad extends CommonDBChild {
                $username = getUserName($note['users_id'], $showuserlink);
             }
             $create = sprintf(__('Create by %1$s on %2$s'), $username,
-                              Html::convDateTime($note['date']));
+                              Html::convDateTime($note['date_creation']));
             printf(__('%1$s / %2$s'), $update, $create);
             echo "</div>"; // floatright
 

--- a/inc/notepad.class.php
+++ b/inc/notepad.class.php
@@ -192,7 +192,7 @@ class Notepad extends CommonDBChild {
       $tab[] = [
          'id'                 => '201',
          'table'              => 'glpi_notepads',
-         'field'              => 'date',
+         'field'              => 'date_creation',
          'name'               => __('Creation date'),
          'datatype'           => 'datetime',
          'joinparams'         => [

--- a/inc/notificationtargetobjectlock.class.php
+++ b/inc/notificationtargetobjectlock.class.php
@@ -59,7 +59,8 @@ class NotificationTargetObjectLock extends NotificationTarget {
                     'objectlock.name'                 => __('Item Name'),
                     'objectlock.id'                   => __('Item ID'),
                     'objectlock.type'                 => __('Item Type'),
-                    'objectlock.date_mod'             => __('Lock date'),
+                    'objectlock.date'                 => __('Lock date'),
+                    'objectlock.date_mod'             => __('Lock date'), // old field name
                     'objectlock.lockedby.lastname'    => __('Lastname of locking user'),
                     'objectlock.lockedby.firstname'   => __('Firstname of locking user'),
                     'objectlock.requester.lastname'   => __('Requester Lastname'),
@@ -110,8 +111,9 @@ class NotificationTargetObjectLock extends NotificationTarget {
       $this->data['##objectlock.name##']     = $object->fields['name'];
       $this->data['##objectlock.id##']       = $options['item']->fields['items_id'];
       $this->data['##objectlock.type##']     = $options['item']->fields['itemtype'];
-      $this->data['##objectlock.date_mod##'] = Html::convDateTime($options['item']->fields['date_mod'],
+      $this->data['##objectlock.date##']     = Html::convDateTime($options['item']->fields['date_mod'],
                                                                    $user->fields['date_format']);
+      $this->data['##objectlock.date_mod##'] = $this->data['##objectlock.date##'];
       $this->data['##objectlock.lockedby.lastname##']
                                               = $user->fields['realname'];
       $this->data['##objectlock.lockedby.firstname##']

--- a/inc/objectlock.class.php
+++ b/inc/objectlock.class.php
@@ -268,7 +268,7 @@ class ObjectLock extends CommonDBTM {
       $msg = "<strong class='nowrap'>";
       $msg .= sprintf(__('Locked by %s'), "<a href='" . $user->getLinkURL() . "'>" . $userdata['name'] . "</a>");
       $msg .= "&nbsp;" . Html::showToolTip($userdata["comment"], ['link' => $userdata['link'], 'display' => false]);
-      $msg .= " -> " . Html::convDateTime($this->fields['date_mod']);
+      $msg .= " -> " . Html::convDateTime($this->fields['date']);
       $msg .= "</strong>";
       if ($showAskUnlock) {
          $msg .= "<a class='vsubmit' onclick='javascript:askUnlock();'>".__('Ask for unlock')."</a>";
@@ -556,7 +556,7 @@ class ObjectLock extends CommonDBTM {
          $tab[] = [
             'id'            => '206',
             'table'         => getTableForItemType('ObjectLock'),
-            'field'         => 'date_mod',
+            'field'         => 'date',
             'datatype'      => 'datetime',
             'name'          => __('Locked date'),
             'joinparams'    => ['jointype' => 'itemtype_item'],
@@ -626,7 +626,7 @@ class ObjectLock extends CommonDBTM {
 
       $lockedItems = getAllDataFromTable(
          getTableForItemType(__CLASS__), [
-            'date_mod' => ['<', date("Y-m-d H:i:s", time() - ($task->fields['param'] * HOUR_TIMESTAMP))]
+            'date' => ['<', date("Y-m-d H:i:s", time() - ($task->fields['param'] * HOUR_TIMESTAMP))]
          ]
       );
 

--- a/inc/printerlog.class.php
+++ b/inc/printerlog.class.php
@@ -107,7 +107,7 @@ class PrinterLog extends CommonDBChild {
       $bdate = new DateTime();
       $bdate->sub(new DateInterval('P1Y'));
       $filters = [
-         'date_creation' => ['>', $bdate->format('Y-m-d')]
+         'date' => ['>', $bdate->format('Y-m-d')]
       ];
       $filters = array_merge($filters, $user_filters);
 
@@ -140,9 +140,9 @@ class PrinterLog extends CommonDBChild {
       $labels = [];
       $i = 0;
       foreach ($raw_metrics as $metrics) {
-         $date = new DateTime($metrics['date_creation']);
+         $date = new DateTime($metrics['date']);
          $labels[] = $date->format(__('Y-m-d'));
-         unset($metrics['id'], $metrics['date_creation'], $metrics['printers_id']);
+         unset($metrics['id'], $metrics['date'], $metrics['printers_id']);
 
          foreach ($metrics as $key => $value) {
             if ($value > 0) {

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -930,8 +930,8 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
       $tab[] = [
          'id'                 => '115',
          'table'              => ProjectTask::getTable(),
-         'field'              => 'date',
-         'name'               => __('Opening date'),
+         'field'              => 'date_creation',
+         'name'               => __('Creation date'),
          'datatype'           => 'datetime',
          'massiveaction'      => false,
          'forcegroupby'       => true,

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -406,9 +406,6 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
       if (!isset($input['users_id'])) {
          $input['users_id'] = Session::getLoginUserID();
       }
-      if (!isset($input['date'])) {
-         $input['date'] = $_SESSION['glpi_currenttime'];
-      }
 
       if (isset($input["plan"])) {
          $input["plan_start_date"] = $input['plan']["begin"];
@@ -640,7 +637,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
          echo "<tr class='tab_bg_1'>";
          echo "<td>".__('Creation date')."</td>";
          echo "<td>";
-         echo sprintf(__('%1$s by %2$s'), Html::convDateTime($this->fields["date"]),
+         echo sprintf(__('%1$s by %2$s'), Html::convDateTime($this->fields["date_creation"]),
                                        getUserName($this->fields["users_id"], $showuserlink));
          echo "</td>";
          echo "<td>".__('Last update')."</td>";
@@ -957,10 +954,10 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
       ];
 
       $tab[] = [
-         'id'                 => '15',
+         'id'                 => '121',
          'table'              => $this->getTable(),
-         'field'              => 'date',
-         'name'               => __('Opening date'),
+         'field'              => 'date_creation',
+         'name'               => __('Creation date'),
          'datatype'           => 'datetime',
          'massiveaction'      => false
       ];

--- a/inc/system/diagnostic/abstractdatabasechecker.class.php
+++ b/inc/system/diagnostic/abstractdatabasechecker.class.php
@@ -79,15 +79,46 @@ abstract class AbstractDatabaseChecker {
     * @return array
     */
    protected function getColumnsNames(string $table_name): array {
+      $this->fetchTableColumns($table_name);
+
+      return array_column($this->columns[$table_name], 'Field');
+   }
+
+   /**
+    * Return column type.
+    *
+    * @param string $table_name
+    * @param string $column_name
+    *
+    * @return null|string
+    */
+   protected function getColumnType(string $table_name, string $column_name): ?string {
+      $this->fetchTableColumns($table_name);
+
+      foreach ($this->columns[$table_name] as $column_specs) {
+         if ($column_specs['Field'] === $column_name) {
+            return $column_specs['Type'];
+         }
+      }
+
+      return null;
+   }
+
+   /**
+    * Return column type.
+    *
+    * @param string $table_name
+    *
+    * @return void
+    */
+   private function fetchTableColumns(string $table_name): void {
       if (!array_key_exists($table_name, $this->columns)) {
          if (($columns_res = $this->db->query('SHOW COLUMNS FROM ' . $this->db->quoteName($table_name))) === false) {
             throw new \Exception(sprintf('Unable to get table "%s" columns', $table_name));
          }
 
-         $this->columns[$table_name] = array_column($columns_res->fetch_all(MYSQLI_ASSOC), 'Field');
+         $this->columns[$table_name] = $columns_res->fetch_all(MYSQLI_ASSOC);
       }
-
-      return $this->columns[$table_name];
    }
 
    /**

--- a/inc/system/diagnostic/abstractdatabasechecker.class.php
+++ b/inc/system/diagnostic/abstractdatabasechecker.class.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\System\Diagnostic;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use DBmysql;
+
+/**
+ * @since 10.0.0
+ */
+abstract class AbstractDatabaseChecker {
+
+   /**
+    * DB instance.
+    *
+    * @var DBmysql
+    */
+   protected $db;
+
+   /**
+    * Local cache for tables columns.
+    *
+    * @var array
+    */
+   private $columns = [];
+
+   /**
+    * Local cache for tables indexes.
+    *
+    * @var array
+    */
+   private $indexes = [];
+
+   /**
+    * @param DBmysql $db   DB instance.
+    */
+   public function __construct(DBmysql $db) {
+      $this->db = $db;
+   }
+
+   /**
+    * Return list of column names for given table.
+    *
+    * @param string $table_name
+    *
+    * @return array
+    */
+   protected function getColumnsNames(string $table_name): array {
+      if (!array_key_exists($table_name, $this->columns)) {
+         if (($columns_res = $this->db->query('SHOW COLUMNS FROM ' . $this->db->quoteName($table_name))) === false) {
+            throw new \Exception(sprintf('Unable to get table "%s" columns', $table_name));
+         }
+
+         $this->columns[$table_name] = array_column($columns_res->fetch_all(MYSQLI_ASSOC), 'Field');
+      }
+
+      return $this->columns[$table_name];
+   }
+
+   /**
+    * Return index for given table.
+    * Array keys are index key, and values are fields related to this key.
+    *
+    * @param string $table_name
+    *
+    * @return array
+    */
+   protected function getIndex(string $table_name): array {
+      if (!array_key_exists($table_name, $this->indexes)) {
+         if (($keys_res = $this->db->query('SHOW INDEX FROM ' . $this->db->quoteName($table_name))) === false) {
+            throw new \Exception(sprintf('Unable to get table "%s" index', $table_name));
+         }
+
+         $index = [];
+         while ($key_specs = $keys_res->fetch_assoc()) {
+            if ($key_specs['Index_type'] === 'FULLTEXT') {
+               continue; // Ignore FULLTEXT keys
+            }
+            $key_name = $key_specs['Key_name'];
+            if (!array_key_exists($key_name, $index)) {
+               $index[$key_name] = [];
+            }
+            $index[$key_name][$key_specs['Seq_in_index'] - 1] = $key_specs['Column_name'];
+         }
+
+         $this->indexes[$table_name] = $index;
+      }
+
+      return $this->indexes[$table_name];
+   }
+}

--- a/inc/system/diagnostic/databaseschemaconsistencychecker.class.php
+++ b/inc/system/diagnostic/databaseschemaconsistencychecker.class.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\System\Diagnostic;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ * @since 10.0.0
+ */
+class DatabaseSchemaConsistencyChecker extends AbstractDatabaseChecker {
+
+   /**
+    * Get list of missing fields, basing detection on other fields.
+    *
+    * @param string $table_name
+    *
+    * @return array
+    */
+   public function getMissingFields(string $table_name): array {
+      $missing_columns = [];
+
+      $columns = $this->getColumnsNames($table_name);
+      foreach ($columns as $column_name) {
+         switch ($column_name) {
+            case 'date_creation':
+               if (!in_array('date_mod', $columns) && !$this->shouldIgnoreMissingDateMod($table_name)) {
+                  $missing_columns[] = 'date_mod';
+               }
+               break;
+            case 'date_mod':
+               if (!in_array('date_creation', $columns) && !$this->shouldIgnoreMissingDateCreation($table_name)) {
+                  $missing_columns[] = 'date_creation';
+               }
+               break;
+         }
+      }
+
+      return $missing_columns;
+   }
+
+   /**
+    * Check if missing date_creation field should be ignored on given table.
+    *
+    * @param string $table_name
+    *
+    * @return bool
+    */
+   private function shouldIgnoreMissingDateCreation(string $table_name): bool {
+      return in_array(
+         $table_name,
+         [
+            // Logs cannot be modified and their date is stored on `date_mod`.
+            // It would be more logical to have a `date` instead, but renaming it is not so simple as table
+            // can contains millions of rows.
+            'glpi_logs',
+            // ObjectLocks cannot be modified and their date is stored on `date_mod`.
+            // It would be more logical to have a `date` instead, but renaming it is not so simple as field
+            // name may be used in notifications templates.
+            'glpi_objectlocks',
+         ]
+      );
+   }
+
+   /**
+    * Check if missing date_mod field should be ignored on given table.
+    *
+    * @param string $table_name
+    *
+    * @return bool
+    */
+   private function shouldIgnoreMissingDateMod(string $table_name): bool {
+      return in_array(
+         $table_name,
+         [
+            'glpi_knowbaseitems_revisions', // KB revisions should not be modified
+            'glpi_networkportconnectionlogs', // Network connections log should not be modified
+            'glpi_networkportmetrics', // Network metrics is kind of a log, should not be modified
+            'glpi_printerlogs', // Printer log should not be modified
+         ]
+      );
+   }
+}

--- a/inc/system/diagnostic/databaseschemaintegritychecker.class.php
+++ b/inc/system/diagnostic/databaseschemaintegritychecker.class.php
@@ -42,7 +42,7 @@ use SebastianBergmann\Diff\Differ;
 /**
  * @since 10.0.0
  */
-class DatabaseSchemaChecker {
+class DatabaseSchemaIntegrityChecker {
 
    /**
     * DB instance.

--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -99,6 +99,15 @@ class Transfer extends CommonDBTM {
       ];
 
       $tab[] = [
+         'id'                 => '121',
+         'table'              => $this->getTable(),
+         'field'              => 'date_creation',
+         'name'               => __('Creation date'),
+         'datatype'           => 'datetime',
+         'massiveaction'      => false
+      ];
+
+      $tab[] = [
          'id'                 => '16',
          'table'              => $this->getTable(),
          'field'              => 'comment',

--- a/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
@@ -365,25 +365,23 @@ if (!$DB->tableExists('glpi_printerlogs')) {
          `color_copies` int NOT NULL DEFAULT '0',
          `scanned` int NOT NULL DEFAULT '0',
          `faxed` int NOT NULL DEFAULT '0',
-         `date_creation` timestamp NULL DEFAULT NULL,
+         `date` timestamp NULL DEFAULT NULL,
          PRIMARY KEY (`id`),
          KEY `printers_id` (`printers_id`),
-         KEY `date_creation` (`date_creation`)
+         KEY `date` (`date`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
    $DB->queryOrDie($query, "10.0 add table glpi_printerlogs");
-} else {
-   $migration->addKey('glpi_printerlogs', 'date_creation');
 }
 
 if (!$DB->tableExists('glpi_networkportconnectionlogs')) {
    $query = "CREATE TABLE `glpi_networkportconnectionlogs` (
          `id` int NOT NULL AUTO_INCREMENT,
-         `date_creation` timestamp NULL DEFAULT NULL,
+         `date` timestamp NULL DEFAULT NULL,
          `connected` tinyint NOT NULL DEFAULT '0',
          `networkports_id_source` int NOT NULL DEFAULT '0',
          `networkports_id_destination` int NOT NULL DEFAULT '0',
          PRIMARY KEY (`id`),
-         KEY `date_creation` (`date_creation`),
+         KEY `date` (`date`),
          KEY `networkports_id_destination` (`networkports_id_destination`),
          KEY `networkports_id_source` (`networkports_id_source`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
@@ -396,14 +394,14 @@ if (!$DB->tableExists('glpi_networkportconnectionlogs')) {
 if (!$DB->tableExists('glpi_networkportmetrics')) {
    $query = "CREATE TABLE `glpi_networkportmetrics` (
          `id` int NOT NULL AUTO_INCREMENT,
-         `date_creation` timestamp NULL DEFAULT NULL,
+         `date` timestamp NULL DEFAULT NULL,
          `ifinbytes` bigint NOT NULL DEFAULT '0',
          `ifinerrors` bigint NOT NULL DEFAULT '0',
          `ifoutbytes` bigint NOT NULL DEFAULT '0',
          `ifouterrors` bigint NOT NULL DEFAULT '0',
          `networkports_id` int NOT NULL DEFAULT '0',
          PRIMARY KEY (`id`),
-         KEY `date_creation` (`date_creation`),
+         KEY `date` (`date`),
          KEY `networkports_id` (`networkports_id`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
    $DB->queryOrDie($query, "10.0 add table glpi_networkportmetrics");

--- a/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
@@ -707,20 +707,8 @@ foreach ($tables as $table) {
       $migration->addKey($table, 'date_creation');
    }
 }
-$migration->addPostQuery(
-   $DB->buildUpdate(
-      'glpi_displaypreferences',
-      ['num' => '121'],
-      ['num' => '5', 'itemtype' => 'KnowbaseItem']
-   )
-);
-$migration->addPostQuery(
-   $DB->buildUpdate(
-      'glpi_displaypreferences',
-      ['num' => '121'],
-      ['num' => '15', 'itemtype' => 'KnowbaseItem']
-   )
-);
+$migration->changeSearchOption(KnowbaseItem::class, 5, 121);
+$migration->changeSearchOption(ProjectTask::class, 15, 121);
 
 // Rename `glpi_objectlocks` `date_mod` to `date`
 if ($DB->fieldExists('glpi_objectlocks', 'date_mod', false)) {

--- a/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
@@ -77,6 +77,9 @@ $migration->changeField('glpi_notimportedemails', 'subject', 'subject', 'text', 
 
 // Drop malformed keys
 $malformed_keys = [
+   'glpi_ipaddresses' => [
+      'textual',
+   ],
    'glpi_items_softwareversions' => [
       'is_deleted',
       'is_template',
@@ -255,6 +258,7 @@ $missing_keys = [
    'glpi_apiclients' => [
       'entities_id',
       'is_recursive',
+      'name',
    ],
    'glpi_appliances' => [
       'date_mod',
@@ -262,6 +266,18 @@ $missing_keys = [
    ],
    'glpi_appliancetypes' => [
       'is_recursive',
+   ],
+   'glpi_authldapreplicates' => [
+      'name',
+   ],
+   'glpi_authldaps' => [
+      'name',
+   ],
+   'glpi_authmails' => [
+      'name',
+   ],
+   'glpi_blacklistedmailcontents' => [
+      'name',
    ],
    'glpi_businesscriticities' => [
       'entities_id',
@@ -280,12 +296,16 @@ $missing_keys = [
    'glpi_clusters' => [
       'date_creation',
       'date_mod',
+      'name',
    ],
    'glpi_computerantiviruses' => [
       'manufacturers_id',
    ],
    'glpi_computervirtualmachines' => [
       'virtualmachinetypes_id',
+   ],
+   'glpi_configs' => [
+      'name',
    ],
    'glpi_consumableitems' => [
       'is_recursive',
@@ -297,16 +317,24 @@ $missing_keys = [
       'is_recursive',
       'is_template',
    ],
+   'glpi_crontasks' => [
+      'name',
+   ],
+   'glpi_dashboards_dashboards' => [
+      'name',
+   ],
    'glpi_dashboards_rights' => [
       'item' => ['itemtype', 'items_id'],
    ],
    'glpi_datacenters' => [
       'date_creation',
       'date_mod',
+      'name',
    ],
    'glpi_dcrooms' => [
       'date_creation',
       'date_mod',
+      'name',
    ],
    'glpi_devicesensors' => [
       'devicesensormodels_id',
@@ -340,11 +368,13 @@ $missing_keys = [
    'glpi_enclosures' => [
       'date_creation',
       'date_mod',
+      'name',
    ],
    'glpi_entities' => [
       'authldaps_id',
       'calendars_id',
       'entities_id_software',
+      'name',
    ],
    'glpi_fieldblacklists' => [
       'entities_id',
@@ -354,6 +384,7 @@ $missing_keys = [
       'entities_id',
       'is_active',
       'is_recursive',
+      'name',
    ],
    'glpi_groups' => [
       'is_recursive',
@@ -364,6 +395,12 @@ $missing_keys = [
    'glpi_holidays' => [
       'entities_id',
       'is_recursive',
+   ],
+   'glpi_impactcompounds' => [
+      'name',
+   ],
+   'glpi_ipaddresses' => [
+      'name',
    ],
    'glpi_ipnetworks' => [
       'ipnetworks_id',
@@ -437,9 +474,17 @@ $missing_keys = [
       'states_id',
       'date_creation',
       'date_mod',
+      'name',
    ],
    'glpi_links' => [
       'is_recursive',
+      'name',
+   ],
+   'glpi_mailcollectors' => [
+      'name',
+   ],
+   'glpi_manuallinks' => [
+      'name',
    ],
    'glpi_monitors' => [
       'date_mod',
@@ -449,6 +494,9 @@ $missing_keys = [
    ],
    'glpi_networkequipments' => [
       'is_recursive',
+   ],
+   'glpi_networkports' => [
+      'name',
    ],
    'glpi_networkportwifis' => [
       'networkportwifis_id',
@@ -480,6 +528,7 @@ $missing_keys = [
    'glpi_passivedcequipments' => [
       'date_creation',
       'date_mod',
+      'name',
    ],
    'glpi_pdumodels' => [
       'date_creation',
@@ -488,6 +537,7 @@ $missing_keys = [
    'glpi_pdus' => [
       'date_creation',
       'date_mod',
+      'name',
    ],
    'glpi_pdus_plugs' => [
       'date_creation',
@@ -497,8 +547,23 @@ $missing_keys = [
       'date_creation',
       'date_mod',
    ],
+   'glpi_planningexternalevents' => [
+      'name',
+   ],
+   'glpi_planningexternaleventtemplates' => [
+      'name',
+   ],
+   'glpi_plugins' => [
+      'name',
+   ],
    'glpi_printers' => [
       'is_recursive',
+   ],
+   'glpi_profilerights' => [
+      'name',
+   ],
+   'glpi_profiles' => [
+      'name',
    ],
    'glpi_projects' => [
       'is_deleted',
@@ -513,9 +578,14 @@ $missing_keys = [
    'glpi_racks' => [
       'date_creation',
       'date_mod',
+      'name',
    ],
    'glpi_recurrentchanges' => [
       'calendars_id',
+      'name',
+   ],
+   'glpi_refusedequipments' => [
+      'name',
    ],
    'glpi_registeredids' => [
       'item' => ['itemtype', 'items_id'],
@@ -523,6 +593,21 @@ $missing_keys = [
    'glpi_remindertranslations' => [
       'date_creation',
       'date_mod',
+   ],
+   'glpi_reminders' => [
+      'name',
+   ],
+   'glpi_rulerightparameters' => [
+      'name',
+   ],
+   'glpi_rules' => [
+      'name',
+   ],
+   'glpi_savedsearches' => [
+      'name',
+   ],
+   'glpi_softwarecategories' => [
+      'name',
    ],
    'glpi_softwarelicenses' => [
       'is_recursive',
@@ -543,6 +628,9 @@ $missing_keys = [
       'entities_id',
       'is_recursive',
    ],
+   'glpi_ssovariables' => [
+      'name',
+   ],
    'glpi_states' => [
       'entities_id',
       'is_recursive',
@@ -552,13 +640,26 @@ $missing_keys = [
    ],
    'glpi_ticketrecurrents' => [
       'calendars_id',
+      'name',
    ],
    'glpi_tickets_tickets' => [
       'tickets_id_2',
    ],
+   'glpi_transfers' => [
+      'name',
+   ],
    'glpi_users' => [
       'auths_id',
       'default_requesttypes_id',
+   ],
+   'glpi_virtualmachinestates' => [
+      'name',
+   ],
+   'glpi_virtualmachinesystems' => [
+      'name',
+   ],
+   'glpi_virtualmachinetypes' => [
+      'name',
    ],
    'glpi_vlans' => [
       'is_recursive',

--- a/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
@@ -250,7 +250,7 @@ foreach ($useless_keys as $table => $keys) {
    }
 }
 
-// Add missing keys (based on glpi:database:check_keys detection)
+// Add missing keys (based on glpi:tools:check_database_keys detection)
 $missing_keys = [
    'glpi_apiclients' => [
       'entities_id',

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -58,6 +58,7 @@ CREATE TABLE `glpi_authldapreplicates` (
   `name` varchar(255) DEFAULT NULL,
   `timeout` int NOT NULL DEFAULT '10',
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `authldaps_id` (`authldaps_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
@@ -117,6 +118,7 @@ CREATE TABLE `glpi_authldaps` (
   `use_bind` tinyint NOT NULL DEFAULT '1',
   `timeout` int NOT NULL DEFAULT '10',
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `is_default` (`is_default`),
   KEY `is_active` (`is_active`),
@@ -138,6 +140,7 @@ CREATE TABLE `glpi_authmails` (
   `comment` text,
   `is_active` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `is_active` (`is_active`)
@@ -162,6 +165,7 @@ CREATE TABLE `glpi_apiclients` (
   `dolog_method` tinyint NOT NULL DEFAULT '0',
   `comment` text,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `is_active` (`is_active`),
@@ -193,6 +197,7 @@ CREATE TABLE `glpi_blacklistedmailcontents` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -236,6 +241,7 @@ CREATE TABLE `glpi_savedsearches` (
   `last_execution_date` timestamp NULL DEFAULT NULL,
   `counter` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `type` (`type`),
   KEY `itemtype` (`itemtype`),
   KEY `entities_id` (`entities_id`),
@@ -1208,7 +1214,8 @@ CREATE TABLE `glpi_configs` (
   `name` varchar(150) DEFAULT NULL,
   `value` text,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unicity` (`context`,`name`)
+  UNIQUE KEY `unicity` (`context`,`name`),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_impacts
@@ -1233,7 +1240,8 @@ CREATE TABLE `glpi_impactcompounds` (
   `id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(255) DEFAULT '',
   `color` varchar(255) NOT NULL DEFAULT '',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -1575,6 +1583,7 @@ CREATE TABLE `glpi_crontasks` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`itemtype`,`name`),
+  KEY `name` (`name`),
   KEY `mode` (`mode`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
@@ -1589,7 +1598,8 @@ CREATE TABLE `glpi_dashboards_dashboards` (
   `name` varchar(100) NOT NULL,
   `context` varchar(100) NOT NULL DEFAULT 'core',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `key` (`key`)
+  UNIQUE KEY `key` (`key`),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_dashboards_items
@@ -2728,6 +2738,7 @@ CREATE TABLE `glpi_entities` (
   `transfers_id` int NOT NULL DEFAULT '-2',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`entities_id`,`name`),
+  KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`),
   KEY `tickettemplates_id` (`tickettemplates_id`),
@@ -2844,6 +2855,7 @@ CREATE TABLE `glpi_fieldunicities` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `is_active` (`is_active`),
@@ -3144,8 +3156,8 @@ CREATE TABLE `glpi_ipaddresses` (
   `mainitems_id` int NOT NULL DEFAULT '0',
   `mainitemtype` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
-  KEY `textual` (`name`),
   KEY `binary` (`binary_0`,`binary_1`,`binary_2`,`binary_3`),
   KEY `is_deleted` (`is_deleted`),
   KEY `is_dynamic` (`is_dynamic`),
@@ -3914,6 +3926,7 @@ CREATE TABLE `glpi_lines` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `comment` text,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `is_deleted` (`is_deleted`),
@@ -3978,6 +3991,7 @@ CREATE TABLE `glpi_links` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `date_mod` (`date_mod`),
@@ -4078,6 +4092,7 @@ CREATE TABLE `glpi_mailcollectors` (
   `add_cc_to_observer` tinyint NOT NULL DEFAULT '0',
   `collect_only_unread` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `is_active` (`is_active`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
@@ -4527,6 +4542,7 @@ CREATE TABLE `glpi_networkports` (
   `trunk` tinyint NOT NULL DEFAULT '0',
   `lastup` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
@@ -4841,6 +4857,7 @@ CREATE TABLE `glpi_passivedcequipments` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `locations_id` (`locations_id`),
@@ -5142,6 +5159,7 @@ CREATE TABLE `glpi_plugins` (
   `license` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`directory`),
+  KEY `name` (`name`),
   KEY `state` (`state`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
@@ -5422,7 +5440,8 @@ CREATE TABLE `glpi_profilerights` (
   `name` varchar(255) DEFAULT NULL,
   `rights` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unicity` (`profiles_id`,`name`)
+  UNIQUE KEY `unicity` (`profiles_id`,`name`),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_profiles
@@ -5447,6 +5466,7 @@ CREATE TABLE `glpi_profiles` (
   `managed_domainrecordtypes` text,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `interface` (`interface`),
   KEY `is_default` (`is_default`),
   KEY `date_mod` (`date_mod`),
@@ -5859,6 +5879,7 @@ CREATE TABLE `glpi_reminders` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `uuid` (`uuid`),
+  KEY `name` (`name`),
   KEY `date` (`date`),
   KEY `begin` (`begin`),
   KEY `end` (`end`),
@@ -6049,6 +6070,7 @@ CREATE TABLE `glpi_rulerightparameters` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -6073,6 +6095,7 @@ CREATE TABLE `glpi_rules` (
   `condition` int NOT NULL DEFAULT '0',
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_active` (`is_active`),
   KEY `sub_type` (`sub_type`),
@@ -6299,6 +6322,7 @@ CREATE TABLE `glpi_softwarecategories` (
   `ancestors_cache` longtext,
   `sons_cache` longtext,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `softwarecategories_id` (`softwarecategories_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
@@ -6552,6 +6576,7 @@ CREATE TABLE `glpi_ssovariables` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -6791,6 +6816,7 @@ CREATE TABLE `glpi_ticketrecurrents` (
   `calendars_id` int NOT NULL DEFAULT '0',
   `end_date` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `is_active` (`is_active`),
@@ -6818,6 +6844,7 @@ CREATE TABLE `glpi_recurrentchanges` (
   `calendars_id` int NOT NULL DEFAULT '0',
   `end_date` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `is_active` (`is_active`),
@@ -7211,6 +7238,7 @@ CREATE TABLE `glpi_transfers` (
   `comment` text,
   `keep_disk` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -7395,6 +7423,7 @@ CREATE TABLE `glpi_virtualmachinestates` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -7410,6 +7439,7 @@ CREATE TABLE `glpi_virtualmachinesystems` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -7425,6 +7455,7 @@ CREATE TABLE `glpi_virtualmachinetypes` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -7710,6 +7741,7 @@ CREATE TABLE `glpi_datacenters` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `locations_id` (`locations_id`),
@@ -7733,6 +7765,7 @@ CREATE TABLE `glpi_dcrooms` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `locations_id` (`locations_id`),
@@ -7807,6 +7840,7 @@ CREATE TABLE `glpi_racks` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `locations_id` (`locations_id`),
@@ -7885,6 +7919,7 @@ CREATE TABLE `glpi_enclosures` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `locations_id` (`locations_id`),
@@ -7976,6 +8011,7 @@ CREATE TABLE `glpi_pdus` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `locations_id` (`locations_id`),
@@ -8123,6 +8159,7 @@ CREATE TABLE `glpi_clusters` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `users_id_tech` (`users_id_tech`),
   KEY `group_id_tech` (`groups_id_tech`),
   KEY `is_deleted` (`is_deleted`),
@@ -8171,6 +8208,7 @@ CREATE TABLE `glpi_planningexternalevents` (
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `uuid` (`uuid`),
+  KEY `name` (`name`),
   KEY `planningexternaleventtemplates_id` (`planningexternaleventtemplates_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
@@ -8203,6 +8241,7 @@ CREATE TABLE `glpi_planningexternaleventtemplates` (
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `state` (`state`),
   KEY `planningeventcategories_id` (`planningeventcategories_id`),
@@ -8639,6 +8678,7 @@ CREATE TABLE `glpi_refusedequipments` (
   `date_creation` timestamp NULL DEFAULT NULL,
   `date_mod` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),
   KEY `agents_id` (`agents_id`),
   KEY `rules_id` (`rules_id`),
@@ -8749,6 +8789,7 @@ CREATE TABLE `glpi_manuallinks` (
   `date_creation` timestamp NULL DEFAULT NULL,
   `date_mod` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `name` (`name`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `items_id` (`items_id`),
   KEY `date_creation` (`date_creation`),

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -134,10 +134,12 @@ CREATE TABLE `glpi_authmails` (
   `connect_string` varchar(255) DEFAULT NULL,
   `host` varchar(255) DEFAULT NULL,
   `date_mod` timestamp NULL DEFAULT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
   `comment` text,
   `is_active` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`),
   KEY `is_active` (`is_active`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
@@ -150,6 +152,7 @@ CREATE TABLE `glpi_apiclients` (
   `is_recursive` tinyint NOT NULL DEFAULT '0',
   `name` varchar(255) DEFAULT NULL,
   `date_mod` timestamp NULL DEFAULT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
   `is_active` tinyint NOT NULL DEFAULT '0',
   `ipv4_range_start` bigint DEFAULT NULL,
   `ipv4_range_end` bigint DEFAULT NULL,
@@ -160,6 +163,7 @@ CREATE TABLE `glpi_apiclients` (
   `comment` text,
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`),
   KEY `is_active` (`is_active`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
@@ -3818,7 +3822,7 @@ CREATE TABLE `glpi_knowbaseitems` (
   `is_faq` tinyint NOT NULL DEFAULT '0',
   `users_id` int NOT NULL DEFAULT '0',
   `view` int NOT NULL DEFAULT '0',
-  `date` timestamp NULL DEFAULT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
   `date_mod` timestamp NULL DEFAULT NULL,
   `begin_date` timestamp NULL DEFAULT NULL,
   `end_date` timestamp NULL DEFAULT NULL,
@@ -3826,6 +3830,7 @@ CREATE TABLE `glpi_knowbaseitems` (
   KEY `users_id` (`users_id`),
   KEY `knowbaseitemcategories_id` (`knowbaseitemcategories_id`),
   KEY `is_faq` (`is_faq`),
+  KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`),
   KEY `begin_date` (`begin_date`),
   KEY `end_date` (`end_date`),
@@ -4608,7 +4613,7 @@ CREATE TABLE `glpi_notepads` (
   `id` int NOT NULL AUTO_INCREMENT,
   `itemtype` varchar(100) DEFAULT NULL,
   `items_id` int NOT NULL DEFAULT '0',
-  `date` timestamp NULL DEFAULT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
   `date_mod` timestamp NULL DEFAULT NULL,
   `users_id` int NOT NULL DEFAULT '0',
   `users_id_lastupdater` int NOT NULL DEFAULT '0',
@@ -4616,7 +4621,7 @@ CREATE TABLE `glpi_notepads` (
   PRIMARY KEY (`id`),
   KEY `item` (`itemtype`,`items_id`),
   KEY `date_mod` (`date_mod`),
-  KEY `date` (`date`),
+  KEY `date_creation` (`date_creation`),
   KEY `users_id_lastupdater` (`users_id_lastupdater`),
   KEY `users_id` (`users_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -5620,7 +5625,7 @@ CREATE TABLE `glpi_projecttasks` (
   `is_recursive` tinyint NOT NULL DEFAULT '0',
   `projects_id` int NOT NULL DEFAULT '0',
   `projecttasks_id` int NOT NULL DEFAULT '0',
-  `date` timestamp NULL DEFAULT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
   `date_mod` timestamp NULL DEFAULT NULL,
   `plan_start_date` timestamp NULL DEFAULT NULL,
   `plan_end_date` timestamp NULL DEFAULT NULL,
@@ -5644,7 +5649,7 @@ CREATE TABLE `glpi_projecttasks` (
   KEY `is_recursive` (`is_recursive`),
   KEY `projects_id` (`projects_id`),
   KEY `projecttasks_id` (`projecttasks_id`),
-  KEY `date` (`date`),
+  KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`),
   KEY `users_id` (`users_id`),
   KEY `plan_start_date` (`plan_start_date`),
@@ -7202,10 +7207,12 @@ CREATE TABLE `glpi_transfers` (
   `keep_cartridge` int NOT NULL DEFAULT '0',
   `keep_consumable` int NOT NULL DEFAULT '0',
   `date_mod` timestamp NULL DEFAULT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
   `comment` text,
   `keep_disk` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `date_mod` (`date_mod`)
+  KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -8354,6 +8361,7 @@ CREATE TABLE `glpi_appliances` (
   `groups_id` int NOT NULL DEFAULT '0',
   `groups_id_tech` int NOT NULL DEFAULT '0',
   `date_mod` timestamp NULL DEFAULT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
   `states_id` int NOT NULL DEFAULT '0',
   `externalidentifier` varchar(255) DEFAULT NULL,
   `serial` varchar(255) DEFAULT NULL,
@@ -8377,7 +8385,8 @@ CREATE TABLE `glpi_appliances` (
   KEY `serial` (`serial`),
   KEY `otherserial` (`otherserial`),
   KEY `is_helpdesk_visible` (`is_helpdesk_visible`),
-  KEY `date_mod` (`date_mod`)
+  KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_appliances_items`;
@@ -8482,9 +8491,11 @@ CREATE TABLE `glpi_lockedfields` (
   `items_id` int NOT NULL DEFAULT '0',
   `field` varchar(50) NOT NULL,
   `value` varchar(255) DEFAULT NULL,
+  `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`itemtype`,`items_id`,`field`),
+  KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -4761,11 +4761,11 @@ CREATE TABLE `glpi_objectlocks` (
   `itemtype` varchar(100) NOT NULL COMMENT 'Type of locked object',
   `items_id` int NOT NULL COMMENT 'RELATION to various tables, according to itemtype (ID)',
   `users_id` int NOT NULL COMMENT 'id of the locker',
-  `date_mod` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp of the lock',
+  `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `item` (`itemtype`,`items_id`),
   KEY `users_id` (`users_id`),
-  KEY `date_mod` (`date_mod`)
+  KEY `date` (`date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -7533,12 +7533,12 @@ CREATE TABLE `glpi_knowbaseitems_revisions` (
   `answer` longtext,
   `language` varchar(10) DEFAULT NULL,
   `users_id` int NOT NULL DEFAULT '0',
-  `date_creation` timestamp NULL DEFAULT NULL,
+  `date` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`knowbaseitems_id`,`revision`,`language`),
   KEY `revision` (`revision`),
   KEY `users_id` (`users_id`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date` (`date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_knowbaseitems_comments
@@ -8627,22 +8627,22 @@ CREATE TABLE `glpi_printerlogs` (
   `color_copies` int NOT NULL DEFAULT '0',
   `scanned` int NOT NULL DEFAULT '0',
   `faxed` int NOT NULL DEFAULT '0',
-  `date_creation` timestamp NULL DEFAULT NULL,
+  `date` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `printers_id` (`printers_id`),
-  KEY `date_creation` (`date_creation`)
+  KEY `date` (`date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
 DROP TABLE IF EXISTS `glpi_networkportconnectionlogs`;
 CREATE TABLE `glpi_networkportconnectionlogs` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `date_creation` timestamp NULL DEFAULT NULL,
+  `date` timestamp NULL DEFAULT NULL,
   `connected` tinyint NOT NULL DEFAULT '0',
   `networkports_id_source` int NOT NULL DEFAULT '0',
   `networkports_id_destination` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `date_creation` (`date_creation`),
+  KEY `date` (`date`),
   KEY `networkports_id_source` (`networkports_id_source`),
   KEY `networkports_id_destination` (`networkports_id_destination`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -8651,14 +8651,14 @@ CREATE TABLE `glpi_networkportconnectionlogs` (
 DROP TABLE IF EXISTS `glpi_networkportmetrics`;
 CREATE TABLE `glpi_networkportmetrics` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `date_creation` timestamp NULL DEFAULT NULL,
+  `date` timestamp NULL DEFAULT NULL,
   `ifinbytes` bigint NOT NULL DEFAULT '0',
   `ifinerrors` bigint NOT NULL DEFAULT '0',
   `ifoutbytes` bigint NOT NULL DEFAULT '0',
   `ifouterrors` bigint NOT NULL DEFAULT '0',
   `networkports_id` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `date_creation` (`date_creation`),
+  KEY `date` (`date`),
   KEY `networkports_id` (`networkports_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -492,7 +492,7 @@ class DbUtils extends DbTestCase {
          ->if($this->newTestedInstance)
          ->then
             ->boolean($this->testedInstance->isIndex('glpi_configs', 'fakeField'))->isFalse()
-            ->boolean($this->testedInstance->isIndex('glpi_configs', 'name'))->isFalse()
+            ->boolean($this->testedInstance->isIndex('glpi_configs', 'name'))->isTrue()
             ->boolean($this->testedInstance->isIndex('glpi_configs', 'value'))->isFalse()
             ->boolean($this->testedInstance->isIndex('glpi_users', 'locations_id'))->isTrue()
             ->boolean($this->testedInstance->isIndex('glpi_users', 'unicityloginauth'))->isTrue()
@@ -506,7 +506,7 @@ class DbUtils extends DbTestCase {
 
       //keep testing old method from db.function
       $this->boolean(isIndex('glpi_configs', 'fakeField'))->isFalse();
-      $this->boolean(isIndex('glpi_configs', 'name'))->isFalse();
+      $this->boolean(isIndex('glpi_configs', 'name'))->isTrue();
       $this->boolean(isIndex('glpi_users', 'locations_id'))->isTrue();
       $this->boolean(isIndex('glpi_users', 'unicityloginauth'))->isTrue();
 

--- a/tests/functionnal/Glpi/CalDAV/Server.php
+++ b/tests/functionnal/Glpi/CalDAV/Server.php
@@ -1408,7 +1408,7 @@ VCALENDAR
       ]);
       $this->integer($project_task_team_id)->isGreaterThan(0);
 
-      $creation_date = $project_task->fields['date'];
+      $creation_date = $project_task->fields['date_creation'];
 
       $project_task_path = 'calendars/users/' . $user->fields['name'] . '/calendar/' . $project_task->fields['uuid'] . '.ics';
 
@@ -1459,7 +1459,7 @@ VCALENDAR
       $this->boolean($project_task->getFromDBByCrit(['uuid' => $project_task->fields['uuid']]))->isTrue();
       $this->array($project_task->fields)
          ->string['uuid']->isEqualTo($project_task->fields['uuid'])
-         ->string['date']->isEqualTo($creation_date) // be sure that creation date is not overrided
+         ->string['date_creation']->isEqualTo($creation_date) // be sure that creation date is not overrided
          ->string['content']->isEqualTo('Updated description.')
          ->integer['percent_done']->isEqualTo(35);
 
@@ -1494,7 +1494,7 @@ VCALENDAR
       $this->boolean($project_task->getFromDBByCrit(['uuid' => $project_task->fields['uuid']]))->isTrue();
       $this->array($project_task->fields)
          ->string['uuid']->isEqualTo($project_task->fields['uuid'])
-         ->string['date']->isEqualTo($creation_date) // be sure that creation date is not overrided
+         ->string['date_creation']->isEqualTo($creation_date) // be sure that creation date is not overrided
          ->string['content']->isEqualTo('Updated description.')
          ->integer['percent_done']->isEqualTo(100)
          ->string['plan_start_date']->isEqualTo('2019-11-01 08:00:00') // 1 hour offset between Europe/Paris and UTC

--- a/tests/functionnal/Glpi/Inventory/Assets/Printer.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Printer.php
@@ -156,7 +156,7 @@ class Printer extends AbstractInventoryAsset {
       $result = $iterator->next();
 
       unset($result['id']);
-      unset($result['date_creation']);
+      unset($result['date']);
 
       $this->array($result)->isIdenticalTo([
          'printers_id' => $printer->fields['id'],

--- a/tests/functionnal/NetworkPortMetrics.php
+++ b/tests/functionnal/NetworkPortMetrics.php
@@ -78,7 +78,7 @@ class NetworkPortMetrics extends DbTestCase {
             'ifouterrors'  => 50,
             'ifinbytes'    => 1076823325,
             'ifoutbytes'   => 2179528910,
-            'date_creation' => $value['date_creation'],
+            'date' => $value['date'],
             'id' => $value['id']
       ];
       $this->array($value)->isEqualTo($expected);
@@ -104,7 +104,7 @@ class NetworkPortMetrics extends DbTestCase {
             'ifouterrors'  => 0,
             'ifinbytes'    => 1056823325,
             'ifoutbytes'   => 2159528910,
-            'date_creation' => $value['date_creation'],
+            'date' => $value['date'],
             'id' => $value['id']
       ];
       $this->array($value1)->isIdenticalTo($value);

--- a/tests/functionnal/PrinterLog.php
+++ b/tests/functionnal/PrinterLog.php
@@ -59,7 +59,7 @@ class PrinterLog extends DbTestCase {
          'color_pages' => 1799,
          'rv_pages' => 4389,
          'scanned' => 7846,
-         'date_creation' => $cdate1->format('Y-m-d')
+         'date' => $cdate1->format('Y-m-d')
       ];
       $this->integer($log->add($input))->isGreaterThan(0);
 
@@ -72,7 +72,7 @@ class PrinterLog extends DbTestCase {
          'color_pages' => 2151,
          'rv_pages' => 5987,
          'scanned' => 15542,
-         'date_creation' => $cdate2->format('Y-m-d')
+         'date' => $cdate2->format('Y-m-d')
       ];
       $this->integer($log->add($input))->isGreaterThan(0);
 
@@ -83,7 +83,7 @@ class PrinterLog extends DbTestCase {
          'color_pages' => 3041,
          'rv_pages' => 7654,
          'scanned' => 28177,
-         'date_creation' => $now->format('Y-m-d')
+         'date' => $now->format('Y-m-d')
       ];
       $this->integer($log->add($input))->isGreaterThan(0);
 
@@ -91,6 +91,6 @@ class PrinterLog extends DbTestCase {
       $this->array($log->getMetrics($printer))->hasSize(2);
 
       //change filter to include first one
-      $this->array($log->getMetrics($printer, ['date_creation' => ['>=', $cdate1->format('Y-m-d')]]))->hasSize(3);
+      $this->array($log->getMetrics($printer, ['date' => ['>=', $cdate1->format('Y-m-d')]]))->hasSize(3);
    }
 }

--- a/tests/units/Glpi/System/Diagnostic/DatabaseSchemaConsistencyChecker.php
+++ b/tests/units/Glpi/System/Diagnostic/DatabaseSchemaConsistencyChecker.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\System\Diagnostic;
+
+class DatabaseSchemaConsistencyChecker extends \GLPITestCase {
+
+   protected function sqlProvider(): iterable {
+      // `date_creation` should always be associated with `date_mod`
+      yield [
+         'create_table_sql'   => <<<SQL
+CREATE TABLE `%s` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB
+SQL
+         ,
+         'expected_missing'   => [
+            'date_mod'
+         ],
+      ];
+      yield [
+         'create_table_sql'   => <<<SQL
+CREATE TABLE `%s` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `date_mod` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB
+SQL
+         ,
+         'expected_missing'   => [
+            'date_creation'
+         ],
+      ];
+      yield [
+         'create_table_sql'   => <<<SQL
+CREATE TABLE `%s` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
+  `date_mod` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB
+SQL
+         ,
+         'expected_missing'   => [],
+      ];
+   }
+
+   /**
+    * @dataProvider sqlProvider
+    */
+   public function testGetMissingFields(
+      string $create_table_sql,
+      array $expected_missing
+   ) {
+
+      global $DB;
+
+      $table_name = sprintf('glpitests_%s', uniqid());
+
+      $this->newTestedInstance($DB);
+      $DB->query(sprintf($create_table_sql, $table_name));
+      $missing_fields = $this->testedInstance->getMissingFields($table_name);
+      $DB->query(sprintf('DROP TABLE `%s`', $table_name));
+
+      $this->array($missing_fields)->isEqualTo($expected_missing);
+   }
+}

--- a/tests/units/Glpi/System/Diagnostic/DatabaseSchemaDiffChecker.php
+++ b/tests/units/Glpi/System/Diagnostic/DatabaseSchemaDiffChecker.php
@@ -32,7 +32,7 @@
 
 namespace tests\units\Glpi\System\Diagnostic;
 
-class DatabaseSchemaChecker extends \GLPITestCase {
+class DatabaseSchemaIntegrityChecker extends \GLPITestCase {
 
    protected function sqlProvider() {
       return [

--- a/tools/checkdatabasekeyscommand.class.php
+++ b/tools/checkdatabasekeyscommand.class.php
@@ -40,24 +40,24 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CheckKeysCommand extends AbstractCommand {
+class CheckDatabaseKeysCommand extends AbstractCommand {
 
    /**
-    * Error code returned when missing keys found.
+    * Error code returned when missing keys are found.
     *
     * @var integer
     */
    const ERROR_FOUND_MISSING_KEYS = 1;
 
    /**
-    * Error code returned when misnamed keys found.
+    * Error code returned when misnamed keys are found.
     *
     * @var integer
     */
    const ERROR_FOUND_MISNAMED_KEYS = 2;
 
    /**
-    * Error code returned when useless keys found.
+    * Error code returned when useless keys are found.
     *
     * @var integer
     */
@@ -66,8 +66,8 @@ class CheckKeysCommand extends AbstractCommand {
    protected function configure() {
       parent::configure();
 
-      $this->setName('glpi:database:check_keys');
-      $this->setAliases(['db:check_keys']);
+      $this->setName('glpi:tools:check_database_keys');
+      $this->setAliases(['tools:check_database_keys']);
       $this->setDescription(__('Check database for missing and errounous keys.'));
 
       $this->addOption(

--- a/tools/checkdatabaseschemaconsistencycommand.class.php
+++ b/tools/checkdatabaseschemaconsistencycommand.class.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use Glpi\Console\AbstractCommand;
+use Glpi\System\Diagnostic\DatabaseSchemaConsistencyChecker;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CheckDatabaseSchemaConsistencyCommand extends AbstractCommand {
+
+   /**
+    * Error code returned when missing fields are found.
+    *
+    * @var integer
+    */
+   const ERROR_FOUND_MISSING_FIELDS = 1;
+
+   protected function configure() {
+      parent::configure();
+
+      $this->setName('glpi:tools:check_database_schema_consistency');
+      $this->setAliases(['tools:check_database_schema_consistency']);
+      $this->setDescription(__('Check database schema consistency.'));
+   }
+
+   protected function execute(InputInterface $input, OutputInterface $output) {
+
+      $checker = new DatabaseSchemaConsistencyChecker($this->db);
+
+      $has_missing_fields = false;
+
+      $table_iterator = $this->db->listTables('glpi\_%', ['NOT' => ['table_name' => ['LIKE', 'glpi\_plugin\_%']]]);
+      foreach ($table_iterator as $table_data) {
+         $table_name = $table_data['TABLE_NAME'];
+
+         $missing_fields  = $checker->getMissingfields($table_name);
+         if (count($missing_fields) > 0) {
+            ksort($missing_fields);
+            $has_missing_fields = true;
+            $message = sprintf(
+               __('Table "%s" has missing fields: `%s`'),
+               $table_name,
+               implode('`,`', $missing_fields)
+            );
+            $output->writeln('<error>' . $message . '</error>', OutputInterface::VERBOSITY_QUIET);
+         }
+      }
+
+      if ($has_missing_fields) {
+         return self::ERROR_FOUND_MISSING_FIELDS;
+      }
+
+      $output->writeln('<info>' . __('Database schema is consistent.') . '</info>');
+
+      return 0; // Success
+   }
+}

--- a/tools/fake_metrics.php
+++ b/tools/fake_metrics.php
@@ -65,7 +65,7 @@ if ($printers_id !== false) {
       $scanned += $scans;
 
       $input = [
-         'date_creation'  => $dt->format('Y-m-d'),
+         'date'           => $dt->format('Y-m-d'),
          'total_pages'    => $total_pages,
          'bw_pages'       => $bw_pages,
          'color_pages'    => $color_pages,
@@ -98,7 +98,7 @@ if ($networkports_id !== false) {
       $outerrors = random_int(0, 750);
 
       $input = [
-         'date_creation'   => $dt->format('Y-m-d'),
+         'date'            => $dt->format('Y-m-d'),
          'ifinbytes'       => $inbytes,
          'ifoutbytes'      => $outbytes,
          'ifinerrors'      => $inerrors,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Add a checks on date fields consistency (`date_creation` and `date_mod` should not be used separately).
2. Fields that store a valuable date should be named `date`.
3. Add a check to ensure `name` fields are indexed (as this is the default field used for sorting lists).