### PR TITLE
Fix minification on build script

### DIFF
--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -50,11 +50,11 @@ $WORKING_DIR/bin/console locales:compile
 
 echo "Minify stylesheets and javascripts"
 find $WORKING_DIR/css $WORKING_DIR/lib $WORKING_DIR/public/lib \( -iname "*.css" ! -iname "*.min.css" \) \
-    -exec sh -c 'echo "> {}" && $WORKING_DIR/node_modules/.bin/csso {} --output $(dirname {})/$(basename {} ".css").min.css' \;
+    -exec sh -c 'echo "> {}" && '"$WORKING_DIR"'/node_modules/.bin/csso {} --output $(dirname {})/$(basename {} ".css").min.css' \;
 
 echo "Minify javascripts"
 find $WORKING_DIR/js $WORKING_DIR/lib $WORKING_DIR/public/lib \( -iname "*.js" ! -iname "*.min.js" \) \
-    -exec sh -c 'echo "> {}" && $WORKING_DIR/node_modules/.bin/terser {} --mangle --output $(dirname {})/$(basename {} ".js").min.js' \;
+    -exec sh -c 'echo "> {}" && '"$WORKING_DIR"'/node_modules/.bin/terser {} --mangle --output $(dirname {})/$(basename {} ".js").min.js' \;
 
 echo "Compile SCSS"
 $WORKING_DIR/bin/console build:compile_scss


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`$WORKING_DIR` was not evaluated as it was inside single quotes.

Minification was silently failing, see build step of https://github.com/glpi-project/glpi/runs/3911509757?check_suite_focus=true