### PR TITLE
Fix: report by contract failing

### DIFF
--- a/front/report.contract.list.php
+++ b/front/report.contract.list.php
@@ -150,7 +150,6 @@ if (isset($_POST["item_type"]) && is_array($_POST["item_type"])) {
       } else {
          $criteria['SELECT'] = array_merge($criteria['SELECT'], [
             "$itemtable.is_deleted AS itemdeleted",
-            'glpi_locations.completename AS location',
             'glpi_infocoms.buy_date',
             'glpi_infocoms.warranty_duration'
          ]);
@@ -164,12 +163,19 @@ if (isset($_POST["item_type"]) && is_array($_POST["item_type"])) {
                ]
             ]
          ];
-         $criteria['LEFT JOIN']['glpi_locations'] = [
-            'ON'  => [
-               $itemtable        => 'locations_id',
-               'glpi_locations'   => 'id'
-            ]
-         ];
+         if ($DB->fieldExists($itemtable, 'locations_id')) {
+            $criteria['SELECT'] = array_merge($criteria['SELECT'], ['glpi_locations.completename AS location']);
+            $criteria['LEFT JOIN']['glpi_locations'] = [
+               'ON'  => [
+                  $itemtable        => 'locations_id',
+                  'glpi_locations'   => 'id'
+               ]
+            ];
+         } else {
+            $criteria['SELECT'] = array_merge($criteria['SELECT'], 
+               [new QueryExpression("'' AS location")]);
+         }
+
          if ($DB->fieldExists($itemtable, 'is_template')) {
             $criteria['WHERE'][] = ["$itemtable.is_template" => 0];
          }

--- a/front/report.contract.list.php
+++ b/front/report.contract.list.php
@@ -164,7 +164,7 @@ if (isset($_POST["item_type"]) && is_array($_POST["item_type"])) {
             ]
          ];
          if ($DB->fieldExists($itemtable, 'locations_id')) {
-            $criteria['SELECT'] = array_merge($criteria['SELECT'], ['glpi_locations.completename AS location']);
+            $criteria['SELECT'][] = 'glpi_locations.completename AS location';
             $criteria['LEFT JOIN']['glpi_locations'] = [
                'ON'  => [
                   $itemtable        => 'locations_id',

--- a/front/report.contract.list.php
+++ b/front/report.contract.list.php
@@ -172,7 +172,7 @@ if (isset($_POST["item_type"]) && is_array($_POST["item_type"])) {
                ]
             ];
          } else {
-            $criteria['SELECT'] = array_merge($criteria['SELECT'], 
+            $criteria['SELECT'] = array_merge($criteria['SELECT'],
                [new QueryExpression("'' AS location")]);
          }
 

--- a/front/report.contract.list.php
+++ b/front/report.contract.list.php
@@ -172,8 +172,7 @@ if (isset($_POST["item_type"]) && is_array($_POST["item_type"])) {
                ]
             ];
          } else {
-            $criteria['SELECT'] = array_merge($criteria['SELECT'],
-               [new QueryExpression("'' AS location")]);
+            $criteria['SELECT'][] = new QueryExpression("'' AS location");
          }
 
          if ($DB->fieldExists($itemtable, 'is_template')) {


### PR DESCRIPTION
Report by contract was failling because of missing location_id in clusters, the change simply set the location complete name to  empty string

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | None created
