### PR TITLE
fix(notification): fix private items from timeline

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6877,6 +6877,7 @@ abstract class CommonITILObject extends CommonDBTM {
          'with_validations' => true,
          'expose_private' => false,
          'bypass_rights' => false,
+         'is_self_service' => false,
       ];
 
       if (is_array($options) && count($options)) {
@@ -6914,6 +6915,12 @@ abstract class CommonITILObject extends CommonDBTM {
          ];
       }
 
+      if ($params['is_self_service']) {
+         $restrict_fup = [
+               'is_private'   => 0
+         ];
+      }
+
       $restrict_fup['itemtype'] = static::getType();
       $restrict_fup['items_id'] = $this->getID();
 
@@ -6925,6 +6932,12 @@ abstract class CommonITILObject extends CommonDBTM {
                                     ? Session::getLoginUserID()
                                     : 0
             ]
+         ];
+      }
+
+      if ($params['is_self_service']) {
+         $restrict_task = [
+               'is_private'   => 0
          ];
       }
 

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1030,7 +1030,6 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
       global $CFG_GLPI, $DB;
 
       $is_self_service = $options['additionnaloption']['is_self_service'] ?? true;
-      $need_anonymize = Entity::getAnonymizeConfig($this->getEntity()) !== Entity::ANONYMIZE_DISABLED;
       $objettype = strtolower($item->getType());
 
       $data["##$objettype.title##"]        = $item->getField('name');
