### PR TITLE
Suppress ticket list refresh when modal open

### DIFF
--- a/front/ticket.php
+++ b/front/ticket.php
@@ -40,7 +40,13 @@ if (Session::getCurrentInterface() == "helpdesk") {
    Html::header(Ticket::getTypeName(Session::getPluralNumber()), '', "helpdesk", "ticket");
 }
 
-echo Html::manageRefreshPage();
+$callback = <<<JS
+   if ($('div[role="dialog"]:visible').length === 0) {
+      window.location.reload();
+   }
+JS;
+
+echo Html::manageRefreshPage(false, $callback);
 
 if ($default = Glpi\Dashboard\Grid::getDefaultDashboardForMenu('mini_ticket', true)) {
    $dashboard = new Glpi\Dashboard\Grid($default, 33, 2, 'mini_core');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #9006 

Only applies to 9.5.X since 10.0.0 implements an AJAX-based refresh for search lists.
Since the `manageRefresh` function already puts the refresh code inside `setInterval` instead of `setTimeout`, we just need to check if a modal is open and skip the current refresh period.
I only did this for the ticket list in case some other code relies on refreshing while a modal is open.