### PR TITLE
Hook constants / Hooks Manager

### DIFF
--- a/front/helpdesk.public.php
+++ b/front/helpdesk.public.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Plugin\Hooks;
+
 include ('../inc/includes.php');
 
 // Change profile system
@@ -125,7 +127,7 @@ if (isset($_GET['create_ticket'])) {
    echo "<tr class='noHover'>";
    echo "<td class='top' width='50%'><br>";
    echo "<table class='central'>";
-   Plugin::doHook('display_central');
+   Plugin::doHook(Hooks::DISPLAY_CENTRAL);
    if (Session::haveRight('ticket', CREATE)) {
       echo "<tr class='noHover'><td class='top'>";
       Ticket::showCentralCount(true);

--- a/front/lock.form.php
+++ b/front/lock.form.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Plugin\Hooks;
+
 /**
  * @since 0.84
  */
@@ -69,7 +71,7 @@ if (isset($_POST['itemtype'])) {
          }
 
          //Execute hook to unlock fields managed by a plugin, if needed
-         Plugin::doHookFunction('unlock_fields', $_POST);
+         Plugin::doHookFunction(Hooks::UNLOCK_FIELDS, $_POST);
 
       } else if (isset($_POST["purge"])) {
          foreach ($actions as $type) {

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -31,6 +31,7 @@
  */
 
 use Glpi\Event;
+use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\Sanitizer;
 
 if (!defined('GLPI_ROOT')) {
@@ -265,7 +266,7 @@ class Auth extends CommonGLPI {
          if ($this->user_found && @ldap_bind($this->ldap_connection, $dn, $password)) {
 
             //Hook to implement to restrict access by checking the ldap directory
-            if (Plugin::doHookFunction("restrict_ldap_auth", $infos)) {
+            if (Plugin::doHookFunction(Hooks::RESTRICT_LDAP_AUTH, $infos)) {
                return $infos;
             }
             $this->addToError(__('User not authorized to connect in GLPI'));

--- a/inc/central.class.php
+++ b/inc/central.class.php
@@ -31,6 +31,7 @@
  */
 
 use Glpi\Event;
+use Glpi\Plugin\Hooks;
 
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
@@ -109,7 +110,7 @@ class Central extends CommonGLPI {
 
    public function showGlobalDashboard() {
       echo "<table class='tab_cadre_central'>";
-      Plugin::doHook('display_central');
+      Plugin::doHook(Hooks::DISPLAY_CENTRAL);
       echo "</table>";
 
       self::showMessages();
@@ -173,7 +174,7 @@ class Central extends CommonGLPI {
 
       echo "<table class='tab_cadre_central'>";
 
-      Plugin::doHook('display_central');
+      Plugin::doHook(Hooks::DISPLAY_CENTRAL);
 
       echo "<tr><th colspan='2'>";
       self::showMessages();

--- a/inc/commondbchild.class.php
+++ b/inc/commondbchild.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Plugin\Hooks;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -873,7 +875,7 @@ abstract class CommonDBChild extends CommonDBConnexity {
       echo "<td>";
       if ($this->fields['id'] && $this->fields['is_dynamic']) {
          ob_start();
-         Plugin::doHook("autoinventory_information", $this);
+         Plugin::doHook(Hooks::AUTOINVENTORY_INFORMATION, $this);
          $info = ob_get_clean();
          if (empty($info)) {
             $info = __('Yes');

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -32,6 +32,7 @@
 
 use Glpi\Event;
 use Glpi\Features\CacheableListInterface;
+use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\RichText;
 
 if (!defined('GLPI_ROOT')) {
@@ -527,7 +528,7 @@ class CommonDBTM extends CommonGLPI {
       $this->post_getEmpty();
 
       // Call the plugin hook - $this->fields can be altered
-      Plugin::doHook("item_empty", $this);
+      Plugin::doHook(Hooks::ITEM_EMPTY, $this);
       return true;
    }
 
@@ -1137,7 +1138,7 @@ class CommonDBTM extends CommonGLPI {
 
       // Call the plugin hook - $this->input can be altered
       // This hook get the data from the form, not yet altered
-      Plugin::doHook("pre_item_add", $this);
+      Plugin::doHook(Hooks::PRE_ITEM_ADD, $this);
 
       if ($this->input && is_array($this->input)) {
 
@@ -1152,7 +1153,7 @@ class CommonDBTM extends CommonGLPI {
       if ($this->input && is_array($this->input)) {
          // Call the plugin hook - $this->input can be altered
          // This hook get the data altered by the object method
-         Plugin::doHook("post_prepareadd", $this);
+         Plugin::doHook(Hooks::POST_PREPAREADD, $this);
       }
 
       if ($this->input && is_array($this->input)) {
@@ -1224,7 +1225,7 @@ class CommonDBTM extends CommonGLPI {
                   //Check if we have to automatical fill dates
                   Infocom::manageDateOnStatusChange($this);
                }
-               Plugin::doHook("item_add", $this);
+               Plugin::doHook(Hooks::ITEM_ADD, $this);
 
                // As add have suceed, clean the old input value
                if (isset($this->input['_add'])) {
@@ -1505,7 +1506,7 @@ class CommonDBTM extends CommonGLPI {
       }
 
       // Plugin hook - $this->input can be altered
-      Plugin::doHook("pre_item_update", $this);
+      Plugin::doHook(Hooks::PRE_ITEM_UPDATE, $this);
       if ($this->input && is_array($this->input)) {
          $this->input = $this->prepareInputForUpdate($this->input);
 
@@ -1595,7 +1596,7 @@ class CommonDBTM extends CommonGLPI {
                                                                       : []))) {
                      $this->manageLocks();
                      $this->addMessageOnUpdateAction();
-                     Plugin::doHook("item_update", $this);
+                     Plugin::doHook(Hooks::ITEM_UPDATE, $this);
 
                      // As update have suceed, clean the old input value
                      if (isset($this->input['_update'])) {
@@ -1891,9 +1892,9 @@ class CommonDBTM extends CommonGLPI {
 
       // Purge
       if ($force) {
-         Plugin::doHook("pre_item_purge", $this);
+         Plugin::doHook(Hooks::PRE_ITEM_PURGE, $this);
       } else {
-         Plugin::doHook("pre_item_delete", $this);
+         Plugin::doHook(Hooks::PRE_ITEM_DELETE, $this);
       }
 
       if (!is_array($this->input)) {
@@ -1911,7 +1912,7 @@ class CommonDBTM extends CommonGLPI {
                if ($this instanceof CacheableListInterface) {
                   $this->invalidateListCache();
                }
-               Plugin::doHook("item_purge", $this);
+               Plugin::doHook(Hooks::ITEM_PURGE, $this);
                Impact::clean($this);
             } else {
                $this->addMessageOnDeleteAction();
@@ -1935,7 +1936,7 @@ class CommonDBTM extends CommonGLPI {
                if ($this instanceof CacheableListInterface) {
                   $this->invalidateListCache();
                }
-               Plugin::doHook("item_delete", $this);
+               Plugin::doHook(Hooks::ITEM_DELETE, $this);
             }
             if ($this->notificationqueueonaction) {
                Toolbox::deprecated('$notificationqueueonaction property usage is deprecated');
@@ -2081,7 +2082,7 @@ class CommonDBTM extends CommonGLPI {
 
       // Store input in the object to be available in all sub-method / hook
       $this->input = $input;
-      Plugin::doHook("pre_item_restore", $this);
+      Plugin::doHook(Hooks::PRE_ITEM_RESTORE, $this);
       if (!is_array($this->input)) {
          // $input clear by a hook to cancel retore
          return false;
@@ -2108,7 +2109,7 @@ class CommonDBTM extends CommonGLPI {
          if ($this instanceof CacheableListInterface) {
             $this->invalidateListCache();
          }
-         Plugin::doHook("item_restore", $this);
+         Plugin::doHook(Hooks::ITEM_RESTORE, $this);
          if ($this->notificationqueueonaction) {
             Toolbox::deprecated('$notificationqueueonaction property usage is deprecated');
             QueuedNotification::forceSendFor($this->getType(), $this->fields['id']);
@@ -2569,7 +2570,7 @@ class CommonDBTM extends CommonGLPI {
          }
       }
 
-      Plugin::doHook("post_item_form", ['item' => $this, 'options' => &$params]);
+      Plugin::doHook(Hooks::POST_ITEM_FORM, ['item' => $this, 'options' => &$params]);
 
       if ($params['formfooter'] === null) {
           $this->showDates($params);
@@ -2909,7 +2910,7 @@ class CommonDBTM extends CommonGLPI {
          echo "</th></tr>\n";
       }
 
-      Plugin::doHook("pre_item_form", ['item' => $this, 'options' => &$params]);
+      Plugin::doHook(Hooks::PRE_ITEM_FORM, ['item' => $this, 'options' => &$params]);
 
       // If in modal : do not display link on message after redirect
       if (isset($_REQUEST['_in_modal']) && $_REQUEST['_in_modal']) {
@@ -2998,7 +2999,7 @@ class CommonDBTM extends CommonGLPI {
 
       /* Hook to restrict user right on current item @since 9.2 */
       $this->right = $right;
-      Plugin::doHook("item_can", $this);
+      Plugin::doHook(Hooks::ITEM_CAN, $this);
       if ($this->right !== $right) {
          return false;
       }

--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Plugin\Hooks;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -622,7 +624,7 @@ class CommonGLPI {
             $options['withtemplate'] = $withtemplate;
 
             if ($tabnum == 'main') {
-               Plugin::doHook('pre_show_item', ['item' => $item, 'options' => &$options]);
+               Plugin::doHook(Hooks::PRE_SHOW_ITEM, ['item' => $item, 'options' => &$options]);
                $ret = $item->showForm($item->getID(), $options);
 
                $lockedfield = new Lockedfield();
@@ -644,7 +646,7 @@ JAVASCRIPT;
                      echo Html::scriptBlock($locked_js);
                   }
                }
-               Plugin::doHook('post_show_item', ['item' => $item, 'options' => $options]);
+               Plugin::doHook(Hooks::POST_SHOW_ITEM, ['item' => $item, 'options' => $options]);
                return $ret;
             }
 
@@ -652,9 +654,9 @@ JAVASCRIPT;
                 && ($obj = getItemForItemtype($itemtype))) {
                $options['tabnum'] = $tabnum;
                $options['itemtype'] = $itemtype;
-               Plugin::doHook('pre_show_tab', [ 'item' => $item, 'options' => &$options]);
+               Plugin::doHook(Hooks::PRE_SHOW_TAB, [ 'item' => $item, 'options' => &$options]);
                $ret = $obj->displayTabContentForItem($item, $tabnum, $withtemplate);
-               Plugin::doHook('post_show_tab', ['item' => $item, 'options' => $options]);
+               Plugin::doHook(Hooks::POST_SHOW_TAB, ['item' => $item, 'options' => $options]);
                return $ret;
             }
             break;
@@ -815,9 +817,9 @@ JAVASCRIPT;
       }
       echo "<div class='form_content'>";
       echo "<div class='$class'>";
-      Plugin::doHook('pre_show_item', ['item' => $this, 'options' => &$options]);
+      Plugin::doHook(Hooks::PRE_SHOW_ITEM, ['item' => $this, 'options' => &$options]);
       $this->showForm($options['id'], $options);
-      Plugin::doHook('post_show_item', ['item' => $this, 'options' => $options]);
+      Plugin::doHook(Hooks::POST_SHOW_ITEM, ['item' => $this, 'options' => $options]);
       echo "</div>";
       echo "</div>";
    }

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -34,6 +34,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\RichText;
 use Glpi\Toolbox\Sanitizer;
 
@@ -5217,7 +5218,7 @@ abstract class CommonITILObject extends CommonDBTM {
       }
 
       $this->showStatsDates();
-      Plugin::doHook('show_item_stats', $this);
+      Plugin::doHook(Hooks::SHOW_ITEM_STATS, $this);
       $this->showStatsTimes();
    }
 
@@ -6796,7 +6797,7 @@ abstract class CommonITILObject extends CommonDBTM {
               "javascript:viewAddSubitem".$this->fields['id']."$rand(\"Solution\");'>"
               ."<i class='fa fa-check'></i>"._n('Solution', 'Solutions', 1)."</li>";
       }
-      Plugin::doHook('timeline_actions', ['item' => $this, 'rand' => $rand]);
+      Plugin::doHook(Hooks::TIMELINE_ACTIONS, ['item' => $this, 'rand' => $rand]);
 
       echo "</ul>"; // timeline_choices
       echo "<div class='clear'>&nbsp;</div>";
@@ -7139,7 +7140,7 @@ abstract class CommonITILObject extends CommonDBTM {
          } else {
             $obj = $item;
          }
-         Plugin::doHook('pre_show_item', ['item' => $obj, 'options' => &$options]);
+         Plugin::doHook(Hooks::PRE_SHOW_ITEM, ['item' => $obj, 'options' => &$options]);
 
          if (is_array($obj)) {
             $item_i = $obj['item'];
@@ -7576,7 +7577,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
          $timeline_index++;
 
-         Plugin::doHook('post_show_item', ['item' => $obj, 'options' => $options]);
+         Plugin::doHook(Hooks::POST_SHOW_ITEM, ['item' => $obj, 'options' => $options]);
 
       } // end foreach timeline
 
@@ -7756,7 +7757,7 @@ abstract class CommonITILObject extends CommonDBTM {
       echo "</th>";
       echo "</tr>";
 
-      Plugin::doHook("pre_item_form", ['item' => $this, 'options' => &$options]);
+      Plugin::doHook(Hooks::PRE_ITEM_FORM, ['item' => $this, 'options' => &$options]);
    }
 
    /**

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -33,6 +33,7 @@
 use Glpi\Cache\CacheManager;
 use Glpi\Dashboard\Grid;
 use Glpi\Exception\PasswordTooWeakException;
+use Glpi\Plugin\Hooks;
 use Glpi\System\RequirementsManager;
 use Glpi\Toolbox\Sanitizer;
 use Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator;
@@ -277,7 +278,7 @@ class Config extends CommonDBTM {
             && in_array($fields['name'], self::$undisclosedFields)) {
             unset($fields['value']);
          } else {
-            $fields = Plugin::doHookFunction('undiscloseConfigValue', $fields);
+            $fields = Plugin::doHookFunction(Hooks::UNDISCLOSED_CONFIG_VALUE, $fields);
          }
       }
    }

--- a/inc/contact.class.php
+++ b/inc/contact.class.php
@@ -34,6 +34,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use Glpi\Plugin\Hooks;
 use Sabre\VObject;
 
 /**
@@ -519,7 +520,7 @@ class Contact extends CommonDBTM{
       }
 
       // Get more data from plugins such as an IM contact
-      $data = Plugin::doHook('vcard_data', ['item' => $this, 'data' => []])['data'];
+      $data = Plugin::doHook(Hooks::VCARD_DATA, ['item' => $this, 'data' => []])['data'];
       foreach ($data as $field => $additional_field) {
          $vcard->add($additional_field['name'], $additional_field['value'] ?? '', $additional_field['params'] ?? []);
       }

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -31,6 +31,7 @@
  */
 
 use Glpi\Event;
+use Glpi\Plugin\Hooks;
 
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
@@ -1409,7 +1410,7 @@ class Entity extends CommonTreeDropdown {
 
       echo "<table class='tab_cadre_fixe'>";
 
-      Plugin::doHook("pre_item_form", ['item' => $entity, 'options' => []]);
+      Plugin::doHook(Hooks::PRE_ITEM_FORM, ['item' => $entity, 'options' => []]);
 
       echo "<tr><th colspan='4'>".__('Address')."</th></tr>";
 
@@ -1489,7 +1490,7 @@ class Entity extends CommonTreeDropdown {
       Html::autocompletionTextField($entity, "altitude");
       echo "</td></tr>";
 
-      Plugin::doHook("post_item_form", ['item' => $entity, 'options' => []]);
+      Plugin::doHook(Hooks::POST_ITEM_FORM, ['item' => $entity, 'options' => []]);
       echo "</table>";
 
       if ($canedit) {
@@ -1525,7 +1526,7 @@ class Entity extends CommonTreeDropdown {
 
       echo "<table class='tab_cadre_fixe'>";
 
-      Plugin::doHook("pre_item_form", ['item' => $entity, 'options' => []]);
+      Plugin::doHook(Hooks::PRE_ITEM_FORM, ['item' => $entity, 'options' => []]);
 
       echo "<tr><th colspan='2'>".__('Values for the generic rules for assignment to entities').
            "</th></tr>";
@@ -1576,7 +1577,7 @@ class Entity extends CommonTreeDropdown {
          echo "</td></tr>";
       }
 
-      Plugin::doHook("post_item_form", ['item' => $entity, 'options' => &$options]);
+      Plugin::doHook(Hooks::POST_ITEM_FORM, ['item' => $entity, 'options' => &$options]);
 
       echo "</table>";
 
@@ -1612,7 +1613,7 @@ class Entity extends CommonTreeDropdown {
 
       echo "<table class='tab_cadre_fixe'>";
 
-      Plugin::doHook("pre_item_form", ['item' => $entity, 'options' => []]);
+      Plugin::doHook(Hooks::PRE_ITEM_FORM, ['item' => $entity, 'options' => []]);
 
       echo "<tr><th colspan='4'>".__('Autofill dates for financial and administrative information').
            "</th></tr>";
@@ -1772,7 +1773,7 @@ class Entity extends CommonTreeDropdown {
       echo "</td>";
       echo "</td><td colspan='2'></td></tr>";
 
-      Plugin::doHook("post_item_form", ['item' => $entity, 'options' => &$options]);
+      Plugin::doHook(Hooks::POST_ITEM_FORM, ['item' => $entity, 'options' => &$options]);
 
       echo "</table>";
 
@@ -1813,7 +1814,7 @@ class Entity extends CommonTreeDropdown {
 
       echo "<table class='tab_cadre_fixe'>";
 
-      Plugin::doHook("pre_item_form", ['item' => $entity, 'options' => []]);
+      Plugin::doHook(Hooks::PRE_ITEM_FORM, ['item' => $entity, 'options' => []]);
 
       echo "<tr><th colspan='4'>".__('Notification options')."</th></tr>";
 
@@ -2196,7 +2197,7 @@ class Entity extends CommonTreeDropdown {
       }
       echo "</td></tr>";
 
-      Plugin::doHook("post_item_form", ['item' => $entity, 'options' => &$options]);
+      Plugin::doHook(Hooks::POST_ITEM_FORM, ['item' => $entity, 'options' => &$options]);
 
       echo "</table>";
 
@@ -2244,7 +2245,7 @@ class Entity extends CommonTreeDropdown {
 
       echo "<table class='tab_cadre_fixe custom_css_configuration'>";
 
-      Plugin::doHook("pre_item_form", ['item' => $entity, 'options' => []]);
+      Plugin::doHook(Hooks::PRE_ITEM_FORM, ['item' => $entity, 'options' => []]);
 
       $rand = mt_rand();
 
@@ -2295,7 +2296,7 @@ class Entity extends CommonTreeDropdown {
          ]
       );
 
-      Plugin::doHook("post_item_form", ['item' => $entity, 'options' => &$options]);
+      Plugin::doHook(Hooks::POST_ITEM_FORM, ['item' => $entity, 'options' => &$options]);
 
       echo "</table>";
 
@@ -2448,7 +2449,7 @@ class Entity extends CommonTreeDropdown {
 
       echo "<table class='tab_cadre_fixe'>";
 
-      Plugin::doHook("pre_item_form", ['item' => $entity, 'options' => []]);
+      Plugin::doHook(Hooks::PRE_ITEM_FORM, ['item' => $entity, 'options' => []]);
 
       echo "<tr><th colspan='4'>".__('Templates configuration')."</th></tr>";
 
@@ -2840,7 +2841,7 @@ class Entity extends CommonTreeDropdown {
 
       echo "</td></tr>";
 
-      Plugin::doHook("post_item_form", ['item' => $entity, 'options' => &$options]);
+      Plugin::doHook(Hooks::POST_ITEM_FORM, ['item' => $entity, 'options' => &$options]);
 
       echo "</table>";
 

--- a/inc/features/inventoriable.class.php
+++ b/inc/features/inventoriable.class.php
@@ -38,6 +38,7 @@ use Computer;
 use Computer_Item;
 use DatabaseInstance;
 use Glpi\Inventory\Conf;
+use Glpi\Plugin\Hooks;
 use Html;
 use Plugin;
 use RefusedEquipment;
@@ -154,7 +155,7 @@ trait Inventoriable {
       if (!empty($this->fields['id'])
           && $this->fields["is_dynamic"]) {
          echo "<tr class='tab_bg_1'><td colspan='4'>";
-         Plugin::doHook("autoinventory_information", $this);
+         Plugin::doHook(Hooks::AUTOINVENTORY_INFORMATION, $this);
          echo "</td></tr>";
       }
    }

--- a/inc/glpikey.class.php
+++ b/inc/glpikey.class.php
@@ -34,6 +34,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\Sanitizer;
 
 /**
@@ -184,8 +185,8 @@ class GLPIKey {
       global $PLUGIN_HOOKS;
 
       $fields = $this->fields;
-      if (isset($PLUGIN_HOOKS['secured_fields'])) {
-         foreach ($PLUGIN_HOOKS['secured_fields'] as $plugfields) {
+      if (isset($PLUGIN_HOOKS[Hooks::SECURED_FIELDS])) {
+         foreach ($PLUGIN_HOOKS[Hooks::SECURED_FIELDS] as $plugfields) {
             $fields = array_merge($fields, $plugfields);
          }
       }
@@ -203,8 +204,8 @@ class GLPIKey {
 
       $configs = $this->configs;
 
-      if (isset($PLUGIN_HOOKS['secured_configs'])) {
-         foreach ($PLUGIN_HOOKS['secured_configs'] as $plugin => $plugconfigs) {
+      if (isset($PLUGIN_HOOKS[Hooks::SECURED_CONFIGS])) {
+         foreach ($PLUGIN_HOOKS[Hooks::SECURED_CONFIGS] as $plugin => $plugconfigs) {
             $configs['plugin:' . $plugin] = $plugconfigs;
          }
       }

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -30,6 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\Sanitizer;
 use ScssPhp\ScssPhp\Compiler;
 
@@ -1389,9 +1390,9 @@ class Html {
              $CFG_GLPI["root_doc"]."/pics/favicon.ico' >\n";
 
       // Add specific css for plugins
-      if (isset($PLUGIN_HOOKS['add_css']) && count($PLUGIN_HOOKS['add_css'])) {
+      if (isset($PLUGIN_HOOKS[Hooks::ADD_CSS]) && count($PLUGIN_HOOKS[Hooks::ADD_CSS])) {
 
-         foreach ($PLUGIN_HOOKS["add_css"] as $plugin => $files) {
+         foreach ($PLUGIN_HOOKS[Hooks::ADD_CSS] as $plugin => $files) {
             if (!Plugin::isPluginActive($plugin)) {
                continue;
             }
@@ -6818,8 +6819,8 @@ JAVASCRIPT;
       Html::displayAjaxMessageAfterRedirect();
 
       // Add specific javascript for plugins
-      if (isset($PLUGIN_HOOKS['add_javascript']) && count($PLUGIN_HOOKS['add_javascript'])) {
-         foreach ($PLUGIN_HOOKS["add_javascript"] as $plugin => $files) {
+      if (isset($PLUGIN_HOOKS[Hooks::ADD_JAVASCRIPT]) && count($PLUGIN_HOOKS[Hooks::ADD_JAVASCRIPT])) {
+         foreach ($PLUGIN_HOOKS[Hooks::ADD_JAVASCRIPT] as $plugin => $files) {
             $plugin_root_dir = Plugin::getPhpDir($plugin, true);
             $plugin_web_dir  = Plugin::getWebDir($plugin, false);
             if (!Plugin::isPluginActive($plugin)) {
@@ -7211,7 +7212,7 @@ JAVASCRIPT;
          }
       }
 
-      $menu = Plugin::doHookFunction("redefine_menus", $menu);
+      $menu = Plugin::doHookFunction(Hooks::REDEFINE_MENUS, $menu);
 
       $already_used_shortcut = ['1'];
 

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -34,6 +34,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\RichText;
 
 /**
@@ -1028,7 +1029,7 @@ JAVASCRIPT;
          echo "<input type='hidden' name='id' value='$ID'>";
       }
 
-      Plugin::doHook("post_item_form", ['item' => $this, 'options' => &$params]);
+      Plugin::doHook(Hooks::POST_ITEM_FORM, ['item' => $this, 'options' => &$params]);
 
       echo "<tr class='tab_bg_2'>";
       echo "<td class='center' colspan='".($params['colspan']*2)."'>";

--- a/inc/lock.class.php
+++ b/inc/lock.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Plugin\Hooks;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -87,7 +89,7 @@ class Lock extends CommonGLPI {
       echo "<th>".__('Locked items')."</th></tr>";
 
       //Use a hook to allow external inventory tools to manage per field lock
-      $results =  Plugin::doHookFunction('display_locked_fields', ['item'   => $item,
+      $results =  Plugin::doHookFunction(Hooks::DISPLAY_LOCKED_FIELDS, ['item'   => $item,
                                                                         'header' => $header]);
       $header |= $results['header'];
 

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Plugin\Hooks;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -130,7 +132,7 @@ class NotificationTarget extends CommonDBChild {
 
       // add new target by plugin
       unset($this->data);
-      Plugin::doHook('item_add_targets', $this);
+      Plugin::doHook(Hooks::ITEM_ADD_TARGETS, $this);
       asort($this->notification_targets);
    }
 
@@ -561,7 +563,7 @@ class NotificationTarget extends CommonDBChild {
             'itemtype' => User::class,
             'items_id' => $data['users_id'],
          ];
-         Plugin::doHook('add_recipient_to_target', $this);
+         Plugin::doHook(Hooks::ADD_RECIPIENT_TO_TARGET, $this);
          unset($this->recipient_data);
       }
    }
@@ -773,7 +775,7 @@ class NotificationTarget extends CommonDBChild {
             'itemtype' => Group::class,
             'items_id' => $group_id,
          ];
-         Plugin::doHook('add_recipient_to_target', $this);
+         Plugin::doHook(Hooks::ADD_RECIPIENT_TO_TARGET, $this);
          unset($this->recipient_data);
       }
    }
@@ -817,7 +819,7 @@ class NotificationTarget extends CommonDBChild {
 
       $this->events = $this->getEvents();
       //If plugin adds new events for an already defined type
-      Plugin::doHook('item_get_events', $this);
+      Plugin::doHook(Hooks::ITEM_GET_EVENTS, $this);
 
       return $this->events;
    }
@@ -1037,7 +1039,7 @@ class NotificationTarget extends CommonDBChild {
          'itemtype' => Profile::class,
          'items_id' => $profiles_id,
       ];
-      Plugin::doHook('add_recipient_to_target', $this);
+      Plugin::doHook(Hooks::ADD_RECIPIENT_TO_TARGET, $this);
       unset($this->recipient_data);
    }
 
@@ -1202,7 +1204,7 @@ class NotificationTarget extends CommonDBChild {
       }
       // action for target from plugin
       $this->data = $data;
-      Plugin::doHook('item_action_targets', $this);
+      Plugin::doHook(Hooks::ITEM_ACTION_TARGETS, $this);
 
    }
 
@@ -1276,7 +1278,7 @@ class NotificationTarget extends CommonDBChild {
 
       $this->addDataForTemplate($event, $options);
 
-      Plugin::doHook('item_get_datas', $this);
+      Plugin::doHook(Hooks::ITEM_GET_DATA, $this);
 
       return $this->data;
    }

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -40,6 +40,7 @@ if (!defined('GLPI_ROOT')) {
 
 use Glpi\Marketplace\Controller as MarketplaceController;
 use Glpi\Marketplace\View as MarketplaceView;
+use Glpi\Plugin\Hooks;
 
 class Plugin extends CommonDBTM {
 
@@ -227,7 +228,7 @@ class Plugin extends CommonDBTM {
             }
          }
          // For plugins which require action after all plugin init
-         Plugin::doHook("post_init");
+         Plugin::doHook(Hooks::POST_INIT);
       }
    }
 
@@ -779,8 +780,8 @@ class Plugin extends CommonDBTM {
          self::load($this->fields['directory'], true);
 
          // No activation if not CSRF compliant
-         if (!isset($PLUGIN_HOOKS['csrf_compliant'][$this->fields['directory']])
-             || !$PLUGIN_HOOKS['csrf_compliant'][$this->fields['directory']]) {
+         if (!isset($PLUGIN_HOOKS[Hooks::CSRF_COMPLIANT][$this->fields['directory']])
+             || !$PLUGIN_HOOKS[Hooks::CSRF_COMPLIANT][$this->fields['directory']]) {
             Session::addMessageAfterRedirect(
                sprintf(__('Plugin %1$s is not CSRF compliant!'), $this->fields['name']),
                true,
@@ -817,17 +818,17 @@ class Plugin extends CommonDBTM {
                            'state' => self::ACTIVATED]);
 
             // Initialize session for the plugin
-            if (isset($PLUGIN_HOOKS['init_session'][$this->fields['directory']])
-                && is_callable($PLUGIN_HOOKS['init_session'][$this->fields['directory']])) {
+            if (isset($PLUGIN_HOOKS[Hooks::INIT_SESSION][$this->fields['directory']])
+                && is_callable($PLUGIN_HOOKS[Hooks::INIT_SESSION][$this->fields['directory']])) {
 
-               call_user_func($PLUGIN_HOOKS['init_session'][$this->fields['directory']]);
+               call_user_func($PLUGIN_HOOKS[Hooks::INIT_SESSION][$this->fields['directory']]);
             }
 
             // Initialize profile for the plugin
-            if (isset($PLUGIN_HOOKS['change_profile'][$this->fields['directory']])
-                && is_callable($PLUGIN_HOOKS['change_profile'][$this->fields['directory']])) {
+            if (isset($PLUGIN_HOOKS[Hooks::CHANGE_PROFILE][$this->fields['directory']])
+                && is_callable($PLUGIN_HOOKS[Hooks::CHANGE_PROFILE][$this->fields['directory']])) {
 
-               call_user_func($PLUGIN_HOOKS['change_profile'][$this->fields['directory']]);
+               call_user_func($PLUGIN_HOOKS[Hooks::CHANGE_PROFILE][$this->fields['directory']]);
             }
             // reset menu
             if (isset($_SESSION['glpimenu'])) {
@@ -1108,7 +1109,7 @@ class Plugin extends CommonDBTM {
       );
 
       //Add plugins types
-      $typetoname = self::doHookFunction("migratetypes", $typetoname);
+      $typetoname = self::doHookFunction(Hooks::MIGRATE_TYPES, $typetoname);
 
       foreach ($types as $num => $name) {
          $typetoname[$num] = $name;
@@ -2253,8 +2254,8 @@ class Plugin extends CommonDBTM {
                }
                ob_end_clean();
                $function = 'plugin_' . $directory . '_check_prerequisites';
-               if (!isset($PLUGIN_HOOKS['csrf_compliant'][$directory])
-                   || !$PLUGIN_HOOKS['csrf_compliant'][$directory]) {
+               if (!isset($PLUGIN_HOOKS[Hooks::CSRF_COMPLIANT][$directory])
+                   || !$PLUGIN_HOOKS[Hooks::CSRF_COMPLIANT][$directory]) {
                   $output .= "<span class='error'>" . __('Not CSRF compliant') . "</span>";
                   $do_activate = false;
                } else if (function_exists($function) && $do_activate) {

--- a/inc/plugin/hookmanager.class.php
+++ b/inc/plugin/hookmanager.class.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Plugin;
+
+class HookManager
+{
+   protected string $plugin;
+
+   public function __construct(string $plugin) {
+      $this->plugin = $plugin;
+   }
+
+   /**
+    * Enable CSRF
+    */
+   public function enableCSRF(): void {
+      $PLUGIN_HOOKS[Hooks::CSRF_COMPLIANT][$this->plugin] = true;
+   }
+
+   /**
+    * Add a given javascript file
+    *
+    * @param string $file
+    */
+   public function registerJavascriptFile(string $file): void {
+      $this->registerFile(Hooks::ADD_JAVASCRIPT, $file);
+   }
+
+   /**
+    * Add a given CSS file
+    *
+    * @param string $file
+    */
+   public function registerCSSFile(string $file): void {
+      $this->registerFile(Hooks::ADD_CSS, $file);
+   }
+
+   /**
+    * Add a given file for the given hook
+    *
+    * @param string $hook
+    * @param string $file
+    */
+   protected function registerFile(string $hook, string $file): void {
+      global $PLUGIN_HOOKS;
+
+      // Check if the given hook is a valid file hook
+      $allowed_file_hooks = Hooks::getFileHooks();
+      if (!isset($allowed_file_hooks[$hook])) {
+         trigger_error("Invalid file hook: '$hook'", E_USER_ERROR);
+      }
+
+      // Init target array if needed
+      if (!isset($PLUGIN_HOOKS[$hook][$this->plugin])) {
+         $PLUGIN_HOOKS[$hook][$this->plugin] = [];
+      }
+
+      // Register file
+      $PLUGIN_HOOKS[$hook][$this->plugin][] = $file;
+   }
+
+   /**
+    * Add a functionnal hook
+    *
+    * @param string $hook
+    * @param string $file
+    */
+   public function registerFunctionnalHook(
+      string $hook,
+      callable $function
+   ): void {
+      global $PLUGIN_HOOKS;
+
+      // Check if the given hook is a valid functionnal hook
+      $allowed_file_hooks = Hooks::getFonctionnalHooks();
+      if (!isset($allowed_file_hooks[$hook])) {
+         trigger_error("Invalid functionnal hook: '$hook'", E_USER_ERROR);
+      }
+
+      $PLUGIN_HOOKS[$hook][$this->plugin] = $function;
+   }
+
+   /**
+    * Add an item hook
+    *
+    * @param string $hook
+    * @param string $itemtype
+    * @param string $file
+    */
+   public function registerItemHook(
+      string $hook,
+      string $itemtype,
+      callable $function
+   ): void {
+      global $PLUGIN_HOOKS;
+
+      // Check if the given hook is a valid item hook
+      $allowed_file_hooks = Hooks::getItemHooks();
+      if (!isset($allowed_file_hooks[$hook])) {
+         trigger_error("Invalid functionnal hook: '$hook'", E_USER_ERROR);
+      }
+
+      $PLUGIN_HOOKS[$hook][$this->plugin][$itemtype] = $function;
+   }
+
+   /**
+    * Register fields that need to be encrypted
+    *
+    * @param array $fields array of table.field
+    */
+   public function registerSecureFields(array $fields): void {
+      global $PLUGIN_HOOKS;
+
+      $PLUGIN_HOOKS[Hooks::SECURED_FIELDS][$this->plugin] = $fields;
+   }
+
+   /**
+    * Register configuration values that need to be encrypted
+    *
+    * @param array $configs
+    */
+   public function registerSecureConfigs(array $configs): void {
+      global $PLUGIN_HOOKS;
+
+      $PLUGIN_HOOKS[Hooks::SECURED_CONFIGS][$this->plugin] = $configs;
+   }
+}

--- a/inc/plugin/hookmanager.class.php
+++ b/inc/plugin/hookmanager.class.php
@@ -102,7 +102,7 @@ class HookManager
       global $PLUGIN_HOOKS;
 
       // Check if the given hook is a valid functionnal hook
-      $allowed_file_hooks = Hooks::getFonctionnalHooks();
+      $allowed_file_hooks = Hooks::getFunctionalHooks();
       if (!isset($allowed_file_hooks[$hook])) {
          trigger_error("Invalid functional hook: '$hook'", E_USER_ERROR);
       }

--- a/inc/plugin/hookmanager.class.php
+++ b/inc/plugin/hookmanager.class.php
@@ -95,7 +95,7 @@ class HookManager
     * @param string $hook
     * @param string $file
     */
-   public function registerFunctionnalHook(
+   public function registerFunctionalHook(
       string $hook,
       callable $function
    ): void {
@@ -104,7 +104,7 @@ class HookManager
       // Check if the given hook is a valid functionnal hook
       $allowed_file_hooks = Hooks::getFonctionnalHooks();
       if (!isset($allowed_file_hooks[$hook])) {
-         trigger_error("Invalid functionnal hook: '$hook'", E_USER_ERROR);
+         trigger_error("Invalid functional hook: '$hook'", E_USER_ERROR);
       }
 
       $PLUGIN_HOOKS[$hook][$this->plugin] = $function;

--- a/inc/plugin/hooks.class.php
+++ b/inc/plugin/hooks.class.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Plugin;
+
+class Hooks
+{
+   // Boolean hooks
+   const CSRF_COMPLIANT = 'csrf_compliant';
+
+   // File hooks
+   const ADD_CSS        = 'add_css';
+   const ADD_JAVASCRIPT = 'add_javascript';
+
+   // Function hooks with no parameters
+   const CHANGE_ENTITY    = 'change_entity';
+   const CHANGE_PROFILE   = 'change_profile';
+   const DISPLAY_LOGIN    = 'display_login';
+   const DISPLAY_CENTRAL  = 'display_central';
+   const INIT_SESSION     = 'init_session';
+   const POST_INIT        = 'post_init';
+
+   // Specific function hooks with parameters
+   const RULE_MATCHED        = 'rule_matched';
+   const VCARD_DATA          = 'vcard_data';
+
+   // Function hooks with parameters and output
+   const DISPLAY_LOCKED_FIELDS         = 'display_locked_fields';
+   const MIGRATE_TYPES                 = 'migratetypes';
+   const POST_KANBAN_CONTENT           = 'post_kanban_content';
+   const PRE_KANBAN_CONTENT            = 'pre_kanban_content';
+   const REDEFINE_MENUS                = 'redefine_menus';
+   const RETRIEVE_MORE_DATA_FROM_LDAP  = 'retrieve_more_data_from_ldap';
+   const RETRIEVE_MORE_FIELD_FROM_LDAP = 'retrieve_more_field_from_ldap';
+   const RESTRICT_LDAP_AUTH            = 'restrict_ldap_auth';
+   const UNLOCK_FIELDS                 = 'unlock_fields';
+   const UNDISCLOSED_CONFIG_VALUE      = 'undiscloseConfigValue';
+
+   // Item hooks expecting an 'item' parameter
+   const ADD_RECIPIENT_TO_TARGET   = 'add_recipient_to_target';
+   const AUTOINVENTORY_INFORMATION = 'autoinventory_information';
+   const ITEM_ACTION_TARGETS       = 'item_action_targets';
+   const ITEM_ADD                  = 'item_add';
+   const ITEM_ADD_TARGETS          = 'item_add_targets';
+   const ITEM_CAN                  = 'item_can';
+   const ITEM_EMPTY                = 'item_empty';
+   const ITEM_DELETE               = 'item_delete';
+   const ITEM_GET_DATA             = 'item_get_datas';
+   const ITEM_GET_EVENTS           = 'item_get_events';
+   const ITEM_UPDATE               = 'item_update';
+   const ITEM_PURGE                = 'item_purge';
+   const ITEM_RESTORE              = 'item_restore';
+   const POST_PREPAREADD           = 'post_prepareadd';
+   const PRE_ITEM_ADD              = 'pre_item_add';
+   const PRE_ITEM_UPDATE           = 'pre_item_update';
+   const PRE_ITEM_DELETE           = 'pre_item_delete';
+   const PRE_ITEM_PURGE            = 'pre_item_purge';
+   const PRE_ITEM_RESTORE          = 'pre_item_restore';
+   const SHOW_ITEM_STATS           = 'show_item_stats';
+
+   // Item hooks expecting an array parameter (available keys: item, options)
+   const ITEM_TRANSFER    = 'item_transfer';
+   const POST_ITEM_FORM   = 'post_item_form';
+   const POST_SHOW_ITEM   = 'post_show_item';
+   const POST_SHOW_TAB    = 'post_show_tab';
+   const PRE_ITEM_FORM    = 'pre_item_form';
+   const PRE_SHOW_ITEM    = 'pre_show_item';
+   const PRE_SHOW_TAB     = 'pre_show_tab';
+   const TIMELINE_ACTIONS = 'timeline_actions';  // (keys: item, rand)
+
+   // Security hooks (data to encypt)
+   const SECURED_FIELDS  = 'secured_fields';
+   const SECURED_CONFIGS = 'secured_configs';
+
+   /**
+    * Get file hooks
+    *
+    * @return array
+    */
+   public static function getFileHooks(): array {
+      return [
+         self::ADD_CSS,
+         self::ADD_JAVASCRIPT,
+      ];
+   }
+
+   /**
+    * Get functionnals hooks
+    *
+    * @return array
+    */
+   public static function getFonctionnalHooks(): array {
+      return [
+         self::CHANGE_ENTITY,
+         self::CHANGE_PROFILE,
+         self::DISPLAY_LOCKED_FIELDS,
+         self::DISPLAY_LOGIN,
+         self::DISPLAY_CENTRAL,
+         self::INIT_SESSION,
+         self::MIGRATE_TYPES,
+         self::POST_KANBAN_CONTENT,
+         self::PRE_KANBAN_CONTENT,
+         self::POST_INIT,
+         self::RETRIEVE_MORE_DATA_FROM_LDAP,
+         self::RETRIEVE_MORE_FIELD_FROM_LDAP,
+         self::RESTRICT_LDAP_AUTH,
+         self::RULE_MATCHED,
+         self::UNDISCLOSED_CONFIG_VALUE,
+         self::UNLOCK_FIELDS,
+         self::VCARD_DATA,
+      ];
+   }
+
+   /**
+    * Get items hooks
+    *
+    * @return array
+    */
+   public static function getItemHooks(): array {
+      return [
+         self::ADD_RECIPIENT_TO_TARGET,
+         self::ITEM_ACTION_TARGETS,
+         self::ITEM_ADD,
+         self::ITEM_ADD_TARGETS,
+         self::ITEM_CAN,
+         self::ITEM_EMPTY,
+         self::ITEM_DELETE,
+         self::ITEM_GET_DATA,
+         self::ITEM_GET_EVENTS,
+         self::ITEM_UPDATE,
+         self::ITEM_PURGE,
+         self::ITEM_RESTORE,
+         self::ITEM_TRANSFER,
+         self::PRE_ITEM_ADD,
+         self::PRE_ITEM_UPDATE,
+         self::PRE_ITEM_DELETE,
+         self::PRE_ITEM_FORM,
+         self::PRE_ITEM_PURGE,
+         self::PRE_ITEM_RESTORE,
+         self::PRE_SHOW_ITEM,
+         self::PRE_SHOW_TAB,
+         self::POST_ITEM_FORM,
+         self::POST_SHOW_ITEM,
+         self::POST_SHOW_TAB,
+         self::POST_PREPAREADD,
+         self::SHOW_ITEM_STATS,
+         self::TIMELINE_ACTIONS,
+      ];
+   }
+}
+

--- a/inc/plugin/hooks.class.php
+++ b/inc/plugin/hooks.class.php
@@ -118,7 +118,7 @@ class Hooks
     *
     * @return array
     */
-   public static function getFonctionnalHooks(): array {
+   public static function getFunctionalHooks(): array {
       return [
          self::CHANGE_ENTITY,
          self::CHANGE_PROFILE,

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -34,6 +34,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\RichText;
 
 /**
@@ -2228,7 +2229,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
          ];
 
          $content = "<div class='kanban-plugin-content'>";
-         $plugin_content_pre = Plugin::doHookFunction('pre_kanban_content', [
+         $plugin_content_pre = Plugin::doHookFunction(Hooks::PRE_KANBAN_CONTENT, [
             'itemtype' => $itemtype,
             'items_id' => $item['id'],
          ]);
@@ -2270,7 +2271,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
 
          $content .= "</div>";
          $content .= "<div class='kanban-plugin-content'>";
-         $plugin_content_post = Plugin::doHookFunction('post_kanban_content', [
+         $plugin_content_post = Plugin::doHookFunction(Hooks::POST_KANBAN_CONTENT, [
             'itemtype' => $itemtype,
             'items_id' => $item['id'],
          ]);

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Plugin\Hooks;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -1442,7 +1444,7 @@ class Rule extends CommonDBTM {
             $hook_params["ruleid"]   = $this->fields["id"];
             $hook_params["input"]    = $input;
             $hook_params["output"]   = $output;
-            Plugin::doHook("rule_matched", $hook_params);
+            Plugin::doHook(Hooks::RULE_MATCHED, $hook_params);
             $output["_rule_process"] = true;
          }
       }

--- a/inc/ruleimportentity.class.php
+++ b/inc/ruleimportentity.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Plugin\Hooks;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -323,7 +325,7 @@ class RuleImportEntity extends Rule {
                $hook_params["ruleid"]   = $this->fields["id"];
                $hook_params["input"]    = $input;
                $hook_params["output"]   = $output;
-               Plugin::doHook("rule_matched", $hook_params);
+               Plugin::doHook(Hooks::RULE_MATCHED, $hook_params);
                $output["_rule_process"] = true;
             }
          }

--- a/inc/savedsearch_alert.class.php
+++ b/inc/savedsearch_alert.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Plugin\Hooks;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -331,7 +333,7 @@ class SavedSearch_Alert extends CommonDBChild {
       $_SESSION = $context['$_SESSION'];
       $CFG_GLPI = $context['$CFG_GLPI'];
       Session::loadLanguage();
-      Plugin::doHook("init_session");
+      Plugin::doHook(Hooks::INIT_SESSION);
    }
 
    /**

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -31,6 +31,7 @@
  */
 
 use Glpi\Event;
+use Glpi\Plugin\Hooks;
 
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
@@ -156,7 +157,7 @@ class Session {
                }
 
                // glpiprofiles -> other available profile with link to the associated entities
-               Plugin::doHook("init_session");
+               Plugin::doHook(Hooks::INIT_SESSION);
 
                self::initEntityProfiles(self::getLoginUserID());
 
@@ -414,7 +415,7 @@ class Session {
             }
          }
          self::loadGroups();
-         Plugin::doHook("change_entity");
+         Plugin::doHook(Hooks::CHANGE_ENTITY);
          return true;
       }
       return false;
@@ -460,7 +461,7 @@ class Session {
                   self::changeActiveEntities("all");
                }
             }
-            Plugin::doHook("change_profile");
+            Plugin::doHook(Hooks::CHANGE_PROFILE);
          }
       }
       // Clean specific datas

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -34,6 +34,7 @@ use Glpi\ContentTemplates\Parameters\TicketParameters;
 use Glpi\ContentTemplates\ParametersPreset;
 use Glpi\ContentTemplates\TemplateManager;
 use Glpi\Event;
+use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\RichText;
 
 if (!defined('GLPI_ROOT')) {
@@ -4043,7 +4044,7 @@ JAVASCRIPT;
       echo "<input type='hidden' name='entities_id' value='".$_SESSION["glpiactive_entity"]."'>";
       echo "<div class='center'><table class='tab_cadre_fixe'>";
 
-      Plugin::doHook("pre_item_form", ['item' => $this, 'options' => &$options]);
+      Plugin::doHook(Hooks::PRE_ITEM_FORM, ['item' => $this, 'options' => &$options]);
 
       echo "<tr><th>".__('Describe the incident or request')."</th><th>";
       if (Session::isMultiEntitiesMode()) {
@@ -4253,7 +4254,7 @@ JAVASCRIPT;
 
          echo "</td></tr>";
       }
-      Plugin::doHook("post_item_form", ['item' => $this, 'options' => &$options]);
+      Plugin::doHook(Hooks::POST_ITEM_FORM, ['item' => $this, 'options' => &$options]);
 
       if (!$ticket_template) {
          echo "<tr class='tab_bg_1'>";
@@ -5314,7 +5315,7 @@ JAVASCRIPT;
          echo "</tr>";
       }
 
-      Plugin::doHook("post_item_form", ['item' => $this, 'options' => &$options]);
+      Plugin::doHook(Hooks::POST_ITEM_FORM, ['item' => $this, 'options' => &$options]);
 
       echo "</table>";
 

--- a/inc/tickettask.class.php
+++ b/inc/tickettask.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Plugin\Hooks;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -275,7 +277,7 @@ class TicketTask extends CommonITILTask {
          echo "<input type='hidden' name='id' value='$ID'>";
       }
 
-      Plugin::doHook("post_item_form", ['item' => $this, 'options' => &$params]);
+      Plugin::doHook(Hooks::POST_ITEM_FORM, ['item' => $this, 'options' => &$params]);
 
       echo "<tr class='tab_bg_2'>";
       echo "<td class='center' colspan='".($params['colspan']*2)."'>";

--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Plugin\Hooks;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -1267,7 +1269,7 @@ class Transfer extends CommonDBTM {
                $this->transferItemSoftwares($itemtype, $ID);
             }
 
-            Plugin::doHook("item_transfer", ['type'        => $itemtype,
+            Plugin::doHook(Hooks::ITEM_TRANSFER, ['type'        => $itemtype,
                                                   'id'          => $ID,
                                                   'newID'       => $newID,
                                                   'entities_id' => $this->to]);

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -35,6 +35,7 @@ if (!defined('GLPI_ROOT')) {
 }
 
 use Glpi\Exception\ForgetPasswordException;
+use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\Sanitizer;
 use Sabre\VObject;
 
@@ -1588,7 +1589,7 @@ class User extends CommonDBTM {
          $fields  = AuthLDAP::getSyncFields($ldap_method);
 
          //Hook to allow plugin to request more attributes from ldap
-         $fields = Plugin::doHookFunction("retrieve_more_field_from_ldap", $fields);
+         $fields = Plugin::doHookFunction(Hooks::RETRIEVE_MORE_FIELD_FROM_LDAP, $fields);
 
          $fields  = array_filter($fields);
          $f       = self::getLdapFieldNames($fields);
@@ -1767,7 +1768,7 @@ class User extends CommonDBTM {
             $this->fields['_ldap_result'] = $v;
             $this->fields['_ldap_conn']   = $ldap_connection;
             //Hook to retrieve more information for ldap
-            $this->fields = Plugin::doHookFunction("retrieve_more_data_from_ldap", $this->fields);
+            $this->fields = Plugin::doHookFunction(Hooks::RETRIEVE_MORE_DATA_FROM_LDAP, $this->fields);
             unset($this->fields['_ldap_result']);
          }
          return true;
@@ -4288,7 +4289,7 @@ JAVASCRIPT;
       $vcard->add('TEL', $this->fields["mobile"], ['type' => 'WORK;CELL']);
 
       // Get more data from plugins such as an IM contact
-      $data = Plugin::doHook('vcard_data', ['item' => $this, 'data' => []])['data'];
+      $data = Plugin::doHook(Hooks::VCARD_DATA, ['item' => $this, 'data' => []])['data'];
       foreach ($data as $field => $additional_field) {
          $vcard->add($additional_field['name'], $additional_field['value'] ?? '', $additional_field['params'] ?? []);
       }

--- a/index.php
+++ b/index.php
@@ -36,6 +36,7 @@ if (version_compare(PHP_VERSION, '7.4.0') < 0) {
    die('PHP >= 7.4.0 required');
 }
 
+use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\RichText;
 
 //Load GLPI constants
@@ -217,7 +218,7 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
    }
 
    echo "<div id='display-login'>";
-   Plugin::doHook('display_login');
+   Plugin::doHook(Hooks::DISPLAY_LOGIN);
    echo "</div>";
 
 

--- a/tests/functionnal/Config.php
+++ b/tests/functionnal/Config.php
@@ -33,6 +33,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Plugin\Hooks;
 use Log;
 use PHPMailer\PHPMailer\PHPMailer;
 use Session;
@@ -753,7 +754,7 @@ class Config extends DbTestCase {
    protected function logConfigChangeProvider() {
       global $PLUGIN_HOOKS;
 
-      $PLUGIN_HOOKS['secured_configs']['tester'] = ['passwd'];
+      $PLUGIN_HOOKS[Hooks::SECURED_CONFIGS]['tester'] = ['passwd'];
 
       return [
          [


### PR DESCRIPTION
These changes make using hooks in plugins easier thanks to some new constants and helper methods.  
Main benefits are auto completion ( = less reliant on documentation) and "easier to look for" references (= allow searching on the const name instead of the string value which may return a lot of unrelated code).  
No impact on existing plugins, the new helper methods brought by `HookManager` are completely optional.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
