### PR TITLE
remove path column from savedsearches

### DIFF
--- a/install/migrations/update_9.5.x_to_10.0.0/savedsearch.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/savedsearch.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+ /**
+ * @var Migration $migration
+ */
+
+$migration->dropField("glpi_savedsearches", "path");

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -234,7 +234,6 @@ CREATE TABLE `glpi_savedsearches` (
   `is_private` tinyint NOT NULL DEFAULT '1',
   `entities_id` int NOT NULL DEFAULT '-1',
   `is_recursive` tinyint NOT NULL DEFAULT '0',
-  `path` varchar(255) DEFAULT NULL,
   `query` text,
   `last_execution_time` int DEFAULT NULL,
   `do_count` tinyint NOT NULL DEFAULT '2' COMMENT 'Do or do not count results on list display see SavedSearch::COUNT_* constants',


### PR DESCRIPTION
path can be derived from itemtype

Ths PR fixes problem when a plugin is moved between marketplace folder and plugins folder, and GLPI has a saved search in one of its itemtypes. After move of the plugin, the path becomes invalid.