### PR TITLE
Do not display tickets stats in days

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -5164,7 +5164,7 @@ abstract class CommonITILObject extends CommonDBTM {
       if (isset($this->fields['takeintoaccount_delay_stat'])) {
          echo "<tr class='tab_bg_2'><td>".__('Take into account')."</td><td>";
          if ($this->fields['takeintoaccount_delay_stat'] > 0) {
-            echo Html::timestampToString($this->fields['takeintoaccount_delay_stat'], 0);
+            echo Html::timestampToString($this->fields['takeintoaccount_delay_stat'], 0, false);
          } else {
             echo '&nbsp;';
          }
@@ -5176,7 +5176,7 @@ abstract class CommonITILObject extends CommonDBTM {
          echo "<tr class='tab_bg_2'><td>".__('Resolution')."</td><td>";
 
          if ($this->fields['solve_delay_stat'] > 0) {
-            echo Html::timestampToString($this->fields['solve_delay_stat'], 0);
+            echo Html::timestampToString($this->fields['solve_delay_stat'], 0, false);
          } else {
             echo '&nbsp;';
          }
@@ -5186,7 +5186,7 @@ abstract class CommonITILObject extends CommonDBTM {
       if (in_array($this->fields['status'], $this->getClosedStatusArray())) {
          echo "<tr class='tab_bg_2'><td>".__('Closure')."</td><td>";
          if ($this->fields['close_delay_stat'] > 0) {
-            echo Html::timestampToString($this->fields['close_delay_stat']);
+            echo Html::timestampToString($this->fields['close_delay_stat'], true, false);
          } else {
             echo '&nbsp;';
          }
@@ -5195,7 +5195,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       echo "<tr class='tab_bg_2'><td>".__('Pending')."</td><td>";
       if ($this->fields['waiting_duration'] > 0) {
-         echo Html::timestampToString($this->fields['waiting_duration'], 0);
+         echo Html::timestampToString($this->fields['waiting_duration'], 0, false);
       } else {
          echo '&nbsp;';
       }


### PR DESCRIPTION
The tickets stats are confusing for the users because the times are computed according to their custom calendar but are displayed as 24 hours days.

It seems best to avoid this issue by displayed the duration in hours so there is no possible misinterpretation for the user.


**Before:**
![image](https://user-images.githubusercontent.com/42734840/124571491-1cf8a180-de48-11eb-8a8a-28350350bc92.png)

  
  

**After :**
![image](https://user-images.githubusercontent.com/42734840/124571420-0c482b80-de48-11eb-9db0-41189ec6200b.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22239
