### PR TITLE
Re-add ability to add items on ticket creation

### DIFF
--- a/ajax/dropdownTrackingDeviceType.php
+++ b/ajax/dropdownTrackingDeviceType.php
@@ -102,10 +102,10 @@ if ($isValidItemtype) {
    );
 
    // Auto update summary of active or just solved tickets
-   echo "<span id='item_ticket_selection_information$rand' class='ms-1'></span>";
+   echo "<span id='item_ticket_selection_information{$_POST["myname"]}_$rand' class='ms-1'></span>";
    Ajax::updateItemOnSelectEvent(
       $field_id,
-      "item_ticket_selection_information$rand",
+      "item_ticket_selection_information{$_POST["myname"]}_$rand",
       $CFG_GLPI["root_doc"]."/ajax/ticketiteminformation.php",
       [
          'items_id' => '__VALUE__',

--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -223,8 +223,6 @@ class Item_Ticket extends CommonItilObject_Item {
          }
       }
 
-
-
       $rand  = mt_rand();
       $count = 0;
 

--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access directly to this file");
 }
@@ -172,14 +174,13 @@ class Item_Ticket extends CommonItilObject_Item {
    static function itemAddForm(Ticket $ticket, $options = []) {
       global $CFG_GLPI;
 
-      $params = ['id'                  => (isset($ticket->fields['id'])
-                                                && $ticket->fields['id'] != '')
-                                                   ? $ticket->fields['id']
-                                                   : 0,
-                      '_users_id_requester' => 0,
-                      'items_id'            => [],
-                      'itemtype'            => '',
-                      '_canupdate'          => false];
+      $params = [
+         'id'  => (isset($ticket->fields['id']) && $ticket->fields['id'] != '') ? $ticket->fields['id'] : 0,
+         '_users_id_requester' => 0,
+         'items_id'            => [],
+         'itemtype'            => '',
+         '_canupdate'          => false
+      ];
 
       $opt = [];
 
@@ -197,6 +198,7 @@ class Item_Ticket extends CommonItilObject_Item {
                   && $params['_canupdate']);
 
       // Ticket update case
+      $usedcount = 0;
       if ($params['id'] > 0) {
          // Get requester
          $class        = new $ticket->userlinkclass();
@@ -210,7 +212,6 @@ class Item_Ticket extends CommonItilObject_Item {
 
          // Get associated elements for ticket
          $used = self::getUsedItems($params['id']);
-         $usedcount = 0;
          foreach ($used as $itemtype => $items) {
             foreach ($items as $items_id) {
                if (!isset($params['items_id'][$itemtype])
@@ -222,42 +223,49 @@ class Item_Ticket extends CommonItilObject_Item {
          }
       }
 
+
+
+      $rand  = mt_rand();
+      $count = 0;
+
+      $twig_params = [
+         'rand'               => $rand,
+         'can_edit'           => $canedit,
+         'my_items_dropdown'  => '',
+         'all_items_dropdown' => '',
+         'items_to_add'       => [],
+         'params'             => $params,
+         'opt'                => []
+      ];
+
       // Get ticket template
       $tt = new TicketTemplate();
       if (isset($options['_tickettemplate'])) {
          $tt                  = $options['_tickettemplate'];
          if (isset($tt->fields['id'])) {
-            $opt['templates_id'] = $tt->fields['id'];
+            $twig_params['opt']['templates_id'] = $tt->fields['id'];
          }
       } else if (isset($options['templates_id'])) {
          $tt->getFromDBWithData($options['templates_id']);
          if (isset($tt->fields['id'])) {
-            $opt['templates_id'] = $tt->fields['id'];
+            $twig_params['opt']['templates_id'] = $tt->fields['id'];
          }
       }
-
-      $rand  = mt_rand();
-      $count = 0;
-
-      echo "<div id='itemAddForm$rand'>";
-
       // Show associated item dropdowns
       if ($canedit) {
          $p = ['used'       => $params['items_id'],
-                    'rand'       => $rand,
-                    'tickets_id' => $params['id']];
+            'rand'       => $rand,
+            'tickets_id' => $params['id']];
          // My items
          if ($params['_users_id_requester'] > 0) {
-            Item_Ticket::dropdownMyDevices($params['_users_id_requester'], $ticket->fields["entities_id"], $params['itemtype'], 0, $p);
+            ob_start();
+            self::dropdownMyDevices($params['_users_id_requester'], $ticket->fields["entities_id"], $params['itemtype'], 0, $p);
+            $twig_params['my_items_dropdown'] = ob_get_clean();
          }
          // Global search
-         Item_Ticket::dropdownAllDevices("itemtype", $params['itemtype'], 0, 1, $params['_users_id_requester'], $ticket->fields["entities_id"], $p);
-
-         // Add button
-         echo "<a href='javascript:itemAction$rand(\"add\");' class='btn btn-sm btn-outline-secondary'>
-               <i class='fas fa-plus'></i>
-               <span>"._sx('button', 'Add')."</span>
-            </a>";
+         ob_start();
+         self::dropdownAllDevices("itemtype", $params['itemtype'], 0, 1, $params['_users_id_requester'], $ticket->fields["entities_id"], $p);
+         $twig_params['all_items_dropdown'] = ob_get_clean();
       }
 
       // Display list
@@ -275,7 +283,7 @@ class Item_Ticket extends CommonItilObject_Item {
          foreach ($params['items_id'] as $itemtype => $items) {
             foreach ($items as $items_id) {
                $count++;
-               echo self::showItemToAdd(
+               $twig_params['items_to_add'][] = self::showItemToAdd(
                   $params['id'],
                   $itemtype,
                   $items_id,
@@ -288,41 +296,14 @@ class Item_Ticket extends CommonItilObject_Item {
             }
          }
       }
-
-      if ($count == 0) {
-         echo "<input type='hidden' value='0' name='items_id'>";
-      }
-
-      if ($params['id'] > 0 && $usedcount != $count) {
-         $count_notsaved = $count - $usedcount;
-         echo "<i>" . sprintf(_n('%1$s item not saved', '%1$s items not saved', $count_notsaved), $count_notsaved)  . "</i>";
-      }
-      if ($params['id'] > 0 && $usedcount > 5) {
-         echo "<i><a href='".$ticket->getFormURLWithID($params['id'])."&amp;forcetab=Item_Ticket$1'>"
-                  .__('Display all items')." (".$usedcount.")</a></i>";
-      }
-      echo "</div>";
+      $twig_params['count'] = $count;
+      $twig_params['usedcount'] = $usedcount;
 
       foreach (['id', '_users_id_requester', 'items_id', 'itemtype', '_canupdate'] as $key) {
-         $opt[$key] = $params[$key];
+         $twig_params['opt'][$key] = $params[$key];
       }
 
-      $js  = " function itemAction$rand(action, itemtype, items_id) {";
-      $js .= "    $.ajax({
-                     url: '".$CFG_GLPI['root_doc']."/ajax/itemTicket.php',
-                     dataType: 'html',
-                     data: {'action'     : action,
-                            'rand'       : $rand,
-                            'params'     : ".json_encode($opt).",
-                            'my_items'   : $('#dropdown_my_items$rand').val(),
-                            'itemtype'   : (itemtype === undefined) ? $('#dropdown_itemtype$rand').val() : itemtype,
-                            'items_id'   : (items_id === undefined) ? $('#dropdown_add_items_id$rand').val() : items_id},
-                     success: function(response) {";
-      $js .= "          $(\"#itemAddForm$rand\").replaceWith(response);";
-      $js .= "       }";
-      $js .= "    });";
-      $js .= " }";
-      echo Html::scriptBlock($js);
+      TemplateRenderer::getInstance()->display('components/itilobject/add_items.html.twig', $twig_params);
    }
 
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -4332,6 +4332,12 @@ JAVASCRIPT;
 
       $sla = new SLA;
       $ola = new OLA;
+      $item_ticket = null;
+
+      $options['_canupdate'] = Session::haveRight('ticket', CREATE);
+      if ($options['_canupdate']) {
+         $item_ticket = new Item_Ticket;
+      }
 
       TemplateRenderer::getInstance()->display('components/itilobject/layout.html.twig', [
          'item'               => $this,
@@ -4342,6 +4348,7 @@ JAVASCRIPT;
          'itiltemplate'       => $tt,
          'predefined_fields'  => Toolbox::prepareArrayForInput($predefined_fields),
          'ticket_ticket'      => new Ticket_Ticket,
+         'item_ticket'        => $item_ticket,
          'sla'                => $sla,
          'ola'                => $ola,
          'canupdate'          => $canupdate,

--- a/templates/components/itilobject/add_items.html.twig
+++ b/templates/components/itilobject/add_items.html.twig
@@ -1,0 +1,44 @@
+<div id='itemAddForm{{ rand }}'>
+   {% if can_edit %}
+      {{ my_items_dropdown|raw }}
+      {{ all_items_dropdown|raw }}
+      <a href='javascript:itemAction{{ rand }}("add");' class='btn btn-sm btn-outline-secondary'>
+         <i class='fas fa-plus'></i>
+         <span>{{ _x('button', 'Add') }}</span>
+      </a>
+   {% endif %}
+
+   {% for item_to_add in items_to_add %}
+      {{ item_to_add|raw }}
+   {% endfor %}
+
+   {% if count == 0 %}
+      <input type='hidden' value='0' name='items_id'>
+   {% endif %}
+
+   {% if params.id > 0 and usedcount != count %}
+      <i>{{ _n('%1$s item not saved', '%1$s items not saved', (count - usedcount))|format((count - usedcount)) }}</i>
+   {% endif %}
+   {% if params.id > 0 and usedcount > 5 %}
+      <i><a href="">{{ __('Display all items') ~ '(' ~ usedcount ~ ')' }}</a></i>
+   {% endif %}
+</div>
+
+<script>
+   function itemAction{{ rand }}(action, itemtype, items_id) {
+      $.ajax({
+         url: CFG_GLPI.root_doc + '/ajax/itemTicket.php',
+         dataType: 'html',
+         data: {
+            'action'     : action,
+            'rand'       : {{ rand }},
+            'params'     : {{ opt|json_encode|raw }},
+            'my_items'   : $('#dropdown_my_items{{ rand }}').val(),
+            'itemtype'   : (itemtype === undefined) ? $('#dropdown_itemtype{{ rand }}').val() : itemtype,
+            'items_id'   : (items_id === undefined) ? $('#dropdown_add_items_id{{ rand }}').val() : items_id},
+         success: function(response) {
+            $("#itemAddForm{{ rand }}").replaceWith(response);
+         }
+      });
+   }
+</script>

--- a/templates/components/itilobject/add_items.html.twig
+++ b/templates/components/itilobject/add_items.html.twig
@@ -20,7 +20,7 @@
       <i>{{ _n('%1$s item not saved', '%1$s items not saved', (count - usedcount))|format((count - usedcount)) }}</i>
    {% endif %}
    {% if params.id > 0 and usedcount > 5 %}
-      <i><a href="">{{ __('Display all items') ~ '(' ~ usedcount ~ ')' }}</a></i>
+      <i><a href="{{ 'Ticket'|itemtype_form_path(params.id) }}&amp;forcetab=Item_Ticket$1">{{ __('Display all items') ~ '(' ~ usedcount ~ ')' }}</a></i>
    {% endif %}
 </div>
 

--- a/templates/components/itilobject/add_items.html.twig
+++ b/templates/components/itilobject/add_items.html.twig
@@ -1,9 +1,9 @@
-<div id='itemAddForm{{ rand }}'>
+<div id="itemAddForm{{ rand }}">
    {% if can_edit %}
       {{ my_items_dropdown|raw }}
       {{ all_items_dropdown|raw }}
-      <a href='javascript:itemAction{{ rand }}("add");' class='btn btn-sm btn-outline-secondary'>
-         <i class='fas fa-plus'></i>
+      <a href="javascript:itemAction{{ rand }}('add');" class="btn btn-sm btn-outline-secondary">
+         <i class="fas fa-plus"></i>
          <span>{{ _x('button', 'Add') }}</span>
       </a>
    {% endif %}
@@ -13,7 +13,7 @@
    {% endfor %}
 
    {% if count == 0 %}
-      <input type='hidden' value='0' name='items_id'>
+      <input type="hidden" value="0" name="items_id">
    {% endif %}
 
    {% if params.id > 0 and usedcount != count %}

--- a/templates/components/itilobject/add_items.html.twig
+++ b/templates/components/itilobject/add_items.html.twig
@@ -25,6 +25,12 @@
 </div>
 
 <script>
+   function refreshItemCounter{{ rand }}() {
+      const item_form = $("#itemAddForm{{ rand }}");
+      const item_count = item_form.find('> div').length - 2;
+      item_form.closest('.accordion-item').find('.item-counter').text(item_count);
+   }
+
    function itemAction{{ rand }}(action, itemtype, items_id) {
       $.ajax({
          url: CFG_GLPI.root_doc + '/ajax/itemTicket.php',
@@ -38,7 +44,9 @@
             'items_id'   : (items_id === undefined) ? $('#dropdown_add_items_id{{ rand }}').val() : items_id},
          success: function(response) {
             $("#itemAddForm{{ rand }}").replaceWith(response);
+            refreshItemCounter{{ rand }}();
          }
       });
    }
+   refreshItemCounter{{ rand }}();
 </script>

--- a/templates/components/itilobject/add_items.html.twig
+++ b/templates/components/itilobject/add_items.html.twig
@@ -1,3 +1,34 @@
+{#
+ # ---------------------------------------------------------------------
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ # Copyright (C) 2015-2021 Teclib' and contributors.
+ #
+ # http://glpi-project.org
+ #
+ # based on GLPI - Gestionnaire Libre de Parc Informatique
+ # Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # GLPI is free software; you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation; either version 2 of the License, or
+ # (at your option) any later version.
+ #
+ # GLPI is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ # ---------------------------------------------------------------------
+ #}
+
 <div id="itemAddForm{{ rand }}">
    {% if can_edit %}
       {{ my_items_dropdown|raw }}

--- a/templates/components/itilobject/add_items.html.twig
+++ b/templates/components/itilobject/add_items.html.twig
@@ -27,7 +27,8 @@
 <script>
    function refreshItemCounter{{ rand }}() {
       const item_form = $("#itemAddForm{{ rand }}");
-      const item_count = item_form.find('> div').length - 2;
+      let item_count = item_form.find('> div').length - 2;
+      item_count += item_form.find('> input[type="hidden"]').length;
       item_form.closest('.accordion-item').find('.item-counter').text(item_count);
    }
 

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -220,7 +220,7 @@
             <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#items" aria-expanded="true" aria-controls="items">
                <i class="fa fa-users me-1"></i>
                <span>{{ _n('Item', 'Items', get_plural_number()) }}</span>
-               <span class="badge bg-secondary ms-2"></span>
+               <span class="item-counter badge bg-secondary ms-2"></span>
             </button>
          </h2>
          <div id="items" class="accordion-collapse collapse show" aria-labelledby="items-heading">

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -214,6 +214,23 @@
       </div>
    </div>
 
+   {% if item_ticket is defined and item_ticket is not null %}
+      <div class="accordion-item">
+         <h2 class="accordion-header" id="items-heading">
+            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#items" aria-expanded="true" aria-controls="items">
+               <i class="fa fa-users me-1"></i>
+               <span>{{ _n('Item', 'Items', get_plural_number()) }}</span>
+               <span class="badge bg-secondary ms-2"></span>
+            </button>
+         </h2>
+         <div id="items" class="accordion-collapse collapse show" aria-labelledby="items-heading">
+            <div class="accordion-body accordion-items row m-0 mt-n2">
+               {{ item_ticket.itemAddForm(item, params|default({})) }}
+            </div>
+         </div>
+      </div>
+   {% endif %}
+
    {% if item.getType() == 'Ticket' %}
       {% set nb_la = (item.fields['slas_id_tto'] > 0 ? 1 : 0) + (item.fields['slas_id_ttr'] > 0 ? 1 : 0) + (item.fields['olas_id_tto'] > 0 ? 1 : 0) + (item.fields['olas_id_ttr'] > 0 ? 1 : 0) %}
       <div class="accordion-item">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Re-implemented the previous code that let you select one or more items during ticket creation. Currently, you have to add all of the items one at a time after the ticket is created.