### PR TITLE
explicit multiple selection mode for ajax dropdowns

### DIFF
--- a/inc/abstractrightsdropdown.class.php
+++ b/inc/abstractrightsdropdown.class.php
@@ -79,6 +79,7 @@ abstract class AbstractRightsDropdown
       $params = [
          'values' => $values,
          'valuesnames' => self::getValueNames($values),
+         'multiple'    => true,
       ];
 
       return Html::jsAjaxDropdown($name, $field_id, $url, $params);

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -4643,25 +4643,28 @@ JAVASCRIPT
    static function jsAjaxDropdown($name, $field_id, $url, $params = []) {
       global $CFG_GLPI;
 
-      if (!array_key_exists('value', $params)) {
-         $value = 0;
-         $valuename = Dropdown::EMPTY_VALUE;
-      } else {
-         $value = $params['value'];
-         $valuename = $params['valuename'];
-      }
-      $on_change = '';
-      if (isset($params["on_change"])) {
-         $on_change = $params["on_change"];
-         unset($params["on_change"]);
-      }
-      $width = '80%';
-      if (isset($params["width"])) {
-         $width = $params["width"];
-         unset($params["width"]);
-      }
+      $default_options = [
+         'value'               => 0,
+         'valuename'           => Dropdown::EMPTY_VALUE,
+         'multiple'            => false,
+         'values'              => [],
+         'valuesnames'         => [],
+         'on_change'           => '',
+         'width'               => '80%',
+         'placeholder'         => '',
+         'display_emptychoice' => false,
+         'specific_tags'       => [],
+      ];
+      $params = array_merge($default_options, $params);
 
+      $value = $params['value'];
+      $width = $params["width"];
+      $valuename = $params['valuename'];
+      $on_change = $params["on_change"];
       $placeholder = $params['placeholder'] ?? '';
+      unset($params["on_change"]);
+      unset($params["width"]);
+
       $allowclear =  "false";
       if (strlen($placeholder) > 0 && !$params['display_emptychoice']) {
          $allowclear = "true";
@@ -4673,12 +4676,7 @@ JAVASCRIPT
       ];
 
       // manage multiple select (with multiple values)
-      if (isset($params['values'])
-         && (
-            count($params['values'])
-            || !isset($params['value'])
-         )
-      ) {
+      if ($params['multiple']) {
          $values = array_combine($params['values'], $params['valuesnames']);
          $options['multiple'] = 'multiple';
          $options['selected'] = $params['values'];
@@ -4695,13 +4693,11 @@ JAVASCRIPT
       unset($params['value']);
       unset($params['valuename']);
 
-      if (!empty($params['specific_tags'])) {
-         foreach ($params['specific_tags'] as $tag => $val) {
-            if (is_array($val)) {
-               $val = implode(' ', $val);
-            }
-            $options[$tag] = $val;
+      foreach ($params['specific_tags'] as $tag => $val) {
+         if (is_array($val)) {
+            $val = implode(' ', $val);
          }
+         $options[$tag] = $val;
       }
 
       $output = '';

--- a/inc/netpoint.class.php
+++ b/inc/netpoint.class.php
@@ -128,10 +128,10 @@ class Netpoint extends CommonDropdown {
 
       $field_id = Html::cleanId("dropdown_".$myname.$rand);
       $param    = ['value'               => $value,
-                        'valuename'           => $name,
-                        'entity_restrict'     => $entity_restrict,
-                        'devtype'             => $devtype,
-                        'locations_id'        => $locations_id];
+                   'valuename'           => $name,
+                   'entity_restrict'     => $entity_restrict,
+                   'devtype'             => $devtype,
+                   'locations_id'        => $locations_id];
       echo Html::jsAjaxDropdown($myname, $field_id,
                                 $CFG_GLPI['root_doc']."/ajax/getDropdownNetpoint.php",
                                 $param);


### PR DESCRIPTION
Bad behavior of technician filter on dashboards : the filter allows multiple selection but should allow selection of one item only.

I think there is currently only one multiple selection ajax dropdown (the new abstract rights dropdown made by @AdrienClairembault ), but I may be wrong. 

![image](https://user-images.githubusercontent.com/14139801/132018960-a25077ec-cc37-47b6-91ec-18c4f946d12b.png)

