### PR TITLE
[Modern UI] Fix select2 search autofocus

### DIFF
--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -1060,13 +1060,23 @@ class Dropdown {
 
 
    /**
-    * Display a menu to select a itemtype which open the search form
+    * Display a menu to select an itemtype which open the search form (by default)
     *
-    * @param $title     string   title to display
-    * @param $optgroup  array    (group of dropdown) of array (itemtype => localized name)
-    * @param $value     string   URL of selected current value (default '')
+    * @param string     $title     title to display
+    * @param array      $optgroup  (group of dropdown) of array (itemtype => localized name)
+    * @param string     $value     URL of selected current value (default '')
+    * @param array      $options
+    *
+    * @return void
    **/
-   static function showItemTypeMenu($title, $optgroup, $value = '') {
+   static function showItemTypeMenu(string $title, array $optgroup, string $value = '', array $options = []): void {
+      $params = [
+         'on_change'             => "var _value = this.options[this.selectedIndex].value; if (_value != 0) {window.location.href=_value;}",
+         'width'                 => '300px',
+         'display_emptychoice'   => true,
+      ];
+      $params = array_replace($params, $options);
+
       echo "<div class='container-fluid text-start'>";
       echo "<div class='mb-3 row'>";
       echo "<label class='col-sm-1 col-form-label'>$title</label>";
@@ -1084,10 +1094,10 @@ class Dropdown {
       }
       echo "<div class='col-sm-11'>";
       Dropdown::showFromArray('dpmenu', $values, [
-         'on_change'           => "var _value = this.options[this.selectedIndex].value; if (_value != 0) {window.location.href=_value;}",
+         'on_change'           => $params['on_change'],
          'value'               => $selected,
-         'display_emptychoice' => true,
-         'width'               => '300px',
+         'display_emptychoice' => $params['display_emptychoice'],
+         'width'               => $params['width'],
       ]);
       echo "</div>";
       echo "</div>";

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -4334,10 +4334,11 @@ JAVASCRIPT
       $templateselection = $params["templateSelection"] ?? "templateSelection";
 
       $js = "$(function() {
-         $('#$id').select2({
+         const select2_el = $('#$id').select2({
             $placeholder
             width: '$width',
             dropdownAutoWidth: true,
+            dropdownParent: $('#$id').closest('div.modal, body'),
             quietMillis: 100,
             minimumResultsForSearch: ".$CFG_GLPI['ajax_limit_count'].",
             matcher: function(params, data) {
@@ -4425,6 +4426,7 @@ JAVASCRIPT
             $('#$id').val(value).trigger('change');
          })
          $('label[for=$id]').on('click', function(){ $('#$id').select2('open'); });
+         $(`.select2-search__field[aria-controls='select2-\${e.target.id}-results']`).focus();
       });";
       return Html::scriptBlock($js);
    }
@@ -4523,13 +4525,14 @@ JAVASCRIPT
       }
       $js.= "};
 
-         $('#$field_id').select2({
+         const select2_el = $('#$field_id').select2({
             width: '$width',
             placeholder: '$placeholder',
             allowClear: $allowclear,
             minimumInputLength: 0,
             quietMillis: 100,
             dropdownAutoWidth: true,
+            dropdownParent: $('#$field_id').closest('div.modal, body'),
             minimumResultsForSearch: ".$CFG_GLPI['ajax_limit_count'].",
             ajax: {
                url: '$url',
@@ -4598,6 +4601,7 @@ JAVASCRIPT
       }
 
       $js .= " $('label[for=$field_id]').on('click', function(){ $('#$field_id').select2('open'); });";
+      $js .= " $(`.select2-search__field[aria-controls='select2-\${e.target.id}-results']`).focus();";
 
       $output .= Html::scriptBlock('$(function() {' . $js . '});');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This fixes two issues with the search input focus:
- The search box is no longer automatically focused when the select2 dropdown is opened. This seems to be a known issue but has not been fixed upstream.
https://github.com/select2/select2/issues/5993
As a workaround, we need to manually set the focus when the dropdown is opened. The user can still use the arrow keys to select an option when the search is focused.
- When the dropdown is in a Bootstrap modal, it is impossible to interact with the search box. The modal seems to change the focus to its close button instead. For this, we need to be able to specify the `dropdownParent` property during the select2 initialization. I added the ability to manually specify the dropdown parent selector or by default it automatically uses the parent modal or document body (select2 default).