### PR TITLE
Fix handling of mailer-daemon e-mails in collector; fixes #9306

### DIFF
--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -1408,10 +1408,6 @@ class MailCollector  extends CommonDBTM {
 
       $sender_email = $this->getEmailFromHeader($message, 'from');
 
-      if (preg_match('/^(mailer-daemon|postmaster)@/i', $sender_email) === 1) {
-         return [];
-      }
-
       $to = $this->getEmailFromHeader($message, 'to');
 
       $reply_to_addr = Toolbox::strtolower($this->getEmailFromHeader($message, 'reply-to'));

--- a/tests/emails-tests/27-autoreply.eml
+++ b/tests/emails-tests/27-autoreply.eml
@@ -1,0 +1,12 @@
+Date: Thu, 7 Jun 2018 12:05:51 +0200 (CEST)
+From: Mail Delivery Subsystem <MAILER-DAEMON@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <1695134010.1757889.1528365951040.JavaMail.zimbra@glpi-project.org>
+Auto-Submitted: auto-replied
+Subject: Undelivered Mail Returned to Sender
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+I'm sorry to inform you that the message below could not be delivered.
+....

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -449,7 +449,7 @@ class MailCollector extends DbTestCase {
       $msg = $this->collector->collect($this->mailgate_id);
 
       $total_count                     = count(glob(GLPI_ROOT . '/tests/emails-tests/*.eml'));
-      $expected_refused_count          = 2;
+      $expected_refused_count          = 3;
       $expected_error_count            = 2;
       $expected_blacklist_count        = 1;
       $expected_expected_already_seen  = 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #9306 

When an e-mail is received from a mailer-daemon/postmaster address, header parsing is skipped, so default rule that is made to reject e-mail having a `Auto-Submitted: auto-replied` header cannot match, and e-mail is not refused.

Depending on GLPI configuration, it can lead to different results:
 - if anonymous ticket creation is not allowed, ticket will be refused as sender address is empty (due to lack of headers parsing);
 - if anonymous ticket creation is allowed, a ticket will be created, which should not happen, according to rules.

The removed piece of code is really old (introduced in commit 50d65d6b40669816cae8e97a72af4f687e024693 in 2007), and I guess it should have been removed when `Auto-Submitted` rejection rule has been introduced (commit a08228a306e6723919cfc8f784236fa73c77107f).