### PR TITLE
fix colors in savedsearches panel

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -299,7 +299,7 @@ table {
 
 .list-group .list-group-item {
    color: inherit;
-   border: $input-border-width solid $input-border-color;
+   border-color: $table-border-color;
    &:hover {
       background-color: $hover-bg;
    }

--- a/css/includes/components/_saved-searches.scss
+++ b/css/includes/components/_saved-searches.scss
@@ -64,7 +64,7 @@
       }
    }
 
-   .card-tabs {
+   .saved-searches-tabs {
       display: flex;
       flex-direction: column;
       min-height: 0;

--- a/templates/layout/parts/saved_searches.html.twig
+++ b/templates/layout/parts/saved_searches.html.twig
@@ -59,7 +59,7 @@
       </li>
    </div>
 
-   <div class="card-tabs">
+   <div class="saved-searches-tabs">
       <ul class="nav nav-tabs border-0" data-bs-toggle="tabs">
          <li class="nav-item">
             <a class="nav-link active" data-bs-target="#itemtype-filtered" data-bs-toggle="tab"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

fix 2 issues:

- Follow #9719, i found color of list separator to be too agressive (and border size too much).
- Also, maybe to recent tabler update, tabs in this panel lost its active color, i changed the main class of content for fixing that.

This last change may me think future tabler updates may broke components more than we want.
