### PR TITLE
Fixes link generated by infocom cron

### DIFF
--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -100,7 +100,8 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                'name'      => $row['admin_email_name']
             ];
             if ($usr->getFromDBbyEmail($row['admin_email'])) {
-               $admins[array_key_last($admins)]['users_id'] = $usr->getID();
+               //$admins[array_key_last($admins)]['users_id'] = $usr->getID();
+               $admins[count($admins)-1]['users_id'] = $usr->getID();
             };
          }
       }

--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -91,7 +91,7 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
       ]);
 
       $admins = [];
-
+      $usr = new User();
       while ($row = $iterator->next()) {
          if (NotificationMailing::isUserAddressValid($row['admin_email'])) {
             $admins[] = [
@@ -99,6 +99,9 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                'email'     => $row['admin_email'],
                'name'      => $row['admin_email_name']
             ];
+            if ($usr->getFromDBbyEmail($row['admin_email'])) {
+               $admins[array_key_last($admins)]['users_id'] = $usr->getID();
+            };
          }
       }
 

--- a/inc/notificationeventmailing.class.php
+++ b/inc/notificationeventmailing.class.php
@@ -94,15 +94,15 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
       $usr = new User();
       while ($row = $iterator->next()) {
          if (NotificationMailing::isUserAddressValid($row['admin_email'])) {
-            $admins[] = [
+            $admin = [
                'language'  => $CFG_GLPI['language'],
                'email'     => $row['admin_email'],
                'name'      => $row['admin_email_name']
             ];
             if ($usr->getFromDBbyEmail($row['admin_email'])) {
-               //$admins[array_key_last($admins)]['users_id'] = $usr->getID();
-               $admins[count($admins)-1]['users_id'] = $usr->getID();
-            };
+               $admin['users_id'] = $usr->getID();
+            }
+            $admins[] = $admin;
          }
       }
 

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -525,7 +525,7 @@ class NotificationTarget extends CommonDBChild {
       }
 
       // Pass user type as argument ? forced for specific cases
-      if (isset($data['usertype'])) {
+      if ($notificationoption['usertype'] == self::ANONYMOUS_USER && isset($data['usertype'])) {
          $notificationoption['usertype'] = $data['usertype'];
       }
 


### PR DESCRIPTION
When the entity administrator is a LDAP user, he is considered like a GLPI_USER instead of EXTERNAL_USER in the function NotificationTarget::addToRecipientlist()
So in the sended email the link contain the parameter "noAUTO=1"


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | #9326
