### PR TITLE
Allow validators to add followups

### DIFF
--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -164,4 +164,13 @@ class DbTestCase extends \GLPITestCase {
       }
       return array_unique($classes);
    }
+
+   protected function createItems($itemtype, $inputs) {
+      foreach ($inputs as $input) {
+         $item = new $itemtype();
+         $id = $item->add($input);
+         $this->integer($id)->isGreaterThan(0);
+         $this->checkInput($item, $id, $input);
+      }
+   }
 }

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -165,6 +165,12 @@ class DbTestCase extends \GLPITestCase {
       return array_unique($classes);
    }
 
+   /**
+    * Create multiples items of the given class
+    *
+    * @param string $itemtype
+    * @param array $inputs
+    */
    protected function createItems($itemtype, $inputs) {
       foreach ($inputs as $input) {
          $item = new $itemtype();

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -3637,7 +3637,7 @@ HTML
    /**
     * @dataProvider convertContentForTicketProvider
     */
-    public function testConvertContentForTicket(string $content, array $files, array $tags, string $expected) {
+   public function testConvertContentForTicket(string $content, array $files, array $tags, string $expected) {
       $this->newTestedInstance();
 
       $this->string($this->testedInstance->convertContentForTicket($content, $files, $tags))->isEqualTo($expected);


### PR DESCRIPTION
Validators aren't allowed to add followups to tickets.
It seems useful to allow them to add followups for the tickets they validate, in case they need to add some additional informations later.

Changes:
* Allow validator to add followups for tickets they validate (new function CommonITILObject::isValidator + tests)
* Improve readability of canAddFollowups conditions
* Add a new `createItems` function in tests to avoid writing the same boiler plate code every tests.

Side note as it isn't related to the PR changes but having to check "manually" if validation is enabled on an itemtype (`if (!$this instanceof Ticket && !$this instanceof Change)` and building "manually" the validation class (`$validation_class = static::class . "Validation";`) should IMO be done with more robust polymorphic functions like `$this->supportValidation()` and `$this->getValidationClass()`.
Didn't want to add them and replace the existing code here as it is a bugfix but maybe a possible improvement in master 😉 .

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22325
