### PR TITLE
Feat/remove itilobject dropdowns

### DIFF
--- a/inc/application/view/extension/itemtypeextension.class.php
+++ b/inc/application/view/extension/itemtypeextension.class.php
@@ -55,6 +55,7 @@ class ItemtypeExtension extends AbstractExtension {
          new TwigFilter('itemtype_form_path', [$this, 'getItemtypeFormPath']),
          new TwigFilter('itemtype_icon', [$this, 'getItemtypeIcon']),
          new TwigFilter('itemtype_name', [$this, 'getItemtypeName']),
+         new TwigFilter('itemtype_table', [$this, 'getItemtypeTable']),
          new TwigFilter('itemtype_search_path', [$this, 'getItemtypeSearchPath']),
       ];
    }
@@ -128,6 +129,17 @@ class ItemtypeExtension extends AbstractExtension {
     */
    public function getItemtypeName(string $itemtype, $count = 1): ?string {
       return is_a($itemtype, CommonGLPI::class, true) ? $itemtype::getTypeName($count) : null;
+   }
+
+   /**
+    * Returns table of given itemtype.
+    *
+    * @param string $itemtype
+    *
+    * @return string|null
+    */
+   public function getItemtypeTable(string $itemtype): ?string {
+      return is_a($itemtype, CommonGLPI::class, true) ? $itemtype::getTable() : null;
    }
 
    /**

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -157,7 +157,10 @@
 
             {{ include('components/itilobject/fields/priority_matrix.html.twig') }}
 
-            {% if item.isField('locations_id') %}
+            {% if item.isField('locations_id') and call('countElementsInTable', [
+               'Location'|itemtype_table,
+               {}
+            ]) > 0 %}
                {{ fields.dropdownField(
                   'Location',
                   'locations_id',
@@ -167,7 +170,10 @@
                ) }}
             {% endif %}
 
-            {% if item.isNewItem() and item.getType() == 'Ticket' %}
+            {% if item.isNewItem() and item.getType() == 'Ticket' and call('countElementsInTable', [
+               'Contract'|itemtype_table,
+               {'is_deleted': 0}
+            ]) > 0 %}
                {{ fields.dropdownField(
                   'Contract',
                   '_contracts_id',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

When adding #9492 (btw this pr depends on that), i though we can condition the display of the field  by checking content of contract table (we can gain some vertical space in this case).
I added also location as in helpdesk context, it's not often used, we may want also to remove some other fields (itilcategories, requesttypes ?)

I checked trashbin but i think we may check also entity tree maybe (but the code will become not very lisible), your thoughts ?
