### PR TITLE
Enhance getById method

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -5661,17 +5661,17 @@ class CommonDBTM extends CommonGLPI {
     *
     * @param integer $ID ID of the item to get
     *
-    * @return static|boolean false on failure
+    * @return CommonDBTM|null false on failure
    */
-   public static function getById(?int $id) {
+   public static function getById(?int $id): ?CommonDBTM {
       if (is_null($id)) {
-         return false;
+         return null;
       }
 
       $item = new static();
 
       if (!$item->getFromDB($id)) {
-         return false;
+         return null;
       }
 
       return $item;

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -150,6 +150,39 @@ class CommonDBTM extends DbTestCase {
       $this->boolean($instance->isNewItem())->isTrue();
    }
 
+   public function testGetById() {
+      $itemtype = \Computer::class;
+
+      // test null ID
+      $output = $itemtype::getById(null);
+      $this->variable($output)->isNull();
+
+      // test existing item
+      $instance = new $itemtype();
+      $instance->getFromDBByRequest([
+         'WHERE' => ['name' => '_test_pc01'],
+      ]);
+      $this->boolean($instance->isNewItem())->isFalse();
+      $output = $itemtype::getById($instance->getID());
+      $this->object($output)->isInstanceOf($itemtype);
+
+      // test non-existing item
+      $instance = new $itemtype();
+      $instance->add([
+         'name' => 'to be deleted',
+         'entities_id' => 0,
+      ]);
+      $this->boolean($instance->isNewItem())->isFalse();
+      $nonExistingId = $instance->getID();
+      $instance->delete([
+         'id' => $nonExistingId,
+      ], 1);
+      $this->boolean($instance->getFromDB($nonExistingId))->isFalse();
+
+      $output = $itemtype::getById($nonExistingId);
+      $this->variable($output)->isNull();
+   }
+
    public function testGetFromResultSet() {
       global $DB;
       $result = $DB->request([


### PR DESCRIPTION
An improvement to set a return type on the method.

Add unit tests

It looks like that the method was added while implementing pending reasons. A lot of calls were found in  the code.

I examined all of them
- return value of some calls is is assumed an object, without any check. I assume is is explicitly expected the method suceeeds, thanks to the call context.
- return value is tested as a boolean in if () expressions. As null == false, there is no problem changing the failure return value into null.

