### PR TITLE
Fix pager rounding error

### DIFF
--- a/templates/components/pager.html.twig
+++ b/templates/components/pager.html.twig
@@ -59,7 +59,7 @@
 {% endif %}
 
 {% set nb_pages = (count / limit)|round(0, 'ceil') %}
-{% set current_page = (current_start / limit)|round(0) + 1 %}
+{% set current_page = (current_start / limit)|round(0, 'ceil') + 1 %}
 
 {# limit the number of adjacents links displayed #}
 {% set adjacents = 2 %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When clicking the `last` pager button it was going to the second to last page.