### PR TITLE
[Modern UI] Fix massive action box display checks

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1578,6 +1578,7 @@ class Search {
          'start'               => $search['start'] ?? 0,
          'limit'               => $_SESSION['glpilist_limit'],
          'count'               => $data['data']['totalcount'] ?? 0,
+         'item'                => $item,
          'itemtype'            => $itemtype,
          'href'                => $href,
          'prehref'             => $prehref,
@@ -1595,8 +1596,8 @@ class Search {
             DisplayPreference::PERSONAL,
             DisplayPreference::GENERAL
          ]),
-         'may_be_deleted'      => $item && $item->maybeDeleted(),
-         'may_be_located'      => $item && $item->maybeLocated(),
+         'may_be_deleted'      => $item instanceof CommonDBTM && $item->maybeDeleted(),
+         'may_be_located'      => $item instanceof CommonDBTM && $item->maybeLocated(),
       ]);
 
       // Add items in item list


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

To reproduce:
1. create a Computer in root entity + child entities
2. go in a sub entity
3. display the computers list
-> the massive action checkbox should not be displayed, as item is not updatable when displayed outside its own entity context

Check was based on `item` variable, that was not passed to the template (`{% elseif item is instanceof('CommonDBTM') and item.maybeRecursive() and not has_access_to_entity(row['entities_id'])  %}`).