### PR TITLE
Fix meta search on database instances

### DIFF
--- a/inc/databaseinstance.class.php
+++ b/inc/databaseinstance.class.php
@@ -382,7 +382,7 @@ class DatabaseInstance extends CommonDBTM {
    public static function getTypes($all = false): array {
       global $CFG_GLPI;
 
-      $types = $CFG_GLPI['database_types'];
+      $types = $CFG_GLPI['databaseinstance_types'];
 
       foreach ($types as $key => $type) {
          if (!class_exists($type)) {

--- a/inc/define.php
+++ b/inc/define.php
@@ -487,7 +487,7 @@ $CFG_GLPI['appliance_relation_types'] = ['Location', 'Network', 'Domain'];
 
 $CFG_GLPI['remote_management_types'] = ['Computer', 'Phone'];
 
-$CFG_GLPI['database_types'] = ['Computer'];
+$CFG_GLPI['databaseinstance_types'] = ['Computer'];
 
 $dashboard_libs = [
    'dashboard', 'gridstack',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Meta search options are based on `*_types`. As items are linked to `DatabaseInstance`, corresponding config key has to be `databaseinstance_types`.