### PR TITLE
Improve horizontal nav

### DIFF
--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -95,7 +95,7 @@
                   {{ include('layout/parts/user_header.html.twig') }}
                </div>
 
-               <div class="collapse navbar-collapse flex-grow-0" id="navbar-menu">
+               <div class="collapse navbar-collapse justify-content-center" id="navbar-menu">
                   {{ include('layout/parts/menu.html.twig') }}
                   {% if get_current_interface() == 'central' %}
                   <button class="btn btn-outline-secondary mx-1 trigger-fuzzy" title="{{ __('Ctrl+Alt+G') }}">


### PR DESCRIPTION
Proposal to improve the horizontal mode: 
* Center navigation bar.
* Add a small margin between the "->" icon and the "Go to..." text.

Before: 
![image](https://user-images.githubusercontent.com/42734840/136913643-0e3e0aa0-2dc5-4280-a3f5-c43d40c1949f.png)

After:
![image](https://user-images.githubusercontent.com/42734840/136913817-4a4e5d7a-7055-4462-af5c-45948042483c.png)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
