### PR TITLE
Fix old migration warning on PHP 8.1

### DIFF
--- a/install/migrations/update_0.84.x_to_0.85.0.php
+++ b/install/migrations/update_0.84.x_to_0.85.0.php
@@ -115,7 +115,7 @@ function update084xto0850() {
          foreach ($configs as $name => $value) {
             $query = "INSERT INTO `glpi_configs`
                              (`context`, `name`, `value`)
-                      VALUES ('core', '$name', '".addslashes($value)."');";
+                      VALUES ('core', '$name', '".addslashes($value ?? '')."');";
             $DB->query($query);
          }
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes following warning: `Deprecated: addslashes(): Passing null to parameter #1 ($string) of type string is deprecated in /var/glpi/install/migrations/update_0.84.x_to_0.85.0.php on line 118`