### PR TITLE
Fix autoName with new XSS clean chars

### DIFF
--- a/inc/toolbox/sanitizer.class.php
+++ b/inc/toolbox/sanitizer.class.php
@@ -44,7 +44,7 @@ class Sanitizer {
 
    private const LEGACY_CHARS_MAPPING = [
       '<'  => '&lt;',
-      '>'  =>  '&gt;',
+      '>'  => '&gt;',
    ];
 
    /**
@@ -129,7 +129,11 @@ class Sanitizer {
     */
    public static function isSanitized(string $value): bool {
       $special_chars_pattern   = '/(<|>|(&(?!#?[a-z0-9]+;)))/i';
-      $sanitized_chars_pattern = '/(' . implode('|', array_merge(self::CHARS_MAPPING, self::LEGACY_CHARS_MAPPING)) . ')/';
+      $sanitized_chars = array_merge(
+         array_values(self::CHARS_MAPPING),
+         array_values(self::LEGACY_CHARS_MAPPING)
+      );
+      $sanitized_chars_pattern = '/(' . implode('|', $sanitized_chars) . ')/';
 
       return preg_match($special_chars_pattern, $value) === 0
          && preg_match($sanitized_chars_pattern, $value) === 1;

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -1165,7 +1165,39 @@ class DbUtils extends DbTestCase {
             'itemtype'     => 'Computer',
             'entities_id'  => 2,
             'expected'     => '_test_pc14'
-         ]
+         ], [
+            // existing on entity, new XSS clean output
+            'name'         => '&#60;_test_pc##&#62;',
+            'field'       => 'name',
+            'is_template'  => true,
+            'itemtype'     => 'Computer',
+            'entities_id'  => 2,
+            'expected'     => '_test_pc14'
+         ], [
+            // existing on entity, not sanitized
+            'name'         => '<_test_pc##>',
+            'field'       => 'name',
+            'is_template'  => true,
+            'itemtype'     => 'Computer',
+            'entities_id'  => 2,
+            'expected'     => '_test_pc14'
+         ], [
+            // not existing on entity, new XSS clean output, and containing a special char
+            'name'         => '&#60;pc_&#60;_##&#62;',
+            'field'       => 'name',
+            'is_template'  => true,
+            'itemtype'     => 'Computer',
+            'entities_id'  => 2,
+            'expected'     => 'pc_&#60;_01'
+         ], [
+            // not existing on entity, not sanitized, and containing a special char
+            'name'         => '<pc_>_##>',
+            'field'       => 'name',
+            'is_template'  => true,
+            'itemtype'     => 'Computer',
+            'entities_id'  => 2,
+            'expected'     => 'pc_>_01'
+         ],
       ];
    }
 

--- a/tests/units/Glpi/Toolbox/Sanitizer.php
+++ b/tests/units/Glpi/Toolbox/Sanitizer.php
@@ -67,6 +67,10 @@ class Sanitizer extends \GLPITestCase {
          'sanitized_value' => 'mystring',
       ];
       yield [
+         'value'           => '5 > 1',
+         'sanitized_value' => '5 &#62; 1',
+      ];
+      yield [
          'value'           => '<strong>string</strong>',
          'sanitized_value' => '&#60;strong&#62;string&#60;/strong&#62;',
       ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1) Fix sanitized string detection.
2) Ensure `autoName` is compatible with both old and new "XSS cleaning" process.

Bonus: `autoName` is now also compatible with non sanitized value, and will return a non sanitized value in this case.