### PR TITLE
Don't try to load TinyMCE English langs

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -3541,6 +3541,13 @@ JS;
       }
       $pluginsjs = json_encode($plugins);
 
+      $language_opts = '';
+      if ($language !== 'en_GB') {
+         $language_opts = json_encode([
+            'language' => $language,
+            'language_url' => $language_url
+         ]);
+      }
       // init tinymce
       $js = <<<JS
          $(function() {
@@ -3548,15 +3555,12 @@ JS;
             var richtext_layout = "{$_SESSION['glpirichtext_layout']}";
 
             // init editor
-            tinyMCE.init({
+            tinyMCE.init(Object.assign({
                selector: '#{$name}',
 
                plugins: {$pluginsjs},
 
                // Appearance
-               language: '{$language}',
-               language_url: '{$language_url}',
-
                skin_url: is_dark
                   ? CFG_GLPI['root_doc']+'/public/lib/tinymce/skins/ui/oxide-dark'
                   : CFG_GLPI['root_doc']+'/public/lib/tinymce/skins/ui/oxide',
@@ -3637,7 +3641,7 @@ JS;
                      submitparentForm($('#$name'));
                   });
                }
-            });
+            }, {$language_opts}));
          });
 JS;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

TinyMCE I18n doesn't provide English locale files anymore. Trying to load an English locale file (implicitly or as fallback) resulted in a request for the non-existing file which on my end took around 1 second. For English, we don't need to specify any of the language options.