### PR TITLE
fix: fix controllers prepare()…

### DIFF
--- a/inc/inventory/asset/controller.class.php
+++ b/inc/inventory/asset/controller.class.php
@@ -57,18 +57,16 @@ class Controller extends Device
                if (property_exists($val, $origin)) {
                   $val->$dest = $val->$origin;
                }
-
-               if (property_exists($val, 'pciid')) {
-                  $exploded = explode(":", $val->pciids);
-
-                  //manufacturer
-                  if ($pci_manufacturer = $pcivendor->getManufacturer($exploded[0])) {
-                     $val->manufacturers_id = $pci_manufacturer;
-                  }
-
-                  //product name
-                  if ($pci_product = $pcivendor->getProductName($exploded[0], $exploded[1])) {
-                     $val->designation = $pci_product;
+            }
+            if (property_exists($val, 'vendorid')) {
+               //manufacturer
+               if ($pci_manufacturer = $pcivendor->getManufacturer($val->vendor_id)) {
+                  $val->manufacturers_id = $pci_manufacturer;
+                  if (property_exists($val, 'productid')) {
+                     //product name
+                     if ($pci_product = $pcivendor->getProductName($val->vendor_id, $val->productid)) {
+                        $val->designation = $pci_product;
+                     }
                   }
                }
             }

--- a/inc/inventory/asset/controller.class.php
+++ b/inc/inventory/asset/controller.class.php
@@ -60,11 +60,11 @@ class Controller extends Device
             }
             if (property_exists($val, 'vendorid')) {
                //manufacturer
-               if ($pci_manufacturer = $pcivendor->getManufacturer($val->vendor_id)) {
+               if ($pci_manufacturer = $pcivendor->getManufacturer($val->vendorid)) {
                   $val->manufacturers_id = $pci_manufacturer;
                   if (property_exists($val, 'productid')) {
                      //product name
-                     if ($pci_product = $pcivendor->getProductName($val->vendor_id, $val->productid)) {
+                     if ($pci_product = $pcivendor->getProductName($val->vendorid, $val->productid)) {
                         $val->designation = $pci_product;
                      }
                   }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a

Fix controllers prepare() as controllers/pciid is not supported  by JSON format and as it could be converted to vendorid and productid in converter.
The fix should guaranty "designation" is finally well computed from `PCIVendor()` object.
See [converter lib](https://github.com/glpi-project/inventory_format/blob/5cb12d1334ba2c2ebf3cfb4919793960f180d47b/lib/php/Converter.php#L878) and [checkPciid()](https://github.com/glpi-project/inventory_format/blob/5cb12d1334ba2c2ebf3cfb4919793960f180d47b/lib/php/Converter.php#L1363) where pciid is removed and replaced by vendorid & productid.
On the glpi agent side, only ESX task was still using controllers/pciid but it is fixed in [fix: replace pciid usage by vendorid/productid on esx controllers](https://github.com/glpi-project/glpi-agent/commit/4a8a88b98690900e88732ec45be06c35b0bde611).