### PR TITLE
Fix recursive documents in knowbase

### DIFF
--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -1630,7 +1630,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
                   'WHERE'  => [
                      'items_id'  => $data["id"],
                      'itemtype'  => 'KnowbaseItem'
-                  ] + getEntitiesRestrictCriteria()
+                  ] + getEntitiesRestrictCriteria('', '', '', true)
                ]);
                while ($docs = $iterator->next()) {
                   $doc = new Document();


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

If you access the Browser tab of the knowledge base, the articles are grouped by category.
In the list of articles if one of them is created in the parent entity it is not possible to see the documents assigned to the articles if the user is in a child entity even if the documents and the article have recursion enabled.