### PR TITLE
Handle marketplace API failure

### DIFF
--- a/css/marketplace.scss
+++ b/css/marketplace.scss
@@ -123,6 +123,10 @@ $break_s_screen: 1400px;
             }
          }
 
+         .warning {
+            flex-basis: 100%;
+         }
+
          .plugin {
             $margin_width: 10px;
             width: calc(25% - #{$margin_width}); //minus margin

--- a/inc/marketplace/view.class.php
+++ b/inc/marketplace/view.class.php
@@ -283,7 +283,7 @@ class View extends CommonGLPI {
       }
 
       header("X-GLPI-Marketplace-Total: $nb_plugins");
-      self::displayList($plugins, "discover", $only_lis, $nb_plugins, $sort);
+      self::displayList($plugins, "discover", $only_lis, $nb_plugins, $sort, $api->isListTruncated());
    }
 
 
@@ -323,10 +323,19 @@ class View extends CommonGLPI {
       string $tab = "",
       bool $only_lis = false,
       int $nb_plugins = 0,
-      string $sort = 'sort-alpha-asc'
+      string $sort = 'sort-alpha-asc',
+      bool $is_list_truncated = false
    ) {
       if (!self::canView()) {
          return false;
+      }
+
+      $messages = '';
+      if ($is_list_truncated) {
+         $msg = count($plugins) === 0
+            ? sprintf(__('Unable to fetch plugin list due to %s services website unavailability. Please try again later.'), 'GLPI Network')
+            : sprintf(__('Plugin list may be truncated due to %s services website unavailability. Please try again later.'), 'GLPI Network');
+         $messages = '<li class="warning"><i class="fa fa-exclamation-triangle fa-3x"></i>'.$msg.'</li>';
       }
 
       $plugins_li = "";
@@ -407,6 +416,7 @@ class View extends CommonGLPI {
                   </div>
                </div>
                <ul class='plugins'>
+                  {$messages}
                   {$plugins_li}
                </ul>
                $pagination
@@ -421,7 +431,7 @@ class View extends CommonGLPI {
 HTML;
          echo $marketplace;
       } else {
-         echo $plugins_li;
+         echo $messages . $plugins_li;
       }
 
       $js = <<<JS


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Add a retry mechanism on paginated plugin list fetching.
2. Add a flag to indicate when paginated plugin list may be incomplete.
3. Display a warning when list is empty/incomplete due to marketplace API failure.
4. Do not cache results when plugin list may be incomplete.
5. Handle `null` value on `Plugins::$plugins` static variable, to prevent trying to fetch again the list from API when first attempt fails. Previously, on `installed` tab, when full list fetching was failing and resulted in an empty list, this full list was fetch about 5 times for each installed plugin.

Tip: ignoring whitespaces during review may help.

![image](https://user-images.githubusercontent.com/33253653/138915241-5d2ee711-59e5-4fc5-b2d2-117cf8f80610.png)
