### PR TITLE
fix(richtext): use richtext instead of textarea

### DIFF
--- a/inc/notificationtemplatetranslation.class.php
+++ b/inc/notificationtemplatetranslation.class.php
@@ -107,8 +107,6 @@ class NotificationTemplateTranslation extends CommonDBChild {
       $template = new NotificationTemplate();
       $template->getFromDB($notificationtemplates_id);
 
-      Html::initEditorSystem('content_html');
-
       $this->showFormHeader($options);
 
       echo "<tr class='tab_bg_1'>";
@@ -155,8 +153,15 @@ class NotificationTemplateTranslation extends CommonDBChild {
       echo "<td>";
       echo __('Email HTML body');
       echo "</td><td colspan='3'>";
-      echo "<textarea cols='100' rows='15' name='content_html'>".$this->fields["content_html"];
-      echo "</textarea>";
+      $content_id = "content$rand";
+      Html::textarea(['name'              => 'content_html',
+                         'value'             => RichText::getSafeHtml($this->fields['content_html'], true, true),
+                         'rand'              => $rand,
+                         'editor_id'         => $content_id,
+                         'enable_fileupload' => false,
+                         'enable_richtext'   => true,
+                         'cols'              => 100,
+                         'rows'              => 15]);
       echo "<input type='hidden' name='notificationtemplates_id' value='".
              $template->getField('id')."'>";
       echo "</td></tr>";


### PR DESCRIPTION

Fix RichText area

![image](https://user-images.githubusercontent.com/7335054/130749654-dc111726-2491-4952-ac06-6b6e0b267674.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
