### PR TITLE
retro compatibility

### DIFF
--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -2126,7 +2126,7 @@ class Dropdown {
     *
     * @since 0.83
    **/
-   static function showOutputFormat($itemtype = NULL) {
+   static function showOutputFormat($itemtype = null) {
       global $CFG_GLPI;
 
       $values[Search::PDF_OUTPUT_LANDSCAPE]     = __('Current page in landscape PDF');

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -2126,7 +2126,7 @@ class Dropdown {
     *
     * @since 0.83
    **/
-   static function showOutputFormat($itemtype) {
+   static function showOutputFormat($itemtype = NULL) {
       global $CFG_GLPI;
 
       $values[Search::PDF_OUTPUT_LANDSCAPE]     = __('Current page in landscape PDF');


### PR DESCRIPTION
$itemtype is used only in case of stat, all the other cases don't need params, without default it create a compatibility issue with reports plugin (and I guess other piece of code)



| Q             | A
| ------------- | ---
| Bug fix?      | yes (but on master)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
