### PR TITLE
Re-add item_form hooks support for ITILObjects

### DIFF
--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -16,6 +16,8 @@
       <div id="ticket-main" class="accordion-collapse collapse show" aria-labelledby="heading-main-ticket">
          <div class="accordion-body row m-0 mt-n2">
 
+            {{ call_plugin_hook('pre_item_form', {"item": item}) }}
+
             {% if is_multi_entities_mode() %}
                {% if item.isNewItem() %}
                   {{ fields.dropdownField(
@@ -193,6 +195,8 @@
                   field_options
                ) }}
             {% endif %}
+
+            {{ call_plugin_hook('post_item_form', {"item": item}) }}
          </div>
       </div>
    </div>

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -45,6 +45,7 @@
                action="{{ subitem.getFormURL() }}" enctype="multipart/form-data" data-track-changes="true">
             <input type="hidden" name="itemtype" value="{{ item.getType() }}" />
             <input type="hidden" name="items_id" value="{{ item.fields['id'] }}" />
+            {{ call_plugin_hook('pre_item_form', {"item": subitem}) }}
 
             {% set openfollowup = _get['_openfollowup'] ?? false %}
             {% if openfollowup %}
@@ -155,6 +156,7 @@
                </div>
             </div>
 
+            {{ call_plugin_hook('post_item_form', {"item": subitem}) }}
             <div class="d-flex card-footer mx-n3 mb-n3">
                {% if subitem.fields['id'] <= 0 %}
                   <div class="input-group">

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -47,6 +47,7 @@
             <input type="hidden" name="itemtype" value="{{ item.getType() }}" />
             <input type="hidden" name="items_id" value="{{ item.fields['id'] }}" />
             <input type="hidden" name="_no_message_link" value="1" />
+            {{ call_plugin_hook('pre_item_form', {"item": subitem}) }}
 
             {% if call('Ticket_Ticket::countOpenChildren', [item.fields['id']]) > 0 %}
                <div class="alert alert-important alert-warning">
@@ -175,6 +176,7 @@
             </div>
 
          {% if not noform %}
+               {{ call_plugin_hook('post_item_form', {"item": subitem}) }}
                <div class="d-flex card-footer mx-n3 mb-n3">
                   {% if subitem.fields['id'] <= 0 %}
                      <button class="btn btn-primary me-2" type="submit" name="add">

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -124,6 +124,7 @@
                action="{{ subitem.getFormURL() }}" enctype="multipart/form-data" data-track-changes="true">
             <input type="hidden" name="itemtype" value="{{ item.getType() }}" />
             <input type="hidden" name="{{ item.getForeignKeyField() }}" value="{{ item.fields['id'] }}" />
+            {{ call_plugin_hook('pre_item_form', {"item": subitem}) }}
 
             <div class="row">
                <div class="col-12 col-md-9">
@@ -316,6 +317,7 @@
                </div>
             </div>
 
+            {{ call_plugin_hook('post_item_form', {"item": subitem}) }}
             <div class="d-flex card-footer mx-n3 mb-n3">
                {% if subitem.fields['id'] <= 0 %}
                   <div class="input-group">

--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -14,6 +14,7 @@
                <input type="hidden" name="id" value="{{ entry_i['id'] }}" />
                <input type="hidden" name="users_id_validate" value="{{ entry_i['users_id_validate'] }}" />
                <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+               {{ call_plugin_hook('pre_item_form', {"item": subitem}) }}
 
                <div class="mb-3 comment-part">
                   {{ fields.textareaField(
@@ -110,6 +111,7 @@
                </div>
             </div>
 
+            {{ call_plugin_hook('post_item_form', {"item": subitem}) }}
             <div class="d-flex card-footer mx-n3 mb-n3">
                {% if subitem.fields['id'] <= 0 %}
                   <button class="btn btn-primary me-2" type="submit" name="add">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Without an actual form tab for ITILObjects, the `pre_item_form` and `post_item_form` hooks were never used in these items. This breaks compatibility at least with the Tags plugin. I added calls for these hooks at the start and end of the main accordion in the new sidebar.