### PR TITLE
[Modern UI] Video Lightbox

### DIFF
--- a/css/includes/components/_pictures.scss
+++ b/css/includes/components/_pictures.scss
@@ -42,6 +42,12 @@
       min-width: 100px;
       justify-content: flex-end;
 
+      span.pswp-trigger {
+         height: 50px;
+         background-color: var(--dark);
+         color: var(--light);
+      }
+
       img {
          max-height: 7em;
       }

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -309,7 +309,7 @@
          {% if url is not empty %}
             <a href="{{ url }}" {{ Html__parseAttributes(options['link_attribs']|default('')) }}>
                {% endif %}
-               <img src="{{ value }}" {{ Html__parseAttributes(options) }} {{ url is defined ? 'class="pointer"' : '' }}/>
+               <img src="{{ value }}" {{ Html__parseAttributes(options) }}/>
                {% if url is defined %}
             </a>
          {% endif %}

--- a/templates/components/itilobject/timeline/sub_documents.html.twig
+++ b/templates/components/itilobject/timeline/sub_documents.html.twig
@@ -1,11 +1,11 @@
 {% set documents = entry['documents'] ?? [] %}
 <ul class="list-group list-group-hoverable sub-documents">
-   {% set image_docs = documents|filter(d => d['_is_image']) %}
-   {% set other_docs = documents|filter(d => not d['_is_image']) %}
+   {% set media_docs = documents|filter(d => d['_is_image'] or d['item']['mime'] starts with 'video') %}
+   {% set other_docs = documents|filter(d => not (d['_is_image'] or d['item']['mime'] starts with 'video')) %}
 
-   {% if image_docs|length > 0 %}
+   {% if media_docs|length > 0 %}
       {% set imgs = [] %}
-      {% for document in image_docs %}
+      {% for document in media_docs %}
          {% set docpath = path("front/document.send.php?docid=" ~ document['item']['id']) %}
          {% set fk = item.getForeignKeyField() %}
          {% set delete_link = form_url(item.getType()) ~ "?delete_document&documents_id=" ~ document['item']['id'] ~ "&" ~ fk ~ "=" ~ item.fields['id'] %}
@@ -29,18 +29,34 @@
             </div>
          {% endset %}
 
