### PR TITLE
fix(infocom): prevent 'division by zero' warning

### DIFF
--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -784,7 +784,11 @@ class Infocom extends CommonDBChild {
 
       $elapsed_years = $now->format('Y') - $usedate->format('Y');
 
-      $annuity = $value * (1 / $duration);
+      $annuity = 0;
+      if ($duration) {
+         $annuity = $value * (1 / $duration);
+      }
+
       $years = [];
       for ($i = 0; $i <= $elapsed_years; ++$i) {
          $begin_value      = $value;


### PR DESCRIPTION
Prevent warning from infocom when ```Amortization duration``` is 0

![image](https://user-images.githubusercontent.com/7335054/130759984-165652d0-b79b-4c04-b091-ba22e9125978.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 21118


