### PR TITLE
Missing config entry at install

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -298,6 +298,7 @@ $default_prefs = [
    // Default size corresponds to the 'upload_max_filesize' directive in Mio (rounded down) or 1 Mio if 'upload_max_filesize' is too low.
    'document_max_size'                       => max(1, floor(Toolbox::return_bytes_from_ini_vars(ini_get('upload_max_filesize')) / 1024 / 1024)),
    'planning_work_days'                      => exportArrayToDB([0, 1, 2, 3, 4, 5, 6]),
+   'system_user'                             => '',
 ];
 
 $tables['glpi_configs'] = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

To prevent an undefined index on `system_user` configuration entry (apparently missed in #8706)
