### PR TITLE
Fix fields consistency on add/update

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -574,6 +574,7 @@ class CommonDBTM extends CommonGLPI {
 
       if (count($oldvalues)) {
          Log::constructHistory($this, $oldvalues, $this->fields);
+         $this->getFromDB($this->fields['id']);
       }
 
       return true;

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -599,6 +599,7 @@ class CommonDBTM extends CommonGLPI {
             $params[$key] = $value;
          }
 
+         $this->fields = Toolbox::stripslashes_deep($this->fields);
          $result = $DB->insert($this->getTable(), $params);
          if ($result) {
             if (!isset($this->fields['id'])

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -599,7 +599,6 @@ class CommonDBTM extends CommonGLPI {
             $params[$key] = $value;
          }
 
-         $this->fields = Toolbox::stripslashes_deep($this->fields);
          $result = $DB->insert($this->getTable(), $params);
          if ($result) {
             if (!isset($this->fields['id'])
@@ -607,6 +606,8 @@ class CommonDBTM extends CommonGLPI {
                   || ($this->fields['id'] == 0)) {
                $this->fields['id'] = $DB->insertId();
             }
+
+            $this->getFromDB($this->fields['id']);
 
             return $this->fields['id'];
          }

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -139,32 +139,33 @@ class Computer extends CommonDBTM {
 
       $changes = [];
       $update_count = count($this->updates ?? []);
+      $input = Toolbox::addslashes_deep($this->fields);
       for ($i=0; $i < $update_count; $i++) {
          // Update contact of attached items
          if ($this->updates[$i] == 'contact_num' && $CFG_GLPI['is_contact_autoupdate']) {
-            $changes['contact_num'] = $this->fields['contact_num'];
+            $changes['contact_num'] = $input['contact_num'];
          }
          if ($this->updates[$i] == 'contact' && $CFG_GLPI['is_contact_autoupdate']) {
-            $changes['contact'] = $this->fields['contact'];
+            $changes['contact'] = $input['contact'];
          }
          // Update users and groups of attached items
          if ($this->updates[$i] == 'users_id'
              && $CFG_GLPI['is_user_autoupdate']) {
-            $changes['users_id'] = $this->fields['users_id'];
+            $changes['users_id'] = $input['users_id'];
          }
          if ($this->updates[$i] == 'groups_id'
              && $CFG_GLPI['is_group_autoupdate']) {
-            $changes['groups_id'] = $this->fields['groups_id'];
+            $changes['groups_id'] = $input['groups_id'];
          }
          // Update state of attached items
          if (($this->updates[$i] == 'states_id')
              && ($CFG_GLPI['state_autoupdate_mode'] < 0)) {
-            $changes['states_id'] = $this->fields['states_id'];
+            $changes['states_id'] = $input['states_id'];
          }
          // Update loction of attached items
          if ($this->updates[$i] == 'locations_id'
              && $CFG_GLPI['is_location_autoupdate']) {
-            $changes['locations_id'] = $this->fields['locations_id'];
+            $changes['locations_id'] = $input['locations_id'];
          }
       }
 

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -852,6 +852,36 @@ class CommonDBTM extends DbTestCase {
       $_SESSION['glpi_currenttime'] = $bkp_current;
    }
 
+   public function testUpdate() {
+      $computer = new \Computer();
+      $ent0 = getItemByTypeName('Entity', '_test_root_entity', true);
+      $bkp_current = $_SESSION['glpi_currenttime'];
+      $_SESSION['glpi_currenttime'] = '2000-01-01 00:00:00';
+
+      //test with date set
+      $computerID = $computer->add(\Toolbox::addslashes_deep([
+         'name'            => 'Computer01',
+         'date_creation'   => '2018-01-01 11:22:33',
+         'date_mod'        => '2018-01-01 22:33:44',
+         'entities_id'     => $ent0
+      ]));
+      $this->string($computer->fields['name'])->isIdenticalTo("Computer01");
+
+      $this->integer($computerID)->isGreaterThan(0);
+      $this->boolean(
+         $computer->getFromDB($computerID)
+      )->isTrue();
+      $this->string($computer->fields['name'])->isIdenticalTo("Computer01");
+
+      $this->boolean(
+         $computer->update(['id' => $computerID, 'name' => \Toolbox::addslashes_deep('Computer01 \'')])
+      )->isTrue();
+      $this->string($computer->fields['name'])->isIdenticalTo('Computer01 \'');
+      $this->boolean($computer->getFromDB($computerID))->isTrue();
+      $this->string($computer->fields['name'])->isIdenticalTo('Computer01 \'');
+   }
+
+
    public function testTimezones() {
       global $DB;
 

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -816,12 +816,13 @@ class CommonDBTM extends DbTestCase {
       $_SESSION['glpi_currenttime'] = '2000-01-01 00:00:00';
 
       //test with date set
-      $computerID = $computer->add([
-         'name'            => 'Computer01',
+      $computerID = $computer->add(\Toolbox::addslashes_deep([
+         'name'            => 'Computer01 \'',
          'date_creation'   => '2018-01-01 11:22:33',
          'date_mod'        => '2018-01-01 22:33:44',
          'entities_id'     => $ent0
-      ]);
+      ]));
+      $this->string($computer->fields['name'])->isIdenticalTo("Computer01 '");
 
       $this->integer($computerID)->isGreaterThan(0);
       $this->boolean(
@@ -830,12 +831,14 @@ class CommonDBTM extends DbTestCase {
       // Verify you can override creation and modifcation dates from add
       $this->string($computer->fields['date_creation'])->isEqualTo('2018-01-01 11:22:33');
       $this->string($computer->fields['date_mod'])->isEqualTo('2018-01-01 22:33:44');
+      $this->string($computer->fields['name'])->isIdenticalTo("Computer01 '");
 
       //test with default date
-      $computerID = $computer->add([
-         'name'            => 'Computer01',
+      $computerID = $computer->add(\Toolbox::addslashes_deep([
+         'name'            => 'Computer01 \'',
          'entities_id'     => $ent0
-      ]);
+      ]));
+      $this->string($computer->fields['name'])->isIdenticalTo("Computer01 '");
 
       $this->integer($computerID)->isGreaterThan(0);
       $this->boolean(
@@ -844,6 +847,7 @@ class CommonDBTM extends DbTestCase {
       // Verify default date has been used
       $this->string($computer->fields['date_creation'])->isEqualTo('2000-01-01 00:00:00');
       $this->string($computer->fields['date_mod'])->isEqualTo('2000-01-01 00:00:00');
+      $this->string($computer->fields['name'])->isIdenticalTo("Computer01 '");
 
       $_SESSION['glpi_currenttime'] = $bkp_current;
    }

--- a/tests/functionnal/ITILSolution.php
+++ b/tests/functionnal/ITILSolution.php
@@ -66,7 +66,7 @@ class ITILSolution extends DbTestCase {
       $this->boolean($ticket->getFromDB($ticket->getID()))->isTrue();
 
       $this->variable($ticket->getField('status'))->isEqualTo($ticket::SOLVED);
-      $this->string($solution->getField('content'))->isIdenticalTo('Current friendly ticket\r\nis solved!');
+      $this->string($solution->getField('content'))->isIdenticalTo("Current friendly ticket\r\nis solved!");
 
       $this->boolean($solution->getFromDB($solution->getID()))->isTrue();
       $this->integer((int)$solution->fields['status'])->isIdenticalTo(\CommonITILValidation::WAITING);
@@ -168,7 +168,7 @@ class ITILSolution extends DbTestCase {
       $this->boolean($problem->getFromDB($problem->getID()))->isTrue();
 
       $this->variable($problem->getField('status'))->isEqualTo($problem::SOLVED);
-      $this->string($solution->getField('content'))->isIdenticalTo('Current friendly problem\r\nis solved!');
+      $this->string($solution->getField('content'))->isIdenticalTo("Current friendly problem\r\nis solved!");
 
       $this->boolean($solution->getFromDB($solution->getID()))->isTrue();
       $this->integer((int)$solution->fields['status'])->isIdenticalTo(\CommonITILValidation::ACCEPTED);
@@ -201,7 +201,7 @@ class ITILSolution extends DbTestCase {
       $this->boolean($change->getFromDB($change->getID()))->isTrue();
 
       $this->variable($change->getField('status'))->isEqualTo($change::SOLVED);
-      $this->string($solution->getField('content'))->isIdenticalTo('Current friendly change\r\nis solved!');
+      $this->string($solution->getField('content'))->isIdenticalTo("Current friendly change\r\nis solved!");
 
       $this->boolean($solution->getFromDB($solution->getID()))->isTrue();
       $this->integer((int)$solution->fields['status'])->isIdenticalTo(\CommonITILValidation::ACCEPTED);

--- a/tests/functionnal/ProjectTask.php
+++ b/tests/functionnal/ProjectTask.php
@@ -180,7 +180,7 @@ class ProjectTask extends DbTestCase {
 
       $this->hasSessionMessages(
          WARNING, [
-            "The user $usr_str is busy at the selected timeframe.<br/>- Project task: from 2019-08-11  to 2019-08-12 :<br/><a href='".
+            "The user $usr_str is busy at the selected timeframe.<br/>- Project task: from 2019-08-11 00:00 to 2019-08-12 00:00:<br/><a href='".
             $ptask->getFormURLWithID($task_id)."'>first test, whole period</a><br/>"
          ]
       );

--- a/tests/functionnal/TicketTask.php
+++ b/tests/functionnal/TicketTask.php
@@ -313,7 +313,7 @@ class TicketTask extends DbTestCase {
       $usr_str = '<a href="' . $user->getFormURLWithID($users_id) . '">' . $user->getName() . '</a>';
       $this->hasSessionMessages(
          WARNING, [
-            "The user $usr_str is busy at the selected timeframe.<br/>- Ticket task: from 2019-08-13  to 2019-08-14 :<br/><a href='".
+            "The user $usr_str is busy at the selected timeframe.<br/>- Ticket task: from 2019-08-13 00:00 to 2019-08-14 00:00:<br/><a href='".
             $ticket->getFormURLWithID($tid)."&amp;forcetab=TicketTask$1'>ticket title</a><br/>"
          ]
       );

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -137,10 +137,12 @@ class Migration extends \GLPITestCase {
          0 => 'SELECT * FROM `glpi_configs` WHERE `context` = \'core\' AND `name` IN (\'one\', \'two\')',
          1 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'one\'',
          2 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'one\', \'key\')',
-         3 => 'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \''.$_SESSION['glpi_currenttime'].'\', \'1\', \'one \', \'key\')',
-         4 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'two\'',
-         5 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'two\', \'value\')',
-         6 => 'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \''.$_SESSION['glpi_currenttime'].'\', \'1\', \'two \', \'value\')',
+         3 => 'SELECT * FROM `glpi_configs` WHERE `glpi_configs`.`id` = \'0\' LIMIT 1',
+         4 => 'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \''.$_SESSION['glpi_currenttime'].'\', \'1\', \'one \', \'key\')',
+         5 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'two\'',
+         6 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'two\', \'value\')',
+         7 => 'SELECT * FROM `glpi_configs` WHERE `glpi_configs`.`id` = \'0\' LIMIT 1',
+         8 => 'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \''.$_SESSION['glpi_currenttime'].'\', \'1\', \'two \', \'value\')',
       ];
       $this->array($this->queries)->isIdenticalTo($core_queries);
 
@@ -161,10 +163,12 @@ class Migration extends \GLPITestCase {
          0 => 'SELECT * FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` IN (\'one\', \'two\')',
          1 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'one\'',
          2 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'one\', \'key\')',
-         3 => 'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \''.$_SESSION['glpi_currenttime'].'\', \'1\', \'one (test-context) \', \'key\')',
-         4 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'two\'',
-         5 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'two\', \'value\')',
-         6 => 'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \''.$_SESSION['glpi_currenttime'].'\', \'1\', \'two (test-context) \', \'value\')',
+         3 => 'SELECT * FROM `glpi_configs` WHERE `glpi_configs`.`id` = \'0\' LIMIT 1',
+         4 => 'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \''.$_SESSION['glpi_currenttime'].'\', \'1\', \'one (test-context) \', \'key\')',
+         5 => 'SELECT `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'two\'',
+         6 => 'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'two\', \'value\')',
+         7 => 'SELECT * FROM `glpi_configs` WHERE `glpi_configs`.`id` = \'0\' LIMIT 1',
+         8 => 'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \''.$_SESSION['glpi_currenttime'].'\', \'1\', \'two (test-context) \', \'value\')',
       ]);
 
       //test with one existing value => only new key should be inserted


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`CommonDBTM::$fields` property may be inconsistent. When adding or updating such an object; `fields` property is populated from `input` property, which is sanitized. When loading from DB, the `fields` property is loaded verbatim (ie. not sanitized).
This can cause difficult to handle cases, with required extra decoding.

The change may seem huge; but I do not think this would break. Indeed, this change would just make any extra `stripslashes` (and others) useless; calling such methods on clean data should not be a big issue; there were only a few problems in core right now.