### PR TITLE
Add flags to skip some ITILObject add behaviors

### DIFF
--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -152,22 +152,24 @@ class Change extends CommonITILObject {
          return false;
       }
 
-      // Manage auto assign
-      $auto_assign_mode = Entity::getUsedConfig('auto_assign_mode', $input['entities_id']);
+      if (!isset($input['_skip_auto_assign']) || $input['_skip_auto_assign'] === false) {
+         // Manage auto assign
+         $auto_assign_mode = Entity::getUsedConfig('auto_assign_mode', $input['entities_id']);
 
-      switch ($auto_assign_mode) {
-         case Entity::CONFIG_NEVER :
-            break;
+         switch ($auto_assign_mode) {
+            case Entity::CONFIG_NEVER :
+               break;
 
-         case Entity::AUTO_ASSIGN_HARDWARE_CATEGORY :
-         case Entity::AUTO_ASSIGN_CATEGORY_HARDWARE :
-            // Auto assign tech/group from Category
-            // Changes are not associated to a hardware then both settings behave the same way
-            $input = $this->setTechAndGroupFromItilCategory($input);
-            break;
+            case Entity::AUTO_ASSIGN_HARDWARE_CATEGORY :
+            case Entity::AUTO_ASSIGN_CATEGORY_HARDWARE :
+               // Auto assign tech/group from Category
+               // Changes are not associated to a hardware then both settings behave the same way
+               $input = $this->setTechAndGroupFromItilCategory($input);
+               break;
+         }
+
+         $input = $this->assign($input);
       }
-
-      $input = $this->assign($input);
 
       return $input;
    }

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -1815,14 +1815,16 @@ abstract class CommonITILObject extends CommonDBTM {
          }
       }
 
-      // No Auto set Import for external source
-      if (($uid = Session::getLoginUserID())
-          && !isset($input['_auto_import'])) {
-         $input["users_id_recipient"] = $uid;
-      } else if (isset($input["_users_id_requester"]) && $input["_users_id_requester"]
-                 && !isset($input["users_id_recipient"])) {
-         if (!is_array($input['_users_id_requester'])) {
-            $input["users_id_recipient"] = $input["_users_id_requester"];
+      if (!isset($input['_skip_auto_assign']) || $input['_skip_auto_assign'] === false) {
+         // No Auto set Import for external source
+         if (($uid = Session::getLoginUserID())
+            && !isset($input['_auto_import'])) {
+            $input["users_id_recipient"] = $uid;
+         } else if (isset($input["_users_id_requester"]) && $input["_users_id_requester"]
+            && !isset($input["users_id_recipient"])) {
+            if (!is_array($input['_users_id_requester'])) {
+               $input["users_id_recipient"] = $input["_users_id_requester"];
+            }
          }
       }
 

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -278,22 +278,24 @@ class Problem extends CommonITILObject {
          return false;
       }
 
-      // Manage auto assign
-      $auto_assign_mode = Entity::getUsedConfig('auto_assign_mode', $input['entities_id']);
+      if (!isset($input['_skip_auto_assign']) || $input['_skip_auto_assign'] === false) {
+         // Manage auto assign
+         $auto_assign_mode = Entity::getUsedConfig('auto_assign_mode', $input['entities_id']);
 
-      switch ($auto_assign_mode) {
-         case Entity::CONFIG_NEVER :
-            break;
+         switch ($auto_assign_mode) {
+            case Entity::CONFIG_NEVER :
+               break;
 
-         case Entity::AUTO_ASSIGN_HARDWARE_CATEGORY :
-         case Entity::AUTO_ASSIGN_CATEGORY_HARDWARE :
-            // Auto assign tech/group from Category
-            // Problems are not associated to a hardware then both settings behave the same way
-            $input = $this->setTechAndGroupFromItilCategory($input);
-            break;
+            case Entity::AUTO_ASSIGN_HARDWARE_CATEGORY :
+            case Entity::AUTO_ASSIGN_CATEGORY_HARDWARE :
+               // Auto assign tech/group from Category
+               // Problems are not associated to a hardware then both settings behave the same way
+               $input = $this->setTechAndGroupFromItilCategory($input);
+               break;
+         }
+
+         $input = $this->assign($input);
       }
-
-      $input = $this->assign($input);
 
       return $input;
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add some input flag values to skip some of the default behaviors done when a Ticket, Change, or Problem is created.

Skippable behaviors:
- Delegatee permission check (self-service user creating a ticket for another user)
- Adding a default contract if none is specified
- Rules processing
- SLA/OLA automatic assignment
- Auto assignment (including user preference to assign self if not assigned to another user and automatic assignment based on item user/group)