### PR TITLE
fix(ldap): force user auths_id for LDAP auth

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -846,6 +846,11 @@ class Auth extends CommonGLPI {
                      || $this->user->fields["authtype"] == $this::LDAP) {
 
                   if (Toolbox::canUseLdap()) {
+                     if ($this->user->fields["auths_id"] == 0) {
+                        if ($this->user->getFromDBbyName(addslashes($login_name))) {
+                           $this->user->fields["auths_id"] = $this->user->getField('auths_id');
+                        }
+                     }
                      AuthLDAP::tryLdapAuth($this, $login_name, $login_password,
                                              $this->user->fields["auths_id"]);
                      if (!$this->auth_succeded && !$this->user_found) {

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -846,6 +846,9 @@ class Auth extends CommonGLPI {
                      || $this->user->fields["authtype"] == $this::LDAP) {
 
                   if (Toolbox::canUseLdap()) {
+                     // Attempted to retrieve auths_id via login_name.
+                     // This allows the user to be authenticated against their LDAP directory
+                     // rather than testing all active LDAP directories in GLPI.
                      if ($this->user->fields["auths_id"] == 0) {
                         if ($this->user->getFromDBbyName(addslashes($login_name))) {
                            $this->user->fields["auths_id"] = $this->user->getField('auths_id');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22553

This is a quick&dirty fix, it certainly deserves better code, with unit tests ;)

If a user has already authenticate (or imported from bin/console ldap) : it's LDAP server is filled (auths_id field), so we can use it for the authentication instead of trying all LDAP servers.

The """same""" thing is done for external authentication (SSO type):
https://github.com/glpi-project/glpi/blob/dfe5f08270886aeb0277d60fe6b295b5d310d820/inc/auth.class.php#L741

