### PR TITLE
search sticky header should take its parent background color

### DIFF
--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -95,7 +95,7 @@
                border-bottom: 0;
                position: sticky;
                top: -1px;
-               background-color: $card-cap-bg;
+               background-color: inherit;
             }
          }
 

--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -96,6 +96,7 @@
                position: sticky;
                top: -1px;
                background-color: inherit;
+               z-index: $zindex-sticky;
             }
          }
 
@@ -112,7 +113,7 @@
             @include media-breakpoint-up(sm) {
                thead:first-child {
                   th {
-                     z-index: 5;
+                     z-index: $zindex-sticky;
                      position: sticky;
                      top: 49px;
                      border: 1px solid $card-border-color;


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Follow #9854 (sticky search header), the background color was light in dark paletttes:

![image](https://user-images.githubusercontent.com/418844/141789655-d80befa7-6b36-4883-8cd2-3f1661edfa04.png)

