### PR TITLE
reload tab should force load of html

### DIFF
--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -377,7 +377,7 @@ JAVASCRIPT;
             // Update href and load tab contents
             var currenthref = active_link.attr('href');
             active_link.attr('href', currenthref + '&' + add);
-            loadTabContents(active_link);
+            loadTabContents(active_link, true);
 
             // Restore href
             active_link.attr('href', currenthref);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Changing "Display (number of items)" in softwares list in a computer form doesn't reload the the current tab
