### PR TITLE
Twig content templates in place documentation

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -5385,6 +5385,28 @@ tr.log_history_filter_row {
    dd {
       margin-left: 20px;
    }
+
+   td, th {
+      padding-right: 24px;
+      padding-bottom: 8px;
+      font-size: 12px;
+   }
+
+   th {
+      text-align: left;
+   }
+}
+
+.documentation-large {
+   max-width: 1000px;
+}
+
+.documentation-footer {
+   #footer-login {
+      position: unset;
+      text-align: center;
+      padding-bottom: 30px;
+   }
 }
 
 td.diff {
@@ -6519,7 +6541,7 @@ input[name=as_map] {
 }
 
 @media screen and (min-width: $break_lphones) {
-   .documentation #summary {
+   .documentation #summary, .documentation .summary {
       position: fixed;
       top: 40px;
       left: 15px;
@@ -6538,6 +6560,12 @@ input[name=as_map] {
 
 @media screen and (max-width: 1100px) {
    .documentation {
+      margin-left: 200px;
+   }
+}
+
+@media screen and (max-width: 1400px) {
+   .documentation-large {
       margin-left: 200px;
    }
 }

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -5401,7 +5401,7 @@ tr.log_history_filter_row {
    max-width: 1000px;
 }
 
-.documentation-footer {
+.documentation-page {
    #footer-login {
       position: unset;
       text-align: center;

--- a/front/contenttemplates/documentation.php
+++ b/front/contenttemplates/documentation.php
@@ -41,15 +41,14 @@ if (is_null($preset)) {
    Toolbox::throwError(400, "Missing mandatory 'preset' parameter", "string");
 }
 
-echo "<div id='page'>";
 echo Html::includeHeader(__("Template variables documentation"));
+echo "<div id='page'>";
 echo "<div class='documentation documentation-large'>";
 
 // Parse markdown
 $md = new MarkdownExtra();
 $md->header_id_func = function($headerName) {
-   $headerName = str_replace(['(', ')'], '', $headerName);
-   return rawurlencode(strtolower(strtr($headerName, [' ' => '-'])));
+   return Toolbox::slugify($headerName, '');
 };
 echo $md->transform(TemplateManager::generateMarkdownDocumentation($preset));
 
@@ -59,4 +58,3 @@ echo "</div>";
 echo "<div class='documentation-footer'>";
 echo "<div>";
 Html::nullFooter();
-echo "</div>";

--- a/front/contenttemplates/documentation.php
+++ b/front/contenttemplates/documentation.php
@@ -30,36 +30,35 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\ContentTemplates\Parameters;
+include ('../../inc/includes.php');
 
-use CommonDBTM;
-use Glpi\ContentTemplates\Parameters\ParametersTypes\AttributeParameter;
-use Glpi\Toolbox\Sanitizer;
+use Glpi\ContentTemplates\ParametersPreset;
+use Glpi\ContentTemplates\TemplateManager;
+use Michelf\MarkdownExtra;
 
-if (!defined('GLPI_ROOT')) {
-   die("Sorry. You can't access this file directly");
+// Check mandatory parameter
+$preset = $_GET['preset'] ?? null;
+if (is_null($preset)) {
+   Toolbox::throwError(400, "Missing mandatory 'preset' parameter", "string");
 }
 
-/**
- * Abstract parameters class for "CommonTreeDropdown" items.
- *
- * @since 10.0.0
- */
-abstract class TreeDropdownParameters extends DropdownParameters
-{
-   public function defineParameters(): array {
-      $parameter = parent::defineParameters();
-      $parameter[] = new AttributeParameter("completename", __('Complete name'));
-      return $parameter;
-   }
+echo "<div id='page'>";
+echo Html::includeHeader(__("Template variables documentation"));
+echo "<div class='documentation documentation-large'>";
 
-   protected function defineValues(CommonDBTM $item): array {
+// Parse markdown
+$md = new MarkdownExtra();
+$md->header_id_func = function($headerName) {
+   $headerName = str_replace(['(', ')'], '', $headerName);
+   return rawurlencode(strtolower(strtr($headerName, [' ' => '-'])));
+};
+$parameters = ParametersPreset::getByKey($preset);
+echo $md->transform(TemplateManager::generateMarkdownDocumentation($parameters));
 
-      // Output "unsanitized" values
-      $fields = Sanitizer::unsanitize($item->fields);
+echo "</div>";
+echo "</div>";
 
-      $values = parent::defineValues($item);
-      $values['completename'] = $fields['completename'];
-      return $values;
-   }
-}
+echo "<div class='documentation-footer'>";
+echo "<div>";
+Html::nullFooter();
+echo "</div>";

--- a/front/contenttemplates/documentation.php
+++ b/front/contenttemplates/documentation.php
@@ -52,8 +52,7 @@ $md->header_id_func = function($headerName) {
    $headerName = str_replace(['(', ')'], '', $headerName);
    return rawurlencode(strtolower(strtr($headerName, [' ' => '-'])));
 };
-$parameters = ParametersPreset::getByKey($preset);
-echo $md->transform(TemplateManager::generateMarkdownDocumentation($parameters));
+echo $md->transform(TemplateManager::generateMarkdownDocumentation($preset));
 
 echo "</div>";
 echo "</div>";

--- a/front/contenttemplates/documentation.php
+++ b/front/contenttemplates/documentation.php
@@ -32,7 +32,6 @@
 
 include ('../../inc/includes.php');
 
-use Glpi\ContentTemplates\ParametersPreset;
 use Glpi\ContentTemplates\TemplateManager;
 use Michelf\MarkdownExtra;
 

--- a/front/contenttemplates/documentation.php
+++ b/front/contenttemplates/documentation.php
@@ -42,6 +42,7 @@ if (is_null($preset)) {
 }
 
 echo Html::includeHeader(__("Template variables documentation"));
+echo "<body class='documentation-page'>";
 echo "<div id='page'>";
 echo "<div class='documentation documentation-large'>";
 
@@ -55,6 +56,7 @@ echo $md->transform(TemplateManager::generateMarkdownDocumentation($preset));
 echo "</div>";
 echo "</div>";
 
-echo "<div class='documentation-footer'>";
+// Footer closes main and div
+echo "<main>";
 echo "<div>";
 Html::nullFooter();

--- a/inc/abstractitilchildtemplate.class.php
+++ b/inc/abstractitilchildtemplate.class.php
@@ -30,11 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\ContentTemplates\Parameters\ChangeParameters;
-use Glpi\ContentTemplates\Parameters\ParametersTypes\AttributeParameter;
-use Glpi\ContentTemplates\Parameters\ParametersTypes\ObjectParameter;
-use Glpi\ContentTemplates\Parameters\ProblemParameters;
-use Glpi\ContentTemplates\Parameters\TicketParameters;
+use Glpi\ContentTemplates\ParametersPreset;
 use Glpi\ContentTemplates\TemplateManager;
 
 if (!defined('GLPI_ROOT')) {
@@ -52,12 +48,17 @@ abstract class AbstractITILChildTemplate extends CommonDropdown
       parent::showForm($ID, $options);
 
       // Add autocompletion for ticket properties (twig templates)
-      Html::activateUserTemplateAutocompletion('textarea[name=content]', [
-         (new AttributeParameter('itemtype', __('Itemtype')))->compute(),
-         (new ObjectParameter(new TicketParameters()))->compute(),
-         (new ObjectParameter(new ChangeParameters()))->compute(),
-         (new ObjectParameter(new ProblemParameters()))->compute(),
-      ]);
+      $parameters = ParametersPreset::getForAbstractTemplates();
+      Html::activateUserTemplateAutocompletion(
+         'textarea[name=content]',
+         TemplateManager::computeParameters($parameters)
+      );
+
+      // Add related documentation
+      Html::addTemplateDocumentationLinkJS(
+         'textarea[name=content]',
+         ParametersPreset::ABSTRACT_TEMPLATE
+      );
    }
 
    function prepareInputForAdd($input) {

--- a/inc/abstractitilchildtemplate.class.php
+++ b/inc/abstractitilchildtemplate.class.php
@@ -57,7 +57,7 @@ abstract class AbstractITILChildTemplate extends CommonDropdown
       // Add related documentation
       Html::addTemplateDocumentationLinkJS(
          'textarea[name=content]',
-         ParametersPreset::ABSTRACT_TEMPLATE
+         ParametersPreset::ITIL_CHILD_TEMPLATE
       );
    }
 

--- a/inc/contenttemplates/parameters/abstractparameters.class.php
+++ b/inc/contenttemplates/parameters/abstractparameters.class.php
@@ -53,7 +53,7 @@ abstract class AbstractParameters implements TemplatesParametersInterface
     *
     * @return \Glpi\ContentTemplates\Parameters\ParametersTypes\AbstractParameterType[]
     */
-   abstract protected function defineParameters(): array;
+   abstract public function defineParameters(): array;
 
    /**
     * To by defined in each subclasses, get the exposed values for a given item
@@ -73,6 +73,13 @@ abstract class AbstractParameters implements TemplatesParametersInterface
     * @return array
     */
    abstract protected function getTargetClasses(): array;
+
+   /**
+    * Get label for the target itemtype of this parameter
+    *
+    * @return string
+    */
+   abstract static function getObjectLabel(): string;
 
    public function getValues(CommonDBTM $item): array {
       $valid_class = false;

--- a/inc/contenttemplates/parameters/abstractparameters.class.php
+++ b/inc/contenttemplates/parameters/abstractparameters.class.php
@@ -53,7 +53,7 @@ abstract class AbstractParameters implements TemplatesParametersInterface
     *
     * @return \Glpi\ContentTemplates\Parameters\ParametersTypes\AbstractParameterType[]
     */
-   abstract public function defineParameters(): array;
+   abstract public function getAvailableParameters(): array;
 
    /**
     * To by defined in each subclasses, get the exposed values for a given item
@@ -89,15 +89,5 @@ abstract class AbstractParameters implements TemplatesParametersInterface
       }
 
       return $this->defineValues($item);
-   }
-
-   public function getAvailableParameters(): array {
-      $parameters = [];
-
-      foreach ($this->defineParameters() as $parameter) {
-         $parameters[] = $parameter->compute();
-      }
-
-      return $parameters;
    }
 }

--- a/inc/contenttemplates/parameters/abstractparameters.class.php
+++ b/inc/contenttemplates/parameters/abstractparameters.class.php
@@ -74,13 +74,6 @@ abstract class AbstractParameters implements TemplatesParametersInterface
     */
    abstract protected function getTargetClasses(): array;
 
-   /**
-    * Get label for the target itemtype of this parameter
-    *
-    * @return string
-    */
-   abstract static function getObjectLabel(): string;
-
    public function getValues(CommonDBTM $item): array {
       $valid_class = false;
       foreach ($this->getTargetClasses() as $class) {

--- a/inc/contenttemplates/parameters/abstractparameters.class.php
+++ b/inc/contenttemplates/parameters/abstractparameters.class.php
@@ -64,13 +64,6 @@ abstract class AbstractParameters implements TemplatesParametersInterface
     */
    abstract protected function getTargetClasses(): array;
 
-   /**
-    * Get the parameters values for a given item
-    *
-    * @param CommonDBTM $item
-    *
-    * @return array
-    */
    public function getValues(CommonDBTM $item): array {
       $valid_class = false;
       foreach ($this->getTargetClasses() as $class) {

--- a/inc/contenttemplates/parameters/abstractparameters.class.php
+++ b/inc/contenttemplates/parameters/abstractparameters.class.php
@@ -46,16 +46,6 @@ if (!defined('GLPI_ROOT')) {
 abstract class AbstractParameters implements TemplatesParametersInterface
 {
    /**
-    * To be defined in each subclasses, define all available parameters for one or more itemtypes.
-    * These parameters informations are meant to be used for autocompletion on the client side.
-    *
-    * Result will be returned by `self::getAvailableParameters()`.
-    *
-    * @return \Glpi\ContentTemplates\Parameters\ParametersTypes\AbstractParameterType[]
-    */
-   abstract public function getAvailableParameters(): array;
-
-   /**
     * To by defined in each subclasses, get the exposed values for a given item
     * These values will be used as parameters when rendering a twig template.
     *
@@ -74,6 +64,13 @@ abstract class AbstractParameters implements TemplatesParametersInterface
     */
    abstract protected function getTargetClasses(): array;
 
+   /**
+    * Get the parameters values for a given item
+    *
+    * @param CommonDBTM $item
+    *
+    * @return array
+    */
    public function getValues(CommonDBTM $item): array {
       $valid_class = false;
       foreach ($this->getTargetClasses() as $class) {

--- a/inc/contenttemplates/parameters/assetparameters.class.php
+++ b/inc/contenttemplates/parameters/assetparameters.class.php
@@ -62,7 +62,7 @@ class AssetParameters extends AbstractParameters
       return $CFG_GLPI["asset_types"];
    }
 
-   public function defineParameters(): array {
+   public function getAvailableParameters(): array {
       return [
          new AttributeParameter("id", __('ID')),
          new AttributeParameter("name", __('Name')),

--- a/inc/contenttemplates/parameters/assetparameters.class.php
+++ b/inc/contenttemplates/parameters/assetparameters.class.php
@@ -62,7 +62,7 @@ class AssetParameters extends AbstractParameters
       return $CFG_GLPI["asset_types"];
    }
 
-   protected function defineParameters(): array {
+   public function defineParameters(): array {
       return [
          new AttributeParameter("id", __('ID')),
          new AttributeParameter("name", __('Name')),

--- a/inc/contenttemplates/parameters/commonitilobjectparameters.class.php
+++ b/inc/contenttemplates/parameters/commonitilobjectparameters.class.php
@@ -57,7 +57,7 @@ if (!defined('GLPI_ROOT')) {
  */
 abstract class CommonITILObjectParameters extends AbstractParameters
 {
-   public function defineParameters(): array {
+   public function getAvailableParameters(): array {
       return [
          new AttributeParameter("id", __('ID')),
          new AttributeParameter("ref", __("Reference (# + id)")),

--- a/inc/contenttemplates/parameters/commonitilobjectparameters.class.php
+++ b/inc/contenttemplates/parameters/commonitilobjectparameters.class.php
@@ -57,7 +57,7 @@ if (!defined('GLPI_ROOT')) {
  */
 abstract class CommonITILObjectParameters extends AbstractParameters
 {
-   protected function defineParameters(): array {
+   public function defineParameters(): array {
       return [
          new AttributeParameter("id", __('ID')),
          new AttributeParameter("ref", __("Reference (# + id)")),

--- a/inc/contenttemplates/parameters/dropdownparameters.class.php
+++ b/inc/contenttemplates/parameters/dropdownparameters.class.php
@@ -47,7 +47,7 @@ if (!defined('GLPI_ROOT')) {
  */
 abstract class DropdownParameters extends AbstractParameters
 {
-   protected function defineParameters(): array {
+   public function defineParameters(): array {
       return [
          new AttributeParameter("id", __('ID')),
          new AttributeParameter("name", __('Name')),

--- a/inc/contenttemplates/parameters/dropdownparameters.class.php
+++ b/inc/contenttemplates/parameters/dropdownparameters.class.php
@@ -47,7 +47,7 @@ if (!defined('GLPI_ROOT')) {
  */
 abstract class DropdownParameters extends AbstractParameters
 {
-   public function defineParameters(): array {
+   public function getAvailableParameters(): array {
       return [
          new AttributeParameter("id", __('ID')),
          new AttributeParameter("name", __('Name')),

--- a/inc/contenttemplates/parameters/knowbaseitemparameters.class.php
+++ b/inc/contenttemplates/parameters/knowbaseitemparameters.class.php
@@ -60,7 +60,7 @@ class KnowbaseItemParameters extends AbstractParameters
       return [KnowbaseItem::class];
    }
 
-   protected function defineParameters(): array {
+   public function defineParameters(): array {
       return [
          new AttributeParameter("id", __('ID')),
          new AttributeParameter("name", __('Subject')),

--- a/inc/contenttemplates/parameters/knowbaseitemparameters.class.php
+++ b/inc/contenttemplates/parameters/knowbaseitemparameters.class.php
@@ -60,7 +60,7 @@ class KnowbaseItemParameters extends AbstractParameters
       return [KnowbaseItem::class];
    }
 
-   public function defineParameters(): array {
+   public function getAvailableParameters(): array {
       return [
          new AttributeParameter("id", __('ID')),
          new AttributeParameter("name", __('Subject')),

--- a/inc/contenttemplates/parameters/levelagreementparameters.class.php
+++ b/inc/contenttemplates/parameters/levelagreementparameters.class.php
@@ -48,7 +48,7 @@ if (!defined('GLPI_ROOT')) {
  */
 abstract class LevelAgreementParameters extends AbstractParameters
 {
-   public function defineParameters(): array {
+   public function getAvailableParameters(): array {
       return [
          new AttributeParameter("id", __('ID')),
          new AttributeParameter("name", __('Name')),

--- a/inc/contenttemplates/parameters/levelagreementparameters.class.php
+++ b/inc/contenttemplates/parameters/levelagreementparameters.class.php
@@ -48,7 +48,7 @@ if (!defined('GLPI_ROOT')) {
  */
 abstract class LevelAgreementParameters extends AbstractParameters
 {
-   protected function defineParameters(): array {
+   public function defineParameters(): array {
       return [
          new AttributeParameter("id", __('ID')),
          new AttributeParameter("name", __('Name')),

--- a/inc/contenttemplates/parameters/parameterstypes/abstractparametertype.class.php
+++ b/inc/contenttemplates/parameters/parameterstypes/abstractparametertype.class.php
@@ -53,26 +53,12 @@ abstract class AbstractParameterType
    protected $key;
 
    /**
-    * The parameter label, to be displayed in the client side autocompletion
-    *
-    * @var string
-    */
-   protected $label;
-
-   /**
     * To be defined in each subclasses, convert the parameter data into an array
     * that can be shared to the client side code as json and used for autocompletion.
     *
     * @return array
     */
    abstract public function compute(): array;
-
-   /**
-    * Field name for this parameter's documentation
-    *
-    * @return string
-    */
-   abstract public function getDocumentationField(): string;
 
    /**
     * Label to use for this parameter's documentation
@@ -97,5 +83,12 @@ abstract class AbstractParameterType
     */
    abstract public function getDocumentationReferences(): ?AbstractParameters;
 
-
+   /**
+    * Field name for this parameter's documentation
+    *
+    * @return string
+    */
+   public function getDocumentationField(): string {
+      return $this->key;
+   }
 }

--- a/inc/contenttemplates/parameters/parameterstypes/abstractparametertype.class.php
+++ b/inc/contenttemplates/parameters/parameterstypes/abstractparametertype.class.php
@@ -72,14 +72,14 @@ abstract class AbstractParameterType
     *
     * @return string
     */
-   abstract function getDocumentationField(): string;
+   abstract public function getDocumentationField(): string;
 
    /**
     * Label to use for this parameter's documentation
     *
     * @return string
     */
-   abstract function getDocumentationLabel(): string;
+   abstract public function getDocumentationLabel(): string;
 
    /**
     * Recommended usage (twig code) to use for this parameter's documentation
@@ -88,14 +88,14 @@ abstract class AbstractParameterType
     *
     * @return string
     */
-   abstract function getDocumentationUsage(?string $parent = null): string;
+   abstract public function getDocumentationUsage(?string $parent = null): string;
 
    /**
     * Reference to others parameters for this parameter's documentation
     *
     * @return AbstractParameters|null
     */
-   abstract function getDocumentationReferences(): ?AbstractParameters;
+   abstract public function getDocumentationReferences(): ?AbstractParameters;
 
 
 }

--- a/inc/contenttemplates/parameters/parameterstypes/abstractparametertype.class.php
+++ b/inc/contenttemplates/parameters/parameterstypes/abstractparametertype.class.php
@@ -32,6 +32,8 @@
 
 namespace Glpi\ContentTemplates\Parameters\ParametersTypes;
 
+use Glpi\ContentTemplates\Parameters\AbstractParameters;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -60,6 +62,40 @@ abstract class AbstractParameterType
    /**
     * To be defined in each subclasses, convert the parameter data into an array
     * that can be shared to the client side code as json and used for autocompletion.
+    *
+    * @return array
     */
    abstract public function compute(): array;
+
+   /**
+    * Field name for this parameter's documentation
+    *
+    * @return string
+    */
+   abstract function getDocumentationField(): string;
+
+   /**
+    * Label to use for this parameter's documentation
+    *
+    * @return string
+    */
+   abstract function getDocumentationLabel(): string;
+
+   /**
+    * Recommended usage (twig code) to use for this parameter's documentation
+    *
+    * @param string|null $parent
+    *
+    * @return string
+    */
+   abstract function getDocumentationUsage(?string $parent = null): string;
+
+   /**
+    * Reference to others parameters for this parameter's documentation
+    *
+    * @return AbstractParameters|null
+    */
+   abstract function getDocumentationReferences(): ?AbstractParameters;
+
+
 }

--- a/inc/contenttemplates/parameters/parameterstypes/arrayparameter.class.php
+++ b/inc/contenttemplates/parameters/parameterstypes/arrayparameter.class.php
@@ -87,4 +87,21 @@ class ArrayParameter extends AbstractParameterType
          'content'   => $this->content->compute(),
       ];
    }
+
+   public function getDocumentationField(): string {
+      return $this->key;
+   }
+
+   public function getDocumentationLabel(): string {
+      return $this->label;
+   }
+
+   public function getDocumentationUsage(?string $parent = null): string {
+      $parent = !empty($parent) ? "$parent." : "";
+      return "{% for {$this->items_key} in {$parent}{$this->key} %}";
+   }
+
+   public function getDocumentationReferences(): ?AbstractParameters {
+      return $this->content->getTemplateParameters();
+   }
 }

--- a/inc/contenttemplates/parameters/parameterstypes/arrayparameter.class.php
+++ b/inc/contenttemplates/parameters/parameterstypes/arrayparameter.class.php
@@ -32,7 +32,7 @@
 
 namespace Glpi\ContentTemplates\Parameters\ParametersTypes;
 
-use Glpi\ContentTemplates\Parameters\AbstractParameters;
+use Glpi\ContentTemplates\Parameters\TemplatesParametersInterface;
 
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
@@ -48,63 +48,43 @@ if (!defined('GLPI_ROOT')) {
 class ArrayParameter extends AbstractParameterType
 {
    /**
-    * This parameter will need to be handled in a loop, this key will be the
-    * suggested variable name when iterating on its children.
-    *
-    * @var string
-    */
-   protected $items_key;
-
-   /**
     * Parameters of each item contained in this array.
     *
-    * @var ObjectParameter
+    * @var TemplatesParametersInterface
     */
-   protected $content;
+   protected $template_parameters;
 
    /**
-    * The parameter label, to be displayed in the client side autocompletion
-    *
-    * @var string
-    */
-    protected $label;
-
-   /**
-    * @param string              $key        Key to access this value
-    * @param AbstractParameters  $parameters Parameters of each item contained in this array
-    * @param string              $label      Label to display in the autocompletion widget
+    * @param string                       $key        Key to access this value
+    * @param TemplatesParametersInterface $parameters Parameters of each item contained in this array
+    * @param string                       $label      Label to display in the autocompletion widget
     */
    public function __construct(
       string $key,
-      AbstractParameters $parameters,
+      TemplatesParametersInterface $parameters,
       string $label
    ) {
-      $this->key = $key;
-      $this->label = $label;
-      $this->items_key = $parameters->getDefaultNodeName();
-      $this->content = new ObjectParameter($parameters);
+      parent::__construct($key, $label);
+      $this->template_parameters = $parameters;
    }
 
    public function compute(): array {
+      $object_parameters = new ObjectParameter($this->template_parameters);
       return [
          'type'      => "ArrayParameter",
          'key'       => $this->key,
          'label'     => $this->label,
-         'items_key' => $this->items_key,
-         'content'   => $this->content->compute(),
+         'items_key' => $this->template_parameters->getDefaultNodeName(),
+         'content'   => $object_parameters->compute(),
       ];
-   }
-
-   public function getDocumentationLabel(): string {
-      return $this->label;
    }
 
    public function getDocumentationUsage(?string $parent = null): string {
       $parent = !empty($parent) ? "$parent." : "";
-      return "{% for {$this->items_key} in {$parent}{$this->key} %}";
+      return "{% for {$this->template_parameters->getDefaultNodeName()} in {$parent}{$this->key} %}";
    }
 
-   public function getDocumentationReferences(): ?AbstractParameters {
-      return $this->content->getTemplateParameters();
+   public function getDocumentationReferences(): ?TemplatesParametersInterface {
+      return $this->template_parameters;
    }
 }

--- a/inc/contenttemplates/parameters/parameterstypes/arrayparameter.class.php
+++ b/inc/contenttemplates/parameters/parameterstypes/arrayparameter.class.php
@@ -63,6 +63,13 @@ class ArrayParameter extends AbstractParameterType
    protected $content;
 
    /**
+    * The parameter label, to be displayed in the client side autocompletion
+    *
+    * @var string
+    */
+    protected $label;
+
+   /**
     * @param string              $key        Key to access this value
     * @param AbstractParameters  $parameters Parameters of each item contained in this array
     * @param string              $label      Label to display in the autocompletion widget
@@ -86,10 +93,6 @@ class ArrayParameter extends AbstractParameterType
          'items_key' => $this->items_key,
          'content'   => $this->content->compute(),
       ];
-   }
-
-   public function getDocumentationField(): string {
-      return $this->key;
    }
 
    public function getDocumentationLabel(): string {

--- a/inc/contenttemplates/parameters/parameterstypes/attributeparameter.class.php
+++ b/inc/contenttemplates/parameters/parameterstypes/attributeparameter.class.php
@@ -32,6 +32,8 @@
 
 namespace Glpi\ContentTemplates\Parameters\ParametersTypes;
 
+use Glpi\ContentTemplates\Parameters\AbstractParameters;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -73,5 +75,23 @@ class AttributeParameter extends AbstractParameterType
          'label'  => $this->label,
          'filter' => $this->filter,
       ];
+   }
+
+   public function getDocumentationField(): string {
+      return $this->key;
+   }
+
+   public function getDocumentationLabel(): string {
+      return $this->label;
+   }
+
+   public function getDocumentationUsage(?string $parent = null): string {
+      $parent = !empty($parent)       ? "$parent."          : "";
+      $filter = !empty($this->filter) ? "| {$this->filter}" : "";
+      return "{{ {$parent}{$this->key} $filter }}";
+   }
+
+   public function getDocumentationReferences(): ?AbstractParameters {
+      return null;
    }
 }

--- a/inc/contenttemplates/parameters/parameterstypes/attributeparameter.class.php
+++ b/inc/contenttemplates/parameters/parameterstypes/attributeparameter.class.php
@@ -32,7 +32,7 @@
 
 namespace Glpi\ContentTemplates\Parameters\ParametersTypes;
 
-use Glpi\ContentTemplates\Parameters\AbstractParameters;
+use Glpi\ContentTemplates\Parameters\TemplatesParametersInterface;
 
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
@@ -58,20 +58,12 @@ class AttributeParameter extends AbstractParameterType
    protected $filter;
 
    /**
-    * The parameter label, to be displayed in the client side autocompletion
-    *
-    * @var string
-    */
-    protected $label;
-
-   /**
     * @param string $key    Key to access this value
     * @param string $label  Label to display in the autocompletion widget
     * @param string $filter Recommanded twig filter to apply on this value
     */
    public function __construct(string $key, string $label, string $filter = "") {
-      $this->key = $key;
-      $this->label = $label;
+      parent::__construct($key, $label);
       $this->filter = $filter;
    }
 
@@ -84,17 +76,13 @@ class AttributeParameter extends AbstractParameterType
       ];
    }
 
-   public function getDocumentationLabel(): string {
-      return $this->label;
-   }
-
    public function getDocumentationUsage(?string $parent = null): string {
       $parent = !empty($parent)       ? "$parent."          : "";
       $filter = !empty($this->filter) ? "| {$this->filter}" : "";
       return "{{ {$parent}{$this->key} $filter }}";
    }
 
-   public function getDocumentationReferences(): ?AbstractParameters {
+   public function getDocumentationReferences(): ?TemplatesParametersInterface {
       return null;
    }
 }

--- a/inc/contenttemplates/parameters/parameterstypes/attributeparameter.class.php
+++ b/inc/contenttemplates/parameters/parameterstypes/attributeparameter.class.php
@@ -58,6 +58,13 @@ class AttributeParameter extends AbstractParameterType
    protected $filter;
 
    /**
+    * The parameter label, to be displayed in the client side autocompletion
+    *
+    * @var string
+    */
+    protected $label;
+
+   /**
     * @param string $key    Key to access this value
     * @param string $label  Label to display in the autocompletion widget
     * @param string $filter Recommanded twig filter to apply on this value
@@ -75,10 +82,6 @@ class AttributeParameter extends AbstractParameterType
          'label'  => $this->label,
          'filter' => $this->filter,
       ];
-   }
-
-   public function getDocumentationField(): string {
-      return $this->key;
    }
 
    public function getDocumentationLabel(): string {

--- a/inc/contenttemplates/parameters/parameterstypes/objectparameter.class.php
+++ b/inc/contenttemplates/parameters/parameterstypes/objectparameter.class.php
@@ -79,10 +79,6 @@ class ObjectParameter extends AbstractParameterType
       return $this->template_parameters;
    }
 
-   public function getDocumentationField(): string {
-      return $this->key;
-   }
-
    public function getDocumentationLabel(): string {
       return $this->template_parameters->getObjectLabel();
    }

--- a/inc/contenttemplates/parameters/parameterstypes/objectparameter.class.php
+++ b/inc/contenttemplates/parameters/parameterstypes/objectparameter.class.php
@@ -70,4 +70,25 @@ class ObjectParameter extends AbstractParameterType
          'properties' => $this->template_parameters->getAvailableParameters(),
       ];
    }
+
+   public function getTemplateParameters(): AbstractParameters {
+      return $this->template_parameters;
+   }
+
+   public function getDocumentationField(): string {
+      return $this->key;
+   }
+
+   public function getDocumentationLabel(): string {
+      return $this->template_parameters->getObjectLabel();
+   }
+
+   public function getDocumentationUsage(?string $parent = null): string {
+      $parent = !empty($parent) ? "$parent." : "";
+      return "{{ {$parent}{$this->key}.XXX }}";
+   }
+
+   public function getDocumentationReferences(): ?AbstractParameters {
+      return $this->template_parameters;
+   }
 }

--- a/inc/contenttemplates/parameters/parameterstypes/objectparameter.class.php
+++ b/inc/contenttemplates/parameters/parameterstypes/objectparameter.class.php
@@ -32,7 +32,7 @@
 
 namespace Glpi\ContentTemplates\Parameters\ParametersTypes;
 
-use Glpi\ContentTemplates\Parameters\AbstractParameters;
+use Glpi\ContentTemplates\Parameters\TemplatesParametersInterface;
 use Glpi\ContentTemplates\TemplateManager;
 
 if (!defined('GLPI_ROOT')) {
@@ -50,16 +50,19 @@ class ObjectParameter extends AbstractParameterType
    /**
     * Parameters availables in the item that will be linked.
     *
-    * @var AbstractParameters
+    * @var TemplatesParametersInterface
     */
    protected $template_parameters;
 
    /**
-    * @param AbstractParameters $template_parameters  Parameters to add
-    * @param null|string $key                         Key to access this value
+    * @param TemplatesParametersInterface $template_parameters Parameters to add
+    * @param null|string                  $key                 Key to access this value
     */
-   public function __construct(AbstractParameters $template_parameters, ?string $key = null) {
-      $this->key = $key ?? $template_parameters->getDefaultNodeName();
+   public function __construct(TemplatesParametersInterface $template_parameters, ?string $key = null) {
+      parent::__construct(
+         $key ?? $template_parameters->getDefaultNodeName(),
+         $template_parameters->getObjectLabel()
+      );
       $this->template_parameters = $template_parameters;
    }
 
@@ -70,17 +73,9 @@ class ObjectParameter extends AbstractParameterType
       return [
          'type'       => "ObjectParameter",
          'key'        => $this->key,
-         'label'      => $this->template_parameters->getObjectLabel(),
+         'label'      => $this->label,
          'properties' => $properties,
       ];
-   }
-
-   public function getTemplateParameters(): AbstractParameters {
-      return $this->template_parameters;
-   }
-
-   public function getDocumentationLabel(): string {
-      return $this->template_parameters->getObjectLabel();
    }
 
    public function getDocumentationUsage(?string $parent = null): string {
@@ -88,7 +83,7 @@ class ObjectParameter extends AbstractParameterType
       return "{{ {$parent}{$this->key}.XXX }}";
    }
 
-   public function getDocumentationReferences(): ?AbstractParameters {
+   public function getDocumentationReferences(): ?TemplatesParametersInterface {
       return $this->template_parameters;
    }
 }

--- a/inc/contenttemplates/parameters/parameterstypes/objectparameter.class.php
+++ b/inc/contenttemplates/parameters/parameterstypes/objectparameter.class.php
@@ -33,6 +33,7 @@
 namespace Glpi\ContentTemplates\Parameters\ParametersTypes;
 
 use Glpi\ContentTemplates\Parameters\AbstractParameters;
+use Glpi\ContentTemplates\TemplateManager;
 
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
@@ -63,11 +64,14 @@ class ObjectParameter extends AbstractParameterType
    }
 
    public function compute(): array {
+      $sub_parameters = $this->template_parameters->getAvailableParameters();
+      $properties =  TemplateManager::computeParameters($sub_parameters);
+
       return [
          'type'       => "ObjectParameter",
          'key'        => $this->key,
          'label'      => $this->template_parameters->getObjectLabel(),
-         'properties' => $this->template_parameters->getAvailableParameters(),
+         'properties' => $properties,
       ];
    }
 

--- a/inc/contenttemplates/parameters/parameterstypes/parametertypeinterface.class.php
+++ b/inc/contenttemplates/parameters/parameterstypes/parametertypeinterface.class.php
@@ -32,45 +32,54 @@
 
 namespace Glpi\ContentTemplates\Parameters\ParametersTypes;
 
+use Glpi\ContentTemplates\Parameters\TemplatesParametersInterface;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
 /**
- * Define the base interface for parameters types.
+ * Interface for parameters types.
  *
  * @since 10.0.0
  */
-abstract class AbstractParameterType implements ParameterTypeInterface
+interface ParameterTypeInterface
 {
    /**
-    * The parameter key that need to be used to retrieve its value in a template.
+    * To be defined in each subclasses, convert the parameter data into an array
+    * that can be shared to the client side code as json and used for autocompletion.
     *
-    * @var string
+    * @return array
     */
-   protected $key;
+   public function compute(): array;
 
    /**
-    * The parameter label, to be displayed in the client side autocompletion.
+    * Label to use for this parameter's documentation
     *
-    * @var string
+    * @return string
     */
-    protected $label;
+   public function getDocumentationLabel(): string;
 
    /**
-    * @param string  $key     Key to access this value
-    * @param string  $label   Label to display in the autocompletion widget
+    * Recommended usage (twig code) to use for this parameter's documentation
+    *
+    * @param string|null $parent
+    *
+    * @return string
     */
-   public function __construct(string $key, string $label) {
-      $this->key = $key;
-      $this->label = $label;
-   }
+   public function getDocumentationUsage(?string $parent = null): string;
 
-   public function getDocumentationField(): string {
-      return $this->key;
-   }
+   /**
+    * Reference to others parameters for this parameter's documentation
+    *
+    * @return TemplatesParametersInterface|null
+    */
+   public function getDocumentationReferences(): ?TemplatesParametersInterface;
 
-   public function getDocumentationLabel(): string {
-      return $this->label;
-   }
+   /**
+    * Field name for this parameter's documentation
+    *
+    * @return string
+    */
+   public function getDocumentationField(): string;
 }

--- a/inc/contenttemplates/parameters/supplierparameters.class.php
+++ b/inc/contenttemplates/parameters/supplierparameters.class.php
@@ -60,7 +60,7 @@ class SupplierParameters extends TreeDropdownParameters
       return [Supplier::class];
    }
 
-   protected function defineParameters(): array {
+   public function defineParameters(): array {
       return [
          new AttributeParameter("id", __('ID')),
          new AttributeParameter("name", __('Name')),

--- a/inc/contenttemplates/parameters/supplierparameters.class.php
+++ b/inc/contenttemplates/parameters/supplierparameters.class.php
@@ -60,7 +60,7 @@ class SupplierParameters extends TreeDropdownParameters
       return [Supplier::class];
    }
 
-   public function defineParameters(): array {
+   public function getAvailableParameters(): array {
       return [
          new AttributeParameter("id", __('ID')),
          new AttributeParameter("name", __('Name')),

--- a/inc/contenttemplates/parameters/templatesparametersinterface.class.php
+++ b/inc/contenttemplates/parameters/templatesparametersinterface.class.php
@@ -63,7 +63,6 @@ interface TemplatesParametersInterface
     * Get values for a given item, used for template rendering
     *
     * @param CommonDBTM $item
-    * @param bool       $root
     *
     * @return array
     */
@@ -73,7 +72,7 @@ interface TemplatesParametersInterface
     * To be defined in each subclasses, define all available parameters for one or more itemtypes.
     * These parameters informations are meant to be used for autocompletion on the client side.
     *
-    * @return \Glpi\ContentTemplates\Parameters\ParametersTypes\AbstractParameterType[]
+    * @return \Glpi\ContentTemplates\Parameters\ParametersTypes\ParameterTypeInterface[]
     */
    public function getAvailableParameters(): array;
 }

--- a/inc/contenttemplates/parameters/templatesparametersinterface.class.php
+++ b/inc/contenttemplates/parameters/templatesparametersinterface.class.php
@@ -70,9 +70,10 @@ interface TemplatesParametersInterface
    public function getValues(CommonDBTM $item): array;
 
    /**
-    * Get the available parameters, used by autocomplete
+    * To be defined in each subclasses, define all available parameters for one or more itemtypes.
+    * These parameters informations are meant to be used for autocompletion on the client side.
     *
-    * @return array
+    * @return \Glpi\ContentTemplates\Parameters\ParametersTypes\AbstractParameterType[]
     */
    public function getAvailableParameters(): array;
 }

--- a/inc/contenttemplates/parameters/ticketparameters.class.php
+++ b/inc/contenttemplates/parameters/ticketparameters.class.php
@@ -71,7 +71,7 @@ class TicketParameters extends CommonITILObjectParameters
       return [Ticket::class];
    }
 
-   protected function defineParameters(): array {
+   public function defineParameters(): array {
       return array_merge(parent::defineParameters(), [
          new AttributeParameter("type", _n('Type', 'Types', 1)),
          new AttributeParameter("global_validation", _n('Approval', 'Approvals', 1)),

--- a/inc/contenttemplates/parameters/ticketparameters.class.php
+++ b/inc/contenttemplates/parameters/ticketparameters.class.php
@@ -71,8 +71,8 @@ class TicketParameters extends CommonITILObjectParameters
       return [Ticket::class];
    }
 
-   public function defineParameters(): array {
-      return array_merge(parent::defineParameters(), [
+   public function getAvailableParameters(): array {
+      return array_merge(parent::getAvailableParameters(), [
          new AttributeParameter("type", _n('Type', 'Types', 1)),
          new AttributeParameter("global_validation", _n('Approval', 'Approvals', 1)),
          new AttributeParameter("tto", __('Time to own'), 'date("d/m/y H:i")'),

--- a/inc/contenttemplates/parameters/treedropdownparameters.class.php
+++ b/inc/contenttemplates/parameters/treedropdownparameters.class.php
@@ -47,8 +47,8 @@ if (!defined('GLPI_ROOT')) {
  */
 abstract class TreeDropdownParameters extends DropdownParameters
 {
-   public function defineParameters(): array {
-      $parameter = parent::defineParameters();
+   public function getAvailableParameters(): array {
+      $parameter = parent::getAvailableParameters();
       $parameter[] = new AttributeParameter("completename", __('Complete name'));
       return $parameter;
    }

--- a/inc/contenttemplates/parameters/userparameters.class.php
+++ b/inc/contenttemplates/parameters/userparameters.class.php
@@ -61,7 +61,7 @@ class UserParameters extends AbstractParameters
       return [User::class];
    }
 
-   protected function defineParameters(): array {
+   public function defineParameters(): array {
       return [
          new AttributeParameter("id", __('ID')),
          new AttributeParameter("login", __('Login')),

--- a/inc/contenttemplates/parameters/userparameters.class.php
+++ b/inc/contenttemplates/parameters/userparameters.class.php
@@ -61,7 +61,7 @@ class UserParameters extends AbstractParameters
       return [User::class];
    }
 
-   public function defineParameters(): array {
+   public function getAvailableParameters(): array {
       return [
          new AttributeParameter("id", __('ID')),
          new AttributeParameter("login", __('Login')),

--- a/inc/contenttemplates/parameterspreset.class.php
+++ b/inc/contenttemplates/parameterspreset.class.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\ContentTemplates;
+
+use Glpi\ContentTemplates\Parameters\ChangeParameters;
+use Glpi\ContentTemplates\Parameters\ParametersTypes\AttributeParameter;
+use Glpi\ContentTemplates\Parameters\ParametersTypes\ObjectParameter;
+use Glpi\ContentTemplates\Parameters\ProblemParameters;
+use Glpi\ContentTemplates\Parameters\TicketParameters;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ * Helper class to get some predefined groups of twig parameters
+ */
+class ParametersPreset
+{
+   /**
+    * Twig parameters that will be avaiable in solution/task/followup form
+    */
+   public const ABSTRACT_TEMPLATE = 0;
+
+   /**
+    * Twig parameters that will be available in the solution massive actions
+    * form for tickets
+    */
+   public const TICKET_SOLUTION = 1;
+
+   /**
+    * Get parameters from their unique key (one of the contant above).
+    * This is useful when sending data through a form, the controller can
+    * receive a key value and fetch the parameters with this method.
+    *
+    * @param string $key
+    *
+    * @return array
+    */
+   public static function getByKey(string $key): array {
+      switch ($key) {
+         case self::ABSTRACT_TEMPLATE:
+            return self::getForAbstractTemplates();
+
+         case self::TICKET_SOLUTION:
+            return self::getForTicketSolution();
+
+         default:
+            return [];
+      }
+   }
+
+   /**
+    * Twig parameters that will be avaiable in solution/task/followup form
+    *
+    * @return array
+    */
+   public static function getForAbstractTemplates(): array {
+      return [
+         new AttributeParameter('itemtype', __('Itemtype')),
+         new ObjectParameter(new TicketParameters()),
+         new ObjectParameter(new ChangeParameters()),
+         new ObjectParameter(new ProblemParameters())
+      ];
+   }
+
+   /**
+    * Twig parameters that will be available in the solution massive actions
+    * form for tickets
+    *
+    * @return array
+    */
+   public static function getForTicketSolution(): array {
+      return [
+         new AttributeParameter('itemtype', __('Itemtype')),
+         new ObjectParameter(new TicketParameters()),
+      ];
+   }
+
+}

--- a/inc/contenttemplates/parameterspreset.class.php
+++ b/inc/contenttemplates/parameterspreset.class.php
@@ -37,6 +37,7 @@ use Glpi\ContentTemplates\Parameters\ParametersTypes\AttributeParameter;
 use Glpi\ContentTemplates\Parameters\ParametersTypes\ObjectParameter;
 use Glpi\ContentTemplates\Parameters\ProblemParameters;
 use Glpi\ContentTemplates\Parameters\TicketParameters;
+use ITILSolution;
 use SolutionTemplate;
 use TaskTemplate;
 use TicketTemplate;
@@ -53,13 +54,13 @@ class ParametersPreset
    /**
     * Twig parameters that will be avaiable in solution/task/followup form
     */
-   public const ABSTRACT_TEMPLATE = 0;
+   public const ITIL_CHILD_TEMPLATE = 'itilchildtemplate';
 
    /**
     * Twig parameters that will be available in the solution massive actions
     * form for tickets
     */
-   public const TICKET_SOLUTION = 1;
+   public const TICKET_SOLUTION = 'ticketsolution';
 
    /**
     * Get parameters from their unique key (one of the contant above).
@@ -72,7 +73,7 @@ class ParametersPreset
     */
    public static function getByKey(string $key): array {
       switch ($key) {
-         case self::ABSTRACT_TEMPLATE:
+         case self::ITIL_CHILD_TEMPLATE:
             return self::getForAbstractTemplates();
 
          case self::TICKET_SOLUTION:
@@ -92,17 +93,17 @@ class ParametersPreset
     */
    public static function getContextByKey(string $key): string {
       switch ($key) {
-         case self::ABSTRACT_TEMPLATE:
+         case self::ITIL_CHILD_TEMPLATE:
             $types = [
-               TicketTemplate::getTypeName(0),
-               TaskTemplate::getTypeName(0),
-               SolutionTemplate::getTypeName(0),
+               TicketTemplate::getTypeName(1),
+               TaskTemplate::getTypeName(1),
+               SolutionTemplate::getTypeName(1),
             ];
 
-            return strtolower(implode("/", $types));
+            return implode("/", $types);
 
          case self::TICKET_SOLUTION:
-            return __("ticket solutions");
+            return ITILSolution::getTypeName(1);
 
          default:
             return "";

--- a/inc/contenttemplates/parameterspreset.class.php
+++ b/inc/contenttemplates/parameterspreset.class.php
@@ -37,6 +37,9 @@ use Glpi\ContentTemplates\Parameters\ParametersTypes\AttributeParameter;
 use Glpi\ContentTemplates\Parameters\ParametersTypes\ObjectParameter;
 use Glpi\ContentTemplates\Parameters\ProblemParameters;
 use Glpi\ContentTemplates\Parameters\TicketParameters;
+use SolutionTemplate;
+use TaskTemplate;
+use TicketTemplate;
 
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
@@ -77,6 +80,32 @@ class ParametersPreset
 
          default:
             return [];
+      }
+   }
+
+   /**
+    * Get context to be displayed in the variable list page for each keys
+    *
+    * @param string $key
+    *
+    * @return string
+    */
+   public static function getContextByKey(string $key): string {
+      switch ($key) {
+         case self::ABSTRACT_TEMPLATE:
+            $types = [
+               TicketTemplate::getTypeName(0),
+               TaskTemplate::getTypeName(0),
+               SolutionTemplate::getTypeName(0),
+            ];
+
+            return strtolower(implode("/", $types));
+
+         case self::TICKET_SOLUTION:
+            return __("ticket solutions");
+
+         default:
+            return "";
       }
    }
 

--- a/inc/contenttemplates/templatedocumentation.class.php
+++ b/inc/contenttemplates/templatedocumentation.class.php
@@ -139,7 +139,7 @@ class TemplateDocumentation
 
       // Add a row for each parameters
       foreach ($parameters as $parameter) {
-         /** @var \Glpi\ContentTemplates\Parameters\ParametersTypes\AbstractParameterType $parameter */
+         /** @var \Glpi\ContentTemplates\Parameters\ParametersTypes\ParameterTypeInterface $parameter */
          $row = [
             $parameter->getDocumentationField(),
             $parameter->getDocumentationLabel(),

--- a/inc/contenttemplates/templatedocumentation.class.php
+++ b/inc/contenttemplates/templatedocumentation.class.php
@@ -161,7 +161,7 @@ class TemplateDocumentation
       foreach ($references as $reference) {
          $this->addSection(
             $reference->getObjectLabel(),
-            $reference->defineParameters(),
+            $reference->getAvailableParameters(),
             $reference->getDefaultNodeName()
          );
       }

--- a/inc/contenttemplates/templatedocumentation.class.php
+++ b/inc/contenttemplates/templatedocumentation.class.php
@@ -60,7 +60,15 @@ class TemplateDocumentation
     */
    protected $sections;
 
-   public function __construct() {
+   /**
+    * Context of the displayed variables
+    *
+    * @var string
+    */
+   protected $context;
+
+   public function __construct(string $context) {
+      $this->context = $context;
       $this->sections = [];
       $this->summary = [];
    }
@@ -75,7 +83,7 @@ class TemplateDocumentation
 
       // Build header
       $header = new MarkdownBuilder();
-      $header->addH1(__("Templates variables documentation"));
+      $header->addH1(__("Available variables ($this->context)"));
       $content .= $header->getMarkdown();
 
       // Build summary

--- a/inc/contenttemplates/templatedocumentation.class.php
+++ b/inc/contenttemplates/templatedocumentation.class.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\ContentTemplates;
+
+use Glpi\Toolbox\MarkdownBuilder;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ * Class used to build the twig variable documentation for a given set of
+ * parameters
+ */
+class TemplateDocumentation
+{
+   /**
+    * Documentation summary, keep link to all the sections
+    *
+    * @var array
+    */
+   protected $summary;
+
+   /**
+    * Sections of the documentations.
+    * The first section contains the available parameters, the followings
+    * sections contains any extra references needed to work on this parameters
+    *
+    * @var array
+    */
+   protected $sections;
+
+   public function __construct() {
+      $this->sections = [];
+      $this->summary = [];
+   }
+
+   /**
+    * Build the documentation as markdown
+    *
+    * @return string
+    */
+   public function build(): string {
+      $content = "";
+
+      // Build header
+      $header = new MarkdownBuilder();
+      $header->addH1(__("Templates variables documentation"));
+      $content .= $header->getMarkdown();
+
+      // Build summary
+      $summary = new MarkdownBuilder();
+      $summary->addH2(_x("Documentation", "Summary"), "summary");
+      foreach ($this->summary as $section_title) {
+         $summary->addSummaryEntry($section_title);
+      }
+      $content .= $summary->getMarkdown();
+
+      // Build main content
+      foreach ($this->sections as $section) {
+         $content .= $section->getMarkdown();
+      }
+
+      return $content;
+   }
+
+   /**
+    * Add a section to the documentation.
+    *
+    * @param string $title              Section's title
+    * @param array $parameters          Parameters to be displayed in this section
+    * @param string|null $fields_prefix Prefix to happen to the parameters fields name
+    */
+   public function addSection(
+      string $title,
+      array $parameters,
+      ?string $fields_prefix = null
+   ) {
+      // Check if this section is already defined, needed as some parameters
+      // might have the same references
+      if (isset($this->sections[$title])) {
+         return;
+      }
+
+      // Keep track of this section in the summary
+      $this->summary[] = $title;
+
+      $new_section = new MarkdownBuilder();
+      $new_section->addH2($title);
+
+      // Set table header
+      $new_section->addTableHeader([
+         __("Variable"),
+         __("Label"),
+         __("Usage"),
+         __("References"),
+      ]);
+
+      // Keep track of parameters needing aditionnal references
+      $references = [];
+
+      // Add a row for each parameters
+      foreach ($parameters as $parameter) {
+         /** @var AbstractParameterType $parameter */
+         $row = [
+            $parameter->getDocumentationField(),
+            $parameter->getDocumentationLabel(),
+            MarkdownBuilder::code($parameter->getDocumentationUsage($fields_prefix)),
+         ];
+
+         $ref = $parameter->getDocumentationReferences();
+         if (!is_null($ref)) {
+            $row[] = MarkdownBuilder::navigationLink($ref->getObjectLabel());
+            $references[] = $ref;
+         }
+
+         $new_section->addTableRow($row);
+      }
+
+      $this->sections[$title] = $new_section;
+
+      // Add sections for each references
+      foreach ($references as $reference) {
+         $this->addSection(
+            $reference->getObjectLabel(),
+            $reference->defineParameters(),
+            $reference->getDefaultNodeName()
+         );
+      }
+   }
+}

--- a/inc/contenttemplates/templatedocumentation.class.php
+++ b/inc/contenttemplates/templatedocumentation.class.php
@@ -83,7 +83,7 @@ class TemplateDocumentation
 
       // Build header
       $header = new MarkdownBuilder();
-      $header->addH1(__("Available variables ($this->context)"));
+      $header->addH1(sprintf(__("Available variables (%s)"), $this->context));
       $content .= $header->getMarkdown();
 
       // Build summary
@@ -139,7 +139,7 @@ class TemplateDocumentation
 
       // Add a row for each parameters
       foreach ($parameters as $parameter) {
-         /** @var AbstractParameterType $parameter */
+         /** @var \Glpi\ContentTemplates\Parameters\ParametersTypes\AbstractParameterType $parameter */
          $row = [
             $parameter->getDocumentationField(),
             $parameter->getDocumentationLabel(),

--- a/inc/contenttemplates/templatemanager.class.php
+++ b/inc/contenttemplates/templatemanager.class.php
@@ -180,12 +180,17 @@ class TemplateManager
    /**
     * Generate the documentation of the given parameters
     *
-    * @param array $parameters
+    * @param int $preset_parameters_key
     *
     * @return string
     */
-   public static function generateMarkdownDocumentation(array $parameters): string {
-      $documentation = new TemplateDocumentation();
+   public static function generateMarkdownDocumentation(
+      int $preset_parameters_key
+   ): string {
+      $parameters = ParametersPreset::getByKey($preset_parameters_key);
+      $context = ParametersPreset::getContextByKey($preset_parameters_key);
+
+      $documentation = new TemplateDocumentation($context);
       $documentation->addSection(__("Variables"), $parameters);
       return $documentation->build();
    }

--- a/inc/contenttemplates/templatemanager.class.php
+++ b/inc/contenttemplates/templatemanager.class.php
@@ -176,4 +176,30 @@ class TemplateManager
       $functions = ['date', 'max', 'min','random', 'range'];
       return new SecurityPolicy($tags, $filters, $methods, $properties, $functions);
    }
+
+   /**
+    * Generate the documentation of the given parameters
+    *
+    * @param array $parameters
+    *
+    * @return string
+    */
+   public static function generateMarkdownDocumentation(array $parameters): string {
+      $documentation = new TemplateDocumentation();
+      $documentation->addSection(__("Variables"), $parameters);
+      return $documentation->build();
+   }
+
+   /**
+    * Compute the given parameters
+    *
+    * @param array $parameters
+    *
+    * @return array
+    */
+   public static function computeParameters(array $parameters) {
+      return array_map(function($parameter) {
+         return $parameter->compute();
+      }, $parameters);
+   }
 }

--- a/inc/contenttemplates/templatemanager.class.php
+++ b/inc/contenttemplates/templatemanager.class.php
@@ -180,18 +180,18 @@ class TemplateManager
    /**
     * Generate the documentation of the given parameters
     *
-    * @param int $preset_parameters_key
+    * @param string $preset_parameters_key
     *
     * @return string
     */
    public static function generateMarkdownDocumentation(
-      int $preset_parameters_key
+      string $preset_parameters_key
    ): string {
       $parameters = ParametersPreset::getByKey($preset_parameters_key);
       $context = ParametersPreset::getContextByKey($preset_parameters_key);
 
       $documentation = new TemplateDocumentation($context);
-      $documentation->addSection(__("Variables"), $parameters);
+      $documentation->addSection(__("Root variables"), $parameters);
       return $documentation->build();
    }
 

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -4087,6 +4087,58 @@ JAVASCRIPT
    }
 
    /**
+    * Insert an html link to the twig template variables documentation page
+    *
+    * @param int $preset_traget Preset of parameters for which to show documentation
+    * @param string|null $link_id Useful if you need to interract with the link through client side code
+    */
+   public static function addTemplateDocumentationLink(
+      int $preset_target,
+      ?string $link_id = null
+   ) {
+      global $CFG_GLPI;
+
+      $url = "/front/contenttemplates/documentation.php?preset=$preset_target";
+      $params = [
+         'link' => $CFG_GLPI['root_doc'] . $url,
+         'linktarget' => '_blank',
+      ];
+
+      if (!is_null($link_id)) {
+         $params['linkid'] = $link_id;
+      }
+
+      Html::showToolTip("Documentation", $params);
+   }
+
+   /**
+    * Insert an html link to the twig template variables documentation page and
+    * move it before the given textarea.
+    * Useful if you don't have access to the form where you want to put this link at
+    *
+    * @param string $selector JQuery selector to find the target textarea
+    * @param int $preset_traget Preset of parameters for which to show documentation
+    */
+   public static function addTemplateDocumentationLinkJS(
+      string $selector,
+      int $preset_target
+   ) {
+      $link_id = "template_documentation_" . mt_rand();
+      self::addTemplateDocumentationLink($preset_target, $link_id);
+
+      // Move link before the given textarea
+      echo Html::scriptBlock(<<<JAVASCRIPT
+         $(
+            function() {
+               $('{$selector}').parent().prev().append("&nbsp;&nbsp;");
+               $('{$selector}').parent().prev().append($('#{$link_id}'));
+            }
+         );
+JAVASCRIPT
+      );
+   }
+
+   /**
     * Convert rich text content to simple text content
     *
     * @since 9.2

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -4093,7 +4093,7 @@ JAVASCRIPT
     * @param string|null $link_id  Useful if you need to interract with the link through client side code
     */
    public static function addTemplateDocumentationLink(
-      string  $preset_target,
+      string $preset_target,
       ?string $link_id = null
    ) {
       global $CFG_GLPI;

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -4089,11 +4089,11 @@ JAVASCRIPT
    /**
     * Insert an html link to the twig template variables documentation page
     *
-    * @param int $preset_traget Preset of parameters for which to show documentation
-    * @param string|null $link_id Useful if you need to interract with the link through client side code
+    * @param string $preset_traget Preset of parameters for which to show documentation (key)
+    * @param string|null $link_id  Useful if you need to interract with the link through client side code
     */
    public static function addTemplateDocumentationLink(
-      int $preset_target,
+      string  $preset_target,
       ?string $link_id = null
    ) {
       global $CFG_GLPI;
@@ -4120,11 +4120,11 @@ JAVASCRIPT
     * Useful if you don't have access to the form where you want to put this link at
     *
     * @param string $selector JQuery selector to find the target textarea
-    * @param int $preset_traget Preset of parameters for which to show documentation
+    * @param string $preset_traget   Preset of parameters for which to show documentation (key)
     */
    public static function addTemplateDocumentationLinkJS(
       string $selector,
-      int $preset_target
+      string $preset_target
    ) {
       $link_id = "template_documentation_" . mt_rand();
       self::addTemplateDocumentationLink($preset_target, $link_id);

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -4099,16 +4099,19 @@ JAVASCRIPT
       global $CFG_GLPI;
 
       $url = "/front/contenttemplates/documentation.php?preset=$preset_target";
+      $link =  $CFG_GLPI['root_doc'] . $url;
       $params = [
-         'link' => $CFG_GLPI['root_doc'] . $url,
-         'linktarget' => '_blank',
+         'target' => '_blank',
+         'style'  => 'margin-top:6px; display: block'
       ];
 
       if (!is_null($link_id)) {
-         $params['linkid'] = $link_id;
+         $params['id'] = $link_id;
       }
 
-      Html::showToolTip("Documentation", $params);
+      $text = __('Available variables') . ' <i class="fas fa-question-circle"></i>';
+
+      echo Html::link($text, $link, $params);
    }
 
    /**
@@ -4130,8 +4133,7 @@ JAVASCRIPT
       echo Html::scriptBlock(<<<JAVASCRIPT
          $(
             function() {
-               $('{$selector}').parent().prev().append("&nbsp;&nbsp;");
-               $('{$selector}').parent().prev().append($('#{$link_id}'));
+               $('{$selector}').parent().append($('#{$link_id}'));
             }
          );
 JAVASCRIPT
@@ -5321,7 +5323,7 @@ JAVASCRIPT;
          unset($options['confirm']);
       }
       // Do not escape title if it is an image or a i tag (fontawesome)
-      if (!preg_match('/^<i(mg)?.*/', $text)) {
+      if (!preg_match('/<i(mg)?.*/', $text)) {
          $text = Html::cleanInputText($text);
       }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2669,7 +2669,6 @@ JAVASCRIPT;
 
             echo "<label for='content'>";
             echo "$label&nbsp;&nbsp;";
-            Html::addTemplateDocumentationLink(ParametersPreset::TICKET_SOLUTION);
             echo "</label>";
             Html::textarea(['name'              => 'content',
                             'value'             => '',
@@ -2682,6 +2681,7 @@ JAVASCRIPT;
                             'enable_images'     => false,
                             'cols'              => 12,
                             'rows'              => 80]);
+            Html::addTemplateDocumentationLink(ParametersPreset::TICKET_SOLUTION);
             $parameters = ParametersPreset::getForTicketSolution();
             Html::activateUserTemplateAutocompletion(
                'textarea[name=content]',

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -30,9 +30,9 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\ContentTemplates\Parameters\ParametersTypes\AttributeParameter;
-use Glpi\ContentTemplates\Parameters\ParametersTypes\ObjectParameter;
 use Glpi\ContentTemplates\Parameters\TicketParameters;
+use Glpi\ContentTemplates\ParametersPreset;
+use Glpi\ContentTemplates\TemplateManager;
 use Glpi\Event;
 use Glpi\Toolbox\RichText;
 
@@ -2666,7 +2666,11 @@ JAVASCRIPT;
 
             echo '<div class="form-row-vertical">';
             $label = __('Description');
-            echo "<label for='content'>$label</label>";
+
+            echo "<label for='content'>";
+            echo "$label&nbsp;&nbsp;";
+            Html::addTemplateDocumentationLink(ParametersPreset::TICKET_SOLUTION);
+            echo "</label>";
             Html::textarea(['name'              => 'content',
                             'value'             => '',
                             'rand'              => $rand,
@@ -2678,10 +2682,12 @@ JAVASCRIPT;
                             'enable_images'     => false,
                             'cols'              => 12,
                             'rows'              => 80]);
-            Html::activateUserTemplateAutocompletion('textarea[name=content]', [
-               (new AttributeParameter('itemtype', __('Itemtype')))->compute(),
-               (new ObjectParameter(new TicketParameters()))->compute(),
-            ]);
+            $parameters = ParametersPreset::getForTicketSolution();
+            Html::activateUserTemplateAutocompletion(
+               'textarea[name=content]',
+               TemplateManager::computeParameters($parameters)
+            );
+
             echo '</div>'; // .form-row
 
             echo '</div>'; // .horizontal-form

--- a/inc/toolbox/markdownbuilder.class.php
+++ b/inc/toolbox/markdownbuilder.class.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Toolbox;
+
+/**
+ * Helper class to build markdown content
+ */
+class MarkdownBuilder
+{
+   /**
+    * Generated markdown content
+    *
+    * @var string
+    */
+   protected $content;
+
+   public function __construct() {
+      $this->content = "";
+   }
+
+   /**
+    * Get the generated markdown content
+    *
+    * @return string
+    */
+   public function getMarkdown(): string {
+      return $this->content;
+   }
+
+   /**
+    * Add a header to the markdown content
+    *
+    * @param string $prefix Header type (#, ##, ...)
+    * @param string $content Header content
+    * @param string|null $css_class Css class to add to this header
+    */
+   protected function addHeader(
+      string $prefix,
+      string $content,
+      ?string $css_class = null
+   ) {
+      $css_class = !is_null($css_class) ? "{.$css_class}" : "";
+      $this->content .= sprintf("%s %s %s \n", $prefix, $content, $css_class);
+   }
+
+   /**
+    * Add a h1 header
+    *
+    * @param string $content Header content
+    * @param string|null $css_class Css class to add to this header
+    */
+   public function addH1(string $content, ?string $css_class = null) {
+      $this->addHeader("#", $content, $css_class);
+   }
+
+   /**
+    * Add a h2 header
+    *
+    * @param string $content Header content
+    * @param string|null $css_class Css class to add to this header
+    */
+   public function addH2(string $content, ?string $css_class = null) {
+      $this->addHeader("##", $content, $css_class);
+   }
+
+   /**
+    * Add a h3 header
+    *
+    * @param string $content Header content
+    * @param string|null $css_class Css class to add to this header
+    */
+   public function addH3(string $content, ?string $css_class = null) {
+      $this->addHeader("###", $content, $css_class);
+   }
+
+   /**
+    * Add a h4 header
+    *
+    * @param string $content Header content
+    * @param string|null $css_class Css class to add to this header
+    */
+   public function addH4(string $content, ?string $css_class = null) {
+      $this->addHeader("####", $content, $css_class);
+   }
+
+   /**
+    * Add a h5 header
+    *
+    * @param string $content Header content
+    * @param string|null $css_class Css class to add to this header
+    */
+   public function addH5(string $content, ?string $css_class = null) {
+      $this->addHeader("#####", $content, $css_class);
+   }
+
+   /**
+    * Add a h6 header
+    *
+    * @param string $content Header content
+    * @param string|null $css_class Css class to add to this header
+    */
+   public function addH6(string $content, ?string $css_class = null) {
+      $this->addHeader("######", $content, $css_class);
+   }
+
+   /**
+    * Add a table row
+    *
+    * @param array $values
+    */
+   public function addTableRow(array $values) {
+      $this->content .= "|" . implode("|", $values) . "\n";
+   }
+
+   /**
+    * Add a table header
+    *
+    * @param array $values
+    */
+   public function addTableHeader(array $headers) {
+      $separator = array_fill(0, count($headers), '------');
+      $this->addTableRow($headers);
+      $this->addTableRow($separator);
+   }
+
+   /**
+    * Helper function to encapsulate single line code
+    *
+    * @return string
+    */
+   public static function code($code): string {
+      return sprintf("```%s```", $code);
+   }
+
+   /**
+    * Helper function create a navigation link
+    *
+    * @return string
+    */
+   public static function navigationLink($label) {
+      $link = strtolower($label);
+      $link = str_replace(" ", "-", $link);
+      return "[$label](#$link)";
+   }
+
+   /**
+    * Helper function create a summary entry
+    *
+    * @return string
+    */
+   public function addSummaryEntry($label) {
+      $link = self::navigationLink($label);
+      $this->content .= "* $link\n";
+   }
+}

--- a/inc/toolbox/markdownbuilder.class.php
+++ b/inc/toolbox/markdownbuilder.class.php
@@ -32,6 +32,8 @@
 
 namespace Glpi\Toolbox;
 
+use Toolbox;
+
 /**
  * Helper class to build markdown content
  */
@@ -42,11 +44,7 @@ class MarkdownBuilder
     *
     * @var string
     */
-   protected $content;
-
-   public function __construct() {
-      $this->content = "";
-   }
+   protected $content = "";
 
    /**
     * Get the generated markdown content
@@ -168,8 +166,7 @@ class MarkdownBuilder
     * @return string
     */
    public static function navigationLink($label) {
-      $link = strtolower($label);
-      $link = str_replace(" ", "-", $link);
+      $link = Toolbox::slugify($label, '');
       return "[$label](#$link)";
    }
 

--- a/tests/functionnal/Glpi/ContentTemplates/Parameters/AbstractParameters.php
+++ b/tests/functionnal/Glpi/ContentTemplates/Parameters/AbstractParameters.php
@@ -33,10 +33,13 @@
 namespace tests\units\Glpi\ContentTemplates\Parameters;
 
 use DbTestCase;
+use Glpi\ContentTemplates\TemplateManager;
 
 class AbstractParameters extends DbTestCase
 {
    protected function testGetAvailableParameters($values, $parameters): void {
+      $parameters = TemplateManager::computeParameters($parameters);
+
       $values_keys = array_keys($values);
       $parameters_keys = array_column($parameters, 'key');
 


### PR DESCRIPTION
Related: #9291, #9325.

Added an "in place" documentation for the twig templates variables, similar to what we use for the API

The first section of the documentation contain the exposed "root" variables in the current form.
The following sections contains the dependencies of these root variables.
For example if the root variable have a `TicketParameter` then we have a `Ticket` dependencies with all the ticket fields displayed.
Each dependency may have its own dependencies (the entity of the ticket, the category, ...) that will also be displayed in their own sections.

![image](https://user-images.githubusercontent.com/42734840/127329676-c5b86e0f-87f8-4d86-bf4e-80e92dd52a33.png)

![image](https://user-images.githubusercontent.com/42734840/127329777-ada82438-2dc3-4306-a97e-efa2f3eb95f7.png)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22419
