### PR TITLE
Fix PHP notice when changing ITIL status from task form

### DIFF
--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -334,7 +334,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
          //Also check if item status has changed
          if (!$proceed) {
             if (isset($this->input['_status'])
-               && $this->input['status'] != $item->getField('status')
+               && $this->input['_status'] != $item->getField('status')
             ) {
                $proceed = true;
             }


### PR DESCRIPTION
Added missing _ in front of status


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
