### PR TITLE
Cleanup other obsolete inventory property

### DIFF
--- a/inc/inventory/asset/drive.class.php
+++ b/inc/inventory/asset/drive.class.php
@@ -46,7 +46,6 @@ class Drive extends Device
 
    public function prepare() :array {
       $mapping = [
-         'serialnumber' => 'serial',
          'name'         => 'designation',
          'type'         => 'interfacetypes_id',
          'manufacturer' => 'manufacturers_id',

--- a/inc/inventory/asset/harddrive.class.php
+++ b/inc/inventory/asset/harddrive.class.php
@@ -46,8 +46,7 @@ class HardDrive extends Device
          'disksize'      => 'capacity',
          'interface'     => 'interfacetypes_id',
          'manufacturer'  => 'manufacturers_id',
-         'model'         => 'designation',
-         'serialnumber'  => 'serial'
+         'model'         => 'designation'
       ];
 
       foreach ($this->data as &$val) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a

Very little cleanup as `storages/serialnumber` has still been replaced in inventory_format specs by `storages/serial`.