### PR TITLE
fix overlap of template name field with header's ribbon

### DIFF
--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -35,9 +35,9 @@
             {% set nametype = __('Created from the template %s')|format(template_name) %}
          {% elseif withtemplate == 1 %}
             <input type="hidden" name="is_template" value="1" />
-            <input type="text" class="form-control" placeholder="{{ __('Template name') }}"
-                  name="template_name" id="textfield_template_name{{ rand }}"
-                  value="{{ template_name }}" />
+            <input type="text" class="form-control ms-4 mb-2" placeholder="{{ __('Template name') }}"
+                   name="template_name" id="textfield_template_name{{ rand }}"
+                   value="{{ template_name }}" />
          {% elseif item.isNewItem() %}
             {% set nametype = __('%1$s - %2$s')|format(__('New item'), nametype) %}
          {% else %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Before:
![image](https://user-images.githubusercontent.com/418844/131973468-4e5a938f-2882-433f-a0a4-9571c2673dc0.png)

