### PR TITLE
Don't display public ticket form if not enabled

### DIFF
--- a/front/helpdesk.php
+++ b/front/helpdesk.php
@@ -33,6 +33,12 @@
 
 include ('../inc/includes.php');
 
+global $CFG_GLPI;
+
+if ((int)$CFG_GLPI['use_anonymous_helpdesk'] === 0) {
+    Html::redirect($CFG_GLPI["root_doc"] . "/front/central.php");
+}
+
 echo "<!DOCTYPE html>";
 echo "<html lang=\"{$CFG_GLPI["languages"][$_SESSION['glpilanguage']][3]}\">";
 ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8510

If anonymous helpdesk is not enabled, redirect to the central page (which would redirect to the login if not logged in).