### PR TITLE
ensure notifications are send with data for the correct user's timezone

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -237,7 +237,7 @@ class DBmysql {
     *
     * @since 9.5.0
     */
-   protected function guessTimezone() {
+   public function guessTimezone() {
       if (isset($_SESSION['glpi_tz'])) {
          $zone = $_SESSION['glpi_tz'];
       } else {

--- a/inc/notificationeventabstract.class.php
+++ b/inc/notificationeventabstract.class.php
@@ -118,7 +118,6 @@ abstract class NotificationEventAbstract {
                         $DB->setTimezone($orig_tz);
                      }
 
-
                      if ($tid = $template->getTemplateByLanguage($notificationtarget,
                                                                   $users_infos, $event,
                                                                   $options)) {

--- a/inc/notificationeventabstract.class.php
+++ b/inc/notificationeventabstract.class.php
@@ -60,7 +60,7 @@ abstract class NotificationEventAbstract {
       $notify_me,
       $emitter = null
    ) {
-      global $CFG_GLPI;
+      global $CFG_GLPI, $DB;
       if ($CFG_GLPI['notifications_' . $options['mode']]) {
          $entity = $notificationtarget->getEntity();
          if (isset($options['processed'])) {
@@ -86,6 +86,9 @@ abstract class NotificationEventAbstract {
             'notify_me'          => $notify_me
          ]);
 
+         // get original timezone
+         $orig_tz = $DB->guessTimezone();
+
          //Foreach notification targets
          foreach ($targets as $target) {
             //Get all users affected by this notification
@@ -104,6 +107,18 @@ abstract class NotificationEventAbstract {
                                                    [$key]);
                      }
                      $options['item'] = $item;
+
+                     // set timezone from user
+                     // as we work on a copy of the item object, no reload is required after
+                     if (isset($users_infos['additionnaloption']['timezone'])) {
+                        $DB->setTimezone($users_infos['additionnaloption']['timezone']);
+                        // reload object for get timezone correct dates
+                        $options['item']->getFromDB($item->fields['id']);
+
+                        $DB->setTimezone($orig_tz);
+                     }
+
+
                      if ($tid = $template->getTemplateByLanguage($notificationtarget,
                                                                   $users_infos, $event,
                                                                   $options)) {

--- a/inc/notificationtarget.class.php
+++ b/inc/notificationtarget.class.php
@@ -522,6 +522,11 @@ class NotificationTarget extends CommonDBChild {
                  && Auth::isAlternateAuth(Auth::checkAlternateAuthSystems()))) {
             $notificationoption['usertype'] = self::EXTERNAL_USER;
          }
+
+         // retrieve timezone of the user if exists
+         if (!empty($user->fields['timezone']) && 'null' !== strtolower($user->fields['timezone'])) {
+            $notificationoption['timezone'] = $user->fields['timezone'];
+         }
       }
 
       // Pass user type as argument ? forced for specific cases


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

I though notifications was already send with user set timezone, seems not.
As the item is loaded before iteration on each actor, i need to reload the object for concerned user (as timezone "translations" are managed by mysql)

internal ref !22951

