### PR TITLE
[Modern-UI] Fix dropdown forms

### DIFF
--- a/templates/dropdown_form.html.twig
+++ b/templates/dropdown_form.html.twig
@@ -33,8 +33,16 @@
 
                {# Dynamically show additional fields unique to certain dropdowns #}
                {% for field in additional_fields %}
-                  {% if field['name'] not in picture_fields and field['name'] != 'entities_id' and item.fields['id'] != 0 %}
-                     {% set type = field['type']|default('') %}
+                  {% set type = field['type']|default('') %}
+                  {% set show_field = true %}
+                  {% if field['name'] == 'entities_id' and (type != 'parent' or item.fields['id'] == 0) %}
+                     {# Show entity selector only if it is a "parent" field #}
+                     {% set show_field = false %}
+                  {% endif %}
+                  {% if field['name'] in picture_fields %}
+                     {% set show_field = false %}
+                  {% endif %}
+                  {% if show_field %}
 
                      {% if field['name'] == 'header' %}
                         <tr class="tab_bg_1"><th colspan="2">{{ field['label'] }}</th></tr>
@@ -114,7 +122,7 @@
                      {% elseif type == 'picture' %}
                         {% if item.fields[field['name']] is not empty %}
                            {{ fields.imageField(field['name'], item.fields[field['name']]|picture_url, field['label'], params|merge({
-                              'clearable': item.canUpdateItem()
+                              'clearable': (not item.isNewItem() and item.canUpdateItem())
                            })) }}
                         {% else %}
                            {{ fields.fileField(field['name'], null, field['label'], {
@@ -128,7 +136,7 @@
                            {% set picture_urls = picture_urls|merge([picture|picture_url]) %}
                         {% endfor %}
                         {{ fields.imageGalleryField(field['name'], picture_urls, field['label'], params|merge({
-                           'clearable': item.canUpdateItem()
+                           'clearable': (not item.isNewItem() and item.canUpdateItem())
                         })) }}
                      {% elseif type == 'password' %}
                         {{ fields.passwordField(field['name'], item.fields[field['name']], field['label'], params) }}
@@ -156,107 +164,6 @@
                      {% set has_picture_field = true %}
                   {% endif %}
                {% endfor %}
-
-               {% if field['name'] == 'header' %}
-                  <tr class="tab_bg_1"><th colspan="2">{{ field['label'] }}</th></tr>
-               {% elseif type == 'UserDropdown' %}
-                  {{ fields.dropdownField(
-                     'User',
-                     field['name'],
-                     subitem.fields[field['name']],
-                     _n('User', 'Users', get_plural_number()),
-                     {
-                        'full_width': true,
-                        'entity': item.fields['entities_id'],
-                        'right': field['right']|default('interface'),
-                        'rand': rand,
-                     }
-                  ) }}
-               {% elseif type == 'dropdownValue' %}
-                  {% set dropdown_params = {
-                     'entity': item.fields['entities_id']
-                  } %}
-                  {% if field['condition'] is defined %}
-                     {% set dropdown_params = dropdown_params|merge({'condition': field['condition']}) %}
-                  {% endif %}
-                  {% set dropdown_itemtype = call('getItemtypeForForeignKeyField', [field['name']]) %}
-                  {{ fields.dropdownField(dropdown_itemtype, field['name'], item.fields[field['name']], field['label'], dropdown_params) }}
-               {% elseif type == 'text' %}
-                  {{ fields.autoNameField(field['name'], item, field['label'], withtemplate, params) }}
-               {% elseif type == 'textarea' %}
-                  {{ fields.textareaField(field['name'], item.fields[field['name']], field['label'], params) }}
-               {% elseif type == 'integer' %}
-                  {% set params = {'value': item.fields[field['name']]} %}
-                  {% if field['min'] is defined %}
-                     {% set params = params|merge({'min': field['min']}) %}
-                  {% endif %}
-                  {% if field['step'] is defined %}
-                     {% set params = params|merge({'step': field['step']}) %}
-                  {% endif %}
-                  {% if field['max'] is defined %}
-                     {% set params = params|merge({'max': field['max']}) %}
-                  {% endif %}
-                  {% if field['html'] %}
-                     {% set params = params|merge({'type': 'number'}) %}
-                     {{ fields.numberField(field['name'], item.fields[field['name']], field['label'], params) }}
-                  {% else %}
-                     {{ fields.dropdownNumberField(field['name'], item.fields[field['name']], field['label'], params) }}
-                  {% endif %}
-               {% elseif type == 'timestamp' %}
-                  {% set params = {'value': item.fields[field['name']]} %}
-                  {% if field['min'] is defined %}
-                     {% set params = params|merge({'min': field['min']}) %}
-                  {% endif %}
-                  {% if field['step'] is defined %}
-                     {% set params = params|merge({'step': field['step']}) %}
-                  {% endif %}
-                  {% if field['max'] is defined %}
-                     {% set params = params|merge({'max': field['max']}) %}
-                  {% endif %}
-                  {{ fields.dropdownTimestampField(field['name'], item.fields[field['name']], field['label'], params) }}
-               {% elseif type == 'parent' %}
-                  {% set restrict = field['name'] == 'entities_id' ? -1 : item.getEntityID() %}
-                  {% set params = params|merge({'entity': restrict}) %}
-                  {% set params = params|merge({'used': (item.fields['id'] > 0 ? call('getSonsOf', [item.getTable(), item.fields['id']]) : [])}) %}
-                  {{ fields.dropdownField(item, field['name'], item.fields[field['name']], field['label'], params) }}
-               {% elseif type == 'icon' %}
-                  {{ fields.dropdownIcons(field['name'], item.fields[field['name']], field['label'], params) }}
-                  {% if item.fields[field['name']] is not empty %}
-                     <img class="align-middle" alt="" src="{{ config('typedoc_icon_dir') ~ '/' ~ item.fields[field['name']] }}" />
-                  {% endif %}
-               {% elseif type == 'bool' %}
-                  {{ fields.dropdownYesNo(field['name'], item.fields[field['name']], field['label'], params) }}
-               {% elseif type == 'color' %}
-                  {{ fields.colorField(field['name'], item.fields[field['name']], field['label'], params) }}
-               {% elseif type == 'date' %}
-                  {{ fields.dateField(field['name'], item.fields[field['name']], field['label'], params) }}
-               {% elseif type == 'datetime' %}
-                  {{ fields.datetimeField(field['name'], item.fields[field['name']], field['label'], params) }}
-               {% elseif type == 'picture' %}
-                  {% if item.fields[field['name']] is not empty %}
-                     {{ fields.imageField(field['name'], item.fields[field['name']]|picture_url, field['label'], params) }}
-                  {% else %}
-                     {{ fields.fileField(field['name'], null, field['label'], {
-                        'onlyimages': true
-                     }) }}
-                  {% endif %}
-               {% elseif type == 'password' %}
-                  {{ fields.passwordField(field['name'], item.fields[field['name']], field['label'], params) }}
-               {% elseif type == 'tinymce' %}
-                  {% set params = params|merge({'enable_richtext': true}) %}
-                  {{ fields.textareaField(field['name'], item.fields[field['name']], field['label'], params) }}
-               {% elseif type == 'duration' %}
-                  {% set toadd = [] %}
-                  {% for i in 9..100 %}
-                     {% set toadd = toadd|merge([i * constant('HOUR_TIMESTAMP')]) %}
-                  {% endfor %}
-                  {{ fields.dropdownTimestampField(field['name'], item.fields[field['name']], field['label'], params) }}
-               {% elseif type == 'itemtypename' %}
-                  {% if field['itemtype_list'] is defined %}
-                     {% set params = params|merge({'types': config(field['itemtype_list'])}) %}
-                  {% endif %}
-                  {{ fields.dropdownItemTypes(field['name'], item.fields[field['name']], field['label'], params) }}
-               {% endif %}
 
                {% if has_picture_field %}
                   {{ fields.largeTitle(_n('Picture', 'Pictures', get_plural_number()), 'fas fa-image') }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Aditionnal fields code was duplicated outside the `{% for field in additional_fields %}` loop, certainly due to a bad merge.
2. Aditionnal fields were nos available for new items due to `item.fields['id'] != 0` condition, which, I guess, was unvoluntarly applied to all fields, instead of being only applied to `entities_id` field (i.e not parent entity selection when on root entity form).
