### PR TITLE
fix: inventory import fails on found blacklisted value in model fields

### DIFF
--- a/inc/blacklist.class.php
+++ b/inc/blacklist.class.php
@@ -503,7 +503,7 @@ class Blacklist extends CommonDropdown {
             && preg_match('/^.+models_id/', $key)
             && '' == $this->process(self::MODEL, $value->$key)
          ) {
-            unset($value[$key]);
+            unset($value->$key);
          }
       }
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a

Fix the following error blocking inventory import:
```
[2021-07-21 15:30:33] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Cannot use object of type stdClass as array in /var/www/glpi/inc/blacklist.class.php at line 506
  Backtrace :
  inc/inventory/asset/inventoryasset.class.php:161   Blacklist->processBlackList()
  inc/inventory/asset/mainasset.class.php:566        Glpi\Inventory\Asset\InventoryAsset->handleLinks()
  inc/ruleimportasset.class.php:922                  Glpi\Inventory\Asset\MainAsset->rulepassed()
  inc/rule.class.php:1437                            RuleImportAsset->executeActions()
  inc/rulecollection.class.php:1469                  Rule->process()
  inc/inventory/asset/mainasset.class.php:492        RuleCollection->processAllRules()
  inc/inventory/inventory.class.php:629              Glpi\Inventory\Asset\MainAsset->handle()
  inc/inventory/inventory.class.php:328              Glpi\Inventory\Inventory->handleItem()
  inc/inventory/request.class.php:131                Glpi\Inventory\Inventory->doInventory()
  inc/inventory/request.class.php:77                 Glpi\Inventory\Request->inventory()
  ...ent/communication/abstractrequest.class.php:256 Glpi\Inventory\Request->handleQuery()
  ...ent/communication/abstractrequest.class.php:196 Glpi\Agent\Communication\AbstractRequest->handleJSONRequest()
  front/inventory.php:54                             Glpi\Agent\Communication\AbstractRequest->handleRequest()
```

The error was triggered by a json inventory where `content/bios/smodel` property was set to `System Product Name`. This value is listed in `inc/blacklist.class.php` at line 416.