### PR TITLE
fix(doc): no recusivity for upload doc from richtext

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -5205,6 +5205,16 @@ class CommonDBTM extends CommonGLPI {
             $entities_id = $input['_job']->fields['entities_id'];
          }
 
+         //retrieve is_recursive
+         $is_recursive = 0;
+         if (isset($this->fields["is_recursive"])) {
+            $is_recursive = $this->fields["is_recursive"];
+         } else if (isset($input['is_recursive'])) {
+            $is_recursive = $input['is_recursive'];
+         } else if (isset($input['_job']->fields['is_recursive'])) {
+            $is_recursive = $input['_job']->fields['is_recursive'];
+         }
+
          // Check for duplicate
          if ($doc->getFromDBbyContent($entities_id, $filename)) {
             if (!$doc->fields['is_blacklisted']) {
@@ -5236,7 +5246,7 @@ class CommonDBTM extends CommonGLPI {
             }
 
             $input2["entities_id"]             = $entities_id;
-            $input2["is_recursive"]            = 0;
+            $input2["is_recursive"]            = $is_recursive;
             $input2["documentcategories_id"]   = $CFG_GLPI["documentcategories_id_forticket"];
             $input2["_only_if_upload_succeed"] = 1;
             $input2["_filename"]               = [$file];

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -5236,7 +5236,7 @@ class CommonDBTM extends CommonGLPI {
             }
 
             $input2["entities_id"]             = $entities_id;
-            $input2["is_recursive"]            = 1;
+            $input2["is_recursive"]            = 0;
             $input2["documentcategories_id"]   = $CFG_GLPI["documentcategories_id_forticket"];
             $input2["_only_if_upload_succeed"] = 1;
             $input2["_filename"]               = [$file];


### PR DESCRIPTION
Like document upload form (from timeline)
docs / images paste or drop into richtext need to be no recursifs.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22626
