### PR TITLE
Fix handling of images in mail collector; fixes #9193

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -6703,7 +6703,7 @@ class Ticket extends CommonITILObject {
             // Set tag if image matches
             foreach ($files as $data => $filename) {
                if (preg_match("/".$data."/i", $src)) {
-                  $html = preg_replace("/<img.*src=['|\"]".preg_quote($src, '/')."['|\"][^>]*\>/s", "<p>".Document::getImageTag($tags[$filename])."</p>", $html);
+                  $html = preg_replace("/<img[^>]*src=['|\"]".preg_quote($src, '/')."['|\"][^>]*\>/s", "<p>".Document::getImageTag($tags[$filename])."</p>", $html);
                }
             }
          }

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -3577,4 +3577,67 @@ class Ticket extends DbTestCase {
       $this->boolean((boolean)$ticket->canAddFollowups())->isTrue();
    }
 
+   protected function convertContentForTicketProvider(): iterable {
+      yield [
+         'content'  => '',
+         'files'    => [],
+         'tags'     => [],
+         'expected' => '',
+      ];
+
+      // Content with embedded image.
+      yield [
+         'content'  => <<<HTML
+Here is the screenshot:
+<img src="screenshot.png" />
+blabla
+HTML
+         ,
+         'files'    => [
+            'screenshot.png' => 'screenshot.png',
+         ],
+         'tags'     => [
+            'screenshot.png' => '9faff0a6-f37490bd-60e2af9721f420.96500246',
+         ],
+         'expected' => <<<HTML
+Here is the screenshot:
+<p>#9faff0a6-f37490bd-60e2af9721f420.96500246#</p>
+blabla
+HTML
+         ,
+      ];
+
+      // Content with leading external image that will not be replaced by a tag.
+      yield [
+         'content'  => <<<HTML
+<img src="http://test.glpi-project.org/logo.png" />
+Here is the screenshot:
+<img src="img.jpg" />
+blabla
+HTML
+         ,
+         'files'    => [
+            'img.jpg' => 'img.jpg',
+         ],
+         'tags'     => [
+            'img.jpg' => '3eaff0a6-f37490bd-60e2a59721f420.96500246',
+         ],
+         'expected' => <<<HTML
+<img src="http://test.glpi-project.org/logo.png" />
+Here is the screenshot:
+<p>#3eaff0a6-f37490bd-60e2a59721f420.96500246#</p>
+blabla
+HTML
+         ,
+      ];
+   }
+
+   /**
+    * @dataProvider convertContentForTicketProvider
+    */
+   public function testConvertContentForTicket(string $content, array $files, array $tags, string $expected) {
+      $this->newTestedInstance();
+
+      $this->string($this->testedInstance->convertContentForTicket($content, $files, $tags))->isEqualTo($expected);
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #9193

When a collected mail contains both external and embedded images, some content was sometime stripped due to usage of a wildcard in regex.