### PR TITLE
To prevent followup creation form after re-open of an item

### DIFF
--- a/front/itilfollowup.form.php
+++ b/front/itilfollowup.form.php
@@ -51,7 +51,7 @@ if (isset($_POST["add"])) {
    Event::log($fup->getField('items_id'), strtolower($_POST['itemtype']), 4, "tracking",
               //TRANS: %s is the user login
               sprintf(__('%s adds a followup'), $_SESSION["glpiname"]));
-   Html::back();
+   Html::redirect($track->getFormURLWithID($fup->getField('items_id')));
 
 } else if (isset($_POST['add_close'])
            ||isset($_POST['add_reopen'])) {


### PR DESCRIPTION
When an item is re-open (like a ticket) it proposes a followup to input reason, but after post of the followup, it proposes again a followup creation.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #
