### PR TITLE
force gristack item to be 100% width when responsive display

### DIFF
--- a/css/standalone/gridstack-grids.scss
+++ b/css/standalone/gridstack-grids.scss
@@ -63,3 +63,8 @@ $gridstack-columns: 100 !default;
 @for $j from $gridstack-columns-start through $gridstack-columns {
    @include grid-stack-items($j);
 }
+
+/* Fix responsive width */
+.grid-stack.grid-stack-1 > .grid-stack-item {
+   width: 100% !important;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Chartist graph fails to get a width as we don't force anymore 100% width for gridstack item when a responsive view is used.
