### PR TITLE
[Modern-UI] Simplify central cards code

### DIFF
--- a/inc/central.class.php
+++ b/inc/central.class.php
@@ -255,14 +255,10 @@ class Central extends CommonGLPI {
          ];
          $idor = Session::getNewIDORToken($list['itemtype'], $card_params);
          $twig_params['cards'][] = [
-            'type'         => 'lazy',
-            'body_class'   => 'p-0',
-            'content'   => [
-               'itemtype'  => $list['itemtype'],
-               'widget'    => 'central_list',
-               'params'    => $card_params + [
-                  '_idor_token'  => $idor
-               ]
+            'itemtype'  => $list['itemtype'],
+            'widget'    => 'central_list',
+            'params'    => $card_params + [
+               '_idor_token'  => $idor
             ]
          ];
       }
@@ -272,27 +268,19 @@ class Central extends CommonGLPI {
       ];
       $idor = Session::getNewIDORToken(Planning::class, $card_params);
       $twig_params['cards'][] = [
-         'type'         => 'lazy',
-         'body_class'   => 'p-0',
-         'content'   => [
-            'itemtype'  => Planning::class,
-            'widget'    => 'central_list',
-            'params'    => $card_params + [
-               '_idor_token'  => $idor
-            ]
+         'itemtype'  => Planning::class,
+         'widget'    => 'central_list',
+         'params'    => $card_params + [
+            '_idor_token'  => $idor
          ]
       ];
 
       $idor = Session::getNewIDORToken(Reminder::class);
       $twig_params['cards'][] = [
-         'type'         => 'lazy',
-         'body_class'   => 'p-0',
-         'content'   => [
-            'itemtype'  => Reminder::class,
-            'widget'    => 'central_list',
-            'params'    => [
-               '_idor_token'  => $idor
-            ]
+         'itemtype'  => Reminder::class,
+         'widget'    => 'central_list',
+         'params'    => [
+            '_idor_token'  => $idor
          ]
       ];
       $idor = Session::getNewIDORToken(Reminder::class, [
@@ -300,15 +288,11 @@ class Central extends CommonGLPI {
       ]);
       if (Session::haveRight("reminder_public", READ)) {
          $twig_params['cards'][] = [
-            'type'         => 'lazy',
-            'body_class'   => 'p-0',
-            'content'   => [
-               'itemtype'  => Reminder::class,
-               'widget'    => 'central_list',
-               'params'    => [
-                  'personal'     => 'false',
-                  '_idor_token'  => $idor
-               ]
+            'itemtype'  => Reminder::class,
+            'widget'    => 'central_list',
+            'params'    => [
+               'personal'     => 'false',
+               '_idor_token'  => $idor
             ]
          ];
       }
@@ -331,15 +315,11 @@ class Central extends CommonGLPI {
          'messages'  => self::getMessages(),
          'cards'     => [
             [
-               'type'         => 'lazy',
-               'body_class'   => 'p-0',
-               'content'   => [
-                  'itemtype'  => RSSFeed::class,
-                  'widget'    => 'central_list',
-                  'params'    => [
-                     'personal'     => 'true',
-                     '_idor_token'  => $idor
-                  ]
+               'itemtype'  => RSSFeed::class,
+               'widget'    => 'central_list',
+               'params'    => [
+                  'personal'     => 'true',
+                  '_idor_token'  => $idor
                ]
             ]
          ]
@@ -349,15 +329,11 @@ class Central extends CommonGLPI {
             'personal'  => 'false'
          ]);
          $twig_params['cards'][] = [
-            'type'         => 'lazy',
-            'body_class'   => 'p-0',
-            'content'   => [
-               'itemtype'  => RSSFeed::class,
-               'widget'    => 'central_list',
-               'params'    => [
-                  'personal'     => 'false',
-                  '_idor_token'  => $idor
-               ]
+            'itemtype'  => RSSFeed::class,
+            'widget'    => 'central_list',
+            'params'    => [
+               'personal'     => 'false',
+               '_idor_token'  => $idor
             ]
          ];
       }
@@ -447,14 +423,10 @@ class Central extends CommonGLPI {
          ];
          $idor = Session::getNewIDORToken($list['itemtype'], $card_params);
          $twig_params['cards'][] = [
-            'type'         => 'lazy',
-            'body_class'   => 'p-0',
-            'content'   => [
-               'itemtype'  => $list['itemtype'],
-               'widget'    => 'central_list',
-               'params'    => $card_params + [
-                  '_idor_token'  => $idor
-               ]
+            'itemtype'  => $list['itemtype'],
+            'widget'    => 'central_list',
+            'params'    => $card_params + [
+               '_idor_token'  => $idor
             ]
          ];
       }

--- a/templates/central/widget_tab.html.twig
+++ b/templates/central/widget_tab.html.twig
@@ -8,30 +8,11 @@
    {% set grid_items = [] %}
    {% for card in cards %}
       {% set card_html %}
-         <div class="card {{ card.class|default('') }}">
-            {% if card.title is defined %}
-               <div class="card-header">
-                  {% if card.icon is defined and card.icon is not null %}
-                     <i class="{{ card.icon }}"></i>
-                  {% endif %}
-                  {{ card.title }}
-               </div>
-            {% endif %}
-            <div class="card-body {{ card.body_class|default('') }}">
-               {% if card.type is not defined or card.type == 'raw' %}
-                  {{ card.content|raw }}
-               {% elseif card.type == 'table' %}
-                  {% include 'components/table.html.twig' with {
-                     'class': card.content.class|default(''),
-                     'header_rows': card.content.header_rows|default({}),
-                     'rows': card.content.rows|default({}),
-                  } %}
-               {% elseif card.type == 'lazy' %}
-                  <div class="lazy-widget" data-itemtype="{{ card.content.itemtype }}" data-widget="{{ card.content.widget }}"
-                     data-params="{{ card.content.params|default({})|json_encode }}"
-                     data-idor="{{ card.content._idor_token }}">
-                  </div>
-               {% endif %}
+         <div class="card">
+            <div class="card-body p-0">
+              <div class="lazy-widget" data-itemtype="{{ card.itemtype }}" data-widget="{{ card.widget }}"
+                 data-params="{{ card.params|default({})|json_encode }}">
+              </div>
             </div>
          </div>
       {% endset %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. All cards are using the `lazy` type. `raw` and `table` types are not used.
2. `title` property is never set.
3. All cards have the same body class (`p-0`).
4. `_idor_token` is inside params, so `data-idor` is always empty, thus it was not used.