### PR TITLE
Fix array to string warning and add append_params tests

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -182,7 +182,11 @@ class Search {
             ],
             '&amp;'
          );
-         $parameters = "as_map=0&amp;sort=".$data['search']['sort']."&amp;order=".$data['search']['order'].'&amp;'.
+         $sort_params = Toolbox::append_params([
+            'sort'   => $data['search']['sort'],
+            'order'  => $data['search']['order']
+         ], '&amp;');
+         $parameters = "as_map=0&amp;".$sort_params.'&amp;'.
                         $globallinkto;
 
          if (strpos($target, '?') == false) {

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -1070,4 +1070,52 @@ class Toolbox extends DbTestCase {
    public function testHasTrait($class, $trait, $result) {
       $this->boolean(\Toolbox::hasTrait($class, $trait))->isIdenticalTo((bool)$result);
    }
+
+   public function appendParametersProvider() {
+      return [
+         [
+            [
+               'a'   => 'test1',
+               'b'   => 'test2'
+            ], '&', 'a=test1&b=test2'
+         ],
+         [
+            [
+               'a'   => [
+                  'test1', 'test2'
+               ],
+               'b'   => 'test3'
+            ], '&', 'a%5B0%5D=test1&a%5B1%5D=test2&b=test3' // '[' converted to %5B, ']' converted to %5D
+         ],
+         [
+            [
+               'a'   => [
+                  'test1', 'test2'
+               ],
+               'b'   => 'test3*'
+            ], '&', 'a%5B0%5D=test1&a%5B1%5D=test2&b=test3%2A' // '[' converted to %5B, ']' converted to %5D
+         ],
+         [
+            [
+               'a'   => 'test1',
+               'b'   => 'test2'
+            ], '_', 'a=test1_b=test2'
+         ],
+         [
+            [
+               'a'   => [
+                  'test1', 'test2'
+               ],
+               'b'   => 'test3'
+            ], '_', 'a%5B0%5D=test1_a%5B1%5D=test2_b=test3' // '[' converted to %5B, ']' converted to %5D
+         ]
+      ];
+   }
+
+   /**
+    * @dataProvider appendParametersProvider
+    */
+   public function testAppendParameters(array $params, string $separator, string $expected) {
+      $this->string(\Toolbox::append_params($params, $separator))->isEqualTo($expected);
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since adding the multi-sort feature for the Search engine, the map view showed an array to string conversion warning. This properly handles converting the new sort/order arrays into query string parameters.
I also added tests for `Toolbox::append_parameters` since none existed.