### PR TITLE
Ticket: Add time spent in closed status to waiting_duration when the ticket is reopened

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -1298,11 +1298,21 @@ abstract class CommonITILObject extends CommonDBTM {
 
       // Manage come back to waiting state
       if (!is_null($this->fields['begin_waiting_date'])
-          && (($key = array_search('status', $this->updates)) !== false)
-          && (($this->oldvalues['status'] == self::WAITING)
-               // From solved to another state than closed
-              || (in_array($this->oldvalues["status"], $this->getSolvedStatusArray())
-                  && !in_array($this->fields["status"], $this->getClosedStatusArray())))) {
+         && ($key = array_search('status', $this->updates)) !== false
+         && (
+            $this->oldvalues['status'] == self::WAITING
+            // From solved to another state than closed
+            || (
+               in_array($this->oldvalues["status"], $this->getSolvedStatusArray())
+               && !in_array($this->fields["status"], $this->getClosedStatusArray())
+            )
+            // From closed to any open state
+            || (
+               in_array($this->oldvalues["status"], $this->getClosedStatusArray())
+               && in_array($this->fields["status"], $this->getNotSolvedStatusArray())
+            )
+         )
+      ) {
 
          // Compute ticket waiting time use calendar if exists
          $calendar     = new Calendar();


### PR DESCRIPTION
While doing some SLA/TTR tests for !22239 I came across an issue.

Let's take two ticket.
Both tickets are expected to be solve in 5 min (this is a very efficient support i guess).

One ticket is immediately resolved:
![image](https://user-images.githubusercontent.com/42734840/124946432-4fa0c680-e00f-11eb-90f1-95c753f1f9a9.png)

The other is immediately resolved and closed:
![image](https://user-images.githubusercontent.com/42734840/124946472-56c7d480-e00f-11eb-8824-1412055cff9f.png)


Stats seems OK for now on both tickets.

Let's wait 5+ mins and reopen both tickets:

Ticket 1:
![image](https://user-images.githubusercontent.com/42734840/124946599-719a4900-e00f-11eb-823f-add4148c7973.png)


Ticket 2:
![image](https://user-images.githubusercontent.com/42734840/124946560-69420e00-e00f-11eb-8da6-c48dd948b6ed.png)


The stats of the first ticket are still OK because the time spent as resolved was considered as "waiting time" so we are still good on our 5 min TTR.
The stats of the second tickets are KO because the time spent as closed was not added into the waiting time so the 5 min TTR is expired.

To fix this I've made sure the time spent as closed is added in the waiting time when the ticket is reopened.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
