### PR TITLE
Fix OS meta criteria

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5388,6 +5388,24 @@ JAVASCRIPT;
          return $JOIN;
       }
 
+      if ($from_referencetype === 'Computer' && $to_type === 'OperatingSystem') {
+         // From OperatingSystem to glpi_items_operatingsystems
+         $operatingsystemitems_alias = "glpi_items_operatingsystems{$alias_suffix}";
+         if (!in_array($operatingsystemitems_alias, $already_link_tables2)) {
+            array_push($already_link_tables2, $operatingsystemitems_alias);
+            $JOIN .= "$LINK `glpi_items_operatingsystems` AS `$operatingsystemitems_alias`
+                         ON (`$from_table`.`id` = `$operatingsystemitems_alias`.`items_id` AND `$operatingsystemitems_alias`.`itemtype` = '$from_referencetype') ";
+         }
+         if (!in_array($to_table, $already_link_tables2)) {
+            array_push($already_link_tables2, $to_table);
+            $JOIN .= "$LINK `$to_table`
+                         ON (`$to_table`.`id` = `$operatingsystemitems_alias`.`operatingsystems_id`
+                             AND `$operatingsystemitems_alias`.`itemtype` = '$from_referencetype'
+                             $to_entity_restrict) ";
+         }
+         return $JOIN;
+      }
+
       // Generic JOIN
       $from_obj      = getItemForItemtype($from_referencetype);
       $to_obj        = getItemForItemtype($to_type);

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -5388,7 +5388,7 @@ JAVASCRIPT;
          return $JOIN;
       }
 
-      if ($from_referencetype === 'Computer' && $to_type === 'OperatingSystem') {
+      if ($to_type === 'OperatingSystem' && in_array($from_referencetype, $CFG_GLPI['operatingsystem_types'])) {
          // From OperatingSystem to glpi_items_operatingsystems
          $operatingsystemitems_alias = "glpi_items_operatingsystems{$alias_suffix}";
          if (!in_array($operatingsystemitems_alias, $already_link_tables2)) {

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -84,6 +84,34 @@ class Search extends DbTestCase {
       return $data;
    }
 
+   public function testMetaComputerOS() {
+      $search_params = ['is_deleted'   => 0,
+                        'start'        => 0,
+                        'criteria'     => [0 => ['field'      => 'view',
+                                                 'searchtype' => 'contains',
+                                                 'value'      => '']],
+                        'metacriteria' => [0 => ['link'       => 'AND',
+                                                 'itemtype'   => 'OperatingSystem',
+                                                 'field'      => 1, //name
+                                                 'searchtype' => 'contains',
+                                                 'value'      => 'windows']]];
+
+      $data = $this->doSearch('Computer', $search_params);
+
+      //try to find LEFT JOIN clause
+      $this->string($data['sql']['search'])
+         ->matches("/"
+         ."(LEFT\s*JOIN\s*`glpi_operatingsystems`\s*"
+         ."ON\s*\(`glpi_operatingsystems`\.`id`\s*=\s*`glpi_items_operatingsystems_OperatingSystem`\.`operatingsystems_id`\s*"
+         ."AND `glpi_items_operatingsystems_OperatingSystem`\.`itemtype`\s*=\s*'Computer'\s*\))"
+         ."/im");
+
+      //try to match WHERE clause
+      $this->string($data['sql']['search'])
+         ->matches("/(\(`glpi_operatingsystems`\.`name`\s*LIKE\s*'%windows%'\s*\)\s*\))/im");
+   }
+
+
    public function testMetaComputerSoftwareLicense() {
       $search_params = ['is_deleted'   => 0,
                         'start'        => 0,


### PR DESCRIPTION
Meta criteria for OS no longer work

GLPI tries to make the relation (LEFT JOIN) from ```glpi_computers_items``` instead of ```glpi_items_operatingsystems```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Internal 22385
