### PR TITLE
Preserve npm lockfile version during dependencies install

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -44,7 +44,7 @@ if (isset($_SERVER['argv'])) {
 // Handle specific dependencies update command that cannot be made upon symfony console
 if (isset($_SERVER['argv']) && ['dependencies', 'install'] === array_slice($_SERVER['argv'], 1, 2)) {
    $composer_command = 'composer install --ansi --no-interaction';
-   $npm_command = 'npm install';
+   $npm_command = 'npm install --no-save';
 
    if (array_key_exists('composer-options', $options) && is_string($options['composer-options'])) {
       $composer_command .= ' ' . $options['composer-options'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Replaces #9489 as we do not want to switch to lockfile v2 since npm v7 is not yet available in node LTS bundles.