### PR TITLE
FIX: clone notification template

### DIFF
--- a/inc/notificationtemplate.class.php
+++ b/inc/notificationtemplate.class.php
@@ -38,6 +38,7 @@ if (!defined('GLPI_ROOT')) {
  * NotificationTemplate Class
 **/
 class NotificationTemplate extends CommonDBTM {
+   use Glpi\Features\Clonable;
 
    // From CommonDBTM
    public $dohistory = true;
@@ -50,7 +51,11 @@ class NotificationTemplate extends CommonDBTM {
 
    static $rightname = 'config';
 
-
+   public function getCloneRelations() :array {
+      return [
+         NotificationTemplateTranslation::class
+      ];
+   }
 
    static function getTypeName($nb = 0) {
       return _n('Notification template', 'Notification templates', $nb);
@@ -581,29 +586,5 @@ class NotificationTemplate extends CommonDBTM {
       parent::prepareInputForClone($input);
       $input['name'] = $input['name'] . ' (clone)';
       return $input;
-   }
-
-   function post_clone($source, $history) {
-      global $DB;
-      parent::post_clone($source, $history);
-
-      $iterator = $DB->request([
-         'SELECT' => 'id',
-         'FROM'   => 'glpi_notificationtemplatetranslations',
-         'WHERE'  => [
-            'notificationtemplates_id' => $source->getField('id')
-         ]
-      ]);
-
-      $succeed = true;
-      $translation = new NotificationTemplateTranslation();
-      while ($data = $iterator->next()) {
-         $translation->getFromDB($data['id']);
-         $translation->fields['notificationtemplates_id'] = $this->getField('id');
-         if ($translation->clone() === false) {
-            $succeed = false;
-         }
-      }
-      return $succeed;
    }
 }

--- a/tests/functionnal/NotificationTemplate.php
+++ b/tests/functionnal/NotificationTemplate.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+*/
+
+namespace tests\units;
+
+use \DbTestCase;
+
+/* Test for inc/notificationtemplate.class.php */
+
+class NotificationTemplate extends DbTestCase {
+
+   public function testClone() {
+      global $DB;
+
+      $iterator = $DB->request([
+         'SELECT' => 'notificationtemplates_id',
+         'FROM'   => \NotificationTemplateTranslation::getTable(),
+         'LIMIT'  => 1
+      ]);
+
+      if ($data = $iterator->next()) {
+         $template = new \NotificationTemplate();
+         $template->getFromDB($data['notificationtemplates_id']);
+         $added = $template->clone();
+         $this->integer((int)$added)->isGreaterThan(0);
+
+         $clonedTemplate = new \NotificationTemplate();
+         $this->boolean($clonedTemplate->getFromDB($added))->isTrue();
+
+         unset($template->fields['id']);
+         unset($template->fields['name']);
+         unset($template->fields['date_creation']);
+         unset($template->fields['date_mod']);
+
+         unset($clonedTemplate->fields['id']);
+         unset($clonedTemplate->fields['name']);
+         unset($clonedTemplate->fields['date_creation']);
+         unset($clonedTemplate->fields['date_mod']);
+
+         $this->array($template->fields)->isIdenticalTo($clonedTemplate->fields);
+      }
+   }
+}

--- a/tests/functionnal/NotificationTemplate.php
+++ b/tests/functionnal/NotificationTemplate.php
@@ -47,26 +47,25 @@ class NotificationTemplate extends DbTestCase {
          'LIMIT'  => 1
       ]);
 
-      if ($data = $iterator->next()) {
-         $template = new \NotificationTemplate();
-         $template->getFromDB($data['notificationtemplates_id']);
-         $added = $template->clone();
-         $this->integer((int)$added)->isGreaterThan(0);
+      $data = $iterator->next();
+      $template = new \NotificationTemplate();
+      $template->getFromDB($data['notificationtemplates_id']);
+      $added = $template->clone();
+      $this->integer((int)$added)->isGreaterThan(0);
 
-         $clonedTemplate = new \NotificationTemplate();
-         $this->boolean($clonedTemplate->getFromDB($added))->isTrue();
+      $clonedTemplate = new \NotificationTemplate();
+      $this->boolean($clonedTemplate->getFromDB($added))->isTrue();
 
-         unset($template->fields['id']);
-         unset($template->fields['name']);
-         unset($template->fields['date_creation']);
-         unset($template->fields['date_mod']);
+      unset($template->fields['id']);
+      unset($template->fields['name']);
+      unset($template->fields['date_creation']);
+      unset($template->fields['date_mod']);
 
-         unset($clonedTemplate->fields['id']);
-         unset($clonedTemplate->fields['name']);
-         unset($clonedTemplate->fields['date_creation']);
-         unset($clonedTemplate->fields['date_mod']);
+      unset($clonedTemplate->fields['id']);
+      unset($clonedTemplate->fields['name']);
+      unset($clonedTemplate->fields['date_creation']);
+      unset($clonedTemplate->fields['date_mod']);
 
-         $this->array($template->fields)->isIdenticalTo($clonedTemplate->fields);
-      }
+      $this->array($template->fields)->isIdenticalTo($clonedTemplate->fields);
    }
 }

--- a/tests/functionnal/NotificationTemplateTranslation.php
+++ b/tests/functionnal/NotificationTemplateTranslation.php
@@ -34,9 +34,9 @@ namespace tests\units;
 
 use \DbTestCase;
 
-/* Test for inc/notificationtemplate.class.php */
+/* Test for inc/notificationtemplatetranslation.class.php */
 
