### PR TITLE
Fix meta JOIN

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2149,18 +2149,6 @@ class Search {
          return [];
       }
 
-      $key_to_itemtypes = [
-         'directconnect_types'  => ['Computer'],
-         'infocom_types'        => ['Budget', 'Infocom'],
-         'linkgroup_types'      => ['Group'],
-         // 'linkgroup_tech_types' => 'Group', // Cannot handle ambiguity with 'Group' from 'linkgroup_types'
-         'linkuser_types'       => ['User'],
-         // 'linkuser_tech_types'  => 'User', // Cannot handle ambiguity with 'User' from 'linkuser_types'
-         'project_asset_types'  => ['Project'],
-         'rackable_types'       => ['Enclosure', 'Rack'],
-         'ticket_types'         => ['Change', 'Problem', 'Ticket'],
-      ];
-
       $linked = [];
       foreach ($CFG_GLPI as $key => $values) {
          if ($key === 'link_types') {
@@ -2173,22 +2161,13 @@ class Search {
             continue;
          }
 
-         $matches = [];
-         if (preg_match('/^(.+)_types$/', $key, $matches)) {
-            $config_itemtypes = array_key_exists($key, $key_to_itemtypes)
-               ? $key_to_itemtypes[$key]
-               : [ucwords($matches[1])];
-            foreach ($config_itemtypes as $config_itemtype) {
-               if (!is_a($config_itemtype, CommonDBTM::class, true)) {
-                  continue;
-               }
-               if ($itemtype === $config_itemtype::getType()) {
-                  // List is related to source itemtype, all types of list are so linked
-                  $linked = array_merge($linked, $values);
-               } else if (in_array($itemtype, $values)) {
-                  // Source itemtype is inside list, type corresponding to list is so linked
-                  $linked[] = $config_itemtype::getType();
-               }
+         foreach (self::getMetaParentItemtypesForTypesConfig($key) as $config_itemtype) {
+            if ($itemtype === $config_itemtype::getType()) {
+               // List is related to source itemtype, all types of list are so linked
+               $linked = array_merge($linked, $values);
+            } else if (in_array($itemtype, $values)) {
+               // Source itemtype is inside list, type corresponding to list is so linked
+               $linked[] = $config_itemtype::getType();
             }
          }
       }
@@ -2196,7 +2175,69 @@ class Search {
       return array_unique($linked);
    }
 
+   /**
+    * Returns parents itemtypes having subitems defined in given config key.
+    * This list is filtered and is only valid in a "meta" search context.
+    *
+    * @param string $config_key
+    *
+    * @return string[]
+    */
+   private static function getMetaParentItemtypesForTypesConfig(string $config_key): array {
+      $matches = [];
+      if (preg_match('/^(.+)_types$/', $config_key, $matches) === 0) {
+         return [];
+      }
 
+      $key_to_itemtypes = [
+         'directconnect_types'  => ['Computer'],
+         'infocom_types'        => ['Budget', 'Infocom'],
+         'linkgroup_types'      => ['Group'],
+         // 'linkgroup_tech_types' => ['Group'], // Cannot handle ambiguity with 'Group' from 'linkgroup_types'
+         'linkuser_types'       => ['User'],
+         // 'linkuser_tech_types'  => ['User'], // Cannot handle ambiguity with 'User' from 'linkuser_types'
+         'project_asset_types'  => ['Project'],
+         'rackable_types'       => ['Enclosure', 'Rack'],
+         'ticket_types'         => ['Change', 'Problem', 'Ticket'],
+      ];
+
+      if (array_key_exists($config_key, $key_to_itemtypes)) {
+         return $key_to_itemtypes[$config_key];
+      }
+
+      $itemclass = $matches[1];
+      if (is_a($itemclass, CommonDBTM::class, true)) {
+         return [$itemclass::getType()];
+      }
+
+      return [];
+   }
+
+   /**
+    * Check if an itemtype is a possible subitem of another itemtype in a "meta" search context.
+    *
+    * @param string $parent_itemtype
+    * @param string $child_itemtype
+    *
+    * @return boolean
+    */
+   private static function isPossibleMetaSubitemOf(string $parent_itemtype, string $child_itemtype) {
+      global $CFG_GLPI;
+
+      if (is_a($parent_itemtype, CommonITILObject::class, true)
+          && in_array($child_itemtype, array_keys($parent_itemtype::getAllTypesForHelpdesk()))) {
+         return true;
+      }
+
+      foreach ($CFG_GLPI as $key => $values) {
+         if (in_array($parent_itemtype, self::getMetaParentItemtypesForTypesConfig($key))
+             && in_array($child_itemtype, $values)) {
+            return true;
+         }
+      }
+
+      return false;
+   }
 
    /**
     * @since 0.85
@@ -5355,15 +5396,22 @@ JAVASCRIPT;
 
       // Generic JOIN
       $from_obj      = getItemForItemtype($from_referencetype);
+      $from_item_obj = null;
       $to_obj        = getItemForItemtype($to_type);
-      $from_item_obj = getItemForItemtype($from_referencetype . '_Item');
-      if (!$from_item_obj) {
-         $from_item_obj = getItemForItemtype('Item_' . $from_referencetype);
+      $to_item_obj   = null;
+      if (self::isPossibleMetaSubitemOf($from_referencetype, $to_type)) {
+         $from_item_obj = getItemForItemtype($from_referencetype . '_Item');
+         if (!$from_item_obj) {
+            $from_item_obj = getItemForItemtype('Item_' . $from_referencetype);
+         }
       }
-      $to_item_obj   = getItemForItemtype($to_type . '_Item');
-      if (!$to_item_obj) {
-         $to_item_obj = getItemForItemtype('Item_' . $to_type);
+      if (self::isPossibleMetaSubitemOf($to_type, $from_referencetype)) {
+         $to_item_obj   = getItemForItemtype($to_type . '_Item');
+         if (!$to_item_obj) {
+            $to_item_obj = getItemForItemtype('Item_' . $to_type);
+         }
       }
+
       if ($from_obj && $from_obj->isField($to_fk)) {
          // $from_table has a foreign key corresponding to $to_table
          if (!in_array($to_table, $already_link_tables2)) {

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -81,6 +81,37 @@ class Search extends DbTestCase {
       return $data;
    }
 
+   public function testMetaComputerOS() {
+      $search_params = ['is_deleted'   => 0,
+                        'start'        => 0,
+                        'criteria'     => [0 => ['field'      => 'view',
+                                                 'searchtype' => 'contains',
+                                                 'value'      => '']],
+                        'metacriteria' => [0 => ['link'       => 'AND',
+                                                 'itemtype'   => 'OperatingSystem',
+                                                 'field'      => 1, //name
+                                                 'searchtype' => 'contains',
+                                                 'value'      => 'windows']]];
+
+      $data = $this->doSearch('Computer', $search_params);
+
+      //try to find LEFT JOIN clauses
+      $this->string($data['sql']['search'])
+         ->matches("/"
+         ."LEFT\s*JOIN\s*`glpi_items_operatingsystems`\s*AS\s*`glpi_items_operatingsystems_OperatingSystem`\s*"
+         ."ON\s*\(`glpi_items_operatingsystems_OperatingSystem`\.`items_id`\s*=\s*`glpi_computers`\.`id`\s*"
+         ."AND `glpi_items_operatingsystems_OperatingSystem`\.`itemtype`\s*=\s*'Computer'\s*"
+         ."AND `glpi_items_operatingsystems_OperatingSystem`\.`is_deleted`\s*=\s*0\s*\)\s*"
+         ."LEFT\s*JOIN\s*`glpi_operatingsystems`\s*"
+         ."ON\s*\(`glpi_items_operatingsystems_OperatingSystem`\.`operatingsystems_id`\s*=\s*`glpi_operatingsystems`\.`id`\s*\)"
+         ."/im");
+
+      //try to match WHERE clause
+      $this->string($data['sql']['search'])
+         ->matches("/(\(`glpi_operatingsystems`\.`name`\s*LIKE\s*'%windows%'\s*\)\s*\))/im");
+   }
+
+
    public function testMetaComputerSoftwareLicense() {
       $search_params = ['is_deleted'   => 0,
                         'start'        => 0,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22385

More global solution than #9329 .

The generic JOIN logic tries to find a link between main item and meta item through either `{$from_type}_Item` and `{$to_type}_Item`  types. The problem was that both types may exist, and JOIN has to be made on the right one.
For example, when searching form a `Computer` that has a specific `OperatingSystem`, JOIN chain was `glpi_computers -> glpi_computers_items -> glpi_operatingsystems` instead of `glpi_computers -> glpi_items_operatingsystems -> glpi_operatingsystems`.

So I keep the original generic logic, but I added a check based on `$CFG_GLPI[*_types]` (the same one that is used to define available meta types), in order to use the right `_items` table.

It fixes many cases :
 - searching a computer having a specific OS,
 - searching a computer having a specific Appliance,
 - searching a computer having a specific Domain,
 - ...