### PR TITLE
Fixed missing empty choice string for timezone settings

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -2694,7 +2694,8 @@ JAVASCRIPT;
                   'timezone',
                   $timezones, [
                      'value'                 => $this->fields["timezone"],
-                     'display_emptychoice'   => true
+                     'display_emptychoice'   => true,
+                     'emptylabel'            => __('Use server configuration')
                   ]
                );
             } else if (Session::haveRight("config", READ)) {

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -2210,7 +2210,8 @@ JAVASCRIPT;
                'timezone',
                $timezones, [
                   'value'                 => $this->fields["timezone"],
-                  'display_emptychoice'   => true
+                  'display_emptychoice'   => true,
+                  'emptylabel'            => __('Use server configuration')
                ]
             );
          } else if (Session::haveRight("config", READ)) {


### PR DESCRIPTION
On main tab for personal settings


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
