### PR TITLE
Enhance handling of db escape/unescape in Sanitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The present file will list all changes made to the project; according to the
 - `Transfer::transferDropdownNetpoint()` has been renamed to `Transfer::transferDropdownSocket()`.
 
 #### Deprecated
+- Handling of encoded/escaped value in `autoName()`
 - `Netpoint` has been deprecated and replaced by `Socket`
 - `Html::clean()`
 - `RuleImportComputer` class

--- a/ajax/inputtext.php
+++ b/ajax/inputtext.php
@@ -45,6 +45,6 @@ if (isset($_POST['name'])) {
    echo "<input type='text' ".(isset($_POST["size"])?" size='".$_POST["size"]."' ":"")." ".
          (isset($_POST["maxlength"])?"maxlength='".$_POST["maxlength"]."' ":"")." name='".
          $_POST['name']."' value=\"".
-         Html::cleanInputText(Sanitizer::sanitize(rawurldecode(stripslashes($_POST["data"])))).
+         Html::cleanInputText(Sanitizer::sanitize(rawurldecode(stripslashes($_POST["data"])), false)).
         "\">";
 }

--- a/ajax/textarea.php
+++ b/ajax/textarea.php
@@ -43,6 +43,6 @@ Session::checkLoginUser();
 if (isset($_POST['name'])) {
    echo "<textarea ".(isset($_POST['rows'])?" rows='".$_POST['rows']."' ":"")." ".
          (isset($_POST['cols'])?" cols='".$_POST['cols']."' ":"")."  name='".$_POST['name']."'>";
-   echo Html::cleanPostForTextArea(Sanitizer::sanitize(rawurldecode(($_POST["data"]))));
+   echo Html::cleanPostForTextArea(Sanitizer::sanitize(rawurldecode(($_POST["data"])), false));
    echo "</textarea>";
 }

--- a/inc/abstractitilchildtemplate.class.php
+++ b/inc/abstractitilchildtemplate.class.php
@@ -94,7 +94,7 @@ abstract class AbstractITILChildTemplate extends CommonDropdown
       }
 
       $err_msg = null;
