### PR TITLE
Prevent full page refresh when changing limit

### DIFF
--- a/templates/components/pager.html.twig
+++ b/templates/components/pager.html.twig
@@ -67,7 +67,7 @@
 
 <div class="flex-grow-1 d-flex flex-wrap flex-md-nowrap  align-items-center justify-content-between mb-2 search-pager">
    {% set limitdropdown = include('components/dropdown/limit.html.twig', {
-      'on_change': true,
+      'no_onchange': true,
       'select_class': 'search-limit-dropdown',
    }) %}
    <span class="search-limit d-none d-md-block">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The search results limit dropdown's onchange is handled by the new fluid search and should not cause a full page refresh anymore. Having it refresh the page and trigger the AJAX call leads to a race condition where it sometimes doesn't properly update the value.