### PR TITLE
add timeline hook for plugins

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6419,6 +6419,8 @@ abstract class CommonITILObject extends CommonDBTM {
          }
       }
 
+      Plugin::doHook(Hooks::SHOW_IN_TIMELINE, ['item' => $this, 'timeline' => &$timeline]);
+
       //sort timeline items by date
       $reverse = $params['sort_by_date_desc'];
       usort($timeline, function($a, $b) use ($reverse) {

--- a/inc/plugin/hooks.class.php
+++ b/inc/plugin/hooks.class.php
@@ -98,6 +98,7 @@ class Hooks
    const PRE_SHOW_TAB            = 'pre_show_tab';
    const TIMELINE_ACTIONS        = 'timeline_actions';  // (keys: item, rand)
    const TIMELINE_ANSWER_ACTIONS = 'timeline_answer_actions';  // (keys: item)
+   const SHOW_IN_TIMELINE        = 'show_in_timeline';  // (keys: item)
 
    // Security hooks (data to encypt)
    const SECURED_FIELDS  = 'secured_fields';


### PR DESCRIPTION
If wanted, a plugin can add its informations on ticket timeline history


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
