### PR TITLE
Fix data export (CSV, SYLK)

### DIFF
--- a/inc/caldav/traits/vobjectconvertertrait.class.php
+++ b/inc/caldav/traits/vobjectconvertertrait.class.php
@@ -126,7 +126,7 @@ trait VobjectConverterTrait {
       }
       if ($description !== null) {
          // Transform HTML text to plain text
-         $vcomp->DESCRIPTION = RichText::getTextFromHtml($description, true, false);
+         $vcomp->DESCRIPTION = RichText::getTextFromHtml($description, true);
       }
 
       $vcomp->URL = $CFG_GLPI['url_base'] . $this->getFormURLWithID($fields['id'], false);

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -4662,7 +4662,7 @@ class CommonDBTM extends CommonGLPI {
 
                case "text" :
                   if (isset($searchoptions['htmltext']) && $searchoptions['htmltext']) {
-                     $value = RichText::getTextFromHtml($value, true, true);
+                     $value = RichText::getTextFromHtml($value, true, false, true);
                   }
 
                   return $options['html'] ? nl2br($value) : $value;

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1887,7 +1887,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
          printf(
             __('%1$s %2$s'),
             $link,
-            Html::resume_text(RichText::getTextFromHtml($job->fields['content'], false, true), 50)
+            Html::resume_text(RichText::getTextFromHtml($job->fields['content'], false, true, true), 50)
          );
 
          echo "</a>";

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -1611,11 +1611,11 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
                }
                echo Search::showItem($output_type,
                                        "<div class='kb'>$toadd <i class='fa fa-fw $fa_class' title='$fa_title'></i> <a $href>".Html::resume_text($name, 80)."</a></div>
-                                       <div class='kb_resume'>".Html::resume_text(RichText::getTextFromHtml($answer, false, true), 600)."</div>",
+                                       <div class='kb_resume'>".Html::resume_text(RichText::getTextFromHtml($answer, false, false, true), 600)."</div>",
                                        $item_num, $row_num);
             } else {
                echo Search::showItem($output_type, $name, $item_num, $row_num);
-               echo Search::showItem($output_type, RichText::getTextFromHtml($answer, true, true, true), $item_num, $row_num);
+               echo Search::showItem($output_type, RichText::getTextFromHtml($answer, true, false, true, true), $item_num, $row_num);
             }
 
             $showuserlink = 0;

