### PR TITLE
Fix is_recursive in CommonDBChild creation form

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -2874,7 +2874,7 @@ class CommonDBTM extends CommonGLPI {
                   if ($params['canedit']) {
                      if ($this instanceof CommonDBChild) {
                         echo Dropdown::getYesNo($this->isRecursive());
-                        if (isset($this->fields["is_recursive"])) {
+                        if (isset($this->fields["is_recursive"]) && !empty($this->fields["is_recursive"])) {
                            echo "<input type='hidden' name='is_recursive' value='".$this->fields["is_recursive"]."'>";
                         }
                         $comment = __("Can't change this attribute. It's inherited from its parent.");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I do not understand why some `CommonDBChild` have `is_recursive` fields, but in this case, creating a new item produces an error (see https://github.com/glpi-project/glpi/pull/9042#issuecomment-931112162 ). On 9.5 branch, it only produces a silented warning.

Another solution would be to completely drop `entities_id` and `is_recursive` files on `CommonDBChild` items, as, I guess, child items should always have the same entities restrictions as their parent.