### PR TITLE
feat(agent): allow plugin to request agent

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -489,7 +489,7 @@ class Agent extends CommonDBTM {
     *
     * @return Response
     */
-   protected function requestAgent($endpoint): Response {
+   public function requestAgent($endpoint): Response {
       global $CFG_GLPI;
 
       if (self::$found_adress !== false) {


### PR DESCRIPTION
Allow plugins to call ```requestAgent```


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
