### PR TITLE
Log mailcollector exceptions

### DIFF
--- a/inc/glpi.class.php
+++ b/inc/glpi.class.php
@@ -46,7 +46,6 @@ if (!defined('GLPI_ROOT')) {
 class GLPI {
 
    private $error_handler;
-   private $loggers;
    private $log_level;
 
    /**
@@ -55,7 +54,7 @@ class GLPI {
     * @return void
     */
    public function initLogger() {
-      global $PHPLOGGER, $SQLLOGGER;
+      global $PHPLOGGER, $PHP_LOG_HANDLER, $SQLLOGGER, $SQL_LOG_HANDLER;
 
       $this->log_level = Logger::WARNING;
       if (defined('TU_USER')) {
@@ -81,10 +80,17 @@ class GLPI {
             $handler->setFormatter($formatter);
          }
          $logger->pushHandler($handler);
-         $this->loggers[$type] = $logger;
+         switch ($type) {
+            case 'php':
+               $PHPLOGGER = $logger;
+               $PHP_LOG_HANDLER = $handler;
+               break;
+            case 'sql':
+               $SQLLOGGER = $logger;
+               $SQL_LOG_HANDLER = $handler;
+               break;
+         }
       }
-      $PHPLOGGER = $this->loggers['php'];
-      $SQLLOGGER = $this->loggers['sql'];
    }
 
    /**

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -673,7 +673,7 @@ class MailCollector  extends CommonDBTM {
     * @return string|void
    **/
    function collect($mailgateID, $display = 0) {
-      global $CFG_GLPI;
+      global $CFG_GLPI, $GLPI;
 
       if ($this->getFromDB($mailgateID)) {
          $this->uid          = -1;
@@ -720,7 +720,15 @@ class MailCollector  extends CommonDBTM {
                   $this->fetch_emails++;
                   $messages[$this->storage->getUniqueId($this->storage->key())] = $this->storage->current();
                } catch (\Exception $e) {
-                  Toolbox::logInFile('mailgate', sprintf(__('Message is invalid: %1$s').'<br/>', $e->getMessage()));
+                  $GLPI->getErrorHandler()->handleException($e);
+                  Toolbox::logInFile(
+                     'mailgate',
+                     sprintf(
+                        __('Message is invalid (%s). Check in "%s" for more details')."\n",
+                        $e->getMessage(),
+                        GLPI_LOG_DIR . '/php-errors.log'
+                     )
+                  );
                   ++$error;
                }
             } while ($this->fetch_emails < $this->maxfetch_emails);
@@ -766,7 +774,15 @@ class MailCollector  extends CommonDBTM {
                   }
                } catch (Throwable $e) {
                   $error++;
-                  Toolbox::logInFile('mailgate', sprintf(__('Error during message parsing: %1$s').'<br/>', $e->getMessage()));
+                  $GLPI->getErrorHandler()->handleException($e);
+                  Toolbox::logInFile(
+                     'mailgate',
+                     sprintf(
+                        __('Error during message parsing (%s). Check in "%s" for more details')."\n",
+                        $e->getMessage(),
+                        GLPI_LOG_DIR . '/php-errors.log'
+                     )
+                  );
                   $rejinput['reason'] = NotImportedEmail::FAILED_OPERATION;
                   $rejected->add($rejinput);
                   continue;

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -54,22 +54,19 @@ class GLPITestCase extends atoum {
       global $GLPI_CACHE;
       $GLPI_CACHE->clear();
 
-      global $PHPLOGGER;
-      $handlers = $PHPLOGGER->getHandlers();
-      foreach ($handlers as $handler) {
-         $records  = $handler->getRecords();
-         $messages = array_column($records, 'message');
-         $this->integer(count($records))
-            ->isEqualTo(
-               0,
-               sprintf(
-                  'Unexpected logs records found in %s::%s() test: %s',
-                  static::class,
-                  $method,
-                  "\n" . implode("\n", $messages)
-               )
-            );
-      }
+      global $PHP_LOG_HANDLER;
+      $records  = $PHP_LOG_HANDLER->getRecords();
+      $messages = array_column($records, 'message');
+      $this->integer(count($records))
+         ->isEqualTo(
+            0,
+            sprintf(
+               'Unexpected logs records found in %s::%s() test: %s',
+               static::class,
+               $method,
+               "\n" . implode("\n", $messages)
+            )
+         );
 
       if (isset($_SESSION['MESSAGE_AFTER_REDIRECT']) && !$this->has_failed) {
          unset($_SESSION['MESSAGE_AFTER_REDIRECT'][INFO]);

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -661,6 +661,17 @@ class MailCollector extends DbTestCase {
       foreach ($expected_followups as $expected_followup) {
          $this->integer(countElementsInTable(ITILFollowup::getTable(), $expected_followup))->isEqualTo(1);
       }
+
+      // Check error log and clean it (to prevent test failure, see GLPITestCase::afterTestMethod()).
+      global $PHP_LOG_HANDLER;
+      $records  = $PHP_LOG_HANDLER->getRecords();
+      $messages = array_column($records, 'message');
+      $this->array($messages)->hasSize(2);
+      // 05-empty-from.eml
+      $this->string($messages[0])->contains('The input is not a valid email address. Use the basic format local-part@hostname');
+      // 17-malformed-email.eml
+      $this->string($messages[1])->contains('Header with Name date or date not found');
+      $PHP_LOG_HANDLER->clear();
    }
 
    protected function mailServerProtocolsProvider() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`mailgate.log` contains just summary information of errors that can happen during mail collect.
Adding the full trace of exceptions in GLPI error log may help to invatigate on errors.

Example of exception log:
```
==> files/_log/php-errors.log <==
[2021-07-15 09:25:28] glpiphplog.CRITICAL:   *** Uncaught Exception Laminas\Mail\Storage\Exception\InvalidArgumentException: Header with Name message_id or message_id not found in /var/www/glpi/vendor/laminas/laminas-mail/src/Storage/Part.php at line 307
  Backtrace :
  inc/mailcollector.class.php:1455                   Laminas\Mail\Storage\Part->getHeader()
  inc/mailcollector.class.php:970                    MailCollector->getHeaders()
  inc/mailcollector.class.php:758                    MailCollector->buildTicket()
  front/mailcollector.form.php:88                    MailCollector->collect()
  

==> files/_log/mailgate.log <==
2021-07-15 03:25:28 [2@69509cfe24fe]
Error during message parsing (Header with Name message_id or message_id not found). Check in "/var/www/glpi/files/_log/php-errors.log" for more details
```