### PR TITLE
[Modern UI] Fix pager in item log and events list

### DIFF
--- a/front/event.php
+++ b/front/event.php
@@ -38,14 +38,6 @@ Session::checkRight("logs", READ);
 
 Html::header(Event::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "Glpi\\Event");
 
-// Show last events
-if (isset($_GET["order"])) {
-   if (!isset($_GET["start"])) {
-      $_GET["start"] = 0;
-   }
-   Event::showList($_SERVER['PHP_SELF'], $_GET["order"], $_GET["sort"], $_GET["start"]);
-} else {
-   Event::showList($_SERVER['PHP_SELF']);
-}
+Event::showList($_SERVER['PHP_SELF'], $_GET['order'] ?? 'DESC', $_GET['sort']  ?? 'date', $_GET['start'] ?? 0);
 
 Html::footer();

--- a/js/modules/Search/Table.js
+++ b/js/modules/Search/Table.js
@@ -194,6 +194,7 @@ window.GLPI.Search.Table = class Table extends GenericView {
       });
 
       $(ajax_container).on('click', '.pagination .page-link', (e) => {
+         e.preventDefault();
          this.onPageChange(e.target);
       });
 

--- a/templates/components/logs.html.twig
+++ b/templates/components/logs.html.twig
@@ -4,7 +4,7 @@
    </div>
 {% else %}
 
-   {{ include('components/search/pager.html.twig', {count: filtered_number}) }}
+   {{ include('components/pager.html.twig', {count: filtered_number}) }}
    <div class="table-responsive">
    <table class="table table-hover">
       <thead>
@@ -20,7 +20,7 @@
                      <i class="fas fa-filter"></i>
                      <span class="d-none d-xl-block">{{ __('Filter') }}</span>
                   </button>
-                  <a href="{{ csv_url }}" class="btn btn-sm btn-icon btn-outline-secondary">
+                  <button href="{{ csv_url }}" class="btn btn-sm btn-icon btn-outline-secondary">
                      <i class="fas fa-file-download"></i>
                      <span class="d-none d-xl-block">{{ __('Export') }}</span>
                   </button>

--- a/templates/components/pager.html.twig
+++ b/templates/components/pager.html.twig
@@ -1,3 +1,15 @@
+{% if additional_params is not defined %}
+   {% set additional_params = "" %}
+{% else %}
+   {% if additional_params|length > 0 and not (additional_params starts with '&') %}
+      {% set additional_params = "&" ~ additional_params %}
+   {% endif %}
+{% endif %}
+
+{% set href = href ~ "&start=%start%" ~ additional_params %}
+{% if is_tab is defined and is_tab == true %}
+   {% set href = "javascript:reloadTab('start=%start%" ~ additional_params ~ "');" %}
+{% endif %}
 {% if limit is not defined %}
    {% set limit = user_pref('list_limit') %}
 {% endif %}
@@ -37,12 +49,12 @@
       {% set is_last_page = forward >= count %}
 
       <li class="page-item {% if is_first_page %}disabled{% endif %}">
-         <a class="page-link page-link-start" href="#" title="{{ __('Start') }}" data-start="0" {% if is_first_page %}aria-disabled="true"{% endif %}>
+         <a class="page-link page-link-start" href="{{ href|replace({'%start%': 0}) }}" title="{{ __('Start') }}" data-start="0" {% if is_first_page %}aria-disabled="true"{% endif %}>
             <i class="fas fa-angle-double-left"></i>
          </a>
       </li>
       <li class="page-item {% if is_first_page %}disabled{% endif %}">
-         <a class="page-link page-link-prev" href="#" title="{{ __('Previous') }}" data-start="{{ back }}" {% if is_first_page %}aria-disabled="true"{% endif %}>
+         <a class="page-link page-link-prev" href="{{ href|replace({'%start%': back}) }}" title="{{ __('Previous') }}" data-start="{{ back }}" {% if is_first_page %}aria-disabled="true"{% endif %}>
             <i class="fas fa-angle-left"></i>
          </a>
       </li>
@@ -50,7 +62,7 @@
          {% if current_page - adjacents <= page and current_page + adjacents >= page %}
             {% set page_start = (page - 1) * limit %}
             <li class="page-item {% if page == current_page %}active selected{% endif %}">
-               <a class="page-link page-link-num" href="#" data-start="{{ page_start }}">{{ page }}</a>
+               <a class="page-link page-link-num" href="{{ href|replace({'%start%': page_start}) }}" data-start="{{ page_start }}">{{ page }}</a>
             </li>
             {% if current_page + adjacents == page %}
                {% set skip_adjacents = false %}
@@ -64,12 +76,12 @@
       {% endfor %}
 
       <li class="page-item {% if is_last_page %}disabled{% endif %}">
-         <a class="page-link page-link-next" href="#" title="{{ __('Next') }}" data-start="{{ forward }}" {% if is_last_page %}aria-disabled="true"{% endif %}>
+         <a class="page-link page-link-next" href="{{ href|replace({'%start%': forward}) }}" title="{{ __('Next') }}" data-start="{{ forward }}" {% if is_last_page %}aria-disabled="true"{% endif %}>
             <i class="fas fa-angle-right"></i>
          </a>
       </li>
       <li class="page-item {% if is_last_page %}disabled{% endif %}">
-         <a class="page-link page-link-last" href="#" title="{{ __('End') }}" data-start="{{ end }}" {% if is_last_page %}aria-disabled="true"{% endif %}>
+         <a class="page-link page-link-last" href="{{ href|replace({'%start%': end}) }}" title="{{ __('End') }}" data-start="{{ end }}" {% if is_last_page %}aria-disabled="true"{% endif %}>
             <i class="fas fa-angle-double-right"></i>
          </a>
       </li>

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -39,7 +39,7 @@
       {% if count > 0 %}
          {% if data['display_type'] != constant('Search::GLOBAL_SEARCH') and data['search']['as_map'] == 0 %}
             <div class="card-footer search-footer">
-               {{ include('components/search/pager.html.twig') }}
+               {{ include('components/pager.html.twig') }}
             </div>
          {% endif %}
       {% elseif data['search']['as_map'] == 1 %}

--- a/templates/pages/admin/events_list.html.twig
+++ b/templates/pages/admin/events_list.html.twig
@@ -63,7 +63,9 @@
                </div>
 
                <div class="search-footer card-footer">
-                  {{ include('components/search/pager.html.twig', {
+                  {{ include('components/pager.html.twig', {
+                     'href': target ~ '?',
+                     'additional_params': 'sort=' ~ sort ~ '&order=' ~ order,
                      'count': count
                   }) }}
                </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. I put back href that was removed in #9058. `e.preventDefault();` set by search page AJAX logic will result in ignoring this.
2. From items log, the default `reloadTab()` logic is done.
3. From events list, as we are not in a tab context, href and its additionnal params must be explicitely passed to the template, as it was already done for the limit dropdown template include.
4. I moved the template file in a lower level, as it is not only related to the search feature.