### PR TITLE
fix(massiveaction): fix databaseinstance massive action

### DIFF
--- a/inc/databaseinstance.class.php
+++ b/inc/databaseinstance.class.php
@@ -58,6 +58,10 @@ class DatabaseInstance extends CommonDBTM {
       ];
    }
 
+   function useDeletedToLockIfDynamic() {
+      return false;
+   }
+
    static function getTypeName($nb = 0) {
       return _n('Database instance', 'Database instances', $nb);
    }

--- a/tests/functionnal/DatabaseInstance.php
+++ b/tests/functionnal/DatabaseInstance.php
@@ -62,7 +62,7 @@ class DatabaseInstance extends DbTestCase {
       )->isGreaterThan(0);
 
       //test removal
-      $this->boolean($db->delete(['id' => $dbid, 1]))->isTrue();
+      $this->boolean($db->delete(['id' => $dbid], 1))->isTrue();
       $this->boolean($db->getFromDB($dbid))->isFalse();
 
       //ensure instance has been dropped aswell


### PR DESCRIPTION

Delete massive action is broken (GLPI display 'Purge' but item is only deleted and the next step 'purge' not working)
because of ```is_deleted``` and ```is_dynamic``` fields.

like computers,  ```DatabaseInstance``` need to return false when ```Massiveaction``` class check for ```useDeletedToLockIfDynamic```


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
