### PR TITLE
Fix breadcrumb & context links responsive display

### DIFF
--- a/templates/layout/parts/breadcrumbs.html.twig
+++ b/templates/layout/parts/breadcrumbs.html.twig
@@ -1,5 +1,5 @@
-<ol class="breadcrumb breadcrumb-alternate pe-3" aria-label="breadcrumbs">
-   <li class="breadcrumb-item">
+<ol class="breadcrumb breadcrumb-alternate pe-3 flex-nowrap" aria-label="breadcrumbs">
+   <li class="breadcrumb-item text-truncate">
       <a href="{{ index_path() }}" title="{{ __('Home') }}">
          <i class="fas fa-home"></i>
          {{ __('Home') }}
@@ -7,7 +7,7 @@
    </li>
 
    {% if menu[sector] is defined %}
-   <li class="breadcrumb-item">
+   <li class="breadcrumb-item text-truncate">
       <a href="{{ path(menu[sector]['default'] ?? '/front/central.php') }}" title="{{ menu[sector]['title'] }}">
          <i class="{{ menu[sector]['icon'] ?? '' }}"></i>
          {{ menu[sector]['title'] }}
@@ -19,7 +19,7 @@
    {% if menu[sector]['content'][item] is defined %}
       {% if menu[sector]['content'][item]['page'] is defined %}
       {% set with_option = option is not empty and menu[sector]['content'][item]['options'][option]['title'] is defined and menu[sector]['content'][item]['options'][option]['page'] is defined %}
-      <li class="breadcrumb-item">
+      <li class="breadcrumb-item text-truncate">
          <a href="{{ path(menu[sector]['content'][item]['page']) }}"
             class="{{ with_option ? '' : 'here' }}"
             title="{{ menu[sector]['content'][item]['title'] }}" >
@@ -30,7 +30,7 @@
       {% endif %}
 
       {% if with_option %}
-      <li class="breadcrumb-item">
+      <li class="breadcrumb-item text-truncate">
          <a href="{{ path(menu[sector]['content'][item]['options'][option]['page']) }}"
             class="here"
             title="{{ menu[sector]['content'][item]['options'][option]['title'] }}" >

--- a/templates/layout/parts/context_links.html.twig
+++ b/templates/layout/parts/context_links.html.twig
@@ -8,7 +8,7 @@
 <li class="nav-item">
    <a href="{{ path(links['add']) }}" class="btn btn-icon btn-sm btn-outline-secondary me-1 pe-2" title="{{ __('Add') }}">
       <i class="fas fa-plus"></i>
-      <span class="d-none d-md-block">{{ __('Add') }}</span>
+      <span class="d-none d-xxl-block">{{ __('Add') }}</span>
    </a>
 </li>
 {% endif %}
@@ -17,7 +17,7 @@
 <li class="nav-item">
    <a href="{{ path(links['search']) }}" class="btn btn-icon btn-sm btn-outline-secondary me-1 pe-2" title="{{ __('Search') }}">
       <i class="fas fa-search"></i>
-      <span class="d-none d-md-block">{{ __('Search') }}</span>
+      <span class="d-none d-xxl-block">{{ __('Search') }}</span>
    </a>
 </li>
 {% endif %}
@@ -27,7 +27,7 @@
    <a href="#" class="btn btn-icon btn-sm btn-outline-secondary me-1 pe-2 show-saved-searches"
       data-itemtype="{{ item }}" title="{{ __('Lists') }}">
       <i class="fas fa-star"></i>
-      <span class="d-none d-md-block">{{ __('Lists') }}</span>
+      <span class="d-none d-xxl-block">{{ __('Lists') }}</span>
    </a>
 </li>
 {% endif %}
@@ -38,7 +38,7 @@
       <li class="nav-item">
          <a href="{{ path(link) }}" class="btn btn-icon btn-sm btn-outline-secondary me-1 pe-2" title="{{ __('Manage templates...') }}">
             <i class="fas fa-layer-group"></i>
-            <span class="d-none d-md-block">{{ __('Templates') }}</span>
+            <span class="d-none d-xxl-block">{{ __('Templates') }}</span>
          </a>
       </li>
    {% elseif type == 'showall' %}
@@ -48,28 +48,28 @@
                <i class="fas fa-check fa-stack-1x" style="top: 1px; left: -7px; font-size: 1.2em"></i>
                <i class="far fa-clock fa-stack-1x" style="top: 6px; left: -3px"></i>
             </span>
-            <span class="d-none d-md-block">{{ __('Show all') }}</span>
+            <span class="d-none d-xxl-block">{{ __('Show all') }}</span>
          </a>
       </li>
    {% elseif type == 'summary' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" class="btn btn-icon btn-sm btn-outline-secondary me-1 pe-2" title="{{ __('Summary') }}">
             <i class="fas fa-stream"></i>
-            <span class="d-none d-md-block">{{ __('Summary') }}</span>
+            <span class="d-none d-xxl-block">{{ __('Summary') }}</span>
          </a>
       </li>
    {% elseif type == 'summary_kanban' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" class="btn btn-icon btn-sm btn-outline-secondary me-1 pe-2" title="{{ __('Global Kanban') }}">
             <i class="fas fa-columns"></i>
-            <span class="d-none d-md-block">{{ __('Global Kanban') }}</span>
+            <span class="d-none d-xxl-block">{{ __('Global Kanban') }}</span>
          </a>
       </li>
    {% elseif type == 'config' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" class="btn btn-icon btn-sm btn-outline-secondary me-1 pe-2" title="{{ __('Setup') }}">
             <img src="{{ path('/pics/menu_config.png') }}" />
-            <span class="d-none d-md-block">{{ __('Setup') }}</span>
+            <span class="d-none d-xxl-block">{{ __('Setup') }}</span>
          </a>
       </li>
    {% else %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Currently working on my laptop, the top part was displayed on two lines.

![image](https://user-images.githubusercontent.com/418844/135287953-ec5362f5-9b07-4b01-a41f-61b0f8855a5c.png)


Proposed changes when the screen is too small:
- elipsis on breadcrumb
- hide text of context links 

![image](https://user-images.githubusercontent.com/418844/135287491-4b52b309-bf8e-45bd-b28b-86e85ca7d65c.png)
