### PR TITLE
permits to set transparent color in dashboard cards

### DIFF
--- a/css/includes/_dark.scss
+++ b/css/includes/_dark.scss
@@ -31,6 +31,8 @@
 
 $table_header_bg: $dark !default;
 
+$input-bg: darken($dark, 2%) !default;
+$input-color: $light !default;
 $input-focus-bg: #444444 !default;
 $input-focus-border-color: #868686 !default;
 

--- a/css/includes/_global-variables.scss
+++ b/css/includes/_global-variables.scss
@@ -52,6 +52,8 @@
    --dark-mode-text: #{$dark-mode-text};
 
    // Form elements
+   --input-bg: #{$input-bg};
+   --input-color: #{$input-color};
    --input-border: #{$input-border};
    --input-border-color: #{$input-border-color};
    --input-border-radius: #{$border-radius};

--- a/css/palettes/_auror_dark.scss
+++ b/css/palettes/_auror_dark.scss
@@ -43,7 +43,7 @@ $secondary-fg: #262d3d;
 }
 
 $dark: #232e3c;
-$light: #8892a8;
+$light: #9ca8c0;
 $link-color: #b6c3e0;
 
 $text-muted: #757d91;

--- a/inc/dashboard/grid.class.php
+++ b/inc/dashboard/grid.class.php
@@ -580,7 +580,7 @@ HTML;
       }
 
       $color    = $data_option['color'] ?? "#FFFFFF";
-      $fg_color = Toolbox::getFgColor($color, 100);
+      $fg_color = Toolbox::getFgColor($color, 100, true);
 
       // add card options in data attribute
       $data_option_attr = "";

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3265,12 +3265,26 @@ HTML;
     *
     * @param string $color the background color in hexadecimal notation (ex #FFFFFF) to compute
     * @param int $offset how much we need to darken/lighten the color
+    * @param bool $inherit_if_transparent if color contains an opacity value, and if this value is too transparent return 'inherit'
     *
     * @return string hexadecimal fg color (ex #FFFFFF)
     */
-   static function getFgColor(string $color = "", int $offset = 40): string {
+   static function getFgColor(string $color = "", int $offset = 40, bool $inherit_if_transparent = false): string {
       $fg_color = "FFFFFF";
       if ($color !== "") {
+         $color = str_replace("#", "", $color);
+
+         // if transparency present, get only the color part
+         if (preg_match('/^[a-fA-F0-9]+$/', $color) && strlen($color) === 8) {
+            $tmp = $color;
+            $alpha = hexdec(substr($tmp, 6, 2));
+            $color = substr($color, 0, 6);
+
+            if ($alpha <= 100) {
+               return "inherit";
+            }
+         }
+
          $color_inst = new Color($color);
 
          // adapt luminance part

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3275,7 +3275,7 @@ HTML;
          $color = str_replace("#", "", $color);
 
          // if transparency present, get only the color part
-         if (preg_match('/^[a-fA-F0-9]+$/', $color) && strlen($color) === 8) {
+         if (strlen($color) === 8 && preg_match('/^[a-fA-F0-9]+$/', $color)) {
             $tmp = $color;
             $alpha = hexdec(substr($tmp, 6, 2));
             $color = substr($color, 0, 6);

--- a/lib/bundles/base.js
+++ b/lib/bundles/base.js
@@ -107,6 +107,24 @@ require('fittext.js');
 require('qtip2');
 require('qtip2/dist/jquery.qtip.css');
 
+// color input
+require('@eastdesire/jscolor');
+jscolor.presets.default = {
+   'alphaChannel': true,
+   'palette': [
+      '#000000', '#7d7d7d', '#870014', '#ec1c23', '#ff7e26',
+      '#fef100', '#22b14b', '#00a1e7', '#3f47cc', '#a349a4',
+      '#ffffff', '#c3c3c3', '#b87957', '#feaec9', '#ffc80d',
+      '#eee3af', '#b5e61d', '#99d9ea', '#7092be', '#c8bfe7',
+   ],
+   'paletteCols': 15,
+   'padding': 8,
+   'borderRadius': getComputedStyle(document.documentElement).getPropertyValue('--input-border-radius').trim(),
+   'backgroundColor': getComputedStyle(document.documentElement).getPropertyValue('--input-bg').trim(),
+   'borderColor': getComputedStyle(document.documentElement).getPropertyValue('--input-border').trim(),
+   'controlBorderColor:': getComputedStyle(document.documentElement).getPropertyValue('--input-border').trim(),
+};
+
 // Select2
 // use full for compat; see https://select2.org/upgrading/migrating-from-35
 require('select2/dist/js/select2.full');

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,11 @@
             "integrity": "sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==",
             "dev": true
         },
+        "@eastdesire/jscolor": {
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@eastdesire/jscolor/-/jscolor-2.4.5.tgz",
+            "integrity": "sha512-LDCEGN7qKKO3tq6yYtx6cbz/tQlr9LqKNSFaG2GIIn03y67ot3doucpDGoQjCwXG2xUB4pDXRuH2lobjjxhtJA=="
+        },
         "@eslint/eslintrc": {
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
@@ -1081,15 +1086,15 @@
                 }
             }
         },
-        "dhtmlx-gantt": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/dhtmlx-gantt/-/dhtmlx-gantt-7.1.0.tgz",
-            "integrity": "sha512-yExLwld7NFi2kJqYYpWXCoKFrrnhLN4E99O3feeJc/ubF9p/nwItAcIZtlReii3sVHPcWXvYpomN6vhcht25ZQ=="
-        },
         "desandro-matches-selector": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/desandro-matches-selector/-/desandro-matches-selector-2.0.2.tgz",
             "integrity": "sha1-cXvu1NwT59jzdi9wem1YpndCGOE="
+        },
+        "dhtmlx-gantt": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/dhtmlx-gantt/-/dhtmlx-gantt-7.1.0.tgz",
+            "integrity": "sha512-yExLwld7NFi2kJqYYpWXCoKFrrnhLN4E99O3feeJc/ubF9p/nwItAcIZtlReii3sVHPcWXvYpomN6vhcht25ZQ=="
         },
         "diff-match-patch": {
             "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "description": "GLPI dependencies",
     "license": "GPL-2.0",
     "dependencies": {
+        "@eastdesire/jscolor": "^2.4.5",
         "@fortawesome/fontawesome-free": "^5.12.1",
         "@fullcalendar/bootstrap": "^4.4.0",
         "@fullcalendar/core": "^4.4.0",

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -269,12 +269,17 @@
 
 {% macro colorField(name, value, label = '', options = {}) %}
    {% set field %}
-      <input type="color" id="%id%"
-             class="form-control form-control-color"
+      <input data-jscolor="" id="%id%"
+             class="form-control"
              name="{{ name }}" value="{{ value|safe_value }}"
          {{ options.readonly ? 'readonly' : '' }}
          {{ options.disabled ? 'disabled' : '' }}
          {{ options.required ? 'required' : '' }} />
+      <script>
+      $(function() {
+         jscolor.install();
+      });
+      </script>
    {% endset %}
    {{ _self.field(name, field, label, options) }}
 {% endmacro %}


### PR DESCRIPTION
small changes to permits usage of opacity for cards background in dashboards.
The change in `Toolbox::getFgColor` permits to match the general background by giving an `inherit` value, usefull for dark thme