### PR TITLE
remain of dockblock clean on notepad causes fail of notepad display

### DIFF
--- a/inc/notepad.class.php
+++ b/inc/notepad.class.php
@@ -95,7 +95,6 @@ class Notepad extends CommonDBChild {
       return $input;
    }
 
-   /**
    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
 
       if (Session::haveRight($item::$rightname, READNOTE)) {


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

I cannot find the previous commit causing this issue, maybe a bad merge
