### PR TITLE
Fix/actor emails

### DIFF
--- a/ajax/dropdownItilActors.php
+++ b/ajax/dropdownItilActors.php
@@ -63,17 +63,20 @@ if (isset($_POST["type"])
                              'ldap_import' => true];
 
             if ($CFG_GLPI["notifications_mailing"]) {
-               $paramscomment = ['value'       => '__VALUE__',
-                                      'allow_email' => $withemail,
-                                      'field'       => "_itil_".$_POST["actortype"],
-                                      'use_notification' => $_POST["use_notif"]];
+               $paramscomment = ['value' => '__VALUE__',
+                  'allow_email' => $withemail,
+                  'field' => "_itil_" . $_POST["actortype"],
+                  'use_notification' => $_POST["use_notif"]];
                // Fix rand value
-               $options['rand']     = $rand;
-               $options['toupdate'] = ['value_fieldname' => 'value',
-                                            'to_update'       => "notif_user_$rand",
-                                            'url'             => $CFG_GLPI["root_doc"].
-                                                                     "/ajax/uemailUpdate.php",
-                                            'moreparams'      => $paramscomment];
+               $options['rand'] = $rand;
+               if ($withemail) {
+                  $options['toupdate'] = [
+                     'value_fieldname' => 'value',
+                     'to_update'       => "notif_user_$rand",
+                     'url'             => $CFG_GLPI["root_doc"] . "/ajax/uemailUpdate.php",
+                     'moreparams'      => $paramscomment
+                  ];
+               }
             }
 
             if (($_POST["itemtype"] == 'Ticket')
@@ -162,11 +165,14 @@ if (isset($_POST["type"])
                                       'use_notification' => $_POST["use_notif"]];
                // Fix rand value
                $options['rand']     = $rand;
-               $options['toupdate'] = ['value_fieldname' => 'value',
-                                            'to_update'       => "notif_supplier_$rand",
-                                            'url'             => $CFG_GLPI["root_doc"].
-                                                                     "/ajax/uemailUpdate.php",
-                                            'moreparams'      => $paramscomment];
+               if ($withemail) {
+                  $options['toupdate'] = [
+                     'value_fieldname' => 'value',
+                     'to_update'       => "notif_supplier_$rand",
+                     'url'             => $CFG_GLPI["root_doc"] . "/ajax/uemailUpdate.php",
+                     'moreparams'      => $paramscomment
+                  ];
+               }
             }
             if ($_POST["itemtype"] == 'Ticket') {
                $toupdate = [];

--- a/ajax/dropdownItilActors.php
+++ b/ajax/dropdownItilActors.php
@@ -42,6 +42,8 @@ if (isset($_POST["type"])
     && isset($_POST["actortype"])
     && isset($_POST["itemtype"])) {
    $rand = mt_rand();
+   $withemail = isset($_POST['allow_email']) && filter_var($_POST['allow_email'], FILTER_VALIDATE_BOOLEAN);
+
    if ($item = getItemForItemtype($_POST["itemtype"])) {
       switch ($_POST["type"]) {
          case "user" :
@@ -61,7 +63,6 @@ if (isset($_POST["type"])
                              'ldap_import' => true];
 
             if ($CFG_GLPI["notifications_mailing"]) {
-               $withemail     = (isset($_POST["allow_email"]) ? $_POST["allow_email"] : false);
                $paramscomment = ['value'       => '__VALUE__',
                                       'allow_email' => $withemail,
                                       'field'       => "_itil_".$_POST["actortype"],
@@ -154,7 +155,6 @@ if (isset($_POST["type"])
                              'entity'    => $_POST['entity_restrict'],
                              'rand'      => $rand];
             if ($CFG_GLPI["notifications_mailing"]) {
-               $withemail     = (isset($_POST["allow_email"]) ? $_POST["allow_email"] : false);
                $paramscomment = ['value'       => '__VALUE__',
                                       'allow_email' => $withemail,
                                       'field'       => '_itil_'.$_POST["actortype"],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixed issues with the ITIL Actor dropdown AJAX endpoint with the `allow_email` parameter set to false. During the call, the boolean value gets converted to a string and since both "true" and "false" strings evaluate true, it was impossible to show the actor dropdown and hide the email fields.
The second issue is even with the correct evaluation, it would hide the fields initially but then add them after selecting an actor.