### PR TITLE
$_SESSION['glpiname'] is undefined

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -4369,7 +4369,7 @@ class CommonDBTM extends CommonGLPI {
                                        'inventory',
                                        //TRANS: %1$s is the user login, %2$s the message
                                        sprintf(__('%1$s trying to add an item that already exists: %2$s'),
-                                               $_SESSION["glpiname"], $message_text));
+                                               Session::getLoginUserID(false), $message_text));
                         }
                      }
                      if ($fields['action_refuse']) {


### PR DESCRIPTION
When script is executed by console $_SESSION['glpiname'] is undefined.



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
