### PR TITLE
FAQ: Fix full text search with illegal chars

### DIFF
--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -1247,8 +1247,18 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
          case 'search' :
             if (strlen($params["contains"]) > 0) {
                $search  = Toolbox::unclean_cross_side_scripting_deep($params["contains"]);
-               $search_wilcard = explode(' ', $search);
-               $search_wilcard = implode('* ', $search_wilcard).'*';
+
+               // Replace all non word characters with spaces (see: https://stackoverflow.com/a/26537463)
+               $search_wilcard = preg_replace('/[^\p{L}\p{N}_]+/u', ' ', $search);
+
+               // Remove last space to avoid illegal syntax with " *"
+               $search_wilcard = trim($search_wilcard);
+
+               // Merge spaces since we are using them to split the string later
+               $search_wilcard = preg_replace('!\s+!', ' ', $search_wilcard);
+
+               $search_wilcard = explode(' ', $search_wilcard);
+               $search_wilcard = (implode('* ', $search_wilcard).'*');
 
                $addscore = [];
                if (KnowbaseItemTranslation::isKbTranslationActive()

--- a/tests/functionnal/KnowbaseItem.php
+++ b/tests/functionnal/KnowbaseItem.php
@@ -325,4 +325,39 @@ class KnowbaseItem extends DbTestCase {
          ->hasSize(1)
          ->contains(-1);
    }
+
+   protected function testGetListRequestProvider(): array {
+      return [
+         [
+            'params' => [
+               'knowbaseitemcategories_id' => 0,
+               'faq' => false,
+               'contains' => "test1 ",
+            ],
+            'type' => 'search'
+         ],
+         [
+            'params' => [
+               'knowbaseitemcategories_id' => 0,
+               'faq' => false,
+               'contains' => "test1 / test2 ( test3 )",
+            ],
+            'type' => 'search'
+         ]
+      ];
+   }
+
+   /**
+    * @dataprovider testGetListRequestProvider
+    */
+   public function testGetListRequest(array $params, string $type): void {
+      global $DB;
+
+      // Build criteria array
+      $criteria = \KnowbaseItem::getListRequest($params, $type);
+      $this->array($criteria);
+
+      // Check that the request is valid
+      $DB->request($criteria);
+   }
 }


### PR DESCRIPTION
Some FAQ searches trigger an SQL error if they contains boolean search mode operators.

For example, this search:

![image](https://user-images.githubusercontent.com/42734840/139238048-93d0f625-11b9-461d-8d26-46ebd7081bfa.png)

Will trigger this error:
```sql
SELECT 
  `glpi_knowbaseitems`.*, 
  `glpi_knowbaseitemcategories`.`completename` AS `category`, 
  COUNT(
    `glpi_knowbaseitems_users`.`id`
  ) + COUNT(
    `glpi_groups_knowbaseitems`.`id`
  ) + COUNT(
    `glpi_knowbaseitems_profiles`.`id`
  ) + COUNT(
    `glpi_entities_knowbaseitems`.`id`
  ) AS `visibility_count`, 
  (
    MATCH(
      `glpi_knowbaseitems`.`name`, `glpi_knowbaseitems`.`answer`
    ) AGAINST(
      'test* /* test* (* test3* )*' IN BOOLEAN MODE
    )
  ) AS SCORE 
FROM 
  `glpi_knowbaseitems` 
  LEFT JOIN `glpi_knowbaseitems_users` ON (
    `glpi_knowbaseitems_users`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`
  ) 
  LEFT JOIN `glpi_groups_knowbaseitems` ON (
    `glpi_groups_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`
  ) 
  LEFT JOIN `glpi_knowbaseitems_profiles` ON (
    `glpi_knowbaseitems_profiles`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`
  ) 
  LEFT JOIN `glpi_entities_knowbaseitems` ON (
    `glpi_entities_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`
  ) 
  LEFT JOIN `glpi_knowbaseitemcategories` ON (
    `glpi_knowbaseitemcategories`.`id` = `glpi_knowbaseitems`.`knowbaseitemcategories_id`
  ) 
WHERE 
  (
    (
      (
        `glpi_knowbaseitems`.`name` LIKE '%test / test  test3%'
      ) 
      OR (
        `glpi_knowbaseitems`.`answer` LIKE '%test / test  test3%'
      )
    )
  ) 
  AND (
    (
      (
        (
          `glpi_knowbaseitems`.`begin_date` IS NULL
        ) 
        OR (
          `glpi_knowbaseitems`.`begin_date` < NOW()
        )
      )
    ) 
    AND (
      (
        (
          `glpi_knowbaseitems`.`end_date` IS NULL
        ) 
        OR (
          `glpi_knowbaseitems`.`end_date` > NOW()
        )
      )
    )
  ) 
GROUP BY 
  `glpi_knowbaseitems`.`id`, 
  `glpi_knowbaseitemcategories`.`completename` 
ORDER BY 
  `SCORE` DESC

  Error: syntax error, unexpected $end, expecting FTS_TERM or FTS_NUMB or '*'
  Backtrace :
  inc/dbmysqliterator.class.php:95                   
  inc/dbmysql.class.php:876                          DBmysqlIterator->execute()
  inc/knowbaseitem.class.php:1437                    DBmysql->request()
  inc/knowbase.class.php:135                         KnowbaseItem::showList()
  inc/knowbase.class.php:82                          Knowbase::showSearchView()
  inc/commonglpi.class.php:637                       Knowbase::displayTabContentForItem()
  ajax/common.tabs.php:106                           CommonGLPI::displayStandardTab()
```

I've also found that ending the search with an empty space will trigger an error too.

---

I've fixed this issue by removing all non words chars from the search and trimming the extra spaces.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22849
