### PR TITLE
Fix/anonymize heldesk

### DIFF
--- a/inc/dbutils.class.php
+++ b/inc/dbutils.class.php
@@ -1472,7 +1472,7 @@ final class DbUtils {
          if (count($iterator) == 1) {
             $data     = $iterator->next();
 
-            $anon_name = Session::getCurrentInterface() == 'helpdesk' ? User::getAnonymizedNameForUser($ID) : null;
+            $anon_name = $ID != ($_SESSION['glpiID'] ?? 0) && Session::getCurrentInterface() == 'helpdesk' ? User::getAnonymizedNameForUser($ID) : null;
             if ($anon_name !== null) {
                $username = $anon_name;
             } else {

--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -952,6 +952,26 @@ class Group extends CommonTreeDropdown {
       ) > 0;
    }
 
+   function getName($options = []) {
+      if (Session::getCurrentInterface() == 'helpdesk'
+          && ($anon = self::getAnonymizedName()) !== "") {
+         return $anon;
+      }
+
+      return parent::getName($options);
+   }
+
+
+   function getRawCompleteName() {
+      if (Session::getCurrentInterface() == 'helpdesk'
+         && ($anon = $this->getAnonymizedName()) !== null) {
+         return $anon;
+      }
+
+      return parent::getRawCompleteName();
+   }
+
+
    public static function getAnonymizedName(?int $entities_id = null): string {
       switch (Entity::getAnonymizeConfig($entities_id)) {
          default:

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -5740,8 +5740,10 @@ JAVASCRIPT;
     * @return string
     */
    public function getUserLink(bool $enable_anonymization = false): string {
-
-      if ($enable_anonymization && Session::getCurrentInterface() == 'helpdesk' && ($anon = $this->getAnonymizedName()) !== null) {
+      if ($enable_anonymization
+          && $this->fields['id'] != $_SESSION['glpiID']
+          && Session::getCurrentInterface() == 'helpdesk'
+          && ($anon = $this->getAnonymizedName()) !== null) {
          // if anonymized name active, return only the anonymized name
          return $anon;
       }

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -18,8 +18,12 @@
          <div class="timeline-badges">
             {% if entry_i['users_id_tech'] %}
                <span class="badge bg-orange-lt">
-                  <i class="fas fa-user me-1"></i>
-                  {{ get_item_link('User', entry_i['users_id_tech'], {'enable_anonymization': true}) }}
+                  {% set is_current_tech = (entry_i['users_id_tech'] == session('glpiID')) %}
+                  {% set anonym_tech = (get_current_interface() == 'helpdesk' and not is_current_tech and entity_config('anonymize_support_agents') != constant('Entity::ANONYMIZE_DISABLED')) %}
+                  {{ include('components/user/link_with_tooltip.html.twig', {
+                     'users_id': entry_i['users_id_tech'],
+                     'enable_anonymization': anonym_tech
+                  }, with_context = false) }}
                </span>
             {% endif %}
 

--- a/templates/components/itilobject/timeline/main_description.html.twig
+++ b/templates/components/itilobject/timeline/main_description.html.twig
@@ -13,10 +13,10 @@
                <div class="d-flex timeline-header">
                   <div class="d-flex creator">
                      {{ include('components/itilobject/timeline/timeline_item_header_badges.html.twig', {
-                        'creator': get_item_link('User', users_id, {'enable_anonymization': true}),
+                        'users_id': users_id,
                         'date_creation': item.fields['date_creation'],
                         'date_mod': item.fields['date_mod'],
-                        'editor': get_item_link('User', item.fields['users_id_lastupdater'], {'enable_anonymization': true}),
+                        'users_id_editor': item.fields['users_id_lastupdater'],
                      }, with_context = false) }}
                   </div>
 

--- a/templates/components/itilobject/timeline/main_description.html.twig
+++ b/templates/components/itilobject/timeline/main_description.html.twig
@@ -17,6 +17,7 @@
                         'date_creation': item.fields['date_creation'],
                         'date_mod': item.fields['date_mod'],
                         'users_id_editor': item.fields['users_id_lastupdater'],
+                        'anonym_user': anonym_user,
                      }, with_context = false) }}
                   </div>
 

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -10,8 +10,7 @@
       {% set date_mod = entry_i['date_mod'] %}
       {% set entry_rand = random() %}
       {% set is_current_user = users_id == session('glpiID') %}
-      {% set anonym_user = (not is_current_user and entity_config('anonymize_support_agents') != constant('Entity::ANONYMIZE_DISABLED')) %}
-      {# {% set anonym_user = (get_current_interface() == 'helpdesk' and not is_current_user and entity_config('anonymize_support_agents') != constant('Entity::ANONYMIZE_DISABLED')) %} #}
+      {% set anonym_user = (get_current_interface() == 'helpdesk' and not is_current_user and entity_config('anonymize_support_agents') != constant('Entity::ANONYMIZE_DISABLED')) %}
 
       {# Fix solution type #}
       {% if entry['type'] is same as 'Solution' %}

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -9,6 +9,9 @@
       {% set date_creation = entry_i['date_creation'] ?? entry_i['date'] %}
       {% set date_mod = entry_i['date_mod'] %}
       {% set entry_rand = random() %}
+      {% set is_current_user = users_id == session('glpiID') %}
+      {% set anonym_user = (not is_current_user and entity_config('anonymize_support_agents') != constant('Entity::ANONYMIZE_DISABLED')) %}
+      {# {% set anonym_user = (get_current_interface() == 'helpdesk' and not is_current_user and entity_config('anonymize_support_agents') != constant('Entity::ANONYMIZE_DISABLED')) %} #}
 
       {# Fix solution type #}
       {% if entry['type'] is same as 'Solution' %}
@@ -77,17 +80,19 @@
                   {% set user_fields = user_fields|merge({user_name: entry_user.getFriendlyName()|verbatim_value}) %}
                   {% set user_fields = user_fields|merge({email: entry_user.getDefaultEmail()}) %}
                   <span id="timeline-avatar{{ avatar_rand }}">
-                     {{ include('components/user/picture.html.twig', {'users_id': users_id, 'enable_anonymization': true}, with_context = false) }}
+                     {{ include('components/user/picture.html.twig', {
+                        'users_id': users_id,
+                        'enable_anonymization': anonym_user
+                     }, with_context = false) }}
                   </span>
-                  {% if entity_config('anonymize_support_agents') == constant('Entity::ANONYMIZE_DISABLED') %}
+                  {% if not anonym_user %}
                      {% do call('Html::showToolTip', [
-                        include('components/user/info_card.html.twig',
-                           {
-                              'user': user_fields,
-                              'enable_anonymization': true,
-                           },
-                           with_context = false),
-                        {'applyto': 'timeline-avatar' ~ avatar_rand}]) %}
+                        include('components/user/info_card.html.twig', {
+                           'user': user_fields,
+                           'enable_anonymization': false,
+                        }, with_context = false), {
+                           'applyto': 'timeline-avatar' ~ avatar_rand
+                        }]) %}
                   {% endif %}
                {% else %}
                   <span id="timeline-avatar{{ avatar_rand }}"><span class="avatar avatar-md rounded"></span></span>

--- a/templates/components/itilobject/timeline/timeline_item_header.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header.html.twig
@@ -1,10 +1,11 @@
 <div class="d-flex timeline-header">
    <div class="d-flex creator">
       {{ include('components/itilobject/timeline/timeline_item_header_badges.html.twig', {
-         'creator': get_item_link('User', users_id, {'enable_anonymization': true}),
+         'users_id': users_id,
          'date_creation': date_creation,
          'date_mod': date_mod,
-         'editor': get_item_link('User', entry_i['users_id_editor'], {'enable_anonymization': true}),
+         'users_id_editor': entry_i['users_id_editor'],
+         'anonym_user': anonym_user,
       }, with_context = false) }}
    </div>
 

--- a/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
@@ -6,11 +6,12 @@
       </span>
    {% endset %}
 
-   {% if creator|length > 0 %}
+   {% if users_id > 0 %}
       {% set creator_span %}
-         <span >
-            <i class="far fa-user me-1"></i>{{ creator|raw }}
-         </span>
+         {{ include('components/user/link_with_tooltip.html.twig', {
+            'users_id': users_id,
+            'enable_anonymization': anonym_user
+         }, with_context = false) }}
       {% endset %}
 
       {{ __('Created: %1$s by %2$s')|format(date_span, creator_span)|raw }}
@@ -19,7 +20,7 @@
    {% endif %}
 </span>
 
-{% if editor|length > 0 and date_creation != date_mod %}
+{% if users_id_editor > 0 and date_creation != date_mod %}
    <span class="badge text-wrap ms-1 d-none d-md-block">
       {% set date_span %}
          <span title="{{ date_mod|formatted_datetime }}"
@@ -28,10 +29,13 @@
          </span>
       {% endset %}
 
+      {% set is_current_editor = (users_id_editor == session('glpiID')) %}
+      {% set anonym_editor = (get_current_interface() == 'helpdesk' and not is_current_editor and entity_config('anonymize_support_agents') != constant('Entity::ANONYMIZE_DISABLED')) %}
       {% set editor_span %}
-         <span>
-            <i class="far fa-user me-1"></i>{{ editor|raw }}
-         </span>
+         {{ include('components/user/link_with_tooltip.html.twig', {
+            'users_id': users_id_editor,
+            'enable_anonymization': anonym_editor
+         }, with_context = false) }}
       {% endset %}
 
       {{ __('Last update: %1$s by %2$s')|format(date_span, editor_span)|raw }}

--- a/templates/components/user/info_card.html.twig
+++ b/templates/components/user/info_card.html.twig
@@ -3,7 +3,12 @@
 <div class="p-0 user-info-card">
    <div class="row">
       <div class="col pt-1">
-         {{ include('components/user/picture.html.twig', {'users_id': user['id'], 'enable_anonymization': enable_anonymization}) }}
+         {% if user['id'] %}
+            {{ include('components/user/picture.html.twig', {
+               'users_id': user['id'],
+               'enable_anonymization': enable_anonymization
+            }) }}
+         {% endif %}
       </div>
       <div class="col-auto ms-2">
          <h4 class="card-title mb-1">

--- a/templates/components/user/link_with_tooltip.html.twig
+++ b/templates/components/user/link_with_tooltip.html.twig
@@ -1,0 +1,21 @@
+{% set rand = random() %}
+
+<span id="user_{{ rand }}">
+   <i class="far fa-user ms-1"></i>
+   {{ get_item_link('User', users_id, {
+      'enable_anonymization': enable_anonymization
+   })|raw }}
+</span>
+
+{% if not enable_anonymization %}
+   {% set user = get_item('User', users_id) %}
+   {% set user_fields = user.fields %}
+   {% set user_fields = user_fields|merge({user_name: user.getFriendlyName()|verbatim_value}) %}
+   {% set user_fields = user_fields|merge({email: user.getDefaultEmail()}) %}
+   {% do call('Html::showToolTip', [
+      include('components/user/info_card.html.twig', {
+         'user': (user_fields ?? []),
+      }, with_context = false), {
+         'applyto': "user_" ~ rand
+      }]) %}
+{% endif %}

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -106,7 +106,12 @@ class DbTestCase extends \GLPITestCase {
 
       if (count($input)) {
          foreach ($input as $k => $v) {
-            $this->variable($object->getField($k))->isEqualTo($v);
+            $this->variable($object->fields[$k])->isEqualTo(
+               $v,
+               "
+                '$k' key current value '{$object->fields[$k]}' (".gettype($object->fields[$k]).")
+                is not equal to '$v' (".gettype($v).")"
+            );
          }
       }
    }

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -532,17 +532,17 @@ class Entity extends DbTestCase {
          [
             'interface' => 'central',
             'setting'   => \Entity::ANONYMIZE_DISABLED,
-            'expected'  => TU_USER,
+            'expected'  => 'test_anon_user',
          ],
          [
             'interface' => 'helpdesk',
             'setting'   => \Entity::ANONYMIZE_DISABLED,
-            'expected'  => TU_USER,
+            'expected'  => 'test_anon_user',
          ],
          [
             'interface' => 'central',
             'setting'   => \Entity::ANONYMIZE_USE_GENERIC,
-            'expected'  => TU_USER,
+            'expected'  => 'test_anon_user',
          ],
          [
             'interface' => 'helpdesk',
@@ -552,7 +552,7 @@ class Entity extends DbTestCase {
          [
             'interface' => 'central',
             'setting'   => \Entity::ANONYMIZE_USE_NICKNAME,
-            'expected'  => TU_USER,
+            'expected'  => 'test_anon_user',
             'user_nick' => 'user_nick_6436345654'
          ],
          [
@@ -576,7 +576,7 @@ class Entity extends DbTestCase {
       global $DB;
 
       $this->login();
-      $possible_values = [TU_USER, 'user_nick_6436345654', "Helpdesk user"];
+      $possible_values = ['test_anon_user', 'user_nick_6436345654', "Helpdesk user"];
 
       // Set entity setting
       $entity = getItemByTypeName("Entity", "_test_root_entity");
@@ -586,8 +586,15 @@ class Entity extends DbTestCase {
       ]);
       $this->boolean($update)->isTrue();
 
+      // create a user for this test (avoid using current logged user as we don't anonymize him)
+      $user_obj = new \User();
+      $user_obj->add([
+         'name'     => 'test_anon_user',
+         'password' => 'test_anon_user'
+      ]);
+
       // // Set user nickname
-      $user = getItemByTypeName('User', TU_USER);
+      $user = getItemByTypeName('User', 'test_anon_user');
 
       if ($user_nick == "" && $user->fields['nickname'] == null) {
          // Special case, glpi wont update null to "" so we need to set
@@ -613,17 +620,17 @@ class Entity extends DbTestCase {
       $this->login();
       $ticket = new Ticket();
       $tickets_id = $ticket->add($input = [
-         'name'             => 'test',
-         'content'          => 'test',
-         '_users_id_assign' => getItemByTypeName('User', TU_USER, true),
-         '_users_id_requester' => getItemByTypeName('User', 'post-only', true),
-         'entities_id'      => $entity->getID(),
-         'users_id_recipient' => getItemByTypeName('User', TU_USER, true),
+         'name'                 => 'test',
+         'content'              => 'test',
+         '_users_id_assign'     => getItemByTypeName('User', 'test_anon_user', true),
+         '_users_id_requester'  => getItemByTypeName('User', 'post-only', true),
+         'entities_id'          => $entity->getID(),
+         'users_id_recipient'   => getItemByTypeName('User', TU_USER, true),
          'users_id_lastupdater' => getItemByTypeName('User', TU_USER, true),
          // The default requesttype is "Helpdesk" and will mess up our tests,
          // we need another one to be sure the "Helpdesk" string will only be
          // printed by the anonymization code
-         'requesttypes_id'  => 4,
+         'requesttypes_id'      => 4,
       ]);
       $this->integer($tickets_id)->isGreaterThan(0);
 
@@ -643,13 +650,13 @@ class Entity extends DbTestCase {
       $this->array(iterator_to_array($ticket_users))->isEqualTo([
          0 => [
             'tickets_id' => $tickets_id,
-            'users_id' => getItemByTypeName('User', 'post-only', true),
-            'type' => CommonITILActor::REQUESTER,
+            'users_id'   => getItemByTypeName('User', 'post-only', true),
+            'type'       => CommonITILActor::REQUESTER,
          ],
          1 => [
             'tickets_id' => $tickets_id,
-            'users_id' => getItemByTypeName('User', TU_USER, true),
-            'type' => CommonITILActor::ASSIGN,
+            'users_id'   => getItemByTypeName('User', 'test_anon_user', true),
+            'type'       => CommonITILActor::ASSIGN,
          ],
       ]);
 
@@ -657,8 +664,8 @@ class Entity extends DbTestCase {
       $fup = new ITILFollowup();
       $fup_id = $fup->add([
          'content' => 'test',
-         'users_id' => getItemByTypeName('User', TU_USER, true),
-         'users_id_editor' => getItemByTypeName('User', TU_USER, true),
+         'users_id' => getItemByTypeName('User', 'test_anon_user', true),
+         'users_id_editor' => getItemByTypeName('User', 'test_anon_user', true),
          'itemtype' => 'Ticket',
          'items_id' => $tickets_id,
       ]);
@@ -668,8 +675,8 @@ class Entity extends DbTestCase {
       $solution = new ITILSolution();
       $solutions_id = $solution->add([
          'content' => 'test',
-         'users_id' => getItemByTypeName('User', TU_USER, true),
-         'users_id_editor' => getItemByTypeName('User', TU_USER, true),
+         'users_id' => getItemByTypeName('User', 'test_anon_user', true),
+         'users_id_editor' => getItemByTypeName('User', 'test_anon_user', true),
          'itemtype' => 'Ticket',
          'items_id' => $tickets_id,
       ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

important changes:

- harmonize how a tooltip card is applied on a user link
- a user should not be anonymized if it's the current connected in session
- actors fields should also be anonymized

Warning when testing, anonymization is **only applied in helpdesk (self-service) interface**.
You can tempory do an easier test protocol by altering the return of `Session::getCurrentInterface()`