### PR TITLE
Check if _locales exist

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -360,7 +360,7 @@ class Plugin extends CommonDBTM {
          );
       }
 
-      $plugin_folders = scandir(GLPI_LOCAL_I18N_DIR);
+      $plugin_folders = is_dir(GLPI_LOCAL_I18N_DIR) ? scandir(GLPI_LOCAL_I18N_DIR) : [];
       $plugin_folders = array_filter($plugin_folders, function($dir) use ($plugin_key) {
          if (!is_dir(GLPI_LOCAL_I18N_DIR . "/$dir")) {
             return false;

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -642,7 +642,7 @@ class Session {
 
       $TRANSLATE->addTranslationFile('gettext', GLPI_I18N_DIR.$newfile, 'glpi', $trytoload);
 
-      $core_folders = scandir(GLPI_LOCAL_I18N_DIR);
+      $core_folders = is_dir(GLPI_LOCAL_I18N_DIR) ? scandir(GLPI_LOCAL_I18N_DIR) : [];
       $core_folders = array_filter($core_folders, function($dir) {
          if (!is_dir(GLPI_LOCAL_I18N_DIR . "/$dir")) {
             return false;


### PR DESCRIPTION
Introduced by 53bc94e2ba7b2ac959f15da06e975a850cc0f5c7.

The commit above assume the `_locales` folder always exist.
Despite the folder being a part of GLPI since 9.5.0, this is not always the case as users will copy their "outdated" `files` folder when upgrading from older versions.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | :22665
