### PR TITLE
Add ##timeline## tag for notifications

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6875,6 +6875,7 @@ abstract class CommonITILObject extends CommonDBTM {
          'with_documents' => true,
          'with_validations' => true,
          'expose_private' => false,
+         'bypass_rights' => false,
       ];
 
       if (is_array($options) && count($options)) {
@@ -6927,7 +6928,7 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       //add followups to timeline
-      if ($followup_obj->canview()) {
+      if ($followup_obj->canview() || $params['bypass_rights']) {
          $followups = $followup_obj->find(['items_id'  => $this->getID()] + $restrict_fup, ['date DESC', 'id DESC']);
          foreach ($followups as $followups_id => $followup) {
             $followup_obj->getFromDB($followups_id);
@@ -6939,7 +6940,7 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       //add tasks to timeline
-      if ($task_obj->canview()) {
+      if ($task_obj->canview() || $params['bypass_rights']) {
          $tasks = $task_obj->find([$foreignKey => $this->getID()] + $restrict_task, 'date DESC');
          foreach ($tasks as $tasks_id => $task) {
             $task_obj->getFromDB($tasks_id);

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7016,7 +7016,7 @@ abstract class CommonITILObject extends CommonDBTM {
                   'id'        => $validations_id,
                   'date'      => $validation['submission_date'],
                   'content'   => __('Validation request')." => ".$user->getlink().
-                                                "<br>".$validation['comment_submission'],
+                                                 "<br>".$validation['comment_submission'],
                   'users_id'  => $validation['users_id'],
                   'can_edit'  => $canedit,
                   'can_answer'   => $cananswer,
@@ -7033,7 +7033,7 @@ abstract class CommonITILObject extends CommonDBTM {
                      'id'        => $validations_id,
                      'date'      => $validation['validation_date'],
                      'content'   => __('Validation request answer')." : ". _sx('status',
-                                                ucfirst($validation_class::getStatus($validation['status'])))
+                                                 ucfirst($validation_class::getStatus($validation['status'])))
                                                    ."<br>".$validation['comment_validation'],
                      'users_id'  => $validation['users_id_validate'],
                      'status'    => "status_".$validation['status'],

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6900,7 +6900,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       //checks rights
       $restrict_fup = $restrict_task = [];
-      if (!Session::haveRight("followup", ITILFollowup::SEEPRIVATE)) {
+      if (!$params['expose_private'] && $task_obj->maybePrivate() && !Session::haveRight("followup", ITILFollowup::SEEPRIVATE)) {
          $restrict_fup = [
             'OR' => [
                'is_private'   => 0,
@@ -6909,15 +6909,11 @@ abstract class CommonITILObject extends CommonDBTM {
          ];
       }
 
-      //if is from notif and if we want private too
-      if (!Session::haveRight("followup", ITILFollowup::SEEPRIVATE) && $params['expose_private']) {
-         $restrict_fup = [];
-      }
 
       $restrict_fup['itemtype'] = static::getType();
       $restrict_fup['items_id'] = $this->getID();
 
-      if ($task_obj->maybePrivate() && !Session::haveRight("task", CommonITILTask::SEEPRIVATE)) {
+      if (!$params['expose_private'] && $task_obj->maybePrivate() && !Session::haveRight("task", CommonITILTask::SEEPRIVATE)) {
          $restrict_task = [
             'OR' => [
                'is_private'   => 0,
@@ -6926,11 +6922,6 @@ abstract class CommonITILObject extends CommonDBTM {
                                     : 0
             ]
          ];
-      }
-
-      //if is from notif and if we want private too
-      if (!Session::haveRight("task", CommonITILTask::SEEPRIVATE) && $params['expose_private']) {
-         $restrict_task = [];
       }
 
       //add followups to timeline

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6866,7 +6866,7 @@ abstract class CommonITILObject extends CommonDBTM {
     *
     * @return mixed[] Timeline items
     */
-   function getTimelineItems($options) {
+   function getTimelineItems(array $options = []) {
 
       $params = [
          'with_documents' => true,
@@ -6879,8 +6879,6 @@ abstract class CommonITILObject extends CommonDBTM {
             $params[$key] = $val;
          }
       }
-
-
 
       $objType = static::getType();
       $foreignKey = static::getForeignKeyField();
@@ -6931,7 +6929,7 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       //if is from notif and if we want private too
-      if (!Session::haveRight("followup", ITILFollowup::SEEPRIVATE) && $params['expose_private']) {
+      if (!Session::haveRight("task", CommonITILTask::SEEPRIVATE) && $params['expose_private']) {
          $restrict_task = [];
       }
 

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6898,7 +6898,7 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       //is requested from notification only public
-      if ($from_notification){
+      if ($from_notification) {
          $restrict_fup = [
             'is_private'   => 0,
          ];
@@ -6919,7 +6919,7 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       //is requested from notification only public
-      if ($from_notification){
+      if ($from_notification) {
          $restrict_task = [
                'is_private'   => 0,
          ];
@@ -7145,7 +7145,6 @@ abstract class CommonITILObject extends CommonDBTM {
 
          // set item position depending on field timeline_position
          $user_position = self::getUserPositionFromTimelineItemPosition($item_i['timeline_position']);
-
 
          //display solution in middle
          if (($item['type'] == "Solution") && $item_i['status'] != CommonITILValidation::REFUSED

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6897,11 +6897,9 @@ abstract class CommonITILObject extends CommonDBTM {
          ];
       }
 
-      //is requested only public
+      //if is from notif and if we want private too
       if ($from_notification && $get_private) {
-         $restrict_fup = [
-            'is_private'   => 0,
-         ];
+         $restrict_fup = [];
       }
 
       $restrict_fup['itemtype'] = static::getType();
@@ -6918,11 +6916,9 @@ abstract class CommonITILObject extends CommonDBTM {
          ];
       }
 
-      //is requested only public
+      //if is from notif and if we want private too
       if ($from_notification && $get_private) {
-         $restrict_task = [
-               'is_private'   => 0,
-         ];
+         $restrict_task = [];
       }
 
       //add followups to timeline

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6861,7 +6861,10 @@ abstract class CommonITILObject extends CommonDBTM {
    /**
     * Retrieves all timeline items for this ITILObject
     *
-    * @param boolean $from_notification define if timeline is requested from notification
+    * @param array $options Possible options:
+    * - with_documents : include documents elements
+    * - with_validations : include validation elements
+    * - expose_private : force presence of private items (followup/tasks), even if session does not allow it
     * @since 9.4.0
     *
     * @return mixed[] Timeline items
@@ -6871,7 +6874,7 @@ abstract class CommonITILObject extends CommonDBTM {
       $params = [
          'with_documents' => true,
          'with_validations' => true,
-         'expose_private' => false, // Force presence of private items (followup/tasks), even if session does not allow it
+         'expose_private' => false,
       ];
 
       if (is_array($options) && count($options)) {
@@ -6948,7 +6951,6 @@ abstract class CommonITILObject extends CommonDBTM {
          }
       }
 
-      //add documents to timeline if it not requested from notification
       if ($params['with_documents']) {
          $document_obj   = new Document();
          $document_items = $document_item_obj->find([
@@ -6999,7 +7001,6 @@ abstract class CommonITILObject extends CommonDBTM {
          ];
       }
 
-      //add validation workflow to timeline if it not requested from notification
       if ($params['with_validations']) {
          if ($supportsValidation and $validation_class::canView()) {
             $validations = $valitation_obj->find([$foreignKey => $this->getID()]);

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6866,7 +6866,7 @@ abstract class CommonITILObject extends CommonDBTM {
     *
     * @return mixed[] Timeline items
     */
-   function getTimelineItems($from_notification = false) {
+   function getTimelineItems($from_notification = false, $get_private = false) {
 
       $objType = static::getType();
       $foreignKey = static::getForeignKeyField();
@@ -6897,8 +6897,8 @@ abstract class CommonITILObject extends CommonDBTM {
          ];
       }
 
-      //is requested from notification only public
-      if ($from_notification) {
+      //is requested only public
+      if ($from_notification && $get_private) {
          $restrict_fup = [
             'is_private'   => 0,
          ];
@@ -6918,8 +6918,8 @@ abstract class CommonITILObject extends CommonDBTM {
          ];
       }
 
-      //is requested from notification only public
-      if ($from_notification) {
+      //is requested only public
+      if ($from_notification && $get_private) {
          $restrict_task = [
                'is_private'   => 0,
          ];

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6912,7 +6912,6 @@ abstract class CommonITILObject extends CommonDBTM {
          ];
       }
 
-
       $restrict_fup['itemtype'] = static::getType();
       $restrict_fup['items_id'] = $this->getID();
 

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6865,6 +6865,7 @@ abstract class CommonITILObject extends CommonDBTM {
     * - with_documents : include documents elements
     * - with_validations : include validation elements
     * - expose_private : force presence of private items (followup/tasks), even if session does not allow it
+    * - bypass_rights : bypass current session rights
     * @since 9.4.0
     *
     * @return mixed[] Timeline items

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6900,7 +6900,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       //checks rights
       $restrict_fup = $restrict_task = [];
-      if (!$params['expose_private'] && $task_obj->maybePrivate() && !Session::haveRight("followup", ITILFollowup::SEEPRIVATE)) {
+      if (!$params['expose_private'] && !Session::haveRight("followup", ITILFollowup::SEEPRIVATE)) {
          $restrict_fup = [
             'OR' => [
                'is_private'   => 0,

--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -292,11 +292,7 @@ JAVASCRIPT;
    }
 
    function prepareInputForAdd($input) {
-<<<<<<< HEAD
       if (!isset($input['users_id']) && !(Session::isCron() || strpos($_SERVER['REQUEST_URI'], 'crontask.form.php') !== false)) {
-=======
-      if (!isset($input['users_id']) && (Session::isCron() || strpos($_SERVER['REQUEST_URI'], 'crontask.form.php') !== false)) {
->>>>>>> revert change from another PR
          $input['users_id'] = Session::getLoginUserID();
       }
 

--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -292,7 +292,11 @@ JAVASCRIPT;
    }
 
    function prepareInputForAdd($input) {
+<<<<<<< HEAD
       if (!isset($input['users_id']) && !(Session::isCron() || strpos($_SERVER['REQUEST_URI'], 'crontask.form.php') !== false)) {
+=======
+      if (!isset($input['users_id']) && (Session::isCron() || strpos($_SERVER['REQUEST_URI'], 'crontask.form.php') !== false)) {
+>>>>>>> revert change from another PR
          $input['users_id'] = Session::getLoginUserID();
       }
 

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1531,9 +1531,12 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
          foreach ($timeline as $timeline_data) {
 
             if ($timeline_data['type'] == "Solution"){
-               $timeline_data['type'] = ITILSolution::getType();
+               $tmptimelineitems['##timelineitems.type##'] = ITILSolution::getType();
+            }else{
+               $tmptimelineitems['##timelineitems.type##'] = $timeline_data['type']::getType();
             }
-            $tmptimelineitems['##timelineitems.type##']        = $timeline_data['type']::getTypeName(0);
+
+            $tmptimelineitems['##timelineitems.typename##']    = $tmptimelineitems['##timelineitems.type##']::getTypeName(0);
             $tmptimelineitems['##timelineitems.date##']        = $timeline_data['item']['date'];
             $tmptimelineitems['##timelineitems.description##'] = $timeline_data['item']['content'];
             $tmptimelineitems['##timelineitems.position##']    = CommonITILObject::getUserPositionFromTimelineItemPosition($timeline_data['item']['timeline_position']);
@@ -1686,9 +1689,10 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
                                                                    Entity::getTypeName(1), __('Country')),
                     'timelineitems.author'              => __('Writer'),
                     'timelineitems.date'                => __('Opening date'),
-                    'timelineitems.type'                => __('Type'),
+                    'timelineitems.type'                => __('Internal type'),
+                    'timelineitems.typename'            => __('Type'),
                     'timelineitems.description'         => __('Description'),
-                    'timelineitems.position'         => __('Position'),
+                    'timelineitems.position'            => __('Position'),
 
                    ];
 

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1529,6 +1529,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
             'with_documents' => false,
             'with_validations' => false,
             'expose_private' => $show_private,
+            'bypass_rights' => true,
          ];
 
          $timeline = $item->getTimelineItems($options);

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1708,7 +1708,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
                     'costs'     => _n('Cost', 'Costs', Session::getPluralNumber()),
                     'authors'   => _n('Requester', 'Requesters', Session::getPluralNumber()),
                     'suppliers' => _n('Supplier', 'Suppliers', Session::getPluralNumber()),
-                    'timelineitems' => __('Processing '.strtolower($objettype))];
+                    'timelineitems' => sprintf(__('Processing %1$s'), strtolower($objettype))];
 
       foreach ($tags as $tag => $label) {
          $this->addTagToList(['tag'     => $tag,

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1725,7 +1725,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
                     $objettype.'.log'                => __('Historical'),
                     $objettype.'.tasks'              => _n('Task', 'Tasks', Session::getPluralNumber()),
                     $objettype.'.costs'              => _n('Cost', 'Costs', Session::getPluralNumber()),
-                    $objettype.'.timelineitems'       => __('Processing '.strtolower($objettype))];
+                    $objettype.'.timelineitems'       => sprintf(__('Processing %1$s'), strtolower($objettype))];
 
       foreach ($tags as $tag => $label) {
          $this->addTagToList(['tag'   => $tag,

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1552,9 +1552,6 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
                } else {
                   $tmptimelineitems['##timelineitems.author##'] = getUserName($timeline_data['item']['users_id']);
                }
-            } else if ($timeline_data['type'] == "Solution") {
-               //empty author like GLPI timeline
-               $tmptimelineitems['##timelineitems.author##'] = '';
             } else {
                $tmptimelineitems['##timelineitems.author##'] = getUserName($timeline_data['item']['users_id']);
             }

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1530,21 +1530,22 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
             'with_validations' => false,
             'expose_private' => $show_private,
          ];
-         $tmptimelineitems = [];
-         $timeline = $item->getTimelineItems(true, $options);
+         
+         $timeline = $item->getTimelineItems($options);
 
          foreach ($timeline as $timeline_data) {
+            $tmptimelineitem = [];
 
             if ($timeline_data['type'] == "Solution") {
-               $tmptimelineitems['##timelineitems.type##'] = ITILSolution::getType();
+               $tmptimelineitem['##timelineitems.type##'] = ITILSolution::getType();
             } else {
-               $tmptimelineitems['##timelineitems.type##'] = $timeline_data['type']::getType();
+               $tmptimelineitem['##timelineitems.type##'] = $timeline_data['type']::getType();
             }
 
-            $tmptimelineitems['##timelineitems.typename##']    = $tmptimelineitems['##timelineitems.type##']::getTypeName(0);
-            $tmptimelineitems['##timelineitems.date##']        = $timeline_data['item']['date'];
-            $tmptimelineitems['##timelineitems.description##'] = $timeline_data['item']['content'];
-            $tmptimelineitems['##timelineitems.position##']    = CommonITILObject::getUserPositionFromTimelineItemPosition($timeline_data['item']['timeline_position']);
+            $tmptimelineitem['##timelineitems.typename##']    = $tmptimelineitem['##timelineitems.type##']::getTypeName(0);
+            $tmptimelineitem['##timelineitems.date##']        = $timeline_data['item']['date'];
+            $tmptimelineitem['##timelineitems.description##'] = $timeline_data['item']['content'];
+            $tmptimelineitem['##timelineitems.position##']    = CommonITILObject::getUserPositionFromTimelineItemPosition($timeline_data['item']['timeline_position']);
 
             if ($timeline_data['type'] == ITILFollowup::getType()) {
                // Check if the author need to be anonymized
@@ -1555,14 +1556,14 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
                      $item->getField('entities_id')
                   ))
                ) {
-                  $tmptimelineitems['##timelineitems.author##'] = $anon_name;
+                  $tmptimelineitem['##timelineitems.author##'] = $anon_name;
                } else {
-                  $tmptimelineitems['##timelineitems.author##'] = getUserName($timeline_data['item']['users_id']);
+                  $tmptimelineitem['##timelineitems.author##'] = getUserName($timeline_data['item']['users_id']);
                }
             } else {
-               $tmptimelineitems['##timelineitems.author##'] = getUserName($timeline_data['item']['users_id']);
+               $tmptimelineitem['##timelineitems.author##'] = getUserName($timeline_data['item']['users_id']);
             }
-            $data['timelineitems'][] = $tmptimelineitems;
+            $data['timelineitems'][] = $tmptimelineitem;
          }
 
       }

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1524,7 +1524,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
          $data["##$objettype.numberoftasks##"] = count($data['tasks']);
 
          $data['timelineitems'] = [];
-         $timeline = $item->getTimelineItems(true);
+         $timeline = $item->getTimelineItems(true, $show_private);
 
          foreach ($timeline as $timeline_data) {
 

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1530,7 +1530,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
             'with_validations' => false,
             'expose_private' => $show_private,
          ];
-         
+
          $timeline = $item->getTimelineItems($options);
 
          foreach ($timeline as $timeline_data) {

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1523,16 +1523,14 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
 
          $data["##$objettype.numberoftasks##"] = count($data['tasks']);
 
-
          $data['timelineitems'] = [];
          $timeline = $item->getTimelineItems(true);
 
-
          foreach ($timeline as $timeline_data) {
 
-            if ($timeline_data['type'] == "Solution"){
+            if ($timeline_data['type'] == "Solution") {
                $tmptimelineitems['##timelineitems.type##'] = ITILSolution::getType();
-            }else{
+            } else {
                $tmptimelineitems['##timelineitems.type##'] = $timeline_data['type']::getType();
             }
 
@@ -1554,6 +1552,9 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
                } else {
                   $tmptimelineitems['##timelineitems.author##'] = getUserName($timeline_data['item']['users_id']);
                }
+            } else if ($timeline_data['type'] == "Solution") {
+               //empty author like GLPI timeline
+               $tmptimelineitems['##timelineitems.author##'] = '';
             } else {
                $tmptimelineitems['##timelineitems.author##'] = getUserName($timeline_data['item']['users_id']);
             }
@@ -1690,7 +1691,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
                     'timelineitems.author'              => __('Writer'),
                     'timelineitems.date'                => __('Opening date'),
                     'timelineitems.type'                => __('Internal type'),
-                    'timelineitems.typename'            => __('Type'),
+                    'timelineitems.typename'            => _n('Type', 'Types', 1),
                     'timelineitems.description'         => __('Description'),
                     'timelineitems.position'            => __('Position'),
 

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1524,7 +1524,14 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
          $data["##$objettype.numberoftasks##"] = count($data['tasks']);
 
          $data['timelineitems'] = [];
-         $timeline = $item->getTimelineItems(true, $show_private);
+
+         $options = [
+            'with_documents' => false,
+            'with_validations' => false,
+            'expose_private' => $show_private,
+         ];
+         $tmptimelineitems = [];
+         $timeline = $item->getTimelineItems(true, $options);
 
          foreach ($timeline as $timeline_data) {
 

--- a/inc/notificationtemplatetranslation.class.php
+++ b/inc/notificationtemplatetranslation.class.php
@@ -162,6 +162,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
                          'enable_richtext'   => true,
                          'cols'              => 100,
                          'rows'              => 15]);
+
       echo "<input type='hidden' name='notificationtemplates_id' value='".
              $template->getField('id')."'>";
       echo "</td></tr>";

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -4075,6 +4075,19 @@ $tables['glpi_notificationtemplatetranslations'] = [
  ##lang.followup.requesttype## ##followup.requesttype##
 
 ##ENDFOREACHfollowups##
+
+##FOREACHtimelineitems##
+
+ [##timelineitems.date##]
+ ##lang.timelineitems.author## ##timelineitems.author##
+ ##lang.timelineitems.description## ##timelineitems.description##
+ ##lang.timelineitems.date## ##timelineitems.date##
+ ##lang.timelineitems.position## ##timelineitems.position##
+ ##lang.timelineitems.type## ##timelineitems.type##
+ ##lang.timelineitems.typename## ##timelineitems.typename##
+
+##ENDFOREACHtimelineitems##
+
  ##lang.ticket.numberoftasks## : ##ticket.numberoftasks##
 
 ##FOREACHtasks##
@@ -4104,6 +4117,11 @@ $tables['glpi_notificationtemplatetranslations'] = [
 <p>##FOREACHfollowups##</p>
 <div class="description b"><br /> <strong> [##followup.date##] <em>##lang.followup.isprivate## : ##followup.isprivate## </em></strong><br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.followup.author## </span> ##followup.author##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.followup.description## </span> ##followup.description##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.followup.date## </span> ##followup.date##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.followup.requesttype## </span> ##followup.requesttype##</div>
 <p>##ENDFOREACHfollowups##</p>
+<p>##ENDFOREACHtimelineitems##</p>
+<div class="description b"><br /><strong> [##timelineitems.date##]</strong><br /><span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.timelineitems.author## </span> ##<span style="color: #000000; font-weight: bold; text-decoration: underline; background-color: #ffffff;">timelineitems</span>.author##<br /><span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.timelineitems.description## </span> ##<span style="color: #000000; font-weight: bold; text-decoration: underline;">timelineitems</span>.description##<br /><span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.timelineitems.date## </span> ##<span style="color: #000000; font-weight: bold; text-decoration: underline;">timelineitems</span>.date##<br /><span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;">##lang.timelineitems.position## </span><span style="color: #000000;"> ##<span style="font-weight: bold; text-decoration: underline;">timelineitems</span>.<span style="font-weight: bold; text-decoration: underline;">position</span>##</span></div>
+<div class="description b"><span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;">##lang.timelineitems.type## </span> ##<span style="color: #000000;"><span style="font-weight: bold; text-decoration: underline;">timelineitems</span>.<span style="font-weight: bold; text-decoration: underline;">type</span>##</span></div>
+<div class="description b"><span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;">##lang.timelineitems.typename## </span> #<span style="color: #000000;">#<span style="font-weight: bold; text-decoration: underline;">timelineitems</span>.<span style="font-weight: bold; text-decoration: underline;">typename</span>##</span></div>
+<p>##ENDFOREACHtimelineitems##</p>
 <div class="description b">##lang.ticket.numberoftasks##&#160;: ##ticket.numberoftasks##</div>
 <p>##FOREACHtasks##</p>
 <div class="description b"><br /> <strong> [##task.date##] <em>##lang.task.isprivate## : ##task.isprivate## </em></strong><br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.task.author##</span> ##task.author##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.task.description##</span> ##task.description##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.task.time##</span> ##task.time##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.task.category##</span> ##task.category##</div>

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -4064,41 +4064,19 @@ $tables['glpi_notificationtemplatetranslations'] = [
  ##lang.ticket.solution.type## : ##ticket.solution.type##
  ##lang.ticket.solution.description## : ##ticket.solution.description##
  ##ENDIFticket.storestatus##
- ##lang.ticket.numberoffollowups## : ##ticket.numberoffollowups##
-
-##FOREACHfollowups##
-
- [##followup.date##] ##lang.followup.isprivate## : ##followup.isprivate##
- ##lang.followup.author## ##followup.author##
- ##lang.followup.description## ##followup.description##
- ##lang.followup.date## ##followup.date##
- ##lang.followup.requesttype## ##followup.requesttype##
-
-##ENDFOREACHfollowups##
 
 ##FOREACHtimelineitems##
-
- [##timelineitems.date##]
- ##lang.timelineitems.author## ##timelineitems.author##
- ##lang.timelineitems.description## ##timelineitems.description##
- ##lang.timelineitems.date## ##timelineitems.date##
- ##lang.timelineitems.position## ##timelineitems.position##
- ##lang.timelineitems.type## ##timelineitems.type##
- ##lang.timelineitems.typename## ##timelineitems.typename##
-
+[##timelineitems.date##]
+##lang.timelineitems.author## ##timelineitems.author##
+##lang.timelineitems.description## ##timelineitems.description##
+##lang.timelineitems.date## ##timelineitems.date##
+##lang.timelineitems.position## ##timelineitems.position##
+##lang.timelineitems.type## ##timelineitems.type##
+##lang.timelineitems.typename## ##timelineitems.typename##
 ##ENDFOREACHtimelineitems##
 
- ##lang.ticket.numberoftasks## : ##ticket.numberoftasks##
-
-##FOREACHtasks##
-
- [##task.date##] ##lang.task.isprivate## : ##task.isprivate##
- ##lang.task.author## ##task.author##
- ##lang.task.description## ##task.description##
- ##lang.task.time## ##task.time##
- ##lang.task.category## ##task.category##
-
-##ENDFOREACHtasks##',
+##lang.ticket.numberoffollowups## : ##ticket.numberoffollowups##
+##lang.ticket.numberoftasks## : ##ticket.numberoftasks##',
       'content_html'             => '<!-- description{ color: inherit; background: #ebebeb; border-style: solid;border-color: #8d8d8d; border-width: 0px 1px 1px 0px; }    -->
 <div>##IFticket.storestatus=5##</div>
 <div>##lang.ticket.url## : <a href="##ticket.urlapprove##">##ticket.urlapprove##</a> <strong>&#160;</strong></div>
@@ -4113,19 +4091,13 @@ $tables['glpi_notificationtemplatetranslations'] = [
 <p>##ENDFOREACHitems##</p>
 ##IFticket.assigntousers## <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.ticket.assigntousers##</span>&#160;: ##ticket.assigntousers## ##ENDIFticket.assigntousers##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;">##lang.ticket.status## </span>&#160;: ##ticket.status##<br /> ##IFticket.assigntogroups## <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.ticket.assigntogroups##</span>&#160;: ##ticket.assigntogroups## ##ENDIFticket.assigntogroups##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.ticket.urgency##</span>&#160;: ##ticket.urgency##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.ticket.impact##</span>&#160;: ##ticket.impact##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.ticket.priority##</span>&#160;: ##ticket.priority## <br /> ##IFticket.user.email##<span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.ticket.user.email##</span>&#160;: ##ticket.user.email ##ENDIFticket.user.email##    <br /> ##IFticket.category##<span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;">##lang.ticket.category## </span>&#160;:##ticket.category## ##ENDIFticket.category## ##ELSEticket.category## ##lang.ticket.nocategoryassigned## ##ENDELSEticket.category##    <br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.ticket.content##</span>&#160;: ##ticket.content##</p>
 <br />##IFticket.storestatus=6##<br /><span style="text-decoration: underline;"><strong><span style="color: #888888;">##lang.ticket.solvedate##</span></strong></span> : ##ticket.solvedate##<br /><span style="color: #888888;"><strong><span style="text-decoration: underline;">##lang.ticket.solution.type##</span></strong></span> : ##ticket.solution.type##<br /><span style="text-decoration: underline; color: #888888;"><strong>##lang.ticket.solution.description##</strong></span> : ##ticket.solution.description##<br />##ENDIFticket.storestatus##</p>
-<div class="description b">##lang.ticket.numberoffollowups##&#160;: ##ticket.numberoffollowups##</div>
-<p>##FOREACHfollowups##</p>
-<div class="description b"><br /> <strong> [##followup.date##] <em>##lang.followup.isprivate## : ##followup.isprivate## </em></strong><br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.followup.author## </span> ##followup.author##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.followup.description## </span> ##followup.description##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.followup.date## </span> ##followup.date##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.followup.requesttype## </span> ##followup.requesttype##</div>
-<p>##ENDFOREACHfollowups##</p>
 <p>##ENDFOREACHtimelineitems##</p>
 <div class="description b"><br /><strong> [##timelineitems.date##]</strong><br /><span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.timelineitems.author## </span> ##<span style="color: #000000; font-weight: bold; text-decoration: underline; background-color: #ffffff;">timelineitems</span>.author##<br /><span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.timelineitems.description## </span> ##<span style="color: #000000; font-weight: bold; text-decoration: underline;">timelineitems</span>.description##<br /><span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.timelineitems.date## </span> ##<span style="color: #000000; font-weight: bold; text-decoration: underline;">timelineitems</span>.date##<br /><span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;">##lang.timelineitems.position## </span><span style="color: #000000;"> ##<span style="font-weight: bold; text-decoration: underline;">timelineitems</span>.<span style="font-weight: bold; text-decoration: underline;">position</span>##</span></div>
 <div class="description b"><span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;">##lang.timelineitems.type## </span> ##<span style="color: #000000;"><span style="font-weight: bold; text-decoration: underline;">timelineitems</span>.<span style="font-weight: bold; text-decoration: underline;">type</span>##</span></div>
 <div class="description b"><span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;">##lang.timelineitems.typename## </span> #<span style="color: #000000;">#<span style="font-weight: bold; text-decoration: underline;">timelineitems</span>.<span style="font-weight: bold; text-decoration: underline;">typename</span>##</span></div>
 <p>##ENDFOREACHtimelineitems##</p>
-<div class="description b">##lang.ticket.numberoftasks##&#160;: ##ticket.numberoftasks##</div>
-<p>##FOREACHtasks##</p>
-<div class="description b"><br /> <strong> [##task.date##] <em>##lang.task.isprivate## : ##task.isprivate## </em></strong><br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.task.author##</span> ##task.author##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.task.description##</span> ##task.description##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.task.time##</span> ##task.time##<br /> <span style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"> ##lang.task.category##</span> ##task.category##</div>
-<p>##ENDFOREACHtasks##</p>',
+<div class="description b">##lang.ticket.numberoffollowups##&#160;: ##ticket.numberoffollowups##</div>
+<div class="description b">##lang.ticket.numberoftasks##&#160;: ##ticket.numberoftasks##</div>',
    ], [
       'id'                       => '5',
       'notificationtemplates_id' => '12',

--- a/tests/functionnal/NotificationEventAjax.php
+++ b/tests/functionnal/NotificationEventAjax.php
@@ -192,12 +192,11 @@ Associated item :
   No defined category 
  Description : 
  
- Number of followups : 0
 
 
- Number of tasks : 0
 
-
+Number of followups : 0
+Number of tasks : 0
 
 -- 
 

--- a/tests/functionnal/NotificationTargetTicket.php
+++ b/tests/functionnal/NotificationTargetTicket.php
@@ -312,7 +312,7 @@ class NotificationTargetTicket extends DbTestCase {
 
       $ret = $notiftargetticket->getDataForObject($ticket, $basic_options);
 
-      //get only private task / solution / followup (because is post_only)
+      //get only public task / followup (because is post_only)
       $expected = [
          [
             "##timelineitems.type##"        => "TicketTask",

--- a/tests/functionnal/NotificationTargetTicket.php
+++ b/tests/functionnal/NotificationTargetTicket.php
@@ -275,7 +275,7 @@ class NotificationTargetTicket extends DbTestCase {
             "##timelineitems.date##"        => $solution->fields['date_creation'],
             "##timelineitems.description##" => $solution->fields['content'],
             "##timelineitems.position##"    => "right",
-            "##timelineitems.author##"      => "", //empty
+            "##timelineitems.author##"      => "tech", //empty
          ],[
             "##timelineitems.type##" => "ITILFollowup",
             "##timelineitems.typename##"=> "Followups",
@@ -302,7 +302,6 @@ class NotificationTargetTicket extends DbTestCase {
 
       $this->array($ret['timelineitems'])->isIdenticalTo($expected);
 
-      $auth = new \Auth();
       $this->boolean((boolean)$this->login('post-only', 'postonly', true))->isTrue();
 
       $basic_options = [
@@ -328,7 +327,7 @@ class NotificationTargetTicket extends DbTestCase {
             "##timelineitems.date##"        => $solution->fields['date_creation'],
             "##timelineitems.description##" => $solution->fields['content'],
             "##timelineitems.position##"    => "right",
-            "##timelineitems.author##"      => "", //empty
+            "##timelineitems.author##"      => "tech", //empty
          ],[
             "##timelineitems.type##"        => "ITILFollowup",
             "##timelineitems.typename##"    => "Followups",

--- a/tests/functionnal/NotificationTargetTicket.php
+++ b/tests/functionnal/NotificationTargetTicket.php
@@ -139,5 +139,163 @@ class NotificationTargetTicket extends DbTestCase {
 
       // switch back to default language
       $_SESSION["glpilanguage"] = \Session::loadLanguage('en_GB');
+
+   }
+
+
+   public function testTimelineTag() {
+
+      $entity = getItemByTypeName("Entity", "_test_root_entity");
+      global $DB;
+      // Build test ticket
+      $this->login('tech', 'tech');
+      $ticket = new \Ticket();
+      $tickets_id = $ticket->add($input = [
+         'name'             => 'test',
+         'content'          => 'test',
+         '_users_id_assign' => getItemByTypeName('User', 'tech', true),
+         '_users_id_requester' => getItemByTypeName('User', 'post-only', true),
+         'entities_id'      => $entity->getID(),
+         'users_id_recipient' => getItemByTypeName('User', 'tech', true),
+         'users_id_lastupdater' => getItemByTypeName('User', 'tech', true),
+         'requesttypes_id'  => 4,
+      ]);
+      $this->integer($tickets_id)->isGreaterThan(0);
+
+      // Unset temporary fields that will not be found in tickets table
+      unset($input['_users_id_assign']);
+      unset($input['_users_id_requester']);
+
+      // Check expected fields and reload object from DB
+      $this->checkInput($ticket, $tickets_id, $input);
+
+
+      // Add followup from tech
+      $fup_tech = new \ITILFollowup();
+      $fup1_id = $fup_tech->add([
+         'content' => 'test followup',
+         'users_id' => getItemByTypeName('User', 'tech', true),
+         'users_id_editor' => getItemByTypeName('User', 'tech', true),
+         'itemtype' => 'Ticket',
+         'is_private' => 0,
+         'items_id' => $tickets_id,
+      ]);
+      $this->integer($fup1_id)->isGreaterThan(0);
+
+
+      // Add followup from post_only
+      $fup_post_only = new \ITILFollowup();
+      $fup2_id = $fup_post_only->add([
+         'content' => 'test post_only',
+         'users_id' => getItemByTypeName('User', 'post-only', true),
+         'users_id_editor' => getItemByTypeName('User', 'post-only', true),
+         'itemtype' => 'Ticket',
+         'is_private' => 0,
+         'items_id' => $tickets_id,
+      ]);
+      $this->integer($fup2_id)->isGreaterThan(0);
+
+      // Add private followup to tech
+      $fup_private_tech = new \ITILFollowup();
+      $fup3_id = $fup_private_tech->add([
+         'content' => 'test private followup',
+         'users_id' => getItemByTypeName('User', 'tech', true),
+         'users_id_editor' => getItemByTypeName('User', 'tech', true),
+         'itemtype' => 'Ticket',
+         'is_private' => 1,
+         'items_id' => $tickets_id,
+      ]);
+      $this->integer($fup3_id)->isGreaterThan(0);
+
+
+      //add private task from tech
+      $task_private = new \TicketTask();
+      $task1_id = $task_private->add([
+         'state'             => \Planning::TODO,
+         'tickets_id'        => $tickets_id,
+         'tasktemplates_id'  => '0',
+         'is_private'        => 1,
+         'taskcategories_id' => '0',
+         'actiontime'        => "172800",                                  //1hours
+         'content'           => "Private Task",
+         'users_id_tech'     => getItemByTypeName('User', 'tech', true),
+      ]);
+      $this->integer($task1_id)->isGreaterThan(0);
+
+      //add task from tech
+      $task_tech = new \TicketTask();
+      $task2_id = $task_tech->add([
+         'state'             => \Planning::TODO,
+         'tickets_id'        => $tickets_id,
+         'tasktemplates_id'  => '0',
+         'taskcategories_id' => '0',
+         'is_private'        => 0,
+         'actiontime'        => "172800",                                  //1hours
+         'content'           => "Task",
+         'users_id_tech'     => getItemByTypeName('User', 'tech', true),
+      ]);
+      $this->integer($task2_id)->isGreaterThan(0);
+
+      // Add solution to test ticket
+      $solution = new \ITILSolution();
+      $solutions_id = $solution->add([
+         'content' => 'test',
+         'users_id' => getItemByTypeName('User', 'tech', true),
+         'users_id_editor' => getItemByTypeName('User', 'tech', true),
+         'itemtype' => 'Ticket',
+         'items_id' => $tickets_id,
+      ]);
+      $this->integer($solutions_id)->isGreaterThan(0);
+
+
+
+
+      $auth = new \Auth();
+      $this->boolean((boolean)$auth->login('tech', 'tech', true))->isTrue();
+      
+      $basic_options = [
+         'additionnaloption' => [
+            'usertype' => ''
+         ]
+      ];
+
+      $notiftargetticket = new \NotificationTargetTicket(getItemByTypeName('Entity', '_test_root_entity', true), 'new', $ticket );
+      $ret = $notiftargetticket->getDataForObject($ticket, $basic_options);
+
+      //get only task / solution / followup not private
+      $expected = [
+         [
+            "##timelineitems.type##"        => "TicketTask",
+            "##timelineitems.typename##"    => "Ticket tasks",
+            "##timelineitems.date##"        => $task_tech->fields['date'],
+            "##timelineitems.description##" => $task_tech->fields['content'],
+            "##timelineitems.position##"    => "right",
+            "##timelineitems.author##"      => "tech",
+         ],[
+            "##timelineitems.type##"        => "ITILSolution",
+            "##timelineitems.typename##"    => "Solutions",
+            "##timelineitems.date##"        => $solution->fields['date_creation'],
+            "##timelineitems.description##" => $solution->fields['content'],
+            "##timelineitems.position##"    => "right",
+            "##timelineitems.author##"      => "tech",
+         ],[
+            "##timelineitems.type##"        => "ITILFollowup",
+            "##timelineitems.typename##"    => "Followups",
+            "##timelineitems.date##"        => $fup_post_only->fields['date'],
+            "##timelineitems.description##" => $fup_post_only->fields['content'],
+            "##timelineitems.position##"    => "left",
+            "##timelineitems.author##"      => "post-only",
+         ],[
+            "##timelineitems.type##" => "ITILFollowup",
+            "##timelineitems.typename##" => "Followups",
+            "##timelineitems.date##"        => $fup_tech->fields['date'],
+            "##timelineitems.description##" => $fup_tech->fields['content'],
+            "##timelineitems.position##" => "right",
+            "##timelineitems.author##" => "tech",
+         ]
+      ];
+
+      $this->array($ret['timelineitems'])->isIdenticalTo($expected);
+
    }
 }

--- a/tests/functionnal/NotificationTargetTicket.php
+++ b/tests/functionnal/NotificationTargetTicket.php
@@ -169,7 +169,6 @@ class NotificationTargetTicket extends DbTestCase {
       // Check expected fields and reload object from DB
       $this->checkInput($ticket, $tickets_id, $input);
 
-
       // Add followup from tech
       $fup_tech = new \ITILFollowup();
       $fup1_id = $fup_tech->add([
@@ -181,7 +180,6 @@ class NotificationTargetTicket extends DbTestCase {
          'items_id' => $tickets_id,
       ]);
       $this->integer($fup1_id)->isGreaterThan(0);
-
 
       // Add followup from post_only
       $fup_post_only = new \ITILFollowup();
@@ -206,7 +204,6 @@ class NotificationTargetTicket extends DbTestCase {
          'items_id' => $tickets_id,
       ]);
       $this->integer($fup3_id)->isGreaterThan(0);
-
 
       //add private task from tech
       $task_private = new \TicketTask();
@@ -247,12 +244,9 @@ class NotificationTargetTicket extends DbTestCase {
       ]);
       $this->integer($solutions_id)->isGreaterThan(0);
 
-
-
-
       $auth = new \Auth();
       $this->boolean((boolean)$auth->login('tech', 'tech', true))->isTrue();
-      
+
       $basic_options = [
          'additionnaloption' => [
             'usertype' => ''
@@ -277,7 +271,7 @@ class NotificationTargetTicket extends DbTestCase {
             "##timelineitems.date##"        => $solution->fields['date_creation'],
             "##timelineitems.description##" => $solution->fields['content'],
             "##timelineitems.position##"    => "right",
-            "##timelineitems.author##"      => "tech",
+            "##timelineitems.author##"      => "", //empty
          ],[
             "##timelineitems.type##"        => "ITILFollowup",
             "##timelineitems.typename##"    => "Followups",

--- a/tests/functionnal/NotificationTargetTicket.php
+++ b/tests/functionnal/NotificationTargetTicket.php
@@ -305,8 +305,6 @@ class NotificationTargetTicket extends DbTestCase {
 
       $this->array($ret['timelineitems'])->isIdenticalTo($expected);
 
-
-
       $auth = new \Auth();
       $this->boolean((boolean)$auth->login('post-only', 'postonly', true))->isTrue();
 
@@ -318,41 +316,40 @@ class NotificationTargetTicket extends DbTestCase {
 
       $ret = $notiftargetticket->getDataForObject($ticket, $basic_options);
 
-            //get only private task / solution / followup (because is post_only)
-            $expected = [
-               [
-                  "##timelineitems.type##"        => "TicketTask",
-                  "##timelineitems.typename##"    => "Ticket tasks",
-                  "##timelineitems.date##"        => $task_tech->fields['date'],
-                  "##timelineitems.description##" => $task_tech->fields['content'],
-                  "##timelineitems.position##"    => "right",
-                  "##timelineitems.author##"      => "tech",
-               ],[
-                  "##timelineitems.type##"        => "ITILSolution",
-                  "##timelineitems.typename##"    => "Solutions",
-                  "##timelineitems.date##"        => $solution->fields['date_creation'],
-                  "##timelineitems.description##" => $solution->fields['content'],
-                  "##timelineitems.position##"    => "right",
-                  "##timelineitems.author##"      => "", //empty
-               ],[
-                  "##timelineitems.type##"        => "ITILFollowup",
-                  "##timelineitems.typename##"    => "Followups",
-                  "##timelineitems.date##"        => $fup_post_only->fields['date'],
-                  "##timelineitems.description##" => $fup_post_only->fields['content'],
-                  "##timelineitems.position##"    => "left",
-                  "##timelineitems.author##"      => "post-only",
-               ],[
-                  "##timelineitems.type##" => "ITILFollowup",
-                  "##timelineitems.typename##" => "Followups",
-                  "##timelineitems.date##"        => $fup_tech->fields['date'],
-                  "##timelineitems.description##" => $fup_tech->fields['content'],
-                  "##timelineitems.position##" => "right",
-                  "##timelineitems.author##" => "tech",
-               ]
-            ];
-      
-            $this->array($ret['timelineitems'])->isIdenticalTo($expected);
+      //get only private task / solution / followup (because is post_only)
+      $expected = [
+         [
+            "##timelineitems.type##"        => "TicketTask",
+            "##timelineitems.typename##"    => "Ticket tasks",
+            "##timelineitems.date##"        => $task_tech->fields['date'],
+            "##timelineitems.description##" => $task_tech->fields['content'],
+            "##timelineitems.position##"    => "right",
+            "##timelineitems.author##"      => "tech",
+         ],[
+            "##timelineitems.type##"        => "ITILSolution",
+            "##timelineitems.typename##"    => "Solutions",
+            "##timelineitems.date##"        => $solution->fields['date_creation'],
+            "##timelineitems.description##" => $solution->fields['content'],
+            "##timelineitems.position##"    => "right",
+            "##timelineitems.author##"      => "", //empty
+         ],[
+            "##timelineitems.type##"        => "ITILFollowup",
+            "##timelineitems.typename##"    => "Followups",
+            "##timelineitems.date##"        => $fup_post_only->fields['date'],
+            "##timelineitems.description##" => $fup_post_only->fields['content'],
+            "##timelineitems.position##"    => "left",
+            "##timelineitems.author##"      => "post-only",
+         ],[
+            "##timelineitems.type##" => "ITILFollowup",
+            "##timelineitems.typename##" => "Followups",
+            "##timelineitems.date##"        => $fup_tech->fields['date'],
+            "##timelineitems.description##" => $fup_tech->fields['content'],
+            "##timelineitems.position##" => "right",
+            "##timelineitems.author##" => "tech",
+         ]
+      ];
 
-            
+      $this->array($ret['timelineitems'])->isIdenticalTo($expected);
+
    }
 }

--- a/tests/functionnal/NotificationTargetTicket.php
+++ b/tests/functionnal/NotificationTargetTicket.php
@@ -244,9 +244,6 @@ class NotificationTargetTicket extends DbTestCase {
       ]);
       $this->integer($solutions_id)->isGreaterThan(0);
 
-      $auth = new \Auth();
-      $this->boolean((boolean)$auth->login('tech', 'tech', true))->isTrue();
-
       $basic_options = [
          'additionnaloption' => [
             'usertype' => ''
@@ -306,7 +303,7 @@ class NotificationTargetTicket extends DbTestCase {
       $this->array($ret['timelineitems'])->isIdenticalTo($expected);
 
       $auth = new \Auth();
-      $this->boolean((boolean)$auth->login('post-only', 'postonly', true))->isTrue();
+      $this->boolean((boolean)$this->login('post-only', 'postonly', true))->isTrue();
 
       $basic_options = [
          'additionnaloption' => [

--- a/tests/functionnal/NotificationTargetTicket.php
+++ b/tests/functionnal/NotificationTargetTicket.php
@@ -256,7 +256,7 @@ class NotificationTargetTicket extends DbTestCase {
       $notiftargetticket = new \NotificationTargetTicket(getItemByTypeName('Entity', '_test_root_entity', true), 'new', $ticket );
       $ret = $notiftargetticket->getDataForObject($ticket, $basic_options);
 
-      //get only task / solution / followup not private
+      //get all task / solution / followup (because is tech)
       $expected = [
          [
             "##timelineitems.type##"        => "TicketTask",
@@ -266,12 +266,26 @@ class NotificationTargetTicket extends DbTestCase {
             "##timelineitems.position##"    => "right",
             "##timelineitems.author##"      => "tech",
          ],[
+            "##timelineitems.type##"        => "TicketTask",
+            "##timelineitems.typename##"    => "Ticket tasks",
+            "##timelineitems.date##"        => $task_private->fields['date'],
+            "##timelineitems.description##" => $task_private->fields['content'],
+            "##timelineitems.position##"    => "right",
+            "##timelineitems.author##"      => "tech",
+         ],[
             "##timelineitems.type##"        => "ITILSolution",
             "##timelineitems.typename##"    => "Solutions",
             "##timelineitems.date##"        => $solution->fields['date_creation'],
             "##timelineitems.description##" => $solution->fields['content'],
             "##timelineitems.position##"    => "right",
             "##timelineitems.author##"      => "", //empty
+         ],[
+            "##timelineitems.type##" => "ITILFollowup",
+            "##timelineitems.typename##"=> "Followups",
+            "##timelineitems.date##"        => $fup_private_tech->fields['date'],
+            "##timelineitems.description##" => $fup_private_tech->fields['content'],
+            "##timelineitems.position##"=> "right",
+            "##timelineitems.author##"=> "tech",
          ],[
             "##timelineitems.type##"        => "ITILFollowup",
             "##timelineitems.typename##"    => "Followups",
@@ -291,5 +305,54 @@ class NotificationTargetTicket extends DbTestCase {
 
       $this->array($ret['timelineitems'])->isIdenticalTo($expected);
 
+
+
+      $auth = new \Auth();
+      $this->boolean((boolean)$auth->login('post-only', 'postonly', true))->isTrue();
+
+      $basic_options = [
+         'additionnaloption' => [
+            'usertype' => ''
+         ]
+      ];
+
+      $ret = $notiftargetticket->getDataForObject($ticket, $basic_options);
+
+            //get only private task / solution / followup (because is post_only)
+            $expected = [
+               [
+                  "##timelineitems.type##"        => "TicketTask",
+                  "##timelineitems.typename##"    => "Ticket tasks",
+                  "##timelineitems.date##"        => $task_tech->fields['date'],
+                  "##timelineitems.description##" => $task_tech->fields['content'],
+                  "##timelineitems.position##"    => "right",
+                  "##timelineitems.author##"      => "tech",
+               ],[
+                  "##timelineitems.type##"        => "ITILSolution",
+                  "##timelineitems.typename##"    => "Solutions",
+                  "##timelineitems.date##"        => $solution->fields['date_creation'],
+                  "##timelineitems.description##" => $solution->fields['content'],
+                  "##timelineitems.position##"    => "right",
+                  "##timelineitems.author##"      => "", //empty
+               ],[
+                  "##timelineitems.type##"        => "ITILFollowup",
+                  "##timelineitems.typename##"    => "Followups",
+                  "##timelineitems.date##"        => $fup_post_only->fields['date'],
+                  "##timelineitems.description##" => $fup_post_only->fields['content'],
+                  "##timelineitems.position##"    => "left",
+                  "##timelineitems.author##"      => "post-only",
+               ],[
+                  "##timelineitems.type##" => "ITILFollowup",
+                  "##timelineitems.typename##" => "Followups",
+                  "##timelineitems.date##"        => $fup_tech->fields['date'],
+                  "##timelineitems.description##" => $fup_tech->fields['content'],
+                  "##timelineitems.position##" => "right",
+                  "##timelineitems.author##" => "tech",
+               ]
+            ];
+      
+            $this->array($ret['timelineitems'])->isIdenticalTo($expected);
+
+            
    }
 }


### PR DESCRIPTION
Add new tags to display timeline items (```Followup```, ```Task```, ```Solution```) (not private)

 ```##lang.timelineitems.author##``` ```##timelineitems.author##```
 ```##lang.timelineitems.description##``` ```##timelineitems.description##```
 ```##lang.timelineitems.date##``` ```##timelineitems.date##```
 ```##lang.timelineitems.position##``` ```##timelineitems.position##```
 ```##lang.timelineitems.type##``` ```##timelineitems.type##``` (internal ref ex: TicketTask (usefull for css class name))
 ```##lang.timelineitems.typename##``` ```##timelineitems.typename##``` (ex: Ticket task)

Compliant with ```##FOREACHtimelineitems##``` and ```##ENDFOREACHtimelineitems##```

```##timelineitems.position##``` and ```##timelineitems.type##``` is used  for CSS 

Example

![image](https://user-images.githubusercontent.com/7335054/131479925-e835b95c-e2f9-447e-b9ca-4e1cf99ec303.png)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
| Depends on | https://github.com/glpi-project/glpi/pull/9514
