### PR TITLE
Fix plugin locales loading from files/_locales

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -374,7 +374,7 @@ class Plugin extends CommonDBTM {
       });
 
       foreach ($plugin_folders as $plugin_folder) {
-         $mofile = str_replace($locales_dir, GLPI_LOCAL_I18N_DIR . '/'. $plugin_folder . '/', $mofile);
+         $mofile = GLPI_LOCAL_I18N_DIR . "/$plugin_folder/$coretrytoload.mo";
          $phpfile = str_replace('.mo', '.php', $mofile);
 
          // Load local PHP file if it exists


### PR DESCRIPTION
#9180 wasn't working properly for plugins.
This issue is the `$mofile` variable being modified inside the loop, which affect negatively the next iteration.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
