### PR TITLE
Fix "appendto" cleaning in assign rules

### DIFF
--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -238,10 +238,13 @@ class RuleTicket extends Rule {
                      }
                   }
 
-                  // Remove values that may have been added by any "append" rule action on same field.
+                  // Remove values that may have been added by any "append" rule action on same actor field.
+                  // Appended actors are stored on `_additional_*` keys.
                   $actions = $this->getActions();
                   $append_key = $actions[$action->fields["field"]]["appendto"] ?? null;
-                  if ($append_key !== null && array_key_exists($append_key, $output)) {
+                  if ($append_key !== null
+                      && preg_match('/^_additional_/', $append_key) === 1
+                      && array_key_exists($append_key, $output)) {
                      unset($output[$append_key]);
                   }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Follows #6907 .

Sometimes, the `appendto` field is the exact same as the field where assigned value is stored (see https://github.com/glpi-project/glpi/runs/3006356686?check_suite_focus=true).

I propose to limit cleaning to fiels prefixed by `_additional_`, which corresponds to additionnal actors set by `append` rules.