### PR TITLE
Don't reload form tabs by default

### DIFF
--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -338,10 +338,13 @@ JAVASCRIPT;
          echo  "</div>"; // .tab-content
          echo "</div>"; // .container-fluid
          $js = "
-         var loadTabContents = function (tablink) {
+         var loadTabContents = function (tablink, force_reload = false) {
             var url = tablink.attr('href');
             var target = tablink.attr('data-bs-target');
             var index = tablink.closest('.nav-item').index();
+            if ($(target).html() && !force_reload) {
+                return;
+            }
             $(target).html('<i class=\"fas fa-3x fa-spinner fa-pulse position-absolute top-50 start-50\"></i>');
 
             $.get(url, function(data) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #9447 

The form tabs currently always reload when you click on the tab link. This is causing lost data going between tabs without saving (and it bypasses the unsaved changes warning), and JS errors when trying to re-initialize elements like the impact graph.