### PR TITLE
Enhance deprecated database usages handling

### DIFF
--- a/.github/actions/test_update-from-9.5.sh
+++ b/.github/actions/test_update-from-9.5.sh
@@ -5,7 +5,7 @@ mkdir -p $(dirname "$LOG_FILE")
 
 bin/console glpi:database:configure \
   --config-dir=./tests/config --no-interaction --ansi \
-  --reconfigure --db-name=glpitest-9.5.3 --db-host=db --db-user=root --use-utf8mb4 \
+  --reconfigure --db-name=glpitest-9.5.3 --db-host=db --db-user=root \
   --log-deprecation-warnings
 
 # Force ROW_FORMAT=DYNAMIC to prevent tests MySQL 5.6 and MariaDB 10.1 databases
@@ -59,7 +59,7 @@ bin/console glpi:database:check_schema_integrity --config-dir=./tests/config --a
 # Check updated data
 bin/console glpi:database:configure \
   --config-dir=./tests/config --no-interaction --ansi \
-  --reconfigure --db-name=glpi --db-host=db --db-user=root --use-utf8mb4 \
+  --reconfigure --db-name=glpi --db-host=db --db-user=root \
   --log-deprecation-warnings
 mkdir -p ./tests/files/_cache
 tests/bin/test-updated-data --host=db --user=root --fresh-db=glpi --updated-db=glpitest-9.5.3 --ansi --no-interaction

--- a/.github/actions/test_update-from-older-version.sh
+++ b/.github/actions/test_update-from-older-version.sh
@@ -79,6 +79,6 @@ bin/console glpi:database:check_schema_integrity --config-dir=./tests/config --a
 # Check updated data
 bin/console glpi:database:configure \
   --config-dir=./tests/config --no-interaction --ansi \
-  --reconfigure --db-name=glpi --db-host=db --db-user=root --use-utf8mb4 \
+  --reconfigure --db-name=glpi --db-host=db --db-user=root \
   --log-deprecation-warnings
 tests/bin/test-updated-data --host=db --user=root --fresh-db=glpi --updated-db=glpitest080 --ansi --no-interaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The present file will list all changes made to the project; according to the
 - `Transfer::transferDropdownNetpoint()` has been renamed to `Transfer::transferDropdownSocket()`.
 
 #### Deprecated
+- Usage of `MyISAM` engine in database, in favor of `InnoDB` engine.
 - Usage of `utf8mb3` charset/collation in database in favor of `utf8mb4` charset/collation.
 - Handling of encoded/escaped value in `autoName()`
 - `Netpoint` has been deprecated and replaced by `Socket`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ The present file will list all changes made to the project; according to the
 - `Config::displayCheckExtensions()`
 - `Config::getCache()`
 - `DBMysql::affected_rows()`
+- `DBMysql::areTimezonesAvailable()`
 - `DBMysql::data_seek()`
 - `DBMysql::fetch_array()`
 - `DBMysql::fetch_assoc()`
@@ -138,6 +139,7 @@ The present file will list all changes made to the project; according to the
 - `DBMysql::insert_id()`
 - `DBMysql::isMySQLStrictMode()`
 - `DBMysql::list_fields()`
+- `DBMysql::notTzMigrated()`
 - `DBMysql::num_fields()`
 - `DbUtils::getRealQueryForTreeItem()`
 - `Dropdown::getDropdownNetpoint()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The present file will list all changes made to the project; according to the
 - `Transfer::transferDropdownNetpoint()` has been renamed to `Transfer::transferDropdownSocket()`.
 
 #### Deprecated
+- Usage of `utf8mb3` charset/collation in database in favor of `utf8mb4` charset/collation.
 - Handling of encoded/escaped value in `autoName()`
 - `Netpoint` has been deprecated and replaced by `Socket`
 - `Html::clean()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The present file will list all changes made to the project; according to the
 #### Deprecated
 - Usage of `MyISAM` engine in database, in favor of `InnoDB` engine.
 - Usage of `utf8mb3` charset/collation in database in favor of `utf8mb4` charset/collation.
+- Usage of `datetime` field type in database, in favor of `timestamp` field type.
 - Handling of encoded/escaped value in `autoName()`
 - `Netpoint` has been deprecated and replaced by `Socket`
 - `Html::clean()`

--- a/inc/central.class.php
+++ b/inc/central.class.php
@@ -479,13 +479,10 @@ class Central extends CommonGLPI {
                count($myisam_tables)
             );
          }
