### PR TITLE
Fix/intempestive partial load

### DIFF
--- a/ajax/savedsearch.php
+++ b/ajax/savedsearch.php
@@ -77,7 +77,11 @@ if (!isset($_GET['action'])) {
 
 if ($_GET['action'] == 'display_mine') {
    header("Content-Type: text/html; charset=UTF-8");
-   $savedsearch->displayMine($_GET["itemtype"], (bool) ($_GET["inverse"] ?? false));
+   $savedsearch->displayMine(
+      $_GET["itemtype"],
+      (bool) ($_GET["inverse"] ?? false),
+      false
+   );
 }
 
 if ($_GET['action'] == 'reorder') {

--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -572,7 +572,11 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria {
             }
             // Display message
             if ($partial_load && Session::getCurrentInterface() != "helpdesk") {
-               Session::addMessageAfterRedirect(__('Partial load of the saved search.'), false, ERROR);
+               Session::addMessageAfterRedirect(
+                  sprintf(__('Partial load of the saved search: %s'), $this->getName()),
+                  false,
+                  ERROR
+               );
             }
             // add reset value
             $query_tab['reset'] = 'reset';

--- a/templates/layout/parts/saved_searches.html.twig
+++ b/templates/layout/parts/saved_searches.html.twig
@@ -111,6 +111,8 @@ $(function() {
 
       $.get(url, function(data) {
          $(target).html(data);
+
+         displayAjaxMessageAfterRedirect();
       });
    });
    // load initial tab


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

"Partial load of the saved search" warning should only be displayed when we do a real loading of the saved search.

When counting results in the side panel, there is annoying warnings about this.
On my side the error is due to a missing plugin for a particular search option with no easy possibility to identify the plugin (i just get the search option id).

I'm not sure about the best way to fix the issue, i'm not particularly ok with the proposed solution (follow of a parameter in the backtrace). If anybody can suggest a better way, i take.
