### PR TITLE
Add safety check on planning data

### DIFF
--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -867,6 +867,11 @@ class Planning extends CommonGLPI {
    static function showSingleLinePlanningFilter($filter_key, $filter_data, $options = []) {
       global $CFG_GLPI;
 
+      // Invalid data, skip
+      if (!isset($filter_data['type'])) {
+         return;
+      }
+
       $params['show_delete']        = true;
       $params['filter_color_index'] = 0;
       if (is_array($options) && count($options)) {


### PR DESCRIPTION
I found some invalid planning data on an instance:
![image](https://user-images.githubusercontent.com/42734840/131315629-5e5e0998-129c-4d9b-9f8c-7e48b0f7c20e.png)

It seems the code in `Planning::showSingleLinePlanningFilter()` expect a "type" key for each items, which you can see is missing for "user_22043" in the screenshot above.

This throw an exception and prevent the whole planning from loading as some mandatory code is never executed and we end up with null references.

These changes prevent the planning from failing to load in case of faulty data.
It would also be nice to fix the source that add this incorrect data but I was unable to find it (this data come directly from the database so it isn't easy to find its origin).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22513
