### PR TITLE
Fix printer cloning/creation from template

### DIFF
--- a/inc/cartridge.class.php
+++ b/inc/cartridge.class.php
@@ -40,7 +40,7 @@ if (!defined('GLPI_ROOT')) {
  * @see CartridgeItem
  * @author Julien Dombre
  **/
-class Cartridge extends CommonDBChild {
+class Cartridge extends CommonDBRelation {
    use Glpi\Features\Clonable;
 
    // From CommonDBTM
@@ -48,9 +48,11 @@ class Cartridge extends CommonDBChild {
    public $dohistory                   = true;
    public $no_form_page                = true;
 
-   // From CommonDBChild
-   static public $itemtype             = 'CartridgeItem';
-   static public $items_id             = 'cartridgeitems_id';
+   static public $itemtype_1 = 'CartridgeItem';
+   static public $items_id_1 = 'cartridgeitems_id';
+
+   static public $itemtype_2 = 'Printer';
+   static public $items_id_2 = 'printers_id';
 
    public function getCloneRelations() :array {
       return [
@@ -94,7 +96,7 @@ class Cartridge extends CommonDBChild {
 
    function prepareInputForAdd($input) {
 
-      $item = static::getItemFromArray(static::$itemtype, static::$items_id, $input);
+      $item = static::getItemFromArray(CartridgeItem::class, CartridgeItem::getForeignKeyField(), $input);
       if ($item === false) {
          return false;
       }

--- a/inc/cartridge.class.php
+++ b/inc/cartridge.class.php
@@ -106,6 +106,21 @@ class Cartridge extends CommonDBRelation {
                    "date_in"           => date("Y-m-d")];
    }
 
+   function post_addItem() {
+
+      // inherit infocom
+      $infocoms = Infocom::getItemsAssociatedTo(CartridgeItem::getType(), $this->fields[CartridgeItem::getForeignKeyField()]);
+      if (count($infocoms)) {
+         $infocom = reset($infocoms);
+         $infocom->clone([
+            'itemtype'  => self::getType(),
+            'items_id'  => $this->getID()
+         ]);
+      }
+
+      parent::post_addItem();
+   }
+
 
    function post_updateItem($history = 1) {
 

--- a/inc/commondbchild.class.php
+++ b/inc/commondbchild.class.php
@@ -452,23 +452,10 @@ abstract class CommonDBChild extends CommonDBConnexity {
     * @return void
    **/
    function post_addItem() {
-      global $CFG_GLPI;
 
       $item = $this->getItem();
       if ($item === false) {
          return;
-      }
-
-      if (in_array(static::class, $CFG_GLPI["infocom_types"], true) && in_array(static::$itemtype, $CFG_GLPI["infocom_types"], true)) {
-         // inherit infocom
-         $infocoms = Infocom::getItemsAssociatedTo(static::$itemtype::getType(), $this->fields[static::$itemtype::getForeignKeyField()]);
-         if (count($infocoms)) {
-            $infocom = reset($infocoms);
-            $infocom->clone([
-               'itemtype'  => self::getType(),
-               'items_id'  => $this->getID()
-            ]);
-         }
       }
 
       if ($item->dohistory

--- a/inc/consumable.class.php
+++ b/inc/consumable.class.php
@@ -100,6 +100,21 @@ class Consumable extends CommonDBChild {
       return [];
    }
 
+   function post_addItem() {
+
+      // inherit infocom
+      $infocoms = Infocom::getItemsAssociatedTo(ConsumableItem::getType(), $this->fields[ConsumableItem::getForeignKeyField()]);
+      if (count($infocoms)) {
+         $infocom = reset($infocoms);
+         $infocom->clone([
+            'itemtype'  => self::getType(),
+            'items_id'  => $this->getID()
+         ]);
+      }
+
+      parent::post_addItem();
+   }
+
 
    /**
     * send back to stock

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -61,7 +61,6 @@ class Printer  extends CommonDBTM {
          Document_Item::class,
          Computer_Item::class,
          KnowbaseItem_Item::class,
-         Cartridge::class
       ];
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8218

Fix I initially proposed on https://github.com/glpi-project/glpi/issues/8218#issuecomment-724065718

1. Cartridge is a CommonDBRelation
2. When a printer is cloned, its cartridge should not (and cannot) be cloned, as a cartridge cannot be on 2 distinct printers.

I targeted master branch, as changing extended class may have side effects.