### PR TITLE
Search engine: Fix group criteria after meta criteria

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -957,7 +957,10 @@ class Search {
              && isset($criterion['itemtype'])) {
             $itemtype = $criterion['itemtype'];
             $meta = true;
-            $searchopt = &self::getOptions($itemtype);
+            $meta_searchopt = &self::getOptions($itemtype);
+         } else {
+            // Not a meta, use the same search option everywhere
+            $meta_searchopt = $searchopt;
          }
 
          // common search
@@ -986,7 +989,7 @@ class Search {
             }
 
             if (isset($criterion['criteria']) && count($criterion['criteria'])) {
-               $sub_sql = self::constructCriteriaSQL($criterion['criteria'], $data, $searchopt, $is_having);
+               $sub_sql = self::constructCriteriaSQL($criterion['criteria'], $data, $meta_searchopt, $is_having);
                if (strlen($sub_sql)) {
                   if ($NOT) {
                      $sql .= "$LINK NOT($sub_sql)";
@@ -994,7 +997,7 @@ class Search {
                      $sql .= "$LINK ($sub_sql)";
                   }
                }
-            } else if (isset($searchopt[$criterion['field']]["usehaving"])
+            } else if (isset($meta_searchopt[$criterion['field']]["usehaving"])
                        || ($meta && "AND NOT" === $criterion['link'])) {
                if (!$is_having) {
                   // the having part will be managed in a second pass

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1450,6 +1450,43 @@ class Search extends DbTestCase {
          ->contains("ORDER BY `ITEM_SearchTest\Computer_1` ASC");
    }
 
+   public function testGroupParamAfterMeta() {
+      // Try to run this query without warnings
+      $this->doSearch('Ticket', [
+         'reset'      => 'reset',
+         'is_deleted' => 0,
+         'start'      => 0,
+         'search'     => 'Search',
+         'criteria'   => [
+            [
+               'link'       => 'AND',
+               'field'      => 12,
+               'searchtype' => 'equals',
+               'value'      => 'notold',
+            ],
+            [
+               'link'       => 'AND',
+               'itemtype'   => 'Computer',
+               'meta'       => true,
+               'field'      => 1,
+               'searchtype' => 'contains',
+               'value'      => 'ù',
+            ],
+            [
+               'link' => 'AND',
+               'criteria' => [
+                  [
+                     'link'       => 'AND+NOT',
+                     'field'      => 'view',
+                     'searchtype' => 'contains',
+                     'value'      => '233',
+                  ]
+               ]
+            ]
+         ]
+      ]);
+   }
+
    /**
     * Check that search result is valid.
     *


### PR DESCRIPTION
Bug reported by @cedric-anne.
The search engine throw some warning when searching for a very specific query:

![image](https://user-images.githubusercontent.com/42734840/133760980-37b75d02-d2bb-4a93-b35c-a3c023e875fa.png)

This seems to be introduced by c4c332dd1ace71bc7960d8b86e3a175f9c0d3b0d which override the `$searchopt` variable when a meta criteria is present.
This lead to undefined indexes as some part of the code tries to fetch fields from the original value of `$searchopt`.

The "override" from c4c332dd1ace71bc7960d8b86e3a175f9c0d3b0d  can't just be reverted because it seems to be needed for some search options to run (`testSearchAllMeta` will fail if removed).

Fix seems to be keeping the original `$searchopt` value for some calls and send the alternate `$meta_searchopt` to others.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
