### PR TITLE
Display infocom report for all `infocom_types` compatible items

### DIFF
--- a/front/report.infocom.php
+++ b/front/report.infocom.php
@@ -90,6 +90,10 @@ function display_infocoms_report($itemtype, $begin, $end) {
    global $DB, $valeurtot, $valeurnettetot, $valeurnettegraphtot, $valeurgraphtot, $CFG_GLPI, $stat, $chart_opts;
 
    $itemtable = getTableForItemType($itemtype);
+   // report need name and ticket_tco, many asset type don't have it therefore are not compatible
+   if(!$DB->fieldExists($itemtable, "ticket_tco", false)){
+      return false;
+   }
    $criteria = [
       'SELECT'       => [
          'glpi_infocoms.*',
@@ -287,7 +291,7 @@ function display_infocoms_report($itemtype, $begin, $end) {
    return false;
 }
 
-$types = ['Computer', 'Monitor', 'NetworkEquipment', 'Peripheral', 'Phone', 'Printer'];
+$types = $CFG_GLPI["infocom_types"];
 
 $i = 0;
 echo "<table><tr><td class='top'>";

--- a/front/report.infocom.php
+++ b/front/report.infocom.php
@@ -91,7 +91,7 @@ function display_infocoms_report($itemtype, $begin, $end) {
 
    $itemtable = getTableForItemType($itemtype);
    // report need name and ticket_tco, many asset type don't have it therefore are not compatible
-   if(!$DB->fieldExists($itemtable, "ticket_tco", false)){
+   if (!$DB->fieldExists($itemtable, "ticket_tco", false)) {
       return false;
    }
    $criteria = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ??
| Fixed tickets | NA

The asset types in the report were ard coded, this change use the `infocom_types` as reference and then do the report for the one that does have a field called ticket_tco (name is misleading by the way, should be asset_tco)



