### PR TITLE
Handle display of itemtype fields values

### DIFF
--- a/inc/notificationmailing.class.php
+++ b/inc/notificationmailing.class.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * ---------------------------------------------------------------------
  * GLPI - Gestionnaire Libre de Parc Informatique

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -57,7 +57,7 @@
    {% set field %}
       <input type="{{ options.type }}" id="%id%"
              class="form-control"
-             name="{{ name }}" value="{{ value }}"
+             name="{{ name }}" value="{{ value|safe_value }}"
              {{ options.readonly ? 'readonly' : '' }}
              {{ options.disabled ? 'disabled' : '' }}
              {{ options.required ? 'required' : '' }} />
@@ -136,7 +136,7 @@
    {% endif %}
 
    {% set value %}
-      <span class="form-control" readonly>{{ value|raw }}</span>
+      <span class="form-control" readonly>{{ value|safe_value }}</span>
    {% endset %}
    {{ _self.field(name, value, label, options) }}
 {% endmacro %}
@@ -154,7 +154,7 @@
       <textarea class="form-control" id="{{ id }}" name="{{ name }}" rows="3"
                 style="width: 100%;"
                 {{ options.disabled ? 'disabled' : '' }}
-                {{ options.required ? 'required' : '' }}>{{ value|raw }}</textarea>
+                {{ options.required ? 'required' : '' }}>{{ value|safe_value }}</textarea> {# TODO safe_html #}
    {% endset %}
 
    {% if options.enable_richtext %}
@@ -201,7 +201,7 @@
       {# .rounded-start added to prevent issue with bootstrap .input-group #}
       {# the first element is an input[type=hidden] added by flatpickr and so we don't have border-radius on the start #}
       <input type="text" class="form-control rounded-start ps-2" data-input
-             name="{{ name }}" value="{{ value }}"
+             name="{{ name }}" value="{{ value|safe_value }}"
              {{ options.required ? 'required' : "" }}
              {{ options.disabled ? 'disabled' : "" }}>
       <i class="input-group-text far fa-calendar" data-toggle role="button"></i>
@@ -271,7 +271,7 @@
    {% set field %}
       <input type="color" id="%id%"
              class="form-control form-control-color"
-             name="{{ name }}" value="{{ value }}"
+             name="{{ name }}" value="{{ value|safe_value }}"
          {{ options.readonly ? 'readonly' : '' }}
          {{ options.disabled ? 'disabled' : '' }}
          {{ options.required ? 'required' : '' }} />
@@ -284,7 +284,7 @@
    {% set field %}
       <input type="password" id="%id%"
              class="form-control"
-             name="{{ name }}" value="{{ value }}"
+             name="{{ name }}" value="{{ value|safe_value }}"
          {{ options.readonly ? 'readonly' : '' }}
          {{ options.disabled ? 'disabled' : '' }}
          {{ options.required ? 'required' : '' }} />
@@ -360,7 +360,7 @@
    {% set field %}
       <input type="hidden" id="%id%"
              class="form-control"
-             name="{{ name }}" value="{{ value }}"
+             name="{{ name }}" value="{{ value|safe_value }}"
          {{ options.readonly ? 'readonly' : '' }}
          {{ options.disabled ? 'disabled' : '' }}
          {{ options.required ? 'required' : '' }} />

--- a/templates/components/itilobject/selfservice.html.twig
+++ b/templates/components/itilobject/selfservice.html.twig
@@ -218,7 +218,7 @@
 
                {{ fields.textareaField(
                   "content",
-                  getSafeHtml(params['content'] ?? "", true, true),
+                  getSafeHtml(params['content'] ?? "", true),
                   __('Description'),
                   right_field_options|merge({
                      'enable_richtext': true,

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -38,7 +38,7 @@
                <div class="col-12 col-md-9">
                   {{ fields.textareaField(
                      'content',
-                     getSafeHtml(subitem.fields['content'], true, true),
+                     getSafeHtml(subitem.fields['content'], true),
                      '',
                      {
                         'full_width': true,

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -57,7 +57,7 @@
 
                   {{ fields.textareaField(
                      'content',
-                     getSafeHtml(content, true, true),
+                     getSafeHtml(content, true),
                      '',
                      {
                         'full_width': true,

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -94,7 +94,7 @@
                <div class="col-12 col-md-9">
                   {{ fields.textareaField(
                      'content',
-                     getSafeHtml(subitem.fields['content'], true, true),
+                     getSafeHtml(subitem.fields['content'], true),
                      '',
                      {
                         'full_width': true,

--- a/templates/components/itilobject/timeline/simple_form.html.twig
+++ b/templates/components/itilobject/timeline/simple_form.html.twig
@@ -24,7 +24,7 @@
 
       {{ fields.textareaField(
          "content",
-         getSafeHtml(item.fields['content'], true, true),
+         getSafeHtml(item.fields['content'], true),
          __('Description'),
          field_options|merge({
             'enable_richtext': true,

--- a/templates/dropdown_form.html.twig
+++ b/templates/dropdown_form.html.twig
@@ -242,7 +242,7 @@
                   {{ fields.passwordField(field['name'], item.fields[field['name']], field['label'], params) }}
                {% elseif type == 'tinymce' %}
                   {% set params = params|merge({'enable_richtext': true}) %}
-                  {{ fields.textareaField(field['name'], getSafeHtml(item.fields[field['name']], true, true), field['label'], params) }}
+                  {{ fields.textareaField(field['name'], getSafeHtml(item.fields[field['name']], true), field['label'], params) }}
                {% elseif type == 'duration' %}
                   {% set toadd = [] %}
                   {% for i in 9..100 %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Almost all values that are rendered in templates are either a runtime generated html (like a link or a tooltip) or a "sanitized" value (like an item field value). Both of them are so already "escaped" (in a Twig point of view) and must be printed with a `|raw` filter.
There is 2 problems with this.
First, it may happen that an item field value has been generated on runtime and is not "sanitized", so using the `|raw` filter may introduce a security issue.
Second, in the future, we may want to remove the sanitize process. If we use the `|raw` filter for both legitimate HTML and "sanitized" values, it will be hard to distinguish both usages, and migration of templates will be a real pain.

This PR propose a solution for both problems, by intoducing a `safe_value` filter. This filter accept same arguments as the [Twig escape filter](https://twig.symfony.com/doc/3.x/filters/escape.html), and will be responsible to detect whether the value to print is already sanitized or not, in order to "unsanitize" it if it is required. The value is then forwarded to the Twig escape filter in order to print a HTML/CSS/JS safe code.