### PR TITLE
Load palette after plugins

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1408,7 +1408,6 @@ class Html {
 
       echo Html::scss('css/palettes/' . $theme);
 
-
       // Custom CSS for active entity
       if ($DB instanceof DBmysql && $DB->connected) {
          $entity = new Entity();

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1369,7 +1369,6 @@ class Html {
       if (isset($_SESSION['glpihighcontrast_css']) && $_SESSION['glpihighcontrast_css']) {
          echo Html::scss('css/highcontrast');
       }
-      echo Html::scss('css/palettes/' . $theme);
 
       echo Html::css('css/print.css', ['media' => 'print']);
       echo "<link rel='shortcut icon' type='images/x-icon' href='".
@@ -1406,6 +1405,9 @@ class Html {
             }
          }
       }
+
+      echo Html::scss('css/palettes/' . $theme);
+
 
       // Custom CSS for active entity
       if ($DB instanceof DBmysql && $DB->connected) {


### PR DESCRIPTION
Color palette are currently loaded before plugins css.

It is common for experienced user to create their own palettes thus making it possibly a "user defined style" (like editing css in the entities).
I think this kind of styles are best loaded last so they are no overwritten by any "programmer defined styles".

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22428
