### PR TITLE
Drop zone identifier alternative data stream files

### DIFF
--- a/pics/logos/sources/GLPI_Logo-color.svg:Zone.Identifier
+++ b/pics/logos/sources/GLPI_Logo-color.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://mattermost.teclib.com/api/v4/files/bae9qsre5fripezbkr7s6gyfko?download=1

--- a/pics/logos/sources/GLPI_Logo-white.svg:Zone.Identifier
+++ b/pics/logos/sources/GLPI_Logo-white.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://mattermost.teclib.com/api/v4/files/z3ca81tm1prij8gs8ihdy6fy3o?download=1


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #9717

Remove Zone.Identifier files. These are supposed to be alternative data steams for other files when downloaded from the Internet on Windows computers. Their addition here seems like a mistake and prevents cloning the repo on Windows since the colon is not a valid character in files names. Internally it is used to separate file names from an alternative data stream name.