-         {% set imgs = imgs|merge([{
-            'title': '',
-            'thumbnail_src': docpath ~ '&context=timeline',
-            'thumbnail_w': 'auto',
-            'thumbnail_h': 'auto',
-            'src': docpath,
-            'w': document['_size'][0],
-            'h': document['_size'][1],
-            'img_class': 'shadow',
-            'gallery_item_class': 'list-group-item border-0 d-flex',
-            'post_figure_content': post_figure_content
-         }]) %}
+         {% if document['_is_image'] %}
+            {% set imgs = imgs|merge([{
+               'title': '',
+               'thumbnail_src': docpath ~ '&context=timeline',
+               'thumbnail_w': 'auto',
+               'thumbnail_h': 'auto',
+               'src': docpath,
+               'w': document['_size'][0],
+               'h': document['_size'][1],
+               'img_class': 'shadow ',
+               'gallery_item_class': 'list-group-item border-0 d-flex',
+               'post_figure_content': post_figure_content
+            }]) %}
+         {% else %}
+            {% set video_html %}
+               <span class="d-flex justify-content-center align-items-center mt-5">
+                  <video controls="controls" width="90%" src="{{ docpath }}"></video>
+               </span>
+            {% endset %}
+            {% set imgs = imgs|merge([{
+               'title': '',
+               '_video': true,
+               'html': video_html,
+               'img_class': 'shadow',
+               'gallery_item_class': 'list-group-item border-0 d-flex',
+               'post_figure_content': post_figure_content
+            }]) %}
+         {% endif %}
       {% endfor %}
       {% include 'components/photoswipe.html.twig' with {
          'imgs': imgs,

--- a/templates/components/itilobject/timeline/sub_documents.html.twig
+++ b/templates/components/itilobject/timeline/sub_documents.html.twig
@@ -61,6 +61,7 @@
       {% include 'components/photoswipe.html.twig' with {
          'imgs': imgs,
          'gallery_type': 'horizontal',
+         'controls': {'close': true, 'share': true, 'fullscreen': true, 'zoom': true}
       } %}
    {% endif %}
 

--- a/templates/components/photoswipe.html.twig
+++ b/templates/components/photoswipe.html.twig
@@ -130,7 +130,7 @@
          lightbox.init();
 
          // Prevent dragging around cusotm HTML slide content
-         $(lightbox.container).find('.pswp__item :not(.pswp__zoom-wrap)').on('pointerdown MSPointerDown touchstart mousedown', function (e) {
+         $(lightbox.container).find('.pswp__item span').on('pointerdown MSPointerDown touchstart mousedown', function (e) {
             return false;
          });
          lightbox.listen('destroy', function() {

--- a/templates/components/photoswipe.html.twig
+++ b/templates/components/photoswipe.html.twig
@@ -1,5 +1,5 @@
 {% import "components/form/fields_macros.html.twig" as fields %}
-{% set rand = rand|default(random()) %}
+{% set rand = random() %}
 {% set field_name = field_name|default('psgallery' ~ rand) %}
 
 <div id="psgallery{{ rand }}" class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
@@ -65,9 +65,15 @@
                {{ img['pre_figure_content']|raw }}
             {% endif %}
             <figure itemprop="associatedMedia" itemscope itemtype="https://schema.org/ImageObject" class="d-flex flex-column me-2">
-               <a href="{{ img['src']|escape }}" itemprop="contentUrl" data-index="0">
-                  <img src="{{ img['thumbnail_src']|default(img['src'])|escape }}" itemprop="thumbnail" alt="{{ img['title']|default('') }}" class="{{ img['img_class']|default('') }}">
-               </a>
+                  {% if img['_video'] %}
+                     <span class="bg-black pswp-trigger pointer d-flex justify-content-center align-items-center">
+                        <i class="fas fa-video"></i>
+                     </span>
+                  {% else %}
+                     <a href="{{ img['src']|escape }}" itemprop="contentUrl" data-index="0">
+                        <img src="{{ img['thumbnail_src']|default(img['src'])|escape }}" itemprop="thumbnail" alt="{{ img['title']|default('') }}" class="{{ img['img_class']|default('') }} pointer pswp-trigger">
+                     </a>
+                  {% endif %}
                <figcaption itemprop="caption description">{{ img['title']|default('') }}</figcaption>
             </figure>
             {% if img['post_figure_content'] %}
@@ -87,6 +93,7 @@
                'no_label': true,
                'full_width': true,
                'clearable': clearable,
+               'class': 'pswp-trigger',
                'alt': img['title']|default(''),
                'itemprop': 'thumbnail',
                'link_attribs': {
@@ -103,7 +110,7 @@
 <script>
    (($) => {
       const pswp = document.getElementById("psgallery{{ rand }}");
-      $(".pswp-img{{ rand }}").on('click', 'figure img', function(event) {
+      $(".pswp-img{{ rand }}").on('click', 'figure .pswp-trigger', function(event) {
          event.preventDefault();
          const options = {
             index: $(this).index(),
@@ -121,6 +128,11 @@
          const lightbox = new PhotoSwipe(pswp, PhotoSwipeUI_Default, {{ imgs|json_encode|raw }}, options);
          $(pswp).closest('.card-tabs').css('z-index', 50); // Be sure that tabs are displayed above form in vsplit layout
          lightbox.init();
+
+         // Prevent dragging around cusotm HTML slide content
+         $(lightbox.container).find('.pswp__item :not(.pswp__zoom-wrap)').on('pointerdown MSPointerDown touchstart mousedown', function (e) {
+            return false;
+         });
          lightbox.listen('destroy', function() {
             $(this.container).closest('.card-tabs').css('z-index', '');
          });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Needed for screenshot plugin which has the ability to create and attach screen recordings directly from the ticket timeline. This will allow users and technicians to view these recordings directly from the timeline rather than forcing the user to download the video or having to open it in a new tab in order to view it.

Images and videos may be present in the same gallery.
Videos in the timeline have a placeholder "thumbnail" using `fas fa-video`. I don't think having a proper thumbnail will be possible without a library like `php-ffmpeg`.

This PR also has a fix for having multiple galleries on the same page. Each gallery had the same id previously which caused issues at least with properly closing the gallery.