### PR TITLE
Add cache for areTimezonesAvailable

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -1565,7 +1565,7 @@ class DBmysql {
       if ($cache->has('are_timezones_available')) {
          return $cache->get('are_timezones_available');
       }
-      $cache->set('are_timezones_available', false);
+      $cache->set('are_timezones_available', false, DAY_TIMESTAMP);
 
       $mysql_db_res = $this->request('SHOW DATABASES LIKE ' . $this->quoteValue('mysql'));
       if ($mysql_db_res->count() === 0) {
@@ -1591,7 +1591,7 @@ class DBmysql {
       $iterator = $this->request($criteria);
       $result = $iterator->next();
       if ($result['cpt'] == 0) {
-         $msg = __('Timezones seems not loaded, see https://glpi-install.readthedocs.io/en/latest/timezones.html and clear your cache.');
+         $msg = __('Timezones seems not loaded, see https://glpi-install.readthedocs.io/en/latest/timezones.html.');
          return false;
       }
 

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -1560,12 +1560,12 @@ class DBmysql {
     * @since 9.5.0
     */
    public function areTimezonesAvailable(string &$msg = '') {
-      global $GLPI_CACHE;
+      $cache = Config::getCache('cache_db');
 
-      if ($GLPI_CACHE->has('are_timezones_available')) {
-         return $GLPI_CACHE->get('are_timezones_available');
+      if ($cache->has('are_timezones_available')) {
+         return $cache->get('are_timezones_available');
       }
-      $GLPI_CACHE->set('are_timezones_available', false);
+      $cache->set('are_timezones_available', false);
 
       $mysql_db_res = $this->request('SHOW DATABASES LIKE ' . $this->quoteValue('mysql'));
       if ($mysql_db_res->count() === 0) {
@@ -1595,7 +1595,7 @@ class DBmysql {
          return false;
       }
 
-      $GLPI_CACHE->set('are_timezones_available', true);
+      $cache->set('are_timezones_available', true);
       return true;
    }
 

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -1560,6 +1560,13 @@ class DBmysql {
     * @since 9.5.0
     */
    public function areTimezonesAvailable(string &$msg = '') {
+      global $GLPI_CACHE;
+
+      if ($GLPI_CACHE->has('are_timezones_available')) {
+         return $GLPI_CACHE->get('are_timezones_available');
+      }
+      $GLPI_CACHE->set('are_timezones_available', false);
+
       $mysql_db_res = $this->request('SHOW DATABASES LIKE ' . $this->quoteValue('mysql'));
       if ($mysql_db_res->count() === 0) {
          $msg = __('Access to timezone database (mysql) is not allowed.');
@@ -1584,10 +1591,11 @@ class DBmysql {
       $iterator = $this->request($criteria);
       $result = $iterator->next();
       if ($result['cpt'] == 0) {
-         $msg = __('Timezones seems not loaded, see https://glpi-install.readthedocs.io/en/latest/timezones.html.');
+         $msg = __('Timezones seems not loaded, see https://glpi-install.readthedocs.io/en/latest/timezones.html and clear your cache.');
          return false;
       }
 
+      $GLPI_CACHE->set('are_timezones_available', true);
       return true;
    }
 


### PR DESCRIPTION
`DbMysql::areTimezonesAvailable()` is called in the database initialization process, thus for every page and AJAX request.
This means 10+ execution of `SELECT count(*) FROM mysql.time_zone_name` for each page of the application, see this example of executing a simple search request: 
![image](https://user-images.githubusercontent.com/42734840/131826768-1c7b3fd7-6ec2-4382-8799-4c477d5ffd07.png)

It seems to scale up for each plugin installed since we add another ajax call to `locale.php` by installed plugin.

Despite the fast that this request is extremely fast, it seems to create performance issue in the related internal ref when there is a lot of users on the application.

I suspect the issue to be linked to the internal ref specific environment since we never had any feedback on this before (and I suspect this is not the only query that is executed for each page and ajax request so why would it be a problem ?) but maybe some caching mechanism wouldn't be too bad here to avoid spamming the database with these requests ?

Still looking into others solution to fix the internal ref.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22521 (incomplete, missing some email discussions)
