### PR TITLE
allow plugins to redefine menus

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1787,7 +1787,7 @@ HTML;
          }
       }
 
-      //$menu = Plugin::doHookFunction("redefine_menus", $menu);
+      $menu = Plugin::doHookFunction("redefine_menus", $menu);
 
       TemplateRenderer::getInstance()->display(
          'layout/parts/page_header.html.twig',


### PR DESCRIPTION
For Formcreator and its service catalog : need to redefine menu in self service to prevent direct ticket creation

![image](https://user-images.githubusercontent.com/14139801/140965857-50a9b62c-5777-43d7-9c66-5aec56e39dae.png)
