### PR TITLE
Update htmlawed/htmlawed to 1.2.6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -552,10 +552,10 @@
         },
         {
             "name": "htmlawed/htmlawed",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://www.bioinformatics.org/phplabware/downloads/htmLawed125.zip"
+                "url": "https://www.bioinformatics.org/phplabware/downloads/htmLawed126.zip"
             },
             "type": "library",
             "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I do not know why, but dependabot did not propose this update.

Changelog:
> 1.2.6 - 4 September 2021. Fixes a bug that arises when $config["deny_attribute"] has a data-* attribute with > 1 hyphen character
