### PR TITLE
Fix search on changes validation's status 

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -4466,6 +4466,8 @@ JAVASCRIPT;
 
          case "glpi_tickets.global_validation" :
          case "glpi_ticketvalidations.status" :
+         case "glpi_changes.global_validation" :
+         case "glpi_changevalidations.status" :
             if ($val == 'all') {
                return "";
             }


### PR DESCRIPTION
Before fix, the SQL request try to match the status constant (2) with an id:
![image](https://user-images.githubusercontent.com/42734840/128019501-5c19d959-8fc4-406b-8c1a-88eda4f32e2a.png)

After: 
![image](https://user-images.githubusercontent.com/42734840/128019630-75aa6ede-2b31-4efa-ba87-178afd0ffe1c.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22444
