### PR TITLE
fix(inventoriable): better way to find agent

### DIFF
--- a/inc/features/inventoriable.class.php
+++ b/inc/features/inventoriable.class.php
@@ -125,12 +125,15 @@ trait Inventoriable {
       echo '</tr>';
 
       $agent = new Agent();
-      $iterator = $DB->request(Agent::getTable(), [
+      $iterator = $DB->request([
+         'SELECT'    => ['id'],
+         'FROM'      => Agent::getTable(),
          'WHERE'     => [
             'itemtype' => $this->getType(),
             'items_id' => $this->fields['id']
          ],
-         'ORDERBY'    => ['last_contact DESC'],
+         'ORDERBY'   => ['last_contact DESC'],
+         'LIMIT'     => 1
       ]);
 
       $has_agent = false;


### PR DESCRIPTION
Better way to find agent linked to asset if if we have more than one agent linked

Returns the last agent that contacted GLPI


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
