### PR TITLE
Fix user imports 2

### DIFF
--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -3131,9 +3131,6 @@ class AuthLDAP extends CommonDBTM {
                if ($_SESSION['ldap_import']['authldaps_id'] == NOT_AVAILABLE) {
                   // authldaps_id wasn't submitted by the user -> take entity config
                   $_SESSION['ldap_import']['authldaps_id'] = $entity->getField('authldaps_id');
-               } else {
-                  // authldaps_id was submitted by the user -> use the submitted value
-                  $_SESSION['ldap_import']['authldaps_id'] = $_SESSION['ldap_import']['authldaps_id'];
                }
 
                $_SESSION['ldap_import']['basedn']       = $entity->getField('ldap_dn');


### PR DESCRIPTION
Followup up to https://github.com/glpi-project/glpi/pull/9721
Fix an edge case missed by the previous changes (`$_SESSION['ldap_import']['authldaps_id']` may be set with `NOT_AVAILABLE`, we don't want to use that value).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22797
