### PR TITLE
Fix form header on CommonDBChild

### DIFF
--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -72,9 +72,6 @@
                   {{ entity_name }}
                </span>
 
-               {% set is_dbchild = item is instanceof('CommonDBChild') %}
-               <input type="hidden" name="is_recursive"
-                     value="{{ is_dbchild ? item.fields['is_recursive'] : '0' }}" />
                {% if item.maybeRecursive() %}
                   <span class="badge entity-name mx-1 px-2 py-3">
                      <label class="form-check mt-1">
@@ -82,17 +79,13 @@
                         {% set checked  = item.fields['is_recursive'] ? true : false %}
                         {% set comment  = __('Change visibility in child entities.') %}
 
-                        {% if is_dbchild %}
+                        {% if item is instanceof('CommonDBChild') %}
                            {% set comment  = __('Can՛t change this attribute. It՛s inherited from its parent.') %}
                            {% set disabled = true %}
-                        {% endif %}
-
-                        {% if not item.can(id, 'recursive') %}
+                        {% elseif not item.can(id, 'recursive') %}
                            {% set comment  = __('You are not allowed to change the visibility flag for child entities.') %}
                            {% set disabled = true %}
-                        {% endif %}
-
-                        {% if not item.canUnrecurs() %}
+                        {% elseif not item.canUnrecurs() %}
                            {% set comment  = __('Flag change forbidden. Linked items found.') %}
                            {% set disabled = true %}
                         {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Try to reproduce logic from: https://github.com/glpi-project/glpi/blob/9.5/bugfixes/inc/commondbtm.class.php#L2752

Fixes following error:
```
glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "is_recursive" in /var/www/glpi/inc/commondbtm.class.php at line 2247
  Backtrace :
  .../twig/twig/src/Extension/CoreExtension.php:1544 CommonDBTM->canUnrecurs()
  ...0f1749bc28647c9f021d0e1c7de9431bd9f7a28.php:290 twig_get_attribute()
  vendor/twig/twig/src/Template.php:394              __TwigTemplate_47b9f5d928eeae73128bae2af35f61da506c2874856a05713936656730aa8cb5->doDisplay()
  vendor/twig/twig/src/Template.php:367              Twig\Template->displayWithErrorHandling()
  vendor/twig/twig/src/TemplateWrapper.php:47        Twig\Template->display()
  ...application/view/templaterenderer.class.php:163 Twig\TemplateWrapper->display()
  inc/commondbtm.class.php:2525                      Glpi\Application\View\TemplateRenderer->display()
  inc/socket.class.php:171                           CommonDBTM->showFormHeader()
  inc/commonglpi.class.php:621                       Socket->showForm()
  ajax/common.tabs.php:106                           CommonGLPI::displayStandardTab()
```