### PR TITLE
Add better error for unselected contract for suppliers

### DIFF
--- a/front/contract_supplier.form.php
+++ b/front/contract_supplier.form.php
@@ -41,6 +41,12 @@ include ('../inc/includes.php');
 Session::checkCentralAccess();
 $contractsupplier = new Contract_Supplier();
 if (isset($_POST["add"])) {
+   if (!isset($_POST['contracts_id']) || empty($_POST['contracts_id'])) {
+      $message = sprintf(__('Mandatory fields are not filled. Please correct: %s'),
+         _n('Contract', 'Contract', 1));
+      Session::addMessageAfterRedirect($message, false, ERROR);
+      Html::back();
+   }
    $contractsupplier->check(-1, CREATE, $_POST);
 
    if (isset($_POST["contracts_id"]) && ($_POST["contracts_id"] > 0)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8521 

Display a better error message when trying to associate no contract with a supplier.
Same as #4308 but for this specific case that is handled in a different front file.