### PR TITLE
make texts wrap in side menu

### DIFF
--- a/templates/layout/parts/menu.html.twig
+++ b/templates/layout/parts/menu.html.twig
@@ -65,7 +65,9 @@
                   href="{{ path(sublevel['page']) }}"
                   accesskey="{{ sublevel['shortcut'] ?? '' }}" title="{{ sublevel['title'] }}">
                   <i class="fa-fw {{ sublevel['icon'] ?? '' }}"></i>
-                  {{ sublevel['title']|shortcut(sublevel['shortcut'] ?? '') }}
+                  <span class='text-wrap'>
+                     {{ sublevel['title']|shortcut(sublevel['shortcut'] ?? '') }}
+                  </span>
                </a>
                {% endif %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Due to the fact i mainly use GLPI in en_GB, i didn't see french menu overflows:

**Before:**

![image](https://user-images.githubusercontent.com/418844/142642422-f660b8f8-00ca-4ab6-993c-f04c0b2fad11.png)

**After:**

![image](https://user-images.githubusercontent.com/418844/142642491-74b58341-dffe-4eb5-a899-0a6becf83373.png)
