### PR TITLE
Switch from file-loader to Webpack asset modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -575,12 +575,6 @@
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "dev": true
         },
-        "big.js": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-            "dev": true
-        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1368,91 +1362,6 @@
             "dev": true,
             "requires": {
                 "flat-cache": "^3.0.4"
-            }
-        },
-        "file-loader": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
-            "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
-            "dev": true,
-            "requires": {
-                "loader-utils": "^2.0.0",
-                "schema-utils": "^3.0.0"
-            },
-            "dependencies": {
-                "@types/json-schema": {
-                    "version": "7.0.6",
-                    "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
-                    "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
-                    "dev": true
-                },
-                "ajv": {
-                    "version": "6.12.6",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-                    "dev": true,
-                    "requires": {
-                        "fast-deep-equal": "^3.1.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "ajv-keywords": {
-                    "version": "3.5.2",
-                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-                    "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-                    "dev": true
-                },
-                "emojis-list": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-                    "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-                    "dev": true
-                },
-                "fast-deep-equal": {
-                    "version": "3.1.3",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-                    "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-                    "dev": true
-                },
-                "json5": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-                    "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "^1.2.5"
-                    }
-                },
-                "loader-utils": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-                    "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-                    "dev": true,
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^2.1.2"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.5",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-                    "dev": true
-                },
-                "schema-utils": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-                    "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/json-schema": "^7.0.6",
-                        "ajv": "^6.12.5",
-                        "ajv-keywords": "^3.5.2"
-                    }
-                }
             }
         },
         "file-type": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
         "copy-webpack-plugin": "^9.0.0",
         "css-loader": "^6.2.0",
         "eslint": "^7.1.0",
-        "file-loader": "^6.0.0",
         "glob": "^7.1.6",
         "mini-css-extract-plugin": "^2.0.0",
         "process": "^0.11.10",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,25 +101,23 @@ var libsConfig = {
          {
             // Copy images and fonts
             test: /\.((gif|png|jp(e?)g)|(eot|ttf|svg|woff2?))$/,
-            use: {
-               loader: 'file-loader',
-               options: {
-                  name: function (filename) {
-                     // Keep only relative path
-                     var sanitizedPath = path.relative(__dirname, filename);
+            type: 'asset/resource',
+            generator: {
+               filename: function (pathData) {
+                  // Keep only relative path
+                  var sanitizedPath = path.relative(__dirname, pathData.filename);
 
-                     // Sanitize name
-                     sanitizedPath = sanitizedPath.replace(/[^\\/\w-.]/, '');
+                  // Sanitize name
+                  sanitizedPath = sanitizedPath.replace(/[^\\/\w-.]/, '');
 
-                     // Remove the first directory (lib, node_modules, ...) and empty parts
-                     // and replace directory separator by '/' (windows case)
-                     sanitizedPath = sanitizedPath.split(path.sep)
-                        .filter(function (part, index) {
-                           return '' != part && index != 0;
-                        }).join('/');
+                  // Remove the first directory (lib, node_modules, ...) and empty parts
+                  // and replace directory separator by '/' (windows case)
+                  sanitizedPath = sanitizedPath.split(path.sep)
+                     .filter(function (part, index) {
+                        return '' != part && index != 0;
+                     }).join('/');
 
-                     return sanitizedPath;
-                  },
+                  return sanitizedPath;
                },
             },
          },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since we use Webpack css-loader > 6.0.0, we can directly handle CSS assets with [asset modules configuration](https://webpack.js.org/guides/asset-modules/).

See css-loader changelog: https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#600-2021-07-14