### PR TITLE
feat(inventory): improve comunication protocol

### DIFF
--- a/inc/agent/communication/abstractrequest.class.php
+++ b/inc/agent/communication/abstractrequest.class.php
@@ -56,7 +56,7 @@ abstract class AbstractRequest
    const SNMP_QUERY   = 'SNMP';
    const OLD_SNMP_QUERY   = 'SNMPQUERY';
 
-   //GLPI AGENT
+   //GLPI AGENT ACTION
    const CONTACT_ACTION = 'contact';
    const REGISTER_ACTION = 'register';
    const CONFIG_ACTION = 'configuration';
@@ -67,6 +67,10 @@ abstract class AbstractRequest
    const COLLECT_ACTION = 'collect';
    const DEPLOY_ACTION = 'deploy';
    const WOL_ACTION = 'wakeonlan';
+   const GET_PARAMS = 'get_params';
+
+   //GLPI AGENT TASK
+   const INVENT_TASK = 'inventory';
 
    const COMPRESS_NONE = 0;
    const COMPRESS_ZLIB = 1;
@@ -206,6 +210,15 @@ abstract class AbstractRequest
      * @return boolean
      */
    abstract protected function handleAction($action, $content = null) :bool;
+
+   /**
+   * Handle Task
+   *
+   * @param string $task  Task (one of self::*_tASK)
+   *
+   * @return array
+   */
+   abstract protected function handleTask($task) :array;
 
    /**
     * Handle XML request

--- a/inc/agent/communication/abstractrequest.class.php
+++ b/inc/agent/communication/abstractrequest.class.php
@@ -214,7 +214,7 @@ abstract class AbstractRequest
    /**
    * Handle Task
    *
-   * @param string $task  Task (one of self::*_tASK)
+   * @param string $task  Task (one of self::*_TASK)
    *
    * @return array
    */

--- a/inc/inventory/inventory.class.php
+++ b/inc/inventory/inventory.class.php
@@ -345,6 +345,17 @@ class Inventory
       return $items;
    }
 
+
+   /**
+    * Get rawdata
+    *
+    * @return array
+    */
+    public function getRawData(): Object {
+      return $this->raw_data;
+   }
+
+
    /**
     * Handle inventory file
     *

--- a/inc/inventory/inventory.class.php
+++ b/inc/inventory/inventory.class.php
@@ -351,7 +351,7 @@ class Inventory
     *
     * @return array
     */
-    public function getRawData(): Object {
+   public function getRawData(): Object {
       return $this->raw_data;
    }
 

--- a/inc/inventory/request.class.php
+++ b/inc/inventory/request.class.php
@@ -97,7 +97,7 @@ class Request extends AbstractRequest
 
    /**
      * Handle Task
-     * @param string $task  Task (one of self::*_tASK)
+     * @param string $task  Task (one of self::*_TASK)
      * @return array
      */
    protected function handleTask($task) :array {


### PR DESCRIPTION
Improve communication ```CONTACT``` and ```GET_PARAMS``` protocol

By default GLPI send this
```php
      $response = [
         'expiration'  => self::DEFAULT_FREQUENCY,
         'status'     => 'ok'
      ];
```


improve ```CONTACT``` and allow the plugin to add information to the response (for database plugin for the moment)
```php
array (
  'expiration' => 24,
  'status' => 'ok',
  'tasks' => 
  array (
    'inventory' => 
    array (
      'params' => 
      array (
        0 => 
        array (
          'category' => 'database',
          'use' =>  //agent module
          array (
            0 => 'mysql',
            1 => 'oracle',
          ),
          'params_id' => 3, //object containing more info
        ),
      ),
    ),
  ),
)
```


Manage ```GET_PARAMS``` when agent need more information (and allow the plugin to add information to the response)

```php
array (
  'expiration' => 24,
  'status' => 'ok',
  'credentials' => 
  array (
    0 => 
    array (
      'id' => 3,
      'type' => 'login_password',
      'use' => 'mysql',
      'login' => 'root',
      'password' => 'rootroot',
      'port' => 3306,
    ),
  ),
)
      
```


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
