### PR TITLE
Fix multiple issues in file upload handling

### DIFF
--- a/inc/api/apirest.class.php
+++ b/inc/api/apirest.class.php
@@ -69,6 +69,12 @@ class APIRest extends API {
     */
    public function manageUploadedFiles() {
       foreach (array_keys($_FILES) as $filename) {
+         // Randomize files names
+         $rand_name = uniqid('', true);
+         foreach ($_FILES[$filename]['name'] as &$name) {
+            $name = $rand_name . $name;
+         }
+
          $upload_result
             = GLPIUploadHandler::uploadFiles(['name'           => $filename,
                                               'print_response' => false]);

--- a/inc/glpiuploadhandler.class.php
+++ b/inc/glpiuploadhandler.class.php
@@ -130,10 +130,6 @@ class GLPIUploadHandler extends UploadHandler {
       $params = array_merge($default_params, $params);
 
       $pname = $params['name'];
-      $rand_name = uniqid('', true);
-      foreach ($_FILES[$pname]['name'] as &$name) {
-         $name = $rand_name . $name;
-      }
 
       $upload_dir     = GLPI_TMP_DIR.'/';
       $upload_handler = new self(
@@ -157,9 +153,9 @@ class GLPIUploadHandler extends UploadHandler {
             if (isset($val->error) && file_exists($upload_dir.$val->name)) {
                unlink($upload_dir.$val->name);
             } else {
-               $val->prefix = $rand_name;
                if (isset($val->name)) {
-                  $val->display = str_replace($rand_name, '', $val->name);
+                  $val->prefix = substr($val->name, 0, 23);
+                  $val->display = str_replace($val->prefix, '', $val->name);
                }
                if (isset($val->size)) {
                   $val->filesize = Toolbox::getSize($val->size);

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -5338,6 +5338,7 @@ JAVASCRIPT;
          'name'          => $p['name'],
          'display'       => false,
          'uploads'       => $p['uploads'],
+         'editor_id'     => $p['editor_id'],
       ]);
 
       $max_file_size  = $CFG_GLPI['document_max_size'] * 1024 * 1024;

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -5386,6 +5386,14 @@ JAVASCRIPT;
                                  : DocumentType::getUploadableFilePattern()).",
             maxFileSize: {$max_file_size},
             maxChunkSize: {$max_chunk_size},
+            add: function (e, data) {
+               // randomize filename
+               for (var i = 0; i < data.files.length; i++) {
+                  data.files[i].uploadName = uniqid('', true) + data.files[i].name;
+               }
+               // call default handler
+               $.blueimp.fileupload.prototype.options.add.call(this, e, data);
+            },
             done: function (event, data) {
                handleUploadedFile(
                   data.files, // files as blob
@@ -5394,6 +5402,12 @@ JAVASCRIPT;
                   $('#{$p['filecontainer']}'),
                   '{$p['editor_id']}'
                );
+            },
+            fail: function (e, data) {
+               const err = 'responseText' in data.jqXHR && data.jqXHR.responseText.length > 0
+                  ? data.jqXHR.responseText
+                  : data.jqXHR.statusText;
+               alert(err);
             },
             processfail: function (e, data) {
                $.each(

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -5347,10 +5347,10 @@ JAVASCRIPT;
          // manage file upload without tinymce editor
          $display .= "<span class='b'>".__('Drag and drop your file here, or').'</span><br>';
       }
-      $display .= "<input id='fileupload{$p['rand']}' type='file' name='".$p['name']."[]'
+      $display .= "<input id='fileupload{$p['rand']}' type='file' name='_uploader_".$p['name']."[]'
                       class='form-control'
                       data-url='".$CFG_GLPI["root_doc"]."/ajax/fileupload.php'
-                      data-form-data='{\"name\": \"".$p['name']."\", \"showfilesize\": \"".$p['showfilesize']."\"}'"
+                      data-form-data='{\"name\": \"_uploader_".$p['name']."\", \"showfilesize\": \"".$p['showfilesize']."\"}'"
                       .($p['multiple']?" multiple='multiple'":"")
                       .($p['onlyimages']?" accept='.gif,.png,.jpg,.jpeg'":"").">";
 
@@ -5389,7 +5389,7 @@ JAVASCRIPT;
             done: function (event, data) {
                handleUploadedFile(
                   data.files, // files as blob
-                  data.result.{$p['name']}, // response from '/ajax/fileupload.php'
+                  data.result._uploader_{$p['name']}, // response from '/ajax/fileupload.php'
                   '{$p['name']}',
                   $('#{$p['filecontainer']}'),
                   '{$p['editor_id']}'

--- a/js/common.js
+++ b/js/common.js
@@ -1372,3 +1372,18 @@ function flashIconButton(button, button_classes, icon_classes, duration) {
       ico.addClass(original_ico_classes);
    }, duration);
 }
+
+/**
+ * uniqid() function, providing similar result as PHP does.
+ *
+ * @param {string} prefix
+ * @param {boolean} random
+ * @returns {string}
+ *
+ * @see https://stackoverflow.com/a/48593447
+ */
+function uniqid(prefix = "", more_entropy = false) {
+   const sec = Date.now() * 1000 + Math.random() * 1000;
+   const id = sec.toString(16).replace(/\./g, "").padEnd(14, "0");
+   return `${prefix}${id}${more_entropy ? `.${Math.trunc(Math.random() * 100000000)}`:""}`;
+};

--- a/js/common.js
+++ b/js/common.js
@@ -1386,4 +1386,4 @@ function uniqid(prefix = "", more_entropy = false) {
    const sec = Date.now() * 1000 + Math.random() * 1000;
    const id = sec.toString(16).replace(/\./g, "").padEnd(14, "0");
    return `${prefix}${id}${more_entropy ? `.${Math.trunc(Math.random() * 100000000)}`:""}`;
-};
+}

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -43,17 +43,7 @@ function uploadFile(file, editor) {
       fileupload_container = $(editor.getElement()).closest('form').find('.fileupload');
    }
 
-   fileupload_container.find('[type="file"]')
-      .fileupload('send', {files: [file]})
-      .error(function (request) {
-         // If this is an error on the return
-         if ("responseText" in request && request.responseText.length > 0) {
-            alert(request.responseText);
-         } else {
-            // Error before sending request #3866
-            alert(request.statusText);
-         }
-      });
+   fileupload_container.find('[type="file"]').fileupload('add', {files: [file]});
 }
 
 var handleUploadedFile = function (files, files_data, input_name, container, editor_id) {

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -180,7 +180,13 @@
 
 
 {% macro textareaField(name, value, label = '', options = {}) %}
-   {% set options = {'rand': random()}|merge(options) %}
+   {% set options = {
+      'rand': random(),
+      'enable_richtext': false,
+      'enable_images': true,
+      'enable_fileupload': false
+   }|merge(options) %}
+
    {% if options.fields_template.isMandatoryField(name) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
@@ -200,13 +206,19 @@
          options.rand
       ]) %}
    {% endif %}
+
+   {% set add_html = '' %}
    {% if options.enable_fileupload %}
       {% set add_html %}
          {% do call('Html::file', [{'editor_id': id}]) %}
       {% endset %}
-
-      {% set options = options|merge({'add_field_html': add_html}) %}
+   {% elseif not options.enable_fileupload and options.enable_richtext and options.enable_images %}
+      {% set add_html %}
+         {% do call('Html::file', [{'editor_id': id, 'name': name, 'only_uploaded_files': true}]) %}
+      {% endset %}
    {% endif %}
+
+   {% set options = options|merge({'add_field_html': add_html}) %}
 
    {{ _self.field(name, field, label, options) }}
    {% if options.enable_mentions and config('use_notifications') %}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -184,7 +184,8 @@
       'rand': random(),
       'enable_richtext': false,
       'enable_images': true,
-      'enable_fileupload': false
+      'enable_fileupload': false,
+      'uploads': []
    }|merge(options) %}
 
    {% if options.fields_template.isMandatoryField(name) %}
@@ -210,11 +211,11 @@
    {% set add_html = '' %}
    {% if options.enable_fileupload %}
       {% set add_html %}
-         {% do call('Html::file', [{'editor_id': id, 'multiple': true}]) %}
+         {% do call('Html::file', [{'editor_id': id, 'multiple': true, 'uploads': options.uploads}]) %}
       {% endset %}
    {% elseif not options.enable_fileupload and options.enable_richtext and options.enable_images %}
       {% set add_html %}
-         {% do call('Html::file', [{'editor_id': id, 'name': name, 'only_uploaded_files': true}]) %}
+         {% do call('Html::file', [{'editor_id': id, 'name': name, 'only_uploaded_files': true, 'uploads': options.uploads}]) %}
       {% endset %}
    {% endif %}
 

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -210,7 +210,7 @@
    {% set add_html = '' %}
    {% if options.enable_fileupload %}
       {% set add_html %}
-         {% do call('Html::file', [{'editor_id': id}]) %}
+         {% do call('Html::file', [{'editor_id': id, 'multiple': true}]) %}
       {% endset %}
    {% elseif not options.enable_fileupload and options.enable_richtext and options.enable_images %}
       {% set add_html %}

--- a/templates/components/itilobject/timeline/simple_form.html.twig
+++ b/templates/components/itilobject/timeline/simple_form.html.twig
@@ -53,6 +53,14 @@
          field_options
       ) }}
 
+      {% set uploads = [] %}
+      {% if item.input._content is defined %}
+         {% set uploads = uploads|merge({'_content': item.input._content, '_tag_content': item.input._tag_content}) %}
+      {% endif %}
+      {% if item.input._filename is defined %}
+         {% set uploads = uploads|merge({'_filename': item.input._filename, '_tag_filename': item.input._tag_filename}) %}
+      {% endif %}
+
       {{ fields.textareaField(
          'content',
          item.fields['content'],
@@ -60,6 +68,7 @@
          field_options|merge({
             'enable_richtext': true,
             'enable_fileupload': true,
+            'uploads': uploads,
             'add_field_class': 'col-12 itil-textarea-content',
          })
       ) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Fix a naming conflict between a rich text area and its file upload field. This naming conflict only appears when direct file upload is not allowed.
2. Fix textarea macro to correctly handle rich text without direct file upload enabled.
3. Enable multiple files upload at once in the upload dropzone (same behaviour as in GLPI 9.5).
4. Fix images prefix generation. Prefix generated on server side was ignored in "chunked upload" mode. This prefix has to be generated on client side.
5. Fix already uploaded files display on ITIL template reload (for instance, on category switch).