### PR TITLE
To create correct LDAP filters from a dn

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -1780,8 +1780,7 @@ class User extends CommonDBTM {
       $listgroups = [];
 
       //User dn may contain ( or ), need to espace it!
-      $user_dn = str_replace(["(", ")", "\,", "\+"], ["\(", "\)", "\\\,", "\\\+"],
-                             $user_dn);
+      $user_dn = ldap_escape($user_dn, "", LDAP_ESCAPE_FILTER);
 
       //Only retrive cn and member attributes from groups
       $attrs = ['dn'];


### PR DESCRIPTION
ldap_escape() will escape the chars that must be escaped from the dn to be used in a LDAP filter.
Otherwise some chars are missing, and some are escaped when not mandatory.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
