### PR TITLE
Add search refresh event

### DIFF
--- a/js/modules/Search/Table.js
+++ b/js/modules/Search/Table.js
@@ -165,7 +165,7 @@ window.GLPI.Search.Table = class Table extends GenericView {
          }
 
          $(ajax_container).load(CFG_GLPI.root_doc + '/ajax/search.php', search_data, () => {
-            this.getElement().trigger('search_refresh');
+            this.getElement().trigger('search_refresh', [this.getElement()]);
             this.hideLoadingSpinner();
          });
       } catch (error) {

--- a/js/modules/Search/Table.js
+++ b/js/modules/Search/Table.js
@@ -165,6 +165,7 @@ window.GLPI.Search.Table = class Table extends GenericView {
          }
 
          $(ajax_container).load(CFG_GLPI.root_doc + '/ajax/search.php', search_data, () => {
+            this.getElement().trigger('search_refresh');
             this.hideLoadingSpinner();
          });
       } catch (error) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Needed for `dev` plugin which has a WIP feature that adds a new action to the Plugins search results.
Since the search results can update without a page reload, we need a way to notify that search result customizations need re-applied. In this case, it is used to know to re-add the custom actions.