### PR TITLE
Reduce search engine memory usage

### DIFF
--- a/inc/api/api.class.php
+++ b/inc/api/api.class.php
@@ -1565,7 +1565,7 @@ abstract class API {
       }
 
       $cleaned_data = ['totalcount' => $rawdata['data']['totalcount'],
-                            'count'      => count($rawdata['data']['rows']),
+                            'count'      => $rawdata['data']['count'],
                             'sort'       => $rawdata['search']['sort'],
                             'order'      => $rawdata['search']['order']];
 

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -3418,7 +3418,7 @@ abstract class CommonITILObject extends CommonDBTM {
          'datatype'           => 'itemlink',
          'searchtype'         => 'contains',
          'massiveaction'      => false,
-         'additionalfields'   => ['id', 'content', 'status']
+         'additionalfields'   => ['content', 'status']
       ];
 
       $tab[] = [

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -415,14 +415,6 @@ class Config extends CommonDBTM {
       }
       echo "</td></tr>";
 
-      echo "<tr class='tab_bg_2'>";
-      echo "<td><label for='dropdown_allow_search_all$rand'>" . __('All') . "</label></td><td>";
-      $values = [0 => __('No'),
-                 1 => sprintf(__('%1$s (%2$s)'), __('Yes'), __('last criterion'))];
-      Dropdown::showFromArray('allow_search_all', $values,
-                              ['value' => $CFG_GLPI['allow_search_all'], 'rand' => $rand]);
-      echo "</td><td colspan='2'></td></tr>";
-
       echo "<tr class='tab_bg_1'><td colspan='4' class='center b'>".__('Item locks')."</td></tr>";
 
       echo "<tr class='tab_bg_2'>";

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -866,7 +866,7 @@ class Search {
                      $GROUPBY.
                      $HAVING;
 
-                  if (empty(trim($GROUPBY)) && empty(trim($HAVING))) {
+                  if (empty(trim($HAVING))) {
                      // No HAVING clause: we can keep a simple query
                      $count_tmpquery = self::buildSimpleCountQuery(
                         $COUNT_FROM,
@@ -1026,7 +1026,7 @@ class Search {
                   $ORDER.
                   $LIMIT;
 
-         if (empty(trim($GROUPBY)) && empty(trim($HAVING))) {
+         if (empty(trim($HAVING))) {
             // No HAVING clause: we can keep a simple query
             $COUNT_QUERY = self::buildSimpleCountQuery($COUNT_FROM, $WHERE);
          } else {

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1373,6 +1373,7 @@ class Search {
          $data['data']['totalcount'] = 0;
          $result_num = $DBread->query($data['sql']['count']);
          $data['data']['totalcount'] += $DBread->result($result_num, 0, 0);
+         $data['data']['count'] = intval(min($data['data']['totalcount'], $data['search']['list_limit']));
 
          if ($onlycount) {
             //we just want to coutn results; no need to continue process
@@ -1483,10 +1484,6 @@ class Search {
          // Don't risk overflowing the memory limit by loading the entire
          // resultset, use a generator
          $data['data']['rows'] = self::yieldResults($data, $DBread, $result);
-
-         // We have two variables for the same value here since the LIMIT changes.
-         // Should maybe be merged into one var but it may impact existing code.
-         $data['data']['count'] = $data['data']['totalcount'];
       } else {
          echo $DBread->error();
       }

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1588,6 +1588,10 @@ class Search {
             );
          }
 
+         // Add items in item list
+         $current_type = (isset($newrow['TYPE']) ? $newrow['TYPE'] : $data['itemtype']);
+         Session::addToNavigateListItems($current_type, $newrow["id"]);
+
          yield $i => $newrow;
          $i++;
       }
@@ -1676,12 +1680,6 @@ class Search {
          'may_be_deleted'      => $item instanceof CommonDBTM && $item->maybeDeleted(),
          'may_be_located'      => $item instanceof CommonDBTM && $item->maybeLocated(),
       ]);
-
-      // Add items in item list
-      foreach ($data['data']['rows'] as $row) {
-         $current_type = (isset($row['TYPE']) ? $row['TYPE'] : $data['itemtype']);
-         Session::addToNavigateListItems($current_type, $row["id"]);
-      }
 
       // Clean previous selection
       $_SESSION['glpimassiveactionselected'] = [];

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1373,7 +1373,10 @@ class Search {
          $data['data']['totalcount'] = 0;
          $result_num = $DBread->query($data['sql']['count']);
          $data['data']['totalcount'] += $DBread->result($result_num, 0, 0);
-         $data['data']['count'] = intval(min($data['data']['totalcount'], $data['search']['list_limit']));
+         $data['data']['count'] = min(
+            $data['data']['totalcount'],
+            intval($data['search']['list_limit'])
+         );
 
          if ($onlycount) {
             //we just want to coutn results; no need to continue process

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -556,14 +556,14 @@ class Search {
     *
     * @return array
     */
-   public static function getConditionSearchOptionsIds(array $criteria): array {
+   private static function getConditionSearchOptionsIds(array $criteria): array {
       $condition_search_options_ids = [];
       foreach ($criteria as $crit) {
          if (isset($crit['criteria'])) {
             // Recursion, parse child criteria
             $child_criteria = self::getConditionSearchOptionsIds($crit['criteria']);
-            foreach (array_keys($child_criteria) as $child_crit) {
-               $condition_search_options_ids[$child_crit] = $child_crit['value'] ?? true;
+            foreach ($child_criteria as $child_crit_id => $child_crit_value) {
+               $condition_search_options_ids[$child_crit_id] = $child_crit_value;
             }
 
          } else if (isset($crit['field'])) {
@@ -1129,7 +1129,6 @@ class Search {
                   continue;
                }
 
-               $is_meta =
                $new_having = self::addHaving(
                   $LINK,
                   $NOT,
@@ -1236,7 +1235,7 @@ class Search {
     * @param  string &$FROM                TODO: should be a class property (output parameter)
     * @param  array  &$already_link_tables TODO: should be a class property (output parameter)
     * @param  array  &$data                TODO: should be a class property (output parameter)
-    * @param  bool   &$count_query         Are we building a could query ?
+    * @param  bool   $count_query          Are we building a count query ?
     *
     * @return void
     */
@@ -8030,7 +8029,7 @@ JAVASCRIPT;
     *
     * @return string
     */
-   public static function buildSimpleCountQuery(
+   private static function buildSimpleCountQuery(
       string $FROM,
       string $WHERE
    ): string {
@@ -8048,7 +8047,7 @@ JAVASCRIPT;
     *
     * @return string
     */
-   public static function buildWrappedCountQuery(
+   private static function buildWrappedCountQuery(
       string $SELECT,
       string $FROM,
       string $WHERE,

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -866,7 +866,7 @@ class Search {
                      $GROUPBY.
                      $HAVING;
 
-                  if (empty(trim($HAVING))) {
+                  if (empty(trim($GROUPBY)) && empty(trim($HAVING))) {
                      // No HAVING clause: we can keep a simple query
                      $count_tmpquery = self::buildSimpleCountQuery(
                         $COUNT_FROM,
@@ -1026,7 +1026,7 @@ class Search {
                   $ORDER.
                   $LIMIT;
 
-         if (empty(trim($HAVING))) {
+         if (empty(trim($GROUPBY)) && empty(trim($HAVING))) {
             // No HAVING clause: we can keep a simple query
             $COUNT_QUERY = self::buildSimpleCountQuery($COUNT_FROM, $WHERE);
          } else {

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -458,13 +458,6 @@ class Search {
 
       $data['display_type'] = $data['search']['display_type'];
 
-      if (!$CFG_GLPI['allow_search_all']) {
-         foreach ($p['criteria'] as $val) {
-            if (isset($val['field']) && $val['field'] == 'all') {
-               Html::displayRightError();
-            }
-         }
-      }
       if (!$CFG_GLPI['allow_search_view']) {
          foreach ($p['criteria'] as $val) {
             if (isset($val['field']) && $val['field'] == 'view') {
@@ -480,7 +473,6 @@ class Search {
       if (is_array($forcedisplay) && count($forcedisplay)) {
          $forcetoview = true;
       }
-      $data['search']['all_search']  = false;
       $data['search']['view_search'] = false;
 
       $data['toview'] = self::addDefaultToView($itemtype, $params);
@@ -513,8 +505,6 @@ class Search {
                         && (!isset($criterion['meta'])
                            || !$criterion['meta'])) {
                         array_push($data['toview'], $criterion['field']);
-                     } else if ($criterion['field'] == 'all') {
-                        $data['search']['all_search'] = true;
                      } else if ($criterion['field'] == 'view') {
                         $data['search']['view_search'] = true;
                      }
@@ -704,40 +694,6 @@ class Search {
          }
       }
 
-      // Search all case :
-      if ($data['search']['all_search']) {
-         foreach ($searchopt as $key => $val) {
-            // Do not search on Group Name
-            if (is_array($val) && isset($val['table'])) {
-               if (!in_array($searchopt[$key]["table"], $blacklist_tables)) {
-                  $FROM .= self::addLeftJoin(
-                     $data['itemtype'],
-                     $itemtable,
-                     $already_link_tables,
-                     $searchopt[$key]["table"],
-                     $searchopt[$key]["linkfield"],
-                     0,
-                     0,
-                     $searchopt[$key]["joinparams"],
-                     $searchopt[$key]["field"]
-                  );
-
-                  $COUNT_FROM .= self::addLeftJoin(
-                     $data['itemtype'],
-                     $itemtable,
-                     $count_already_linked_tables,
-                     $searchopt[$key]["table"],
-                     $searchopt[$key]["linkfield"],
-                     0,
-                     0,
-                     $searchopt[$key]["joinparams"],
-                     $searchopt[$key]["field"]
-                  );
-               }
-            }
-         }
-      }
-
       //// 3 - WHERE
 
       // default string
@@ -833,9 +789,9 @@ class Search {
                 && $criterion['meta'];
       });
       if ((count($data['search']['metacriteria']))
-          || count($criteria_with_meta)
-          || !empty($HAVING)
-          || $data['search']['all_search']) {
+         || count($criteria_with_meta)
+         || !empty($HAVING)
+      ) {
          $GROUPBY = " GROUP BY `$itemtable`.`id`";
       }
 
@@ -2597,9 +2553,6 @@ JAVASCRIPT;
       }
       if ($CFG_GLPI['allow_search_view'] == 1 && !isset($request['from_meta'])) {
          $values['view'] = __('Items seen');
-      }
-      if ($CFG_GLPI['allow_search_all'] && !isset($request['from_meta'])) {
-         $values['all'] = __('All');
       }
       $value = '';
 

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -183,7 +183,6 @@ $default_prefs = [
    'refresh_views'                           => '0',
    'set_default_tech'                        => '1',
    'allow_search_view'                       => '2',
-   'allow_search_all'                        => '0',
    'allow_search_global'                     => '1',
    'display_count_on_home'                   => '5',
    'use_password_security'                   => '0',

--- a/install/migrations/update_9.5.5_to_9.5.6.php
+++ b/install/migrations/update_9.5.5_to_9.5.6.php
@@ -82,6 +82,11 @@ function update955to956() {
    }
    /* /Add `date` to glpi_documents_items */
 
+   $DB->deleteOrDie('glpi_configs', [
+      'context' => 'core',
+      'name'    => 'allow_search_all',
+   ]);
+
    // ************ Keep it at the end **************
    $migration->executeMigration();
 

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -168,7 +168,7 @@ class Search extends DbTestCase {
       $data = $this->doSearch('Software', $search_params);
 
       $this->string($data['sql']['search'])
-         ->matches("/HAVING\s*\(`ITEM_Computer_2`\s+IS\s+NOT\s+NULL\s*\)/");
+         ->matches("/HAVING\s*\(`META_ITEM_Computer_2`\s+IS\s+NOT\s+NULL\s*\)/");
    }
 
    public function testMetaComputerUser() {
@@ -401,7 +401,7 @@ class Search extends DbTestCase {
          ->contains("(`glpi_users`.`id` = '2')")
          ->contains("OR (`glpi_users`.`id` = '3')")
          // match having
-         ->matches("/HAVING\s*\(`ITEM_Budget_2`\s+<>\s+5\)\s+AND\s+\(\(`ITEM_Printer_1`\s+NOT LIKE\s+'%HP%'\s+OR\s+`ITEM_Printer_1`\s+IS NULL\)\s*\)/");
+         ->matches("/HAVING\s*\(`META_ITEM_Budget_2`\s+<>\s+5\)\s+AND\s+\(\(`META_ITEM_Printer_1`\s+NOT LIKE\s+'%HP%'\s+OR\s+`META_ITEM_Printer_1`\s+IS NULL\)\s*\)/");
    }
 
    function testViewCriterion() {

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1349,9 +1349,8 @@ class Search extends DbTestCase {
       \Search::constructData($data);
 
       $this->integer($data['data']['totalcount'])->isEqualTo(1);
-      $this->array($data)
-         ->array['data']
-         ->array['rows']
+      $this->array($data)->array['data'];
+      $this->array(iterator_to_array($data['data']['rows']))
          ->array[0]
          ->array['raw']
          ->string['ITEM_Problem_1']->isEqualTo('test problem visibility for tech');
@@ -1401,9 +1400,8 @@ class Search extends DbTestCase {
       \Search::constructData($data);
 
       $this->integer($data['data']['totalcount'])->isEqualTo(1);
-      $this->array($data)
-         ->array['data']
-         ->array['rows']
+      $this->array($data)->array['data'];
+      $this->array(iterator_to_array($data['data']['rows']))
          ->array[0]
          ->array['raw']
          ->string['ITEM_Change_1']->isEqualTo('test Change visibility for tech');
@@ -1762,14 +1760,13 @@ class Search extends DbTestCase {
     */
    private function checkSearchResult($result) {
       $this->array($result)->hasKey('data');
-      $this->array($result['data'])->hasKeys(['count', 'begin', 'end', 'totalcount', 'cols', 'rows', 'items']);
+      $this->array($result['data'])->hasKeys(['count', 'begin', 'end', 'totalcount', 'cols', 'rows']);
       $this->integer($result['data']['count']);
       $this->integer($result['data']['begin']);
       $this->integer($result['data']['end']);
       $this->integer($result['data']['totalcount']);
       $this->array($result['data']['cols']);
-      $this->array($result['data']['rows']);
-      $this->array($result['data']['items']);
+      $this->array(iterator_to_array($result['data']['rows']));
 
       // No errors
       $this->array($result)->hasKey('last_errors');


### PR DESCRIPTION
* Add LIMIT to search queries

#### Current search engine

The search engine currently only use a `LIMIT` clause if there is no search criteria specified.
In this case, it will send a second `COUNT(*)` query after the main search to know the total number of results.

Any query with a defined criteria does not use the `LIMIT` clause.
The full results are send to PHP and we only iterate on the first X results (the number of results to display on one page).

This help execution time as  `COUNT` requests can be costly but is very bad for memory consumption on big databases.

 #### Changes to the search engine

Every search request is now accompanied by a second `COUNT` request.

The mandatory clauses to re-use from the main query are `FROM`, `GROUP BY` and `HAVING`.
The `SELECT` and `FROM` clauses must only contains mandatory fields and joins to get the fastest request as possible.

The simplest case is a search without a `HAVING` clause.
This will results in a very simple `COUNT` request:
```sql
SELECT COUNT(*) FROM {main_table} {mandatory joins for the conditions fields} WHERE {condition}
```

The more complicated case is when we have a `HAVING` clause as we it forces us to add fields in the `SELECT` clause (the `HAVING` clause filters on selected results and thus cannot be done without them in the query).
In this case, we end up with a request like this:
```sql
SELECT COUNT(*) FROM (
   SELECT {having fields} FROM {main_table} {mandatory joins for the conditions fields} WHERE {condition} HAVING ... GROUP BY ...
)
```

#### Benchmark 

Here is a quick benchmark on a ~140k computers database.
We are doing some searches on computers and checking the time used by the `Search::constructData()` function as well as the memory peak of the application.
I've put in bold some values that stand out as worse.

| Search criteria | 9.5 bugfixes | #9495|
| ------------- | ---|-----|
| * | 1.18s (7.64 Mio) | 1.16s(7.60 Mio) |
| name contains 'se'  | 0.35s (**10.36 Mio**) | **0.58s** (7.62 Mio) |
| alternate username contains 'a' and location is not "Caen" | 1.51s (**56.68 Mio**)  | 1.43s (7.63 Mio) |
| manufacturer is 'HP' and status is "Status A" | 0.83s (**36.38 Mio**) | 0.73s (7.64 Mio) |
| comments contains 'ab' or serial contains '44' or uuid contains '7' | 1.78s (**72.88 Mio**)| 1.57s (7.68 Mio) |

On the memory consumption side the results are excellent.
Before these changes the memory peak will scale depending on the numbers of returned results and the number of fields displayed (more fields = more data to send back to PHP).
After these change the memory peak will always stays around the same for a given page size.

On the execution time side the results are more difficult to analyze.
The gains / loses all depend on the `COUNT` query execution time.
If it is almost instantaneous then we gain a little time or are even with the 9.5 bugfixes branches (test 1, 3, 4 and 5).
If it not instantaneous then we have worse performances, it may be a few extra tenth at best and in a few rare cases a possible x2 execution time (the `COUNT` request would be almost as long as the main query in those cases like test 2).

* Remove 'no_search' option

The search engine used this option internally to know if we had a search with no criteria and thus would be able to use the LIMIT query (as described in "Current search engine" section above).
Since we now use `LIMIT` all the time this option is no longer needed and all associated code as been removed.

* Remove 'all' criteria

As we discussed the 'all' criteria is outdated and bugged so this PR is a good opportunity to remove it.

* Fix duplicate aliases

It seems we had a few case of duplicate aliases in the `SELECT` clause of our search requests.
This is not a problem in most simple requests as MySQL allow duplicates in the results.

It is however a problem with wrapped queries like `SELECT COUNT(*) FROM ( {wrapped query} )`, duplicated alias are not allowed in the wrapped query and will cause a SQL error.

There was two kind of duplicated aliases in the code base:
One of them was on Ticket/Problem/Changes and could be fixed in the searchoption by removing an extra field.
The other was on a special case of a meta criteria join on the current itemtype (for example searching for documents on documents).
This case required a fix in the search engine by adding a "META_" prefix to meta criteria aliases in the `SELECT` and `HAVING` clauses.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22511
