### PR TITLE
icons in menu label should have a spacing (was broken in horizontal menu)

### DIFF
--- a/css/includes/components/_global-menu.scss
+++ b/css/includes/components/_global-menu.scss
@@ -77,10 +77,6 @@
             color: rgba($color: $primary, $alpha: .9);
             font-weight: bold;
          }
-
-         .menu-label {
-            margin-left: 0.5em;
-         }
       }
    }
 

--- a/templates/layout/parts/menu.html.twig
+++ b/templates/layout/parts/menu.html.twig
@@ -13,7 +13,7 @@
       <a class="nav-link dropdown-toggle {{ firstlevel_active ? 'active' : '' }} {{ firstlevel_shown ? 'show' : '' }}"
          data-bs-toggle="dropdown" role="button"
          aria-expanded="{{ firstlevel_shown ? 'true' : 'false' }}">
-         <i class="fa-fw {{ firstlevel['icon'] ?? '' }}"></i>
+         <i class="fa-fw {{ firstlevel['icon'] ?? '' }} me-1"></i>
          <span class="menu-label">{{ firstlevel['title'] }}</span>
       </a>
       <div class="dropdown-menu {{ firstlevel_active and is_vertical != false ? '' : 'animate__animated' }} {{ is_vertical ? 'animate__fadeInLeft' : 'animate__zoomIn' }} {{ firstlevel_shown ? 'show' : '' }}">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
