### PR TITLE
Remove autoload error logic

### DIFF
--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -271,16 +271,6 @@ function _nx($ctx, $sing, $plural, $nb, $domain = 'glpi') {
  */
 function glpi_autoload($classname) {
    global $DEBUG_AUTOLOAD;
-   static $notfound = ['xStates'    => true,
-                            'xAllAssets' => true, ];
-   // empty classname or non concerted plugin or classname containing dot (leaving GLPI main treee)
-   if (empty($classname) || is_numeric($classname) || (strpos($classname, '.') !== false)) {
-      trigger_error(
-         sprintf('Trying to load a forbidden class name "%1$s"', $classname),
-         E_USER_ERROR
-      );
-      return false;
-   }
 
    if ($classname === 'phpCAS'
        && file_exists(stream_resolve_include_path("CAS.php"))) {
@@ -353,11 +343,6 @@ function glpi_autoload($classname) {
           && ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE)) {
          $DEBUG_AUTOLOAD[] = $classname;
       }
-
-   } else if (!isset($notfound["x$classname"])) {
-      // trigger an error to get a backtrace, but only once (use prefix 'x' to handle empty case)
-      // trigger_error("GLPI autoload : file $dir$item.class.php not founded trying to load class '$classname'");
-      $notfound["x$classname"] = true;
    }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Trigerring errors on autload dos not really help. If someone tries to instanciate a class that does not exists, then it will anyway result in an error.

Using a numeric (integer) classname.
```
$ php -r '$c = 0; new $c();'

Fatal error: Uncaught Error: Class name must be a valid object or a string in Command line code:1
Stack trace:
#0 {main}
  thrown in Command line code on line 1
```

Using a numeric (string) classname.
```
$ php -r '$c = "0"; new $c();'

Fatal error: Uncaught Error: Class "0" not found in Command line code:1
Stack trace:
#0 {main}
  thrown in Command line code on line 1
```

Using an empty (null) classname:
```
$ php -r '$c = null; new $c();'

Fatal error: Uncaught Error: Class name must be a valid object or a string in Command line code:1
Stack trace:
#0 {main}
  thrown in Command line code on line 1
```

Using an empty (string) classname:
```
$ php -r '$c = ""; new $c();'

Fatal error: Uncaught Error: Class "" not found in Command line code:1
Stack trace:
#0 {main}
  thrown in Command line code on line 1
```

Using a non existing class having a `.` in its name:
```
php -r '$c = "A.B"; new $c();'

Fatal error: Uncaught Error: Class "A.B" not found in Command line code:1
Stack trace:
#0 {main}
  thrown in Command line code on line 1
```