### PR TITLE
Prevent scripts to be executed twice in build process; fixes #9597

### DIFF
--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -56,7 +56,7 @@ $WORKING_DIR/tools/locale/update_mo.pl
 
 echo "Remove dev files and directories"
 # Remove PHP dev dependencies that are not anymore used
-composer update nothing --ignore-platform-reqs --no-dev --working-dir=$WORKING_DIR
+composer update nothing --ignore-platform-reqs --no-dev --no-scripts --working-dir=$WORKING_DIR
 
 # Remove user generated files (i.e. cache and log from CLI commands ran during release)
 find $WORKING_DIR/files -depth -mindepth 2 ! -iname "remove.txt" -exec rm -rf {} \;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #9597 

Scripts are already executed by dependencies install on line 46.