### PR TITLE
Fix Html::nullHeader()

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1879,12 +1879,7 @@ HTML;
 
       self::includeHeader($title);
 
-      // Body with configured stuff
-      echo "<body>";
-      echo "<main role='main' id='page'>";
-      echo "<br><br>";
-      echo "<div id='bloc'>";
-      echo "<div id='logo_bloc'></div>";
+      TemplateRenderer::getInstance()->display('layout/parts/page_header_empty.html.twig');
    }
 
 

--- a/templates/layout/parts/page_header_empty.html.twig
+++ b/templates/layout/parts/page_header_empty.html.twig
@@ -1,0 +1,45 @@
+{#
+ # ---------------------------------------------------------------------
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ # Copyright (C) 2015-2021 Teclib' and contributors.
+ #
+ # http://glpi-project.org
+ #
+ # based on GLPI - Gestionnaire Libre de Parc Informatique
+ # Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # GLPI is free software; you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation; either version 2 of the License, or
+ # (at your option) any later version.
+ #
+ # GLPI is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ # ---------------------------------------------------------------------
+ #}
+
+<body class="horizontal-layout">
+   <div class="page">
+
+      <header class="navbar d-print-none sticky-lg-top shadow-sm topbar">
+         <div class="container-fluid">
+            <a href="{{ index_path() }}" title="{{ __('Home') }}" class="navbar-brand">
+               <span class="glpi-logo"></span>
+            </a>
+         </div>
+      </header>
+
+      <div class="page-wrapper mb-0">
+         <div class="page-body container-fluid">
+            <main role="main" id="page" class="legacy">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix the `null` header, used to display pages that only requires a GLPI logo in their header.

Before:
![image](https://user-images.githubusercontent.com/33253653/142619328-cb82c87f-f0e2-43b7-9c07-fe6cbc9f24fe.png)

After:
![image](https://user-images.githubusercontent.com/33253653/142619260-8a3b7094-4c7c-44ff-949c-2668f50e5242.png)
