### PR TITLE
Use GET request for ajax dashboards

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -940,7 +940,7 @@ var Dashboard = {
 
       return $.ajax({
          url:CFG_GLPI.root_doc+"/ajax/dashboard.php",
-         method: 'POST',
+         method: 'GET',
          data: {
             'action': 'get_cards',
             data: JSON.stringify({ //Preserve integers


### PR DESCRIPTION
AJAX dashboard are supposed to depend on a 40 seconds browser cache as shown in this code from `grid.class.php` :

![image](https://user-images.githubusercontent.com/42734840/133440417-38be468c-643d-4cda-8829-c421f5e08ea5.png)


However, this cache doesn't seem to be working since #9370.
The new code use a `POST` request to fetch data which seems to be the issue.

If I change the method to `GET` then the browser cache works as expected.
From what I understand caching `POST` request is technically allowed but I'm not sure that browsers actually implements it.

Changing to a `GET` request works if you have a small dashboard with a few widgets.
However if you have too many cards you will end up with an `414 URI Too Long` HTTP error since GET requests only allow 2048 chars.

---

Can we get the browser cache to work with the `POST` request ?

Does this request really need such a heavy payload ? 
What is preventing us from only sending the dashboard's ID in a very light `GET` request and fetch the needed data from the database directly ?

---

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
