### PR TITLE
avoid insert empty string in dc model integer fields

### DIFF
--- a/inc/commondcmodeldropdown.class.php
+++ b/inc/commondcmodeldropdown.class.php
@@ -66,7 +66,7 @@ abstract class CommonDCModelDropdown extends CommonDropdown {
             'name'   => 'weight',
             'type'   => 'integer',
             'label'  => __('Weight'),
-            'max'    => 1000
+            'min'    => 0,
          ];
       }
 
@@ -91,7 +91,8 @@ abstract class CommonDCModelDropdown extends CommonDropdown {
          $fields[] = [
             'name'   => 'power_connections',
             'type'   => 'integer',
-            'label'  => __('Power connections')
+            'label'  => __('Power connections'),
+            'min'    => 0,
          ];
       }
 
@@ -101,7 +102,7 @@ abstract class CommonDCModelDropdown extends CommonDropdown {
             'type'   => 'integer',
             'label'  => __('Power consumption'),
             'unit'   => __('watts'),
-            'html'   => true
+            'min'    => 0,
          ];
       }
 
@@ -111,7 +112,7 @@ abstract class CommonDCModelDropdown extends CommonDropdown {
             'type'   => 'integer',
             'label'  => __('Max. power (in watts)'),
             'unit'   => __('watts'),
-            'html'   => true
+            'min'    => 0,
          ];
       }
 

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -114,6 +114,10 @@
       {% set value = call('formatNumber', [value, true]) %}
    {% endif %}
 
+   {% if value == "" %}
+      {% set value = (options.min is defined ? options.min : 0) %}
+   {% endif %}
+
    {% set field %}
       <input type="number" id="%id%"
              class="form-control"
@@ -121,9 +125,9 @@
          {{ options.readonly ? 'readonly' : '' }}
          {{ options.disabled ? 'disabled' : '' }}
          {{ options.required ? 'required' : '' }}
-         {{ options.min ? 'min=' ~ options.min : '' }}
-         {{ options.max ? 'max=' ~ options.max : '' }}
-         {{ options.step ? 'step=' ~ options.step : '' }} />
+         {{ options.min is defined ? 'min=' ~ options.min : '' }}
+         {{ options.max is defined ? 'max=' ~ options.max : '' }}
+         {{ options.step is defined ? 'step=' ~ options.step : '' }} />
    {% endset %}
    {{ _self.field(name, field, label, options) }}
 {% endmacro %}

--- a/templates/dropdown_form.html.twig
+++ b/templates/dropdown_form.html.twig
@@ -73,7 +73,9 @@
                      {% elseif type == 'textarea' %}
                         {{ fields.textareaField(field['name'], item.fields[field['name']], field['label'], params) }}
                      {% elseif type == 'integer' %}
-                        {% set params = {'value': item.fields[field['name']]} %}
+                        {% set params = {
+                           'value': item.fields[field['name']]
+                        } %}
                         {% if field['min'] is defined %}
                            {% set params = params|merge({'min': field['min']}) %}
                         {% endif %}
@@ -83,12 +85,9 @@
                         {% if field['max'] is defined %}
                            {% set params = params|merge({'max': field['max']}) %}
                         {% endif %}
-                        {% if field['html'] %}
-                           {% set params = params|merge({'type': 'number'}) %}
-                           {{ fields.numberField(field['name'], item.fields[field['name']], field['label'], params) }}
-                        {% else %}
-                           {{ fields.dropdownNumberField(field['name'], item.fields[field['name']], field['label'], params) }}
-                        {% endif %}
+
+                        {% set params = params|merge({'type': 'number'}) %}
+                        {{ fields.numberField(field['name'], item.fields[field['name']], field['label'], params) }}
                      {% elseif type == 'timestamp' %}
                         {% set params = {'value': item.fields[field['name']]} %}
                         {% if field['min'] is defined %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

With changes of sql mode in #8424, we have now sql errors when trying to insert dc models (like pdu models). The integers fields are now with empty string values (on modern/ui only, master set 0 values)

So, in integer fields, we force 0 value (or min value) if an empty string is provided

@cconard96 we removed select2 dropdown for integer fields of dropdowns.
Do you see any issues with that ? We didn't see a case where a input[type=number] is not better.