### PR TITLE
Fix $auth->user_found for multiple ldaps

### DIFF
--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -2847,9 +2847,15 @@ class AuthLDAP extends CommonDBTM {
 
       //If no specific source is given, test all ldap directories
       if ($auths_id <= 0) {
+         $user_found = false;
+
          foreach ($auth->authtypes["ldap"] as $ldap_method) {
             if ($ldap_method['is_active']) {
                $auth = self::ldapAuth($auth, $login, $password, $ldap_method, $user_dn);
+
+               if ($auth->user_found) {
+                  $user_found = true;
+               }
 
                if ($auth->auth_succeded
                    && $break) {
@@ -2857,6 +2863,8 @@ class AuthLDAP extends CommonDBTM {
                }
             }
          }
+
+         $auth->user_found = $user_found;
 
       } else if (array_key_exists($auths_id, $auth->authtypes["ldap"])) {
          // Check if the ldap server indicated as the last good one still exists !


### PR DESCRIPTION
If you have multiple ldap sources, a user who fail his password may be considered as deleted from the ldap.

This is because `AuthLdap::tryLdapAuth()` keep only the state of the last ldap connection tested.
So if the user is found on the first ldap but not on the second one then it will be considered as missing from the ldap and trigger the `User::manageDeletedUserInLdap` policy :
![image](https://user-images.githubusercontent.com/42734840/128202678-e29e817f-3702-4dce-a278-6844b34a0016.png)

To fix this `user_found` must be true if the user was found on any ldap, not just the last one.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22420
