### PR TITLE
Restrict private saved seaches to current entities

### DIFF
--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -742,7 +742,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria {
       $private_criteria['WHERE'] = [
          "$table.is_private"  => 1,
          "$table.users_id"    => Session::getLoginUserID()
-      ];
+      ] + getEntitiesRestrictCriteria($table, '', '', true);
       $private_iterator = $DB->request($private_criteria);
 
       // get saved searches


### PR DESCRIPTION
Private searches do not take entities restriction into account when being loaded into the right side pannel.
This may be done on purpose to always show the private ones ? 
It seems a bad idea because it show inconsistent data between the side panel and the saved search management page (which take the correct entity settings into account).

For example let's take this saved search: 
![image](https://user-images.githubusercontent.com/42734840/124626659-29e4b780-de7f-11eb-941a-d6b190b4a736.png)

It is a private search on root entity with no recursion.

-> If I switch to a subentity, I get this conflicting data:
![image](https://user-images.githubusercontent.com/42734840/124626562-15a0ba80-de7f-11eb-84cc-9a31434a18ca.png)
The search is shown on the right panel but not on the main page.

To prevent this I've applied the entity restriction to the right panel.
After:
![image](https://user-images.githubusercontent.com/42734840/124626923-64e6eb00-de7f-11eb-816f-0202958fe23e.png)

This time the data is consistent: 2 items on both sides.



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22341
