### PR TITLE
Fix deleting cartridges

### DIFF
--- a/inc/cartridge.class.php
+++ b/inc/cartridge.class.php
@@ -53,6 +53,7 @@ class Cartridge extends CommonDBRelation {
 
    static public $itemtype_2 = 'Printer';
    static public $items_id_2 = 'printers_id';
+   static public $mustBeAttached_2 = false;
 
    public function getCloneRelations() :array {
       return [
@@ -683,7 +684,7 @@ class Cartridge extends CommonDBRelation {
       if ($canedit && $number) {
          $rand = mt_rand();
          Html::openMassiveActionsForm('mass'.__CLASS__.$rand);
-         $actions = ['delete' => _x('button', 'Delete permanently'),
+         $actions = ['purge' => _x('button', 'Delete permanently'),
                      'Infocom'.MassiveAction::CLASS_ACTION_SEPARATOR.'activate'
                               => __('Enable the financial and administrative information')
                           ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Two issues with deleting cartridges (not the cartridge model).

1. The massive action for deletion is `delete` instead of purge even though the text shown is the text used for purge. Cartridges cannot be trashed, only purged.
2. The Cartridge class extends CommonDBRelation now which wants it linked to an item of both types. For cartridges, it doesn't need to be connected to a printer but if it wasn't the purge right check fails. This probably affected other things like creation but I already had these cartridges in the DB.

The first issue is applicable on both 9.5 and master.
The second issue is only applicable to master.