### PR TITLE
Fix duplicate product_number field

### DIFF
--- a/inc/commondcmodeldropdown.class.php
+++ b/inc/commondcmodeldropdown.class.php
@@ -53,13 +53,6 @@ abstract class CommonDCModelDropdown extends CommonDropdown {
       global $DB;
 
       $fields = parent::getAdditionalFields();
-      if ($DB->fieldExists($this->getTable(), 'product_number')) {
-         $fields[] = [
-            'name'   => 'product_number',
-            'type'   => 'text',
-            'label'  => __('Product Number')
-         ];
-      }
 
       if ($DB->fieldExists($this->getTable(), 'weight')) {
          $fields[] = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The `product_number` field is included in the base CommonDropdown class and in CommonDCModelDropdown. This double inclusion was added in 9.3 with datacenter management but only causes a noticeable issue in 10.0 with having the form creating dynamically instead of statically.