--- a/inc/notificationtemplate.class.php
+++ b/inc/notificationtemplate.class.php
@@ -270,7 +270,7 @@ class NotificationTemplate extends CommonDBTM {
             //If no html content, then send only in text
             if (!empty($template_datas['content_html'])) {
                $signature_html = RichText::getSafeHtml($this->signature, true);
-               $signature_text = RichText::getTextFromHtml($this->signature, false, true);
+               $signature_text = RichText::getTextFromHtml($this->signature, false, false, true);
 
                $template_datas['content_html'] = self::process(
                   $template_datas['content_html'],

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -2223,7 +2223,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
          $card = [
             'id'              => "{$itemtype}-{$item['id']}",
             'title'           => '<span class="pointer">'.$item['name'].'</span>',
-            'title_tooltip'   => Html::resume_text(RichText::getTextFromHtml($item['content'], false, true), 100),
+            'title_tooltip'   => Html::resume_text(RichText::getTextFromHtml($item['content'], false, true, true), 100),
             'is_deleted'      => $item['is_deleted'] ?? false,
          ];
 

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -1558,7 +1558,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
                            = ['id'      => $task->fields['uuid'],
                               'parent_id' => $parent_id,
                               'name'    => $task->fields['name'],
-                              'desc'    => RichText::getTextFromHtml($task->fields['content'], true, true),
+                              'desc'    => RichText::getTextFromHtml($task->fields['content'], true, false, true),
                               'link'    => $task->getlink(),
                               'type'    => 'task',
                               'percent' => $percent,

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -6324,7 +6324,7 @@ JAVASCRIPT;
                      }
                      $count_display++;
 
-                     $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], false, true);
+                     $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], false, true, true);
 
                      if (self::$output_type == self::HTML_OUTPUT && (Toolbox::strlen($plaintext) > $CFG_GLPI['cut'])) {
                         $rand = mt_rand();

--- a/inc/toolbox/richtext.class.php
+++ b/inc/toolbox/richtext.class.php
@@ -93,13 +93,18 @@ class RichText {
     *
     * @param string  $content                HTML string to be made safe
     * @param boolean $keep_presentation      Indicates whether the presentation elements have to be replaced by plaintext equivalents
+    * @param boolean $compact                Indicates whether the output should be compact (limited line length, no links URL, ...)
     * @param boolean $sanitized_input        Indicates whether the input has been transformed by GLPI sanitize process
     * @param boolean $encode_output_entities Indicates whether the output should be encoded (encoding of HTML special chars)
     *
     * @return string
     */
    public static function getTextFromHtml(
-      string $content, bool $keep_presentation = true, bool $sanitized_input = false, bool $encode_output_entities = false
+      string $content,
+      bool $keep_presentation = true,
+      bool $compact = false,
+      bool $sanitized_input = false,
+      bool $encode_output_entities = false
    ): string {
       global $CFG_GLPI;
 
@@ -110,14 +115,20 @@ class RichText {
       $content = self::normalizeHtmlContent($content, false);
 
       if ($keep_presentation) {
-         // Convert domain relative links to absolute links
-         $content = preg_replace(
-            '/((?:href|src)=[\'"])(\/[^\/].*)([\'"])/',
-            '$1' . $CFG_GLPI['url_base'] . '$2$3',
-            $content
-         );
+         if ($compact) {
+            $options = ['do_links' => 'none', 'width' => 0,];
+         } else {
+            $options = ['width' => 0];
 
-         $html = new Html2Text($content, ['width' => 0]);
+            // Convert domain relative links to absolute links
+            $content = preg_replace(
+               '/((?:href|src)=[\'"])(\/[^\/].*)([\'"])/',
+               '$1' . $CFG_GLPI['url_base'] . '$2$3',
+               $content
+            );
+         }
+
+         $html = new Html2Text($content, $options);
          $content = $html->getText();
       } else {
          // Remove HTML tags using htmLawed

--- a/tests/units/Glpi/Toolbox/DataExport.php
+++ b/tests/units/Glpi/Toolbox/DataExport.php
@@ -49,7 +49,7 @@ class DataExport extends \GLPITestCase {
       yield [
          'value'           => \Toolbox::clean_cross_side_scripting_deep(<<<HTML
 <a id="Ticket1" href="/front/ticket.form.php?id=1" data-hasqtip="0">Ticket title</a>
-<div id="contentTicket1" class="invisible"><p>Ticket content ...</p></div>
+<div id="contentTicket1" class="invisible"><div class="content"><p>Ticket content ...</p></div></div>
 <script type="text/javascript">
 //<![CDATA[
 

--- a/tests/units/Glpi/Toolbox/DataExport.php
+++ b/tests/units/Glpi/Toolbox/DataExport.php
@@ -60,7 +60,7 @@ $(function(){\$('#Ticket1').qtip({
 //]]>
 </script>
 HTML),
-         'expected_result' => "Ticket title [{$base_url}/front/ticket.form.php?id=1] ",
+         'expected_result' => "Ticket title ",
       ];
    }
 

--- a/tests/units/Glpi/Toolbox/RichText.php
+++ b/tests/units/Glpi/Toolbox/RichText.php
@@ -345,6 +345,7 @@ HTML,
       yield [
          'content'                => \Toolbox::clean_cross_side_scripting_deep('<p>Some HTML text</p>'),
          'keep_presentation'      => false,
+         'compact'                => false,
          'sanitized_input'        => true,
          'encode_output_entities' => false,
          'expected_result'        => 'Some HTML text',
@@ -354,6 +355,7 @@ HTML,
       yield [
          'content'                => \Toolbox::clean_cross_side_scripting_deep('<div>This HTML is sanitized.</div>'),
          'keep_presentation'      => false,
+         'compact'                => false,
          'sanitized_input'        => false,
          'encode_output_entities' => false,
          'expected_result'        => '<div>This HTML is sanitized.</div>',
@@ -363,6 +365,7 @@ HTML,
       yield [
          'content'                => '<p>Some HTML content with special chars like &gt; &amp; &lt;.</p>',
          'keep_presentation'      => false,
+         'compact'                => false,
          'sanitized_input'        => false,
          'encode_output_entities' => true,
          'expected_result'        => 'Some HTML content with special chars like &gt; &amp; &lt;.',
@@ -381,6 +384,7 @@ XML;
             '<h1>XML example</h1>' . "\n" . htmlentities($xml_sample)
          ),
          'keep_presentation'      => false,
+         'compact'                => false,
          'sanitized_input'        => true,
          'encode_output_entities' => false,
          'expected_result'        => <<<PLAINTEXT
@@ -403,6 +407,7 @@ HTML;
       yield [
          'content'                => $content,
          'keep_presentation'      => false,
+         'compact'                => false,
          'sanitized_input'        => false,
          'encode_output_entities' => false,
          'expected_result'        => 'A title Text in a paragraph el 1 el 2',
@@ -413,6 +418,7 @@ HTML;
       yield [
          'content'                => $content,
          'keep_presentation'      => true,
+         'compact'                => false,
          'sanitized_input'        => false,
          'encode_output_entities' => false,
          'expected_result'        => <<<PLAINTEXT
@@ -426,6 +432,26 @@ Text in a paragraph
  [an image] [{$base_url}/glpi/front/computer.form.php?id=150] 
 PLAINTEXT,
       ];
+
+      // Text with presentation from complex HTML (compact mode)
+      $base_url = GLPI_URI;
+      yield [
+         'content'                => $content,
+         'keep_presentation'      => true,
+         'compact'                => true,
+         'sanitized_input'        => false,
+         'encode_output_entities' => false,
+         'expected_result'        => <<<PLAINTEXT
+A TITLE
+
+Text in a paragraph
+
+ 	* el 1
+ 	* el 2
+
+ [an image] 
+PLAINTEXT,
+      ];
    }
 
    /**
@@ -434,13 +460,14 @@ PLAINTEXT,
    public function testGetTextFromHtml(
       string $content,
       bool $keep_presentation,
+      bool $compact,
       bool $sanitized_input,
       bool $encode_output_entities,
       string $expected_result
    ) {
       $richtext = $this->newTestedInstance();
 
-      $this->string($richtext->getTextFromHtml($content, $keep_presentation, $sanitized_input, $encode_output_entities))
+      $this->string($richtext->getTextFromHtml($content, $keep_presentation, $compact, $sanitized_input, $encode_output_entities))
          ->isEqualTo($expected_result);
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Fix stripping of tooltips in exported data.

2. Remove inlined links from exported data. These links were not present in GLPI 9.5 and adding them seems not a good idea. Indeed, they are polluting data and are usually not really usefull (see below image).
![image](https://user-images.githubusercontent.com/33253653/125405470-11612980-e3b8-11eb-8d45-35e24c3e621f.png)
