### PR TITLE
Do not reset Telemetry task state if disabled

### DIFF
--- a/inc/update.class.php
+++ b/inc/update.class.php
@@ -537,11 +537,13 @@ class Update extends CommonGLPI {
          );
       }
 
-      // reset telemetry
-      $crontask_telemetry = new CronTask;
+      // Reset telemetry if its state is running, assuming it remained stuck due to telemetry service issue (see #7492).
+      $crontask_telemetry = new CronTask();
       $crontask_telemetry->getFromDBbyName("Telemetry", "telemetry");
-      $crontask_telemetry->resetDate();
-      $crontask_telemetry->resetState();
+      if ($crontask_telemetry->fields['state'] === CronTask::STATE_RUNNING) {
+         $crontask_telemetry->resetDate();
+         $crontask_telemetry->resetState();
+      }
 
       //generate security key if missing, and update db
       $glpikey = new GLPIKey();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since 9.4.0, update process forces the Telemetry task state to `WAITING` even if it was disabled (meaning user did not gave its consent to send Telemetry information).