### PR TITLE
Prevent usage of date filters on full LDAP sync

### DIFF
--- a/inc/console/ldap/synchronizeuserscommand.class.php
+++ b/inc/console/ldap/synchronizeuserscommand.class.php
@@ -451,7 +451,7 @@ class SynchronizeUsersCommand extends AbstractCommand {
                   sprintf(__('Unable to parse --%1$s value "%2$s".'), $option_name, $date)
                );
             }
-            $input->setOption($option_name, date('Y:m:d H:i:s', $parsed_date));
+            $input->setOption($option_name, date('Y-m-d H:i:s', $parsed_date));
          }
       }
 

--- a/inc/console/ldap/synchronizeuserscommand.class.php
+++ b/inc/console/ldap/synchronizeuserscommand.class.php
@@ -154,6 +154,10 @@ class SynchronizeUsersCommand extends AbstractCommand {
       $only_create = $input->getOption('only-create-new');
       $only_update = $input->getOption('only-update-existing');
 
+      $ldap_filter = $input->getOption('ldap-filter');
+      $begin_date  = $input->getOption('begin-date');
+      $end_date    = $input->getOption('end-date');
+
       $actions = [];
       if ($only_create) {
          $actions = [
@@ -193,10 +197,6 @@ class SynchronizeUsersCommand extends AbstractCommand {
             $servers_id[] = $server['id'];
          }
       }
-
-      $ldap_filter = $input->getOption('ldap-filter');
-      $begin_date  = $input->getOption('begin-date');
-      $end_date    = $input->getOption('end-date');
 
       if (!$input->getOption('no-interaction')) {
          // Ask for confirmation (unless --no-interaction)
@@ -457,6 +457,11 @@ class SynchronizeUsersCommand extends AbstractCommand {
 
       $begin_date = $input->getOption('begin-date');
       $end_date   = $input->getOption('end-date');
+      if ($only_create === false && $only_update === false && ($begin_date !== null || $end_date !== null)) {
+         throw new \Symfony\Component\Console\Exception\InvalidArgumentException(
+            __('Options --begin-date and --end-date can only be used with --only-create-new or --only-update-existing option.')
+         );
+      }
       if ($begin_date > $end_date) {
          throw new InvalidArgumentException(
             __('Option --begin-date value has to be lower than option --end-date value.')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Unless I am wrong, when running the `AuthLDAP::ACTION_ALL` synchronization mode, users that are not returned by LDAP are considered as deleted on LDAP side. So, in theory, if users try to run this synchronization mode using date filtering, most of users will not be returned and will de beleted/deactivated/whaterver in GLPI, depending on configured deletion strategy.