### PR TITLE
fix(inventory): fix remote inventory / status

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -331,9 +331,16 @@ class Agent extends CommonDBTM {
          $input['tag'] = $metadata['tag'];
       }
 
+      if (!isset($metadata['httpd-port'])) {
+         $input['port'] = $metadata['httpd-port'];
+      }
+
       $input['ip_protocol'] = 'http';
-      if (!isset($metadata['httpd-plugins']['ssl'])) {
-         $input['ip_protocol'] = 'https';
+      if (isset($metadata['httpd-plugins']['ssl']['ports'])) {
+         $ssl_ports[] = $metadata['httpd-plugins']['ssl']['ports'];
+         if (in_array("0", $ssl_ports) || (isset($metadata['httpd-port']) && in_array($metadata['httpd-port'], $ssl_ports))) {
+            $input['ip_protocol'] = 'https';
+         }
       }
 
       if ($deviceid === 'foo') {

--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -424,7 +424,9 @@ class Agent extends CommonDBTM {
          ]);
          while ($row = $ports_iterator->next()) {
             if (!in_array($row['name'], $adresses)) {
-               $adresses[] = $row['name'];
+               if (filter_var($row['name'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+                  $adresses[] = $row['name'];
+               }
             }
          }
 

--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -441,7 +441,7 @@ class Agent extends CommonDBTM {
     *
     * @return Response
     */
-   public function requestAgent($endpoint): Response {
+   private function requestAgent($endpoint): Response {
       global $CFG_GLPI;
 
       $adress = $this->getAgentURL();

--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -157,11 +157,11 @@ class Agent extends CommonDBTM {
       }
       switch ($field) {
          case 'ip_binary':
-         if($ipadress = inet_ntop($values[$field])) {
-            return $ipadress;
-         } else{
-            return __('IP address not properly formatted');
-         }
+            if ($ipadress = inet_ntop($values[$field])) {
+               return $ipadress;
+            } else {
+               return __('IP address not properly formatted');
+            }
       }
 
       return parent::getSpecificValueToDisplay($field, $values, $options);

--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -332,7 +332,7 @@ class Agent extends CommonDBTM {
          $input['tag'] = $metadata['tag'];
       }
 
-      if (!isset($metadata['httpd-port'])) {
+      if (isset($metadata['httpd-port'])) {
          $input['port'] = $metadata['httpd-port'];
       }
 

--- a/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
@@ -74,13 +74,18 @@ if (!$DB->tableExists('glpi_agents')) {
          `useragent` varchar(255) DEFAULT NULL,
          `tag` varchar(255) DEFAULT NULL,
          `port` varchar(6) DEFAULT NULL,
+         `ip_version` tinyint DEFAULT '0',
+         `ip_binary` varbinary(16) NOT NULL DEFAULT '0',
+         `ip_protocol` varchar(5) DEFAULT NULL,
          PRIMARY KEY (`id`),
          KEY `name` (`name`),
          KEY `entities_id` (`entities_id`),
          KEY `is_recursive` (`is_recursive`),
          KEY `item` (`itemtype`,`items_id`),
          UNIQUE KEY `deviceid` (`deviceid`),
-         KEY `agenttypes_id` (`agenttypes_id`),
+         KEY `ip_version` (`ip_version`),
+         KEY `ip_binary` (`ip_binary`),
+         KEY `ip_protocol` (`ip_protocol`),
          CONSTRAINT `agenttypes_id` FOREIGN KEY (`agenttypes_id`) REFERENCES `glpi_agenttypes` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
    ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
    $DB->queryOrDie($query, "10.0 add table glpi_agents");
@@ -92,6 +97,22 @@ if (!$DB->tableExists('glpi_agents')) {
    $migration->addKey('glpi_agents', 'entities_id');
    $migration->addKey('glpi_agents', 'is_recursive');
    $migration->addKey('glpi_agents', ['itemtype', 'items_id'], 'item');
+
+   if (!$DB->fieldExists('glpi_agents', 'ip_version')) {
+      $migration->addField("glpi_agents", "ip_version", "tinyint(3) DEFAULT '0'");
+      $migration->addKey('glpi_agents', 'ip_version');
+   }
+
+   if (!$DB->fieldExists('glpi_agents', 'ip_binary')) {
+      $migration->addField("glpi_agents", "ip_binary", "varbinary(16) NOT NULL DEFAULT '0'");
+      $migration->addKey('glpi_agents', 'ip_binary');
+   }
+
+   if (!$DB->fieldExists('glpi_agents', 'ip_protocol')) {
+      $migration->addField("glpi_agents", "ip_protocol", "varchar(5) DEFAULT NULL");
+      $migration->addKey('glpi_agents', 'ip_protocol');
+   }
+
 }
 $ADDTODISPLAYPREF['Agent'] = [2, 4, 10, 8, 11, 6];
 

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8532,6 +8532,9 @@ CREATE TABLE `glpi_agents` (
   `useragent` varchar(255) DEFAULT NULL,
   `tag` varchar(255) DEFAULT NULL,
   `port` varchar(6) DEFAULT NULL,
+  `ip_version` tinyint DEFAULT '0',
+  `ip_binary` varbinary(16) NOT NULL DEFAULT '0',
+  `ip_protocol` varchar(5) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `deviceid` (`deviceid`),
   KEY `name` (`name`),
@@ -8539,6 +8542,9 @@ CREATE TABLE `glpi_agents` (
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `item` (`itemtype`,`items_id`),
+  KEY `ip_version` (`ip_version`),
+  KEY `ip_binary` (`ip_binary`),
+  KEY `ip_protocol` (`ip_protocol`),
   CONSTRAINT `agenttypes_id` FOREIGN KEY (`agenttypes_id`) REFERENCES `glpi_agenttypes` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 

--- a/tests/functionnal/Agent.php
+++ b/tests/functionnal/Agent.php
@@ -110,7 +110,7 @@ class Agent extends DbTestCase {
       $item = $this->testedInstance->getLinkedItem();
       $this->object($item)->isInstanceOf('Computer');
 
-      $this->array($this->testedInstance->guessAddresses())->isIdenticalTo([
+      $this->array($this->testedInstance->getAddress())->isIdenticalTo([
          'glpixps',
          '192.168.1.142',
          'fe80::b283:4fa3:d3f2:96b1',


### PR DESCRIPTION

Actually, GLPI try to get all addresses from computer to request a remote inventory / status

from a standard inventory GLPI return three addresses (or more depending of inventory) (```NetworkPortLocal``` are excluded)
```https://192.168.1.24:62354/status``` (by ipv4)
```https://2a01:e0a:87c:4ea0:f178:597:e709:8aea:62354/status``` (by ipv6)
```https://Desktop:62354/status``` (by name)

Only IPV4 work

This PR Restrict addresses to get only IPV4 compliant

Perhaps we could save the IP used by the agent during the ```PROLOG``` (into ```Agent``` object)



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
