### PR TITLE
Deprecate Toolbox::log*() usages related to triggerable error levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,7 @@ The present file will list all changes made to the project; according to the
 - `Toolbox::getGlpiSecKey()`
 - `Toolbox::removeHtmlSpecialChars()`
 - `Toolbox::sanitize()`
+- `Toolbox::throwError()`
 - `Toolbox::unclean_html_cross_side_scripting_deep()`
 - `Toolbox::useCache()`
 - `Toolbox::userErrorHandlerDebug()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ The present file will list all changes made to the project; according to the
 - `Toolbox::clean_cross_side_scripting_deep()`
 - `Toolbox::endsWith()`
 - `Toolbox::getHtmlToDisplay()`
+- `Toolbox::logError()`
+- `Toolbox::logNotice()`
+- `Toolbox::logWarning()`
 - `Toolbox::unclean_cross_side_scripting_deep()`
 - `Toolbox::startsWith()`
 - `Toolbox::sodiumDecrypt()`

--- a/ajax/agent.php
+++ b/ajax/agent.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Http\Response;
+
 $AJAX_INCLUDE = 1;
 include ('../inc/includes.php');
 header("Content-Type: application/json; charset=UTF-8");
@@ -41,7 +43,7 @@ Session::checkLoginUser();
 if (isset($_POST['action']) && isset($_POST['id'])) {
    $agent = new Agent();
    if (!$agent->getFromDB($_POST['id'])) {
-      Toolbox::logWarning('Unable to load agent #' . $_POST['id']);
+      Response::sendError(404, 'Unable to load agent #' . $_POST['id']);
       return;
    };
    $answer = [];

--- a/ajax/dropdownTrackingDeviceType.php
+++ b/ajax/dropdownTrackingDeviceType.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Http\Response;
+
 include ('../inc/includes.php');
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
@@ -42,8 +44,7 @@ $itemtype = $_POST["itemtype"] ?? '';
 
 // Check for required params
 if (empty($itemtype)) {
-   http_response_code(400);
-   Toolbox::logWarning("Bad request: itemtype cannot be empty");
+   Response::sendError(400, "Bad request: itemtype cannot be empty", Response::CONTENT_TYPE_TEXT_HTML);
    die;
 }
 

--- a/ajax/getUserPicture.php
+++ b/ajax/getUserPicture.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Http\Response;
+
 $AJAX_INCLUDE = 1;
 
 include ('../inc/includes.php');
@@ -40,10 +42,7 @@ Html::header_nocache();
 Session::checkLoginUser();
 
 if (!isset($_GET['users_id'])) {
-   // Bad request
-   Toolbox::logError("Missing users_id parameter");
-   http_response_code(400);
-   return;
+   Response::sendError(400, "Missing users_id parameter");
 } else if (!is_array($_GET['users_id'])) {
    $_GET['users_id'] = [$_GET['users_id']];
 }

--- a/ajax/impact.php
+++ b/ajax/impact.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * ---------------------------------------------------------------------
  * GLPI - Gestionnaire Libre de Parc Informatique
@@ -31,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Http\Response;
+
 const DELTA_ACTION_ADD    = 1;
 const DELTA_ACTION_UPDATE = 2;
 const DELTA_ACTION_DELETE = 3;
@@ -58,7 +59,7 @@ switch ($_SERVER['REQUEST_METHOD']) {
 
             // Check required params
             if (empty($itemtype)) {
-               Toolbox::throwError(400, "Missing itemtype");
+               Response::sendError(400, "Missing itemtype");
             }
 
             // Execute search
@@ -74,12 +75,12 @@ switch ($_SERVER['REQUEST_METHOD']) {
 
             // Check required params
             if (empty($itemtype) || empty($items_id)) {
-               Toolbox::throwError(400, "Missing itemtype or items_id");
+               Response::sendError(400, "Missing itemtype or items_id");
             }
 
             // Check that the the target asset exist
             if (!Impact::assetExist($itemtype, $items_id)) {
-               Toolbox::throwError(400, "Object[class=$itemtype, id=$items_id] doesn't exist");
+               Response::sendError(400, "Object[class=$itemtype, id=$items_id] doesn't exist");
             }
 
             // Prepare graph
@@ -105,7 +106,7 @@ switch ($_SERVER['REQUEST_METHOD']) {
             break;
 
          default:
-            Toolbox::throwError(400, "Missing or invalid 'action' parameter");
+            Response::sendError(400, "Missing or invalid 'action' parameter");
             break;
       }
       break;
@@ -114,13 +115,13 @@ switch ($_SERVER['REQUEST_METHOD']) {
    case 'POST':
       // Check required params
       if (!isset($_POST['impacts'])) {
-         Toolbox::throwError(400, "Missing 'impacts' payload");
+         Response::sendError(400, "Missing 'impacts' payload");
       }
 
       // Decode data (should be json)
       $data = Toolbox::jsonDecode($_UPOST['impacts'], true);
       if (!is_array($data)) {
-         Toolbox::throwError(400, "Payload should be an array");
+         Response::sendError(400, "Payload should be an array");
       }
       $data = Toolbox::addslashes_deep($data);
 
@@ -142,7 +143,7 @@ switch ($_SERVER['REQUEST_METHOD']) {
 
       // Stop here if readonly graph
       if ($readonly) {
-         Toolbox::throwError(403, "Missing rights");
+         Response::sendError(403, "Missing rights");
       }
 
       $context_id = 0;

--- a/ajax/itilfollowup.php
+++ b/ajax/itilfollowup.php
@@ -34,6 +34,7 @@
  * @since 9.5
  */
 
+use Glpi\Http\Response;
 
 $AJAX_INCLUDE = 1;
 
@@ -46,7 +47,7 @@ Session::checkLoginUser();
 // Mandatory parameter: itilfollowuptemplates_id
 $itilfollowuptemplates_id = $_POST['itilfollowuptemplates_id'] ?? null;
 if ($itilfollowuptemplates_id === null) {
-   Toolbox::throwError(400, "Missing or invalid parameter: 'itilfollowuptemplates_id'");
+   Response::sendError(400, "Missing or invalid parameter: 'itilfollowuptemplates_id'");
 } else if ($itilfollowuptemplates_id == 0) {
    // Reset form
    echo json_encode([
@@ -58,25 +59,25 @@ if ($itilfollowuptemplates_id === null) {
 // Mandatory parameter: items_id
 $parents_id = $_POST['items_id'] ?? 0;
 if (!$parents_id) {
-   Toolbox::throwError(400, "Missing or invalid parameter: 'items_id'");
+   Response::sendError(400, "Missing or invalid parameter: 'items_id'");
 }
 
 // Mandatory parameter: itemtype
 $parents_itemtype = $_POST['itemtype'] ?? '';
 if (empty($parents_itemtype) || !is_subclass_of($parents_itemtype, CommonITILObject::class)) {
-   Toolbox::throwError(400, "Missing or invalid parameter: 'itemtype'");
+   Response::sendError(400, "Missing or invalid parameter: 'itemtype'");
 }
 
 // Load followup template
 $template = new ITILFollowupTemplate();
 if (!$template->getFromDB($itilfollowuptemplates_id)) {
-   Toolbox::throwError(400, "Unable to load template: $itilfollowuptemplates_id");
+   Response::sendError(400, "Unable to load template: $itilfollowuptemplates_id");
 }
 
 // Load parent item
 $parent = new $parents_itemtype();
 if (!$parent->getFromDB($parents_id)) {
-   Toolbox::throwError(400, "Unable to load parent item: $parents_itemtype $parents_id");
+   Response::sendError(400, "Unable to load parent item: $parents_itemtype $parents_id");
 }
 
 // Render template content using twig

--- a/ajax/kanban.php
+++ b/ajax/kanban.php
@@ -33,6 +33,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Features\Kanban;
 use Glpi\Features\Teamwork;
+use Glpi\Http\Response;
 use Glpi\Toolbox\Sanitizer;
 
 $AJAX_INCLUDE = 1;
@@ -45,9 +46,7 @@ Html::header_nocache();
 Session::checkLoginUser();
 
 if (!isset($_REQUEST['action'])) {
-   Toolbox::logError("Missing action parameter");
-   http_response_code(400);
-   return;
+   Response::sendError(400, "Missing action parameter", Response::CONTENT_TYPE_TEXT_HTML);
 }
 $action = $_REQUEST['action'];
 
@@ -57,9 +56,7 @@ if (isset($_REQUEST['itemtype'])) {
    if (!in_array($_REQUEST['action'], $nonkanban_actions) && !Toolbox::hasTrait($_REQUEST['itemtype'], Kanban::class)) {
       // Bad request
       // For all actions, except those in $nonkanban_actions, we expect to be manipulating the Kanban itself.
-      Toolbox::logError("Invalid itemtype parameter");
-      http_response_code(400);
-      return;
+      Response::sendError(400, "Invalid itemtype parameter", Response::CONTENT_TYPE_TEXT_HTML);
    }
    /** @var CommonDBTM $item */
    $itemtype = $_REQUEST['itemtype'];
@@ -104,9 +101,7 @@ if (isset($itemtype)) {
 $checkParams = static function($required) {
    foreach ($required as $param) {
       if (!isset($_REQUEST[$param])) {
-         Toolbox::logError("Missing $param parameter");
-         http_response_code(400);
-         die();
+         Response::sendError(400, "Missing $param parameter");
       }
    }
 };
@@ -188,9 +183,7 @@ if (($_POST['action'] ?? null) === 'update') {
    $tabs = $item->defineTabs();
    $tab_id = array_search(__('Kanban'), $tabs);
    if (false === $tab_id || is_null($tab_id)) {
-      Toolbox::logError("Itemtype does not have a Kanban tab!");
-      http_response_code(400);
-      return;
+      Response::sendError(400, "Itemtype does not have a Kanban tab!", Response::CONTENT_TYPE_TEXT_HTML);
    }
    echo $itemtype::getFormURLWithID($_REQUEST['items_id'], true)."&forcetab={$tab_id}";
 } else if (($_POST['action'] ?? null) === 'create_column') {

--- a/ajax/solution.php
+++ b/ajax/solution.php
@@ -30,6 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Http\Response;
 use Glpi\Toolbox\RichText;
 
 $AJAX_INCLUDE = 1;
@@ -43,7 +44,7 @@ Session::checkLoginUser();
 // Mandatory parameter: solutiontemplates_id
 $solutiontemplates_id = $_POST['solutiontemplates_id'] ?? null;
 if ($solutiontemplates_id === null) {
-   Toolbox::throwError(400, "Missing or invalid parameter: 'solutiontemplates_id'");
+   Response::sendError(400, "Missing or invalid parameter: 'solutiontemplates_id'");
 } else if ($solutiontemplates_id == 0) {
    // Reset form
    echo json_encode([
@@ -72,14 +73,14 @@ if (empty($parents_itemtype) || !is_subclass_of($parents_itemtype, CommonITILObj
 // Load solution template
 $template = new SolutionTemplate();
 if (!$template->getFromDB($solutiontemplates_id)) {
-   Toolbox::throwError(400, "Unable to load template: $solutiontemplates_id");
+   Response::sendError(400, "Unable to load template: $solutiontemplates_id");
 }
 
 if ($apply_twig) {
    // Load parent item
    $parent = new $parents_itemtype();
    if (!$parent->getFromDB($parents_id)) {
-      Toolbox::throwError(400, "Unable to load parent item: $parents_itemtype $parents_id");
+      Response::sendError(400, "Unable to load parent item: $parents_itemtype $parents_id");
    }
 
    // Render template content using twig

--- a/ajax/task.php
+++ b/ajax/task.php
@@ -34,6 +34,8 @@
  * @since 9.1
  */
 
+use Glpi\Http\Response;
+
 $AJAX_INCLUDE = 1;
 
 include ('../inc/includes.php');
@@ -45,7 +47,7 @@ Session::checkLoginUser();
 // Mandatory parameter: tasktemplates_id
 $tasktemplates_id = $_POST['tasktemplates_id'] ?? null;
 if ($tasktemplates_id === null) {
-   Toolbox::throwError(400, "Missing or invalid parameter: 'tasktemplates_id'");
+   Response::sendError(400, "Missing or invalid parameter: 'tasktemplates_id'");
 } else if ($tasktemplates_id == 0) {
    // Reset form
    echo json_encode([
@@ -57,25 +59,25 @@ if ($tasktemplates_id === null) {
 // Mandatory parameter: items_id
 $parents_id = $_POST['items_id'] ?? 0;
 if (!$parents_id) {
-   Toolbox::throwError(400, "Missing or invalid parameter: 'items_id'");
+   Response::sendError(400, "Missing or invalid parameter: 'items_id'");
 }
 
 // Mandatory parameter: itemtype
 $parents_itemtype = $_POST['itemtype'] ?? '';
 if (empty($parents_itemtype) || !is_subclass_of($parents_itemtype, CommonITILObject::class)) {
-   Toolbox::throwError(400, "Missing or invalid parameter: 'itemtype'");
+   Response::sendError(400, "Missing or invalid parameter: 'itemtype'");
 }
 
 // Load task template
 $template = new TaskTemplate();
 if (!$template->getFromDB($tasktemplates_id)) {
-   Toolbox::throwError(400, "Unable to load template: $tasktemplates_id");
+   Response::sendError(400, "Unable to load template: $tasktemplates_id");
 }
 
 // Load parent item
 $parent = new $parents_itemtype();
 if (!$parent->getFromDB($parents_id)) {
-   Toolbox::throwError(400, "Unable to load parent item: $parents_itemtype $parents_id");
+   Response::sendError(400, "Unable to load parent item: $parents_itemtype $parents_id");
 }
 
 // Render template content using twig

--- a/front/contenttemplates/documentation.php
+++ b/front/contenttemplates/documentation.php
@@ -33,12 +33,13 @@
 include ('../../inc/includes.php');
 
 use Glpi\ContentTemplates\TemplateManager;
+use Glpi\Http\Response;
 use Michelf\MarkdownExtra;
 
 // Check mandatory parameter
 $preset = $_GET['preset'] ?? null;
 if (is_null($preset)) {
-   Toolbox::throwError(400, "Missing mandatory 'preset' parameter", "string");
+   Response::sendError(400, "Missing mandatory 'preset' parameter", Response::CONTENT_TYPE_TEXT_HTML);
 }
 
 echo Html::includeHeader(__("Template variables documentation"));

--- a/front/graph.send.php
+++ b/front/graph.send.php
@@ -32,6 +32,7 @@
 
 use Glpi\Csv\CsvResponse;
 use Glpi\Csv\StatCsvExport;
+use Glpi\Http\Response;
 use Glpi\Stat\StatData;
 
 include ('../inc/includes.php');
@@ -44,7 +45,7 @@ $statdata_itemtype = $_UGET['statdata_itemtype'] ?? null;
 
 // Validate stats itemtype
 if (!is_a($statdata_itemtype, StatData::class, true)) {
-    Toolbox::throwError(400, "Invalid stats itemtype", "string");
+    Response::sendError(400, "Invalid stats itemtype", Response::CONTENT_TYPE_TEXT_PLAIN);
 }
 
 // Get data and output csv

--- a/front/impactitem.form.php
+++ b/front/impactitem.form.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Http\Response;
+
 include ('../inc/includes.php');
 
 $impact_item = new ImpactItem();
@@ -39,8 +41,7 @@ if (isset($_POST["update"])) {
 
    // Can't update, id is missing
    if ($id === 0) {
-      Toolbox::logWarning("Can't update the target impact item, id is missing");
-      Html::back();
+      Response::sendError(400, "Can't update the target impact item, id is missing", Response::CONTENT_TYPE_TEXT_HTML);
    }
 
    // Load item and check rights

--- a/front/locale.php
+++ b/front/locale.php
@@ -53,7 +53,7 @@ if ($is_cacheable) {
 
 global $CFG_GLPI, $TRANSLATE;
 
-// Default respoinse to send if locales cannot be loaded.
+// Default response to send if locales cannot be loaded.
 // Prevent JS error for plugins that does not provide any translation files
 $default_response = json_encode(
    [
@@ -83,7 +83,7 @@ $po_file_handle = fopen(
    'rb'
 );
 if (false === $po_file_handle) {
-   Toolbox::logError(sprintf('Unable to extract locales data from "%s".', $po_file));
+   trigger_error(sprintf('Unable to extract locales data from "%s".', $po_file), E_USER_WARNING);
    exit($default_response);
 }
 $in_headers = false;
@@ -107,7 +107,7 @@ while (false !== ($line = fgets($po_file_handle))) {
    }
 }
 if (count(array_diff($header_keys, array_keys($headers))) > 0) {
-   Toolbox::logError(sprintf('Missing mandatory locale headers in "%s".', $po_file));
+   trigger_error(sprintf('Missing mandatory locale headers in "%s".', $po_file), E_USER_WARNING);
    exit($default_response);
 }
 

--- a/front/log/export.php
+++ b/front/log/export.php
@@ -32,6 +32,7 @@
 
 use Glpi\Csv\CsvResponse;
 use Glpi\Csv\LogCsvExport;
+use Glpi\Http\Response;
 
 include ('../../inc/includes.php');
 
@@ -44,18 +45,18 @@ Session::checkRight(Log::$rightname, READ);
 
 // Validate itemtype
 if (!is_a($itemtype, CommonDBTM::class, true)) {
-    Toolbox::throwError(400, "Invalid itemtype", "string");
+    Response::sendError(400, "Invalid itemtype", Response::CONTENT_TYPE_TEXT_PLAIN);
 }
 
 // Validate id
 $item = $itemtype::getById($id);
 if (!$item || !$item->canViewItem()) {
-    Toolbox::throwError(400, "No item found for given id", "string");
+    Response::sendError(400, "No item found for given id", Response::CONTENT_TYPE_TEXT_PLAIN);
 }
 
 // Validate filter
 if (!is_array($filter)) {
-    Toolbox::throwError(400, "Invalid filter", "string");
+    Response::sendError(400, "Invalid filter", Response::CONTENT_TYPE_TEXT_PLAIN);
 }
 
 CsvResponse::output(new LogCsvExport($item, $filter));

--- a/front/manuallink.form.php
+++ b/front/manuallink.form.php
@@ -31,6 +31,7 @@
  */
 
 use Glpi\Event;
+use Glpi\Http\Response;
 
 include ('../inc/includes.php');
 
@@ -38,8 +39,7 @@ Session::checkValidSessionId();
 
 $link = new ManualLink();
 if (array_key_exists('id', $_REQUEST) && !$link->getFromDB($_REQUEST['id'])) {
-   Toolbox::throwError(404, 'No item found for given id', 'string');
-   Html::back();
+   Response::sendError(404, 'No item found for given id', Response::CONTENT_TYPE_TEXT_HTML);
 }
 
 if (array_key_exists('purge', $_POST) || array_key_exists('delete', $_POST)) {

--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -34,6 +34,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use Glpi\Application\ErrorHandler;
 use GuzzleHttp\Client as Guzzle_Client;
 use GuzzleHttp\Psr7\Response;
 
@@ -588,7 +589,7 @@ class Agent extends CommonDBTM {
          $this->requestAgent('now');
          return $this->handleAgentResponse(new Response(), self::ACTION_INVENTORY);
       } catch (\GuzzleHttp\Exception\ClientException $e) {
-         Toolbox::logError($e->getMessage());
+         ErrorHandler::getInstance()->handleException($e);
          //not authorized
          return ['answer' => __('Not allowed')];
       }

--- a/inc/agent/communication/abstractrequest.class.php
+++ b/inc/agent/communication/abstractrequest.class.php
@@ -35,7 +35,7 @@ namespace Glpi\Agent\Communication;
 use DOMDocument;
 use DOMElement;
 use Glpi\Agent\Communication\Headers\Common;
-use Toolbox;
+use Glpi\Application\ErrorHandler;
 
 /**
  * Handle agent requests
@@ -242,7 +242,12 @@ abstract class AbstractRequest
       $xml = simplexml_load_string($data, 'SimpleXMLElement', LIBXML_NOCDATA);
       if (!$xml) {
          $xml_errors = libxml_get_errors();
-         Toolbox::logWarning('Invalid XML: ' . print_r($xml_errors, true));
+         /* @var \LibXMLError $xml_error */
+         foreach ($xml_errors as $xml_error) {
+            ErrorHandler::getInstance()->handleError(
+               E_USER_WARNING, $xml_error->message, $xml_error->file, $xml_error->line
+            );
+         }
          $this->addError('XML not well formed!', 400);
          return false;
       }

--- a/inc/api/api.class.php
+++ b/inc/api/api.class.php
@@ -2629,9 +2629,7 @@ abstract class API {
          } else {
 
             if (!isset($data[$kn_fkey])) {
-               Toolbox::logWarning(
-                  "Invalid value: \"$kn_fkey\" doesn't exist.
-               ");
+               trigger_error(sprintf('Invalid value: "%s" doesn\'t exist.', $kn_fkey), E_USER_WARNING);
                continue;
             }
 
@@ -2643,9 +2641,7 @@ abstract class API {
          // Check itemtype is valid
          $kn_item = getItemForItemtype($kn_itemtype);
          if (!$kn_item) {
-            Toolbox::logWarning(
-               "Invalid itemtype \"$kn_itemtype\" for fkey  \"$kn_fkey\""
-            );
+            trigger_error(sprintf('Invalid itemtype "%s" for fkey "%s".', $kn_itemtype, $kn_fkey), E_USER_WARNING);
             continue;
          }
 

--- a/inc/application/errorhandler.class.php
+++ b/inc/application/errorhandler.class.php
@@ -112,6 +112,13 @@ class ErrorHandler {
    private $last_fatal_trace;
 
    /**
+    * Indicates wether output is disabled.
+    *
+    * @var bool
+    */
+   private $output_disabled = false;
+
+   /**
     * Output handler to use. If not set, output will be directly echoed on a format depending on
     * execution context (Web VS CLI).
     *
@@ -131,6 +138,40 @@ class ErrorHandler {
     */
    public function __construct(LoggerInterface $logger = null) {
       $this->logger = $logger;
+   }
+
+   /**
+    * Return singleton instance of self.
+    *
+    * @return ErrorHandler
+    */
+   public static function getInstance(): ErrorHandler {
+      static $instance = null;
+
+      if ($instance === null) {
+         global $PHPLOGGER;
+         $instance = new static($PHPLOGGER);
+      }
+
+      return $instance;
+   }
+
+   /**
+    * Enable output.
+    *
+    * @return void
+    */
+   public function enableOutput(): void {
+      $this->output_disabled = false;
+   }
+
+   /**
+    * Disable output.
+    *
+    * @return void
+    */
+   public function disableOutput(): void {
+      $this->output_disabled = true;
    }
 
    /**
@@ -279,7 +320,8 @@ class ErrorHandler {
    /**
     * Exception handler.
     *
-    * This handler is called by PHP prior to exiting, when an Exception is not catched.
+    * This handler is called by PHP prior to exiting, when an Exception is not catched,
+    * or manually called by the application to log exception details.
     *
     * @param \Throwable $exception
     * @param bool $quiet
@@ -398,6 +440,10 @@ class ErrorHandler {
     * @return void
     */
    private function outputDebugMessage(string $error_type, string $message, string $log_level, bool $force = false): void {
+
+      if ($this->output_disabled) {
+         return;
+      }
 
       $is_debug_mode = isset($_SESSION['glpi_use_mode']) && $_SESSION['glpi_use_mode'] == \Session::DEBUG_MODE;
       $is_console_context = $this->output_handler instanceof OutputInterface;

--- a/inc/application/view/templaterenderer.class.php
+++ b/inc/application/view/templaterenderer.class.php
@@ -53,7 +53,6 @@ use Glpi\Application\View\Extension\TeamExtension;
 use Plugin;
 use Session;
 use Twig\Environment;
-use Twig\Error\Error;
 use Twig\Extension\DebugExtension;
 use Twig\Extra\String\StringExtension;
 use Twig\Loader\FilesystemLoader;
@@ -147,7 +146,7 @@ class TemplateRenderer {
       try {
          return $this->environment->load($template)->render($variables);
       } catch (\Twig\Error\Error $e) {
-         $this->handleError($e, $template);
+         ErrorHandler::getInstance()->handleTwigError($e);
       }
       return '';
    }
@@ -164,23 +163,7 @@ class TemplateRenderer {
       try {
          $this->environment->load($template)->display($variables);
       } catch (\Twig\Error\Error $e) {
-         $this->handleError($e, $template);
-      }
-   }
-
-   /**
-    * Log Twig error using GLPI error handler.
-    *
-    * @param \Twig\Error\Error $error
-    *
-    * @param string $template
-    */
-   private function handleError(Error $error, string $template): void {
-      global $GLPI;
-
-      $error_handler = $GLPI->getErrorHandler();
-      if ($error_handler instanceof ErrorHandler) {
-         $error_handler->handleTwigError($error, $template);
+         ErrorHandler::getInstance()->handleTwigError($e);
       }
    }
 }

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -257,7 +257,7 @@ class Auth extends CommonGLPI {
                'user_dn'           => $this->user_dn
             ]);
          } catch (\Throwable $e) {
-            ErrorHandler::getInstance()->handleException($e);
+            ErrorHandler::getInstance()->handleException($e, true);
             $this->addToError(__('Unable to connect to the LDAP directory'));
             return false;
          }
@@ -785,7 +785,7 @@ class Auth extends CommonGLPI {
                            ],
                         ]);
                      } catch (\RuntimeException $e) {
-                        ErrorHandler::getInstance()->handleException($e);
+                        ErrorHandler::getInstance()->handleException($e, true);
                         $user_dn = false;
                      }
                      if ($user_dn) {

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -30,6 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\ErrorHandler;
 use Glpi\Event;
 use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\Sanitizer;
@@ -256,7 +257,7 @@ class Auth extends CommonGLPI {
                'user_dn'           => $this->user_dn
             ]);
          } catch (\Throwable $e) {
-            Toolbox::logError($e->getMessage());
+            ErrorHandler::getInstance()->handleException($e);
             $this->addToError(__('Unable to connect to the LDAP directory'));
             return false;
          }
@@ -475,7 +476,7 @@ class Auth extends CommonGLPI {
       switch ($authtype) {
          case self::CAS :
             if (!Toolbox::canUseCAS()) {
-               Toolbox::logError("CAS lib not installed");
+               trigger_error("CAS lib not installed", E_USER_WARNING);
                return false;
             }
 
@@ -784,7 +785,7 @@ class Auth extends CommonGLPI {
                            ],
                         ]);
                      } catch (\RuntimeException $e) {
-                        Toolbox::logError($e->getMessage());
+                        ErrorHandler::getInstance()->handleException($e);
                         $user_dn = false;
                      }
                      if ($user_dn) {

--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -30,6 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\ErrorHandler;
 use Glpi\Toolbox\Sanitizer;
 
 /**
@@ -1767,7 +1768,7 @@ class AuthLDAP extends CommonDBTM {
                   $uid = self::getFieldValue($info[$ligne], $field_for_sync);
 
                   if ($login_field != $field_for_sync && !isset($info[$ligne][$login_field])) {
-                     Toolbox::logWarning("Missing field $login_field for LDAP entry $field_for_sync $uid");
+                     trigger_error("Missing field $login_field for LDAP entry $field_for_sync $uid", E_USER_WARNING);
                      //Login field may be missing... Skip the user
                      continue;
                   }
@@ -2598,7 +2599,7 @@ class AuthLDAP extends CommonDBTM {
                      'id'     => $users_id];
             }
          } catch (\RuntimeException $e) {
-            Toolbox::logError($e->getMessage());
+            ErrorHandler::getInstance()->handleException($e);
             return false;
          }
       } else {
@@ -2738,7 +2739,7 @@ class AuthLDAP extends CommonDBTM {
     */
    static function tryToConnectToServer($ldap_method, $login, $password) {
       if (!function_exists('ldap_connect')) {
-         Toolbox::logError("ldap_connect function is missing. Did you miss install php-ldap extension?");
+         trigger_error("ldap_connect function is missing. Did you miss install php-ldap extension?", E_USER_WARNING);
          return false;
       }
       $ds = self::connectToServer($ldap_method['host'], $ldap_method['port'],

--- a/inc/caldav/server.class.php
+++ b/inc/caldav/server.class.php
@@ -95,6 +95,6 @@ class Server extends DAV\Server {
          return;
       }
 
-      ErrorHandler::getInstance()->handleException($exception);
+      ErrorHandler::getInstance()->handleException($exception, true);
    }
 }

--- a/inc/caldav/server.class.php
+++ b/inc/caldav/server.class.php
@@ -36,6 +36,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use Glpi\Application\ErrorHandler;
 use Glpi\CalDAV\Backend\Auth;
 use Glpi\CalDAV\Backend\Calendar;
 use Glpi\CalDAV\Backend\Principal;
@@ -93,8 +94,7 @@ class Server extends DAV\Server {
          // Ignore server exceptions that does not corresponds to a server error
          return;
       }
-      \Toolbox::logError(
-         get_class($exception) . ': ' . $exception->getMessage() . "\n" . $exception->getTraceAsString()
-      );
+
+      ErrorHandler::getInstance()->handleException($exception);
    }
 }

--- a/inc/caldav/traits/caldavuriutiltrait.class.php
+++ b/inc/caldav/traits/caldavuriutiltrait.class.php
@@ -216,11 +216,12 @@ trait CalDAVUriUtilTrait {
          if ($items_iterator->count() > 1) {
             // Ambiguous response, unable to return matching element.
             // Should never happens as UID has very very low probability to not be unique.
-            \Toolbox::logError(
+            trigger_error(
                sprintf(
                   'Multiple calendar items found with uuid %s. Unable to determine which item should be returned.',
                   $uid
-               )
+               ),
+               E_USER_WARNING
             );
          }
          return null;

--- a/inc/caldav/traits/vobjectconvertertrait.class.php
+++ b/inc/caldav/traits/vobjectconvertertrait.class.php
@@ -32,6 +32,7 @@
 
 namespace Glpi\CalDAV\Traits;
 
+use Glpi\Application\ErrorHandler;
 use Glpi\Toolbox\RichText;
 use Glpi\Toolbox\Sanitizer;
 use RRule\RRule;
@@ -164,9 +165,7 @@ trait VobjectConverterTrait {
             $rrule = new RRule($rrule_specs);
             $vcomp->RRULE = $rrule->rfcString();
          } catch (\InvalidArgumentException $e) {
-            \Toolbox::logError(
-               sprintf('Invalid RRULE "%s" from event "%s"', $fields['rrule'], $fields['id'])
-            );
+            ErrorHandler::getInstance()->handleException($e);
          }
       }
 

--- a/inc/caldav/traits/vobjectconvertertrait.class.php
+++ b/inc/caldav/traits/vobjectconvertertrait.class.php
@@ -165,7 +165,7 @@ trait VobjectConverterTrait {
             $rrule = new RRule($rrule_specs);
             $vcomp->RRULE = $rrule->rfcString();
          } catch (\InvalidArgumentException $e) {
-            ErrorHandler::getInstance()->handleException($e);
+            ErrorHandler::getInstance()->handleException($e, true);
          }
       }
 

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -281,11 +281,13 @@ class CommonDBTM extends CommonGLPI {
          $this->post_getFromDB();
          return true;
       } else if (count($iterator) > 1) {
-         Toolbox::logWarning(
+         trigger_error(
             sprintf(
-               'getFromDB expects to get one result, %1$s found!',
-               count($iterator)
-            )
+               'getFromDB expects to get one result, %1$s found in query "%2$s".',
+               count($iterator),
+               $iterator->getSql()
+            ),
+            E_USER_WARNING
          );
       }
 
@@ -395,12 +397,14 @@ class CommonDBTM extends CommonGLPI {
          $this->post_getFromDB();
          return true;
       } else if (count($iterator) > 1) {
-         Toolbox::logWarning(
-               sprintf(
-                     'getFromDBByRequest expects to get one result, %1$s found!',
-                     count($iterator)
-                     )
-               );
+         trigger_error(
+            sprintf(
+               'getFromDBByRequest expects to get one result, %1$s found in query "%2$s".',
+               count($iterator),
+               $iterator->getSql()
+            ),
+            E_USER_WARNING
+         );
       }
       return false;
    }
@@ -857,11 +861,12 @@ class CommonDBTM extends CommonGLPI {
 
       foreach ($relations_classes as $classname) {
          if (!is_a($classname, CommonDBConnexity::class, true)) {
-            Toolbox::logWarning(
+            trigger_error(
                sprintf(
                   'Unable to clean elements of class %s as it does not extends "CommonDBConnexity"',
                   $classname
-               )
+               ),
+               E_USER_WARNING
             );
             continue;
          }
@@ -1625,7 +1630,7 @@ class CommonDBTM extends CommonGLPI {
             $res = $stmt->execute();
             if ($res === false) {
                if ($DB->errno() != 1062) {
-                  Toolbox::logError('Unable to add locked field!');
+                  trigger_error('Unable to add locked field!', E_USER_WARNING);
                }
 
             }
@@ -3422,7 +3427,7 @@ class CommonDBTM extends CommonGLPI {
             $message = "Duplicate key $optid ({$options[$type][$optid]['name']}/{$opt['name']}) in ".
                   get_class($this) . " searchOptions!";
 
-            Toolbox::logError($message);
+            trigger_error($message, E_USER_WARNING);
          }
 
          foreach ($opt as $k => $v) {
@@ -3516,7 +3521,7 @@ class CommonDBTM extends CommonGLPI {
                $message = "Duplicate key $optid ({$all_options[$optid]['name']}/{$opt['name']}) in ".
                   self::class . " searchOptionsToAdd for $itemtype!";
 
-               Toolbox::logError($message);
+               trigger_error($message, E_USER_WARNING);
             }
          }
 
@@ -3850,7 +3855,10 @@ class CommonDBTM extends CommonGLPI {
                   case 'email' :
                   case 'string' :
                      if (strlen($value) > 255) {
-                        Toolbox::logWarning("$value exceed 255 characters long (".strlen($value)."), it will be truncated.");
+                        trigger_error(
+                           "$value exceed 255 characters long (".strlen($value)."), it will be truncated.",
+                           E_USER_WARNING
+                        );
                         $this->input[$key] = substr($value, 0, 254);
                      }
                      break;
@@ -4033,7 +4041,7 @@ class CommonDBTM extends CommonGLPI {
             $entities_id = $this->fields['entities_id'];
          } else {
             $message = 'Missing entity ID!';
-            Toolbox::logError($message);
+            trigger_error($message, E_USER_WARNING);
          }
 
          $all_fields =  FieldUnicity::getUnicityFieldsConfig(get_class($this), $entities_id);
@@ -5503,7 +5511,11 @@ class CommonDBTM extends CommonGLPI {
             } else {
                $owner_type = isset($model) ? $model::getType() : $itemtype;
                $owner_id = isset($model) ? $model->getID() : $this->getID();
-               \Toolbox::logWarning("The picture '{$src_file}' referenced by the {$owner_type} with ID {$owner_id} does not exist");
+
+               trigger_error(
+                  "The picture '{$src_file}' referenced by the {$owner_type} with ID {$owner_id} does not exist",
+                  E_USER_WARNING
+               );
             }
          }
       }

--- a/inc/computervirtualmachine.class.php
+++ b/inc/computervirtualmachine.class.php
@@ -471,11 +471,13 @@ class ComputerVirtualMachine extends CommonDBChild {
          $result = $iterator->current();
          return $result['id'];
       } else if (count($iterator) > 1) {
-         Toolbox::logWarning(
+         trigger_error(
             sprintf(
-               'findVirtualMachine expects to get one result, %1$s found!',
-               count($iterator)
-            )
+               'findVirtualMachine expects to get one result, %1$s found in query "%2$s".',
+               count($iterator),
+               $iterator->getSql()
+            ),
+            E_USER_WARNING
          );
       }
 

--- a/inc/dashboard/dashboard.class.php
+++ b/inc/dashboard/dashboard.class.php
@@ -109,11 +109,9 @@ class Dashboard extends \CommonDBTM {
          $this->post_getFromDB();
          return true;
       } else if (count($iterator) > 1) {
-         \Toolbox::logWarning(
-            sprintf(
-               'getFromDB expects to get one result, %1$s found!',
-               count($iterator)
-            )
+         trigger_error(
+            sprintf('getFromDB expects to get one result, %1$s found!', count($iterator)),
+            E_USER_WARNING
          );
       }
 

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -1499,7 +1499,10 @@ class Document extends CommonDBTM {
          $etype = exif_imagetype($file);
          return in_array($etype, [IMAGETYPE_JPEG, IMAGETYPE_GIF, IMAGETYPE_PNG, IMAGETYPE_BMP]);
       } else {
-         Toolbox::logWarning('For security reasons, you should consider using exif PHP extension to properly check images.');
+         trigger_error(
+            'For security reasons, you should consider using exif PHP extension to properly check images.',
+            E_USER_WARNING
+         );
          $fileinfo = finfo_open(FILEINFO_MIME_TYPE);
          return in_array(
             finfo_file($fileinfo, $file),

--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -79,30 +79,30 @@ class Document_Item extends CommonDBRelation{
    function prepareInputForAdd($input) {
 
       if (empty($input['itemtype'])) {
-         Toolbox::logError('Item type is mandatory');
+         trigger_error('Item type is mandatory', E_USER_WARNING);
          return false;
       }
 
       if (!class_exists($input['itemtype'])) {
-         Toolbox::logError(sprintf('No class found for type %s', $input['itemtype']));
+         trigger_error(sprintf('No class found for type %s', $input['itemtype']), E_USER_WARNING);
          return false;
       }
 
       if ((empty($input['items_id']))
           && ($input['itemtype'] != 'Entity')) {
-         Toolbox::logError('Item ID is mandatory');
+         trigger_error('Item ID is mandatory', E_USER_WARNING);
          return false;
       }
 
       if (empty($input['documents_id'])) {
-         Toolbox::logError('Document ID is mandatory');
+         trigger_error('Document ID is mandatory', E_USER_WARNING);
          return false;
       }
 
       // Do not insert circular link for document
       if (($input['itemtype'] == 'Document')
           && ($input['items_id'] == $input['documents_id'])) {
-         Toolbox::logError('Cannot link document to itself');
+         trigger_error('Cannot link document to itself', E_USER_WARNING);
          return false;
       }
 
@@ -122,7 +122,7 @@ class Document_Item extends CommonDBRelation{
 
       // Avoid duplicate entry
       if ($this->alreadyExists($input)) {
-         Toolbox::logError('Duplicated document item relation');
+         trigger_error('Duplicated document item relation', E_USER_WARNING);
          return false;
       }
 

--- a/inc/features/clonable.class.php
+++ b/inc/features/clonable.class.php
@@ -93,11 +93,12 @@ trait Clonable {
       $clone_relations = $this->getCloneRelations();
       foreach ($clone_relations as $classname) {
          if (!is_a($classname, CommonDBConnexity::class, true)) {
-            Toolbox::logWarning(
+            trigger_error(
                sprintf(
                   'Unable to clone elements of class %s as it does not extends "CommonDBConnexity"',
                   $classname
-               )
+               ),
+               E_USER_WARNING
             );
             continue;
          }

--- a/inc/features/inventoriable.class.php
+++ b/inc/features/inventoriable.class.php
@@ -42,7 +42,6 @@ use Glpi\Plugin\Hooks;
 use Html;
 use Plugin;
 use RefusedEquipment;
-use Toolbox;
 
 trait Inventoriable {
    /** @var CommonDBTM|null */
@@ -84,7 +83,7 @@ trait Inventoriable {
       if (!file_exists($inventory_dir_path . $filename)) {
          $filename = $conf->buildInventoryFileName($itemtype, $items_id, 'json');
          if (!file_exists($inventory_dir_path . $filename)) {
-            Toolbox::logWarning('Inventory file missing: ' . $filename);
+            trigger_error('Inventory file missing: ' . $filename, E_USER_WARNING);
             return null;
          }
       }

--- a/inc/glpi.class.php
+++ b/inc/glpi.class.php
@@ -108,9 +108,7 @@ class GLPI {
     * @return ErrorHandler
     */
    public function initErrorHandler() {
-      global $PHPLOGGER;
-
-      $this->error_handler = new ErrorHandler($PHPLOGGER);
+      $this->error_handler = ErrorHandler::getInstance();
       $this->error_handler->register();
 
       return $this->error_handler;

--- a/inc/glpinetwork.class.php
+++ b/inc/glpinetwork.class.php
@@ -218,10 +218,13 @@ class GLPINetwork extends CommonGLPI {
       if ($error_message !== null || json_last_error() !== JSON_ERROR_NONE
           || !is_array($registration_data) || !array_key_exists('is_valid', $registration_data)) {
          $informations['validation_message'] = __('Unable to fetch registration information.');
-         Toolbox::logError(
-            'Unable to fetch registration information.',
-            $error_message,
-            $registration_response
+         trigger_error(
+            sprintf(
+               "Unable to fetch registration information.\nError message:%s\nResponse:\n%s",
+               $error_message,
+               $registration_response
+            ),
+            E_USER_WARNING
          );
          return $informations;
       }
@@ -310,10 +313,13 @@ class GLPINetwork extends CommonGLPI {
       $offers = $error_message === null ? json_decode($response) : null;
 
       if ($error_message !== null || json_last_error() !== JSON_ERROR_NONE || !is_array($offers)) {
-         Toolbox::logError(
-            'Unable to fetch offers information.',
-            $error_message,
-            $response
+         trigger_error(
+            sprintf(
+               "Unable to fetch offers information.\nError message:%s\nResponse:\n%s",
+               $error_message,
+               $response
+            ),
+            E_USER_WARNING
          );
          return [];
       }

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -30,6 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\ErrorHandler;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Console\Application;
 use Glpi\Plugin\Hooks;
@@ -184,7 +185,7 @@ class Html {
       try {
          $date = new \DateTime($time);
       } catch (\Exception $e) {
-         Toolbox::logWarning("Invalid date $time!");
+         ErrorHandler::getInstance()->handleException($e);
          Session::addMessageAfterRedirect(
             sprintf(
                __('%1$s %2$s'),
@@ -1610,7 +1611,7 @@ HTML;
                if (file_exists($plugin_root_dir."/{$file}")) {
                   $tpl_vars['js_files'][] = $plugin_web_dir."/{$file}";
                } else {
-                  Toolbox::logWarning("{$file} file not found from plugin $plugin!");
+                  trigger_error("{$file} file not found from plugin $plugin!", E_USER_WARNING);
                }
             }
          }
@@ -1630,7 +1631,7 @@ HTML;
                if (file_exists($plugin_root_dir."/{$file}")) {
                   $tpl_vars['js_modules'][] = $plugin_web_dir."/{$file}";
                } else {
-                  Toolbox::logWarning("{$file} file not found from plugin $plugin!");
+                  trigger_error("{$file} file not found from plugin $plugin!", E_USER_WARNING);
                }
             }
          }
@@ -6086,7 +6087,7 @@ JAVASCRIPT;
                }
             }
             if (!$found) {
-               Toolbox::logError("JS lib $name is not known!");
+               trigger_error("JS lib $name is not known!", E_USER_WARNING);
             }
       }
    }
@@ -6168,7 +6169,7 @@ JAVASCRIPT;
                      'type'      => 'text/javascript'
                   ]);
                } else {
-                  Toolbox::logWarning("{$file} file not found from plugin {$plugin}!");
+                  trigger_error("{$file} file not found from plugin {$plugin}!", E_USER_WARNING);
                }
             }
          }
@@ -6192,7 +6193,7 @@ JAVASCRIPT;
                      'type'      => 'module'
                   ]);
                } else {
-                  Toolbox::logWarning("{$file} file not found from plugin {$plugin}!");
+                  trigger_error("{$file} file not found from plugin {$plugin}!", E_USER_WARNING);
                }
             }
          }
@@ -6506,7 +6507,7 @@ HTML;
       $pathalt = GLPI_ROOT . '/' . implode('/', $pathargs);
 
       if (!file_exists($path) && !file_exists($pathalt)) {
-         Toolbox::logWarning('Requested file ' . $path . ' does not exists.');
+         trigger_error('Requested file ' . $path . ' does not exists.', E_USER_WARNING);
          return '';
       }
       if (!file_exists($path)) {
@@ -6516,7 +6517,7 @@ HTML;
       // Prevent import of a file from ouside GLPI dir
       $path = realpath($path);
       if (!str_starts_with($path, realpath(GLPI_ROOT))) {
-         Toolbox::logWarning('Requested file ' . $path . ' is outside GLPI file tree.');
+         trigger_error('Requested file ' . $path . ' is outside GLPI file tree.', E_USER_WARNING);
          return '';
       }
 

--- a/inc/http/response.class.php
+++ b/inc/http/response.class.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Http;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use Toolbox;
+
+/**
+ * @since 10.0.0
+ */
+class Response {
+
+   /**
+    * "application/json" content type.
+    */
+   const CONTENT_TYPE_JSON = 'application/json';
+
+   /**
+    * "text/html" content type.
+    */
+   const CONTENT_TYPE_TEXT_HTML = 'text/html';
+
+   /**
+    * "text/plain" content type.
+    */
+   const CONTENT_TYPE_TEXT_PLAIN = 'text/plain';
+
+   /**
+    * Send the given HTTP code then die with the error message in the given format.
+    *
+    * @param int     $code          HTTP code to set for the response
+    * @param string  $message       Error message to send
+    * @param string  $content_type  Response content type
+    *
+    * @return void
+    */
+   public static function sendError(int $code, string $message, string $content_type = self::CONTENT_TYPE_JSON): void {
+
+      switch ($content_type) {
+         case self::CONTENT_TYPE_JSON:
+            $output = json_encode(['message' => $message]);
+            break;
+
+         case self::CONTENT_TYPE_TEXT_HTML:
+         default:
+            $output = $message;
+            break;
+      }
+
+      header(sprintf('Content-Type: %s; charset=UTF-8', $content_type), true, $code);
+
+      Toolbox::logDebug($message);
+
+      die($output);
+   }
+}

--- a/inc/inventory/asset/networkport.class.php
+++ b/inc/inventory/asset/networkport.class.php
@@ -295,7 +295,7 @@ class NetworkPort extends InventoryAsset
 
       // Try detect phone + computer on this port
       if (isset($this->connection_ports['Phone']) && count($found_macs) == 2) {
-         \Toolbox::logWarning('Phone/Computer MAC linked');
+         trigger_error('Phone/Computer MAC linked', E_USER_WARNING);
          return;
       }
       if (count($found_macs) > 1) { // MultipleMac

--- a/inc/inventory/conf.class.php
+++ b/inc/inventory/conf.class.php
@@ -625,7 +625,7 @@ class Conf extends CommonGLPI
             __('Some properties are not known: %1$s'),
             implode(', ', array_keys($unknown))
          );
-         Toolbox::logWarning($msg);
+         trigger_error($msg, E_USER_WARNING);
          Session::addMessageAfterRedirect(
             $msg,
             false,
@@ -663,7 +663,7 @@ class Conf extends CommonGLPI
             __('Property %1$s does not exists!'),
             $name
          );
-         Toolbox::logWarning($msg);
+         trigger_error($msg, E_USER_WARNING);
          Session::addMessageAfterRedirect(
             $msg,
             false,

--- a/inc/inventory/inventory.class.php
+++ b/inc/inventory/inventory.class.php
@@ -320,7 +320,6 @@ class Inventory
             }
          }
       } catch (\Exception $e) {
-         Toolbox::logError($e);
          $DB->rollback();
          throw $e;
       } finally {
@@ -397,7 +396,6 @@ class Inventory
       }
 
       if (file_exists($tmpfile)) {
-         //Toolbox::logWarning('Nothing to do, inventory temp file will be removed');
          unlink($tmpfile);
       }
    }

--- a/inc/item_disk.class.php
+++ b/inc/item_disk.class.php
@@ -605,10 +605,11 @@ class Item_Disk extends CommonDBChild {
    static function getEncryptionStatus($status) {
       $all = self::getAllEncryptionStatus();
       if (!isset($all[$status])) {
-         Toolbox::logWarning(
+         trigger_error(
             sprintf(
-               'Encryption status %1$s does not exixts!', $status
-            )
+               'Encryption status %1$s does not exists!', $status
+            ),
+            E_USER_WARNING
          );
          return NOT_AVAILABLE;
       }

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -34,6 +34,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use Glpi\Application\ErrorHandler;
 use Glpi\Toolbox\Sanitizer;
 use Laminas\Mail\Address;
 use Laminas\Mail\Header\AbstractAddressList;
@@ -370,12 +371,7 @@ class MailCollector  extends CommonDBTM {
       try {
          $this->connect();
       } catch (\Throwable $e) {
-         Toolbox::logError(
-            'An error occured trying to connect to collector.',
-            $e->getMessage(),
-            "\n",
-            $e->getTraceAsString()
-         );
+         ErrorHandler::getInstance()->handleException($e);
          echo __('An error occured trying to connect to collector.');
          return;
       }
@@ -582,12 +578,7 @@ class MailCollector  extends CommonDBTM {
             try {
                $collector->connect();
             } catch (\Throwable $e) {
-               Toolbox::logError(
-                  'An error occured trying to connect to collector.',
-                  $e->getMessage(),
-                  "\n",
-                  $e->getTraceAsString()
-               );
+               ErrorHandler::getInstance()->handleException($e);
                continue;
             }
 
@@ -680,12 +671,7 @@ class MailCollector  extends CommonDBTM {
          try {
             $this->connect();
          } catch (\Throwable $e) {
-            Toolbox::logError(
-               'An error occured trying to connect to collector.',
-               $e->getMessage(),
-               "\n",
-               $e->getTraceAsString()
-            );
+            ErrorHandler::getInstance()->handleException($e);
             Session::addMessageAfterRedirect(
                __('An error occured trying to connect to collector.') . "<br/>" . $e->getMessage(),
                false,

--- a/inc/marketplace/api/plugins.class.php
+++ b/inc/marketplace/api/plugins.class.php
@@ -131,9 +131,7 @@ class Plugins {
              $this->last_error['response'] = Message::toString($e->getResponse());
          }
 
-         if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
-            Toolbox::logDebug($this->last_error);
-         }
+         Toolbox::logDebug($this->last_error);
          return false;
       }
 

--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -143,7 +143,6 @@ class MassiveAction {
 
                case 'specialize' :
                   if (!isset($POST['action'])) {
-                     Toolbox::logError('Implementation error!');
                      throw new \Exception(__('Implementation error!'));
                   }
                   if ($POST['action'] == -1) {
@@ -153,7 +152,6 @@ class MassiveAction {
                   if (isset($POST['actions'])) {
                      // First, get the name of current action !
                      if (!isset($POST['actions'][$POST['action']])) {
-                        Toolbox::logError('Implementation error!');
                         throw new \Exception(__('Implementation error!'));
                      }
                      $POST['action_name'] = $POST['actions'][$POST['action']];
@@ -262,7 +260,6 @@ class MassiveAction {
       } else {
          if (($stage != 'process')
              || (!isset($_SESSION['current_massive_action'][$GET['identifier']]))) {
-            Toolbox::logError('Implementation error!');
             throw new \Exception(__('Implementation error!'));
          }
          $identifier = $GET['identifier'];

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -651,8 +651,12 @@ class Migration {
             $newtable,
             ($DB->tableExists($newtable) ? __('nok') : __('ok'))
          );
-         Toolbox::logError($message);
-         die(1);
+         if (isCommandLine()) {
+            throw new \RuntimeException($message);
+         } else {
+            echo $message . "\n";
+            die(1);
+         }
       }
    }
 

--- a/inc/networkport_networkport.class.php
+++ b/inc/networkport_networkport.class.php
@@ -260,7 +260,7 @@ class NetworkPort_NetworkPort extends CommonDBRelation {
    public function prepareInputForAdd($input) {
 
       if ($this->getFromDBForNetworkPort([$input['networkports_id_1'], $input['networkports_id_2']])) {
-         Toolbox::logWarning('Wired non unique!');
+         trigger_error('Wired non unique!', E_USER_WARNING);
          return false;
       }
 

--- a/inc/notificationevent.class.php
+++ b/inc/notificationevent.class.php
@@ -192,7 +192,10 @@ class NotificationEvent extends CommonDBTM {
                   $emitter
                );
             } else {
-               Toolbox::logWarning('Missing event class for mode ' . $data['mode'] . ' (' . $eventclass . ')');
+               trigger_error(
+                  'Missing event class for mode ' . $data['mode'] . ' (' . $eventclass . ')',
+                  E_USER_WARNING
+               );
                $label = Notification_NotificationTemplate::getMode($data['mode'])['label'];
                Session::addMessageAfterRedirect(
                   sprintf(__('Unable to send notification using %1$s'), $label),

--- a/inc/notificationeventajax.class.php
+++ b/inc/notificationeventajax.class.php
@@ -72,7 +72,10 @@ class NotificationEventAjax extends NotificationEventAbstract implements Notific
 
 
    static public function send(array $data) {
-      Toolbox::logError(__METHOD__ . ' should not be called!');
+      trigger_error(
+         __METHOD__ . ' should not be called!',
+         E_USER_WARNING
+      );
       return false;
    }
 }

--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -2023,11 +2023,17 @@ class Planning extends CommonGLPI {
          try {
             $vcalendar = Reader::read($calendar_data);
          } catch (\Sabre\VObject\ParseException $exception) {
-            Toolbox::logError(sprintf('Unable to parse calendar data from URL "%s"', $planning_params['url']));
+            trigger_error(
+               sprintf('Unable to parse calendar data from URL "%s"', $planning_params['url']),
+               E_USER_WARNING
+            );
             continue;
          }
          if (!$vcalendar instanceof VCalendar) {
-            Toolbox::logError(sprintf('No VCalendar object found at URL "%s"', $planning_params['url']));
+            trigger_error(
+               sprintf('No VCalendar object found at URL "%s"', $planning_params['url']),
+               E_USER_WARNING
+            );
             continue;
          }
          foreach ($vcalendar->getComponents() as $vcomp) {

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -1484,7 +1484,7 @@ class Plugin extends CommonDBTM {
             $res['requirements'] = ['glpi' => ['min' => $res['minGlpiVersion']]];
          }
       } else {
-         Toolbox::logError("$fct method must be defined!");
+         trigger_error("$fct method must be defined!", E_USER_WARNING);
          $res = [];
       }
       if (isset($info)) {
@@ -1617,7 +1617,7 @@ class Plugin extends CommonDBTM {
                if (isset($options[$optid])) {
                   $message = "Duplicate key $optid ({$options[$optid]['name']}/{$opt['name']}) in ".
                      $itemtype . " searchOptions!";
-                  Toolbox::logError($message);
+                  trigger_error($message, E_USER_WARNING);
                }
 
                foreach ($opt as $k => $v) {

--- a/inc/rack.class.php
+++ b/inc/rack.class.php
@@ -763,7 +763,7 @@ JAVASCRIPT;
                      $pos = ($row['orientation'] == self::REAR) ? 3 - $d : $d;
                      $val = 1;
                      if (isset($content_filled[self::POS_LEFT][$pos]) && $content_filled[self::POS_LEFT][$pos] != 0) {
-                        Toolbox::logError('Several elements exists in rack at same place :(');
+                        trigger_error('Several elements exists in rack at same place :(', E_USER_WARNING);
                         $val += $content_filled[self::POS_LEFT][$pos];
                      }
                      $content_filled[self::POS_LEFT][$pos] = $val;
@@ -777,7 +777,7 @@ JAVASCRIPT;
                      $pos = ($row['orientation'] == self::REAR) ? 3 - $d : $d;
                      $val = 1;
                      if (isset($content_filled[self::POS_RIGHT][$pos]) && $content_filled[self::POS_RIGHT][$pos] != 0) {
-                        Toolbox::logError('Several elements exists in rack at same place :(');
+                        trigger_error('Several elements exists in rack at same place :(', E_USER_WARNING);
                         $val += $content_filled[self::POS_RIGHT][$pos];
                      }
                      $content_filled[self::POS_RIGHT][$pos] = $val;

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -1920,14 +1920,14 @@ class Rule extends CommonDBTM {
       }
 
       if ($this->getType() == 'Rule' && !isset($input['sub_type'])) {
-          \Toolbox::logError('Sub type not specified creating a new rule');
-          return false;
+         trigger_error('Sub type not specified creating a new rule', E_USER_WARNING);
+         return false;
       }
 
       if (!isset($input['sub_type'])) {
          $input['sub_type'] = $this->getType();
       } else if ($this->getType() != 'Rule' && $input['sub_type'] != $this->getType()) {
-         \Toolbox::logWarning(
+         Toolbox::logDebug(
             sprintf(
                'Creating a %s rule with %s subtype.',
                $this->getType(),

--- a/inc/ruleimportasset.class.php
+++ b/inc/ruleimportasset.class.php
@@ -375,7 +375,7 @@ class RuleImportAsset extends Rule {
                   } else if (isset($definition_criteria['is_global'])
                           && $definition_criteria['is_global']) {
                      //If a value is missing, then there's a problem !
-                     Toolbox::logWarning('A value seems missing, criterion was: ' . $criterion);
+                     trigger_error('A value seems missing, criterion was: ' . $criterion, E_USER_WARNING);
                      return false;
                   }
                } else if ($crit->fields["condition"] == Rule::PATTERN_FIND) {
@@ -384,7 +384,7 @@ class RuleImportAsset extends Rule {
                } else if ($crit->fields["condition"] == Rule::PATTERN_EXISTS) {
                   if (!isset($input[$crit->fields['criteria']])
                           || empty($input[$crit->fields['criteria']])) {
-                     Toolbox::logWarning('A value seems missing, criterion was: ' . $criterion);
+                     trigger_error('A value seems missing, criterion was: ' . $criterion, E_USER_WARNING);
                      return false;
                   }
                } else if ($crit->fields["criteria"] == 'itemtype') {
@@ -414,7 +414,6 @@ class RuleImportAsset extends Rule {
                && $key != "class"
                && !is_object($crit)
             ) {
-               //Toolbox::logWarning('No criterion for ' . $key);
                return false;
             }
          }

--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -34,6 +34,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use Glpi\Application\ErrorHandler;
 use Glpi\Application\View\TemplateRenderer;
 
 /**
@@ -798,7 +799,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria {
             try {
                $search_data = $this->execute(false, $enable_partial_warnings);
             } catch (\RuntimeException $e) {
-               Toolbox::logError($e);
+               ErrorHandler::getInstance()->handleException($e);
                $search_data = false;
             }
             if (isset($search_data['data']['totalcount'])) {
@@ -1138,7 +1139,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria {
                      $DB->executeStatement($stmt);
                   }
                } catch (\Exception $e) {
-                  Toolbox::logError($e);
+                  ErrorHandler::getInstance()->handleException($e);
                }
             }
 
@@ -1150,7 +1151,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria {
             $cron_status = 1;
          }
       } else {
-         Toolbox::logWarning('Count on tabs has been disabled; crontask is inefficient.');
+         trigger_error('Count on tabs has been disabled; crontask is inefficient.', E_USER_WARNING);
       }
 
       return $cron_status;

--- a/inc/savedsearch_alert.class.php
+++ b/inc/savedsearch_alert.class.php
@@ -30,6 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\ErrorHandler;
 use Glpi\Plugin\Hooks;
 
 if (!defined('GLPI_ROOT')) {
@@ -122,7 +123,7 @@ class SavedSearch_Alert extends CommonDBChild {
             $count = $data['data']['totalcount'];
          }
       } catch (\RuntimeException $e) {
-         Toolbox::logError($e);
+         ErrorHandler::getInstance()->handleException($e);
       }
 
       $this->showFormHeader($options);
@@ -479,7 +480,7 @@ class SavedSearch_Alert extends CommonDBChild {
                }
             } catch (\Exception $e) {
                self::restoreContext($context);
-               Toolbox::logError($e);
+               ErrorHandler::getInstance()->handleException($e);
             }
          }
          return 1;

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -652,7 +652,7 @@ class Session {
          // In this case, we may still want to be able to load translations (for instance for requirements checks).
          \Locale::setDefault($trytoload);
       } else {
-         Toolbox::logWarning('Missing required intl PHP extension');
+         trigger_error('Missing required intl PHP extension', E_USER_WARNING);
       }
 
       $TRANSLATE->addTranslationFile('gettext', GLPI_I18N_DIR.$newfile, 'glpi', $trytoload);

--- a/inc/telemetry.class.php
+++ b/inc/telemetry.class.php
@@ -282,7 +282,7 @@ class Telemetry extends CommonGLPI {
          if ($errstr != '') {
             $message .= ": $errstr";
          }
-         Toolbox::logError($message);
+         trigger_error($message, E_USER_WARNING);
          return null; // null = Action aborted
       }
    }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -6430,7 +6430,7 @@ JAVASCRIPT;
 
       if (!$merge_target->canAddFollowups()) {
          foreach ($ticket_ids as $id) {
-            Toolbox::logError(sprintf(__('Not enough rights to merge tickets %d and %d'), $merge_target_id, $id));
+            Toolbox::logDebug(sprintf(__('Not enough rights to merge tickets %d and %d'), $merge_target_id, $id));
             // Set status = 2 : Rights issue
             $status[$id] = 2;
          }
@@ -6660,7 +6660,7 @@ JAVASCRIPT;
             } else {
                $status[$id] = $e->getCode();
             }
-            Toolbox::logError($e->getMessage());
+            Toolbox::logDebug($e->getMessage());
             if (!$in_transaction) {
                $DB->rollBack();
             }

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -2879,34 +2879,6 @@ class Toolbox {
    }
 
    /**
-    * Send the given HTTP code then die with the error message in the given format
-    *
-    * @param int     $code    HTTP code to set for the response
-    * @param string  $message Error message to display
-    * @param string  $format  Output format (json or string)
-    */
-   public static function throwError(
-      int $code,
-      string $message,
-      string $format = "json"
-   ) {
-      switch ($format) {
-         case 'json':
-            $output = json_encode(["message" => $message]);
-            break;
-
-         case 'string':
-         default:
-            $output = $message;
-            break;
-      }
-
-      http_response_code($code);
-      Toolbox::logWarning($message);
-      die($output);
-   }
-
-   /**
     * Return a shortened number with a suffix (K, M, B, T)
     *
     * @param int $number to shorten

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -398,6 +398,11 @@ class Toolbox {
     * PHP notice log
     */
    static function logNotice() {
+      self::deprecated(
+         'Use either native trigger_error($msg, E_USER_NOTICE) to log notices,'
+         . ' either Glpi\\Application\\ErrorHandler::handleException() to log exceptions,'
+         . ' either Toolbox::logInfo() or Toolbox::logDebug() to log messages not related to errors.'
+      );
       self::log(null, Logger::NOTICE, func_get_args());
    }
 
@@ -412,6 +417,11 @@ class Toolbox {
     * PHP warning log
     */
    static function logWarning() {
+      self::deprecated(
+         'Use either native trigger_error($msg, E_USER_WARNING) to log warnings,'
+         . ' either Glpi\\Application\\ErrorHandler::handleException() to log exceptions,'
+         . ' either Toolbox::logInfo() or Toolbox::logDebug() to log messages not related to errors.'
+      );
       self::log(null, Logger::WARNING, func_get_args());
    }
 
@@ -419,6 +429,11 @@ class Toolbox {
     * PHP error log
     */
    static function logError() {
+      self::deprecated(
+         'Use either native trigger_error($msg, E_USER_WARNING) to log errors,'
+         . ' either Glpi\\Application\\ErrorHandler::handleException() to log exceptions,'
+         . ' either Toolbox::logInfo() or Toolbox::logDebug() to log messages not related to errors.'
+      );
       self::log(null, Logger::ERROR, func_get_args());
    }
 

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -1335,7 +1335,7 @@ class Toolbox {
          $msgerr = __('No data available on the web site');
       }
       if (!empty($msgerr)) {
-         Toolbox::logError($msgerr);
+         trigger_error($msgerr, E_USER_WARNING);
       }
       return $content;
    }

--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -30,6 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\ErrorHandler;
 use Glpi\Plugin\Hooks;
 use Glpi\Socket;
 
@@ -254,7 +255,7 @@ class Transfer extends CommonDBTM {
             if (!$intransaction && $DB->inTransaction()) {
                $DB->rollBack();
             }
-            Toolbox::logError($e->getMessage());
+            ErrorHandler::getInstance()->handleException($e);
          }
       } // $to >= 0
    }

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -549,7 +549,10 @@ class User extends CommonDBTM {
    function getFromDBbyToken($token, $field = 'personal_token') {
       $fields = ['personal_token', 'api_token'];
       if (!in_array($field, $fields)) {
-         Toolbox::logWarning('User::getFromDBbyToken() can only be called with $field parameter with theses values: \'' . implode('\', \'', $fields) . '\'');
+         trigger_error(
+            'User::getFromDBbyToken() can only be called with $field parameter with theses values: \'' . implode('\', \'', $fields) . '\'',
+            E_USER_WARNING
+         );
          return false;
       }
 

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -49,21 +49,6 @@ class GLPITestCase extends atoum {
    }
 
    public function afterTestMethod($method) {
-
-      global $PHP_LOG_HANDLER;
-      $records  = $PHP_LOG_HANDLER->getRecords();
-      $messages = array_column($records, 'message');
-      $this->integer(count($records))
-         ->isEqualTo(
-            0,
-            sprintf(
-               'Unexpected logs records found in %s::%s() test: %s',
-               static::class,
-               $method,
-               "\n" . implode("\n", $messages)
-            )
-         );
-
       if (isset($_SESSION['MESSAGE_AFTER_REDIRECT']) && !$this->has_failed) {
          unset($_SESSION['MESSAGE_AFTER_REDIRECT'][INFO]);
          $this->array($_SESSION['MESSAGE_AFTER_REDIRECT'])->isIdenticalTo(

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,6 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\ErrorHandler;
 use Glpi\Cache\CacheManager;
 use Glpi\Cache\SimpleCache;
 use Glpi\Socket;
@@ -75,6 +76,10 @@ if (file_exists(GLPI_CONFIG_DIR . DIRECTORY_SEPARATOR . CacheManager::CONFIG_FIL
 }
 
 include_once __DIR__ . '/../inc/includes.php';
+
+// Disable error handler output.
+ErrorHandler::getInstance()->disableOutput();
+
 include_once __DIR__ . '/GLPITestCase.php';
 include_once __DIR__ . '/DbTestCase.php';
 include_once __DIR__ . '/CsvTestCase.php';

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -136,15 +136,18 @@ class CommonDBTM extends DbTestCase {
       $this->boolean($instance->isNewItem())->isFalse();
 
       $instance = new \Computer();
-      $this->exception(
-         function() use ($instance) {
-            $instance->getFromDbByRequest([
+      $result = null;
+      $this->when(
+         function() use ($instance, &$result) {
+            $result = $instance->getFromDbByRequest([
                'WHERE' => ['contact' => 'johndoe'],
             ]);
          }
-      )->isInstanceOf(\RuntimeException::class)
-      ->message
-      ->contains('getFromDBByRequest expects to get one result, 2 found!');
+      )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('getFromDBByRequest expects to get one result, 2 found in query "SELECT `glpi_computers`.* FROM `glpi_computers` WHERE `contact` = \'johndoe\'".')
+         ->exists();
+      $this->boolean($result)->isFalse();
 
       // the instance must not be populated
       $this->boolean($instance->isNewItem())->isTrue();
@@ -298,7 +301,7 @@ class CommonDBTM extends DbTestCase {
       )->isGreaterThan(0);
 
       //multiple update case
-      $this->exception(
+      $this->when(
          function () use ($DB) {
             $res = $DB->updateOrInsert(
                \Computer::getTable(), [
@@ -308,8 +311,12 @@ class CommonDBTM extends DbTestCase {
                   'name'   => 'serial-to-change'
                ]
             );
+            $this->boolean($res)->isFalse();
          }
-      )->message->contains('Update would change too many rows!');
+      )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('Update would change too many rows!')
+         ->exists();
 
       //allow multiples
       $res = $DB->updateOrInsert(
@@ -369,7 +376,7 @@ class CommonDBTM extends DbTestCase {
       )->isGreaterThan(0);
 
       //multiple update case
-      $this->exception(
+      $this->when(
          function () use ($DB) {
             $res = $DB->updateOrInsert(
                \Computer::getTable(), [
@@ -378,8 +385,12 @@ class CommonDBTM extends DbTestCase {
                   'name'   => 'serial-to-change'
                ]
             );
+            $this->boolean($res)->isFalse();
          }
-      )->message->contains('Update would change too many rows!');
+      )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('Update would change too many rows!')
+         ->exists();
 
       //allow multiples
       $res = $DB->updateOrInsert(

--- a/tests/functionnal/Document_Item.php
+++ b/tests/functionnal/Document_Item.php
@@ -49,55 +49,76 @@ class Document_Item extends DbTestCase {
       $input = [];
       $ditem = $this->newTestedInstance;
 
-      $this->exception(
+      $this->when(
          function () use ($input) {
             $this->boolean($this->testedInstance->add($input))->isFalse();
          }
-      )->message->contains('Item type is mandatory');
+      )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('Item type is mandatory')
+         ->exists();
 
       $input['itemtype'] = '';
-      $this->exception(
+      $this->when(
          function () use ($input) {
             $this->boolean($this->testedInstance->add($input))->isFalse();
          }
-      )->message->contains('Item type is mandatory');
+      )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('Item type is mandatory')
+         ->exists();
 
       $input['itemtype'] = 'NotAClass';
-      $this->exception(
+      $this->when(
          function () use ($input) {
             $this->boolean($this->testedInstance->add($input))->isFalse();
          }
-      )->message->contains('No class found for type NotAClass');
+      )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('No class found for type NotAClass')
+         ->exists();
 
       $input['itemtype'] = 'Computer';
-      $this->exception(
+      $this->when(
          function () use ($input) {
             $this->boolean($this->testedInstance->add($input))->isFalse();
          }
-      )->message->contains('Item ID is mandatory');
+      )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('Item ID is mandatory')
+         ->exists();
 
       $input['items_id'] = 0;
-      $this->exception(
+      $this->when(
          function () use ($input) {
             $this->boolean($this->testedInstance->add($input))->isFalse();
          }
-      )->message->contains('Item ID is mandatory');
+      )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('Item ID is mandatory')
+         ->exists();
 
       $cid = getItemByTypeName('Computer', '_test_pc01', true);
       $input['items_id'] = $cid;
 
-      $this->exception(
+      $this->when(
          function () use ($input) {
             $this->boolean($this->testedInstance->add($input))->isFalse();
          }
-      )->message->contains('Document ID is mandatory');
+      )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('Document ID is mandatory')
+         ->exists();
 
       $input['documents_id'] = 0;
-      $this->exception(
+      $this->when(
          function () use ($input) {
             $this->boolean($this->testedInstance->add($input))->isFalse();
          }
-      )->message->contains('Document ID is mandatory');
+      )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('Document ID is mandatory')
+         ->exists();
 
       $document = new \Document();
       $this->integer(

--- a/tests/functionnal/NotificationEventAjax.php
+++ b/tests/functionnal/NotificationEventAjax.php
@@ -65,11 +65,14 @@ class NotificationEventAjax extends DbTestCase {
    }
 
    public function testSend() {
-      $this->exception(
+      $this->when(
          function () {
             $this->boolean(\NotificationEventAjax::send([]))->isFalse();
          }
-      )->message->contains('NotificationEventAjax::send should not be called!');
+      )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('NotificationEventAjax::send should not be called!')
+         ->exists();
    }
 
    public function testRaise() {

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -760,16 +760,17 @@ class Search extends DbTestCase {
     * @return void
     */
    public function testGetSearchOptionsWException() {
-      $error = 'Duplicate key 12 (One search option/Any option) in tests\units\DupSearchOpt searchOptions! ';
+      $error = 'Duplicate key 12 (One search option/Any option) in tests\units\DupSearchOpt searchOptions!';
 
-      $this->exception(
+      $this->when(
          function () {
             $item = new DupSearchOpt();
             $item->searchOptions();
          }
-      )
-         ->isInstanceOf('\RuntimeException')
-         ->message->endWith($error);
+      )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage($error)
+         ->exists();
    }
 
    function testManageParams() {

--- a/tests/functionnal/User.php
+++ b/tests/functionnal/User.php
@@ -165,13 +165,14 @@ class User extends \DbTestCase {
       $this->boolean($user2->getFromDBbyToken($token))->isTrue();
       $this->array($user2->fields)->isIdenticalTo($user->fields);
 
-      $this->exception(
+      $this->when(
          function () use ($uid) {
             $this->testedInstance->getFromDBbyToken($uid, 'my_field');
          }
-      )
-         ->isInstanceOf('RuntimeException')
-         ->message->contains('User::getFromDBbyToken() can only be called with $field parameter with theses values: \'personal_token\', \'api_token\'');
+      )->error
+         ->withType(E_USER_WARNING)
+         ->withMessage('User::getFromDBbyToken() can only be called with $field parameter with theses values: \'personal_token\', \'api_token\'')
+         ->exists();
    }
 
    public function testPrepareInputForAdd() {

--- a/tests/router.php
+++ b/tests/router.php
@@ -47,6 +47,7 @@ $DEBUG_SQL = [
     'times'   => [],
 ];
 
+ini_set("display_errors", "Off");
 ini_set("error_log", "tests/web/error.log");
 
 return false;

--- a/tests/units/Glpi/Inventory/Conf.php
+++ b/tests/units/Glpi/Inventory/Conf.php
@@ -108,10 +108,14 @@ class Conf extends \GLPITestCase {
       $this
          ->if($this->newTestedInstance)
          ->then
-            ->exception(
+            ->when(
                function () {
                   $this->variable($this->testedInstance->doesNotExists)->isEqualTo(null);
+                  $this->hasSessionMessages(WARNING, ['Property doesNotExists does not exists!']);
                }
-            )->message->contains('Property doesNotExists does not exists!');
+            )->error
+               ->withType(E_USER_WARNING)
+               ->withMessage('Property doesNotExists does not exists!')
+               ->exists();
    }
 }

--- a/tests/units/Html.php
+++ b/tests/units/Html.php
@@ -61,11 +61,7 @@ class Html extends \GLPITestCase {
       $expected = date('m-d-Y');
       $this->string(\Html::convDate($mydate, 2))->isIdenticalTo($expected);
 
-      $this->exception(
-         function () {
-            $this->string(\Html::convDate('not a date', 2))->isIdenticalTo('not a date');
-         }
-      )->message->contains('Invalid date');
+      $this->string(\Html::convDate('not a date', 2))->isIdenticalTo('not a date');
    }
 
    public function testConvDateTime() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`Toolbox::logError()` and `Toolbox::logWarning()` were historically used to log errors/warnings, but these methods suffer from the following problems:
- messages related to errors/warnings are not shown, even in debug mode, so most of developpers do not even see them,
- backtrace is not added to log, so in many cases, complicating the issue analysis,
- it was trigerring an Exception in test suite context, and so it was impossible to correctly test cases that was generating these methods usage.

Main changes proposed in this PR:

1) 4xx errors in ajax/front files are now logged at debug level. No need to pollute the response with error trace, as it has a 4xx status code that should already result in error message display, or error case handling in JS.

2) `Toolbox::logError()` and `Toolbox::logWarning()` usages are mostly replaced by `trigger_error`, with a `E_USER_WARNING` level (`E_USER_ERROR` would trigger a fatal error, which is not what we want). Exceptions are passed to `Glpi\Application\ErrorHandler::handleException()` in order to be correctly logged.

3) As exceptions are correctly logged since GLPI 9.5.0, useless logs preceding exceptions have been deleted.

4) In test suite, log content is no more checked. Indeed, previously, usage of `Toolbox::logError()` and `Toolbox::logWarning()` was generating exceptions in test suite context, so nothing was written to the log. With usage of `trigger_error`, errors are written normally in logs and it cannot be considered anymore as an error. The counterpart is we can now tests correctly the corresponding cases.

5) In test suite, error handler output is disabled. As atoum fails when an error triggered by `trigger_error` is not explicitely checked, there is no need to pollute anymore test suite output with errors messages.


TIP: To force logging at debug level, developpers can use `define('GLPI_LOG_LVL', 'DEBUG');` in their `config/local.define.php`