### PR TITLE
Fix modal size

### DIFF
--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -212,8 +212,8 @@ HTML;
          }
 
          document.getElementById('iframe$domid').onload = function() {
-            var h =  $('#iframe{$domid}').contents().height();
-            var w =  $('#iframe{$domid}').contents().width();
+            var h =  {$param['height']};
+            var w =  {$param['width']};
 
             $('#iframe{$domid}')
                .height(h);

--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -212,8 +212,16 @@ HTML;
          }
 
          document.getElementById('iframe$domid').onload = function() {
-            var h =  {$param['height']};
-            var w =  {$param['width']};
+            if ({$param['height']} !== 'undefined') {
+               var h =  {$param['height']};
+            } else {
+               var h =  $('#iframe{$domid}').contents().height();
+            }
+            if ({$param['width']} !== 'undefined') {
+               var w =  {$param['width']};
+            } else {
+               var w =  $('#iframe{$domid}').contents().width();
+            }
 
             $('#iframe{$domid}')
                .height(h);


### PR DESCRIPTION
The createModalWindow function doesn't use width & height if you try to define it


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
