### PR TITLE
Fix prolog request handling

### DIFF
--- a/inc/agent/communication/abstractrequest.class.php
+++ b/inc/agent/communication/abstractrequest.class.php
@@ -106,7 +106,7 @@ abstract class AbstractRequest
     *
     * @throw RuntimeException
     */
-   private function setMode($mode) {
+   protected function setMode($mode) {
       $this->mode = $mode;
       switch ($mode) {
          case self::XML_MODE:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes following issue.
```
glpiphplog.CRITICAL:   *** Uncaught Exception Error: Call to private method Glpi\Agent\Communication\AbstractRequest::setMode() from scope Glpi\Inventory\Request in /var/www/glpi/inc/inventory/request.class.php at line 93
  Backtrace :
  inc/inventory/request.class.php:71                 Glpi\Inventory\Request->prolog()
  ...ent/communication/abstractrequest.class.php:237 Glpi\Inventory\Request->handleQuery()
  ...ent/communication/abstractrequest.class.php:194 Glpi\Agent\Communication\AbstractRequest->handleXMLRequest()
  front/inventory.php:54
```