### PR TITLE
important alert should have their class background

### DIFF
--- a/css/includes/_dark.scss
+++ b/css/includes/_dark.scss
@@ -111,7 +111,7 @@ $input-border: $dark-mode-text !default;
    }
 
    // Manually applied patch from unmerged PR tabler/tabler#855
-   .alert {
+   .alert:not(.alert-important) {
       background-color: $dark;
       color: inherit;
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

follow #9719 and changes on alerts

Tabler provides two types of alerts
- simple, ex `.alert.alert-warning`
- important one, ex `.alert.alert-important.alert-warning`

cf : https://preview.tabler.io/docs/alerts.html

In the previous fixe, we fixed the background in dark mode only for simple ones.
Important alert with warning/danger was broken 

before: 

![image](https://user-images.githubusercontent.com/418844/138414422-bc29ef6d-0dc1-4cf0-9ebf-579fd2ec07e5.png)

after:

![image](https://user-images.githubusercontent.com/418844/138414478-05f94906-25e6-45f8-a36b-40ca5f27176f.png)

