### PR TITLE
Reduce search memory usage

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1232,7 +1232,11 @@ class Search {
          if (!$data['search']['no_search']
              || $data['search']['export_all']) {
             $first_row = $result->fetch_assoc();
-            $data['data']['totalcount'] = $first_row['_query_total'];
+            if (is_null($first_row)) {
+               $data['data']['totalcount'] = 0;
+            } else {
+               $data['data']['totalcount'] = $first_row['_query_total'];
+            }
          } else {
             if (!isset($data['sql']['count'])
                || (count($data['sql']['count']) == 0)) {


### PR DESCRIPTION
Improve memory usage by a LOT.

The search module only used LIMIT for searches with no criteria (SELECT *).
These changes force every search request to respect the LIMIT criteria.

It does seem to lower a bit SQL performances (request seems to be between 10 or 20% longer) but completely negate the memory used by the SQL search results.

For example, on a test server with 250k tickets, the server memory limit of 256MB (!!) would be reached if the search returned more than 30k tickets.
Now it doesn't matter how many results are returned: the memory stays around 15MB as we only load the 200 items of the current page instead of up to 250k tickets.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22511
