### PR TITLE
[Modern UI] Muliple FIxes

### DIFF
--- a/inc/application/errorhandler.class.php
+++ b/inc/application/errorhandler.class.php
@@ -347,7 +347,7 @@ class ErrorHandler {
          $exit_code = $this->exit_code;
          register_shutdown_function(
             'register_shutdown_function',
-            function () use ($exit_code) { exit($exit_code); }
+            static function () use ($exit_code) { exit($exit_code); }
          );
       }
    }

--- a/inc/application/errorhandler.class.php
+++ b/inc/application/errorhandler.class.php
@@ -140,7 +140,7 @@ class ErrorHandler {
     *
     * @return void
     */
-   public function setOutputHandler(OutputInterface $output_handler) {
+   public function setOutputHandler(OutputInterface $output_handler): void {
       $this->output_handler = $output_handler;
    }
 
@@ -149,7 +149,7 @@ class ErrorHandler {
     *
     * @return void
     */
-   public function register() {
+   public function register(): void {
       set_error_handler([$this, 'handleError']);
       set_exception_handler([$this, 'handleException']);
       register_shutdown_function([$this, 'handleFatalError']);
@@ -166,7 +166,7 @@ class ErrorHandler {
     *
     * @return boolean
     */
-   public function handleError($error_code, $error_message, $filename, $line_number) {
+   public function handleError(int $error_code, string $error_message, string $filename, int $line_number) {
 
       // Have to false to forward to PHP internal error handler.
       $return = !$this->forward_to_internal_handler;
@@ -249,7 +249,7 @@ class ErrorHandler {
     *
     * @return void
     */
-   public function handleSqlError($error_code, $error_message, $query) {
+   public function handleSqlError(int $error_code, string $error_message, string $query) {
       $this->outputDebugMessage(
          sprintf('SQL Error "%s"', $error_code),
          sprintf('%s in query "%s"', $error_message, preg_replace('/\\n/', ' ', $query)),
@@ -268,7 +268,7 @@ class ErrorHandler {
     *
     * @return void
     */
-   public function handleSqlWarnings($warnings, $query) {
+   public function handleSqlWarnings(array $warnings, string $query) {
       $this->outputDebugMessage(
          'SQL Warnings',
          "\n" . implode("\n", $warnings) . "\n" . sprintf('in query "%s"', $query),
@@ -285,7 +285,7 @@ class ErrorHandler {
     *
     * @return void
     */
-   public function handleException(\Throwable $exception) {
+   public function handleException(\Throwable $exception): void {
       $this->exit_code = 255;
 
       $error_type = sprintf(
@@ -311,7 +311,7 @@ class ErrorHandler {
     *
     * @retun void
     */
-   public function handleFatalError() {
+   public function handleFatalError(): void {
       // Free reserved memory to be able to handle "out of memory" errors
       $this->reserved_memory = null;
 
@@ -359,7 +359,7 @@ class ErrorHandler {
     *
     * @return void
     */
-   public function setForwardToInternalHandler(bool $forward_to_internal_handler) {
+   public function setForwardToInternalHandler(bool $forward_to_internal_handler): void {
       $this->forward_to_internal_handler = $forward_to_internal_handler;
    }
 
@@ -373,7 +373,7 @@ class ErrorHandler {
     *
     * @return void
     */
-   private function logErrorMessage(string $type, string $description, string $trace, string $log_level) {
+   private function logErrorMessage(string $type, string $description, string $trace, string $log_level): void {
       if (!($this->logger instanceof LoggerInterface)) {
          return;
       }
@@ -394,7 +394,7 @@ class ErrorHandler {
     *
     * @return void
     */
-   private function outputDebugMessage(string $error_type, string $message, string $log_level, bool $force = false) {
+   private function outputDebugMessage(string $error_type, string $message, string $log_level, bool $force = false): void {
 
       $is_debug_mode = isset($_SESSION['glpi_use_mode']) && $_SESSION['glpi_use_mode'] == \Session::DEBUG_MODE;
       $is_console_context = $this->output_handler instanceof OutputInterface;

--- a/inc/application/view/extension/ajaxextension.class.php
+++ b/inc/application/view/extension/ajaxextension.class.php
@@ -34,7 +34,6 @@ namespace Glpi\Application\View\Extension;
 
 use Ajax;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/ajaxextension.class.php
+++ b/inc/application/view/extension/ajaxextension.class.php
@@ -40,7 +40,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class AjaxExtension extends AbstractExtension implements ExtensionInterface {
+class AjaxExtension extends AbstractExtension {
 
    public function getFunctions() {
       return [

--- a/inc/application/view/extension/ajaxextension.class.php
+++ b/inc/application/view/extension/ajaxextension.class.php
@@ -42,7 +42,7 @@ use Twig\TwigFunction;
  */
 class AjaxExtension extends AbstractExtension {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('updateItemOnSelectEvent', [Ajax::class, 'updateItemOnSelectEvent']),
       ];

--- a/inc/application/view/extension/alertextension.class.php
+++ b/inc/application/view/extension/alertextension.class.php
@@ -42,7 +42,7 @@ use Twig\TwigFunction;
  */
 class AlertExtension extends AbstractExtension {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('displayLastAlert', [Alert::class, 'displayLastAlert']),
       ];

--- a/inc/application/view/extension/alertextension.class.php
+++ b/inc/application/view/extension/alertextension.class.php
@@ -40,7 +40,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class AlertExtension extends AbstractExtension implements ExtensionInterface {
+class AlertExtension extends AbstractExtension {
 
    public function getFunctions() {
       return [

--- a/inc/application/view/extension/alertextension.class.php
+++ b/inc/application/view/extension/alertextension.class.php
@@ -34,7 +34,6 @@ namespace Glpi\Application\View\Extension;
 
 use Alert;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/commonitilobjectextension.class.php
+++ b/inc/application/view/extension/commonitilobjectextension.class.php
@@ -45,13 +45,13 @@ use Twig\TwigFunction;
  */
 class CommonITILObjectExtension extends AbstractExtension {
 
-   public function getFilters() {
+   public function getFilters(): array {
       return [
          new TwigFilter('getTimelineStats', [$this, 'getTimelineStats'], ['is_safe' => ['html']]),
       ];
    }
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('Item_Ticket_itemAddForm', [Item_Ticket::class, 'itemAddForm']),
       ];

--- a/inc/application/view/extension/commonitilobjectextension.class.php
+++ b/inc/application/view/extension/commonitilobjectextension.class.php
@@ -43,7 +43,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class CommonITILObjectExtension extends AbstractExtension implements ExtensionInterface {
+class CommonITILObjectExtension extends AbstractExtension {
 
    public function getFilters() {
       return [

--- a/inc/application/view/extension/commonitilobjectextension.class.php
+++ b/inc/application/view/extension/commonitilobjectextension.class.php
@@ -36,7 +36,6 @@ use CommonITILObject;
 use Item_Ticket;
 use Planning;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 

--- a/inc/application/view/extension/configextension.class.php
+++ b/inc/application/view/extension/configextension.class.php
@@ -42,7 +42,7 @@ use Twig\TwigFunction;
  */
 class ConfigExtension extends AbstractExtension {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('config', [$this, 'config']),
          new TwigFunction('php_config', [$this, 'phpConfig']),

--- a/inc/application/view/extension/configextension.class.php
+++ b/inc/application/view/extension/configextension.class.php
@@ -40,7 +40,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class ConfigExtension extends AbstractExtension implements ExtensionInterface {
+class ConfigExtension extends AbstractExtension {
 
    public function getFunctions() {
       return [

--- a/inc/application/view/extension/configextension.class.php
+++ b/inc/application/view/extension/configextension.class.php
@@ -34,7 +34,6 @@ namespace Glpi\Application\View\Extension;
 
 use Config;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/configextension.class.php
+++ b/inc/application/view/extension/configextension.class.php
@@ -86,7 +86,7 @@ class ConfigExtension extends AbstractExtension {
     *
     * @return void
     */
-   public function displayPasswordSecurityChecks($field = 'password') {
-      return Config::displayPasswordSecurityChecks($field);
+   public function displayPasswordSecurityChecks($field = 'password'): void {
+      Config::displayPasswordSecurityChecks($field);
    }
 }

--- a/inc/application/view/extension/csrfextension.class.php
+++ b/inc/application/view/extension/csrfextension.class.php
@@ -34,7 +34,6 @@ namespace Glpi\Application\View\Extension;
 
 use Session;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/csrfextension.class.php
+++ b/inc/application/view/extension/csrfextension.class.php
@@ -42,7 +42,7 @@ use Twig\TwigFunction;
  */
 class CsrfExtension extends AbstractExtension {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('csrf_token', [Session::class, 'getNewCSRFToken']),
       ];

--- a/inc/application/view/extension/csrfextension.class.php
+++ b/inc/application/view/extension/csrfextension.class.php
@@ -40,7 +40,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class CsrfExtension extends AbstractExtension implements ExtensionInterface {
+class CsrfExtension extends AbstractExtension {
 
    public function getFunctions() {
       return [

--- a/inc/application/view/extension/dbextension.class.php
+++ b/inc/application/view/extension/dbextension.class.php
@@ -57,7 +57,7 @@ class DBExtension extends AbstractExtension {
       ];
    }
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       $dbu = $this->getDBUtils();
       return [
          new TwigFunction('getPlural', [$dbu, 'getPlural']),

--- a/inc/application/view/extension/dbextension.class.php
+++ b/inc/application/view/extension/dbextension.class.php
@@ -50,7 +50,7 @@ class DBExtension extends AbstractExtension {
       return $dbu;
    }
 
-   public function getFilters() {
+   public function getFilters(): array {
       $dbu = $this->getDBUtils();
       return [
          new TwigFilter('importArrayFromDB', [$dbu, 'importArrayFromDB'])

--- a/inc/application/view/extension/documentextension.class.php
+++ b/inc/application/view/extension/documentextension.class.php
@@ -44,7 +44,7 @@ use Twig\TwigFunction;
  */
 class DocumentExtension extends AbstractExtension {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('getIconForFilename', [$this, 'getIconForFilename']),
          new TwigFunction('getSizeForFilePath', [$this, 'getSizeForFilePath']),

--- a/inc/application/view/extension/documentextension.class.php
+++ b/inc/application/view/extension/documentextension.class.php
@@ -36,7 +36,6 @@ use Document;
 use DocumentType;
 use Toolbox;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/documentextension.class.php
+++ b/inc/application/view/extension/documentextension.class.php
@@ -42,7 +42,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class DocumentExtension extends AbstractExtension implements ExtensionInterface {
+class DocumentExtension extends AbstractExtension {
 
    public function getFunctions() {
       return [

--- a/inc/application/view/extension/dropdownextension.class.php
+++ b/inc/application/view/extension/dropdownextension.class.php
@@ -41,7 +41,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class DropdownExtension extends AbstractExtension implements ExtensionInterface {
+class DropdownExtension extends AbstractExtension {
 
    public function getFunctions() {
       return [

--- a/inc/application/view/extension/dropdownextension.class.php
+++ b/inc/application/view/extension/dropdownextension.class.php
@@ -60,12 +60,12 @@ class DropdownExtension extends AbstractExtension {
       ];
    }
 
-   public function showHours($name, $options = []) {
+   public function showHours($name, $options = []): void {
       // Suppress returned ID value
       Dropdown::showHours($name, $options);
    }
 
-   public function dropdownForOneSoftware($options = []) {
+   public function dropdownForOneSoftware($options = []): void {
       // Suppress returned ID value
       \SoftwareVersion::dropdownForOneSoftware($options);
    }

--- a/inc/application/view/extension/dropdownextension.class.php
+++ b/inc/application/view/extension/dropdownextension.class.php
@@ -35,7 +35,6 @@ namespace Glpi\Application\View\Extension;
 use Dropdown;
 use TicketValidation;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/dropdownextension.class.php
+++ b/inc/application/view/extension/dropdownextension.class.php
@@ -43,7 +43,7 @@ use Twig\TwigFunction;
  */
 class DropdownExtension extends AbstractExtension {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('getDropdownName', [Dropdown::class, 'getDropdownName'], ['is_safe' => ['html']]),
          new TwigFunction('Dropdown__showGlobalSwitch', [Dropdown::class, 'showGlobalSwitch']),

--- a/inc/application/view/extension/entityextension.class.php
+++ b/inc/application/view/extension/entityextension.class.php
@@ -40,7 +40,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class EntityExtension extends AbstractExtension implements ExtensionInterface {
+class EntityExtension extends AbstractExtension {
 
    public function getFunctions() {
       return [

--- a/inc/application/view/extension/entityextension.class.php
+++ b/inc/application/view/extension/entityextension.class.php
@@ -42,7 +42,7 @@ use Twig\TwigFunction;
  */
 class EntityExtension extends AbstractExtension {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('Entity_getUsedConfig', [Entity::class, 'getUsedConfig']),
       ];

--- a/inc/application/view/extension/entityextension.class.php
+++ b/inc/application/view/extension/entityextension.class.php
@@ -34,7 +34,6 @@ namespace Glpi\Application\View\Extension;
 
 use Entity;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/eventextension.class.php
+++ b/inc/application/view/extension/eventextension.class.php
@@ -41,7 +41,7 @@ use Twig\TwigFunction;
  */
 class EventExtension extends AbstractExtension {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('Event_displayItemLogID', [Event::class, 'displayItemLogID'], ['is_safe' => ['html']]),
       ];

--- a/inc/application/view/extension/frontendassetsextension.class.php
+++ b/inc/application/view/extension/frontendassetsextension.class.php
@@ -38,7 +38,6 @@ use Html;
 use Plugin;
 use Session;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/frontendassetsextension.class.php
+++ b/inc/application/view/extension/frontendassetsextension.class.php
@@ -46,7 +46,7 @@ use Twig\TwigFunction;
  */
 class FrontEndAssetsExtension extends AbstractExtension {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('asset_path', [$this, 'assetPath']),
          new TwigFunction('css_path', [$this, 'cssPath']),

--- a/inc/application/view/extension/frontendassetsextension.class.php
+++ b/inc/application/view/extension/frontendassetsextension.class.php
@@ -44,7 +44,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class FrontEndAssetsExtension extends AbstractExtension implements ExtensionInterface {
+class FrontEndAssetsExtension extends AbstractExtension {
 
    public function getFunctions() {
       return [

--- a/inc/application/view/extension/htmlextension.class.php
+++ b/inc/application/view/extension/htmlextension.class.php
@@ -45,7 +45,7 @@ use Twig\TwigFunction;
  */
 class HtmlExtension extends AbstractExtension {
 
-   public function getFilters() {
+   public function getFilters(): array {
       return [
          new TwigFilter('conv_datetime', [$this, 'convDateTime'], ['is_safe' => ['html']]),
          new TwigFilter(
@@ -56,7 +56,7 @@ class HtmlExtension extends AbstractExtension {
       ];
    }
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('showMassiveActions', [$this, 'showMassiveActions']),
          new TwigFunction('isMassiveActionchecked', [$this, 'isMassiveActionchecked']),

--- a/inc/application/view/extension/htmlextension.class.php
+++ b/inc/application/view/extension/htmlextension.class.php
@@ -43,7 +43,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class HtmlExtension extends AbstractExtension implements ExtensionInterface {
+class HtmlExtension extends AbstractExtension {
 
    public function getFilters() {
       return [

--- a/inc/application/view/extension/htmlextension.class.php
+++ b/inc/application/view/extension/htmlextension.class.php
@@ -36,7 +36,6 @@ use Glpi\Toolbox\Sanitizer;
 use Html;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 

--- a/inc/application/view/extension/i18nextension.class.php
+++ b/inc/application/view/extension/i18nextension.class.php
@@ -33,7 +33,6 @@
 namespace Glpi\Application\View\Extension;
 
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/i18nextension.class.php
+++ b/inc/application/view/extension/i18nextension.class.php
@@ -39,7 +39,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class I18nExtension extends AbstractExtension implements ExtensionInterface {
+class I18nExtension extends AbstractExtension {
 
    public function getFunctions() {
       return [

--- a/inc/application/view/extension/i18nextension.class.php
+++ b/inc/application/view/extension/i18nextension.class.php
@@ -41,7 +41,7 @@ use Twig\TwigFunction;
  */
 class I18nExtension extends AbstractExtension {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('__', '__'),
          new TwigFunction('_n', '_n'),

--- a/inc/application/view/extension/infocomextension.class.php
+++ b/inc/application/view/extension/infocomextension.class.php
@@ -43,7 +43,7 @@ use Twig\TwigFunction;
 class InfocomExtension extends AbstractExtension {
 
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('Infocom__Amort', [Infocom::class, 'Amort']),
          new TwigFunction('Infocom__dropdownAmortType', [Infocom::class, 'dropdownAmortType'], ['is_safe' => ['html']]),

--- a/inc/application/view/extension/infocomextension.class.php
+++ b/inc/application/view/extension/infocomextension.class.php
@@ -40,7 +40,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class InfocomExtension extends AbstractExtension implements ExtensionInterface {
+class InfocomExtension extends AbstractExtension {
 
 
    public function getFunctions() {

--- a/inc/application/view/extension/infocomextension.class.php
+++ b/inc/application/view/extension/infocomextension.class.php
@@ -34,7 +34,6 @@ namespace Glpi\Application\View\Extension;
 
 use Infocom;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/itemtypeextension.class.php
+++ b/inc/application/view/extension/itemtypeextension.class.php
@@ -40,7 +40,6 @@ use Computer;
 use Computer_Item;
 use MassiveAction;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 

--- a/inc/application/view/extension/itemtypeextension.class.php
+++ b/inc/application/view/extension/itemtypeextension.class.php
@@ -319,9 +319,9 @@ class ItemtypeExtension extends AbstractExtension {
     *
     * @param CommonDBTM $item
     *
-    * @return string
+    * @return ?array
     */
-   public function getDcBreadcrumb(CommonDBTM $item):?array {
+   public function getDcBreadcrumb(CommonDBTM $item): ?array {
       if (method_exists($item, "getDcBreadcrumb")) {
          return $item->getDcBreadcrumb();
       }
@@ -369,7 +369,7 @@ class ItemtypeExtension extends AbstractExtension {
       return $item::getTable();
    }
 
-   public function getSpecificTypeField(CommonDropdown $item, $ID, $field = []) {
+   public function getSpecificTypeField(CommonDropdown $item, $ID, $field = []): string {
       return $item->getSpecificTypeField((int) $ID, $field);
    }
 }

--- a/inc/application/view/extension/itemtypeextension.class.php
+++ b/inc/application/view/extension/itemtypeextension.class.php
@@ -47,7 +47,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class ItemtypeExtension extends AbstractExtension implements ExtensionInterface {
+class ItemtypeExtension extends AbstractExtension {
 
    public function getFilters() {
       return [

--- a/inc/application/view/extension/itemtypeextension.class.php
+++ b/inc/application/view/extension/itemtypeextension.class.php
@@ -352,7 +352,7 @@ class ItemtypeExtension extends AbstractExtension {
          $input['entity_restrict'] = $item->getEntityID();
       }
 
-      return $ma->getInput();
+      return $input;
    }
 
    public function showForm(CommonDBTM $item, $options = []): void {

--- a/inc/application/view/extension/itemtypeextension.class.php
+++ b/inc/application/view/extension/itemtypeextension.class.php
@@ -49,7 +49,7 @@ use Twig\TwigFunction;
  */
 class ItemtypeExtension extends AbstractExtension {
 
-   public function getFilters() {
+   public function getFilters(): array {
       return [
          new TwigFilter('itemtype_name', [$this, 'itemtypeName']),
          new TwigFilter('get_foreignkey_field', [$this, 'getForeignKeyField']),
@@ -72,7 +72,7 @@ class ItemtypeExtension extends AbstractExtension {
       ];
    }
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('itemInstanceOf', [$this, 'itemInstanceOf']),
          new TwigFunction('maybeRecursive', [$this, 'maybeRecursive']),

--- a/inc/application/view/extension/modelextension.class.php
+++ b/inc/application/view/extension/modelextension.class.php
@@ -40,7 +40,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class ModelExtension extends AbstractExtension implements ExtensionInterface {
+class ModelExtension extends AbstractExtension {
 
    public function getFunctions() {
       return [

--- a/inc/application/view/extension/modelextension.class.php
+++ b/inc/application/view/extension/modelextension.class.php
@@ -34,7 +34,6 @@ namespace Glpi\Application\View\Extension;
 
 use CommonDBTM;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/modelextension.class.php
+++ b/inc/application/view/extension/modelextension.class.php
@@ -42,7 +42,7 @@ use Twig\TwigFunction;
  */
 class ModelExtension extends AbstractExtension {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('getmodelPicture', [$this, 'getmodelPicture']),
          new TwigFunction('getItemtypeOrModelPicture', [$this, 'getItemtypeOrModelPicture'])

--- a/inc/application/view/extension/numberformatextension.class.php
+++ b/inc/application/view/extension/numberformatextension.class.php
@@ -34,7 +34,6 @@ namespace Glpi\Application\View\Extension;
 
 use Toolbox;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFilter;
 
 /**

--- a/inc/application/view/extension/numberformatextension.class.php
+++ b/inc/application/view/extension/numberformatextension.class.php
@@ -40,7 +40,7 @@ use Twig\TwigFilter;
 /**
  * @since 10.0.0
  */
-class NumberFormatExtension extends AbstractExtension implements ExtensionInterface {
+class NumberFormatExtension extends AbstractExtension {
 
    public function getFilters() {
       return [

--- a/inc/application/view/extension/numberformatextension.class.php
+++ b/inc/application/view/extension/numberformatextension.class.php
@@ -42,7 +42,7 @@ use Twig\TwigFilter;
  */
 class NumberFormatExtension extends AbstractExtension {
 
-   public function getFilters() {
+   public function getFilters(): array {
       return [
          new TwigFilter('format_binary', [Toolbox::class, 'getSize']),
       ];

--- a/inc/application/view/extension/pluginextension.class.php
+++ b/inc/application/view/extension/pluginextension.class.php
@@ -41,7 +41,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class PluginExtension extends AbstractExtension implements ExtensionInterface {
+class PluginExtension extends AbstractExtension {
    public function getFunctions() {
       return [
          new TwigFunction('displayLogin', [$this, 'displayLogin'], ['is_safe' => ['html']]),

--- a/inc/application/view/extension/pluginextension.class.php
+++ b/inc/application/view/extension/pluginextension.class.php
@@ -42,7 +42,7 @@ use Twig\TwigFunction;
  * @since 10.0.0
  */
 class PluginExtension extends AbstractExtension {
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('displayLogin', [$this, 'displayLogin'], ['is_safe' => ['html']]),
          new TwigFunction('AutoInventoryInformation', [$this, 'AutoInventoryInformation'], ['is_safe' => ['html']]),

--- a/inc/application/view/extension/pluginextension.class.php
+++ b/inc/application/view/extension/pluginextension.class.php
@@ -35,7 +35,6 @@ namespace Glpi\Application\View\Extension;
 use CommonDBTM;
 use Plugin;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/pluginextension.class.php
+++ b/inc/application/view/extension/pluginextension.class.php
@@ -58,24 +58,24 @@ class PluginExtension extends AbstractExtension {
     *
     * @return void
     */
-   public function displayLogin() {
+   public function displayLogin(): void {
       Plugin::doHook('display_login');
    }
 
 
-   public function AutoInventoryInformation() {
+   public function AutoInventoryInformation(): void {
       Plugin::doHook('autoinventory_information');
    }
 
-   public function preItemForm(CommonDBTM $item, array $params = []) {
+   public function preItemForm(CommonDBTM $item, array $params = []): void {
       Plugin::doHook('pre_item_form', ['item' => $item, 'options' => $params]);
    }
 
-   public function postItemForm(CommonDBTM $item, array $params = []) {
+   public function postItemForm(CommonDBTM $item, array $params = []): void {
       Plugin::doHook('post_item_form', ['item' => $item, 'options' => $params]);
    }
 
-   public function hook_infocom(CommonDBTM $item) {
+   public function hook_infocom(CommonDBTM $item): void {
       Plugin::doHookFunction("infocom", $item);
    }
 

--- a/inc/application/view/extension/richtextextension.class.php
+++ b/inc/application/view/extension/richtextextension.class.php
@@ -41,7 +41,7 @@ use Twig\TwigFunction;
  * @since 10.0.0
  */
 class RichTextExtension extends AbstractExtension {
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('getSafeHtml', [RichText::class, 'getSafeHtml'], ['is_safe' => ['html']]),
          new TwigFunction('getTextFromHtml', [RichText::class, 'getTextFromHtml']),

--- a/inc/application/view/extension/richtextextension.class.php
+++ b/inc/application/view/extension/richtextextension.class.php
@@ -34,7 +34,6 @@ namespace Glpi\Application\View\Extension;
 
 use Glpi\Toolbox\RichText;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/richtextextension.class.php
+++ b/inc/application/view/extension/richtextextension.class.php
@@ -40,7 +40,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class RichTextExtension extends AbstractExtension implements ExtensionInterface {
+class RichTextExtension extends AbstractExtension {
    public function getFunctions() {
       return [
          new TwigFunction('getSafeHtml', [RichText::class, 'getSafeHtml'], ['is_safe' => ['html']]),

--- a/inc/application/view/extension/routingextension.class.php
+++ b/inc/application/view/extension/routingextension.class.php
@@ -45,7 +45,7 @@ use Twig\TwigFunction;
  */
 class RoutingExtension extends AbstractExtension {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('index', [$this, 'index']),
          new TwigFunction('path', [$this, 'path']),

--- a/inc/application/view/extension/routingextension.class.php
+++ b/inc/application/view/extension/routingextension.class.php
@@ -37,7 +37,6 @@ use Html;
 use Session;
 use Toolbox;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/routingextension.class.php
+++ b/inc/application/view/extension/routingextension.class.php
@@ -43,7 +43,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class RoutingExtension extends AbstractExtension implements ExtensionInterface {
+class RoutingExtension extends AbstractExtension {
 
    public function getFunctions() {
       return [

--- a/inc/application/view/extension/searchextension.class.php
+++ b/inc/application/view/extension/searchextension.class.php
@@ -34,7 +34,6 @@ namespace Glpi\Application\View\Extension;
 
 use Search;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/searchextension.class.php
+++ b/inc/application/view/extension/searchextension.class.php
@@ -41,7 +41,7 @@ use Twig\TwigFunction;
  * @since 10.0.0
  */
 class SearchExtension extends AbstractExtension {
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('showItem', [$this, 'showItem']),
          new TwigFunction('displayConfigItem', [$this, 'displayConfigItem']),

--- a/inc/application/view/extension/searchextension.class.php
+++ b/inc/application/view/extension/searchextension.class.php
@@ -40,7 +40,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class SearchExtension extends AbstractExtension implements ExtensionInterface {
+class SearchExtension extends AbstractExtension {
    public function getFunctions() {
       return [
          new TwigFunction('showItem', [$this, 'showItem']),

--- a/inc/application/view/extension/searchextension.class.php
+++ b/inc/application/view/extension/searchextension.class.php
@@ -75,7 +75,7 @@ class SearchExtension extends AbstractExtension {
    }
 
 
-   public function computeTitle(array $data = []):string {
+   public function computeTitle(array $data = []): string {
       return Search::computeTitle($data);
    }
 }

--- a/inc/application/view/extension/sessionextension.class.php
+++ b/inc/application/view/extension/sessionextension.class.php
@@ -38,7 +38,6 @@ use Html;
 use Profile_User;
 use Session;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\Extension\GlobalsInterface;
 use Twig\TwigFunction;
 use User;

--- a/inc/application/view/extension/sessionextension.class.php
+++ b/inc/application/view/extension/sessionextension.class.php
@@ -48,7 +48,7 @@ use User;
  */
 class SessionExtension extends AbstractExtension implements GlobalsInterface {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('have_right', [Session::class, 'haveRight']),
          new TwigFunction('have_rights_and', [Session::class, 'haveRightsAnd']),

--- a/inc/application/view/extension/sessionextension.class.php
+++ b/inc/application/view/extension/sessionextension.class.php
@@ -46,7 +46,7 @@ use User;
 /**
  * @since 10.0.0
  */
-class SessionExtension extends AbstractExtension implements ExtensionInterface, GlobalsInterface {
+class SessionExtension extends AbstractExtension implements GlobalsInterface {
 
    public function getFunctions() {
       return [

--- a/inc/application/view/extension/sessionextension.class.php
+++ b/inc/application/view/extension/sessionextension.class.php
@@ -154,6 +154,7 @@ class SessionExtension extends AbstractExtension implements GlobalsInterface {
     * Get user preference.
     *
     * @param string $name
+    * @param bool   $decode
     *
     * @return null|mixed
     *
@@ -193,7 +194,7 @@ class SessionExtension extends AbstractExtension implements GlobalsInterface {
     *
     * @TODO Add a unit test.
     */
-   public function haveAccessToEntity(int $entities_id):bool {
+   public function haveAccessToEntity(int $entities_id): bool {
       return Session::haveAccessToEntity($entities_id);
    }
 
@@ -216,7 +217,7 @@ class SessionExtension extends AbstractExtension implements GlobalsInterface {
     *
     * @TODO Add a unit test.
     */
-   public function haveRecursiveAccessToEntity(int $entities_id):bool {
+   public function haveRecursiveAccessToEntity(int $entities_id): bool {
       return Session::haveRecursiveAccessToEntity($entities_id);
    }
 
@@ -242,7 +243,7 @@ class SessionExtension extends AbstractExtension implements GlobalsInterface {
     *
     * @TODO Add a unit test.
     */
-   public function haveAccessToOneOfEntities(array $entities = [], int $is_recursive = 0):bool {
+   public function haveAccessToOneOfEntities(array $entities = [], int $is_recursive = 0): bool {
       return Session::haveAccessToOneOfEntities($entities, $is_recursive);
    }
 
@@ -250,14 +251,14 @@ class SessionExtension extends AbstractExtension implements GlobalsInterface {
    /**
     * Check if a given user have access to current entity list
     *
-    * @param array $entities
+    * @param int $users_id
     * @param int $is_recursive
     *
     * @return bool
     *
     * @TODO Add a unit test.
     */
-   public function userhaveAccessToOneOfEntities(int $users_id = 0, int $is_recursive = 0):bool {
+   public function userhaveAccessToOneOfEntities(int $users_id = 0, int $is_recursive = 0): bool {
       return Session::haveAccessToOneOfEntities(Profile_User::getUserEntities($users_id, $is_recursive));
    }
 
@@ -269,7 +270,7 @@ class SessionExtension extends AbstractExtension implements GlobalsInterface {
     *
     * @TODO Add a unit test.
     */
-   public function getMessagesAfterRedirect():array {
+   public function getMessagesAfterRedirect(): array {
       $messages = $_SESSION['MESSAGE_AFTER_REDIRECT'] ?? [];
       $_SESSION['MESSAGE_AFTER_REDIRECT'] = [];
 

--- a/inc/application/view/extension/toolboxextension.class.php
+++ b/inc/application/view/extension/toolboxextension.class.php
@@ -34,7 +34,6 @@ namespace Glpi\Application\View\Extension;
 
 use Toolbox;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/toolboxextension.class.php
+++ b/inc/application/view/extension/toolboxextension.class.php
@@ -40,7 +40,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class ToolboxExtension extends AbstractExtension implements ExtensionInterface {
+class ToolboxExtension extends AbstractExtension {
    public function getFunctions() {
       return [
          new TwigFunction('canUseLdap', [Toolbox::class, 'canUseLdap']),

--- a/inc/application/view/extension/toolboxextension.class.php
+++ b/inc/application/view/extension/toolboxextension.class.php
@@ -41,7 +41,7 @@ use Twig\TwigFunction;
  * @since 10.0.0
  */
 class ToolboxExtension extends AbstractExtension {
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('canUseLdap', [Toolbox::class, 'canUseLdap']),
          new TwigFunction('getMaxInputVar', [Toolbox::class, 'get_max_input_vars']),

--- a/inc/application/view/extension/userextension.class.php
+++ b/inc/application/view/extension/userextension.class.php
@@ -44,7 +44,7 @@ use User;
  */
 class UserExtension extends AbstractExtension {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('User__getPicture', [$this, 'getPicture']),
          new TwigFunction('User__getBgColor', [$this, 'getBgColor']),

--- a/inc/application/view/extension/userextension.class.php
+++ b/inc/application/view/extension/userextension.class.php
@@ -35,7 +35,6 @@ namespace Glpi\Application\View\Extension;
 use Session;
 use Toolbox;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 use User;
 

--- a/inc/application/view/extension/userextension.class.php
+++ b/inc/application/view/extension/userextension.class.php
@@ -42,7 +42,7 @@ use User;
 /**
  * @since 10.0.0
  */
-class UserExtension extends AbstractExtension implements ExtensionInterface {
+class UserExtension extends AbstractExtension {
 
    public function getFunctions() {
       return [

--- a/inc/application/view/extension/validationextension.class.php
+++ b/inc/application/view/extension/validationextension.class.php
@@ -44,7 +44,7 @@ use Twig\TwigFunction;
 /**
  * @since 10.0.0
  */
-class ValidationExtension extends AbstractExtension implements ExtensionInterface {
+class ValidationExtension extends AbstractExtension {
 
    public function getFunctions() {
       return [

--- a/inc/application/view/extension/validationextension.class.php
+++ b/inc/application/view/extension/validationextension.class.php
@@ -55,11 +55,11 @@ class ValidationExtension extends AbstractExtension {
    }
 
 
-   public function alertValidation(CommonITILObject $item, string $type = "status") {
+   public function alertValidation(CommonITILObject $item, string $type = "status"): void {
       if ($item instanceof Ticket) {
-         return TicketValidation::alertValidation($item, $type);
+         TicketValidation::alertValidation($item, $type);
       } else if ($item instanceof Change) {
-         return ChangeValidation::alertValidation($item, $type);
+         ChangeValidation::alertValidation($item, $type);
       }
    }
 }

--- a/inc/application/view/extension/validationextension.class.php
+++ b/inc/application/view/extension/validationextension.class.php
@@ -38,7 +38,6 @@ use CommonITILObject;
 use Ticket;
 use TicketValidation;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 /**

--- a/inc/application/view/extension/validationextension.class.php
+++ b/inc/application/view/extension/validationextension.class.php
@@ -46,7 +46,7 @@ use Twig\TwigFunction;
  */
 class ValidationExtension extends AbstractExtension {
 
-   public function getFunctions() {
+   public function getFunctions(): array {
       return [
          new TwigFunction('TicketValidation__dropdownStatus', [TicketValidation::class, 'dropdownStatus'], ['is_safe' => ['html']]),
          new TwigFunction('TicketValidation__dropdownValidator', [TicketValidation::class, 'dropdownValidator'], ['is_safe' => ['html']]),

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1376,7 +1376,7 @@ HTML;
          'plugins' => [
             'title' => _n('Plugin', 'Plugins', Session::getPluralNumber()),
             'types' => [],
-            'icon'  => 'fa-puzzle-piece'
+            'icon'  => 'fas fa-puzzle-piece'
          ],
          'admin' => [
             'title' => __('Administration'),

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3653,7 +3653,6 @@ JS;
       $plugins = [
          'autoresize',
          'code',
-         'colorpicker',
          'directionality',
          'fullscreen',
          'link',
@@ -3663,7 +3662,6 @@ JS;
          'searchreplace',
          'tabfocus',
          'table',
-         'textcolor',
       ];
       if ($enable_images) {
          $plugins[] = 'image';

--- a/templates/components/logs.html.twig
+++ b/templates/components/logs.html.twig
@@ -78,7 +78,7 @@
                <td>{{ entry['date_mod'] }}</td>
                <td>{{ entry['user_name'] }}</td>
                <td>{{ entry['field'] }}</td>
-               <td width='60%' colspan='2'>{{ entry['change']|raw }}</td>
+               <td colspan='2' style="width: 60%">{{ entry['change']|raw }}</td>
             </tr>
          {% endfor %}
       {% endif %}

--- a/templates/layout/parts/global_search_form.html.twig
+++ b/templates/layout/parts/global_search_form.html.twig
@@ -1,6 +1,6 @@
 
 {% if use_simplified_interface == false %}
-<form action="{{ path('front/search.php') }}" roel="search" method="get">
+<form action="{{ path('front/search.php') }}" role="search" method="get">
    <div class='input-group'>
       <input type="text" class="form-control" name="globalsearch" placeholder="{{ __("Search…") }}">
       <button type="submit" class="btn btn-outline-secondary" title="{{ __("Search…") }}">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Multiple fixes for modern UI branch

Fixes:
- Plugin menu icon was not shown because the `fas` class was missing on the icon element
- The inclusion of some TInyMCE plugins was causing a JS console warning since they have been included in the TinyMCE core since 5.0 (3 years ago).
- Implementing ExtensionInterface on GLPI's Twig extensions is redundant because AbstractExtension already implements this interface.
- Use static closures when access to instance properties are not required to improve performance.
- Add/fix multiple parameter and return types
- Fixed ignored `entity_restrict` in `ItemtypeExtension::getMassiveActions`
- Replaced `width` HTML attribute which is deprecated with the equivalent style attribute value
- Fixed HTML attribute name `roel` to `role`

Best reviewed by commit.