### PR TITLE
Fix search options static cache in PHP 8.1

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -3389,13 +3389,15 @@ class CommonDBTM extends CommonGLPI {
     * @see https://glpi-developer-documentation.rtfd.io/en/master/devapi/search.html
    **/
    public final function searchOptions() {
-      static $options;
+      static $options = [];
 
-      if (isset($options)) {
-         return $options;
+      $type = $this->getType();
+
+      if (isset($options[$type])) {
+         return $options[$type];
       }
 
-      $options = [];
+      $options[$type] = [];
 
       foreach ($this->rawSearchOptions() as $opt) {
          $missingFields = [];
@@ -3421,19 +3423,19 @@ class CommonDBTM extends CommonGLPI {
          $optid = $opt['id'];
          unset($opt['id']);
 
-         if (isset($options[$optid])) {
-            $message = "Duplicate key $optid ({$options[$optid]['name']}/{$opt['name']}) in ".
+         if (isset($options[$type][$optid])) {
+            $message = "Duplicate key $optid ({$options[$type][$optid]['name']}/{$opt['name']}) in ".
                   get_class($this) . " searchOptions!";
 
             Toolbox::logError($message);
          }
 
          foreach ($opt as $k => $v) {
-            $options[$optid][$k] = $v;
+            $options[$type][$optid][$k] = $v;
          }
       }
 
-      return $options;
+      return $options[$type];
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In PHP 8.1, `static` variables declared inside a method will point to a unique reference, regardless of whether it is inherited (see https://wiki.php.net/rfc/static_variable_inheritance).

Due to this, in PHP 8.1, `CommonDBTM::searchOptions()` is completely broken.

I put this in a separated PR, as this change is mandatory to make GLPI compatible with PHP 8.1, unlike other changes proposed in #9663 which are mostly related to deprecation warnings.