### PR TITLE
fix(massiveaction):prevent actions if needed

### DIFF
--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -1143,23 +1143,28 @@ JAVASCRIPT;
             $fup   = new self();
             foreach ($ids as $id) {
                if ($item->getFromDB($id)) {
-                  $input2 = [
-                     'items_id'        => $id,
-                     'itemtype'        => $item->getType(),
-                     'is_private'      => $input['is_private'],
-                     'requesttypes_id' => $input['requesttypes_id'],
-                     'content'         => $input['content']
-                  ];
-                  if ($fup->can(-1, CREATE, $input2)) {
-                     if ($fup->add($input2)) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
-                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
-                        $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
-                     }
-                  } else {
-                     $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                  if (in_array($item->fields['status'], $item->getClosedStatusArray())) {
+                     $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
                      $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
+                  } else {
+                     $input2 = [
+                        'items_id'        => $id,
+                        'itemtype'        => $item->getType(),
+                        'is_private'      => $input['is_private'],
+                        'requesttypes_id' => $input['requesttypes_id'],
+                        'content'         => $input['content']
+                     ];
+                     if ($fup->can(-1, CREATE, $input2)) {
+                        if ($fup->add($input2)) {
+                           $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        } else {
+                           $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                           $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
+                        }
+                     } else {
+                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
+                     }
                   }
                } else {
                   $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -7048,6 +7048,8 @@ class Ticket extends CommonITILObject {
          //for closed Tickets, only keep transfer and unlock
          $excluded[] = 'TicketValidation:submit_validation';
          $excluded[] = 'Ticket:*';
+         $excluded[] = 'ITILFollowup:*';
+         $excluded[] = 'Document_Item:*';
       }
       return $excluded;
    }


### PR DESCRIPTION
When a ticket was closed you could add a followup and document via the massiveaction.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 22529(internal)