-class NotificationTemplate extends DbTestCase {
+class NotificationTemplateTranslation extends DbTestCase {
 
    public function testClone() {
       global $DB;

--- a/tests/functionnal/NotificationTemplateTranslation.php
+++ b/tests/functionnal/NotificationTemplateTranslation.php
@@ -75,22 +75,21 @@ class NotificationTemplate extends DbTestCase {
          'LIMIT'  => 1
       ]);
 
-      if ($data = $iterator->next()) {
-         $template = new \NotificationTemplate();
-         $template->getFromDB($data['notificationtemplates_id']);
-         $added = $template->clone();
+      $data = $iterator->next();
+      $template = new \NotificationTemplate();
+      $template->getFromDB($data['notificationtemplates_id']);
+      $added = $template->clone();
 
-         $translations = $DB->request([
-            'FROM'   => \NotificationTemplateTranslation::getTable(),
-            'WHERE'  => ['notificationtemplates_id' => $data['notificationtemplates_id']]
-         ]);
+      $translations = $DB->request([
+         'FROM'   => \NotificationTemplateTranslation::getTable(),
+         'WHERE'  => ['notificationtemplates_id' => $data['notificationtemplates_id']]
+      ]);
 
-         $clonedTranslations = $DB->request([
-            'FROM'   => \NotificationTemplateTranslation::getTable(),
-            'WHERE'  => ['notificationtemplates_id' => $added]
-         ]);
+      $clonedTranslations = $DB->request([
+         'FROM'   => \NotificationTemplateTranslation::getTable(),
+         'WHERE'  => ['notificationtemplates_id' => $added]
+      ]);
 
-         $this->integer(count($translations))->isIdenticalTo(count($clonedTranslations));
-      }
+      $this->integer(count($translations))->isIdenticalTo(count($clonedTranslations));
    }
 }

--- a/tests/functionnal/NotificationTemplateTranslation.php
+++ b/tests/functionnal/NotificationTemplateTranslation.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+*/
+
+namespace tests\units;
+
+use \DbTestCase;
+
+/* Test for inc/notificationtemplate.class.php */
+
+class NotificationTemplate extends DbTestCase {
+
+   public function testClone() {
+      global $DB;
+
+      $iterator = $DB->request([
+         'SELECT' => 'id',
+         'FROM'   => \NotificationTemplateTranslation::getTable(),
+         'LIMIT'  => 1
+      ]);
+
+      if ($data = $iterator->next()) {
+         $translation = new \NotificationTemplateTranslation();
+         $translation->getFromDB($data['id']);
+         $added = $translation->clone();
+         $this->integer((int)$added)->isGreaterThan(0);
+
+         $clonedTranslation = new \NotificationTemplateTranslation();
+         $this->boolean($clonedTranslation->getFromDB($added))->isTrue();
+
+         unset($translation->fields['id']);
+         unset($clonedTranslation->fields['id']);
+
+         $this->array($translation->fields)->isIdenticalTo($clonedTranslation->fields);
+      }
+   }
+
+   public function testCloneFromTemplate() {
+      global $DB;
+
+      $iterator = $DB->request([
+         'SELECT' => [
+            'id',
+            'notificationtemplates_id'
+         ],
+         'FROM'   => \NotificationTemplateTranslation::getTable(),
+         'LIMIT'  => 1
+      ]);
+
+      if ($data = $iterator->next()) {
+         $template = new \NotificationTemplate();
+         $template->getFromDB($data['notificationtemplates_id']);
+         $added = $template->clone();
+
+         $translations = $DB->request([
+            'FROM'   => \NotificationTemplateTranslation::getTable(),
+            'WHERE'  => ['notificationtemplates_id' => $data['notificationtemplates_id']]
+         ]);
+
+         $clonedTranslations = $DB->request([
+            'FROM'   => \NotificationTemplateTranslation::getTable(),
+            'WHERE'  => ['notificationtemplates_id' => $added]
+         ]);
+
+         $this->integer(count($translations))->isIdenticalTo(count($clonedTranslations));
+      }
+   }
+}

--- a/tests/functionnal/NotificationTemplateTranslation.php
+++ b/tests/functionnal/NotificationTemplateTranslation.php
@@ -47,20 +47,19 @@ class NotificationTemplate extends DbTestCase {
          'LIMIT'  => 1
       ]);
 
-      if ($data = $iterator->next()) {
-         $translation = new \NotificationTemplateTranslation();
-         $translation->getFromDB($data['id']);
-         $added = $translation->clone();
-         $this->integer((int)$added)->isGreaterThan(0);
+      $data = $iterator->next();
+      $translation = new \NotificationTemplateTranslation();
+      $translation->getFromDB($data['id']);
+      $added = $translation->clone();
+      $this->integer((int)$added)->isGreaterThan(0);
 
-         $clonedTranslation = new \NotificationTemplateTranslation();
-         $this->boolean($clonedTranslation->getFromDB($added))->isTrue();
+      $clonedTranslation = new \NotificationTemplateTranslation();
+      $this->boolean($clonedTranslation->getFromDB($added))->isTrue();
 
-         unset($translation->fields['id']);
-         unset($clonedTranslation->fields['id']);
+      unset($translation->fields['id']);
+      unset($clonedTranslation->fields['id']);
 
-         $this->array($translation->fields)->isIdenticalTo($clonedTranslation->fields);
-      }
+      $this->array($translation->fields)->isIdenticalTo($clonedTranslation->fields);
    }
 
    public function testCloneFromTemplate() {


### PR DESCRIPTION
When cloning a notification template, the translations were not cloned.
Add 'clone' in copy name to distinguish both.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22623