@@ -1197,8 +1196,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
 
             if ($user_tmp->getFromDB($uid)) {
                // Check if the user need to be anonymized
-               if ($is_self_service && $need_anonymize
-                  && !empty($anon_name = User::getAnonymizedName(
+               if ($is_self_service && !empty($anon_name = User::getAnonymizedName(
                      $uid,
                      $item->getField('entities_id')
                   ))
@@ -1319,8 +1317,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
             $tmp['##followup.isprivate##']   = Dropdown::getYesNo($followup['is_private']);
 
             // Check if the author need to be anonymized
-            if ($is_self_service && $need_anonymize
-               && ITILFollowup::getById($followup['id'])->isFromSupportAgent()
+            if ($is_self_service && ITILFollowup::getById($followup['id'])->isFromSupportAgent()
                && !empty($anon_name = User::getAnonymizedName(
                   $followup['users_id'],
                   $item->getField('entities_id')
@@ -1551,8 +1548,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
             if ($timeline_data['type'] == ITILFollowup::getType()) {
                // Check if the author need to be anonymized
 
-               if ($is_self_service && $need_anonymize
-                  && ITILFollowup::getById($timeline_data['item']['id'])->isFromSupportAgent()
+               if ($is_self_service && ITILFollowup::getById($timeline_data['item']['id'])->isFromSupportAgent()
                   && !empty($anon_name = User::getAnonymizedName(
                      $timeline_data['item']['users_id'],
                      $item->getField('entities_id')

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1554,7 +1554,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
                if ($is_self_service && $need_anonymize
                   && ITILFollowup::getById($timeline_data['item']['id'])->isFromSupportAgent()
                   && !empty($anon_name = User::getAnonymizedName(
-                     $followup['users_id'],
+                     $timeline_data['item']['users_id'],
                      $item->getField('entities_id')
                   ))) {
                      $tmptimelineitem['##timelineitems.author##'] = $anon_name;

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1030,7 +1030,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
       global $CFG_GLPI, $DB;
 
       $is_self_service = $options['additionnaloption']['is_self_service'] ?? true;
-      $need_anonymize = (Entity::getAnonymizeConfig($this->getEntity()) !== Entity::ANONYMIZE_DISABLED) ? true : false;
+      $need_anonymize = Entity::getAnonymizeConfig($this->getEntity()) !== Entity::ANONYMIZE_DISABLED;
       $objettype = strtolower($item->getType());
 
       $data["##$objettype.title##"]        = $item->getField('name');

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1319,15 +1319,15 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
             $tmp['##followup.isprivate##']   = Dropdown::getYesNo($followup['is_private']);
 
             // Check if the author need to be anonymized
-            $tmp['##followup.author##'] = getUserName($followup['users_id']);
-            if ($is_self_service && $need_anonymize) {
-               if (ITILFollowup::getById($followup['id'])->isFromSupportAgent()
+            if ($is_self_service && $need_anonymize
+               && ITILFollowup::getById($followup['id'])->isFromSupportAgent()
                && !empty($anon_name = User::getAnonymizedName(
                   $followup['users_id'],
                   $item->getField('entities_id')
                ))) {
-                  $tmp['##followup.author##'] = $anon_name;
-               }
+               $tmp['##followup.author##'] = $anon_name;
+            } else {
+               $tmp['##followup.author##'] = getUserName($followup['users_id']);
             }
 
             $tmp['##followup.requesttype##'] = '';
@@ -1551,15 +1551,16 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
             if ($timeline_data['type'] == ITILFollowup::getType()) {
                // Check if the author need to be anonymized
 
-               $tmptimelineitem['##timelineitems.author##'] = getUserName($timeline_data['item']['users_id']);
-               if ($is_self_service && $need_anonymize) {
-                  if (ITILFollowup::getById($timeline_data['item']['id'])->isFromSupportAgent()
+               if ($is_self_service && $need_anonymize
+                  && ITILFollowup::getById($timeline_data['item']['id'])->isFromSupportAgent()
                   && !empty($anon_name = User::getAnonymizedName(
                      $followup['users_id'],
                      $item->getField('entities_id')
                   ))) {
                      $tmptimelineitem['##timelineitems.author##'] = $anon_name;
-                  }
+
+               } else {
+                  $tmptimelineitem['##timelineitems.author##'] = getUserName($timeline_data['item']['users_id']);
                }
 
             } else {

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1321,7 +1321,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
             // Check if the author need to be anonymized
             $tmp['##followup.author##'] = getUserName($followup['users_id']);
             if ($is_self_service && $need_anonymize) {
-               if (ITILFollowup::getById($followup['id'])->isFromSupportAgent() 
+               if (ITILFollowup::getById($followup['id'])->isFromSupportAgent()
                && !empty($anon_name = User::getAnonymizedName(
                   $followup['users_id'],
                   $item->getField('entities_id')

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1319,16 +1319,16 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
             $tmp['##followup.isprivate##']   = Dropdown::getYesNo($followup['is_private']);
 
             // Check if the author need to be anonymized
-            if (ITILFollowup::getById($followup['id'])->isFromSupportAgent()
-               && $is_self_service && $need_anonymize
+            $tmp['##followup.author##'] = getUserName($followup['users_id']);
+            if ($is_self_service && $need_anonymize
                && !empty($anon_name = User::getAnonymizedName(
                   $followup['users_id'],
                   $item->getField('entities_id')
                ))
             ) {
-               $tmp['##followup.author##'] = $anon_name;
-            } else {
-               $tmp['##followup.author##'] = getUserName($followup['users_id']);
+               if (ITILFollowup::getById($followup['id'])->isFromSupportAgent()) {
+                  $tmp['##followup.author##'] = $anon_name;
+               }
             }
 
             $tmp['##followup.requesttype##'] = '';
@@ -1551,17 +1551,19 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
 
             if ($timeline_data['type'] == ITILFollowup::getType()) {
                // Check if the author need to be anonymized
-               if (ITILFollowup::getById($timeline_data['item']['id'])->isFromSupportAgent()
-                  && $is_self_service && $need_anonymize
+
+               $tmptimelineitem['##timelineitems.author##'] = getUserName($timeline_data['item']['users_id']);
+               if ($is_self_service && $need_anonymize
                   && !empty($anon_name = User::getAnonymizedName(
-                     $timeline_data['item']['users_id'],
+                     $followup['users_id'],
                      $item->getField('entities_id')
                   ))
                ) {
-                  $tmptimelineitem['##timelineitems.author##'] = $anon_name;
-               } else {
-                  $tmptimelineitem['##timelineitems.author##'] = getUserName($timeline_data['item']['users_id']);
+                  if (ITILFollowup::getById($timeline_data['item']['id'])->isFromSupportAgent()) {
+                     $tmptimelineitem['##timelineitems.author##'] = $anon_name;
+                  }
                }
+
             } else {
                $tmptimelineitem['##timelineitems.author##'] = getUserName($timeline_data['item']['users_id']);
             }

--- a/inc/notificationtargetcommonitilobject.class.php
+++ b/inc/notificationtargetcommonitilobject.class.php
@@ -1320,13 +1320,12 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
 
             // Check if the author need to be anonymized
             $tmp['##followup.author##'] = getUserName($followup['users_id']);
-            if ($is_self_service && $need_anonymize
+            if ($is_self_service && $need_anonymize) {
+               if (ITILFollowup::getById($followup['id'])->isFromSupportAgent() 
                && !empty($anon_name = User::getAnonymizedName(
                   $followup['users_id'],
                   $item->getField('entities_id')
-               ))
-            ) {
-               if (ITILFollowup::getById($followup['id'])->isFromSupportAgent()) {
+               ))) {
                   $tmp['##followup.author##'] = $anon_name;
                }
             }
@@ -1553,13 +1552,12 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget {
                // Check if the author need to be anonymized
 
                $tmptimelineitem['##timelineitems.author##'] = getUserName($timeline_data['item']['users_id']);
-               if ($is_self_service && $need_anonymize
+               if ($is_self_service && $need_anonymize) {
+                  if (ITILFollowup::getById($timeline_data['item']['id'])->isFromSupportAgent()
                   && !empty($anon_name = User::getAnonymizedName(
                      $followup['users_id'],
                      $item->getField('entities_id')
-                  ))
-               ) {
-                  if (ITILFollowup::getById($timeline_data['item']['id'])->isFromSupportAgent()) {
+                  ))) {
                      $tmptimelineitem['##timelineitems.author##'] = $anon_name;
                   }
                }

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -622,7 +622,6 @@ class Entity extends DbTestCase {
       //and fails to recover the configuration of the anonymization
       $this->setEntity($entity->getID(), true);
 
-
       $ticket = new Ticket();
       $tickets_id = $ticket->add($input = [
          'name'             => 'test',

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -616,6 +616,13 @@ class Entity extends DbTestCase {
 
       // Build test ticket
       $this->login('tech', 'tech');
+
+      //force set entity because $_SESSION['glpiactive_entity'] contains 0 without
+      //and break test from NotificationTargetCommonITILObject::getDataForObject()
+      //and fails to recover the configuration of the anonymization
+      $this->setEntity($entity->getID(), true);
+
+
       $ticket = new Ticket();
       $tickets_id = $ticket->add($input = [
          'name'             => 'test',

--- a/tests/functionnal/NotificationTargetTicket.php
+++ b/tests/functionnal/NotificationTargetTicket.php
@@ -34,6 +34,7 @@ namespace tests\units;
 
 use DbTestCase;
 use Glpi\Toolbox\Sanitizer;
+use NotificationTarget;
 
 /* Test for inc/notificationtargetticket.class.php */
 
@@ -246,7 +247,7 @@ class NotificationTargetTicket extends DbTestCase {
 
       $basic_options = [
          'additionnaloption' => [
-            'usertype' => '2',
+            'usertype' => NotificationTarget::GLPI_USER,
             'is_self_service' => false,
             'show_private'    => true,
          ]
@@ -308,7 +309,7 @@ class NotificationTargetTicket extends DbTestCase {
 
       $basic_options = [
          'additionnaloption' => [
-            'usertype' => '1',
+            'usertype' => NotificationTarget::GLPI_USER,
             'is_self_service' => true,
             'show_private'    => false,
          ]

--- a/tests/functionnal/NotificationTargetTicket.php
+++ b/tests/functionnal/NotificationTargetTicket.php
@@ -246,7 +246,9 @@ class NotificationTargetTicket extends DbTestCase {
 
       $basic_options = [
          'additionnaloption' => [
-            'usertype' => ''
+            'usertype' => '2',
+            'is_self_service' => false,
+            'show_private'    => true,
          ]
       ];
 
@@ -306,13 +308,15 @@ class NotificationTargetTicket extends DbTestCase {
 
       $basic_options = [
          'additionnaloption' => [
-            'usertype' => ''
+            'usertype' => '1',
+            'is_self_service' => true,
+            'show_private'    => false,
          ]
       ];
 
       $ret = $notiftargetticket->getDataForObject($ticket, $basic_options);
 
-      //get only public task / followup (because is post_only)
+      //get only public task / followup / Solution (because is post_only)
       $expected = [
          [
             "##timelineitems.type##"        => "TicketTask",


### PR DESCRIPTION
Fix visibility of private items for self-service profil.

Use ```getTimelineItems```  means the use of sessions to check rights

But from ```NotificationTargetCommonITILObject``` all target have no session (except the current user who triggers the notification)

We need to know if target is a self-service or not to restrict view for private items because 
```show_private``` is combinated to ```bypass_right```

This notion of ```is_self_service``` is introduce by 
https://github.com/glpi-project/glpi/pull/9060/files#diff-f2baa5b27a17ff7ea8035b11b6933f05a1ed3aa1ea898344284fd73d6dc4e9cfR673 

But is calculated only if anonymize option is enabled.

This PR 

- computes ```is_self_service``` even if anonymize is disabled
- add a check to use anonymize or not
- use ```is_self_service``` from ```getTimelineItems``` to restrict access to private items
- adjusts TU to set ```additionnaloption```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22656
