### PR TITLE
Split code of uploaded files handling methods

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -5318,10 +5318,8 @@ class CommonDBTM extends CommonGLPI {
          }
 
          // Check for duplicate
-         if ($doc->getFromDBbyContent($entities_id, $filename)) {
-            if (!$doc->fields['is_blacklisted']) {
-               $docID = $doc->fields["id"];
-            }
+         if ($doc->getDuplicateOf($entities_id, $filename)) {
+            $docID = $doc->fields["id"];
             // File already exist, we replace the tag by the existing one
             if (isset($input['_tag'][$key])
                 && ($docID > 0)

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -1638,4 +1638,25 @@ class Document extends CommonDBTM {
    static function getIcon() {
       return "far fa-file";
    }
+
+
+   /**
+    * find and load a document which is a duplicate of a file, with respect of blacklisting
+    *
+    * @param integer $entity    entity of the document
+    * @param string  $path      path of the searched file
+    *
+    * @return boolean
+    */
+   public function getDuplicateOf(int $entities_id, string $filename): bool {
+      if (!$this->getFromDBbyContent($entities_id, $filename)) {
+         return false;
+      }
+
+      if ($this->fields['is_blacklisted']) {
+         return false;
+      }
+
+      return true;
+   }
 }

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2600,6 +2600,25 @@ class Toolbox {
    }
 
    /**
+    * Find documents data matching the tags found in the string
+    * Tags are deduplicated
+    *
+    * @param string $content_text String to search tags from
+    *
+    * @return array data from documents having tags found
+    */
+   static function getDocumentsFromTag(string $content_text): array {
+      preg_match_all('/'.Document::getImageTag('(([a-z0-9]+|[\.\-]?)+)').'/', $content_text,
+                     $matches, PREG_PATTERN_ORDER);
+      if (!isset($matches[1]) || count($matches[1]) == 0) {
+         return [];
+      }
+
+      $document = new Document();
+      return $document->find(['tag' => array_unique($matches[1])]);
+   }
+
+   /**
     * Convert tag to image
     *
     * @since 9.2
@@ -2617,11 +2636,7 @@ class Toolbox {
       $matches  = [];
       // If no doc data available we match all tags in content
       if (!count($doc_data)) {
-         preg_match_all('/'.Document::getImageTag('(([a-z0-9]+|[\.\-]?)+)').'/', $content_text,
-                        $matches, PREG_PATTERN_ORDER);
-         if (isset($matches[1]) && count($matches[1])) {
-            $doc_data = $document->find(['tag' => array_unique($matches[1])]);
-         }
+         $doc_data = Toolbox::getDocumentsFromTag($content_text);
       }
 
       if (count($doc_data)) {

--- a/tests/functionnal/Document.php
+++ b/tests/functionnal/Document.php
@@ -727,4 +727,47 @@ class Document extends DbTestCase {
       $this->boolean($doc->getFromDB($did2))->isFalse();
       $this->boolean($doc->getFromDB($did3))->isTrue();
    }
+
+   public function testGetDuplicateOf() {
+      $instance = $this->newTestedInstance();
+
+      // Test when the file is not in the DB
+      $output = $instance->getDuplicateOf(0, __DIR__ . '/../fixtures/uploads/foo.png');
+      $this->boolean($output)->isFalse();
+
+      $filename = 'foo.png';
+      copy(__DIR__ . '/../fixtures/uploads/foo.png', GLPI_TMP_DIR . '/' . $filename);
+      $tag = \Rule::getUuid();
+      $input = [
+         'filename' => 'foo.png',
+         '_filename' => [
+            $filename,
+         ],
+         '_tag_filename' => [
+            $tag,
+         ],
+         '_prefix_filename' => [
+            '5e5e92ffd9bd91.11111111',
+         ]
+      ];
+      $document = new \Document();
+      $document->add($input);
+      $this->boolean($document->isnewItem())->isFalse();
+
+      // Check the file is found in the FB
+      $instance = $this->newTestedInstance();
+      $output = $instance->getDuplicateOf(0, __DIR__ . '/../fixtures/uploads/foo.png');
+      $this->boolean($output)->isTrue();
+
+      // togle the blackisted flag
+      $success = $instance->update([
+         'id'             => $instance->getID(),
+         'is_blacklisted' => '1'
+      ]);
+      $this->boolean($success)->isTrue();
+
+      // Test when the document exists and is blacklisted
+      $output = $instance->getDuplicateOf(0, __DIR__ . '/../fixtures/uploads/foo.png');
+      $this->boolean($output)->isFalse();
+   }
 }

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -1031,4 +1031,34 @@ class Toolbox extends DbTestCase {
    public function testHasTrait($class, $trait, $result) {
       $this->boolean(\Toolbox::hasTrait($class, $trait))->isIdenticalTo((bool)$result);
    }
+
+
+   public function testGetDocumentsFromTag() {
+      // No tag provided in the tested text
+      $output = \Toolbox::getDocumentsFromTag('');
+      $this->array($output)->hasSize(0);
+
+      // Create a document to emulate a document upload
+      $filename = 'foo.png';
+      copy(__DIR__ . '/../fixtures/uploads/foo.png', GLPI_TMP_DIR . '/' . $filename);
+      $tag = \Rule::getUuid();
+      $input = [
+         'filename' => 'foo.png',
+         '_filename' => [
+            $filename,
+         ],
+         '_tag_filename' => [
+            $tag,
+         ],
+         '_prefix_filename' => [
+            '5e5e92ffd9bd91.11111111',
+         ]
+      ];
+      $document = new \Document();
+      $document->add($input);
+      $this->boolean($document->isnewItem())->isFalse();
+
+      $output = \Toolbox::getDocumentsFromTag("foo #$tag# bar ");
+      $this->array($output)->hasSize(1);
+   }
 }


### PR DESCRIPTION
To fix some issues in Formcreator I need to create target tickets or target changes with special handling of inline images (added in a textarea question). The best solution is to process them as file uploads aas if the target is created from regular UI.

To complete this purpose, I need to use some lines of code from the core, but want to avoid duplication.


PR in Formcreator: https://github.com/pluginsGLPI/formcreator/pull/2320/files

