### PR TITLE
FIX: remove hardcoded configuration for network port transfert

### DIFF
--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -1057,8 +1057,7 @@ class Transfer extends CommonDBTM {
          if ($item->getFromDB($newID)) {
 
             // Network connection ? keep connected / keep_disconnected / delete
-            if (in_array($itemtype, ['Computer', 'Monitor', 'NetworkEquipment', 'Peripheral',
-                                          'Phone', 'Printer'])) {
+            if (in_array($itemtype, $CFG_GLPI['networkport_types'])) {
                $this->transferNetworkLink($itemtype, $ID, $newID);
             }
 


### PR DESCRIPTION
with the current code, if a network port is added to a new device type the networkport transfer actions won't work


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | --
| Fixed tickets | none
