### PR TITLE
Ticket_Ticket::countOpenChildren() is used statically

### DIFF
--- a/inc/ticket_ticket.class.php
+++ b/inc/ticket_ticket.class.php
@@ -331,7 +331,7 @@ class Ticket_Ticket extends CommonDBRelation {
     *
     * @return integer
     */
-   public function countOpenChildren($pid) {
+   static public function countOpenChildren($pid) {
       global $DB;
 
       $result = $DB->request([

--- a/tests/functionnal/Ticket_Ticket.php
+++ b/tests/functionnal/Ticket_Ticket.php
@@ -168,7 +168,7 @@ class Ticket_Ticket extends DbTestCase {
       )->isGreaterThan(0);
 
       //not a SON_OF => no child
-      $this->integer($link->countOpenChildren($link->getID()))->isIdenticalTo(0);
+      $this->integer(\Ticket_Ticket::countOpenChildren($link->getID()))->isIdenticalTo(0);
 
       $this->boolean(
          $link->update([
@@ -176,7 +176,7 @@ class Ticket_Ticket extends DbTestCase {
             'link'   => \Ticket_Ticket::SON_OF
          ])
       )->isTrue();
-      $this->integer($link->countOpenChildren($ttwo->getID()))->isIdenticalTo(1);
+      $this->integer(\Ticket_Ticket::countOpenChildren($ttwo->getID()))->isIdenticalTo(1);
 
       $this->boolean(
          $tone->update([
@@ -184,6 +184,6 @@ class Ticket_Ticket extends DbTestCase {
             'status' => \Ticket::CLOSED
          ])
       )->isTrue();
-      $this->integer($link->countOpenChildren($ttwo->getID()))->isIdenticalTo(0);
+      $this->integer(\Ticket_Ticket::countOpenChildren($ttwo->getID()))->isIdenticalTo(0);
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

See failure on PHP 7.4 tests: https://github.com/glpi-project/glpi/runs/3787869898?check_suite_focus=true