### PR TITLE
DB Transaction Savepoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The present file will list all changes made to the project; according to the
 ### API changes
 
 #### Added
+- Added `DBMysql::setSavepoint` to create savepoints within a transaction.
 
 #### Changes
 - Format of `Message-Id` header sent in Tickets notifications changed to match format used by other items.
@@ -34,6 +35,7 @@ The present file will list all changes made to the project; according to the
 - Field `date_mod` of ObjectLock has been renamed to `date`.
 - Field `date_creation` of PrinterLog has been renamed to `date`.
 - Field `date` of ProjectTask has been renamed to `date_creation`.
+- `DBMysql::rollBack` supports a `name` parameter for rolling back to a savepoint.
 
 #### Deprecated
 - Usage of `GLPI_FORCE_EMPTY_SQL_MODE` constant

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -1508,6 +1508,9 @@ class DBmysql {
       }
       if ($this->in_transaction) {
          $this->dbh->savepoint($name);
+      } else {
+         // Not already in transaction or failed to start one now
+         Toolbox::logError('Unable to set DB savepoint because no transaction was started');
       }
    }
 

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -49,8 +49,13 @@ class DBmysql {
    public $dbpassword         = "";
    //! Default Database
    public $dbdefault          = "";
-   //! Database Handler
+
+   /**
+    * The database handler
+    * @var mysqli
+    */
    protected $dbh;
+
    //! Database Error
    public $error              = 0;
 
@@ -1497,6 +1502,15 @@ class DBmysql {
       return $this->dbh->begin_transaction();
    }
 
+   public function setSavepoint(string $name, $force = false) {
+      if (!$this->in_transaction && $force) {
+         $this->beginTransaction();
+      }
+      if ($this->in_transaction) {
+         $this->dbh->savepoint($name);
+      }
+   }
+
    /**
     * Commits a transaction
     *
@@ -1508,13 +1522,22 @@ class DBmysql {
    }
 
    /**
-    * Rollbacks a transaction
+    * Rollbacks a transaction completely or to a specified savepoint
     *
     * @return boolean
     */
-   public function rollBack() {
-      $this->in_transaction = false;
-      return $this->dbh->rollback();
+   public function rollBack($savepoint = null) {
+      if (!$savepoint) {
+         $this->in_transaction = false;
+         $this->dbh->rollback();
+      } else {
+         $this->rollbackTo($savepoint);
+      }
+   }
+
+   protected function rollbackTo($name) {
+      // No proper rollback to savepoint support in mysqli extension?
+      $this->query('ROLLBACK TO '.self::quoteName($name));
    }
 
    /**

--- a/tests/units/DB.php
+++ b/tests/units/DB.php
@@ -502,33 +502,30 @@ SQL;
       global $DB;
 
       $DB->beginTransaction();
-      try {
-         $computer = new \Computer();
-         $DB->setSavepoint('save0', false);
-         $computers_id_0 = $computer->add([
-            'name'        => 'computer0',
-            'entities_id' => 0
-         ]);
-         $this->integer($computers_id_0)->isGreaterThan(0);
-         $DB->setSavepoint('save1', false);
-         $computers_id_1 = $computer->add([
-            'name'        => 'computer1',
-            'entities_id' => 0
-         ]);
-         $this->integer($computers_id_1)->isGreaterThan(0);
-         $this->boolean($computer->getFromDB($computers_id_1))->isTrue();
 
-         $DB->rollBack('save1');
-         $this->boolean($computer->getFromDB($computers_id_1))->isFalse();
-         $this->boolean($computer->getFromDB($computers_id_0))->isTrue();
+      $computer = new \Computer();
+      $DB->setSavepoint('save0', false);
+      $computers_id_0 = $computer->add([
+         'name'        => 'computer0',
+         'entities_id' => 0
+      ]);
+      $this->integer($computers_id_0)->isGreaterThan(0);
+      $DB->setSavepoint('save1', false);
+      $computers_id_1 = $computer->add([
+         'name'        => 'computer1',
+         'entities_id' => 0
+      ]);
+      $this->integer($computers_id_1)->isGreaterThan(0);
+      $this->boolean($computer->getFromDB($computers_id_1))->isTrue();
 
-         $DB->rollBack('save0');
-         $this->boolean($computer->getFromDB($computers_id_1))->isFalse();
-         $this->boolean($computer->getFromDB($computers_id_0))->isFalse();
-      } catch (\Exception $e) {
+      $DB->rollBack('save1');
+      $this->boolean($computer->getFromDB($computers_id_1))->isFalse();
+      $this->boolean($computer->getFromDB($computers_id_0))->isTrue();
 
-      } finally {
-         $DB->rollBack();
-      }
+      $DB->rollBack('save0');
+      $this->boolean($computer->getFromDB($computers_id_1))->isFalse();
+      $this->boolean($computer->getFromDB($computers_id_0))->isFalse();
+
+      $DB->rollBack();
    }
 }

--- a/tests/units/DB.php
+++ b/tests/units/DB.php
@@ -497,4 +497,38 @@ SQL;
          }
       )->error()->notExists();
    }
+
+   public function testSavepoints() {
+      global $DB;
+
+      $DB->beginTransaction();
+      try {
+         $computer = new \Computer();
+         $DB->setSavepoint('save0', false);
+         $computers_id_0 = $computer->add([
+            'name'        => 'computer0',
+            'entities_id' => 0
+         ]);
+         $this->integer($computers_id_0)->isGreaterThan(0);
+         $DB->setSavepoint('save1', false);
+         $computers_id_1 = $computer->add([
+            'name'        => 'computer1',
+            'entities_id' => 0
+         ]);
+         $this->integer($computers_id_1)->isGreaterThan(0);
+         $this->boolean($computer->getFromDB($computers_id_1))->isTrue();
+
+         $DB->rollBack('save1');
+         $this->boolean($computer->getFromDB($computers_id_1))->isFalse();
+         $this->boolean($computer->getFromDB($computers_id_0))->isTrue();
+
+         $DB->rollBack('save0');
+         $this->boolean($computer->getFromDB($computers_id_1))->isFalse();
+         $this->boolean($computer->getFromDB($computers_id_0))->isFalse();
+      } catch (\Exception $e) {
+
+      } finally {
+         $DB->rollBack();
+      }
+   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Support more complex transactions using savepoints (InnoDB feature).
See https://dev.mysql.com/doc/refman/5.6/en/savepoint.html

Added new `DBMysql::setSavepoint` method to add a savepoint within a transaction. The `force` parameter here can be set to true to start a transaction if one isn't started already.
The `DBMysql::rollBack` method was changed to allow a `name` parameter. If specified, it rolls back to the specified savepoint.

The mysqli extension only seems to be able to create and release (remove without rollback or commit) savepoints, but not rollback to them so it has to be done with a raw query.