### PR TITLE
fix display of massiveaction modal (append to body)

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -2433,8 +2433,6 @@ HTML;
          // Create Modal window on top
          if ($p['ontop']
              || (isset($p['forcecreate']) && $p['forcecreate'])) {
-                $out .= "<div id='massiveactioncontent$identifier'></div>";
-
             if (!empty($p['tag_to_send'])) {
                $js_modal_fields  = "var items = $('";
                if (!empty($p['container'])) {

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -2455,7 +2455,6 @@ HTML;
                $url,
                [
                   'title'           => $p['title'],
-                  'container'       => 'massiveactioncontent'.$identifier,
                   'extraparams'     => $p['extraparams'],
                   'width'           => $p['width'],
                   'height'          => $p['height'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Due to the recent change of sticky control in search pages, the massiveactions modal fails to have a proper z-index stack.
Appending the modal to the body fix that.

I don't know why, in the first place, modal was applied to a container...
