### PR TITLE
Prevent `--debug` option of atoum to trigger GLPI debug mode

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -105,6 +105,7 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
    }
 
    if (isCommandLine()
+       && !defined('TU_USER') // In test suite context, used --debug option is the atoum one
        && isset($_SERVER['argv'])) {
       $key = array_search('--debug', $_SERVER['argv']);
       if ($key) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This change prevents atoum to exit without any error message.

Before:
![image](https://user-images.githubusercontent.com/33253653/138406341-dcd09522-4d28-4dc5-bffe-77448882d35d.png)

After:
![image](https://user-images.githubusercontent.com/33253653/138406422-518dafdd-da9f-4242-a8a8-9e13c6a32607.png)
