### PR TITLE
Restrict usage of Twig filters and functions

### DIFF
--- a/inc/application/view/expression/filterexpression.class.php
+++ b/inc/application/view/expression/filterexpression.class.php
@@ -30,17 +30,28 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Application\View\Extension;
+namespace Glpi\Application\View\Expression;
 
-use Session;
-use Twig\Extension\ExtensionInterface;
+use Twig\Compiler;
+use Twig\Node\Expression\FilterExpression as BaseExpression;
 
-/**
- * @since 10.0.0
- */
-class CsrfExtension extends AbstractExtension implements ExtensionInterface {
+class FilterExpression extends BaseExpression
+{
+   protected function compileArguments(Compiler $compiler, $isArray = false): void {
 
-   public function __construct() {
-      $this->registerFunction('csrf_token', [Session::class, 'getNewCSRFToken'], [], true);
+      $compiler->raw($isArray ? '[' : '(');
+
+      // Add source as first argument
+      $compiler->raw('$this->source');
+
+      // Compile arguments in a dedicated compiler and print them after removing their surrounding `()` or `[]`
+      $args_compiler = new Compiler($compiler->getEnvironment());
+      parent::compileArguments($args_compiler);
+      if (strlen($args_source = substr($args_compiler->getSource(), 1, -1)) > 0) {
+         $compiler->raw(', ');
+         $compiler->raw($args_source);
+      }
+
+      $compiler->raw($isArray ? ']' : ')');
    }
 }

--- a/inc/application/view/expression/functionexpression.class.php
+++ b/inc/application/view/expression/functionexpression.class.php
@@ -30,17 +30,28 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Application\View\Extension;
+namespace Glpi\Application\View\Expression;
 
-use Session;
-use Twig\Extension\ExtensionInterface;
+use Twig\Compiler;
+use Twig\Node\Expression\FunctionExpression as BaseExpression;
 
-/**
- * @since 10.0.0
- */
-class CsrfExtension extends AbstractExtension implements ExtensionInterface {
+class FunctionExpression extends BaseExpression
+{
+   protected function compileArguments(Compiler $compiler, $isArray = false): void {
 
-   public function __construct() {
-      $this->registerFunction('csrf_token', [Session::class, 'getNewCSRFToken'], [], true);
+      $compiler->raw($isArray ? '[' : '(');
+
+      // Add source as first argument
+      $compiler->raw('$this->source');
+
+      // Compile arguments in a dedicated compiler and print them after removing their surrounding `()` or `[]`
+      $args_compiler = new Compiler($compiler->getEnvironment());
+      parent::compileArguments($args_compiler);
+      if (strlen($args_source = substr($args_compiler->getSource(), 1, -1)) > 0) {
+         $compiler->raw(', ');
+         $compiler->raw($args_source);
+      }
+
+      $compiler->raw($isArray ? ']' : ')');
    }
 }

--- a/inc/application/view/extension/abstractextension.class.php
+++ b/inc/application/view/extension/abstractextension.class.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Application\View\Extension;
+
+use Glpi\Application\View\Expression\FilterExpression;
+use Glpi\Application\View\Expression\FunctionExpression;
+use Twig\Source;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+use Twig\Extension\ExtensionInterface;
+
+/**
+ * @since 10.0.0
+ */
+class AbstractExtension implements ExtensionInterface {
+
+   /**
+    * @var \Twig\TwigFilter[]
+    */
+   protected $filters = [];
+
+   /**
+    * @var \Twig\TwigFunction[]
+    */
+   protected $functions = [];
+
+   /**
+    * Registers a filter.
+    *
+    * @param string $name
+    * @param callable $callable
+    * @param array $options
+    * @param bool $exposed_to_plugins
+    *
+    * @return void
+    */
+   protected function registerFilter(
+      string $name,
+      ?callable $callable = null,
+      array $options = [],
+      bool $exposed_to_plugins = false
+   ): void {
+      $options['node_class'] = FilterExpression::class;
+
+      $this->filters[$name] = $this->getCallableWrapper(
+         TwigFilter::class,
+         $name,
+         $callable,
+         $options,
+         $exposed_to_plugins
+      );
+   }
+
+   /**
+    * Registers a function.
+    *
+    * @param string $name
+    * @param callable $callable
+    * @param array $options
+    * @param bool $exposed_to_plugins
+    */
+   protected function registerFunction(
+      string $name,
+      callable $callable,
+      array $options = [],
+      bool $exposed_to_plugins = false
+   ): void {
+      $options['node_class'] = FunctionExpression::class;
+
+      $this->functions[$name] = $this->getCallableWrapper(
+         TwigFunction::class,
+         $name,
+         $callable,
+         $options,
+         $exposed_to_plugins
+      );
+   }
+
+   public function getFilters() {
+      return $this->filters;
+   }
+
+   public function getFunctions() {
+      return $this->functions;
+   }
+
+   public function getTokenParsers() {
+      return [];
+   }
+
+   public function getNodeVisitors() {
+      return [];
+   }
+
+   public function getTests() {
+      return [];
+   }
+
+   public function getOperators() {
+      return [];
+   }
+
+   private function getCallableWrapper(
+      string $type,
+      string $name,
+      callable $callable,
+      array $options,
+      bool $exposed_to_plugins
+   ) /*: TwigFilter|TwigFunction */ {
+      return new $type(
+         $name,
+         function (Source $source, ...$params) use ($type, $name, $callable, $exposed_to_plugins) {
+            // Check availability in source context.
+            if (!$exposed_to_plugins && preg_match('/@[a-z]+\//', $source->getName())) {
+               trigger_error(
+                  sprintf(
+                     'Usage of "%s" %s is not allowed in plugins (used in %s)',
+                     $name,
+                     strtolower(preg_replace('/^Twig\\\Twig/', '', $type)),
+                     $source->getName()
+                  ),
+                  E_USER_ERROR
+               );
+            }
+
+            // Forward to registered callable.
+            return call_user_func_array($callable, $params);
+         },
+         $options
+      );
+   }
+}

--- a/inc/application/view/extension/commonitilobjectextension.class.php
+++ b/inc/application/view/extension/commonitilobjectextension.class.php
@@ -35,28 +35,18 @@ namespace Glpi\Application\View\Extension;
 use CommonITILObject;
 use Item_Ticket;
 use Planning;
-use Twig\Extension\AbstractExtension;
 use Twig\Extension\ExtensionInterface;
-use Twig\TwigFilter;
-use Twig\TwigFunction;
 
 /**
  * @since 10.0.0
  */
 class CommonITILObjectExtension extends AbstractExtension implements ExtensionInterface {
 
-   public function getFilters() {
-      return [
-         new TwigFilter('getTimelineStats', [$this, 'getTimelineStats'], ['is_safe' => ['html']]),
-      ];
-   }
+   public function __construct() {
+      $this->registerFilter('getTimelineStats', [$this, 'getTimelineStats'], ['is_safe' => ['html']]);
 
-   public function getFunctions() {
-      return [
-         new TwigFunction('Item_Ticket_itemAddForm', [Item_Ticket::class, 'itemAddForm']),
-      ];
+      $this->registerFunction('Item_Ticket_itemAddForm', [Item_Ticket::class, 'itemAddForm']);
    }
-
 
    public function getTimelineStats(CommonITILObject $item): array {
       global $DB;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Technically, Twig's filters and functions are public, which means any plugin developer can use them, even if it wasn't intended by us.

Some have been set up to quickly move forward on the new interface, for very targeted needs, and will probably be reviewed in the short or medium term (e.g. `Item_Ticket_itemAddForm`). For these, it is preferable to prohibit their use now within plugins, so as not to have to maintain their backward compatibility.
Others can on the contrary be legitimately used in plugin templates (e.g. `csrf_token`).

The purpose of this PR is to propose a solution to define whether a filter/function can be used in plugins.

Exemple of error generated by unauthorized usage of a function:
```
[2021-07-22 14:37:12] glpiphplog.ERROR:   *** PHP User Error (256): Usage of "Item_Ticket_itemAddForm" function is not allowed in plugins (used in @barcode/test.html.twig) in /var/www/glpi/inc/application/view/extension/abstractextension.class.php at line 152
  Backtrace :
  .../view/extension/abstractextension.class.php:152 trigger_error()
  ...e646b8157874257ed34c28895ba324f941d98f8d.php:40 Glpi\Application\View\Extension\AbstractExtension->Glpi\Application\View\Extension\{closure}()
  vendor/twig/twig/src/Template.php:394              __TwigTemplate_34c72d7cb8a014efe02a537be951bb93780779926b36a7d802c7d33aa6a444d6->doDisplay()
  vendor/twig/twig/src/Template.php:367              Twig\Template->displayWithErrorHandling()
  vendor/twig/twig/src/TemplateWrapper.php:47        Twig\Template->display()
  ...application/view/templaterenderer.class.php:180 Twig\TemplateWrapper->display()
  inc/central.class.php:156                          Glpi\Application\View\TemplateRenderer->display()
  inc/central.class.php:100                          Central::showGlobalView()
  inc/commonglpi.class.php:659                       Central::displayTabContentForItem()
  ajax/common.tabs.php:106                           CommonGLPI::displayStandardTab()
```

![image](https://user-images.githubusercontent.com/33253653/126657441-15e4e0a1-b548-461d-a782-1bee76ccf535.png)
