### PR TITLE
Add entity restriction to global rule export

### DIFF
--- a/front/rule.backup.php
+++ b/front/rule.backup.php
@@ -69,7 +69,7 @@ switch ($action) {
       if (isset($_SESSION['exportitems'])) {
          $rules_key = array_keys($_SESSION['exportitems']);
       } else {
-         $rules_key = array_keys($rule->find());
+         $rules_key = array_keys($rule->find(getEntitiesRestrictCriteria()));
       }
       $rulecollection->exportRulesToXML($rules_key);
       unset($_SESSION['exportitems']);


### PR DESCRIPTION
The global import/export rules actions doesn't take into account the current entity restrictions.

![image](https://user-images.githubusercontent.com/42734840/138302105-b2134d60-d223-40cf-9f17-548527fb8773.png)


For example here I have only one rule in my entity:

![image](https://user-images.githubusercontent.com/42734840/138302225-0528f855-b61d-4d97-84a9-7fdd3acff9fd.png)

-> clicking the export button give multiple rules:  

![image](https://user-images.githubusercontent.com/42734840/138302461-7b966689-f2fe-48b3-afdf-dbb8b2c45ddc.png)

After fixing the issue, I only have the correct rule in the export: 

![image](https://user-images.githubusercontent.com/42734840/138302548-e41ba6ea-6bc3-4bad-ab4b-4fbb2c660ad7.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22827
