### PR TITLE
Fix wrong cartridge delete action

### DIFF
--- a/inc/cartridge.class.php
+++ b/inc/cartridge.class.php
@@ -666,7 +666,7 @@ class Cartridge extends CommonDBChild {
       if ($canedit && $number) {
          $rand = mt_rand();
          Html::openMassiveActionsForm('mass'.__CLASS__.$rand);
-         $actions = ['delete' => _x('button', 'Delete permanently'),
+         $actions = ['purge' => _x('button', 'Delete permanently'),
                      'Infocom'.MassiveAction::CLASS_ACTION_SEPARATOR.'activate'
                               => __('Enable the financial and administrative information')
                           ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The massive action for deletion is `delete` instead of purge even though the text shown is the text used for purge. Cartridges cannot be trashed, only purged.