### PR TITLE
replicate somehow the entity filtering when selecting a new requester…

### DIFF
--- a/front/change.form.php
+++ b/front/change.form.php
@@ -40,8 +40,10 @@ if (empty($_GET["id"])) {
 
 Session::checkLoginUser();
 
+// as _actors virtual field stores json, bypass automatic escaping
 if (isset($_UPOST['_actors'])) {
    $_POST['_actors'] = json_decode($_UPOST['_actors'], true);
+   $_REQUEST['_actors'] = $_POST['_actors'];
 }
 
 $change = new Change();

--- a/front/problem.form.php
+++ b/front/problem.form.php
@@ -40,8 +40,10 @@ if (empty($_GET["id"])) {
 
 Session::checkLoginUser();
 
+// as _actors virtual field stores json, bypass automatic escaping
 if (isset($_UPOST['_actors'])) {
    $_POST['_actors'] = json_decode($_UPOST['_actors'], true);
+   $_REQUEST['_actors'] = $_POST['_actors'];
 }
 
 $problem = new Problem();

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -57,8 +57,10 @@ foreach ($date_fields as $date_field) {
    }
 }
 
+// as _actors virtual field stores json, bypass automatic escaping
 if (isset($_UPOST['_actors'])) {
    $_POST['_actors'] = json_decode($_UPOST['_actors'], true);
+   $_REQUEST['_actors'] = $_POST['_actors'];
 }
 
 if (isset($_POST["add"])) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -4539,15 +4539,9 @@ JAVASCRIPT;
          $this->check(-1, CREATE, $options);
       }
 
+      $this->userentities = [];
       if (!$ID) {
-         $this->userentities = [];
-         if ($options["_users_id_requester"]) {
-            //Get all the user's entities
-            $requester_entities = Profile_User::getUserEntities($options["_users_id_requester"], true,
-                                                          true);
-            $user_entities = $_SESSION['glpiactiveentities'];
-            $this->userentities = array_intersect($requester_entities, $user_entities);
-         }
+         $this->userentities         = $this->getEntitiesForRequesters($options);
          $this->countentitiesforuser = count($this->userentities);
 
          if (($this->countentitiesforuser > 0)
@@ -4681,6 +4675,7 @@ JAVASCRIPT;
          'canassign'          => $canassign,
          'canassigntome'      => $canassigntome,
          'load_kb_sol'        => $options['load_kb_sol'] ?? 0,
+         'userentities'       => $this->userentities,
       ]);
 
       return true;

--- a/inc/useremail.class.php
+++ b/inc/useremail.class.php
@@ -56,9 +56,9 @@ class UserEmail  extends CommonDBChild {
    /**
     * Get default email for user. If no default email get first one
     *
-    * @param $users_id user ID
+    * @param int $users_id user ID
     *
-    * @return default email, empty if no email set
+    * @return string default email, empty if no email set
    **/
    static function getDefaultForUser($users_id) {
       global $DB;

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -15,6 +15,11 @@
    {% set is_actor_hidden = true %}
 {% endif %}
 
+{% set onchange = "" %}
+{% if item.isNewItem() %}
+   {% set onchange = 'this.form.submit();' %}
+{% endif %}
+
 {% if not is_actor_hidden %}
    <select class="form-select" multiple="true" id="actor_{{ rand }}">
    {% for actor in actors %}
@@ -215,9 +220,11 @@
       };
       $("#actor_{{ rand }}").on('select2:select', function () {
          updateActors{{ rand }}();
+         {{ onchange }}
       });
       $("#actor_{{ rand }}").on('select2:unselect', function () {
          updateActors{{ rand }}();
+         {{ onchange }}
       });
 
       // intercept event for edit notification button

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -17,20 +17,33 @@
          <div class="accordion-body row m-0 mt-n2">
 
             {% if isMultiEntitiesMode() %}
-               {% set entity_html %}
-                  <span class="badge itil-badge bg-secondary">
-                     {{ getDropdownName('glpi_entities', item.fields['entities_id']) }}
-                  </span>
-               {% endset %}
+               {% if item.isNewItem() %}
+                  {{ fields.dropdownField(
+                     'Entity',
+                     'entities_id',
+                     item.fields["entities_id"],
+                     _n('Entity', 'Entities', 1),
+                     field_options|merge({
+                        'entity': userentities,
+                        'on_change': 'this.form.submit()',
+                     })
+                  ) }}
+               {% else %}
+                  {% set entity_html %}
+                     <span class="badge itil-badge bg-secondary">
+                        {{ getDropdownName('glpi_entities', item.fields['entities_id']) }}
+                     </span>
+                  {% endset %}
 
-               {{ fields.field(
-                  '',
-                  entity_html,
-                  _n('Entity', 'Entities', 1),
-                  field_options|merge({
-                     'add_field_class': 'd-flex align-items-center',
-                  })
-               ) }}
+                  {{ fields.field(
+                     '',
+                     entity_html,
+                     _n('Entity', 'Entities', 1),
+                     field_options|merge({
+                        'add_field_class': 'd-flex align-items-center',
+                     })
+                  ) }}
+               {% endif %}
 
                {% if item.isField('is_recursive') %}
                   {{ fields.dropdownYesNo(

--- a/templates/components/itilobject/mainform_open.html.twig
+++ b/templates/components/itilobject/mainform_open.html.twig
@@ -10,9 +10,13 @@
    {% set form_url = path('front/tracking.injector.php') %}
 {% endif %}
 
+{% set track_changes = "true" %}
+{% if item.isNewItem %}
+   {% set track_changes = "false" %}
+{% endif %}
 
 <form method="POST" action="{{ form_url }}" enctype="{{ enctype }}"
-      data-track-changes="true" id="itil-form" class="{{ new_cls }}">
+      data-track-changes="{{ track_changes }}" id="itil-form" class="{{ new_cls }}">
    <input type="hidden" name="id" value="{{ item.fields['id'] ?? 0 }}">
    <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
 


### PR DESCRIPTION
Some changes in the current fields panel of a new ticket form.
I try to replicate as far as possible the behavior of old actors component

On a new ticket:
- if a requester is selected, reload the form
- if requester(s) exists, try to find entities available for him(them)
- permits to change entity dropdown
- if entity dropdown changes, reload the form

During the fix dev, i found that a form reload didn't restore the previously selected actors.
So the first changes in `CommonITILObject::getActorsForType` are here to restore actors from post data.

If everyone can check i didn't miss anything in this pr, it's the last (complex) feature i think we missed from 9.x branches.