-      if (!TemplateManager::validate(stripslashes($input['content']), true, $err_msg)) {
+      if (!TemplateManager::validate($input['content'], $err_msg)) {
          Session::addMessageAfterRedirect(
             sprintf('%s: %s', __('Content'), $err_msg),
             false,

--- a/inc/api/api.class.php
+++ b/inc/api/api.class.php
@@ -1727,7 +1727,7 @@ abstract class API {
                $object["_add"] = true;
 
                //add current item
-               $object = Sanitizer::sanitize($object, true);
+               $object = Sanitizer::sanitize($object);
                $new_id = $item->add($object);
                if ($new_id === false) {
                   $failed++;
@@ -1854,7 +1854,7 @@ abstract class API {
                   }
 
                   //update item
-                  $object = Sanitizer::sanitize((array)$object, true);
+                  $object = Sanitizer::sanitize((array)$object);
                   $update_return = $item->update($object);
                   if ($update_return === false) {
                      $failed++;

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -938,7 +938,7 @@ class Auth extends CommonGLPI {
       if (!$DB->isSlave()) {
          // GET THE IP OF THE CLIENT
          $ip = getenv("HTTP_X_FORWARDED_FOR")?
-            Sanitizer::sanitize(getenv("HTTP_X_FORWARDED_FOR")):
+            Sanitizer::sanitize(getenv("HTTP_X_FORWARDED_FOR"), false):
             getenv("REMOTE_ADDR");
 
          if ($this->auth_succeded) {

--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -1714,7 +1714,7 @@ class AuthLDAP extends CommonDBTM {
       $count    = 0;  //Store the number of results ldap_search
 
       do {
-         $filter = Sanitizer::unsanitize($filter, true);
+         $filter = Sanitizer::unsanitize($filter);
          if (self::isLdapPageSizeAvailable($config_ldap)) {
             $controls = [
                [
@@ -2285,7 +2285,7 @@ class AuthLDAP extends CommonDBTM {
       $cookie = '';
       $count  = 0;
       do {
-         $filter = Sanitizer::unsanitize($filter, true);
+         $filter = Sanitizer::unsanitize($filter);
          if (self::isLdapPageSizeAvailable($config_ldap)) {
             $controls = [
                [
@@ -3430,7 +3430,7 @@ class AuthLDAP extends CommonDBTM {
                   $field_counter++;
                   $field_value = '';
                   if (isset($_SESSION['ldap_import']['criterias'][$field])) {
-                     $field_value = Html::entities_deep(Sanitizer::unsanitize($_SESSION['ldap_import']['criterias'][$field], true));
+                     $field_value = Html::entities_deep(Sanitizer::unsanitize($_SESSION['ldap_import']['criterias'][$field]));
                   }
                   echo "<input type='text' class='form-control' id='criterias$field' name='criterias[$field]' value='$field_value'>";
                   echo "</td>";

--- a/inc/caldav/backend/calendar.class.php
+++ b/inc/caldav/backend/calendar.class.php
@@ -324,7 +324,7 @@ class Calendar extends AbstractBackend {
          $input['uuid'] = Uuid::uuid4();
       }
 
-      $input = Sanitizer::sanitize($input, true);
+      $input = Sanitizer::sanitize($input);
 
       if ($item->isNewItem()) {
          // Auto set entities_id if exists and not set

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -1836,7 +1836,7 @@ abstract class CommonITILObject extends CommonDBTM {
          // Build name based on content
 
          // Unsanitize
-         $content = Sanitizer::unsanitize($input['content'], true);
+         $content = Sanitizer::unsanitize($input['content']);
 
          // Get unformatted text
          $name = RichText::getTextFromHtml($content, false);

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -1845,7 +1845,7 @@ abstract class CommonITILObject extends CommonDBTM {
          $name = Toolbox::substr(preg_replace('/\s{2,}/', ' ', $name), 0, 70);
 
          // Sanitize result
-         $input['name'] = Sanitizer::sanitize($name, true);
+         $input['name'] = Sanitizer::sanitize($name);
       }
 
       // Set default dropdown
@@ -7136,7 +7136,7 @@ abstract class CommonITILObject extends CommonDBTM {
          $tasktemplate_content = $tasktemplate->getRenderedContent($this);
 
          // Sanitize generated HTML before adding it in DB
-         $tasktemplate_content = Sanitizer::sanitize($tasktemplate_content, true);
+         $tasktemplate_content = Sanitizer::sanitize($tasktemplate_content);
 
          $itiltask->add([
             'tasktemplates_id'            => $tasktemplates_id,
@@ -7178,7 +7178,7 @@ abstract class CommonITILObject extends CommonDBTM {
          $new_fup_content = $fup_template->getRenderedContent($this);
 
          // Sanitize generated HTML before adding it in DB
-         $new_fup_content = Sanitizer::sanitize($new_fup_content, true);
+         $new_fup_content = Sanitizer::sanitize($new_fup_content);
 
          // Insert new followup from template
          $fup = new ITILFollowup();

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1950,7 +1950,7 @@ class Config extends CommonDBTM {
       echo wordwrap($msg."\n", $width, "\n\t");
 
       if (isset($_SERVER["HTTP_USER_AGENT"])) {
-         echo "\t" . Sanitizer::sanitize($_SERVER["HTTP_USER_AGENT"]) . "\n";
+         echo "\t" . Sanitizer::sanitize($_SERVER["HTTP_USER_AGENT"], false) . "\n";
       }
 
       foreach ($DB->getInfo() as $key => $val) {

--- a/inc/console/migration/appliancesplugintocorecommand.class.php
+++ b/inc/console/migration/appliancesplugintocorecommand.class.php
@@ -408,7 +408,7 @@ class AppliancesPluginToCoreCommand extends AbstractCommand {
             'appliances_id' => $item['plugin_appliances_appliances_id'],
             'items_id'      => $item['items_id'],
             'itemtype'      => $item['itemtype']
-         ], true);
+         ]);
 
          $appi = new Appliance_Item();
          if (!($appi_id = $appi->getFromDBByCrit($app_fields))) {
@@ -466,7 +466,7 @@ class AppliancesPluginToCoreCommand extends AbstractCommand {
             'id'      => $env['id'],
             'name'    => $env['name'],
             'comment' => $env['comment']
-         ], true);
+         ]);
 
          $appe = new ApplianceEnvironment();
          if (!($appe_id = $appe->getFromDBByCrit($app_fields))) {
@@ -540,7 +540,7 @@ class AppliancesPluginToCoreCommand extends AbstractCommand {
             'externalidentifier'       => $appliance['externalid'],
             'serial'                   => $appliance['serial'],
             'otherserial'              => $appliance['otherserial']
-         ], true);
+         ]);
 
          $app = new Appliance();
          if (!($app_id = $app->getFromDBByCrit($app_fields))) {
@@ -601,7 +601,7 @@ class AppliancesPluginToCoreCommand extends AbstractCommand {
             'name'               => $type['name'],
             'comment'            => $type['comment'],
             'externalidentifier' => $type['externalid']
-         ], true);
+         ]);
 
          $appt = new ApplianceType();
          if (!($appt_id = $appt->getFromDBByCrit($appt_fields))) {
@@ -692,7 +692,7 @@ class AppliancesPluginToCoreCommand extends AbstractCommand {
             'appliances_items_id' => $row['plugin_appliances_appliances_items_id'],
             'itemtype'            => $itemtype,
             'items_id'            => $row['relations_id']
-         ], true);
+         ]);
 
          $appr = new Appliance_Item_Relation();
          if (!($appr_id = $appr->getFromDBByCrit($appr_fields))) {

--- a/inc/console/migration/racksplugintocorecommand.class.php
+++ b/inc/console/migration/racksplugintocorecommand.class.php
@@ -602,7 +602,7 @@ class RacksPluginToCoreCommand extends AbstractCommand {
             $new_model_fields = Sanitizer::sanitize([
                'name'    => $othermodel['name'],
                'comment' => $othermodel['comment'],
-            ], true);
+            ]);
 
             if (!($new_model_id = $new_model->getFromDBByCrit($new_model_fields))
                 && !($new_model_id = $new_model->add($new_model_fields))) {
@@ -655,7 +655,7 @@ class RacksPluginToCoreCommand extends AbstractCommand {
                                        : $otheritem['id'],
                      'entities_id' => $otheritem['entities_id'],
                      $fk_new_model => $new_model_id
-                  ], true);
+                  ]);
 
                   $new_item = new $new_itemtype();
 
@@ -831,8 +831,7 @@ class RacksPluginToCoreCommand extends AbstractCommand {
                [
                   'name'    => $old_model['name'],
                   'comment' => $old_model['comment'],
-               ],
-               true
+               ]
             );
 
             if (!($rackmodel_id = $rackmodel->getFromDBByCrit($rackmodel_fields))
@@ -912,8 +911,7 @@ class RacksPluginToCoreCommand extends AbstractCommand {
                   'entities_id'  => $old_type['entities_id'],
                   'is_recursive' => $old_type['is_recursive'],
                   'comment'      => $old_type['comment'],
-               ],
-               true
+               ]
             );
 
             if (!($racktype_id = $racktype->getFromDBByCrit($racktype_fields))
@@ -991,8 +989,7 @@ class RacksPluginToCoreCommand extends AbstractCommand {
                [
                   'name'      => $old_state['name'],
                   'states_id' => 0,
-               ],
-               true
+               ]
             );
 
             if (!($state_id = $state->getFromDBByCrit($state_fields))) {
@@ -1079,8 +1076,7 @@ class RacksPluginToCoreCommand extends AbstractCommand {
                   'datacenters_id' => $this->datacenter_id,
                   'vis_cols'       => 10,
                   'vis_rows'       => 10,
-               ],
-               true
+               ]
             );
 
             if (!($room_id = $room->getFromDBByCrit($room_fields))
@@ -1205,8 +1201,7 @@ class RacksPluginToCoreCommand extends AbstractCommand {
                   'is_deleted'       => $old_rack['is_deleted'],
                   'dcrooms_id'       => $room_id,
                   'bgcolor'          => "#FEC95C",
-               ],
-               true
+               ]
             );
 
             if (!($rack_id = $rack->getFromDBByCrit($rack_fields))) {

--- a/inc/contenttemplates/templatemanager.class.php
+++ b/inc/contenttemplates/templatemanager.class.php
@@ -58,21 +58,16 @@ class TemplateManager
    /**
     * Boiler plate code to render a template
     *
-    * @param string $content           Template content (html + twig)
-    * @param array $params             Variables to be exposed to the templating engine
-    * @param bool $sanitized_content   Indicates whether the content has been transformed by GLPI sanitize process
+    * @param string $content  Template content (html + twig)
+    * @param array $params    Variables to be exposed to the templating engine
     *
     * @return string The rendered HTML
     */
    public static function render(
       string $content,
-      array $params,
-      bool $sanitized_content = false
+      array $params
    ): string {
-      // Unclean input if needed
-      if ($sanitized_content) {
-         $content = Sanitizer::unsanitize($content);
-      }
+      $content = Sanitizer::getVerbatimValue($content);
 
       // Init twig
       $loader = new ArrayLoader(['template' => $content]);
@@ -111,8 +106,7 @@ class TemplateManager
             [
                'itemtype' => $itil_item->getType(),
                $parameters->getDefaultNodeName() => $parameters->getValues($itil_item),
-            ],
-            true
+            ]
          );
       } catch (\Twig\Error\Error $e) {
          global $GLPI;
@@ -124,16 +118,13 @@ class TemplateManager
    /**
     * Boiler plate code to validate a template that user is trying to submit
     *
-    * @param string $content           Template content (html + twig)
-    * @param bool $sanitized_content   Indicates whether the content has been transformed by GLPI sanitize process
-    * @param null|string $err_msg      Reference to variable that will be filled by error message if validation fails
+    * @param string $content        Template content (html + twig)
+    * @param null|string $err_msg   Reference to variable that will be filled by error message if validation fails
     *
     * @return bool
     */
-   public static function validate(string $content, bool $sanitized_content = false, ?string &$err_msg = null): bool {
-      if ($sanitized_content) {
-         $content = Sanitizer::unsanitize($content);
-      }
+   public static function validate(string $content, ?string &$err_msg = null): bool {
+      $content = Sanitizer::getVerbatimValue($content);
 
       $twig = new Environment(new ArrayLoader(['template' => $content]));
       $twig->addExtension(new SandboxExtension(self::getSecurityPolicy(), true));

--- a/inc/dbutils.class.php
+++ b/inc/dbutils.class.php
@@ -1544,9 +1544,10 @@ final class DbUtils {
 
       $base_name = $objectName;
 
-      $is_sanitized = Sanitizer::isSanitized($objectName);
-      if ($is_sanitized) {
-         $objectName = Sanitizer::unsanitize($objectName);
+      $objectName = Sanitizer::unsanitize($objectName);
+      $was_sanitized = $objectName !== $base_name;
+      if ($was_sanitized) {
+         Toolbox::deprecated('Handling of encoded/escaped value in autoName() is deprecated.');
       }
 
       $matches = [];
@@ -1680,7 +1681,7 @@ final class DbUtils {
          $autoNum
       );
 
-      if ($is_sanitized) {
+      if ($was_sanitized) {
          $objectName = Sanitizer::sanitize($objectName);
       }
 

--- a/inc/dbutils.class.php
+++ b/inc/dbutils.class.php
@@ -1682,7 +1682,7 @@ final class DbUtils {
       );
 
       if ($was_sanitized) {
-         $objectName = Sanitizer::sanitize($objectName);
+         $objectName = Sanitizer::sanitize($objectName, false);
       }
 
       return $objectName;

--- a/inc/features/usermention.class.php
+++ b/inc/features/usermention.class.php
@@ -179,7 +179,7 @@ trait UserMention {
 
       try {
          if ($sanitized) {
-            $content = Sanitizer::unsanitize($content, true);
+            $content = Sanitizer::unsanitize($content);
          }
          libxml_use_internal_errors(true);
          $content_as_xml = new SimpleXMLElement('<div>' . $content . '</div>');

--- a/inc/features/usermention.class.php
+++ b/inc/features/usermention.class.php
@@ -77,14 +77,14 @@ trait UserMention {
          if ($new_value !== null) {
             $mentionned_actors_ids = array_merge(
                $mentionned_actors_ids,
-               $this->getUserIdsFromUserMentions($new_value, true)
+               $this->getUserIdsFromUserMentions($new_value)
             );
          }
 
          if ($previous_value !== null) {
             $previously_mentionned_actors_ids = array_merge(
                $previously_mentionned_actors_ids,
-               $this->getUserIdsFromUserMentions($previous_value, true)
+               $this->getUserIdsFromUserMentions($previous_value)
             );
          }
       }
@@ -170,17 +170,15 @@ trait UserMention {
     * Extract ids of mentionned users.
     *
     * @param string $content
-    * @param bool $sanitized
     *
     * @return int[]
     */
-   protected function getUserIdsFromUserMentions(string $content, bool $sanitized = false) {
+   protected function getUserIdsFromUserMentions(string $content) {
       $ids = [];
 
       try {
-         if ($sanitized) {
-            $content = Sanitizer::unsanitize($content);
-         }
+         $content = Sanitizer::getVerbatimValue($content);
+
          libxml_use_internal_errors(true);
          $content_as_xml = new SimpleXMLElement('<div>' . $content . '</div>');
       } catch (\Throwable $e) {

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3841,7 +3841,7 @@ JAVASCRIPT
          echo "<tr><th>KEY</th><th>=></th><th>VALUE</th></tr>";
 
          foreach ($tab as $key => $val) {
-            $key = Sanitizer::sanitize($key);
+            $key = Sanitizer::sanitize($key, false);
             echo "<tr><td>";
             echo $key;
             $is_array = is_array($val);

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -71,20 +71,20 @@ if (isset($_POST)) {
    if (isset($_POST['_glpi_simple_form'])) {
       $_POST = array_map('urldecode', $_POST);
    }
-   $_POST = Sanitizer::sanitize($_POST, true);
+   $_POST = Sanitizer::sanitize($_POST);
 }
 if (isset($_GET)) {
    $_UGET = $_GET; //keep raw, as a workaround
-   $_GET  = Sanitizer::sanitize($_GET, true);
+   $_GET  = Sanitizer::sanitize($_GET);
 }
 if (isset($_REQUEST)) {
    $_UREQUEST = $_REQUEST; //keep raw, as a workaround
-   $_REQUEST  = Sanitizer::sanitize($_REQUEST, true);
+   $_REQUEST  = Sanitizer::sanitize($_REQUEST);
 }
 if (isset($_FILES)) {
    $_UFILES = $_FILES; //keep raw, as a workaround
    foreach ($_FILES as &$file) {
-      $file['name'] = Sanitizer::sanitize($file['name'], true);
+      $file['name'] = Sanitizer::sanitize($file['name']);
    }
 }
 unset($file);

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -1224,7 +1224,7 @@ class MailCollector  extends CommonDBTM {
          }
       }
 
-      $tkt = Sanitizer::sanitize($tkt, true);
+      $tkt = Sanitizer::sanitize($tkt);
       $tkt['name']    = LitEmoji::encodeShortcode($tkt['name']);
       return $tkt;
    }
@@ -1285,7 +1285,7 @@ class MailCollector  extends CommonDBTM {
    **/
    function cleanSubject($text) {
       $text = str_replace("=20", "\n", $text);
-      $text =  Sanitizer::sanitize($text);
+      $text =  Sanitizer::sanitize($text, false);
       return $text;
    }
 

--- a/inc/notificationajax.class.php
+++ b/inc/notificationajax.class.php
@@ -88,7 +88,7 @@ class NotificationAjax implements NotificationInterface {
 
       $queue = new QueuedNotification();
 
-      if (!$queue->add(Sanitizer::sanitize($data, true))) {
+      if (!$queue->add(Sanitizer::sanitize($data))) {
          Session::addMessageAfterRedirect(__('Error inserting browser notification to queue'), true, ERROR);
          return false;
       } else {

--- a/inc/notificationmailing.class.php
+++ b/inc/notificationmailing.class.php
@@ -158,7 +158,7 @@ class NotificationMailing implements NotificationInterface {
 
       $queue = new QueuedNotification();
 
-      if (!$queue->add(Sanitizer::sanitize($data, true))) {
+      if (!$queue->add(Sanitizer::sanitize($data))) {
          Session::addMessageAfterRedirect(__('Error inserting email to queue'), true, ERROR);
          return false;
       } else {

--- a/inc/notificationtemplatetranslation.class.php
+++ b/inc/notificationtemplatetranslation.class.php
@@ -259,7 +259,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
       $txt = RichText::getTextFromHtml($txt, true);
 
       // Sanitize result
-      $txt = Sanitizer::sanitize($txt, true);
+      $txt = Sanitizer::sanitize($txt);
 
       if (!$txt) {
          // No HTML (nothing to display)

--- a/inc/notificationtemplatetranslation.class.php
+++ b/inc/notificationtemplatetranslation.class.php
@@ -253,7 +253,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
    static function cleanContentHtml(array $input) {
 
       // Unsanitize
-      $txt = Sanitizer::unsanitize($input['content_html'], true);
+      $txt = Sanitizer::unsanitize($input['content_html']);
 
       // Get as text plain text
       $txt = RichText::getTextFromHtml($txt, true);

--- a/inc/ruleticket.class.php
+++ b/inc/ruleticket.class.php
@@ -239,7 +239,7 @@ class RuleTicket extends Rule {
                         $solution_content = $template->getRenderedContent($parent);
 
                         // Sanitize generated HTML before adding it in DB
-                        $solution_content = Sanitizer::sanitize($solution_content, true);
+                        $solution_content = Sanitizer::sanitize($solution_content);
 
                         $solution = new ITILSolution();
                         $solution->add([

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -330,7 +330,8 @@ class Toolbox {
    **/
    static function unclean_cross_side_scripting_deep($value) {
       Toolbox::deprecated('Use "Glpi\Toolbox\Sanitizer::unsanitize()"');
-      return Sanitizer::unsanitize($value);
+      global $DB;
+      return $DB->escape(Sanitizer::unsanitize($value));
    }
 
    /**
@@ -2499,7 +2500,7 @@ class Toolbox {
                      //retrieve dimensions
                      $width = $height = null;
                      $attributes = [];
-                     preg_match_all('/(width|height)=\\\"([^"]*)\\\"/i', $match_img, $attributes);
+                     preg_match_all('/(width|height)="([^"]*)"/i', $match_img, $attributes);
                      if (isset($attributes[1][0])) {
                         ${$attributes[1][0]} = $attributes[2][0];
                      }

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -313,7 +313,7 @@ class Toolbox {
    **/
    static function clean_cross_side_scripting_deep($value) {
       Toolbox::deprecated('Use "Glpi\Toolbox\Sanitizer::sanitize()"');
-      return Sanitizer::sanitize($value);
+      return Sanitizer::sanitize($value, false);
    }
 
 
@@ -2491,7 +2491,7 @@ class Toolbox {
 
                   // 1 - Replace direct tag (with prefix and suffix) by the image
                   $content_text = preg_replace('/'.Document::getImageTag($image['tag']).'/',
-                                               Sanitizer::sanitize($img), $content_text);
+                                               Sanitizer::sanitize($img, false), $content_text);
 
                   // 2 - Replace img with tag in id attribute by the image
                   $regex = '/<img[^>]+' . preg_quote($image['tag'], '/') . '[^<]+>/im';
@@ -2531,7 +2531,7 @@ class Toolbox {
                         $new_image,
                         Sanitizer::unsanitize($content_text)
                      );
-                     $content_text = Sanitizer::sanitize($content_text);
+                     $content_text = Sanitizer::sanitize($content_text, false);
                   }
 
                   // If the tag is from another ticket : link document to ticket

--- a/inc/toolbox/sanitizer.class.php
+++ b/inc/toolbox/sanitizer.class.php
@@ -32,8 +32,6 @@
 
 namespace Glpi\Toolbox;
 
-use Toolbox;
-
 class Sanitizer {
 
    private const CHARS_MAPPING = [
@@ -260,9 +258,8 @@ class Sanitizer {
     * @return string
     */
    private static function dbEscape(string $value): string {
-      // TODO Toolbox::addslashes_deep() should be moved in current class,
-      // but it is widely used, so it will be done later.
-      return Toolbox::addslashes_deep($value);
+      global $DB;
+      return $DB->escape($value);
    }
 
    /**

--- a/inc/toolbox/sanitizer.class.php
+++ b/inc/toolbox/sanitizer.class.php
@@ -48,13 +48,14 @@ class Sanitizer {
    /**
     * Sanitize a value. Resulting value will have its HTML special chars converted into entities
     * and would be printable in a HTML document without having to be escaped.
+    * Also, DB special chars can be escaped to prevent SQL injections.
     *
     * @param mixed $value
     * @param bool  $db_escape
     *
     * @return mixed
     */
-   public static function sanitize($value, bool $db_escape = false) {
+   public static function sanitize($value, bool $db_escape = true) {
       if (is_array($value)) {
          return array_map(
             function ($val) use ($db_escape) {

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -608,7 +608,7 @@ class User extends CommonDBTM {
             if ($input["password"] == $input["password2"]) {
                if (Config::validatePassword($input["password"])) {
                   $input["password"]
-                     = Auth::getPasswordHash(Sanitizer::unsanitize(stripslashes($input["password"])));
+                     = Auth::getPasswordHash(Sanitizer::unsanitize($input["password"]));
 
                   $input['password_last_update'] = $_SESSION['glpi_currenttime'];
                } else {
@@ -804,7 +804,7 @@ class User extends CommonDBTM {
                                -strtotime($this->fields['password_forget_token_date'])) < DAY_TIMESTAMP)
                            && $this->isEmail($input['email'])))) {
                   $input["password"]
-                     = Auth::getPasswordHash(Sanitizer::unsanitize($input["password"], true));
+                     = Auth::getPasswordHash(Sanitizer::unsanitize($input["password"]));
 
                   $input['password_last_update'] = $_SESSION["glpi_currenttime"];
                } else {

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -182,7 +182,7 @@ class DbTestCase extends \GLPITestCase {
     */
    protected function createItem($itemtype, $input): CommonDBTM {
       $item = new $itemtype();
-      $input = Sanitizer::sanitize($input, true);
+      $input = Sanitizer::sanitize($input);
       $id = $item->add($input);
       $this->integer($id)->isGreaterThan(0);
 
@@ -205,7 +205,7 @@ class DbTestCase extends \GLPITestCase {
    protected function updateItem($itemtype, $id, $input) {
       $item = new $itemtype();
       $input['id'] = $id;
-      $input = Sanitizer::sanitize($input, true);
+      $input = Sanitizer::sanitize($input);
       $success = $item->update($input);
       $this->boolean($success)->isTrue();
 

--- a/tests/functionnal/RuleTicket.php
+++ b/tests/functionnal/RuleTicket.php
@@ -483,7 +483,7 @@ class RuleTicket extends DbTestCase {
       $this->boolean($itilSolution->getFromDBByCrit([
          'items_id' => $tickets_id,
          'itemtype' => 'Ticket',
-         'content'  => Sanitizer::sanitize("<p>content of solution template  white ' quote</p>", true)
+         'content'  => Sanitizer::sanitize("<p>content of solution template  white ' quote</p>")
       ]))->isTrue();
 
       $this->integer((int)$itilSolution->getID())->isGreaterThan(0);
@@ -870,7 +870,7 @@ class RuleTicket extends DbTestCase {
       $this->array($ticket_tasks)->hasSize(1);
       $task_data = array_pop($ticket_tasks);
       $this->array($task_data)->hasKey('content');
-      $this->string($task_data['content'])->isEqualTo(Sanitizer::sanitize('<p>test content</p>'));
+      $this->string($task_data['content'])->isEqualTo(Sanitizer::sanitize('<p>test content</p>', false));
 
       // Test on update
       $ticket_em = new \Ticket();
@@ -900,7 +900,7 @@ class RuleTicket extends DbTestCase {
       $task_data = array_pop($ticket_tasks);
       $this->array($task_data)->hasKey('content');
       $this->string($task_data['content'])->isEqualTo(
-         Sanitizer::sanitize('<p>test content</p>')
+         Sanitizer::sanitize('<p>test content</p>', false)
       );
 
       // Add a second action to the rule (test multiple creation)
@@ -930,13 +930,13 @@ class RuleTicket extends DbTestCase {
       $task_data = array_pop($ticket_tasks);
       $this->array($task_data)->hasKey('content');
       $this->string($task_data['content'])->isEqualTo(
-         Sanitizer::sanitize('<p>test content 2</p>')
+         Sanitizer::sanitize('<p>test content 2</p>', false)
       );
 
       $task_data = array_pop($ticket_tasks);
       $this->array($task_data)->hasKey('content');
       $this->string($task_data['content'])->isEqualTo(
-         Sanitizer::sanitize('<p>test content</p>')
+         Sanitizer::sanitize('<p>test content</p>', false)
       );
    }
 
@@ -1001,7 +1001,7 @@ class RuleTicket extends DbTestCase {
       $ticket_followups_data = array_pop($ticket_followups);
       $this->array($ticket_followups_data)->hasKey('content');
       $this->string($ticket_followups_data['content'])->isEqualTo(
-         Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule</p>')
+         Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule</p>', false)
       );
 
       // Test on update
@@ -1036,7 +1036,7 @@ class RuleTicket extends DbTestCase {
       $ticket_followups_data = array_pop($ticket_followups);
       $this->array($ticket_followups_data)->hasKey('content');
       $this->string($ticket_followups_data['content'])->isEqualTo(
-         Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule</p>')
+         Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule</p>', false)
       );
 
       // Add a second action to the rule (test multiple creation)
@@ -1068,13 +1068,13 @@ class RuleTicket extends DbTestCase {
       $ticket_followups_data = array_pop($ticket_followups);
       $this->array($ticket_followups_data)->hasKey('content');
       $this->string($ticket_followups_data['content'])->isEqualTo(
-         Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule 2</p>')
+         Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule 2</p>', false)
       );
 
       $ticket_followups_data = array_pop($ticket_followups);
       $this->array($ticket_followups_data)->hasKey('content');
       $this->string($ticket_followups_data['content'])->isEqualTo(
-         Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule</p>')
+         Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule</p>', false)
       );
    }
 

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -243,7 +243,7 @@ class Ticket extends DbTestCase {
 
       // 6.1 -> check first task
       $taskA = array_shift($found_tasks);
-      $this->string($taskA['content'])->isIdenticalTo(Sanitizer::sanitize('<p>my task template A</p>'));
+      $this->string($taskA['content'])->isIdenticalTo(Sanitizer::sanitize('<p>my task template A</p>', false));
       $this->variable($taskA['taskcategories_id'])->isEqualTo($taskcat_id);
       $this->variable($taskA['actiontime'])->isEqualTo(60);
       $this->variable($taskA['is_private'])->isEqualTo(1);
@@ -253,7 +253,7 @@ class Ticket extends DbTestCase {
 
       // 6.2 -> check second task
       $taskB = array_shift($found_tasks);
-      $this->string($taskB['content'])->isIdenticalTo(Sanitizer::sanitize('<p>my task template B</p>'));
+      $this->string($taskB['content'])->isIdenticalTo(Sanitizer::sanitize('<p>my task template B</p>', false));
       $this->variable($taskB['taskcategories_id'])->isEqualTo($taskcat_id);
       $this->variable($taskB['actiontime'])->isEqualTo(120);
       $this->variable($taskB['is_private'])->isEqualTo(0);

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -580,7 +580,7 @@ class Toolbox extends DbTestCase {
 
       // Processed data is expected to be escaped
       $content_text = \Toolbox::addslashes_deep($content_text);
-      $expected_result = Sanitizer::sanitize($expected_result);
+      $expected_result = Sanitizer::sanitize($expected_result, false);
 
       $this->string(
          \Toolbox::convertTagToImage($content_text, $item, [$doc_id => ['tag' => $img_tag]])
@@ -636,7 +636,7 @@ class Toolbox extends DbTestCase {
 
       // Processed data is expected to be escaped
       $content_text = \Toolbox::addslashes_deep($content_text);
-      $expected_result = Sanitizer::sanitize($expected_result);
+      $expected_result = Sanitizer::sanitize($expected_result, false);
 
       // Save old config
       global $CFG_GLPI;
@@ -709,7 +709,7 @@ class Toolbox extends DbTestCase {
 
       // Processed data is expected to be escaped
       $content_text = \Toolbox::addslashes_deep($content_text);
-      $expected_result = Sanitizer::sanitize($expected_result);
+      $expected_result = Sanitizer::sanitize($expected_result, false);
 
       $this->string(
          \Toolbox::convertTagToImage($content_text, $item, $doc_data)
@@ -753,8 +753,8 @@ class Toolbox extends DbTestCase {
 
       // Processed data is expected to be escaped
       $content_text = \Toolbox::addslashes_deep($content_text);
-      $expected_result_1 = Sanitizer::sanitize($expected_result_1);
-      $expected_result_2 = Sanitizer::sanitize($expected_result_2);
+      $expected_result_1 = Sanitizer::sanitize($expected_result_1, false);
+      $expected_result_2 = Sanitizer::sanitize($expected_result_2, false);
 
       $this->string(
          \Toolbox::convertTagToImage($content_text, $item, [$doc_id_1 => ['tag' => $img_tag]])
@@ -793,7 +793,7 @@ class Toolbox extends DbTestCase {
 
       // Processed data is expected to be escaped
       $content_text = \Toolbox::addslashes_deep($content_text);
-      $expected_result = Sanitizer::sanitize($expected_result);
+      $expected_result = Sanitizer::sanitize($expected_result, false);
 
       $this->string(
          \Toolbox::convertTagToImage($content_text, $item, [$doc_id => ['tag' => $img_tag]])

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -827,7 +827,7 @@ HTML,
       ];
 
       foreach ($expected_followups as $expected_followup) {
-         $this->integer(countElementsInTable(ITILFollowup::getTable(), Sanitizer::sanitize($expected_followup, true)))->isEqualTo(1);
+         $this->integer(countElementsInTable(ITILFollowup::getTable(), Sanitizer::sanitize($expected_followup)))->isEqualTo(1);
       }
    }
 

--- a/tests/units/Glpi/ContentTemplates/TemplateManager.php
+++ b/tests/units/Glpi/ContentTemplates/TemplateManager.php
@@ -86,41 +86,24 @@ class TemplateManager extends GLPITestCase
             'params'    => ['content' => '<p>Item content</p>'],
             'expected'  => '<h1>Test sanitized template</h1><hr /><p>Item content</p>',
             'error'     => null,
-            'sanitized' => true
          ],
          [
             'content'   => '&#60;h1&#62;Test sanitized template 2&#60;/h1&#62;&#60;hr /&#62;{{content|raw}}',
             'params'    => ['content' => 'Item content should not be unsanitized: &#60;--'],
             'expected'  => '<h1>Test sanitized template 2</h1><hr />Item content should not be unsanitized: &#60;--',
             'error'     => null,
-            'sanitized' => true
-         ],
-         [
-            'content'   => '&#60;h1&#62;Test misused sanitized input&#60;/h1&#62;&#60;hr /&#62;{{content|raw}}',
-            'params'    => ['content' => '<p>Item content</p>'],
-            'expected'  => '&#60;h1&#62;Test misused sanitized input&#60;/h1&#62;&#60;hr /&#62;<p>Item content</p>',
-            'error'     => null,
-            'sanitized' => false
          ],
          [
             'content'   => "&#60;p&#62;Test sanitized template {% if count &#62; 5 %}&#60;b&#62;++&#60;/b&#62;{% endif %}&#60;/p&#62;",
             'params'    => ['count' => 25],
             'expected'  => "<p>Test sanitized template <b>++</b></p>",
             'error'     => null,
-            'sanitized' => true
-         ],
-         [
-            'content'   => "Test invalid on missing unsanitizing {% if count &#62; 5 %}test{% endif %}",
-            'params'    => [],
-            'expected'  => "",
-            'error'     => 'Invalid twig template syntax',
          ],
          [
             'content'   => '&#60;h1 onclick="alert(1);"&#62;Test safe HTML2&#60;/h1&#62;&#60;hr /&#62;{{content|raw}}',
             'params'    => ['content' => 'Fill this form:<iframe src="phishing.php"></iframe>'],
             'expected'  => '<h1>Test safe HTML2</h1><hr />Fill this form:',
             'error'     => null,
-            'sanitized' => true
          ],
       ];
    }
@@ -132,8 +115,7 @@ class TemplateManager extends GLPITestCase
       string $content,
       array $params,
       string $expected,
-      ?string $error = null,
-      bool $sanitized = false
+      ?string $error = null
    ): void {
       $manager = $this->newTestedInstance();
 
@@ -141,13 +123,13 @@ class TemplateManager extends GLPITestCase
 
       if ($error !== null) {
          $this->exception(
-            function () use ($manager, $content, $params, $sanitized, &$html) {
-               $html = $manager->render($content, $params, $sanitized);
+            function () use ($manager, $content, $params, &$html) {
+               $html = $manager->render($content, $params);
             }
          );
          return;
       } else {
-         $html = $manager->render($content, $params, $sanitized);
+         $html = $manager->render($content, $params);
       }
 
       $this->string($html)->isEqualTo($expected);
@@ -160,12 +142,11 @@ class TemplateManager extends GLPITestCase
       string $content,
       array $params,
       string $expected,
-      ?string $error = null,
-      bool $sanitized = false
+      ?string $error = null
    ): void {
       $manager = $this->newTestedInstance();
       $err_msg = null;
-      $is_valid = $manager->validate($content, $sanitized, $err_msg);
+      $is_valid = $manager->validate($content, $err_msg);
       $this->boolean($is_valid)->isEqualTo(empty($error));
 
       // Handle error if neeced

--- a/tests/units/Glpi/Toolbox/DataExport.php
+++ b/tests/units/Glpi/Toolbox/DataExport.php
@@ -60,7 +60,7 @@ $(function(){\$('#Ticket1').qtip({
 
 //]]>
 </script>
-HTML),
+HTML, false),
          'expected_result' => "Ticket title ",
       ];
    }

--- a/tests/units/Glpi/Toolbox/RichText.php
+++ b/tests/units/Glpi/Toolbox/RichText.php
@@ -76,7 +76,12 @@ class RichText extends \GLPITestCase {
 XML;
       $content = '<h1>XML example</h1>' . "\n" . htmlentities($xml_sample);
       yield [
-         'content'                => Sanitizer::sanitize($content),
+         'content'                => Sanitizer::sanitize($content, false), // Without quotes escaping
+         'encode_output_entities' => false,
+         'expected_result'        => $content,
+      ];
+      yield [
+         'content'                => Sanitizer::sanitize($content, true), // With quotes escaping
          'encode_output_entities' => false,
          'expected_result'        => $content,
       ];
@@ -351,16 +356,23 @@ HTML,
   <url>http://www.glpi-project.org/void?test=1&amp;debug=1</url>
 </root>
 XML;
+      $content = '<h1>XML example</h1>' . "\n" . htmlentities($xml_sample);
+      $result  = <<<PLAINTEXT
+XML example <?xml version="1.0" encoding="UTF-8"?> <root> <desc><![CDATA[Some CDATA content]]></desc> <url>http://www.glpi-project.org/void?test=1&amp;debug=1</url> </root>
+PLAINTEXT;
       yield [
-         'content'                => Sanitizer::sanitize(
-            '<h1>XML example</h1>' . "\n" . htmlentities($xml_sample)
-         ),
+         'content'                => Sanitizer::sanitize($content, false), // Without quotes escaping
          'keep_presentation'      => false,
          'compact'                => false,
          'encode_output_entities' => false,
-         'expected_result'        => <<<PLAINTEXT
-XML example <?xml version="1.0" encoding="UTF-8"?> <root> <desc><![CDATA[Some CDATA content]]></desc> <url>http://www.glpi-project.org/void?test=1&amp;debug=1</url> </root>
-PLAINTEXT,
+         'expected_result'        => $result,
+      ];
+      yield [
+         'content'                => Sanitizer::sanitize($content, true), // With quotes escaping
+         'keep_presentation'      => false,
+         'compact'                => false,
+         'encode_output_entities' => false,
+         'expected_result'        => $result,
       ];
 
       // Simple text without presentation from complex HTML

--- a/tests/units/Glpi/Toolbox/Sanitizer.php
+++ b/tests/units/Glpi/Toolbox/Sanitizer.php
@@ -84,6 +84,11 @@ class Sanitizer extends \GLPITestCase {
          'sanitized_value' => "text with ending slashable chars \'\\n\\\"",
          'add_slashes'     => true,
       ];
+      yield [
+         'value'           => "<p>HTML containing a code snippet</p><pre>&lt;a href=&quot;/test&quot;&gt;link&lt;/a&gt;</pre>",
+         'sanitized_value' => "&#60;p&#62;HTML containing a code snippet&#60;/p&#62;&#60;pre&#62;&#38;lt;a href=&#38;quot;/test&#38;quot;&#38;gt;link&#38;lt;/a&#38;gt;&#60;/pre&#62;",
+         'add_slashes'     => true,
+      ];
 
       // Strings in array should be sanitized
       yield [
@@ -352,5 +357,23 @@ TXT;
       $sanitizer = $this->newTestedInstance();
 
       $this->boolean($sanitizer->isDbEscaped($value))->isEqualTo($is_escaped, $value);
+   }
+
+   /**
+    * @dataProvider rawValueProvider
+    */
+   public function testSanitizationReversibility(
+      $value,
+      $sanitized_value,
+      bool $add_slashes = false
+   ) {
+      $sanitizer = $this->newTestedInstance();
+
+      // Value should stay the same if it has been sanitized then unsanitized
+      $this->variable($sanitizer->unsanitize($sanitizer->sanitize($value, true)))->isEqualTo($value);
+      $this->variable($sanitizer->unsanitize($sanitizer->sanitize($value, false)))->isEqualTo($value);
+
+      // Re-sanitize a value provide the same result as first sanitization
+      $this->variable($sanitizer->sanitize($sanitizer->unsanitize($value), $add_slashes))->isEqualTo($sanitized_value);
    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Each commit should be reviewed separately.

1. :warning: Plan some headache medication for this one.
Having to precise whether content has its BD special chars escaped or not in `Sanitizer::unsanitize()` will certainly lead to same bugs as we already had, due to the fact that sometimes it is nearly impossible for the developper to know if the value to unsanitize comes from the `$_GET|POST|REQUEST` (in this case DB special chars are escaped) or comes from the DB itself (in this case DB special chars are not escaped). Automatically detecting this escaping state will prevent this kind of issues.
I added lots of tests to ensure this detection is bulletproof. Do not hesitate to propose other tests cases.

2. Some `Glpi\ContentTemplates\TemplateManager` and `Glpi\Features\UserMention` methods had a `$sanitized` parameter used to indicates whether the passed content was sanitized. For same reasons, automatically detecting ot seems a better solution.

3. I found an issue with current handling of DB special chars. To fix #1264, HTML entities corresponding to quotes were replaced by real quotes in sanitization process. The problem with this is that code snippets containing encoded HTML/XML was corrupted (i.e. `&lt;a href=&quot;/test&quot;&gt;` was sanitized to `&#38;lt;a href=\"/test\"&#38;gt;`, then unsanitized to `&lt;a href="/test"&gt;`).
This this replacement of quotes HTML entities is no longer necessary since #9011, as it was due to issues with multiple encoding/decoding conflicting operations that are no longer done.

4. `Sanitizer::sanitize()` is mainly used to sanitize raw values before passing them to `CommonDBTM::add()` or `CommonDBTM::update()` methods. I think that escaping DB chars by default is more secure (may prevent DB injections). Conversely, people who just want to sanitize a value to display it in a page will just get extra backslashes if the misuse the `$db_escape` param. This will be just a small display issue that would be easy to fix.