### PR TITLE
User import: fix ldap selection (simplified mode)

### DIFF
--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -3127,7 +3127,7 @@ class AuthLDAP extends CommonDBTM {
                 && ($entity->getField('authldaps_id') > 0)) {
 
                $authldap->getFromDB($_SESSION['ldap_import']['authldaps_id']);
-               $_SESSION['ldap_import']['authldaps_id'] = $entity->getField('authldaps_id');
+               $_SESSION['ldap_import']['authldaps_id'] = $_SESSION['ldap_import']['authldaps_id'] ?? $entity->getField('authldaps_id');
                $_SESSION['ldap_import']['basedn']       = $entity->getField('ldap_dn');
 
                // No dn specified in entity : use standard one


### PR DESCRIPTION
The "LDAP directory choice" dropdown on user importation page cannot be changed.

![image](https://user-images.githubusercontent.com/42734840/137724493-15ae5344-0c24-4c1d-9380-e622fa2ada73.png)

You can select another value but after submitting the form the default value will be back.
It seems some "simplified mode" specific code reload the configuration from the entity a bit too eagerly.

Fixed by trying to load the posted value first.  

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22797
