### PR TITLE
Replace usage of deprecated Html::autocompletionTextField()

### DIFF
--- a/inc/socket.class.php
+++ b/inc/socket.class.php
@@ -771,7 +771,12 @@ class Socket extends CommonDBChild {
          echo "<tr class='tab_bg_2 center'>";
          echo "<td class='b'>"._n('Network socket', 'Network sockets', 1)."</td>";
          echo "<td>".__('Name')."</td><td>";
-         Html::autocompletionTextField($item, "name", ['value' => '']);
+         echo Html::input(
+            'name',
+            [
+               'value' => '',
+            ]
+         );
          echo "</td>";
          echo "<td>".SocketModel::getTypeName(1)."</td><td>";
          SocketModel::dropdown("socketmodels_id", []);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
