### PR TITLE
Fix empty value for user dropdown

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -4049,7 +4049,7 @@ JAVASCRIPT;
 
       $view_users = self::canView();
 
-      if (strval($p['value']) == 'myself') {
+      if ($p['value'] === 'myself') {
          $default = __("Myself");
       } else if (!empty($p['value']) && ($p['value'] > 0)) {
          $default = $user["name"];

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -4049,7 +4049,7 @@ JAVASCRIPT;
 
       $view_users = self::canView();
 
-      if ($p['value'] == 'myself') {
+      if (strval($p['value']) == 'myself') {
          $default = __("Myself");
       } else if (!empty($p['value']) && ($p['value'] > 0)) {
          $default = $user["name"];


### PR DESCRIPTION
I've noticed a few weird values in the users dropdown: 
![image](https://user-images.githubusercontent.com/42734840/131693479-409609c0-902f-472c-a4b8-fe7c7f07fa6d.png)


It turns out to be a side effect of the new 'Myself' search criteria and PHP weird type casting for loose comparisons:
![image](https://user-images.githubusercontent.com/42734840/131693798-0dc70523-4569-433e-b4c6-cdd800b38288.png)

This issue is only present on PHP 7 as [saner string to number comparisons](https://www.php.net/releases/8.0/en.php#saner-string-to-number-comparisons) were introduced in PHP 8.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