-         if ($DB->areTimezonesAvailable()) {
-            $not_tstamp = $DB->notTzMigrated();
-            if ($not_tstamp > 0) {
-               $messages['warnings'][] = sprintf(__('%1$s columns are not compatible with timezones usage.'), $not_tstamp)
-                  . ' '
-                  . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:timestamps');
-            }
+         if ($DB->use_timezones && ($not_tstamp = $DB->getTzIncompatibleTables()->count()) > 0) {
+            $messages['warnings'][] = sprintf(__('%1$s columns are not compatible with timezones usage.'), $not_tstamp)
+               . ' '
+               . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:timestamps');
          }
          if (($non_utf8mb4_tables = $DB->getNonUtf8mb4Tables()->count()) > 0) {
             $messages['warnings'][] = sprintf(__('%1$s tables not migrated to utf8mb4 collation.'), $non_utf8mb4_tables)

--- a/inc/central.class.php
+++ b/inc/central.class.php
@@ -472,20 +472,18 @@ class Central extends CommonGLPI {
                "install/install.php");
          }
 
-         $myisam_tables = $DB->getMyIsamTables();
-         if (count($myisam_tables)) {
-            $messages['warnings'][] = sprintf(
-               __('%1$s tables not migrated to InnoDB engine.'),
-               count($myisam_tables)
-            );
+         if (($myisam_count = $DB->getMyIsamTables()->count()) > 0) {
+            $messages['warnings'][] = sprintf(__('%d tables are using the deprecated MyISAM storage engine.'), $myisam_count)
+               . ' '
+               . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:myisam_to_innodb');
          }
-         if (($not_tstamp = $DB->getTzIncompatibleTables()->count()) > 0) {
-            $messages['warnings'][] = sprintf(__('%1$s columns are not still using datetime field type.'), $not_tstamp)
+         if (($datetime_count = $DB->getTzIncompatibleTables()->count()) > 0) {
+            $messages['warnings'][] = sprintf(__('%1$s columns are using the deprecated datetime storage field type.'), $datetime_count)
                . ' '
                . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:timestamps');
          }
-         if (($non_utf8mb4_tables = $DB->getNonUtf8mb4Tables()->count()) > 0) {
-            $messages['warnings'][] = sprintf(__('%1$s tables not migrated to utf8mb4 collation.'), $non_utf8mb4_tables)
+         if (($non_utf8mb4_count = $DB->getNonUtf8mb4Tables()->count()) > 0) {
+            $messages['warnings'][] = sprintf(__('%1$s tables are using the deprecated utf8mb3 storage charset.'), $non_utf8mb4_count)
                . ' '
                . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:utf8mb4');
          }

--- a/inc/central.class.php
+++ b/inc/central.class.php
@@ -479,8 +479,8 @@ class Central extends CommonGLPI {
                count($myisam_tables)
             );
          }
-         if ($DB->use_timezones && ($not_tstamp = $DB->getTzIncompatibleTables()->count()) > 0) {
-            $messages['warnings'][] = sprintf(__('%1$s columns are not compatible with timezones usage.'), $not_tstamp)
+         if (($not_tstamp = $DB->getTzIncompatibleTables()->count()) > 0) {
+            $messages['warnings'][] = sprintf(__('%1$s columns are not still using datetime field type.'), $not_tstamp)
                . ' '
                . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:timestamps');
          }

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1297,9 +1297,7 @@ class Config extends CommonDBTM {
       echo "</td>";
       echo "<td><label for='dropdown_timezone$rand'>" . __('Timezone') . "</label></td>";
       echo "<td>";
-      $tz_warning = '';
-      $tz_available = $DB->areTimezonesAvailable($tz_warning);
-      if ($tz_available) {
+      if ($DB->use_timezones) {
          $timezones = $DB->getTimezones();
          Dropdown::showFromArray(
             'timezone',
@@ -1310,8 +1308,9 @@ class Config extends CommonDBTM {
             ]
          );
       } else {
-         echo "<img src=\"{$CFG_GLPI['root_doc']}/pics/warning_min.png\">";
-         echo $tz_warning;
+         echo __('Timezone usage has not been activated.')
+            . ' '
+            . sprintf(__('Run the "php bin/console %1$s" command to activate it.'), 'glpi:database:enable_timezones');
       }
 
       echo "<tr class='tab_bg_2'><td><label for='dropdown_default_central_tab$rand'>".__('Default central tab')."</label></td>";

--- a/inc/console/database/configurecommand.class.php
+++ b/inc/console/database/configurecommand.class.php
@@ -37,7 +37,6 @@ if (!defined('GLPI_ROOT')) {
 }
 
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ConfigureCommand extends AbstractConfigureCommand {
@@ -49,18 +48,11 @@ class ConfigureCommand extends AbstractConfigureCommand {
       $this->setName('glpi:database:configure');
       $this->setAliases(['db:configure']);
       $this->setDescription('Define database configuration');
-
-      $this->addOption(
-         'use-utf8mb4',
-         null,
-         InputOption::VALUE_NONE,
-         __('Use utf8mb4 character set')
-      );
    }
 
    protected function execute(InputInterface $input, OutputInterface $output) {
 
-      $result = $this->configureDatabase($input, $output, $input->getOption('use-utf8mb4'));
+      $result = $this->configureDatabase($input, $output);
 
       if (self::ABORTED_BY_USER === $result) {
          return 0; // Considered as success

--- a/inc/console/database/enabletimezonescommand.class.php
+++ b/inc/console/database/enabletimezonescommand.class.php
@@ -88,7 +88,7 @@ class EnableTimezonesCommand extends AbstractCommand {
       }
 
       if (($datetime_count = $this->db->getTzIncompatibleTables()->count()) > 0) {
-         $message = sprintf(__('%1$s columns are not still using datetime field type.'), $datetime_count)
+         $message = sprintf(__('%1$s columns are using the deprecated datetime storage field type.'), $datetime_count)
             . ' '
             . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:timestamps');
          throw new \Glpi\Console\Exception\EarlyExitException(

--- a/inc/console/database/enabletimezonescommand.class.php
+++ b/inc/console/database/enabletimezonescommand.class.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Database;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use DBConnection;
+use Glpi\Console\AbstractCommand;
+use Glpi\System\Requirement\DbTimezones;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class EnableTimezonesCommand extends AbstractCommand {
+
+   /**
+    * Error code returned if DB configuration file cannot be updated.
+    *
+    * @var integer
+    */
+   const ERROR_UNABLE_TO_UPDATE_CONFIG = 1;
+
+   /**
+    * Error code returned if prerequisites are missing.
+    *
+    * @var integer
+    */
+   const ERROR_MISSING_PREREQUISITES = 2;
+
+   /**
+    * Error code returned if some tables are still using datetime field type.
+    *
+    * @var integer
+    */
+   const ERROR_TIMESTAMP_FIELDS_REQUIRED = 3;
+
+   protected function configure() {
+      parent::configure();
+
+      $this->setName('glpi:database:enable_timezones');
+      $this->setAliases(['db:enable_timezones']);
+      $this->setDescription(__('Enable timezones usage.'));
+   }
+
+   protected function execute(InputInterface $input, OutputInterface $output) {
+      $timezones_requirement = new DbTimezones($this->db);
+
+      if (!$timezones_requirement->isValidated()) {
+         $message = __('Timezones usage cannot be activated due to following errors:');
+         foreach ($timezones_requirement->getValidationMessages() as $validation_message) {
+            $message .= "\n - " . $validation_message;
+         }
+         throw new \Glpi\Console\Exception\EarlyExitException(
+            '<error>' . $message . '</error>',
+            self::ERROR_MISSING_PREREQUISITES
+         );
+      }
+
+      if (($datetime_count = $this->db->getTzIncompatibleTables()->count()) > 0) {
+         $message = sprintf(__('%1$s columns are not still using datetime field type.'), $datetime_count)
+            . ' '
+            . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:timestamps');
+         throw new \Glpi\Console\Exception\EarlyExitException(
+            '<error>' . $message . '</error>',
+            self::ERROR_TIMESTAMP_FIELDS_REQUIRED
+         );
+      }
+
+      if (!DBConnection::updateConfigProperty(DBConnection::PROPERTY_USE_TIMEZONES, true)) {
+         throw new \Glpi\Console\Exception\EarlyExitException(
+            '<error>' . __('Unable to update DB configuration file.') . '</error>',
+            self::ERROR_UNABLE_TO_UPDATE_CONFIG
+         );
+      }
+
+      $output->writeln('<info>' . __('Timezone usage has been enabled.') . '</info>');
+
+      return 0; // Success
+   }
+}

--- a/inc/console/database/installcommand.class.php
+++ b/inc/console/database/installcommand.class.php
@@ -165,7 +165,7 @@ class InstallCommand extends AbstractConfigureCommand {
       }
 
       if (!$this->isDbAlreadyConfigured() || $input->getOption('reconfigure')) {
-         $result = $this->configureDatabase($input, $output, false, true);
+         $result = $this->configureDatabase($input, $output, false, true, false);
 
          if (self::ABORTED_BY_USER === $result) {
             return 0; // Considered as success

--- a/inc/console/database/installcommand.class.php
+++ b/inc/console/database/installcommand.class.php
@@ -165,7 +165,7 @@ class InstallCommand extends AbstractConfigureCommand {
       }
 
       if (!$this->isDbAlreadyConfigured() || $input->getOption('reconfigure')) {
-         $result = $this->configureDatabase($input, $output, false, true, false);
+         $result = $this->configureDatabase($input, $output, false, true, false, false);
 
          if (self::ABORTED_BY_USER === $result) {
             return 0; // Considered as success

--- a/inc/console/migration/dynamicrowformatcommand.class.php
+++ b/inc/console/migration/dynamicrowformatcommand.class.php
@@ -82,10 +82,9 @@ class DynamicRowFormatCommand extends AbstractCommand {
 
       // Check that all tables are using InnoDB engine
       if (($myisam_count = $this->db->getMyIsamTables()->count()) > 0) {
-         $msg = sprintf(
-            __('%d tables are still using MyISAM storage engine. Run "php bin/console glpi:migration:myisam_to_innodb" to fix this.'),
-            $myisam_count
-         );
+         $msg = sprintf(__('%d tables are using the deprecated MyISAM storage engine.'), $myisam_count)
+            . ' '
+            . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:myisam_to_innodb');
          throw new \Glpi\Console\Exception\EarlyExitException('<error>' . $msg . '</error>', self::ERROR_INNODB_REQUIRED);
       }
    }

--- a/inc/console/migration/timestampscommand.class.php
+++ b/inc/console/migration/timestampscommand.class.php
@@ -205,14 +205,13 @@ class TimestampsCommand extends AbstractCommand {
          $this->output->write(PHP_EOL);
       }
 
+      $properties_to_update = [
+         DBConnection::PROPERTY_ALLOW_DATETIME => false,
+      ];
+
       $timezones_requirement = new DbTimezones($this->db);
       if ($timezones_requirement->isValidated()) {
-         if (!DBConnection::updateConfigProperty(DBConnection::PROPERTY_USE_TIMEZONES, true)) {
-            throw new \Glpi\Console\Exception\EarlyExitException(
-               '<error>' . __('Unable to update DB configuration file.') . '</error>',
-               self::ERROR_UNABLE_TO_UPDATE_CONFIG
-            );
-         }
+         $properties_to_update[DBConnection::PROPERTY_USE_TIMEZONES] = true;
       } else {
          $output->writeln(
             '<error>' . __('Timezones usage cannot be activated due to following errors:') . '</error>',
@@ -229,6 +228,13 @@ class TimestampsCommand extends AbstractCommand {
             'glpi:database:enable_timezones'
          );
          $output->writeln('<error>' . $message . '</error>', OutputInterface::VERBOSITY_QUIET);
+      }
+
+      if (!DBConnection::updateConfigProperties($properties_to_update)) {
+         throw new \Glpi\Console\Exception\EarlyExitException(
+            '<error>' . __('Unable to update DB configuration file.') . '</error>',
+            self::ERROR_UNABLE_TO_UPDATE_CONFIG
+         );
       }
 
       if ($tbl_iterator->count() > 0) {

--- a/inc/console/migration/timestampscommand.class.php
+++ b/inc/console/migration/timestampscommand.class.php
@@ -36,14 +36,29 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use DBConnection;
 use Glpi\Console\AbstractCommand;
-use QueryExpression;
+use Glpi\System\Requirement\DbTimezones;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class TimestampsCommand extends AbstractCommand {
+
+   /**
+    * Error code returned when failed to migrate one table.
+    *
+    * @var integer
+    */
+   const ERROR_TABLE_MIGRATION_FAILED = 1;
+
+   /**
+    * Error code returned if DB configuration file cannot be updated.
+    *
+    * @var integer
+    */
+   const ERROR_UNABLE_TO_UPDATE_CONFIG = 2;
 
    protected function configure() {
       parent::configure();
@@ -56,36 +71,7 @@ class TimestampsCommand extends AbstractCommand {
       //convert db
 
       // we are going to update datetime types to timestamp type
-      $tbl_iterator = $this->db->request([
-         'SELECT'       => ['information_schema.columns.table_name as TABLE_NAME'],
-         'DISTINCT'     => true,
-         'FROM'         => 'information_schema.columns',
-         'INNER JOIN'   => [
-            'information_schema.tables' => [
-               'FKEY' => [
-                  'information_schema.tables'  => 'table_name',
-                  'information_schema.columns' => 'table_name',
-                  [
-                     'AND' => [
-                        'information_schema.tables.table_schema' => new QueryExpression(
-                           $this->db->quoteName('information_schema.columns.table_schema')
-                        ),
-                     ]
-                  ],
-               ]
-            ]
-         ],
-         'WHERE'       => [
-            'information_schema.columns.table_schema' => $this->db->dbdefault,
-            'information_schema.columns.table_name'   => ['LIKE', 'glpi\_%'],
-            'information_schema.columns.data_type'    => 'datetime',
-            'information_schema.tables.table_type'    => 'BASE TABLE',
-
-         ],
-         'ORDER'       => [
-            'information_schema.columns.table_name'
-         ]
-      ]);
+      $tbl_iterator = $this->db->getTzIncompatibleTables();
 
       $output->writeln(
          sprintf(
@@ -96,130 +82,158 @@ class TimestampsCommand extends AbstractCommand {
 
       if ($tbl_iterator->count() === 0) {
          $output->writeln('<info>' . __('No migration needed.') . '</info>');
-         return 0; // Success
-      }
+      } else {
+         if (!$input->getOption('no-interaction')) {
+            // Ask for confirmation (unless --no-interaction)
+            /** @var \Symfony\Component\Console\Helper\QuestionHelper $question_helper */
+            $question_helper = $this->getHelper('question');
+            $run = $question_helper->ask(
+               $input,
+               $output,
+               new ConfirmationQuestion(__('Do you want to continue?') . ' [Yes/no]', true)
+            );
+            if (!$run) {
+               $output->writeln(
+                  '<comment>' . __('Migration aborted.') . '</comment>',
+                  OutputInterface::VERBOSITY_VERBOSE
+               );
+               return 0;
+            }
+         }
 
-      if (!$input->getOption('no-interaction')) {
-         // Ask for confirmation (unless --no-interaction)
-         /** @var \Symfony\Component\Console\Helper\QuestionHelper $question_helper */
-         $question_helper = $this->getHelper('question');
-         $run = $question_helper->ask(
-            $input,
-            $output,
-            new ConfirmationQuestion(__('Do you want to continue?') . ' [Yes/no]', true)
-         );
-         if (!$run) {
-            $output->writeln(
-               '<comment>' . __('Migration aborted.') . '</comment>',
+         $progress_bar = new ProgressBar($output, $tbl_iterator->count());
+         $progress_bar->start();
+
+         foreach ($tbl_iterator as $table) {
+            $progress_bar->advance(1);
+
+            $tablealter = ''; // init by default
+
+            // get accurate info from information_schema to perform correct alter
+            $col_iterator = $this->db->request([
+               'SELECT' => [
+                  'table_name AS TABLE_NAME',
+                  'column_name AS COLUMN_NAME',
+                  'column_default AS COLUMN_DEFAULT',
+                  'column_comment AS COLUMN_COMMENT',
+                  'is_nullable AS IS_NULLABLE',
+               ],
+               'FROM'   => 'information_schema.columns',
+               'WHERE'  => [
+                  'table_schema' => $this->db->dbdefault,
+                  'table_name'   => $table['TABLE_NAME'],
+                  'data_type'    => 'datetime'
+               ]
+            ]);
+
+            foreach ($col_iterator as $column) {
+               $nullable = false;
+               $default = null;
+               //check if nullable
+               if ('YES' === $column['IS_NULLABLE']) {
+                  $nullable = true;
+               }
+
+               //guess default value
+               if (is_null($column['COLUMN_DEFAULT']) && !$nullable) { // no default
+                  // Prevent MySQL/MariaDB to force "default current_timestamp on update current_timestamp"
+                  // as "on update current_timestamp" could be a real problem on fields like "date_creation".
+                  $default = "CURRENT_TIMESTAMP";
+               } else if ((is_null($column['COLUMN_DEFAULT']) || strtoupper($column['COLUMN_DEFAULT']) == 'NULL') && $nullable) {
+                  $default = "NULL";
+               } else if (!is_null($column['COLUMN_DEFAULT']) && strtoupper($column['COLUMN_DEFAULT']) != 'NULL') {
+                  if (preg_match('/^current_timestamp(\(\))?$/i', $column['COLUMN_DEFAULT']) === 1) {
+                     $default = $column['COLUMN_DEFAULT'];
+                  } else if ($column['COLUMN_DEFAULT'] < '1970-01-01 00:00:01') {
+                     // Prevent default value to be out of range (lower to min possible value)
+                     $defaultDate = new \DateTime('1970-01-01 00:00:01', new \DateTimeZone('UTC'));
+                     $defaultDate->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+                     $default = $this->db->quoteValue($defaultDate->format("Y-m-d H:i:s"));
+                  } else if ($column['COLUMN_DEFAULT'] > '2038-01-19 03:14:07') {
+                     // Prevent default value to be out of range (greater to max possible value)
+                     $defaultDate = new \DateTime('2038-01-19 03:14:07', new \DateTimeZone('UTC'));
+                     $defaultDate->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+                     $default = $this->db->quoteValue($defaultDate->format("Y-m-d H:i:s"));
+                  } else {
+                     $default = $this->db->quoteValue($column['COLUMN_DEFAULT']);
+                  }
+               }
+
+               //build alter
+               $tablealter .= "\n\t MODIFY COLUMN ".$this->db->quoteName($column['COLUMN_NAME'])." TIMESTAMP";
+               if ($nullable) {
+                  $tablealter .= " NULL";
+               } else {
+                  $tablealter .= " NOT NULL";
+               }
+               if ($default !== null) {
+                  $tablealter .= " DEFAULT $default";
+               }
+               if ($column['COLUMN_COMMENT'] != '') {
+                  $tablealter .= " COMMENT '".$this->db->escape($column['COLUMN_COMMENT'])."'";
+               }
+               $tablealter .= ",";
+            }
+            $tablealter =  rtrim($tablealter, ",");
+
+            // apply alter to table
+            $query = "ALTER TABLE " . $this->db->quoteName($table['TABLE_NAME']) . " " . $tablealter.";\n";
+            $this->writelnOutputWithProgressBar(
+               '<comment>' . sprintf(__('Running %s'), $query) . '</comment>',
+               $progress_bar,
                OutputInterface::VERBOSITY_VERBOSE
             );
-            return 0;
+
+            $result = $this->db->query($query);
+            if (false === $result) {
+               $message = sprintf(
+                  __('Update of `%s` failed with message "(%s) %s".'),
+                  $table['TABLE_NAME'],
+                  $this->db->errno(),
+                  $this->db->error()
+               );
+               $this->writelnOutputWithProgressBar(
+                  '<error>' . $message . '</error>',
+                  $progress_bar,
+                  OutputInterface::VERBOSITY_QUIET
+               );
+               return self::ERROR_TABLE_MIGRATION_FAILED;
+            }
          }
+
+         $progress_bar->finish();
+         $this->output->write(PHP_EOL);
       }
 
-      $progress_bar = new ProgressBar($output, $tbl_iterator->count());
-      $progress_bar->start();
-
-      foreach ($tbl_iterator as $table) {
-         $progress_bar->advance(1);
-
-         $tablealter = ''; // init by default
-
-         // get accurate info from information_schema to perform correct alter
-         $col_iterator = $this->db->request([
-            'SELECT' => [
-               'table_name AS TABLE_NAME',
-               'column_name AS COLUMN_NAME',
-               'column_default AS COLUMN_DEFAULT',
-               'column_comment AS COLUMN_COMMENT',
-               'is_nullable AS IS_NULLABLE',
-            ],
-            'FROM'   => 'information_schema.columns',
-            'WHERE'  => [
-               'table_schema' => $this->db->dbdefault,
-               'table_name'   => $table['TABLE_NAME'],
-               'data_type'    => 'datetime'
-            ]
-         ]);
-
-         foreach ($col_iterator as $column) {
-            $nullable = false;
-            $default = null;
-            //check if nullable
-            if ('YES' === $column['IS_NULLABLE']) {
-               $nullable = true;
-            }
-
-            //guess default value
-            if (is_null($column['COLUMN_DEFAULT']) && !$nullable) { // no default
-               // Prevent MySQL/MariaDB to force "default current_timestamp on update current_timestamp"
-               // as "on update current_timestamp" could be a real problem on fields like "date_creation".
-               $default = "CURRENT_TIMESTAMP";
-            } else if ((is_null($column['COLUMN_DEFAULT']) || strtoupper($column['COLUMN_DEFAULT']) == 'NULL') && $nullable) {
-               $default = "NULL";
-            } else if (!is_null($column['COLUMN_DEFAULT']) && strtoupper($column['COLUMN_DEFAULT']) != 'NULL') {
-               if (preg_match('/^current_timestamp(\(\))?$/i', $column['COLUMN_DEFAULT']) === 1) {
-                  $default = $column['COLUMN_DEFAULT'];
-               } else if ($column['COLUMN_DEFAULT'] < '1970-01-01 00:00:01') {
-                  // Prevent default value to be out of range (lower to min possible value)
-                  $defaultDate = new \DateTime('1970-01-01 00:00:01', new \DateTimeZone('UTC'));
-                  $defaultDate->setTimezone(new \DateTimeZone(date_default_timezone_get()));
-                  $default = $this->db->quoteValue($defaultDate->format("Y-m-d H:i:s"));
-               } else if ($column['COLUMN_DEFAULT'] > '2038-01-19 03:14:07') {
-                  // Prevent default value to be out of range (greater to max possible value)
-                  $defaultDate = new \DateTime('2038-01-19 03:14:07', new \DateTimeZone('UTC'));
-                  $defaultDate->setTimezone(new \DateTimeZone(date_default_timezone_get()));
-                  $default = $this->db->quoteValue($defaultDate->format("Y-m-d H:i:s"));
-               } else {
-                  $default = $this->db->quoteValue($column['COLUMN_DEFAULT']);
-               }
-            }
-
-            //build alter
-            $tablealter .= "\n\t MODIFY COLUMN ".$this->db->quoteName($column['COLUMN_NAME'])." TIMESTAMP";
-            if ($nullable) {
-               $tablealter .= " NULL";
-            } else {
-               $tablealter .= " NOT NULL";
-            }
-            if ($default !== null) {
-               $tablealter .= " DEFAULT $default";
-            }
-            if ($column['COLUMN_COMMENT'] != '') {
-               $tablealter .= " COMMENT '".$this->db->escape($column['COLUMN_COMMENT'])."'";
-            }
-            $tablealter .= ",";
-         }
-         $tablealter =  rtrim($tablealter, ",");
-
-         // apply alter to table
-         $query = "ALTER TABLE " . $this->db->quoteName($table['TABLE_NAME']) . " " . $tablealter.";\n";
-         $this->writelnOutputWithProgressBar(
-            '<comment>' . sprintf(__('Running %s'), $query) . '</comment>',
-            $progress_bar,
-            OutputInterface::VERBOSITY_VERBOSE
-         );
-
-         $result = $this->db->query($query);
-         if (false === $result) {
-            $message = sprintf(
-               __('Update of `%s` failed with message "(%s) %s".'),
-               $table['TABLE_NAME'],
-               $this->db->errno(),
-               $this->db->error()
+      $timezones_requirement = new DbTimezones($this->db);
+      if ($timezones_requirement->isValidated()) {
+         if (!DBConnection::updateConfigProperty(DBConnection::PROPERTY_USE_TIMEZONES, true)) {
+            throw new \Glpi\Console\Exception\EarlyExitException(
+               '<error>' . __('Unable to update DB configuration file.') . '</error>',
+               self::ERROR_UNABLE_TO_UPDATE_CONFIG
             );
-            $this->writelnOutputWithProgressBar(
-               '<error>' . $message . '</error>',
-               $progress_bar,
+         }
+      } else {
+         $output->writeln(
+            '<error>' . __('Timezones usage cannot be activated due to following errors:') . '</error>',
+            OutputInterface::VERBOSITY_QUIET
+         );
+         foreach ($timezones_requirement->getValidationMessages() as $validation_message) {
+            $output->writeln(
+               '<error> - ' . $validation_message . '</error>',
                OutputInterface::VERBOSITY_QUIET
             );
          }
+         $message = sprintf(
+            __('Fix them and run the "php bin/console %1$s" command to enable timezones.'),
+            'glpi:database:enable_timezones'
+         );
+         $output->writeln('<error>' . $message . '</error>', OutputInterface::VERBOSITY_QUIET);
       }
 
-      $progress_bar->finish();
-      $this->output->write(PHP_EOL);
-
-      $output->writeln('<info>' . __('Migration done.') . '</info>');
+      if ($tbl_iterator->count() > 0) {
+         $output->writeln('<info>' . __('Migration done.') . '</info>');
+      }
 
       return 0; // Success
    }

--- a/inc/console/migration/utf8mb4command.class.php
+++ b/inc/console/migration/utf8mb4command.class.php
@@ -112,19 +112,17 @@ class Utf8mb4Command extends AbstractCommand {
 
       // Check that all tables are using InnoDB engine
       if (($myisam_count = $this->db->getMyIsamTables()->count()) > 0) {
-         $msg = sprintf(
-            __('%d tables are still using MyISAM storage engine. Run "php bin/console glpi:migration:myisam_to_innodb" to fix this.'),
-            $myisam_count
-         );
+         $msg = sprintf(__('%d tables are using the deprecated MyISAM storage engine.'), $myisam_count)
+            . ' '
+            . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:myisam_to_innodb');
          throw new \Glpi\Console\Exception\EarlyExitException('<error>' . $msg . '</error>', self::ERROR_INNODB_REQUIRED);
       }
 
       // Check that all tables are using the "Dynamic" row format
       if ($this->db->listTables('glpi\_%', ['row_format' => ['COMPACT', 'REDUNDANT']])->count() > 0) {
-         $msg = sprintf(
-            __('%d tables are still using Compact or Redundant row format. Run "php bin/console glpi:migration:dynamic_row_format" to fix this.'),
-            $myisam_count
-         );
+         $msg = sprintf(__('%d tables are still using Compact or Redundant row format.'), $myisam_count)
+            . ' '
+            . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:dynamic_row_format');
          throw new \Glpi\Console\Exception\EarlyExitException('<error>' . $msg . '</error>', self::ERROR_DYNAMIC_ROW_FORMAT_REQUIRED);
       }
    }

--- a/inc/console/migration/utf8mb4command.class.php
+++ b/inc/console/migration/utf8mb4command.class.php
@@ -190,7 +190,7 @@ class Utf8mb4Command extends AbstractCommand {
          $this->output->write(PHP_EOL);
       }
 
-      if (!DBConnection::updateConfigProperty('use_utf8mb4', true)) {
+      if (!DBConnection::updateConfigProperty(DBConnection::PROPERTY_USE_UTF8MB4, true)) {
          throw new \Glpi\Console\Exception\EarlyExitException(
             '<error>' . __('Unable to update DB configuration file.') . '</error>',
             self::ERROR_UNABLE_TO_UPDATE_CONFIG

--- a/inc/dbconnection.class.php
+++ b/inc/dbconnection.class.php
@@ -41,6 +41,12 @@ if (!defined('GLPI_ROOT')) {
 class DBConnection extends CommonDBTM {
 
    /**
+    * "Use timezones" property name.
+    * @var string
+    */
+   public const PROPERTY_USE_TIMEZONES = 'use_timezones';
+
+   /**
     * "Log deprecation warnings" property name.
     * @var string
     */
@@ -75,6 +81,7 @@ class DBConnection extends CommonDBTM {
     * @param string  $user                      The DB user
     * @param string  $password                  The DB password
     * @param string  $dbname                    The name of the DB
+    * @param boolean $use_timezones             Flag that indicates if timezones usage should be activated
     * @param boolean $log_deprecation_warnings  Flag that indicates if DB deprecation warnings should be logged
     * @param boolean $use_utf8mb4               Flag that indicates if utf8mb4 charset/collation should be used
     * @param boolean $allow_myisam              Flag that indicates if MyISAM engine usage should be allowed
@@ -87,6 +94,7 @@ class DBConnection extends CommonDBTM {
       string $user,
       string $password,
       string $dbname,
+      bool $use_timezones = false,
       bool $log_deprecation_warnings = false,
       bool $use_utf8mb4 = false,
       bool $allow_myisam = true,
@@ -99,6 +107,9 @@ class DBConnection extends CommonDBTM {
          'dbpassword' => rawurlencode($password),
          'dbdefault'  => $dbname,
       ];
+      if ($use_timezones) {
+         $properties[self::PROPERTY_USE_TIMEZONES] = true;
+      }
       if ($log_deprecation_warnings) {
          $properties[self::PROPERTY_LOG_DEPRECATION_WARNINGS] = true;
       }
@@ -202,6 +213,7 @@ class DBConnection extends CommonDBTM {
     * @param string  $user                      The DB user
     * @param string  $password                  The DB password
     * @param string  $dbname                    The name of the DB
+    * @param boolean $use_timezones             Flag that indicates if timezones usage should be activated
     * @param boolean $log_deprecation_warnings  Flag that indicates if DB deprecation warnings should be logged
     * @param boolean $use_utf8mb4               Flag that indicates if utf8mb4 charset/collation should be used
     * @param boolean $allow_myisam              Flag that indicates if MyISAM engine usage should be allowed
@@ -214,6 +226,7 @@ class DBConnection extends CommonDBTM {
       string $user,
       string $password,
       string $dbname,
+      bool $use_timezones = false,
       bool $log_deprecation_warnings = false,
       bool $use_utf8mb4 = false,
       bool $allow_myisam = true,
@@ -233,6 +246,9 @@ class DBConnection extends CommonDBTM {
          'dbpassword' => rawurlencode($password),
          'dbdefault'  => $dbname,
       ];
+      if ($use_timezones) {
+         $properties[self::PROPERTY_USE_TIMEZONES] = true;
+      }
       if ($log_deprecation_warnings) {
          $properties[self::PROPERTY_LOG_DEPRECATION_WARNINGS] = true;
       }
@@ -289,6 +305,7 @@ class DBConnection extends CommonDBTM {
          "glpi",
          "glpi",
          "glpi",
+         $DB->use_timezones,
          $DB->log_deprecation_warnings,
          $DB->use_utf8mb4,
          $DB->allow_myisam
@@ -311,6 +328,7 @@ class DBConnection extends CommonDBTM {
          $user,
          $password,
          $DBname,
+         $DB->use_timezones,
          $DB->log_deprecation_warnings,
          $DB->use_utf8mb4,
          $DB->allow_myisam

--- a/inc/dbconnection.class.php
+++ b/inc/dbconnection.class.php
@@ -64,6 +64,12 @@ class DBConnection extends CommonDBTM {
     */
    public const PROPERTY_ALLOW_MYISAM = 'allow_myisam';
 
+   /**
+    * "Allow datetime" property name.
+    * @var string
+    */
+   public const PROPERTY_ALLOW_DATETIME = 'allow_datetime';
+
    static protected $notable = true;
 
 
@@ -85,6 +91,7 @@ class DBConnection extends CommonDBTM {
     * @param boolean $log_deprecation_warnings  Flag that indicates if DB deprecation warnings should be logged
     * @param boolean $use_utf8mb4               Flag that indicates if utf8mb4 charset/collation should be used
     * @param boolean $allow_myisam              Flag that indicates if MyISAM engine usage should be allowed
+    * @param boolean $allow_datetime            Flag that indicates if datetime fields usage should be allowed
     * @param string  $config_dir
     *
     * @return boolean
@@ -98,6 +105,7 @@ class DBConnection extends CommonDBTM {
       bool $log_deprecation_warnings = false,
       bool $use_utf8mb4 = false,
       bool $allow_myisam = true,
+      bool $allow_datetime = true,
       string $config_dir = GLPI_CONFIG_DIR
    ): bool {
 
@@ -118,6 +126,9 @@ class DBConnection extends CommonDBTM {
       }
       if (!$allow_myisam) {
          $properties[self::PROPERTY_ALLOW_MYISAM] = false;
+      }
+      if (!$allow_datetime) {
+         $properties[self::PROPERTY_ALLOW_DATETIME] = false;
       }
 
       $config_str = '<?php' . "\n" . 'class DB extends DBmysql {' . "\n";
@@ -217,6 +228,7 @@ class DBConnection extends CommonDBTM {
     * @param boolean $log_deprecation_warnings  Flag that indicates if DB deprecation warnings should be logged
     * @param boolean $use_utf8mb4               Flag that indicates if utf8mb4 charset/collation should be used
     * @param boolean $allow_myisam              Flag that indicates if MyISAM engine usage should be allowed
+    * @param boolean $allow_datetime            Flag that indicates if datetime fields usage should be allowed
     * @param string  $config_dir
     *
     * @return boolean for success
@@ -230,6 +242,7 @@ class DBConnection extends CommonDBTM {
       bool $log_deprecation_warnings = false,
       bool $use_utf8mb4 = false,
       bool $allow_myisam = true,
+      bool $allow_datetime = true,
       string $config_dir = GLPI_CONFIG_DIR
    ): bool {
 
@@ -257,6 +270,9 @@ class DBConnection extends CommonDBTM {
       }
       if (!$allow_myisam) {
          $properties[self::PROPERTY_ALLOW_MYISAM] = false;
+      }
+      if (!$allow_datetime) {
+         $properties[self::PROPERTY_ALLOW_DATETIME] = false;
       }
 
       $config_str = '<?php' . "\n" . 'class DB extends DBmysql {' . "\n";
@@ -308,7 +324,8 @@ class DBConnection extends CommonDBTM {
          $DB->use_timezones,
          $DB->log_deprecation_warnings,
          $DB->use_utf8mb4,
-         $DB->allow_myisam
+         $DB->allow_myisam,
+         $DB->allow_datetime
       );
    }
 
@@ -331,7 +348,8 @@ class DBConnection extends CommonDBTM {
          $DB->use_timezones,
          $DB->log_deprecation_warnings,
          $DB->use_utf8mb4,
-         $DB->allow_myisam
+         $DB->allow_myisam,
+         $DB->allow_datetime
       );
    }
 

--- a/inc/dbconnection.class.php
+++ b/inc/dbconnection.class.php
@@ -52,6 +52,12 @@ class DBConnection extends CommonDBTM {
     */
    public const PROPERTY_USE_UTF8MB4 = 'use_utf8mb4';
 
+   /**
+    * "Allow MyISAM" property name.
+    * @var string
+    */
+   public const PROPERTY_ALLOW_MYISAM = 'allow_myisam';
+
    static protected $notable = true;
 
 
@@ -71,6 +77,7 @@ class DBConnection extends CommonDBTM {
     * @param string  $dbname                    The name of the DB
     * @param boolean $log_deprecation_warnings  Flag that indicates if DB deprecation warnings should be logged
     * @param boolean $use_utf8mb4               Flag that indicates if utf8mb4 charset/collation should be used
+    * @param boolean $allow_myisam              Flag that indicates if MyISAM engine usage should be allowed
     * @param string  $config_dir
     *
     * @return boolean
@@ -82,6 +89,7 @@ class DBConnection extends CommonDBTM {
       string $dbname,
       bool $log_deprecation_warnings = false,
       bool $use_utf8mb4 = false,
+      bool $allow_myisam = true,
       string $config_dir = GLPI_CONFIG_DIR
    ): bool {
 
@@ -96,6 +104,9 @@ class DBConnection extends CommonDBTM {
       }
       if ($use_utf8mb4) {
          $properties[self::PROPERTY_USE_UTF8MB4] = true;
+      }
+      if (!$allow_myisam) {
+         $properties[self::PROPERTY_ALLOW_MYISAM] = false;
       }
 
       $config_str = '<?php' . "\n" . 'class DB extends DBmysql {' . "\n";
@@ -193,6 +204,7 @@ class DBConnection extends CommonDBTM {
     * @param string  $dbname                    The name of the DB
     * @param boolean $log_deprecation_warnings  Flag that indicates if DB deprecation warnings should be logged
     * @param boolean $use_utf8mb4               Flag that indicates if utf8mb4 charset/collation should be used
+    * @param boolean $allow_myisam              Flag that indicates if MyISAM engine usage should be allowed
     * @param string  $config_dir
     *
     * @return boolean for success
@@ -204,6 +216,7 @@ class DBConnection extends CommonDBTM {
       string $dbname,
       bool $log_deprecation_warnings = false,
       bool $use_utf8mb4 = false,
+      bool $allow_myisam = true,
       string $config_dir = GLPI_CONFIG_DIR
    ): bool {
 
@@ -225,6 +238,9 @@ class DBConnection extends CommonDBTM {
       }
       if ($use_utf8mb4) {
          $properties[self::PROPERTY_USE_UTF8MB4] = true;
+      }
+      if (!$allow_myisam) {
+         $properties[self::PROPERTY_ALLOW_MYISAM] = false;
       }
 
       $config_str = '<?php' . "\n" . 'class DB extends DBmysql {' . "\n";
@@ -268,7 +284,15 @@ class DBConnection extends CommonDBTM {
    **/
    static function createDBSlaveConfig() {
       global $DB;
-      self::createSlaveConnectionFile("localhost", "glpi", "glpi", "glpi", $DB->log_deprecation_warnings, $DB->use_utf8mb4);
+      self::createSlaveConnectionFile(
+         "localhost",
+         "glpi",
+         "glpi",
+         "glpi",
+         $DB->log_deprecation_warnings,
+         $DB->use_utf8mb4,
+         $DB->allow_myisam
+      );
    }
 
 
@@ -282,7 +306,15 @@ class DBConnection extends CommonDBTM {
    **/
    static function saveDBSlaveConf($host, $user, $password, $DBname) {
       global $DB;
-      self::createSlaveConnectionFile($host, $user, $password, $DBname, $DB->log_deprecation_warnings, $DB->use_utf8mb4);
+      self::createSlaveConnectionFile(
+         $host,
+         $user,
+         $password,
+         $DBname,
+         $DB->log_deprecation_warnings,
+         $DB->use_utf8mb4,
+         $DB->allow_myisam
+      );
    }
 
 

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -225,6 +225,19 @@ class Migration {
 
 
    /**
+    * Display an error
+    *
+    * @param string  $msg Message to display
+    *
+    * @return void
+   **/
+   function displayError(string $message): void {
+      $this->outputMessage($message, 'error');
+      $this->log($message, true);
+   }
+
+
+   /**
     * Define field's format
     *
     * @param string  $type          can be bool, char, string, integer, date, datetime, text, longtext or autoincrement
@@ -1184,6 +1197,11 @@ class Migration {
             $format    = 'comment';
             $verbosity = OutputInterface::VERBOSITY_NORMAL;
             break;
+         case 'error':
+            $msg       = str_pad("!! {$msg}", 100);
+            $format    = 'error';
+            $verbosity = OutputInterface::VERBOSITY_QUIET;
+            break;
          default:
             $msg       = str_pad($msg, 100);
             $format    = 'comment';
@@ -1219,6 +1237,7 @@ class Migration {
             $msg = '<h3>' . $msg . '</h3>';
             break;
          case 'warning':
+         case 'error':
             $msg = '<div class="migred"><p>' . $msg . '</p></div>';
             break;
          case 'strong':

--- a/inc/queryunion.class.php
+++ b/inc/queryunion.class.php
@@ -90,8 +90,6 @@ class QueryUnion extends AbstractQuery {
     * @return string
     */
    public function getQuery() {
-      global $DB;
-
       $union_queries = $this->getQueries();
       if (empty($union_queries
       )) {
@@ -112,7 +110,7 @@ class QueryUnion extends AbstractQuery {
       $alias = $this->alias !== null
          ? $this->alias
          : 'union_' . md5($query);
-      $query .= ' AS ' . $DB->quoteName($alias);
+      $query .= ' AS ' . DBmysql::quoteName($alias);
 
       return $query;
    }

--- a/inc/system/requirement/dbtimezones.class.php
+++ b/inc/system/requirement/dbtimezones.class.php
@@ -56,15 +56,39 @@ class DbTimezones extends AbstractRequirement {
    }
 
    protected function check() {
-      $tz_warning = '';
-      $tz_available = $this->db->areTimezonesAvailable($tz_warning);
-
-      if (!$tz_available) {
+      $mysql_db_res = $this->db->request('SHOW DATABASES LIKE ' . $this->db->quoteValue('mysql'));
+      if ($mysql_db_res->count() === 0) {
          $this->validated = false;
-         $this->validation_messages[] = $tz_warning;
-      } else {
-         $this->validated = true;
-         $this->validation_messages[] = __('Timezones seems loaded in database');
+         $this->validation_messages[] = __('Access to timezone database (mysql) is not allowed.');
+         return;
       }
+
+      $tz_table_res = $this->db->request(
+         'SHOW TABLES FROM '
+         . $this->db->quoteName('mysql')
+         . ' LIKE '
+         . $this->db->quoteValue('time_zone_name')
+      );
+      if ($tz_table_res->count() === 0) {
+         $this->validated = false;
+         $this->validation_messages[] = __('Access to timezone table (mysql.time_zone_name) is not allowed.');
+         return;
+      }
+
+      $iterator = $this->db->request(
+         [
+            'COUNT'  => 'cpt',
+            'FROM'   => 'mysql.time_zone_name',
+         ]
+      );
+      $result = $iterator->current();
+      if ($result['cpt'] === 0) {
+         $this->validated = false;
+         $this->validation_messages[] = __('Timezones seems not loaded, see https://glpi-install.readthedocs.io/en/latest/timezones.html.');
+         return;
+      }
+
+      $this->validated = true;
+      $this->validation_messages[] = __('Timezones seems loaded in database.');
    }
 }

--- a/inc/update.class.php
+++ b/inc/update.class.php
@@ -189,6 +189,31 @@ class Update {
          $function();
       }
 
+      if (($myisam_count = $DB->getMyIsamTables()->count()) > 0) {
+         $message = sprintf(__('%d tables are using the deprecated MyISAM storage engine.'), $myisam_count)
+            . ' '
+            . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:myisam_to_innodb');
+         $this->migration->displayError($message);
+      }
+      if (($datetime_count = $DB->getTzIncompatibleTables()->count()) > 0) {
+         $message = sprintf(__('%1$s columns are using the deprecated datetime storage field type.'), $datetime_count)
+            . ' '
+            . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:timestamps');
+         $this->migration->displayError($message);
+      }
+      /*
+       * FIXME: Remove `$DB->use_utf8mb4` condition GLPI 10.1.
+       * This condition is here only to prevent having this message on every migration GLPI 10.0.
+       * Indeed, as migration command was not available in previous versions, users may not understand
+       * why this is considered as an error.
+       */
+      if ($DB->use_utf8mb4 && ($non_utf8mb4_count = $DB->getNonUtf8mb4Tables()->count()) > 0) {
+         $message = sprintf(__('%1$s tables are using the deprecated utf8mb3 storage charset.'), $non_utf8mb4_count)
+            . ' '
+            . sprintf(__('Run the "php bin/console %1$s" command to migrate them.'), 'glpi:migration:utf8mb4');
+         $this->migration->displayError($message);
+      }
+
       // Update version number and default langage and new version_founded ---- LEAVE AT THE END
       Config::setConfigurationValues('core', ['version'             => GLPI_VERSION,
                                               'dbversion'           => GLPI_SCHEMA_VERSION,

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -2247,12 +2247,10 @@ JAVASCRIPT;
          echo "<tr class='tab_bg_1'><td></td><td></td></tr>";
       }
 
-      $tz_warning = '';
-      $tz_available = $DB->areTimezonesAvailable($tz_warning);
-      if ($tz_available || Session::haveRight("config", READ)) {
+      if ($DB->use_timezones || Session::haveRight("config", READ)) {
          echo "<tr class='tab_bg_1'>";
          echo "<td><label for='timezone'>".__('Time zone')."</label></td><td>";
-         if ($tz_available) {
+         if ($DB->use_timezones) {
             $timezones = $DB->getTimezones();
             Dropdown::showFromArray(
                'timezone',
@@ -2264,8 +2262,9 @@ JAVASCRIPT;
             );
          } else if (Session::haveRight("config", READ)) {
             // Display a warning but only if user is more or less an admin
-            echo "<img src=\"{$CFG_GLPI['root_doc']}/pics/warning_min.png\">";
-            echo $tz_warning;
+            echo __('Timezone usage has not been activated.')
+               . ' '
+               . sprintf(__('Run the "php bin/console %1$s" command to activate it.'), 'glpi:database:enable_timezones');
          }
          echo "</td></tr>";
       }
@@ -2704,12 +2703,10 @@ JAVASCRIPT;
             echo "<tr class='tab_bg_1'><td colspan='2'></td></tr>";
          }
 
-         $tz_warning = '';
-         $tz_available = $DB->areTimezonesAvailable($tz_warning);
-         if ($tz_available || Session::haveRight("config", READ)) {
+         if ($DB->use_timezones || Session::haveRight("config", READ)) {
             echo "<tr class='tab_bg_1'>";
             echo "<td><label for='timezone'>".__('Time zone')."</label></td><td>";
-            if ($tz_available) {
+            if ($DB->use_timezones) {
                $timezones = $DB->getTimezones();
                Dropdown::showFromArray(
                   'timezone',
@@ -2721,8 +2718,9 @@ JAVASCRIPT;
                );
             } else if (Session::haveRight("config", READ)) {
                // Display a warning but only if user is more or less an admin
-               echo "<img src=\"{$CFG_GLPI['root_doc']}/pics/warning_min.png\">";
-               echo $tz_warning;
+               echo __('Timezone usage has not been activated.')
+                  . ' '
+                  . sprintf(__('Run the "php bin/console %1$s" command to activate it.'), 'glpi:database:enable_timezones');
             }
             echo "</td>";
             if ($extauth

--- a/install/install.php
+++ b/install/install.php
@@ -280,6 +280,7 @@ function step4 ($databasename, $newdatabasename) {
             $timezones_requirement->isValidated(),
             false,
             true,
+            false,
             false
          );
          if ($success) {
@@ -307,6 +308,7 @@ function step4 ($databasename, $newdatabasename) {
             $timezones_requirement->isValidated(),
             false,
             true,
+            false,
             false
          );
          if ($success) {
@@ -334,6 +336,7 @@ function step4 ($databasename, $newdatabasename) {
                   $timezones_requirement->isValidated(),
                   false,
                   true,
+                  false,
                   false
                );
             }

--- a/install/install.php
+++ b/install/install.php
@@ -264,7 +264,16 @@ function step4 ($databasename, $newdatabasename) {
          prev_form($host, $user, $password);
 
       } else {
-         if (DBConnection::createMainConfig($host, $user, $password, $databasename, false, true)) {
+         $success = DBConnection::createMainConfig(
+            $host,
+            $user,
+            $password,
+            $databasename,
+            false,
+            true,
+            false
+         );
+         if ($success) {
             Toolbox::createSchema($_SESSION["glpilanguage"]);
             echo "<p>".__('OK - database was initialized')."</p>";
 
@@ -281,7 +290,16 @@ function step4 ($databasename, $newdatabasename) {
       if ($link->select_db($newdatabasename)) {
          echo "<p>".__('Database created')."</p>";
 
-         if (DBConnection::createMainConfig($host, $user, $password, $newdatabasename, false, true)) {
+         $success = DBConnection::createMainConfig(
+            $host,
+            $user,
+            $password,
+            $newdatabasename,
+            false,
+            true,
+            false
+         );
+         if ($success) {
             Toolbox::createSchema($_SESSION["glpilanguage"]);
             echo "<p>".__('OK - database was initialized')."</p>";
             next_form();
@@ -295,9 +313,21 @@ function step4 ($databasename, $newdatabasename) {
          if ($link->query("CREATE DATABASE IF NOT EXISTS `".$newdatabasename."`")) {
             echo "<p>".__('Database created')."</p>";
 
-            if ($link->select_db($newdatabasename)
-                && DBConnection::createMainConfig($host, $user, $password, $newdatabasename, false, true)) {
+            $select_db = $link->select_db($newdatabasename);
+            $success = false;
+            if ($select_db) {
+               $success = DBConnection::createMainConfig(
+                  $host,
+                  $user,
+                  $password,
+                  $newdatabasename,
+                  false,
+                  true,
+                  false
+               );
+            }
 
+            if ($success) {
                Toolbox::createSchema($_SESSION["glpilanguage"]);
                echo "<p>".__('OK - database was initialized')."</p>";
                next_form();

--- a/install/install.php
+++ b/install/install.php
@@ -34,6 +34,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Cache\CacheManager;
 use Glpi\System\Requirement\DbConfiguration;
 use Glpi\System\Requirement\DbEngine;
+use Glpi\System\Requirement\DbTimezones;
 use Glpi\System\RequirementsManager;
 
 define('GLPI_ROOT', realpath('..'));
@@ -255,6 +256,13 @@ function step4 ($databasename, $newdatabasename) {
    $databasename    = $link->real_escape_string($databasename);
    $newdatabasename = $link->real_escape_string($newdatabasename);
 
+   $db = new class($mysqli) extends DBmysql {
+      public function __construct($dbh) {
+         $this->dbh = $dbh;
+      }
+   };
+   $timezones_requirement = new DbTimezones($db);
+
    if (!empty($databasename)) { // use db already created
       $DB_selected = $link->select_db($databasename);
 
@@ -269,6 +277,7 @@ function step4 ($databasename, $newdatabasename) {
             $user,
             $password,
             $databasename,
+            $timezones_requirement->isValidated(),
             false,
             true,
             false
@@ -295,6 +304,7 @@ function step4 ($databasename, $newdatabasename) {
             $user,
             $password,
             $newdatabasename,
+            $timezones_requirement->isValidated(),
             false,
             true,
             false
@@ -321,6 +331,7 @@ function step4 ($databasename, $newdatabasename) {
                   $user,
                   $password,
                   $newdatabasename,
+                  $timezones_requirement->isValidated(),
                   false,
                   true,
                   false

--- a/install/install.php
+++ b/install/install.php
@@ -264,7 +264,7 @@ function step4 ($databasename, $newdatabasename) {
          prev_form($host, $user, $password);
 
       } else {
-         if (DBConnection::createMainConfig($host, $user, $password, $databasename, true)) {
+         if (DBConnection::createMainConfig($host, $user, $password, $databasename, false, true)) {
             Toolbox::createSchema($_SESSION["glpilanguage"]);
             echo "<p>".__('OK - database was initialized')."</p>";
 
@@ -281,7 +281,7 @@ function step4 ($databasename, $newdatabasename) {
       if ($link->select_db($newdatabasename)) {
          echo "<p>".__('Database created')."</p>";
 
-         if (DBConnection::createMainConfig($host, $user, $password, $newdatabasename, true)) {
+         if (DBConnection::createMainConfig($host, $user, $password, $newdatabasename, false, true)) {
             Toolbox::createSchema($_SESSION["glpilanguage"]);
             echo "<p>".__('OK - database was initialized')."</p>";
             next_form();
@@ -296,7 +296,7 @@ function step4 ($databasename, $newdatabasename) {
             echo "<p>".__('Database created')."</p>";
 
             if ($link->select_db($newdatabasename)
-                && DBConnection::createMainConfig($host, $user, $password, $newdatabasename, true)) {
+                && DBConnection::createMainConfig($host, $user, $password, $newdatabasename, false, true)) {
 
                Toolbox::createSchema($_SESSION["glpilanguage"]);
                echo "<p>".__('OK - database was initialized')."</p>";
@@ -396,13 +396,8 @@ function update1($DBname) {
       include_once (GLPI_CONFIG_DIR . "/config_db.php");
       global $DB;
       $DB = new DB();
-      if ($DB->listTables('glpi\_%', ['table_collation' => 'utf8mb4_unicode_ci'])->count() > 0) {
-         // Use utf8mb4 charset for update process if at least one table already uses this charset.
-         if ($success = DBConnection::updateConfigProperty('use_utf8mb4', true)) {
-            $DB->use_utf8mb4 = true;
-            $DB->setConnectionCharset();
-         }
-      }
+
+      $success = DBConnection::updateConfigProperties($DB->getComputedConfigBooleanFlags());
    }
    if ($success) {
       $from_install = true;

--- a/tests/functionnal/CommonDBTM.php
+++ b/tests/functionnal/CommonDBTM.php
@@ -885,7 +885,7 @@ class CommonDBTM extends DbTestCase {
       global $DB;
 
       //check if timezones are available
-      $this->boolean($DB->areTimezonesAvailable())->isTrue();
+      $this->boolean($DB->use_timezones)->isTrue();
       $this->array($DB->getTimezones())->size->isGreaterThan(0);
 
       //login with default TZ

--- a/tests/units/DBConnection.php
+++ b/tests/units/DBConnection.php
@@ -80,6 +80,7 @@ class DBConnection extends \GLPITestCase {
             'name'                     => 'glpi_db',
             'log_deprecation_warnings' => false,
             'use_utf8mb4'              => false,
+            'allow_myisam'             => true,
             'expected'                 => <<<'PHP'
 <?php
 class DB extends DBmysql {
@@ -98,6 +99,7 @@ PHP
             'name'                     => 'db',
             'log_deprecation_warnings' => false,
             'use_utf8mb4'              => true,
+            'allow_myisam'             => false,
             'expected'                 => <<<'PHP'
 <?php
 class DB extends DBmysql {
@@ -106,6 +108,7 @@ class DB extends DBmysql {
    public $dbpassword = '';
    public $dbdefault = 'db';
    public $use_utf8mb4 = true;
+   public $allow_myisam = false;
 }
 
 PHP
@@ -117,6 +120,7 @@ PHP
             'name'                     => 'db',
             'log_deprecation_warnings' => true,
             'use_utf8mb4'              => false,
+            'allow_myisam'             => true,
             'expected'                 => <<<'PHP'
 <?php
 class DB extends DBmysql {
@@ -142,11 +146,21 @@ PHP
       string $name,
       bool $log_deprecation_warnings,
       bool $use_utf8mb4,
+      bool $allow_myisam,
       string $expected
    ): void {
       vfsStream::setup('config-dir', null, []);
 
-      $result = \DBConnection::createMainConfig($host, $user, $password, $name, $log_deprecation_warnings, $use_utf8mb4, vfsStream::url('config-dir'));
+      $result = \DBConnection::createMainConfig(
+         $host,
+         $user,
+         $password,
+         $name,
+         $log_deprecation_warnings,
+         $use_utf8mb4,
+         $allow_myisam,
+         vfsStream::url('config-dir')
+      );
       $this->boolean($result)->isTrue();
 
       $path = vfsStream::url('config-dir/config_db.php');
@@ -163,6 +177,7 @@ PHP
             'name'                     => 'glpi_db',
             'log_deprecation_warnings' => false,
             'use_utf8mb4'              => false,
+            'allow_myisam'             => true,
             'expected'                 => <<<'PHP'
 <?php
 class DB extends DBmysql {
@@ -182,6 +197,7 @@ PHP
             'name'                     => 'db',
             'log_deprecation_warnings' => false,
             'use_utf8mb4'              => true,
+            'allow_myisam'             => false,
             'expected'                 => <<<'PHP'
 <?php
 class DB extends DBmysql {
@@ -195,6 +211,7 @@ class DB extends DBmysql {
    public $dbpassword = '';
    public $dbdefault = 'db';
    public $use_utf8mb4 = true;
+   public $allow_myisam = false;
 }
 
 PHP
@@ -206,6 +223,7 @@ PHP
             'name'                     => 'db',
             'log_deprecation_warnings' => true,
             'use_utf8mb4'              => false,
+            'allow_myisam'             => true,
             'expected'                 => <<<'PHP'
 <?php
 class DB extends DBmysql {
@@ -232,11 +250,21 @@ PHP
       string $name,
       bool $log_deprecation_warnings,
       bool $use_utf8mb4,
+      bool $allow_myisam,
       string $expected
    ): void {
       vfsStream::setup('config-dir', null, []);
 
-      $result = \DBConnection::createSlaveConnectionFile($host, $user, $password, $name, $log_deprecation_warnings, $use_utf8mb4, vfsStream::url('config-dir'));
+      $result = \DBConnection::createSlaveConnectionFile(
+         $host,
+         $user,
+         $password,
+         $name,
+         $log_deprecation_warnings,
+         $use_utf8mb4,
+         $allow_myisam,
+         vfsStream::url('config-dir')
+      );
       $this->boolean($result)->isTrue();
 
       $path = vfsStream::url('config-dir/config_db_slave.php');

--- a/tests/units/DBConnection.php
+++ b/tests/units/DBConnection.php
@@ -82,6 +82,7 @@ class DBConnection extends \GLPITestCase {
             'log_deprecation_warnings' => false,
             'use_utf8mb4'              => false,
             'allow_myisam'             => true,
+            'allow_datetime'           => true,
             'expected'                 => <<<'PHP'
 <?php
 class DB extends DBmysql {
@@ -102,6 +103,7 @@ PHP
             'log_deprecation_warnings' => false,
             'use_utf8mb4'              => true,
             'allow_myisam'             => false,
+            'allow_datetime'           => false,
             'expected'                 => <<<'PHP'
 <?php
 class DB extends DBmysql {
@@ -112,6 +114,7 @@ class DB extends DBmysql {
    public $use_timezones = true;
    public $use_utf8mb4 = true;
    public $allow_myisam = false;
+   public $allow_datetime = false;
 }
 
 PHP
@@ -125,6 +128,7 @@ PHP
             'log_deprecation_warnings' => true,
             'use_utf8mb4'              => false,
             'allow_myisam'             => true,
+            'allow_datetime'           => true,
             'expected'                 => <<<'PHP'
 <?php
 class DB extends DBmysql {
@@ -152,6 +156,7 @@ PHP
       bool $log_deprecation_warnings,
       bool $use_utf8mb4,
       bool $allow_myisam,
+      bool $allow_datetime,
       string $expected
    ): void {
       vfsStream::setup('config-dir', null, []);
@@ -165,6 +170,7 @@ PHP
          $log_deprecation_warnings,
          $use_utf8mb4,
          $allow_myisam,
+         $allow_datetime,
          vfsStream::url('config-dir')
       );
       $this->boolean($result)->isTrue();
@@ -185,6 +191,7 @@ PHP
             'log_deprecation_warnings' => false,
             'use_utf8mb4'              => false,
             'allow_myisam'             => true,
+            'allow_datetime'           => true,
             'expected'                 => <<<'PHP'
 <?php
 class DB extends DBmysql {
@@ -206,6 +213,7 @@ PHP
             'log_deprecation_warnings' => false,
             'use_utf8mb4'              => true,
             'allow_myisam'             => false,
+            'allow_datetime'           => false,
             'expected'                 => <<<'PHP'
 <?php
 class DB extends DBmysql {
@@ -221,6 +229,7 @@ class DB extends DBmysql {
    public $use_timezones = true;
    public $use_utf8mb4 = true;
    public $allow_myisam = false;
+   public $allow_datetime = false;
 }
 
 PHP
@@ -234,6 +243,7 @@ PHP
             'log_deprecation_warnings' => true,
             'use_utf8mb4'              => false,
             'allow_myisam'             => true,
+            'allow_datetime'           => true,
             'expected'                 => <<<'PHP'
 <?php
 class DB extends DBmysql {
@@ -262,6 +272,7 @@ PHP
       bool $log_deprecation_warnings,
       bool $use_utf8mb4,
       bool $allow_myisam,
+      bool $allow_datetime,
       string $expected
    ): void {
       vfsStream::setup('config-dir', null, []);
@@ -275,6 +286,7 @@ PHP
          $log_deprecation_warnings,
          $use_utf8mb4,
          $allow_myisam,
+         $allow_datetime,
          vfsStream::url('config-dir')
       );
       $this->boolean($result)->isTrue();

--- a/tests/units/DBConnection.php
+++ b/tests/units/DBConnection.php
@@ -78,6 +78,7 @@ class DBConnection extends \GLPITestCase {
             'user'                     => 'glpi',
             'password'                 => 'secret',
             'name'                     => 'glpi_db',
+            'use_timezones'            => false,
             'log_deprecation_warnings' => false,
             'use_utf8mb4'              => false,
             'allow_myisam'             => true,
@@ -97,6 +98,7 @@ PHP
             'user'                     => 'root',
             'password'                 => '',
             'name'                     => 'db',
+            'use_timezones'            => true,
             'log_deprecation_warnings' => false,
             'use_utf8mb4'              => true,
             'allow_myisam'             => false,
@@ -107,6 +109,7 @@ class DB extends DBmysql {
    public $dbuser = 'root';
    public $dbpassword = '';
    public $dbdefault = 'db';
+   public $use_timezones = true;
    public $use_utf8mb4 = true;
    public $allow_myisam = false;
 }
@@ -118,6 +121,7 @@ PHP
             'user'                     => 'root',
             'password'                 => 'iT4%dU9*rI9#jT8>',
             'name'                     => 'db',
+            'use_timezones'            => false,
             'log_deprecation_warnings' => true,
             'use_utf8mb4'              => false,
             'allow_myisam'             => true,
@@ -144,6 +148,7 @@ PHP
       string $user,
       string $password,
       string $name,
+      bool $use_timezones,
       bool $log_deprecation_warnings,
       bool $use_utf8mb4,
       bool $allow_myisam,
@@ -156,6 +161,7 @@ PHP
          $user,
          $password,
          $name,
+         $use_timezones,
          $log_deprecation_warnings,
          $use_utf8mb4,
          $allow_myisam,
@@ -175,6 +181,7 @@ PHP
             'user'                     => 'glpi',
             'password'                 => 'secret',
             'name'                     => 'glpi_db',
+            'use_timezones'            => false,
             'log_deprecation_warnings' => false,
             'use_utf8mb4'              => false,
             'allow_myisam'             => true,
@@ -195,6 +202,7 @@ PHP
             'user'                     => 'root',
             'password'                 => '',
             'name'                     => 'db',
+            'use_timezones'            => true,
             'log_deprecation_warnings' => false,
             'use_utf8mb4'              => true,
             'allow_myisam'             => false,
@@ -210,6 +218,7 @@ class DB extends DBmysql {
    public $dbuser = 'root';
    public $dbpassword = '';
    public $dbdefault = 'db';
+   public $use_timezones = true;
    public $use_utf8mb4 = true;
    public $allow_myisam = false;
 }
@@ -221,6 +230,7 @@ PHP
             'user'                     => 'root',
             'password'                 => 'iT4%dU9*rI9#jT8>',
             'name'                     => 'db',
+            'use_timezones'            => false,
             'log_deprecation_warnings' => true,
             'use_utf8mb4'              => false,
             'allow_myisam'             => true,
@@ -248,6 +258,7 @@ PHP
       string $user,
       string $password,
       string $name,
+      bool $use_timezones,
       bool $log_deprecation_warnings,
       bool $use_utf8mb4,
       bool $allow_myisam,
@@ -260,6 +271,7 @@ PHP
          $user,
          $password,
          $name,
+         $use_timezones,
          $log_deprecation_warnings,
          $use_utf8mb4,
          $allow_myisam,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If we want to drop support of `MyISAM` tables, `datetime` fields and `utf8mb3` support in a next GLPI major version (11.0 ?), I think we should add warnings everytime these elements are used in a table create/alter query.

This PR introduces multiple changes.

1) The `use_utf8mb4` configuration flag is now set automatically on update and `db:configure` command usage. If no GLPI core tables is still using the `utf8mb3` charset, then this flag will be set to `true`. It will prevent issues with bad usage of a `--use-utf8mb4` flag.

2) A new `allow_myisam` configuration flag is now set automatically on update and `db:configure` command usage. If no GLPI core tables is still using the `MyISAM` engine, then this flag will be set to `false`. It means that every users that have already run the migration should have this flag set to `false`.
When this flag is set to `false`, then altering/creating tables using this engine is triggering a warning (`Usage of "MyISAM" engine is discouraged, please use "InnoDB" engine.`). This should permit to detect usage of this engine during plugins installation/update.

3) A new `use_timezones` configuration flag is used to replace the runtime check of timezones availability. During database installation/upgrade process, this flag will be set to `true` if all prerequisites are met. Otherwise, on CLI context, a warning will be displayed, to explain the errors.
![image](https://user-images.githubusercontent.com/33253653/143268929-fbe468a1-aaa4-4992-aec4-6b404c5638c1.png)
When this flag is set to `false`, admin users will see following message when `timezone` settings are displayed:
![image](https://user-images.githubusercontent.com/33253653/143269571-6353fd22-5741-46fd-a7b4-604863dee0ed.png)
A new `db:enable_timezones` command has been introduced to active timezone usage at anytime.

4) A new `allow_datetime` configuration flag is now set automatically on update and `db:configure` command usage. If no GLPI core tables is still using a `datetime` field, then this flag will be set to `false`. It means that every users that have already run the migration should have this flag set to `false`.
When this flag is set to `false`, then altering/creating tables using this field type is triggering a warning (`Usage of "DATETIME" fields is discouraged, please use "TIMESTAMP" fields instead.`). This should permit to detect usage of this field type during plugins installation/update.
Also, in central page, warning related to not migrated fields is now displayed whenever timezone usage is activated.

5) Errors are now shown during update process.
![image](https://user-images.githubusercontent.com/33253653/143271128-75cff990-08b9-482a-a2fa-01c45540681e.png)
![image](https://user-images.githubusercontent.com/33253653/143271154-98adb2b6-642a-481b-8539-7efe932e93a8.png)
