### PR TITLE
Fix missing CSRF token when canedit=false

### DIFF
--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -38,7 +38,7 @@
          {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
          </div>
 
-{% if canedit and item.canEdit(item.fields['id']) %}
+{% if canedit or item.canEdit(item.fields['id']) %}
       <div class="card-body mx-n2 mb-4  border-top">
          {% if withtemplate|length > 0 or item.isNewID(id) %}
             {% if id <= 0 or withtemplate == 2 %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

One may want to use the form with `canedit=false` to hide the "Update" button. In this case, the CSRF token and the form ending tag must still be prevent, if `item.canEdit(item.fields['id'])` is evaluated to true.

See https://github.com/glpi-project/glpi/blob/9.5/bugfixes/inc/commondbtm.class.php#L2460