### PR TITLE
Fix kanban add/delete actions

### DIFF
--- a/ajax/kanban.php
+++ b/ajax/kanban.php
@@ -121,14 +121,14 @@ if ($_REQUEST['action'] === 'update') {
    $checkParams(['inputs']);
    $item = new $itemtype();
    $inputs = [];
-   parse_str($_REQUEST['inputs'], $inputs);
+   parse_str($_UPOST['inputs'], $inputs);
 
    $item->add(Sanitizer::sanitize($inputs));
 } else if ($_REQUEST['action'] === 'bulk_add_item') {
    $checkParams(['inputs']);
    $item = new $itemtype();
    $inputs = [];
-   parse_str($_REQUEST['inputs'], $inputs);
+   parse_str($_UPOST['inputs'], $inputs);
 
    $bulk_item_list = preg_split('/\r\n|[\r\n]/', $inputs['bulk_item_list']);
    if (!empty($bulk_item_list)) {
@@ -136,7 +136,7 @@ if ($_REQUEST['action'] === 'update') {
       foreach ($bulk_item_list as $item_entry) {
          $item_entry = trim($item_entry);
          if (!empty($item_entry)) {
-            $item->add(Sanitizer::sanitize($inputs + ['name' => $item_entry]));
+            $item->add(Sanitizer::sanitize($inputs + ['name' => $item_entry, 'content' => '']));
          }
       }
    }

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -1176,7 +1176,6 @@ class GLPIKanbanRights {
                items_id: items_id,
                force: force ? 1 : 0
             },
-            contentType: 'application/json',
             error: function() {
                if (error) {
                   error();

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -777,7 +777,7 @@ class GLPIKanbanRights {
          });
          $('#kanban-add-dropdown li').on('click', function(e) {
             e.preventDefault();
-            const selection = $(e.target);
+            const selection = $(this);
             // The add dropdown is a single-level dropdown, so the parent is the ul element
             const dropdown = selection.parent();
             // Get the button that triggered the dropdown and then get the column that it is a part of
@@ -791,7 +791,7 @@ class GLPIKanbanRights {
          });
          $('#kanban-bulk-add-dropdown li').on('click', function(e) {
             e.preventDefault();
-            const selection = $(e.target);
+            const selection = $(this);
             // Traverse all the way up to the top-level overflow dropdown
             const dropdown = selection.closest('.kanban-dropdown');
             // Get the button that triggered the dropdown and then get the column that it is a part of


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. The delete action was not working, as form data was sent with an `application/json` content type instead of the default `application/x-www-form-urlencoded`.
2. add/bulk_add actions were not working anymore due to #8763. Indeed `&` char is now transformed, so parsed `inputs` were invalid (see below). Using the raw POST fixes this.
3. Having a `null` value on project/projecttask content may result in issues, for instance while this content is handled by `Glpi\Toolbox\RichText` methods which are not expecting to receive a null value. Defining `content` field with an empty string fixes this.