### PR TITLE
Add some Kanban event triggers

### DIFF
--- a/js/kanban.js
+++ b/js/kanban.js
@@ -2032,7 +2032,7 @@ class GLPIKanbanRights {
        * @since 9.5.0
        */
       this.filter = function() {
-         $(self.element).trigger('kanban:pre_filter');
+         $(self.element).trigger('kanban:pre_filter', self.filters);
          // Unhide all items in case they are no longer filtered
          self.clearFiltered();
          // Filter using built-in text filter (Check title)
@@ -2056,7 +2056,7 @@ class GLPIKanbanRights {
          $(self.element + ' .kanban-column').each(function(i, column) {
             self.updateColumnCount(column);
          });
-         $(self.element).trigger('kanban:post_filter');
+         $(self.element).trigger('kanban:post_filter', self.filters);
       };
 
       /**

--- a/js/kanban.js
+++ b/js/kanban.js
@@ -372,6 +372,7 @@ class GLPIKanbanRights {
        * @since 9.5.0
       **/
       const build = function() {
+         self.element.trigger('kanban:pre_build');
          if (self.show_toolbar) {
             buildToolbar();
          }
@@ -446,9 +447,11 @@ class GLPIKanbanRights {
                buildCreateColumnForm();
             }
          }
+         self.element.trigger('kanban:post_build');
       };
 
       const buildToolbar = function() {
+         self.element.trigger('kanban:pre_build_toolbar');
          let toolbar = $("<div class='kanban-toolbar card flex-row'></div>").appendTo(self.element);
          $("<select name='kanban-board-switcher'></select>").appendTo(toolbar);
          let filter_input = $("<input name='filter' class='form-control ms-1' type='text' placeholder='" + __('Search or filter results') + "'/>").appendTo(toolbar);
@@ -464,6 +467,7 @@ class GLPIKanbanRights {
             self.filters._text = text;
             self.filter();
          });
+         self.element.trigger('kanban:post_build_toolbar');
       };
 
       const getColumnElementFromID = function(column_id) {
@@ -947,6 +951,7 @@ class GLPIKanbanRights {
        * @since 9.5.0
        */
       const refreshSortables = function() {
+         self.element.trigger('kanban:refresh_sortables');
          // Make sure all items in the columns can be sorted
          const bodies = $(self.element + ' .kanban-body');
          $.each(bodies, function(b) {
@@ -1151,6 +1156,7 @@ class GLPIKanbanRights {
             success: function() {
                if (success) {
                   success();
+                  $('#'+card).trigger('kanban:card_move');
                }
             }
          });
@@ -1187,6 +1193,7 @@ class GLPIKanbanRights {
                self.updateColumnCount(column);
                if (success) {
                   success();
+                  $('#'+card).trigger('kanban:card_delete');
                }
             }
          });
@@ -1838,6 +1845,7 @@ class GLPIKanbanRights {
                self.filter();
                if (success) {
                   success(columns, textStatus, jqXHR);
+                  $(self.element).trigger('kanban:refresh');
                }
             }).fail(function(jqXHR, textStatus, errorThrown) {
                if (fail) {
@@ -2024,6 +2032,7 @@ class GLPIKanbanRights {
        * @since 9.5.0
        */
       this.filter = function() {
+         $(self.element).trigger('kanban:pre_filter');
          // Unhide all items in case they are no longer filtered
          self.clearFiltered();
          // Filter using built-in text filter (Check title)
@@ -2040,12 +2049,14 @@ class GLPIKanbanRights {
                }
             }
          });
-         // Check specialized filters (By column item property). Not currently supported.
+         // Check specialized filters (By column item property).
+         $(self.element).trigger('kanban:filter', self.filters);
 
          // Update column counters
          $(self.element + ' .kanban-column').each(function(i, column) {
             self.updateColumnCount(column);
          });
+         $(self.element).trigger('kanban:post_filter');
       };
 
       /**
@@ -2200,6 +2211,7 @@ class GLPIKanbanRights {
        * @since 9.5.0
        */
       const loadState = function(callback) {
+         self.element.trigger('kanban:pre_load_state');
          $.ajax({
             type: "GET",
             url: (self.ajax_root + "kanban.php"),
@@ -2238,6 +2250,7 @@ class GLPIKanbanRights {
 
             if (callback) {
                callback(true);
+               self.element.trigger('kanban:post_load_state');
             }
          });
       };
@@ -2256,6 +2269,7 @@ class GLPIKanbanRights {
        * @param {function} always Callback that is called regardless of the success of the save.
        */
       const saveState = function(rebuild_state, force_save, success, fail, always) {
+         self.element.trigger('kanban:pre_save_state');
          rebuild_state = rebuild_state !== undefined ? rebuild_state : false;
          if (!force_save && !self.user_state.is_dirty) {
             if (always) {
@@ -2287,6 +2301,7 @@ class GLPIKanbanRights {
             self.user_state.is_dirty = false;
             if (success) {
                success(data, textStatus, jqXHR);
+               self.element.trigger('kanban:post_save_state');
             }
          }).fail(function(jqXHR, textStatus, errorThrown) {
             if (fail) {
@@ -2301,7 +2316,7 @@ class GLPIKanbanRights {
 
       /**
        * Initialize the background refresh mechanism.
-       * @sicne 9.5.0
+       * @since 9.5.0
        */
       const backgroundRefresh = function() {
          if (self.background_refresh_interval <= 0) {
@@ -2329,6 +2344,7 @@ class GLPIKanbanRights {
        * @since 9.5.0
        */
       this.init = function() {
+         self.element.trigger('kanban:pre_init');
          loadState(function() {
             build();
             $(document).ready(function() {
@@ -2349,7 +2365,9 @@ class GLPIKanbanRights {
                backgroundRefresh();
             });
          });
+         self.element.trigger('kanban:post_init');
       };
+
       initParams(arguments);
    };
 })();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add some event triggers for Kanban as a supported way to expand Kanban functionality in the core or hook into it for plugins.

Events triggered on the Kanban element itself:
- kanban:pre_build - Before the DOM elements are created
- kanban:post_build - After the DOM elements are created
- kanban:pre_build_toolbar - Before the toolbar is created
- kanban:post_build_toolbar - After the toolbar is created (Could be used to determine when it is OK to inject new elements into the toolbar if it isn't already created when the other script is run)
- kanban:refresh_sortables - Called when all sortable (jquery-ui sortable currently) elements should be re-initialized because the old ones are now invalid
- kanban:refresh - Called when the Kanban data is refreshed from the server. This usually happens periodically in the background depending on the ticket/dashboard/kanban refresh interval set in user preferences. This is delayed during periods of activity in the Kanban to help prevent disruptions.
- kanban:pre_filter - Called before the Kanban filters are processed. This gives other scripts the chance to inject their own filters.
- kanban:filter - Called after the core-supported filters are processed. This is when plugin/other script's filters should be processed.
- kanban:post_filter - Called after the core and extra filters are processed.
- kanban:pre_load_state - Called before the Kanban state is loaded from the server. This gives other scripts the change to preserve data before it is potentially wiped out.
- kanban:post_load_state - Called after the Kanban state is loaded from the server. This gives other scripts the change to restore data that was potentially lost.
- kanban:pre_save_state - Called before the Kanban state is saved to the server, This gives other scripts the chance to manipulate the state or save their own extra data.
- kanban:post_save_state - Called after the Kanban state is saved to the server. This is another chance for other scripts to save extra data if they want to be sure the core data saved successfully.
- kanban:pre_init - Called before the Kanban is initialized
- kanban:post_init - Called after the Kanban is initialized

Events triggered on individual cards:
- kanban:card_move - Called after the card is moved successfully and the change is registered by the server
- kanban:card_delete -  Called after the card is deleted successfully and the deletion is registered by the server