### PR TITLE
Change action_type for itilfollowup_template and task_template

### DIFF
--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -251,24 +251,6 @@ class RuleTicket extends Rule {
                      }
                   }
 
-                  if ($action->fields["field"] == 'task_template') {
-                     $template = new TaskTemplate();
-                     if ($template->getFromDB($action->fields["value"])) {
-                        // Store template id in '_tasktemplates_id' special
-                        // input so it can be handled in
-                        // CommonItilObject::handleTaskTemplateInput
-                        $output["_tasktemplates_id"][] = $template->getId();
-                     }
-                  } else if ($action->fields["field"] == 'itilfollowup_template') {
-                     $template = new ITILFollowupTemplate();
-                     if ($template->getFromDB($action->fields["value"])) {
-                        // Store template id in '_tasktemplates_id' special
-                        // input so it can be handled in
-                        // CommonItilObject::handleITILFollowupTemplateInput
-                        $output["_itilfollowuptemplates_id"][] = $template->getId();
-                     }
-                  }
-
                   // special case of appliance
                   if ($action->fields["field"] == "assign_appliance") {
                      if (!array_key_exists("items_id", $output) || $output['items_id'] == '0') {
@@ -876,12 +858,16 @@ class RuleTicket extends Rule {
       $actions['task_template']['name']                      = _n('Task template', 'Task templates', 1);
       $actions['task_template']['type']                      = 'dropdown';
       $actions['task_template']['table']                     = TaskTemplate::getTable();
-      $actions['task_template']['force_actions']             = ['assign'];
+      $actions['task_template']['force_actions']             = ['append'];
+      $actions['task_template']['permitseveral']             = ['append'];
+      $actions['task_template']['appendto']                  = '_tasktemplates_id';
 
       $actions['itilfollowup_template']['name']              = ITILFollowupTemplate::getTypeName(1);
       $actions['itilfollowup_template']['type']              = 'dropdown';
       $actions['itilfollowup_template']['table']             = ITILFollowupTemplate::getTable();
-      $actions['itilfollowup_template']['force_actions']     = ['assign'];
+      $actions['itilfollowup_template']['force_actions']     = ['append'];
+      $actions['itilfollowup_template']['permitseveral']     = ['append'];
+      $actions['itilfollowup_template']['appendto']          = '_itilfollowuptemplates_id';
 
       $actions['global_validation']['name']                  = _n('Validation', 'Validations', 1);
       $actions['global_validation']['type']                  = 'dropdown_validation_status';

--- a/install/migrations/update_9.5.x_to_10.0.0/ruleticketaction.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/ruleticketaction.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+// Change action type for "itilfollowup_template" and "task_template"
+$DB->updateOrDie(
+   "glpi_ruleactions",
+   [
+      "action_type" => "append"
+   ],
+   [
+      "action_type" => "assign",
+      "OR" => [
+         ["field" => "itilfollowup_template"],
+         ["field" => "task_template"],
+      ]
+   ]
+);

--- a/install/migrations/update_9.5.x_to_10.0.0/ruleticketaction.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/ruleticketaction.php
@@ -35,7 +35,7 @@
  */
 
 // Change action type for "itilfollowup_template" and "task_template"
-$DB->updateOrDie(
+$query = $DB->buildUpdate(
    "glpi_ruleactions",
    [
       "action_type" => "append"
@@ -48,3 +48,4 @@ $DB->updateOrDie(
       ]
    ]
 );
+$migration->addPostQuery($query);

--- a/tests/functionnal/RuleTicket.php
+++ b/tests/functionnal/RuleTicket.php
@@ -847,7 +847,7 @@ class RuleTicket extends DbTestCase {
       $rule_action_em = new RuleAction();
       $rule_action_id = $rule_action_em->add($act_input = [
          'rules_id'    => $rule_ticket_id,
-         'action_type' => 'assign',
+         'action_type' => 'append',
          'field'       => 'task_template',
          'value'       => $task_template_id,
       ]);
@@ -899,7 +899,45 @@ class RuleTicket extends DbTestCase {
       $this->array($ticket_tasks)->hasSize(1);
       $task_data = array_pop($ticket_tasks);
       $this->array($task_data)->hasKey('content');
-      $this->string($task_data['content'])->isEqualTo(Sanitizer::sanitize('<p>test content</p>'));
+      $this->string($task_data['content'])->isEqualTo(
+         Sanitizer::sanitize('<p>test content</p>')
+      );
+
+      // Add a second action to the rule (test multiple creation)
+      $this->createItem('TaskTemplate', [
+         'name'    => "template 2",
+         'content' => '<p>test content 2</p>',
+      ]);
+
+      $this->createItem('RuleAction', [
+         'rules_id'    => $rule_ticket_id,
+         'action_type' => 'append',
+         'field'       => 'task_template',
+         'value'       => getItemByTypeName("TaskTemplate", "template 2", true),
+      ]);
+
+      $this->createItem('Ticket', [
+         'name'     => 'test ticket with two tasks',
+         'content'  => 'test',
+         'priority' => 5,
+      ]);
+
+      $ticket_tasks = $ticket_task_em->find([
+         'tickets_id' => getItemByTypeName("Ticket", 'test ticket with two tasks', true),
+      ]);
+      $this->array($ticket_tasks)->hasSize(2);
+
+      $task_data = array_pop($ticket_tasks);
+      $this->array($task_data)->hasKey('content');
+      $this->string($task_data['content'])->isEqualTo(
+         Sanitizer::sanitize('<p>test content 2</p>')
+      );
+
+      $task_data = array_pop($ticket_tasks);
+      $this->array($task_data)->hasKey('content');
+      $this->string($task_data['content'])->isEqualTo(
+         Sanitizer::sanitize('<p>test content</p>')
+      );
    }
 
    public function testFollowupTemplateAssignFromRule() {
@@ -938,7 +976,7 @@ class RuleTicket extends DbTestCase {
       $rule_action = new RuleAction();
       $rule_action_id = $rule_action->add([
          'rules_id'    => $rule_ticket_id,
-         'action_type' => 'assign',
+         'action_type' => 'append',
          'field'       => 'itilfollowup_template',
          'value'       => $followup_template_id,
       ]);
@@ -962,7 +1000,9 @@ class RuleTicket extends DbTestCase {
       $this->array($ticket_followups)->hasSize(1);
       $ticket_followups_data = array_pop($ticket_followups);
       $this->array($ticket_followups_data)->hasKey('content');
-      $this->string($ticket_followups_data['content'])->isEqualTo(Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule</p>'));
+      $this->string($ticket_followups_data['content'])->isEqualTo(
+         Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule</p>')
+      );
 
       // Test on update
       $ticket = new \Ticket();
@@ -995,7 +1035,47 @@ class RuleTicket extends DbTestCase {
       $this->array($ticket_followups)->hasSize(1);
       $ticket_followups_data = array_pop($ticket_followups);
       $this->array($ticket_followups_data)->hasKey('content');
-      $this->string($ticket_followups_data['content'])->isEqualTo(Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule</p>'));
+      $this->string($ticket_followups_data['content'])->isEqualTo(
+         Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule</p>')
+      );
+
+      // Add a second action to the rule (test multiple creation)
+      $this->createItem('ITILFollowupTemplate', [
+         'name'    => "template 2",
+         'content' => '<p>test testFollowupTemplateAssignFromRule 2</p>',
+      ]);
+
+      $this->createItem('RuleAction', [
+         'rules_id'    => $rule_ticket_id,
+         'action_type' => 'append',
+         'field'       => 'itilfollowup_template',
+         'value'       => getItemByTypeName("ITILFollowupTemplate", "template 2", true),
+      ]);
+
+      $this->createItem('Ticket', [
+         'name'     => 'test ticket with two followups',
+         'content'  => 'test',
+         'priority' => 4,
+      ]);
+
+      $ticket_followups = new ITILFollowup();
+      $ticket_followups = $ticket_followups->find([
+         'items_id' => getItemByTypeName("Ticket", 'test ticket with two followups', true),
+         'itemtype' => "Ticket",
+      ]);
+      $this->array($ticket_followups)->hasSize(2);
+
+      $ticket_followups_data = array_pop($ticket_followups);
+      $this->array($ticket_followups_data)->hasKey('content');
+      $this->string($ticket_followups_data['content'])->isEqualTo(
+         Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule 2</p>')
+      );
+
+      $ticket_followups_data = array_pop($ticket_followups);
+      $this->array($ticket_followups_data)->hasKey('content');
+      $this->string($ticket_followups_data['content'])->isEqualTo(
+         Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule</p>')
+      );
    }
 
    public function testGroupRequesterAssignFromUserGroupsAndRegexOnUpdateTicketContent() {


### PR DESCRIPTION
Currently the `itilfollowup_template` and `task_template` use the `assign` action type.

![image](https://user-images.githubusercontent.com/42734840/134004088-5d065731-7b2d-4527-a5e0-106931c1619a.png)


The `append` action type seems more logical (you "add" a followup to ticket) and allows multiple followups or task per rule.

![image](https://user-images.githubusercontent.com/42734840/134004148-98a5f93e-3f46-4f33-beaf-625de4176b4a.png)



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22632
