### PR TITLE
force a light color for inputs

### DIFF
--- a/css/palettes/_defaults.scss
+++ b/css/palettes/_defaults.scss
@@ -33,6 +33,8 @@ $primary: #FEC95C;
 $secondary: #606f91;
 $fg-secondary: #f4f6fa;
 
+$input-bg: rgb(253, 253, 253) !default;
+
 $link-color: #3A5693;
 
 $mainmenu_bg: #2f3f64;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

The main purpose is to distinguish normal input color from disabled input color

I open the pr but i don't find real answers why the input bg is set on `#f4f6fa`.
tabler.io and bootstrap website use `#fff` color...

another issue, my change seems not applied on login page.

