### PR TITLE
Remove Remi's RPM source (unmaintained)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ Please, consider using browsers on editor's supported version
 
 See :
 * [releases](https://github.com/glpi-project/glpi/releases) for tarball packages.
-* [Remi's RPM repository](http://rpms.remirepo.net/) for RPM packages (Fedora, RHEL, CentOS)
 
 
 ## Documentation


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none

See https://mail.ow2.org/wws/arc/glpi-dev/2020-02/msg00000.html : packages will stay on 9.4 version.
As mentioned on the support lifecycle, 9.4 version is unmaintained by the GLPI team.

Thank's to Remi for the long time work in order to maintain theses packages !