### PR TITLE
Twig support in emplates: Fix massive actions

### DIFF
--- a/ajax/itilfollowup.php
+++ b/ajax/itilfollowup.php
@@ -44,9 +44,15 @@ Html::header_nocache();
 Session::checkLoginUser();
 
 // Mandatory parameter: itilfollowuptemplates_id
-$itilfollowuptemplates_id = $_POST['itilfollowuptemplates_id'] ?? 0;
-if (!$itilfollowuptemplates_id) {
+$itilfollowuptemplates_id = $_POST['itilfollowuptemplates_id'] ?? null;
+if ($itilfollowuptemplates_id === null) {
    Toolbox::throwError(400, "Missing or invalid parameter: 'itilfollowuptemplates_id'");
+} else if ($itilfollowuptemplates_id == 0) {
+   // Reset form
+   echo json_encode([
+      'content' => ""
+   ]);
+   die;
 }
 
 // Mandatory parameter: items_id

--- a/ajax/solution.php
+++ b/ajax/solution.php
@@ -41,9 +41,15 @@ Html::header_nocache();
 Session::checkLoginUser();
 
 // Mandatory parameter: solutiontemplates_id
-$solutiontemplates_id = $_POST['solutiontemplates_id'] ?? 0;
-if ($solutiontemplates_id == 0) {
+$solutiontemplates_id = $_POST['solutiontemplates_id'] ?? null;
+if ($solutiontemplates_id === null) {
    Toolbox::throwError(400, "Missing or invalid parameter: 'solutiontemplates_id'");
+} else if ($solutiontemplates_id == 0) {
+   // Reset form
+   echo json_encode([
+      'content' => ""
+   ]);
+   die;
 }
 
 // We can't render the twig template at this state for some cases (e.g. massive

--- a/ajax/task.php
+++ b/ajax/task.php
@@ -43,9 +43,15 @@ Html::header_nocache();
 Session::checkLoginUser();
 
 // Mandatory parameter: tasktemplates_id
-$tasktemplates_id = $_POST['tasktemplates_id'] ?? 0;
-if (!$tasktemplates_id) {
+$tasktemplates_id = $_POST['tasktemplates_id'] ?? null;
+if ($tasktemplates_id === null) {
    Toolbox::throwError(400, "Missing or invalid parameter: 'tasktemplates_id'");
+} else if ($tasktemplates_id == 0) {
+   // Reset form
+   echo json_encode([
+      'content' => ""
+   ]);
+   die;
 }
 
 // Mandatory parameter: items_id

--- a/inc/abstractitilchildtemplate.class.php
+++ b/inc/abstractitilchildtemplate.class.php
@@ -114,23 +114,15 @@ abstract class AbstractITILChildTemplate extends CommonDropdown
     * @return string
     */
    public function getRenderedContent(CommonITILObject $itil_item): string {
-      $parameters_class = $itil_item->getContentTemplatesParametersClass();
-      $parameters = new $parameters_class();
+      $html = TemplateManager::renderContentForCommonITIL(
+         $itil_item,
+         $this->fields['content']
+      );
 
-      try {
-         $html = TemplateManager::render(
-            $this->fields['content'],
-            [
-               'itemtype' => $itil_item->getType(),
-               $parameters->getDefaultNodeName() => $parameters->getValues($itil_item),
-            ],
-            true
-         );
-      } catch (\Twig\Error\Error $e) {
+      if (!$html) {
          $html = $this->fields['content'];
-         global $GLPI;
-         $GLPI->getErrorHandler()->handleException($e);
       }
+
       return $html;
    }
 }

--- a/inc/contenttemplates/templatemanager.class.php
+++ b/inc/contenttemplates/templatemanager.class.php
@@ -32,6 +32,7 @@
 
 namespace Glpi\ContentTemplates;
 
+use CommonITILObject;
 use Glpi\Toolbox\RichText;
 use Glpi\Toolbox\Sanitizer;
 use Twig\Environment;
@@ -55,7 +56,7 @@ if (!defined('GLPI_ROOT')) {
 class TemplateManager
 {
    /**
-    * Boiler plate code to render a user template
+    * Boiler plate code to render a template
     *
     * @param string $content           Template content (html + twig)
     * @param array $params             Variables to be exposed to the templating engine
@@ -89,6 +90,37 @@ class TemplateManager
       return $html;
    }
 
+   /**
+    * Boiler plate for rendering a commonitilobject content from a template
+    *
+    * @param CommonITILObject $itil_item
+    * @param string $template
+    *
+    * @return string|null
+    */
+   public static function renderContentForCommonITIL(
+      CommonITILObject $itil_item,
+      string $template
+   ): ?string {
+      $parameters_class = $itil_item->getContentTemplatesParametersClass();
+      $parameters = new $parameters_class();
+
+      try {
+         $html = TemplateManager::render(
+            $template,
+            [
+               'itemtype' => $itil_item->getType(),
+               $parameters->getDefaultNodeName() => $parameters->getValues($itil_item),
+            ],
+            true
+         );
+      } catch (\Twig\Error\Error $e) {
+         global $GLPI;
+         $GLPI->getErrorHandler()->handleException($e);
+         return null;
+      }
+      return $html;
+   }
    /**
     * Boiler plate code to validate a template that user is trying to submit
     *

--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -34,6 +34,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use Glpi\ContentTemplates\TemplateManager;
 use Glpi\Toolbox\RichText;
 
 /**
@@ -334,6 +335,22 @@ JAVASCRIPT;
       }
 
       $input['status'] = $status;
+
+      // Render twig content, needed for massives action where we the content
+      // can't be rendered directly in the form
+      if (($input['_render_twig'] ?? false) && isset($input['content'])) {
+         $html = TemplateManager::renderContentForCommonITIL(
+            $this->item,
+            $input['content']
+         );
+
+         // Invalid template
+         if (!$html) {
+            return false;
+         }
+
+         $input['content'] = $html;
+      }
 
       return $input;
    }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2630,6 +2630,7 @@ class Ticket extends CommonITILObject {
                'rand'     => $rand,
                'on_change' => "solutiontemplate_update{$rand}(this.value)"
             ]);
+            echo Html::hidden("_render_twig", ['value' => true]);
 
             $JS = <<<JAVASCRIPT
                function solutiontemplate_update{$rand}(value) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\ContentTemplates\Parameters\ParametersTypes\AttributeParameter;
+use Glpi\ContentTemplates\Parameters\ParametersTypes\ObjectParameter;
 use Glpi\ContentTemplates\Parameters\TicketParameters;
 use Glpi\Event;
 use Glpi\Toolbox\RichText;
@@ -2676,6 +2678,10 @@ JAVASCRIPT;
                             'enable_images'     => false,
                             'cols'              => 12,
                             'rows'              => 80]);
+            Html::activateUserTemplateAutocompletion('textarea[name=content]' ,[
+               (new AttributeParameter('itemtype', __('Itemtype')))->compute(),
+               (new ObjectParameter(new TicketParameters()))->compute(),
+            ]);
             echo '</div>'; // .form-row
 
             echo '</div>'; // .horizontal-form

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2678,7 +2678,7 @@ JAVASCRIPT;
                             'enable_images'     => false,
                             'cols'              => 12,
                             'rows'              => 80]);
-            Html::activateUserTemplateAutocompletion('textarea[name=content]' ,[
+            Html::activateUserTemplateAutocompletion('textarea[name=content]', [
                (new AttributeParameter('itemtype', __('Itemtype')))->compute(),
                (new ObjectParameter(new TicketParameters()))->compute(),
             ]);


### PR DESCRIPTION
When adding #9291, we forgot a specific case: it is possible to solve a ticket using a template through the massive actions.

This is not supported by the initial PR because we render the template when it is loaded into the form but this is not possible for this case as we do not have a given item to use as parameter (instead we have multiples items and the template should be rendered differently for each of these items).

The proposed solution is, for this specific case, to not render the template in the form.
Instead, we do it in the `prepareInputForAdd` function.

Example:
1) Using massive actions:
![image](https://user-images.githubusercontent.com/42734840/126798094-3ac6c163-e9ae-4d41-8d98-f51984ca6f52.png)
2) Ticket 102:
![image](https://user-images.githubusercontent.com/42734840/126798159-0a00acee-7835-4b90-8599-f743c9178d5a.png)
3) Ticket 95: 
![image](https://user-images.githubusercontent.com/42734840/126798203-dc248a16-ef6f-4414-9159-a3d0ca963985.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
