### PR TITLE
replace lot of icons by tabler ones (regular style instead solid)

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -166,6 +166,10 @@ body.iframed {
       width: 0.9em;
    }
 
+   &.fa-xs {
+      font-size: .85em;
+   }
+
    &.fa-lg {
       font-size: 1.8em;
       line-height: 0.75em;

--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -167,7 +167,7 @@ body.iframed {
    }
 
    &.fa-xs {
-      font-size: .85em;
+      font-size: 0.85em;
    }
 
    &.fa-lg {

--- a/css/legacy/includes/_impact.scss
+++ b/css/legacy/includes/_impact.scss
@@ -394,6 +394,11 @@ i.fa-impact-manipulation {
       i {
          padding  : 10px 4px;
          font-size: 1.5em;
+
+         &.ti {
+            font-size: 1.8em;
+            line-height: 1.5em;
+         }
       }
 
       &:hover {

--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -884,11 +884,6 @@
       padding: 5px;
    }
 
-   .accepted:not(.itilstatus) {
-      background-color: #9FD6ED;
-      color: #425B64;
-   }
-
    .error {
       color: red;
       margin-top: 20px;

--- a/css/standalone/dashboard.scss
+++ b/css/standalone/dashboard.scss
@@ -274,7 +274,9 @@ $break_tablet: 1400px;
          right: initial;
          left: 5px;
 
-         i.fas {
+         i.fas,
+         i.far,
+         i.ti {
             margin-left: 0;
             font-size: 1em;
          }
@@ -292,12 +294,18 @@ $break_tablet: 1400px;
          }
       }
 
-      i.fas {
+      i.fas,
+      i.far,
+      i.ti {
          font-size: 1.35em;
          cursor: pointer;
          padding: 5px;
          margin-left: 5px;
          border: 2px solid transparent;
+
+         &.ti {
+            font-size: 1.75em;
+         }
 
          @media screen and (max-width: $break_phones) {
             display: none;
@@ -604,7 +612,8 @@ $break_tablet: 1400px;
             cursor: pointer;
 
             i.fas,
-            i.far {
+            i.far,
+            i.ti {
                opacity: 0.6;
 
                &:hover {
@@ -635,7 +644,9 @@ $break_tablet: 1400px;
             border-radius: 3px;
             border: 1px solid transparent;
 
-            .fas {
+            .fas,
+            .far,
+            .ti {
                position: absolute;
                top: calc(50% - 16px);
                left: calc(50% - 16px);

--- a/css/standalone/marketplace.scss
+++ b/css/standalone/marketplace.scss
@@ -325,7 +325,7 @@ $break_s_screen: 1400px;
                      }
                   }
 
-                  > .fa-exclamation-triangle {
+                  > .ti-alert-triangle {
                      color: #8f5a0a;
                      margin: 1px;
                      padding: 3px 5px;

--- a/inc/appliance.class.php
+++ b/inc/appliance.class.php
@@ -369,7 +369,7 @@ class Appliance extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-cubes";
+      return "ti ti-versions";
    }
 
    /**

--- a/inc/appliance.class.php
+++ b/inc/appliance.class.php
@@ -421,7 +421,7 @@ class Appliance extends CommonDBTM {
       if (in_array($itemtype, self::getTypes())) {
          if (self::canUpdate()) {
             $action_prefix                    = 'Appliance_Item'.MassiveAction::CLASS_ACTION_SEPARATOR;
-            $actions[$action_prefix.'add']    = "<i class='fas fa-file-contract'></i>".
+            $actions[$action_prefix.'add']    = "<i class='fa-fw fas fa-file-contract'></i>".
                                                 _x('button', 'Add to an appliance');
             $actions[$action_prefix.'remove'] = _x('button', 'Remove from an appliance');
          }

--- a/inc/applianceenvironment.class.php
+++ b/inc/applianceenvironment.class.php
@@ -39,4 +39,8 @@ class ApplianceEnvironment extends CommonDropdown {
    static function getTypeName($nb = 0) {
       return _n('Appliance environment', 'Appliance environments', $nb);
    }
+
+   static function getIcon() {
+      return Appliance::getIcon();
+   }
 }

--- a/inc/appliancetype.class.php
+++ b/inc/appliancetype.class.php
@@ -39,4 +39,8 @@ class ApplianceType extends CommonDropdown {
    static function getTypeName($nb = 0) {
       return _n('Appliance type', 'Appliance types', $nb);
    }
+
+   static function getIcon() {
+      return Appliance::getIcon();
+   }
 }

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -1720,7 +1720,7 @@ class Auth extends CommonGLPI {
 
 
    static function getIcon() {
-      return "fas fa-sign-in-alt";
+      return "ti ti-login";
    }
 
    /**

--- a/inc/budget.class.php
+++ b/inc/budget.class.php
@@ -886,6 +886,6 @@ class Budget extends CommonDropdown{
 
 
    static function getIcon() {
-      return "fas fa-calculator";
+      return "ti ti-calculator";
    }
 }

--- a/inc/cablestrand.class.php
+++ b/inc/cablestrand.class.php
@@ -207,4 +207,8 @@ class CableStrand extends CommonDropdown {
       echo "</table></div>";
 
    }
+
+   static function getIcon() {
+      return Cable::getIcon();
+   }
 }

--- a/inc/cabletype.class.php
+++ b/inc/cabletype.class.php
@@ -45,4 +45,7 @@ class CableType extends CommonDropdown {
       return self::getTypeName(1);
    }
 
+   static function getIcon() {
+      return Cable::getIcon();
+   }
 }

--- a/inc/cartridge.class.php
+++ b/inc/cartridge.class.php
@@ -1330,7 +1330,7 @@ class Cartridge extends CommonDBRelation {
 
 
    static function getIcon() {
-      return "fas fa-fill-drip";
+      return "ti ti-droplet-filled-2";
    }
 
 }

--- a/inc/certificate.class.php
+++ b/inc/certificate.class.php
@@ -678,6 +678,6 @@ class Certificate extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-certificate";
+      return "ti ti-certificate";
    }
 }

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -1123,7 +1123,7 @@ class Change extends CommonITILObject {
 
 
    static function getIcon() {
-      return "fas fa-clipboard-check";
+      return "ti ti-clipboard-check";
    }
 
    public static function getItemLinkClass(): string {

--- a/inc/cluster.class.php
+++ b/inc/cluster.class.php
@@ -154,6 +154,6 @@ class Cluster extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-project-diagram";
+      return "ti ti-hierarchy-2";
    }
 }

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -3655,7 +3655,7 @@ class CommonDBTM extends CommonGLPI {
 
       if (in_array(static::getType(), Appliance::getTypes(true)) && static::canUpdate()) {
          $actions['Appliance' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_item'] =
-            "<i class='fas fa-cubes'></i>"._x('button', 'Associate to an appliance');
+            "<i class='fa-fw ".Appliance::getIcon()."'></i>"._x('button', 'Associate to an appliance');
       }
 
       return $actions;

--- a/inc/commondropdown.class.php
+++ b/inc/commondropdown.class.php
@@ -921,6 +921,6 @@ abstract class CommonDropdown extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-edit";
+      return "ti ti-edit";
    }
 }

--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -955,7 +955,7 @@ JAVASCRIPT;
             echo "<a href='$cleantarget?id=$first$extraparamhtml'
                      class='btn btn-sm btn-icon btn-ghost-secondary' title=\"".__s('First')."\"
                      data-bs-toggle='tooltip' data-bs-placement='bottom'>
-                     <i class='fas fa-lg fa-angle-double-left'></i>
+                     <i class='fa-lg ti ti-chevrons-left'></i>
                   </a>";
          }
 
@@ -964,7 +964,7 @@ JAVASCRIPT;
                      id='previouspage'
                      class='btn btn-sm btn-icon btn-ghost-secondary' title=\"".__s('Previous')."\"
                      data-bs-toggle='tooltip' data-bs-placement='bottom'>
-                     <i class='fas fa-lg fa-angle-left'></i>
+                     <i class='fa-lg ti ti-chevron-left'></i>
                   </a>";
             $js = '$("body").keydown(function(e) {
                        if ($("input, textarea").is(":focus") === false) {
@@ -1021,7 +1021,7 @@ JAVASCRIPT;
                      class='btn btn-sm btn-icon btn-ghost-secondary'
                      title=\"".__s('Next')."\"
                      data-bs-toggle='tooltip' data-bs-placement='bottom'>" .
-               "<i class='fas fa-lg fa-angle-right'></i>
+               "<i class='fa-lg ti ti-chevron-right'></i>
                     </a>";
             $js = '$("body").keydown(function(e) {
                        if ($("input, textarea").is(":focus") === false) {
@@ -1038,7 +1038,7 @@ JAVASCRIPT;
                      class='btn btn-sm btn-icon btn-ghost-secondary'
                      title=\"".__s('Last')."\"
                      data-bs-toggle='tooltip' data-bs-placement='bottom'>" .
-               "<i class='fas fa-lg fa-angle-double-right'></i></a>";
+               "<i class='fa-lg ti ti-chevrons-right'></i></a>";
          }
 
          echo "</div>"; // .navigationheader

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -4068,7 +4068,7 @@ abstract class CommonITILObject extends CommonDBTM {
    public static function getStatusIcon($status) {
       $class = static::getStatusClass($status);
       $label = static::getStatus($status);
-      return "<i class='$class' title='$label' data-bs-toggle='tooltip'></i>";
+      return "<i class='$class me-1' title='$label' data-bs-toggle='tooltip'></i>";
    }
 
    /**

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -4092,6 +4092,7 @@ abstract class CommonITILObject extends CommonDBTM {
             break;
          case self::PLANNED :
             $class = 'calendar';
+            $solid = false;
             break;
          case self::WAITING :
             $class = 'circle';
@@ -6075,7 +6076,7 @@ abstract class CommonITILObject extends CommonDBTM {
          $itemtypes['answer'] = [
             'type'      => 'ITILFollowup',
             'class'     => 'ITILFollowup',
-            'icon'      => 'far fa-comment',
+            'icon'      => 'ti ti-message-circle',
             'label'     => _x('button', 'Answer'),
             'template'  => 'components/itilobject/timeline/form_followup.html.twig',
             'item'      => $fup
@@ -6085,7 +6086,7 @@ abstract class CommonITILObject extends CommonDBTM {
          $itemtypes['task'] = [
             'type'      => 'ITILTask',
             'class'     => $task_class,
-            'icon'      => 'fas fa-wrench',
+            'icon'      => 'ti ti-checkbox',
             'label'     => _x('button', 'Create a task'),
             'template'  => 'components/itilobject/timeline/form_task.html.twig',
             'item'      => $task
@@ -6095,7 +6096,7 @@ abstract class CommonITILObject extends CommonDBTM {
          $itemtypes['solution'] = [
             'type'      => 'ITILSolution',
             'class'     => 'ITILSolution',
-            'icon'      => 'fas fa-check',
+            'icon'      => 'ti ti-check',
             'label'     => _x('button', 'Add a solution'),
             'template'  => 'components/itilobject/timeline/form_solution.html.twig',
             'item'      => new ITILSolution()
@@ -6105,7 +6106,7 @@ abstract class CommonITILObject extends CommonDBTM {
          $itemtypes['validation'] = [
             'type'      => 'ITILValidation',
             'class'     => $validation_class,
-            'icon'      => 'far fa-thumbs-up',
+            'icon'      => 'ti ti-thumb-up',
             'label'     => _x('button', 'Ask for validation'),
             'template'  => 'components/itilobject/timeline/form_validation.html.twig',
             'item'      => $validation
@@ -6309,7 +6310,7 @@ abstract class CommonITILObject extends CommonDBTM {
                'item' => [
                   'id'        => $validations_id,
                   'date'      => $validation['submission_date'],
-                  'content'   => __('Validation request')." => <i class='fas fa-user text-muted me-1'></i>".$user->getlink().
+                  'content'   => __('Validation request')." => <i class='ti ti-user text-muted me-1'></i>".$user->getlink().
                                                  "<br>".$validation['comment_submission'],
                   'users_id'  => $validation['users_id'],
                   'can_edit'  => $canedit,

--- a/inc/commonitilrecurrent.class.php
+++ b/inc/commonitilrecurrent.class.php
@@ -602,6 +602,6 @@ abstract class CommonITILRecurrent extends CommonDropdown
    }
 
    public static function getIcon() {
-      return "fas fa-stopwatch";
+      return "ti ti-alarm";
    }
 }

--- a/inc/commontreedropdown.class.php
+++ b/inc/commontreedropdown.class.php
@@ -900,6 +900,6 @@ abstract class CommonTreeDropdown extends CommonDropdown {
 
 
    static function getIcon() {
-      return "fas fa-sitemap";
+      return "ti ti-subtask";
    }
 }

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -323,13 +323,13 @@ class Computer extends CommonDBTM {
             'Item_OperatingSystem'.MassiveAction::CLASS_ACTION_SEPARATOR.'update'
                => OperatingSystem::getTypeName(),
             'Computer_Item'.MassiveAction::CLASS_ACTION_SEPARATOR.'add'
-               => "<i class='fas fa-plug'></i>".
+               => "<i class='fa-fw ti ti-plug'></i>".
                   _x('button', 'Connect'),
             'Item_SoftwareVersion'.MassiveAction::CLASS_ACTION_SEPARATOR.'add'
-               => "<i class='fas fa-laptop-medical'></i>".
+               => "<i class='fa-fw fas fa-laptop-medical'></i>".
                   _x('button', 'Install'),
             'Item_SoftwareLicense'.MassiveAction::CLASS_ACTION_SEPARATOR.'add'
-               => "<i class='fas fa-key'></i>".
+               => "<i class='fa-fw ".SoftwareLicense::getIcon()."'></i>".
                   _x('button', 'Add a license'),
 
          ];

--- a/inc/computer_item.class.php
+++ b/inc/computer_item.class.php
@@ -220,7 +220,7 @@ class Computer_Item extends CommonDBRelation{
       $specificities = self::getRelationMassiveActionsSpecificities();
 
       if (in_array($itemtype, $specificities['itemtypes'])) {
-         $actions[$action_prefix.'add']    = "<i class='fas fa-plug'></i>".
+         $actions[$action_prefix.'add']    = "<i class='fa-fw fas fa-plug'></i>".
                                              _x('button', 'Connect');
          $actions[$action_prefix.'remove'] = _x('button', 'Disconnect');
       }

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -3454,7 +3454,7 @@ HTML;
 
 
    static function getIcon() {
-      return "fas fa-cog";
+      return "ti ti-adjustments";
    }
 
    /**

--- a/inc/consumable.class.php
+++ b/inc/consumable.class.php
@@ -828,6 +828,6 @@ class Consumable extends CommonDBChild {
 
 
    static function getIcon() {
-      return "fas fa-box-open";
+      return "ti ti-package";
    }
 }

--- a/inc/contract.class.php
+++ b/inc/contract.class.php
@@ -1707,7 +1707,7 @@ class Contract extends CommonDBTM {
    }
 
    static function getIcon() {
-      return "fas fa-file-signature";
+      return "ti ti-writing-sign";
    }
 
    public static function getExpiredCriteria() {

--- a/inc/contract.class.php
+++ b/inc/contract.class.php
@@ -1602,7 +1602,7 @@ class Contract extends CommonDBTM {
       if (in_array($itemtype, $CFG_GLPI["contract_types"])) {
          if (self::canUpdate()) {
             $action_prefix                    = 'Contract_Item'.MassiveAction::CLASS_ACTION_SEPARATOR;
-            $actions[$action_prefix.'add']    = "<i class='fas fa-file-contract'></i>".
+            $actions[$action_prefix.'add']    = "<i class='fa-fw ".self::getIcon()."'></i>".
                                                 _x('button', 'Add a contract');
             $actions[$action_prefix.'remove'] = _x('button', 'Remove a contract');
          }

--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -1966,6 +1966,6 @@ class CronTask extends CommonDBTM{
 
 
    static function getIcon() {
-      return "fas fa-stopwatch";
+      return "ti ti-settings-automation";
    }
 }

--- a/inc/dashboard/filter.class.php
+++ b/inc/dashboard/filter.class.php
@@ -253,7 +253,7 @@ JAVASCRIPT;
       <fieldset id='filter-{$rand}' class='filter $class' data-filter-id='{$id}'>
          $field
          <legend>$label</legend>
-         <i class='btn btn-sm btn-icon btn-ghost-secondary fas fa-trash delete-filter'></i>
+         <i class='btn btn-sm btn-icon btn-ghost-secondary ti ti-trash delete-filter'></i>
          {$js}
       </fieldset>
 HTML;

--- a/inc/dashboard/grid.class.php
+++ b/inc/dashboard/grid.class.php
@@ -301,25 +301,25 @@ HTML;
             $l_tb_icons.= "<i class='btn btn-outline-secondary fas fa-plus fs-toggle add-dashboard' title='$add_dash_label'></i>";
          }
          if (!$mini && $can_clone) {
-            $r_tb_icons.= "<i class='btn btn-outline-secondary fas fa-clone fs-toggle clone-dashboard' title='$clone_label'></i>";
+            $r_tb_icons.= "<i class='btn btn-outline-secondary ti ti-copy fs-toggle clone-dashboard' title='$clone_label'></i>";
          }
          if (!$mini && $can_edit) {
-            $r_tb_icons.= "<i class='btn btn-outline-secondary fas fa-share-alt fs-toggle open-embed' title='$embed_label'></i>";
+            $r_tb_icons.= "<i class='btn btn-outline-secondary ti ti-share fs-toggle open-embed' title='$embed_label'></i>";
             $rename = "<div class='edit-dashboard-properties'>
                <input type='text' class='dashboard-name form-control' value='{$dashboard_title}' size='1'>
-               <i class='btn btn-outline-secondary fas fa-save save-dashboard-name' title='{$save_label}'></i>
+               <i class='btn btn-outline-secondary far fa-save save-dashboard-name' title='{$save_label}'></i>
                <span class='display-message'></span>
             </div>";
          }
          if (!$mini && $can_purge) {
-            $r_tb_icons.= "<i class='btn btn-outline-secondary fas fa-trash fs-toggle delete-dashboard' title='$delete_label'></i>";
+            $r_tb_icons.= "<i class='btn btn-outline-secondary ti ti-trash fs-toggle delete-dashboard' title='$delete_label'></i>";
          }
          if ($can_edit) {
-            $r_tb_icons.= "<i class='btn btn-outline-secondary fas fa-edit fs-toggle edit-dashboard' title='$edit_label'></i>";
+            $r_tb_icons.= "<i class='btn btn-outline-secondary ti ti-edit fs-toggle edit-dashboard' title='$edit_label'></i>";
          }
 
          if (!$mini) {
-            $r_tb_icons.= "<i class='btn btn-outline-secondary fas fa-expand toggle-fullscreen' title='$fs_label'></i>";
+            $r_tb_icons.= "<i class='btn btn-outline-secondary ti ti-maximize toggle-fullscreen' title='$fs_label'></i>";
          }
 
          if (!$mini) {
@@ -356,7 +356,7 @@ HTML;
          <div class='filters_toolbar'>
             <span class='filters'></span>
             <span class='filters-control'>
-               <i class="btn btn-sm btn-icon btn-ghost-secondary fas fa-plus-square plus-sign add-filter">
+               <i class="btn btn-sm btn-icon btn-ghost-secondary fas fa-plus plus-sign add-filter">
                   <span class='add-filter-lbl'>{$add_filter_lbl}</span>
                </i>
             </span>
@@ -601,9 +601,9 @@ HTML;
                {$data_option_attr}
                style="color: {$fg_color}">
             <span class="controls">
-               <i class="refresh-item fas fa-sync-alt" title="{$refresh_label}"></i>
-               <i class="edit-item fas fa-edit" title="{$edit_label}"></i>
-               <i class="delete-item fas fa-times" title="{$delete_label}"></i>
+               <i class="refresh-item ti ti-refresh" title="{$refresh_label}"></i>
+               <i class="edit-item ti ti-edit" title="{$edit_label}"></i>
+               <i class="delete-item ti ti-x" title="{$delete_label}"></i>
             </span>
             <div class="grid-stack-item-content">{$html}</div>
          </div>
@@ -836,7 +836,7 @@ HTML;
       echo "</div>";
 
       echo "<a href='#' class='btn btn-primary save_rights'>
-         <i class='fas fa-save'></i>
+         <i class='far fa-save'></i>
          <span>".__("Save")."</span>
       </a>";
 

--- a/inc/dashboard/widget.class.php
+++ b/inc/dashboard/widget.class.php
@@ -423,7 +423,7 @@ HTML;
       if ($nodata) {
          $numbers_html = "<span class='line empty-card no-data'>
                <span class='content'>
-                  <i class='icon fas fa-exclamation-triangle'></i>
+                  <i class='icon fas fa-alert-triangle'></i>
                </span>
                <span class='label'>".__('No data found')."</span>
             <span>";

--- a/inc/database.class.php
+++ b/inc/database.class.php
@@ -421,8 +421,8 @@ class Database extends CommonDBChild {
    static function getAdditionalMenuLinks() {
       $links = [];
       if (static::canView()) {
-         $insts = "<i class=\"fas fa-database pointer\" title=\"" . DatabaseInstance::getTypeName(Session::getPluralNumber()) .
-            "\"></i><span class=\"sr-only\">" . DatabaseInstance::getTypeName(Session::getPluralNumber()). "</span>";
+         $insts = "<i class=\"ti ti-database-import\" title=\"" . DatabaseInstance::getTypeName(Session::getPluralNumber()) .
+            "\"></i><span class='d-none d-xxl-block'>" . DatabaseInstance::getTypeName(Session::getPluralNumber()). "</span>";
          $links[$insts] = DatabaseInstance::getSearchURL(false);
 
       }
@@ -438,6 +438,7 @@ class Database extends CommonDBChild {
             'databaseinstance' => [
                'title' => DatabaseInstance::getTypeName(Session::getPluralNumber()),
                'page'  => DatabaseInstance::getSearchURL(false),
+               'icon'  => DatabaseInstance::getIcon(),
                'links' => [
                   'add'    => '/front/databaseinstance.form.php',
                   'search' => '/front/dabataseinstance.php',

--- a/inc/database.class.php
+++ b/inc/database.class.php
@@ -137,7 +137,7 @@ class Database extends CommonDBChild {
 
 
    static function getIcon() {
-      return "fas fa-database";
+      return "ti ti-database";
    }
 
    function rawSearchOptions() {

--- a/inc/databaseinstance.class.php
+++ b/inc/databaseinstance.class.php
@@ -519,4 +519,8 @@ class DatabaseInstance extends CommonDBTM {
          echo "</table>";
       }
    }
+
+   static function getIcon(){
+      return "ti ti-database-import";
+   }
 }

--- a/inc/databaseinstance.class.php
+++ b/inc/databaseinstance.class.php
@@ -520,7 +520,7 @@ class DatabaseInstance extends CommonDBTM {
       }
    }
 
-   static function getIcon(){
+   static function getIcon() {
       return "ti ti-database-import";
    }
 }

--- a/inc/datacenter.class.php
+++ b/inc/datacenter.class.php
@@ -155,7 +155,7 @@ class Datacenter extends CommonDBTM {
    static function getAdditionalMenuLinks() {
       $links = [];
       if (static::canView()) {
-         $rooms = "<i class='fas fa-building pointer'
+         $rooms = "<i class='ti ti-building pointer'
                       title=\"".DCRoom::getTypeName(Session::getPluralNumber())."\"></i>
             <span class='d-none d-xxl-block ps-1'>
                ".DCRoom::getTypeName(Session::getPluralNumber())."
@@ -175,6 +175,7 @@ class Datacenter extends CommonDBTM {
             'dcroom' => [
                'title' => DCRoom::getTypeName(Session::getPluralNumber()),
                'page'  => DCRoom::getSearchURL(false),
+               'icon'  => DCRoom::getIcon(),
                'links' => [
                   'add'    => '/front/dcroom.form.php',
                   'search' => '/front/dcroom.php',

--- a/inc/datacenter.class.php
+++ b/inc/datacenter.class.php
@@ -186,6 +186,6 @@ class Datacenter extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-warehouse";
+      return "ti ti-building-warehouse";
    }
 }

--- a/inc/dcroom.class.php
+++ b/inc/dcroom.class.php
@@ -480,6 +480,6 @@ class DCRoom extends CommonDBTM {
    }
 
    static function getIcon() {
-      return "fas fa-building";
+      return "ti ti-building";
    }
 }

--- a/inc/devicebattery.class.php
+++ b/inc/devicebattery.class.php
@@ -167,6 +167,6 @@ class DeviceBattery extends CommonDevice {
 
 
    static function getIcon() {
-      return "fas fa-battery-half";
+      return "ti ti-battery-2";
    }
 }

--- a/inc/devicecamera.class.php
+++ b/inc/devicecamera.class.php
@@ -227,6 +227,6 @@ class DeviceCamera extends CommonDevice {
    }
 
    static function getIcon() {
-      return "fas fa-camera";
+      return "ti ti-camera";
    }
 }

--- a/inc/devicepowersupply.class.php
+++ b/inc/devicepowersupply.class.php
@@ -148,6 +148,6 @@ class DevicePowerSupply extends CommonDevice {
 
 
    static function getIcon() {
-      return "fas fa-bolt";
+      return "ti ti-bolt";
    }
 }

--- a/inc/devicesoundcard.class.php
+++ b/inc/devicesoundcard.class.php
@@ -150,6 +150,6 @@ class DeviceSoundCard extends CommonDevice {
 
 
    static function getIcon() {
-      return "fas fa-volume-down";
+      return "ti ti-volume-2";
    }
 }

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -1455,7 +1455,7 @@ class Document extends CommonDBTM {
 
       if (self::canApplyOn($itemtype)) {
          if (Document::canView()) {
-            $actions[$action_prefix.'add']    = "<i class='far fa-file'></i>".
+            $actions[$action_prefix.'add']    = "<i class='fa-fw ".self::getIcon()."'></i>".
                                                 _x('button', 'Add a document');
             $actions[$action_prefix.'remove'] = _x('button', 'Remove a document');
          }

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -1639,7 +1639,7 @@ class Document extends CommonDBTM {
 
 
    static function getIcon() {
-      return "far fa-file";
+      return "ti ti-files";
    }
 
 

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -254,12 +254,12 @@ class Dropdown {
              && $item->canCreate()
              && !isset($_REQUEST['_in_modal'])
              && $params['addicon']) {
-               $icons .= '<div class="btn btn-outline-secondary">';
+               $icons .= '<div class="btn btn-outline-secondary"
+                               title=\"'.__s('Add').'\" data-bs-toggle="tooltip">';
                $icons .= Ajax::createIframeModalWindow('add_'.$field_id, $item->getFormURL(), ['display' => false]);
-               $icons .= "<span title=\"".__s('Add')."\"
-                                 data-bs-toggle='modal' data-bs-target='#add_$field_id'
+               $icons .= "<span data-bs-toggle='modal' data-bs-target='#add_$field_id'
                            >
-                  <i class='fas fa-fw fa-plus-circle'></i>
+                  <i class='fa-fw ti ti-plus'></i>
                   <span class='sr-only'>" . __s('Add') . "</span>
                </span>";
                $icons .= '</div>';
@@ -277,8 +277,8 @@ class Dropdown {
          // Location icon
          if ($itemtype == 'Location') {
             $icons .= '<div class="btn btn-outline-secondary">';
-            $icons .= "<span title='".__s('Display on map')."' onclick='showMapForLocation(this)' data-fid='$field_id'>
-               <i class='fas fa-fw fa-globe-americas'></i>
+            $icons .= "<span title='".__s('Display on map')."' data-bs-toggle='tooltip' onclick='showMapForLocation(this)' data-fid='$field_id'>
+               <i class='fa-fw ti ti-map'></i>
             </span>";
             $icons .= '</div>';
          }

--- a/inc/enclosure.class.php
+++ b/inc/enclosure.class.php
@@ -276,6 +276,6 @@ class Enclosure extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-th";
+      return "ti ti-columns";
    }
 }

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -3367,7 +3367,7 @@ class Entity extends CommonTreeDropdown {
    }
 
    static function getIcon() {
-      return "fas fa-layer-group";
+      return "ti ti-stack";
    }
 
    /**

--- a/inc/event.class.php
+++ b/inc/event.class.php
@@ -402,6 +402,6 @@ class Event extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-scroll";
+      return "ti ti-news";
    }
 }

--- a/inc/fieldunicity.class.php
+++ b/inc/fieldunicity.class.php
@@ -632,6 +632,6 @@ class FieldUnicity extends CommonDropdown {
 
 
    static function getIcon() {
-      return "fas fa-fingerprint";
+      return "ti ti-fingerprint";
    }
 }

--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -980,7 +980,7 @@ class Group extends CommonTreeDropdown {
    }
 
    static function getIcon() {
-      return "fas fa-users";
+      return "ti ti-users";
    }
 
    /**

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1289,7 +1289,7 @@ HTML;
                'Rack', 'Enclosure', 'PDU', 'PassiveDCEquipment', 'Unmanaged', 'Cable'
             ], $CFG_GLPI['devices_in_menu']),
             'default_dashboard' => '/front/dashboard_assets.php',
-            'icon'    => 'fas fa-boxes'
+            'icon'    => 'ti ti-package'
          ],
          'helpdesk' => [
             'title' => __('Assistance'),
@@ -1298,7 +1298,7 @@ HTML;
                'Planning', 'Stat', 'TicketRecurrent', 'RecurrentChange'
             ],
             'default_dashboard' => '/front/dashboard_helpdesk.php',
-            'icon'    => 'fas fa-headset'
+            'icon'    => 'ti ti-headset'
          ],
          'management' => [
             'title' => __('Management'),
@@ -1307,7 +1307,7 @@ HTML;
                'Document', 'Line', 'Certificate', 'Datacenter', 'Cluster', 'Domain',
                'Appliance', 'Database'
             ],
-            'icon'  => 'fas fa-wallet'
+            'icon'  => 'ti ti-wallet'
          ],
          'tools' => [
             'title' => __('Tools'),
@@ -1316,12 +1316,12 @@ HTML;
                'ReservationItem', 'Report', 'MigrationCleaner',
                'SavedSearch', 'Impact'
             ],
-            'icon' => 'fas fa-briefcase'
+            'icon' => 'ti ti-briefcase'
          ],
          'plugins' => [
             'title' => _n('Plugin', 'Plugins', Session::getPluralNumber()),
             'types' => [],
-            'icon'  => 'fas fa-puzzle-piece'
+            'icon'  => 'ti ti-puzzle'
          ],
          'admin' => [
             'title' => __('Administration'),
@@ -1329,7 +1329,7 @@ HTML;
                'User', 'Group', 'Entity', 'Rule',
                'Profile', 'QueuedNotification', 'Glpi\\Event', 'Glpi\Inventory\Inventory'
             ],
-            'icon'  => 'fas fa-user-shield'
+            'icon'  => 'ti ti-shield-check'
          ],
          'config' => [
             'title' => __('Setup'),
@@ -1338,7 +1338,7 @@ HTML;
                'SLM', 'Config', 'FieldUnicity', 'CronTask', 'Auth',
                'MailCollector', 'Link', 'Plugin'
             ],
-            'icon'  => 'fas fa-cogs'
+            'icon'  => 'ti ti-settings'
          ],
 
          // special items
@@ -1743,7 +1743,7 @@ HTML;
          $menu['create_ticket'] = [
             'default' => '/front/helpdesk.public.php?create_ticket=1',
             'title'   => __('Create a ticket'),
-            'icon'    => 'fas fa-plus',
+            'icon'    => 'ti ti-plus',
          ];
       }
 
@@ -2466,7 +2466,7 @@ HTML;
          }
          $out .= " href='#modal_massaction_content$identifier' title=\"".htmlentities($p['title'], ENT_QUOTES, 'UTF-8')."\">";
          if ($p['display_arrow']) {
-            $out .= "<i class='fas fa-level-".($p['ontop']?'down':'up')."-alt fa-flip-horizontal mt-2' style='margin-left: -2px;'></i>";
+            $out .= "<i class='ti ti-corner-left-".($p['ontop']?'down':'up')." mt-1' style='margin-left: -2px;'></i>";
          }
          $out .= "<span>".$p['title']."</span>";
          $out .= "</a>";

--- a/inc/impact.class.php
+++ b/inc/impact.class.php
@@ -748,8 +748,8 @@ class Impact extends CommonGLPI {
       echo '<div class="impact-header">';
       echo "<h2>" . __("Impact analysis") . "</h2>";
       echo "<div id='switchview'>";
-      echo "<a id='sviewlist' href='#list'><i class='pointer fa fa-list-alt' title='".__('View as list')."'></i></a>";
-      echo "<a id='sviewgraph' href='#graph'><i class='pointer fa fa-bezier-curve' title='".__('View graphical representation')."'></i></a>";
+      echo "<a id='sviewlist' href='#list'><i class='pointer ti ti-list' title='".__('View as list')."'></i></a>";
+      echo "<a id='sviewgraph' href='#graph'><i class='pointer ti ti-hierarchy-2' title='".__('View graphical representation')."'></i></a>";
       echo "</div>";
       echo "</div>";
 
@@ -1096,20 +1096,20 @@ class Impact extends CommonGLPI {
       echo '</div>'; // div class="impact-side-panel">
 
       echo '<ul>';
-      echo '<li id="save_impact" title="' . __("Save") .'"><i class="fas fa-fw fa-save"></i></li>';
-      echo '<li id="impact_undo" class="impact-disabled" title="' . __("Undo") .'"><i class="fas fa-fw fa-undo"></i></li>';
-      echo '<li id="impact_redo" class="impact-disabled" title="' . __("Redo") .'"><i class="fas fa-fw fa-redo"></i></li>';
+      echo '<li id="save_impact" title="' . __("Save") .'"><i class="fa-fw far fa-save"></i></li>';
+      echo '<li id="impact_undo" class="impact-disabled" title="' . __("Undo") .'"><i class="fa-fw fas fa-undo"></i></li>';
+      echo '<li id="impact_redo" class="impact-disabled" title="' . __("Redo") .'"><i class="fa-fw fas fa-redo"></i></li>';
       echo '<li class="impact-separator"></li>';
-      echo '<li id="add_node" title="' . __("Add asset") .'"><i class="fas fa-fw fa-plus"></i></li>';
-      echo '<li id="add_edge" title="' . __("Add relation") .'"><i class="fas fa-fw fa-slash"></i></li>';
+      echo '<li id="add_node" title="' . __("Add asset") .'"><i class="fa-fw ti ti-plus"></i></li>';
+      echo '<li id="add_edge" title="' . __("Add relation") .'"><i class="fa-fw ti ti-line"></i></li>';
       echo '<li id="add_compound" title="' . __("Add group") .'"><i class="far fa-fw fa-object-group"></i></li>';
-      echo '<li id="delete_element" title="' . __("Delete element") .'"><i class="fas fa-fw fa-trash"></i></li>';
+      echo '<li id="delete_element" title="' . __("Delete element") .'"><i class="fa-fw ti ti-trash"></i></li>';
       echo '<li class="impact-separator"></li>';
-      echo '<li id="export_graph" title="' . __("Download") .'"><i class="fas fa-fw fa-download"></i></li>';
-      echo '<li id="toggle_fullscreen" title="' . __("Fullscreen") .'"><i class="fas fa-fw fa-expand"></i></li>';
-      echo '<li id="impact_settings" title="' . __("Settings") .'"><i class="fas fa-fw fa-cog"></i></li>';
+      echo '<li id="export_graph" title="' . __("Download") .'"><i class="fa-fw ti ti-download"></i></li>';
+      echo '<li id="toggle_fullscreen" title="' . __("Fullscreen") .'"><i class="fa-fw ti ti-maximize"></i></li>';
+      echo '<li id="impact_settings" title="' . __("Settings") .'"><i class="fa-fw ti ti-adjustments"></i></li>';
       echo '</ul>';
-      echo '<span class="impact-side-toggle"><i class="fas fa-2x fa-chevron-left"></i></span>';
+      echo '<span class="impact-side-toggle"><i class="fa-fw ti ti-chevron-left"></i></span>';
       echo '</div>'; // <div class="impact-side impact-side-expanded">
       echo "</td></tr>";
       echo "</table>";

--- a/inc/infocom.class.php
+++ b/inc/infocom.class.php
@@ -1663,7 +1663,7 @@ class Infocom extends CommonDBChild {
 
       if (Infocom::canApplyOn($itemtype)
           && static::canCreate()) {
-         $actions[$action_name] = "<i class='far fa-money-bill-alt'></i>".
+         $actions[$action_name] = "<i class='fa-fw ".self::getIcon()."'></i>".
                                   __('Enable the financial and administrative information');
       }
    }

--- a/inc/inventory/inventory.class.php
+++ b/inc/inventory/inventory.class.php
@@ -725,7 +725,7 @@ class Inventory
    }
 
    static function getIcon() {
-      return "fas fa-cloud-download-alt";
+      return "ti ti-cloud-download";
    }
 
    public function getMetadata(): array {

--- a/inc/item_rack.class.php
+++ b/inc/item_rack.class.php
@@ -121,8 +121,8 @@ class Item_Rack extends CommonDBRelation {
       }
 
       echo "<div id='switchview'>";
-      echo "<i id='sviewlist' class='pointer fa fa-list-alt' title='".__('View as list')."'></i>";
-      echo "<i id='sviewgraph' class='pointer fa fa-th-large selected' title='".__('View graphical representation')."'></i>";
+      echo "<i id='sviewlist' class='pointer ti ti-list' title='".__('View as list')."'></i>";
+      echo "<i id='sviewgraph' class='pointer ti ti-server selected' title='".__('View graphical representation')."'></i>";
       echo "</div>";
 
       $items = iterator_to_array($items);
@@ -841,10 +841,10 @@ JAVASCRIPT;
       $icon = "";
       switch ($itemtype) {
          case "Computer":
-            $icon = "fas fa-server";
+            $icon = "ti ti-server";
             break;
          case "Reserved":
-            $icon = "fas fa-lock";
+            $icon = "ti ti-lock";
             break;
 
          default:

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -2121,6 +2121,6 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
 
 
    static function getIcon() {
-      return "fas fa-question";
+      return "ti ti-lifebuoy";
    }
 }

--- a/inc/knowbaseitem_item.class.php
+++ b/inc/knowbaseitem_item.class.php
@@ -400,10 +400,14 @@ class KnowbaseItem_Item extends CommonDBRelation {
          $action_prefix = __CLASS__.MassiveAction::CLASS_ACTION_SEPARATOR;
 
          $actions[$action_prefix.'add']
-            = "<i class='fas fa-book'></i>".
+            = "<i class='fa-fw ".self::getIcon()."'></i>".
               _x('button', 'Link knowledgebase article');
       }
 
       parent::getMassiveActionsForItemtype($actions, $itemtype, $is_deleted, $checkitem);
+   }
+
+   static function getIcon() {
+      return KnowbaseItem::getIcon();
    }
 }

--- a/inc/line.class.php
+++ b/inc/line.class.php
@@ -212,6 +212,6 @@ class Line extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-phone";
+      return "ti ti-phone-calling";
    }
 }

--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -706,6 +706,6 @@ class Link extends CommonDBTM {
    }
 
    static function getIcon() {
-      return "fas fa-link";
+      return "ti ti-link";
    }
 }

--- a/inc/location.class.php
+++ b/inc/location.class.php
@@ -507,7 +507,7 @@ class Location extends CommonTreeDropdown {
    }
 
    static function getIcon() {
-      return "fas fa-map-marker-alt";
+      return "ti ti-map-pin";
    }
 
    public function prepareInputForAdd($input) {

--- a/inc/lockedfield.class.php
+++ b/inc/lockedfield.class.php
@@ -108,7 +108,7 @@ class Lockedfield extends CommonDBTM {
    }
 
    static function getIcon() {
-      return "fas fa-lock";
+      return "ti ti-lock";
    }
 
    /**

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -2243,6 +2243,6 @@ class MailCollector  extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-inbox";
+      return "ti ti-inbox";
    }
 }

--- a/inc/marketplace/view.class.php
+++ b/inc/marketplace/view.class.php
@@ -74,7 +74,7 @@ class View extends CommonGLPI {
 
 
    static function getIcon() {
-      return "fas fa-store";
+      return "ti ti-building-store";
    }
 
 
@@ -175,7 +175,7 @@ class View extends CommonGLPI {
 
       if (count($messages)) {
          echo "<div class='alert alert-important alert-warning d-flex'>";
-         echo "<i class='fas fa-3x fa-exclamation-triangle '></i>";
+         echo "<i class='fa-3x ti ti-alert-triangle'></i>";
          echo "<ul><li>" . implode('</li><li>', $messages) . "</li></ul>";
          echo "</div>";
       }
@@ -365,32 +365,32 @@ class View extends CommonGLPI {
             <select class='sort-control form-select form-select-sm'>
                <option value='sort-alpha-asc'
                        ".($sort == "sort-alpha-asc" ? "selected" : "")."
-                       data-icon='fas fa-lg fa-sort-alpha-down'>
+                       data-icon='fa-fw fa-lg ti ti-sort-ascending-letters'>
                   ".__("Alpha ASC")."
                </option>
                <option value='sort-alpha-desc'
                        ".($sort == "sort-alpha-desc" ? "selected" : "")."
-                       data-icon='fas fa-lg fa-sort-alpha-down-alt'>
+                       data-icon='fa-fw fa-lg ti ti-sort-descending-letters'>
                   ".__("Alpha DESC")."
                </option>
                <option value='sort-dl'
                        ".($sort == "sort-dl'" ? "selected" : "")."
-                       data-icon='fas fa-lg fa-cloud-download-alt'>
+                       data-icon='fa-fw fa-lg ti ti-cloud-download'>
                   ".__("Most popular")."
                </option>
                <option value='sort-update'
                        ".($sort == "sort-update'" ? "selected" : "")."
-                       data-icon='fas fa-lg fa-history'>
+                       data-icon='fa-fw fas fa-lg fa-history'>
                   ".__("Last updated")."
                </option>
                <option value='sort-added'
                        ".($sort == "sort-added'" ? "selected" : "")."
-                       data-icon='fas fa-lg fa-calendar-plus'>
+                       data-icon='fa-fw fa-lg ti ti-calendar-time'>
                   ".__("Most recent")."
                </option>
                <option value='sort-note'
                        ".($sort == "sort-note'" ? "selected" : "")."
-                       data-icon='fas fa-lg fa-star'>
+                       data-icon='fa-fw fa-lg ti ti-star'>
                   ".__("Best notes")."
                </option>
             </select>";
@@ -409,7 +409,7 @@ class View extends CommonGLPI {
                   <input type='search' class='filter-list form-control' placeholder='{$search_label}'>
                   <div class='controls'>
                      $sort_controls
-                     <i class='fas fa-sync-alt refresh-plugin-list'
+                     <i class='ti ti-refresh refresh-plugin-list'
                         title='{$refresh_lbl}'></i>
                   </div>
                </div>
@@ -478,17 +478,17 @@ JS;
       $authors = Toolbox::stripTags(implode(', ', array_column($plugin['authors'] ?? [], 'name', 'id')));
       $authors_title = Html::entities_deep($authors);
       $authors = strlen($authors)
-         ? "<i class='fas fa-fw fa-user-friends'></i>{$authors}"
+         ? "<i class='fa-fw ti ti-users'></i>{$authors}"
          : "";
 
       $licence = Toolbox::stripTags($plugin['license'] ?? '');
       $licence = strlen($licence)
-         ? "<i class='fas fa-fw fa-balance-scale'></i>{$licence}"
+         ? "<i class='fa-fw ti ti-license'></i>{$licence}"
          : "";
 
       $version = Toolbox::stripTags($plugin['version'] ?? '');
       $version = strlen($version)
-         ? "<i class='fas fa-fw fa-code-branch'></i>{$version}"
+         ? "<i class='fa-fw ti ti-git-branch'></i>{$version}"
          : "";
 
       $stars = ($plugin['note'] ?? -1) > 0
@@ -498,21 +498,21 @@ JS;
       $home_url = Html::entities_deep($plugin['homepage_url'] ?? "");
       $home_url = strlen($home_url)
          ? "<a href='{$home_url}' target='_blank' >
-            <i class='fas fa-home add_tooltip' title='".__s("Homepage")."'></i>
+            <i class='ti ti-home-2 add_tooltip' title='".__s("Homepage")."'></i>
             </a>"
          : "";
 
       $issues_url = Html::entities_deep($plugin['issues_url'] ?? "");
       $issues_url = strlen($issues_url)
          ? "<a href='{$issues_url}' target='_blank' >
-            <i class='fas fa-bug add_tooltip' title='".__s("Get help")."'></i>
+            <i class='ti ti-bug add_tooltip' title='".__s("Get help")."'></i>
             </a>"
          : "";
 
       $readme_url = Html::entities_deep($plugin['readme_url'] ?? "");
       $readme_url = strlen($readme_url)
          ? "<a href='{$readme_url}' target='_blank' >
-            <i class='fas fa-book add_tooltip' title='".__s("Readme")."'></i>
+            <i class='ti ti-book add_tooltip' title='".__s("Readme")."'></i>
             </a>"
          : "";
       $icon    = self::getPluginIcon($plugin);
@@ -658,7 +658,7 @@ HTML;
 
       if (strlen($error)) {
          $rand = mt_rand();
-         $buttons .="<i class='fas fa-exclamation-triangle plugin-error' id='plugin-error-$rand'></i>";
+         $buttons .="<i class='ti ti-alert-triangle plugin-error' id='plugin-error-$rand'></i>";
          Html::showToolTip($error, [
             'applyto' => "plugin-error-$rand",
          ]);
@@ -682,7 +682,7 @@ HTML;
       } else if (!$is_available) {
          if (!$can_run_local_install) {
             $rand = mt_rand();
-            $buttons .="<i class='fas fa-exclamation-triangle plugin-unavailable' id='plugin-tooltip-$rand'></i>";
+            $buttons .="<i class='ti ti-alert-triangle plugin-unavailable' id='plugin-tooltip-$rand'></i>";
             Html::showToolTip(
                __('This plugin is not available for your GLPI version.'),
                [
@@ -719,7 +719,7 @@ HTML;
             $buttons .="<button class='modify_plugin'
                                 data-action='download_plugin'
                                 title='".__s("Download")."'>
-               <i class='fas fa-cloud-download-alt'></i>
+               <i class='ti ti-alert-triangle'></i>
             </button>";
          } else if ($can_be_updated) {
             $update_title = sprintf(
@@ -729,7 +729,7 @@ HTML;
             $buttons .="<button class='modify_plugin'
                                 data-action='update_plugin'
                                 title='{$update_title}'>
-               <i class='fas fa-cloud-download-alt'></i>
+               <i class='ti ti-cloud-download'></i>
             </button>";
          }
       }
@@ -749,7 +749,7 @@ HTML;
 
       if ($can_run_local_install) {
          $title = __s("Install");
-         $icon  = "fas fa-folder-plus";
+         $icon  = "ti ti-folder-plus";
          if ($has_local_update) {
             $title = __s("Update");
             $icon  =  "far fa-caret-square-up";
@@ -781,7 +781,7 @@ HTML;
          $buttons .="<button class='modify_plugin'
                              data-action='uninstall_plugin'
                              title='".__s("Uninstall")."'>
-            <i class='fas fa-folder-minus'></i>
+            <i class='ti ti-folder-x'></i>
          </button>";
 
          if (!strlen($error) && $is_actived && $config_page) {
@@ -789,7 +789,7 @@ HTML;
                $config_url = "$plugin_dir/$config_page";
                $buttons .="<a href='$config_url'>
                   <button class='add_tooltip' title='".__s("Configure")."'>
-                     <i class='fas fa-wrench'></i>
+                     <i class='ti ti-tool'></i>
                   </button>
                </a>";
          }

--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -478,7 +478,7 @@ class MassiveAction {
       if (Session::haveRight('transfer', READ)
           && Session::isMultiEntitiesMode()) {
          $actions[__CLASS__.self::CLASS_ACTION_SEPARATOR.'add_transfer_list']
-                  = "<i class='fas fa-level-up-alt'></i>".
+                  = "<i class='fa-fw fas fa-level-up-alt'></i>".
                     _x('button', 'Add to transfer list');
       }
 
@@ -545,7 +545,7 @@ class MassiveAction {
             $actions[$self_pref.'update'] = _x('button', 'Update');
 
             if (Toolbox::hasTrait($itemtype, Clonable::class)) {
-               $actions[$self_pref . 'clone'] = "<i class='far fa-clone'></i>"._x('button', 'Clone');
+               $actions[$self_pref . 'clone'] = "<i class='fa-fw far fa-clone'></i>"._x('button', 'Clone');
             }
          }
 
@@ -581,12 +581,12 @@ class MassiveAction {
          // Amend comment for objects with a 'comment' field
          $item->getEmpty();
          if ($canupdate && isset($item->fields['comment'])) {
-            $actions[$self_pref.'amend_comment'] = "<i class='far fa-comment'></i>".__("Amend comment");
+            $actions[$self_pref.'amend_comment'] = "<i class='fa-fw far fa-comment'></i>".__("Amend comment");
          }
 
          // Add a note for objects with the UPDATENOTE rights
          if (Session::haveRight($item::$rightname, UPDATENOTE)) {
-            $actions[$self_pref.'add_note'] = "<i class='far fa-sticky-note'></i>".__("Add note");
+            $actions[$self_pref.'add_note'] = "<i class='fa-fw far fa-sticky-note'></i>".__("Add note");
          }
 
          // Plugin Specific actions

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -457,7 +457,7 @@ class Monitor extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-desktop";
+      return "ti ti-device-desktop";
    }
 
 }

--- a/inc/notepad.class.php
+++ b/inc/notepad.class.php
@@ -346,7 +346,7 @@ class Notepad extends CommonDBChild {
                                     ['purge' => 'purge'],
                                     _x('button', 'Delete permanently'),
                                     ['id'   => $note['id']],
-                                    'fa-times-circle',
+                                    'ti ti-circle-x',
                                     '',
                                      __('Confirm the final deletion?'));
             }

--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -680,7 +680,7 @@ class Notification extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-bell";
+      return "ti ti-bell";
    }
 
    public function allowResponse() {

--- a/inc/passivedcequipment.class.php
+++ b/inc/passivedcequipment.class.php
@@ -208,6 +208,6 @@ class PassiveDCEquipment extends CommonDBTM {
    }
 
    static function getIcon() {
-      return "fas fa-th-list";
+      return "ti ti-layout-navbar";
    }
 }

--- a/inc/pdu.class.php
+++ b/inc/pdu.class.php
@@ -213,7 +213,7 @@ class PDU extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-plug";
+      return "ti ti-plug";
    }
 
    function prepareInputForAdd($input) {

--- a/inc/phone.class.php
+++ b/inc/phone.class.php
@@ -449,6 +449,6 @@ class Phone extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-phone";
+      return "ti ti-phone";
    }
 }

--- a/inc/planning.class.php
+++ b/inc/planning.class.php
@@ -2517,6 +2517,6 @@ class Planning extends CommonGLPI {
    }
 
    static function getIcon() {
-      return "far fa-calendar-alt";
+      return "ti ti-calendar-time";
    }
 }

--- a/inc/plug.class.php
+++ b/inc/plug.class.php
@@ -52,6 +52,6 @@ class Plug extends CommonDropdown {
    }
 
    static function getIcon() {
-      return "fas fa-plug";
+      return "ti ti-plug";
    }
 }

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -2458,7 +2458,7 @@ class Plugin extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-puzzle-piece";
+      return "ti ti-puzzle";
    }
 
    function getSpecificMassiveActions($checkitem = null) {

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -716,7 +716,7 @@ class Printer  extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-print";
+      return "ti ti-printer";
    }
 
 }

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -1732,7 +1732,7 @@ class Problem extends CommonITILObject {
 
 
    static function getIcon() {
-      return "fas fa-exclamation-triangle";
+      return "ti ti-alert-triangle";
    }
 
    public static function getItemLinkClass(): string {

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -3362,6 +3362,6 @@ class Profile extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-user-check";
+      return "ti ti-user-check";
    }
 }

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -247,10 +247,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
       if (static::canView()
           || Session::haveRight('projecttask', ProjectTask::READMY)) {
          $pic_validate = '
-            <span class="fa-stack" title="'.__('My tasks').'">
-               <i class="fas fa-check fa-stack-1x" style="top: 1px; left: -2px; font-size: 1.2em"></i>
-               <i class="far fa-clock fa-stack-1x" style="top: 6px; left: 1px"></i>
-            </span>
+            <i class="ti ti-eye-check" title="'.__('My tasks').'"></i>
             <span class="d-none d-xxl-block">
                '.__('My tasks').'
             </span>
@@ -2553,6 +2550,6 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
 
 
    static function getIcon() {
-      return "fas fa-columns";
+      return "ti ti-layout-kanban";
    }
 }

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -75,7 +75,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
    }
 
    public static function getIcon() {
-      return 'fas fa-tasks';
+      return 'ti ti-list-check';
    }
 
 

--- a/inc/queuednotification.class.php
+++ b/inc/queuednotification.class.php
@@ -794,6 +794,6 @@ class QueuedNotification extends CommonDBTM {
 
 
    static function getIcon() {
-      return "far fa-list-alt";
+      return "ti ti-notification";
    }
 }

--- a/inc/rack.class.php
+++ b/inc/rack.class.php
@@ -855,6 +855,6 @@ JAVASCRIPT;
 
 
    static function getIcon() {
-      return "fas fa-server";
+      return "ti ti-server";
    }
 }

--- a/inc/rack.class.php
+++ b/inc/rack.class.php
@@ -320,8 +320,8 @@ class Rack extends CommonDBTM {
       );
 
       echo "<div id='switchview'>";
-      echo "<i id='sviewlist' class='pointer fa fa-list-alt' title='".__('View as list')."'></i>";
-      echo "<i id='sviewgraph' class='pointer fa fa-th-large selected' title='".__('View graphical representation')."'></i>";
+      echo "<i id='sviewlist' class='pointer ti ti-list' title='".__('View as list')."'></i>";
+      echo "<i id='sviewgraph' class='pointer ti ti-layout-grid selected' title='".__('View graphical representation')."'></i>";
       echo "</div>";
 
       $racks = iterator_to_array($racks);

--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -1074,6 +1074,6 @@ class Reminder extends CommonDBVisible implements
 
 
    static function getIcon() {
-      return "far fa-sticky-note";
+      return "ti ti-note";
    }
 }

--- a/inc/report.class.php
+++ b/inc/report.class.php
@@ -543,7 +543,7 @@ class Report extends CommonGLPI{
 
 
    static function getIcon() {
-      return "fas fa-file-medical-alt";
+      return "ti ti-report";
    }
 
 }

--- a/inc/reservation.class.php
+++ b/inc/reservation.class.php
@@ -1182,7 +1182,7 @@ JAVASCRIPT;
 
 
    static function getIcon() {
-      return "fas fa-calendar-check";
+      return "ti ti-calendar-event";
    }
 
 }

--- a/inc/rssfeed.class.php
+++ b/inc/rssfeed.class.php
@@ -1035,6 +1035,6 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria {
 
 
    static function getIcon() {
-      return "fas fa-rss";
+      return "ti ti-rss";
    }
 }

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -3203,7 +3203,7 @@ class Rule extends CommonDBTM {
    }
 
    static function getIcon() {
-      return "fas fa-book";
+      return "ti ti-book";
    }
 
    public function prepareInputForClone($input) {

--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -874,7 +874,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria {
              class='btn btn-ghost-secondary btn-icon btn-sm me-1 bookmark_record save'
              data-bs-toggle='tooltip' data-bs-placement='bottom'
              title='".__s('Save current search')."'>";
-      echo "<i class='fas fa-lg fa-star " . ($active ? 'active' : '') . "'></i>";
+      echo "<i class='ti fa-lg ti-star " . ($active ? 'active' : '') . "'></i>";
       echo "</a>";
 
       $params = [
@@ -1289,6 +1289,6 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria {
 
 
    static function getIcon() {
-      return "far fa-bookmark";
+      return "ti ti-bookmarks";
    }
 }

--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -809,7 +809,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria {
                                 : __s('Counting this saved search would take too long, it has been skipped.');
                if ($count === null) {
                   //no count, just inform the user
-                  $count = "<span class='fa fa-info-circle' title='$info_message'></span>";
+                  $count = "<span class='ti ti-info-circle' title='$info_message'></span>";
                }
             }
 

--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -874,7 +874,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria {
              class='btn btn-ghost-secondary btn-icon btn-sm me-1 bookmark_record save'
              data-bs-toggle='tooltip' data-bs-placement='bottom'
              title='".__s('Save current search')."'>";
-      echo "<i class='ti fa-lg ti-star " . ($active ? 'active' : '') . "'></i>";
+      echo "<i class='ti ti-star " . ($active ? 'active' : '') . "'></i>";
       echo "</a>";
 
       $params = [

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2260,7 +2260,7 @@ class Search {
                   .$p['target']
                   .(strpos($p['target'], '?') ? '&amp;' : '?')
                   ."reset=reset' title=\"".__s('Blank')."\"
-                  ><i class='ti fa-lg ti-circle-x'></i></a>";
+                  ><i class='ti ti-circle-x'></i></a>";
             }
          }
       }

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2241,7 +2241,7 @@ class Search {
       if ($p['mainform']) {
          // Display submit button
          echo "<button class='btn btn-sm btn-primary me-1' type='submit' name='".$p['actionname']."'>
-               <i class='fas fa-search'></i>
+               <i class='ti ti-search'></i>
                <span class='d-none d-sm-block'>".$p['actionvalue']."</span>
             </button>";
          if ($p['showbookmark'] || $p['showreset']) {
@@ -2260,7 +2260,7 @@ class Search {
                   .$p['target']
                   .(strpos($p['target'], '?') ? '&amp;' : '?')
                   ."reset=reset' title=\"".__s('Blank')."\"
-                  ><i class='fas fa-lg fa-undo'></i></a>";
+                  ><i class='ti fa-lg ti-circle-x'></i></a>";
             }
          }
       }

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2223,17 +2223,17 @@ class Search {
       echo "<div class='card-footer d-flex search_actions'>";
       $linked = self::getMetaItemtypeAvailable($itemtype);
       echo "<button id='addsearchcriteria$rand_criteria' class='btn btn-sm btn-outline-secondary me-1' type='button'>
-               <i class='fas fa-plus-square'></i>
+               <i class='ti ti-square-plus'></i>
                <span class='d-none d-sm-block'>".__s('rule')."</span>
             </button>";
       if (count($linked)) {
          echo "<button id='addmetasearchcriteria$rand_criteria' class='btn btn-sm btn-outline-secondary me-1' type='button'>
-                  <i class='far fa-plus-square'></i>
+                  <i class='ti ti-circle-plus'></i>
                   <span class='d-none d-sm-block'>".__s('global rule')."</span>
                </button>";
       }
       echo "<button id='addcriteriagroup$rand_criteria' class='btn btn-sm btn-outline-secondary me-1' type='button'>
-               <i class='fas fa-plus-circle'></i>
+               <i class='ti ti-code-plus'></i>
                <span class='d-none d-sm-block'>".__s('group')."</span>
             </button>";
       $json_p = json_encode($p);
@@ -2241,7 +2241,7 @@ class Search {
       if ($p['mainform']) {
          // Display submit button
          echo "<button class='btn btn-sm btn-primary me-1' type='submit' name='".$p['actionname']."'>
-               <i class='ti ti-search'></i>
+               <i class='ti ti-list-search'></i>
                <span class='d-none d-sm-block'>".$p['actionvalue']."</span>
             </button>";
          if ($p['showbookmark'] || $p['showreset']) {
@@ -2445,7 +2445,7 @@ JAVASCRIPT;
          echo "<button class='btn btn-sm btn-icon btn-ghost-secondary remove-search-criteria' type='button' data-rowid='$rowid'
                        data-bs-toggle='tooltip' data-bs-placement='left'
                        title=\"".__s('Delete a rule')."\">
-            <i class='far fa-minus-square' alt='-'></i>
+            <i class='ti ti-square-minus' alt='-'></i>
          </button>";
          echo "</div>";
       }
@@ -2595,7 +2595,7 @@ JAVASCRIPT;
 
       echo "<div class='col-auto'>";
       echo "<button class='btn btn-sm btn-icon btn-ghost-secondary remove-search-criteria' type='button' data-rowid='$rowid'>
-         <i class='far fa-minus-square' alt='-' title=\"".
+         <i class='ti ti-square-minus' alt='-' title=\"".
          __s('Delete a global rule')."\"></i>
       </button>";
       echo "</div>";
@@ -2690,7 +2690,7 @@ JAVASCRIPT;
                     data-bs-toggle='tooltip' data-bs-placement='left'
                     title=\"".__s('Delete a rule')."\"
       >
-         <i class='far fa-minus-square' alt='-'></i>
+         <i class='ti ti-square-minus' alt='-'></i>
       </button>";
       echo "</div>";
       echo "<div class='col-auto'>";

--- a/inc/slm.class.php
+++ b/inc/slm.class.php
@@ -213,6 +213,6 @@ class SLM extends CommonDBTM {
 
 
    static function getIcon() {
-      return "fas fa-file-contract";
+      return "ti ti-checkup-list";
    }
 }

--- a/inc/snmpcredential.class.php
+++ b/inc/snmpcredential.class.php
@@ -166,6 +166,6 @@ class SNMPCredential extends CommonDBTM {
    }
 
    public static function getIcon() {
-      return "fas fa-user-secret";
+      return "ti ti-key";
    }
 }

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -1058,7 +1058,7 @@ class Software extends CommonDBTM {
    }
 
    static function getIcon() {
-      return "fas fa-cube";
+      return "ti ti-apps";
    }
 
    public function handleCategoryRules(array &$input) {

--- a/inc/softwarelicense.class.php
+++ b/inc/softwarelicense.class.php
@@ -1230,6 +1230,6 @@ class SoftwareLicense extends CommonTreeDropdown {
    }
 
    static function getIcon() {
-      return "fas fa-key";
+      return "ti ti-key";
    }
 }

--- a/inc/stat.class.php
+++ b/inc/stat.class.php
@@ -1932,6 +1932,6 @@ class Stat extends CommonGLPI {
    }
 
    static function getIcon() {
-      return "fas fa-chart-bar";
+      return "ti ti-chart-pie";
    }
 }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2493,7 +2493,7 @@ class Ticket extends CommonITILObject {
       if (Session::getCurrentInterface() == 'central') {
          if (Ticket::canUpdate() && Ticket::canDelete()) {
             $actions[__CLASS__.MassiveAction::CLASS_ACTION_SEPARATOR.'merge_as_followup']
-               = "<i class='fa-fw ti ti-git-branch'></i>".
+               = "<i class='fa-fw ti ti-git-merge'></i>".
                  __('Merge as Followup');
          }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -121,7 +121,7 @@ class Ticket extends CommonITILObject {
             'create_ticket' => [
                'title' => __('Create ticket'),
                'page'  => static::getFormURL(false),
-               'icon'  => 'fas fa-plus',
+               'icon'  => 'ti ti-plus',
             ],
          ];
          return $menu;
@@ -164,10 +164,7 @@ class Ticket extends CommonITILObject {
          $opt['criteria'][4]['link']       = 'AND NOT';
 
          $pic_validate = '
-            <span class="fa-stack" title="'.__s('Ticket waiting for your approval').'">
-                <i class="fas fa-check fa-stack-1x" style="top: 1px; left: -2px; font-size: 1.2em"></i>
-                <i class="far fa-clock fa-stack-1x" style="top: 6px; left: 1px"></i>
-            </span>
+            <i class="ti ti-eye-check" title="'.__s('Ticket waiting for your approval').'"></i>
             <span class="d-none d-xxl-block">
                '.__s('Ticket waiting for your approval').'
             </span>
@@ -5174,7 +5171,7 @@ JAVASCRIPT;
          $twig_params['title']['button'] = [
             'link'   => $CFG_GLPI["root_doc"].'/front/helpdesk.public.php?create_ticket=1',
             'text'   => __('Create a ticket'),
-            'icon'   => 'fa fa-plus',
+            'icon'   => 'ti ti-plus',
          ];
       }
 
@@ -6808,7 +6805,7 @@ JAVASCRIPT;
 
 
    static function getIcon() {
-      return "fas fa-exclamation-circle";
+      return "ti ti-alert-circle";
    }
 
    public static function getItemLinkClass(): string {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -2493,31 +2493,31 @@ class Ticket extends CommonITILObject {
       if (Session::getCurrentInterface() == 'central') {
          if (Ticket::canUpdate() && Ticket::canDelete()) {
             $actions[__CLASS__.MassiveAction::CLASS_ACTION_SEPARATOR.'merge_as_followup']
-               = "<i class='fas fa-code-branch'></i>".
+               = "<i class='fa-fw ti ti-git-branch'></i>".
                  __('Merge as Followup');
          }
 
          if (Item_Ticket::canCreate()) {
             $actions['Item_Ticket'.MassiveAction::CLASS_ACTION_SEPARATOR.'add_item']
-               = "<i class='fas fa-plus'></i>".
+               = "<i class='fa-fw fas fa-plus'></i>".
                  _x('button', 'Add an item');
          }
 
          if (ITILFollowup::canCreate()) {
             $actions['ITILFollowup'.MassiveAction::CLASS_ACTION_SEPARATOR.'add_followup']
-               = "<i class='far fa-comment'></i>".
+               = "<i class='fa-fw ti ti-message-circle'></i>".
                  __('Add a new followup');
          }
 
          if (TicketTask::canCreate()) {
             $actions[__CLASS__.MassiveAction::CLASS_ACTION_SEPARATOR.'add_task']
-               = "<i class='far fa-check-square'></i>".
+               = "<i class='fa-fw ti ti-checkbox'></i>".
                  __('Add a new task');
          }
 
          if (TicketValidation::canCreate()) {
             $actions['TicketValidation'.MassiveAction::CLASS_ACTION_SEPARATOR.'submit_validation']
-               = "<i class='fas fa-check'></i>".
+               = "<i class='fa-fw fas fa-check'></i>".
                  __('Approval request');
          }
 
@@ -2528,18 +2528,18 @@ class Ticket extends CommonITILObject {
 
          if (Session::haveRight(self::$rightname, UPDATE)) {
             $actions[__CLASS__.MassiveAction::CLASS_ACTION_SEPARATOR.'add_actor']
-               = "<i class='fas fa-user'></i>".
+               = "<i class='fa-fw ti ti-user'></i>".
                  __('Add an actor');
             $actions[__CLASS__.MassiveAction::CLASS_ACTION_SEPARATOR.'update_notif']
                = __('Set notifications for all actors');
             $actions['Ticket_Ticket'.MassiveAction::CLASS_ACTION_SEPARATOR.'add']
-               = "<i class='fas fa-link'></i>".
+               = "<i class='fa-fw fas fa-link'></i>".
                  _x('button', 'Link tickets');
             $actions['ProjectTask_Ticket'.MassiveAction::CLASS_ACTION_SEPARATOR.'add']
-               = "<i class='fas fa-link'></i>".
+               = "<i class='fa-fw fas fa-link'></i>".
                _x('button', 'Link project task');
             $actions[__CLASS__.MassiveAction::CLASS_ACTION_SEPARATOR.'add_contract']
-               = "<i class='fas fa-file-signature'></i>".
+               = "<i class='fa-fw ".Contract::getIcon()."'></i>".
                  _x('button', 'Add contract');
 
             KnowbaseItem_Item::getMassiveActionsForItemtype($actions, __CLASS__, 0, $checkitem);
@@ -2547,13 +2547,13 @@ class Ticket extends CommonITILObject {
 
          if (Problem::canUpdate()) {
             $actions[self::getType() . MassiveAction::CLASS_ACTION_SEPARATOR . 'link_to_problem']
-               = "<i class='fas fa-exclamation-triangle' ></i>" .
+               = "<i class='fa-fw ".Problem::getIcon()."' ></i>" .
                __("Link to a problem");
          }
 
          if (self::canUpdate()) {
             $actions[self::getType() . MassiveAction::CLASS_ACTION_SEPARATOR . 'resolve_tickets']
-               = "<i class='fas fa-check'></i>" .
+               = "<i class='fa-fw fas fa-check'></i>" .
                __("Resolve selected tickets");
          }
       }

--- a/inc/unmanaged.class.php
+++ b/inc/unmanaged.class.php
@@ -197,7 +197,7 @@ class Unmanaged extends CommonDBTM {
    }
 
    static function getIcon() {
-      return "fas fa-question";
+      return "ti ti-question-mark";
    }
 
    function getSpecificMassiveActions($checkitem = null) {

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -5656,7 +5656,7 @@ JAVASCRIPT;
    }
 
    static function getIcon() {
-      return "fas fa-user";
+      return "ti ti-user";
    }
 
    /**

--- a/js/common.js
+++ b/js/common.js
@@ -918,7 +918,7 @@ var templateItilStatus = function(option) {
          classes = 'assigned far fa-circle';
          break;
       case 3 :
-         classes = 'planned fas fa-calendar';
+         classes = 'planned far fa-calendar';
          break;
       case 4 :
          classes = 'waiting fas fa-circle';
@@ -964,7 +964,7 @@ var templateValidation = function(option) {
    var classes = "";
    switch (parseInt(status)) {
       case 2 : // WAITING
-         classes = 'waiting fas fa-clock';
+         classes = 'waiting far fa-clock';
          break;
       case 3 : // ACCEPTED
          classes = 'accepted fas fa-check';

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -554,9 +554,9 @@ var Dashboard = {
       var html = ' \
       <div class="grid-stack-item"> \
          <span class="controls"> \
-            <i class="refresh-item fas fa-sync-alt" title="'+__("Refresh this card")+'"></i> \
-            <i class="edit-item fas fa-edit" title="'+__("Edit this card")+'"></i> \
-            <i class="delete-item fas fa-times" title="'+__("Delete this card")+'"></i> \
+            <i class="refresh-item ti ti-refresh" title="'+__("Refresh this card")+'"></i> \
+            <i class="edit-item ti ti-edit" title="'+__("Edit this card")+'"></i> \
+            <i class="delete-item ti ti-x" title="'+__("Delete this card")+'"></i> \
          </span> \
          <div class="grid-stack-item-content"> \
          </div> \

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -142,7 +142,7 @@ var displayUploadedFile = function(file, tag, editor, input_name, filecontainer)
 
    // Delete button
    var elementsIdToRemove = {0:file.id, 1:file.id+'2'};
-   $('<span class="fa fa-times-circle pointer"></span>').click(function() {
+   $('<span class="ti ti-circle-x pointer"></span>').click(function() {
       deleteImagePasted(elementsIdToRemove, tag.tag, editor);
    }).appendTo(p);
 

--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -453,10 +453,10 @@ class GLPIKanbanRights {
             add_itemtype_bulk_dropdown += "<li id='kanban-bulk-add-" + itemtype + "' class='dropdown-item'><span>" + self.supported_itemtypes[itemtype]['name'] + '</span></li>';
          });
          add_itemtype_bulk_dropdown += '</ul>';
-         const add_itemtype_bulk_link = '<a href="#">' + '<i class="fas fa-list"></i>' + __('Bulk add') + '</a>';
+         const add_itemtype_bulk_link = '<a href="#">' + '<i class="fa-fw fas fa-list"></i>' + __('Bulk add') + '</a>';
          column_overflow_dropdown += '<li class="dropdown-trigger dropdown-item">' + add_itemtype_bulk_link + add_itemtype_bulk_dropdown + '</li>';
          if (self.rights.canModifyView()) {
-            column_overflow_dropdown += "<li class='kanban-remove dropdown-item' data-forbid-protected='true'><span>"  + '<i class="fas fa-trash-alt"></i>' + __('Delete') + "</span></li>";
+            column_overflow_dropdown += "<li class='kanban-remove dropdown-item' data-forbid-protected='true'><span>"  + '<i class="fa-fw ti ti-trash"></i>' + __('Delete') + "</span></li>";
          }
          column_overflow_dropdown += '</ul>';
          kanban_container.append(column_overflow_dropdown);
@@ -466,13 +466,13 @@ class GLPIKanbanRights {
          let card_overflow_dropdown = "<ul id='kanban-item-overflow-dropdown' class='kanban-dropdown dropdown-menu' style='display: none'>";
          card_overflow_dropdown += `
             <li class='kanban-item-goto dropdown-item'>
-               <a href="#"><i class="fas fa-share"></i>${__('Go to')}</a>
+               <a href="#"><i class="fa-fw fas fa-share"></i>${__('Go to')}</a>
             </li>`;
          if (self.rights.canDeleteItem()) {
             card_overflow_dropdown += `
                 <li class='kanban-item-remove dropdown-item'>
                    <span>
-                      <i class="fas fa-trash-alt"></i>${__('Delete')}
+                      <i class="fa-fw ti ti-trash"></i>${__('Delete')}
                    </span>
                 </li>`;
          }
@@ -796,9 +796,9 @@ class GLPIKanbanRights {
 
             let delete_action = $(card_overflow_dropdown.find('.kanban-item-remove'));
             if (card.hasClass('deleted')) {
-               delete_action.html('<span><i class="fas fa-trash-alt"></i>'+__('Purge')+'</span>');
+               delete_action.html('<span><i class="ti ti-trash"></i>'+__('Purge')+'</span>');
             } else {
-               delete_action.html('<span><i class="fas fa-trash-alt"></i>'+__('Delete')+'</span>');
+               delete_action.html('<span><i class="ti ti-trash"></i>'+__('Delete')+'</span>');
             }
          });
 
@@ -1734,7 +1734,7 @@ class GLPIKanbanRights {
                <i class="${self.supported_itemtypes[itemtype]['icon']}"></i>
                ${self.supported_itemtypes[itemtype]['name']}
             </span>`;
-         form_header += "<i class='fas fa-times' title='Close' onclick='$(this).parent().parent().remove()'></i></div>";
+         form_header += "<i class='ti ti-x' title='Close' onclick='$(this).parent().parent().remove()'></i></div>";
          add_form += form_header;
 
          add_form += "<div class='kanban-item-content'>";
@@ -1796,7 +1796,7 @@ class GLPIKanbanRights {
                    <i class="${self.supported_itemtypes[itemtype]['icon']}"></i>
                    ${self.supported_itemtypes[itemtype]['name']}
                 </span>
-                <i class='fas fa-times' title='Close' onclick='$(this).parent().parent().remove()'></i>
+                <i class='ti ti-x' title='Close' onclick='$(this).parent().parent().remove()'></i>
                 <div>
                     <span class="kanban-item-subtitle">${__("One item per line")}</span>
                  </div>
@@ -2448,7 +2448,7 @@ class GLPIKanbanRights {
                         ${l.attr('data-name') || `${member_itemtype} (${member_items_id})`}
                      </div>
                      <button type="button" name="delete" class="btn btn-ghost-danger">
-                        <i class="fas fa-times" title="${__('Delete')}"></i>
+                        <i class="ti ti-x" title="${__('Delete')}"></i>
                      </button>
                   `);
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3989,9 +3989,9 @@
             }
         },
         "@tabler/icons": {
-            "version": "1.43.0",
-            "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-1.43.0.tgz",
-            "integrity": "sha512-PM3eIXRM1+kgvRui+vMd/9ppOGUDdhZYF4qk2yAc3Vk7pjRGhGqoEBkVBlwosb+0FUokf/Il8pEqMutybn20rw=="
+            "version": "1.45.0",
+            "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-1.45.0.tgz",
+            "integrity": "sha512-9pfBOIWSM5Fyeeh+3ft0fDF0qvKKzWsE/KUNs8qA6k12CwSLBWSqgGwcha4YMhevs3/eY3jzt0lKSv+OaAptOQ=="
         },
         "@tokenizer/token": {
             "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "@fullcalendar/rrule": "^4.4.0",
         "@fullcalendar/timegrid": "^4.4.0",
         "@tabler/core": "https://github.com/tabler/tabler/tarball/cb3140e98cc8ee1dd55b4704206437ceb61bdb37",
-        "@tabler/icons": "^1.41.2",
+        "@tabler/icons": "^1.45.0",
         "animate.css": "^4.1.1",
         "bootstrap": "^5.1.1",
         "chartist": "^0.11.4",

--- a/templates/components/dashboard/widget_form.html.twig
+++ b/templates/components/dashboard/widget_form.html.twig
@@ -131,7 +131,7 @@
    <div class="modal-footer">
       <button type="submit" class="btn btn-primary {{ edit ? 'edit-widget' : 'add-widget' }}">
          {% if edit %}
-            <i class="fas fa-save"></i>
+            <i class="far fa-save"></i>
             <span>{{ _x('button', 'Update') }}</span>
          {% else %}
             <i class="fas fa-plus"></i>

--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -48,7 +48,7 @@
                </button>
             {% else %}
                <button class="btn btn-primary me-2" type="submit" name="update" value="1">
-                  <i class="fas fa-save"></i>
+                  <i class="far fa-save"></i>
                   <span>{{ _x('button', 'Save') }}</span>
                </button>
             {% endif %}
@@ -59,7 +59,7 @@
 
             {% if canedit and item.can(id, constant('UPDATE')) %}
                <button class="btn btn-primary me-2" type="submit" name="update" value="1">
-                  <i class="fas fa-save"></i>
+                  <i class="far fa-save"></i>
                   <span>{{ _x('button', 'Save') }}</span>
                </button>
             {% endif %}
@@ -69,7 +69,7 @@
                   {% if item.can(id, constant('DELETE')) %}
                      <button class="btn btn-outline-secondary me-2" type="submit"
                              name="restore" value="1">
-                        <i class="fas fa-trash-restore"></i>
+                        <i class="ti ti-trash-off"></i>
                         <span>{{ _x('button', 'Restore') }}</span>
                      </button>
                   {% endif %}
@@ -78,7 +78,7 @@
                      <button class="btn btn-outline-danger me-2" type="submit" name="purge"
                              value="1"
                              onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
-                        <i class="fas fa-trash-alt"></i>
+                        <i class="ti ti-trash"></i>
                         <span>{{ _x('button', 'Delete permanently') }}</span>
                      </button>
                      <div class="d-inline-block">
@@ -96,14 +96,14 @@
                         <button class="btn btn-outline-danger me-2" type="submit" name="purge"
                                 onclick="return confirm('{{ __('Confirm the final deletion?') }}');"
                                 value="1">
-                           <i class="fas fa-trash-alt"></i>
+                           <i class="ti ti-trash"></i>
                            <span>{{ _x('button', 'Delete permanently') }}</span>
                         </button>
                      {% endif %}
                   {% elseif not item.isDeleted() and item.can(id, constant('DELETE')) %}
                      <button class="btn btn-outline-warning me-2" type="submit"
                              name="delete" value="1">
-                        <i class="fas fa-trash-alt"></i>
+                        <i class="ti ti-trash"></i>
                         <span>{{ _x('button', 'Put in trashbin') }}</span>
                      </button>
                   {% endif %}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -373,7 +373,7 @@
             <input type="hidden" name="_blank_{{ name }}" />
             <button type="button" class="btn p-2 position-absolute top-0 start-0" title="{{ __('Delete') }}"
                     onclick="const blank_input = $('input[name=\'_blank_{{ name }}\']'); blank_input.val(blank_input.val() ? '' : true); $(this).toggleClass('btn-danger')">
-               <i class="fas fa-times"></i>
+               <i class="ti ti-x"></i>
             </button>
          {% endif %}
       </div>

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -99,7 +99,7 @@
 
             {% if is_multi_entities_mode() and item is not instanceof('Entity') %}
                <span class="badge entity-name mx-1 px-2 py-3 ms-auto">
-                  <i class="fas fa-layer-group me-2"></i>
+                  <i class="ti ti-stack me-2"></i>
                   {{ entity_name }}
                </span>
 

--- a/templates/components/form/single-action.html.twig
+++ b/templates/components/form/single-action.html.twig
@@ -41,7 +41,7 @@
    <button class="btn {{ onlyicon ? 'btn-icon' : 'dropdown-toggle' }} btn-outline-secondary" type="button"
            id="single-action" data-bs-toggle="dropdown" aria-haspopup="true"
            aria-expanded="false">
-      <i class="fas fa-ellipsis-v"></i>
+      <i class="ti ti-dots-vertical"></i>
       {% if not onlyicon %}
          <span>{{ __('Actions') }}</span>
       {% endif %}

--- a/templates/components/infocom.html.twig
+++ b/templates/components/infocom.html.twig
@@ -329,7 +329,7 @@
       <div class="card-body mx-n2 mb-4  border-top">
          {% if can_global_update %}
             <button class="btn btn-primary me-2" type="submit" name="update">
-               <i class="fas fa-save"></i>
+               <i class="far fa-save"></i>
                <span>{{ _x('button', 'Save') }}</span>
             </button>
          {% endif %}

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -84,24 +84,23 @@
          var alt_email = element.data('alternative-email') ?? option.alternative_email ?? '';
 
          var icon = "";
-         var size = is_selection ? "fa-lg" : ""
          var fk   = "";
          switch (itemtype) {
             case "User":
                if (items_id == 0) {
                   text = alt_email;
-                  icon = `<i class="fas ${size} fa-fw fa-envelope mx-1" title="{{ __('Direct email') }}"></i>`;
+                  icon = `<i class="ti  fa-fw ti-mail mx-1" title="{{ __('Direct email') }}"></i>`;
                } else {
-                  icon = `<i class="fas ${size} fa-fw fa-user mx-1" title="{{ 'User'|itemtype_name }}"></i>`;
+                  icon = `<i class="ti  fa-fw ti-user mx-1" title="{{ 'User'|itemtype_name }}"></i>`;
                }
                fk   = "users_id_assign";
                break;
             case "Group":
-               icon = `<i class="fas ${size} fa-fw fa-users mx-1" title="{{ 'Group'|itemtype_name }}"></i>`;
+               icon = `<i class="ti  fa-fw ti-users mx-1" title="{{ 'Group'|itemtype_name }}"></i>`;
                fk   = "groups_id_assign";
                break;
             case "Supplier":
-               icon = `<i class="fas ${size} fa-fw fa-pallet mx-1" title="{{ 'Supplier'|itemtype_name }}"></i>`;
+               icon = `<i class="ti fa-fw ti-package mx-1" title="{{ 'Supplier'|itemtype_name }}"></i>`;
                fk   = "suppliers_id_assign";
                break;
          }

--- a/templates/components/itilobject/actors/main.html.twig
+++ b/templates/components/itilobject/actors/main.html.twig
@@ -162,7 +162,7 @@
       </div>
       <div class="modal-footer">
          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">
-            <i class="fas fa-times"></i>
+            <i class="ti ti-x"></i>
             <span>{{ __('Close') }}<span>
          </button>
          <button type="button" class="btn btn-primary" id="saveActorNotifySettings">

--- a/templates/components/itilobject/actors/main.html.twig
+++ b/templates/components/itilobject/actors/main.html.twig
@@ -166,7 +166,7 @@
             <span>{{ __('Close') }}<span>
          </button>
          <button type="button" class="btn btn-primary" id="saveActorNotifySettings">
-            <i class="fas fa-save"></i>
+            <i class="far fa-save"></i>
             <span>{{ __('Save') }}</span>
          </button>
       </div>

--- a/templates/components/itilobject/answer.html.twig
+++ b/templates/components/itilobject/answer.html.twig
@@ -44,7 +44,7 @@
                      <div class="clearfix">
                         <button class="btn btn-sm btn-ghost-secondary float-end mb-1 close-itil-answer"
                               data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">
-                           <i class="fas fa-lg fa-times"></i>
+                           <i class="fa-lg ti ti-x"></i>
                         </button>
                      </div>
                      <div>

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -40,7 +40,7 @@
    <div class="accordion-item">
       <h2 class="accordion-header" id="heading-main-ticket">
          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#ticket-main" aria-expanded="true" aria-controls="ticket-main">
-            <i class="fas fa-exclamation-circle me-1"></i>
+            <i class="ti ti-alert-circle me-1"></i>
             <span>{{ item.getTypeName(1) }}</span>
          </button>
       </h2>
@@ -235,7 +235,7 @@
    <div class="accordion-item">
       <h2 class="accordion-header" id="heading-actor">
          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#actors" aria-expanded="true" aria-controls="actors">
-            <i class="fa fa-users me-1"></i>
+            <i class="ti ti-users me-1"></i>
             <span>{{ __('Actors') }}</span>
             <span class="badge bg-secondary ms-2">
                {{ item.countActors() }}
@@ -253,7 +253,7 @@
       <div class="accordion-item">
          <h2 class="accordion-header" id="items-heading">
             <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#items" aria-expanded="true" aria-controls="items">
-               <i class="fa fa-users me-1"></i>
+               <i class="ti ti-package me-1"></i>
                <span>{{ _n('Item', 'Items', get_plural_number()) }}</span>
                <span class="item-counter badge bg-secondary ms-2"></span>
             </button>
@@ -271,7 +271,7 @@
       <div class="accordion-item">
          <h2 class="accordion-header" id="service-levels-heading">
             <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#service-levels" aria-expanded="true" aria-controls="service-levels">
-               <i class="fas fa-stopwatch me-1"></i>
+               <i class="ti ti-alarm me-1"></i>
                <span>{{ _n('Service level', 'Service levels', get_plural_number()) }}</span>
                {% if nb_la > 0 %}
                   <span class="badge bg-secondary ms-2">{{ nb_la }}</span>
@@ -303,7 +303,7 @@
       <div class="accordion-item">
          <h2 class="accordion-header" id="analysis-heading">
             <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#analysis" aria-expanded="true" aria-controls="analysis">
-               <i class="fas fa-binoculars me-1"></i>
+               <i class="ti ti-eyeglass me-1"></i>
                <span>{{ __("Analysis") }}</span>
                {% if nb_analysis > 0 %}
                   <span class="badge bg-secondary ms-2">{{ nb_analysis }}</span>
@@ -347,7 +347,7 @@
       <div class="accordion-item">
          <h2 class="accordion-header" id="plans-heading">
             <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#plans" aria-expanded="true" aria-controls="plans">
-               <i class="fas fa-tasks me-1"></i>
+               <i class="ti ti-checkup-list me-1"></i>
                <span>{{ __("Plans") }}</span>
                {% if nb_plans > 0 %}
                   <span class="badge bg-secondary ms-2">{{ nb_plans }}</span>
@@ -378,7 +378,7 @@
       <div class="accordion-item">
          <h2 class="accordion-header" id="linked_tickets-heading">
             <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#linked_tickets" aria-expanded="true" aria-controls="linked_tickets">
-               <i class="fas fa-link me-1"></i>
+               <i class="ti ti-link me-1"></i>
                {% set linked_tickets = ticket_ticket.getLinkedTicketsTo(item.fields['id']) %}
                {% set nb_linked_tickets = linked_tickets|length %}
                {% if item.isNewItem() and params['_link']['tickets_id_2']|length > 0 %}

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -92,14 +92,14 @@
                      <button class="btn btn-outline-danger" type="submit" name="purge"
                            title="{{ _x('button', 'Delete permanently') }}"
                            onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
-                        <i class="fas fa-trash-alt"></i>
+                        <i class="ti ti-trash"></i>
                         <span class="d-none d-md-block">{{ _x('button', 'Delete permanently') }}</span>
                      </button>
                   {% else %}
                      <button class="btn btn-outline-danger" type="submit" name="delete"
                            title="{{ _x('button', 'Put in trashbin') }}"
                            data-bs-toggle="tooltip" data-bs-placement="top">
-                        <i class="fas fa-trash-alt"></i>
+                        <i class="ti ti-trash"></i>
                      </button>
                   {% endif %}
                {% endif %}
@@ -115,7 +115,7 @@
                {% if display_save_btn %}
                   <button class="btn btn-primary" type="submit" name="update"
                         title="{{ _x('button', 'Save') }}">
-                     <i class="fas fa-save"></i>
+                     <i class="far fa-save"></i>
                      <span class="d-none d-md-block">{{ _x('button', 'Save') }}</span>
                   </button>
                {% endif %}

--- a/templates/components/itilobject/service_levels.html.twig
+++ b/templates/components/itilobject/service_levels.html.twig
@@ -99,7 +99,7 @@
                   </span>
 
                   {% if canupdate %}
-                     <i class="fa fa-times-circle ms-1" role="button"
+                     <i class="ti ti-x ms-1" role="button"
                         onclick="delete_date_{{ rand }}(event)"
                         title="{{ _x('button', 'Delete permanently') }}"
                         data-bs-toggle="tooltip" data-bs-placement="top"></i>

--- a/templates/components/itilobject/timeline/approbation_form.html.twig
+++ b/templates/components/itilobject/timeline/approbation_form.html.twig
@@ -67,7 +67,7 @@
 
                <div class="card-footer">
                   <button class="btn btn-icon btn-outline-danger me-2" name="add_reopen">
-                     <i class="fas fa-times"></i>
+                     <i class="ti ti-x"></i>
                      <span>{{ __('Refuse') }}</span>
                   </button>
 

--- a/templates/components/itilobject/timeline/filter_timeline.html.twig
+++ b/templates/components/itilobject/timeline/filter_timeline.html.twig
@@ -38,31 +38,31 @@
    },
    'followups': {
       'title': _n('Followup', 'Followups', get_plural_number()),
-      'icon': 'far fa-comment',
+      'icon': 'ti ti-message-circle',
       'itemtype': 'ITILFollowup',
       'checked': true,
    },
    'tasks': {
       'title': _n('Task', 'Tasks', get_plural_number()),
-      'icon': 'far fa-check-square',
+      'icon': 'ti ti-checkbox',
       'itemtype': 'ITILTask',
       'checked': true,
    },
    'documents': {
       'title': _n('Document', 'Documents', get_plural_number()),
-      'icon': 'fas fa-paperclip',
+      'icon': 'ti ti-paperclip',
       'itemtype': 'Document_Item',
       'checked': true,
    },
    'validations': {
       'title': _n('Validation', 'Validations', get_plural_number()),
-      'icon': 'far fa-thumbs-up',
+      'icon': 'ti ti-thumb-up',
       'itemtype': 'ITILValidation',
       'checked': true,
    },
    'solutions': {
       'title': _n('Solution', 'Solutions', get_plural_number()),
-      'icon': 'fas fa-check',
+      'icon': 'ti ti-check',
       'itemtype': 'ITILSolution',
       'checked': true,
    },
@@ -86,7 +86,7 @@
             data-bs-toggle="collapse"
             data-bs-target="#filter-timeline-popover"
             data-bs-trigger="click">
-         <i class="fas fa-filter"></i>
+         <i class="ti ti-filter"></i>
       </button>
    </span>
 

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -50,7 +50,7 @@
          {% if entry_i['link'] %}
             <div class="col-auto">
                <a href="{{ entry_i['link'] }}" target="_blank">
-                  <i class="fas fa-external-link"></i>
+                  <i class="ti ti-external-link"></i>
                   {{ entry_i['name'] }}
                </a>
             </div>
@@ -65,14 +65,14 @@
                <a href="{{ 'Document'|itemtype_form_path(entry_i['id']) }}"
                   class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Edit') }}"
                   data-bs-toggle="tooltip" data-bs-placement="top">
-                  <i class="fas fa-edit"></i>
+                  <i class="ti ti-edit"></i>
                </a>
 
                {% set fk = item.getForeignKeyField() %}
                <a href="{{ item.getFormURL() }}?delete_document&amp;documents_id={{ entry_i['id'] }}&amp;{{ fk }}={{ item.fields['id'] }}"
                   class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Delete permanently') }}"
                   data-bs-toggle="tooltip" data-bs-placement="top">
-                  <i class="fas fa-trash-alt"></i>
+                  <i class="ti ti-trash"></i>
                </a>
             </div>
          </div>

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -137,7 +137,7 @@
                      ) }}
 
                      {% set fup_private_lbl %}
-                        <i class="fas fa-lock fa-fw me-1" title="{{ __('Private') }}"></i>
+                        <i class="ti ti-lock fa-fw me-1" title="{{ __('Private') }}"></i>
                      {% endset %}
                      {{ fields.sliderField(
                         'is_private',
@@ -169,7 +169,7 @@
 
                      {% if candedit and can_update_kb and not nokb %}
                         {% set fup_to_kb_lbl %}
-                           <i class="fas fa-save fa-fw me-1" title="{{ __('Save and add to the knowledge base') }}"
+                           <i class="far fa-save fa-fw me-1" title="{{ __('Save and add to the knowledge base') }}"
                               data-bs-toggle="tooltip" data-bs-placement="top"></i>
                         {% endset %}
                         {{ fields.sliderField(
@@ -216,7 +216,7 @@
                {% else %}
                   <input type="hidden" name="id" value="{{ subitem.fields['id'] }}" />
                   <button class="btn btn-primary me-2" type="submit" name="update">
-                     <i class="fas fa-save"></i>
+                     <i class="far fa-save"></i>
                      <span>{{ _x('button', 'Save') }}</span>
                   </button>
 

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -188,7 +188,7 @@
 
                      {% if candedit and can_update_kb and not nokb %}
                         {% set sol_to_kb_lbl %}
-                           <i class="fas fa-save fa-fw me-1" title="{{ __('Save and add to the knowledge base') }}"
+                           <i class="far fa-save fa-fw me-1" title="{{ __('Save and add to the knowledge base') }}"
                               data-bs-toggle="tooltip" data-bs-placement="top"></i>
                         {% endset %}
                         {{ fields.sliderField(
@@ -217,7 +217,7 @@
                   {% else %}
                      <input type="hidden" name="id" value="{{ subitem.fields['id'] }}" />
                      <button class="btn btn-primary me-2" type="submit" name="update">
-                        <i class="fas fa-save"></i>
+                        <i class="far fa-save"></i>
                         <span>{{ _x('button', 'Save') }}</span>
                      </button>
                   {% endif %}

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -228,7 +228,7 @@
 
 
                      {% set task_private_lbl %}
-                        <i class="fas fa-lock fa-fw me-1" title="{{ __('Private') }}"></i>
+                        <i class="ti ti-lock fa-fw me-1" title="{{ __('Private') }}"></i>
                      {% endset %}
                      {{ fields.sliderField(
                         'is_private',
@@ -260,7 +260,7 @@
 
                      {% if candedit and can_update_kb and not nokb %}
                         {% set task_to_kb_lbl %}
-                           <i class="fas fa-save fa-fw me-1" title="{{ __('Save and add to the knowledge base') }}"
+                           <i class="far fa-save fa-fw me-1" title="{{ __('Save and add to the knowledge base') }}"
                               data-bs-toggle="tooltip" data-bs-placement="top"></i>
                         {% endset %}
                         {{ fields.sliderField(
@@ -377,7 +377,7 @@
                {% else %}
                   <input type="hidden" name="id" value="{{ subitem.fields['id'] }}" />
                   <button class="btn btn-primary me-2" type="submit" name="update">
-                     <i class="fas fa-save"></i>
+                     <i class="far fa-save"></i>
                      <span>{{ _x('button', 'Save') }}</span>
                   </button>
 

--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -152,7 +152,7 @@
                {% else %}
                   <input type="hidden" name="id" value="{{ subitem.fields['id'] }}" />
                   <button class="btn btn-primary me-2" type="submit" name="update">
-                     <i class="fas fa-save"></i>
+                     <i class="far fa-save"></i>
                      <span>{{ _x('button', 'Save') }}</span>
                   </button>
 

--- a/templates/components/itilobject/timeline/main_description.html.twig
+++ b/templates/components/itilobject/timeline/main_description.html.twig
@@ -55,11 +55,11 @@
                   {# TODO canedit #}
                   <div class="dropdown ms-auto timeline-item-buttons">
                      <button class="btn btn-sm btn-ghost-secondary timeline-more-actions" type="button" id="more-actions-{{ entry_rand }}" data-bs-toggle="dropdown" aria-expanded="false">
-                        <i class="fas fa fa-ellipsis-h"></i>
+                        <i class="fas ti ti-dots-vertical"></i>
                      </button>
                      <ul class="dropdown-menu" aria-labelledby="more-actions-{{ entry_rand }}">
                         <li><a class="dropdown-item edit-timeline-item" href="#">
-                           <i class="fas fa-fw fa-edit"></i>
+                           <i class="fa-fw ti ti-edit"></i>
                            <span>{{ __('Edit') }}</span>
                         </a></li>
                      </ul>

--- a/templates/components/itilobject/timeline/main_description.html.twig
+++ b/templates/components/itilobject/timeline/main_description.html.twig
@@ -66,7 +66,7 @@
                   </div>
 
                   <button class="btn btn-sm btn-ghost-secondary float-end close-edit-content d-none mx-auto">
-                     <i class="fas fa-times"></i>
+                     <i class="ti ti-x"></i>
                   </button>
                </div>
 

--- a/templates/components/itilobject/timeline/simple_form.html.twig
+++ b/templates/components/itilobject/timeline/simple_form.html.twig
@@ -77,7 +77,7 @@
    {% if not is_new_item and show_form and not params['template_preview'] %}
       <div class="d-flex card-footer mx-n3 mb-n3">
          <button class="btn btn-primary me-2" type="submit" name="update">
-            <i class="fas fa-save"></i>
+            <i class="far fa-save"></i>
             <span>{{ _x('button', 'Save') }}</span>
          </button>
       </div>

--- a/templates/components/itilobject/timeline/sub_documents.html.twig
+++ b/templates/components/itilobject/timeline/sub_documents.html.twig
@@ -47,14 +47,14 @@
                   <a href="{{ 'Document'|itemtype_form_path(document['item']['id']) }}"
                      class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Edit') }}"
                      data-bs-toggle="tooltip" data-bs-placement="top">
-                     <i class="fas fa-edit"></i>
+                     <i class="ti ti-edit"></i>
                   </a>
 
                   {% set fk = item.getForeignKeyField() %}
                   <a href="{{ delete_link }}"
                      class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Delete permanently') }}"
                      data-bs-toggle="tooltip" data-bs-placement="top">
-                     <i class="fas fa-trash-alt"></i>
+                     <i class="ti ti-trash"></i>
                   </a>
                </div>
             </div>

--- a/templates/components/itilobject/timeline/timeline_item_header.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header.html.twig
@@ -46,7 +46,7 @@
          {% set edit_btn %}
             <li>
                <a class="dropdown-item edit-timeline-item" href="#">
-                  <i class="fas fa-fw fa-edit"></i>
+                  <i class="fa-fw ti ti-edit"></i>
                   <span>{{ __('Edit') }}</span>
                </a>
             </li>
@@ -57,7 +57,7 @@
       {% if is_private %}
          <span class="is-private ms-2" title="{{ __('Private') }}"
                data-bs-toggle="tooltip" data-bs-placement="bottom">
-            <i class="fas fa-lock" aria-label="{{ __('Private') }}"></i>
+            <i class="ti ti-lock" aria-label="{{ __('Private') }}"></i>
          </span>
       {% endif %}
 
@@ -65,7 +65,7 @@
          {% set promoted_btn %}
             <li>
                <a class="dropdown-item text-warning" href="{{ 'Ticket'|itemtype_form_path(entry_i['sourceof_items_id']) }}">
-                  <i class="fas fa-fw fa-code-branch"></i>
+                  <i class="fa-fw ti ti-git-branch"></i>
                   <span>{{ __('%s was already promoted')|format(entry['type']|itemtype_name) }}</span>
                </a>
             </li>
@@ -80,7 +80,7 @@
          {% set promote_btn %}
             <li>
                <a class="dropdown-item" href="{{ 'Ticket'|itemtype_form_path ~ promote_url }}">
-                  <i class="fas fa-fw fa-code-branch"></i>
+                  <i class="fa-fw ti ti-git-branch"></i>
                   <span>{{ __('Promote to Ticket') }}</span>
                </a>
             </li>
@@ -91,7 +91,7 @@
       {% if actions|length %}
          <div class="dropdown ms-2">
             <button class="btn btn-sm btn-ghost-secondary timeline-more-actions" type="button" id="more-actions-{{ entry_rand }}" data-bs-toggle="dropdown" aria-expanded="false">
-               <i class="fas fa-ellipsis-v"></i>
+               <i class="ti ti-dots-vertical"></i>
             </button>
             <ul class="dropdown-menu" aria-labelledby="more-actions-{{ entry_rand }}">
                {% for action in actions %}

--- a/templates/components/itilobject/timeline/timeline_item_header.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header.html.twig
@@ -103,6 +103,6 @@
    </div>
 
    <button class="btn btn-sm btn-ghost-secondary float-end close-edit-content d-none ms-auto">
-      <i class="fas fa-times"></i>
+      <i class="ti ti-x"></i>
    </button>
 </div>

--- a/templates/components/kanban/item_panels/default_panel.html.twig
+++ b/templates/components/kanban/item_panels/default_panel.html.twig
@@ -37,7 +37,7 @@
                <i class="{{ itemtype|itemtype_icon }}" title="{{ itemtype|itemtype_name }}"></i>
                {{ item_fields.name|verbatim_value }}
             </a>
-            <button type="button" class="btn-link" onclick="$(this).closest('.item-details-panel').remove()"><i class="fas fa-times"></i></button>
+            <button type="button" class="btn-link" onclick="$(this).closest('.item-details-panel').remove()"><i class="ti ti-x"></i></button>
          </h5>
          <h6 class="card-subtitle">
             {% if item_fields.is_milestone %}

--- a/templates/components/pager.html.twig
+++ b/templates/components/pager.html.twig
@@ -88,12 +88,12 @@
 
       <li class="page-item {% if is_first_page %}disabled{% endif %}">
          <a class="page-link page-link-start" href="{{ href|replace({'%start%': 0}) }}" title="{{ __('Start') }}" data-start="0" {% if is_first_page %}aria-disabled="true"{% endif %}>
-            <i class="fas fa-angle-double-left"></i>
+            <i class="ti ti-chevrons-left"></i>
          </a>
       </li>
       <li class="page-item {% if is_first_page %}disabled{% endif %}">
          <a class="page-link page-link-prev" href="{{ href|replace({'%start%': back}) }}" title="{{ __('Previous') }}" data-start="{{ back }}" {% if is_first_page %}aria-disabled="true"{% endif %}>
-            <i class="fas fa-angle-left"></i>
+            <i class="ti ti-chevron-left"></i>
          </a>
       </li>
       {% for page in range(1, nb_pages) %}
@@ -115,12 +115,12 @@
 
       <li class="page-item {% if is_last_page %}disabled{% endif %}">
          <a class="page-link page-link-next" href="{{ href|replace({'%start%': forward}) }}" title="{{ __('Next') }}" data-start="{{ forward }}" {% if is_last_page %}aria-disabled="true"{% endif %}>
-            <i class="fas fa-angle-right"></i>
+            <i class="ti ti-chevron-right"></i>
          </a>
       </li>
       <li class="page-item {% if is_last_page %}disabled{% endif %}">
          <a class="page-link page-link-last" href="{{ href|replace({'%start%': end}) }}" title="{{ __('End') }}" data-start="{{ end }}" {% if is_last_page %}aria-disabled="true"{% endif %}>
-            <i class="fas fa-angle-double-right"></i>
+            <i class="ti ti-chevrons-right"></i>
          </a>
       </li>
    </ul>

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -42,7 +42,7 @@
                 onclick="toogle('as_map','','',''); document.forms['searchform{{ itemtype|lower }}'].submit();"
                 {{ data['search']['as_map'] == 1 ? 'checked' : '' }} />
          <span class="form-check-label mb-1 mb-sm-0">
-            <i class="fas fa-lg fa-globe-americas"></i>
+            <i class="ti fa-lg ti-map-2"></i>
          </span >
       </label>
    {% endif %}
@@ -55,7 +55,7 @@
                 onclick="toogle('is_deleted','','',''); document.forms['searchform{{ itemtype|lower }}'].submit();"
                 {{ data['search']['is_deleted'] == 1 ? 'checked' : '' }} />
          <span class="form-check-label mb-1 mb-sm-0">
-            <i class="fas fa-lg fa-trash-alt"></i>
+            <i class="ti fa-lg ti-trash"></i>
          </span>
       </label>
    {% endif %}
@@ -66,7 +66,7 @@
       <input type="checkbox" class="form-check-input ms-0 me-1 mt-0 fold-search" role="button"
              {{ session('glpifold_search') ? '' : 'checked' }} autocomplete="off" />
       <span class="form-check-label mb-1 mb-sm-0">
-         <i class="fas fa-lg fa-search"></i>
+         <i class="ti fa-lg ti-search"></i>
       </span>
    </label>
 
@@ -75,7 +75,7 @@
       {% if can_config and count > 0 %}
       <button class="btn btn-sm btn-icon btn-ghost-secondary show_displaypreference_modal me-0 me-sm-1"
              title="{{ __('Select default items to show') }}" data-bs-toggle="tooltip" data-bs-placement="bottom">
-         <i class="fas fa-lg fa-wrench"></i>
+         <i class="ti fa-lg ti-tool"></i>
       </button>
       {% endif %}
 
@@ -83,21 +83,21 @@
          <button class="dropdown-toggle btn btn-sm btn-icon btn-ghost-secondary" type="button" id="dropdown-export"
                data-bs-toggle="dropdown" aria-expanded="false" >
             <span class="py-1 px-2 my-n1 mx-n2"data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ _x('button', 'Export') }}">
-               <i id="export_dropdown_icon" class="fas fa-lg fa-file-download"></i>
+               <i id="export_dropdown_icon" class="ti fa-lg ti-file-download"></i>
             </span>
          </button>
       {% set exporthref = path('/front/report.dynamic.php') ~ '?item_type=' ~ itemtype ~ '&start=' ~ start ~ '&' ~ posthref %}
       <ul class="dropdown-menu" aria-labelledby="dropdown-export">
          <li><a class="dropdown-item" href="{{ exporthref ~ '&display_type=' ~ constant('Search::PDF_OUTPUT_LANDSCAPE') }}">
-            <i class="fas fa-lg fa-file-pdf"></i>
+            <i class="far fa-lg fa-file-pdf"></i>
             {{ __('Current page in landscape PDF') }}
          </a></li>
          <li><a class="dropdown-item" href="{{ exporthref ~ '&display_type=' ~ constant('Search::PDF_OUTPUT_PORTRAIT') }}">
-            <i class="fas fa-lg fa-file-pdf"></i>
+            <i class="far fa-lg fa-file-pdf"></i>
             {{ __('Current page in portrait PDF') }}
          </a></li>
          <li><a class="dropdown-item" href="{{ exporthref ~ '&display_type=' ~ constant('Search::SYLK_OUTPUT') }}">
-            <i class="fas fa-lg fa-file-excel"></i>
+            <i class="far fa-lg fa-file-excel"></i>
             {{ __('Current page in SLK') }}
          </a></li>
          <li><a class="dropdown-item" href="{{ exporthref ~ '&display_type=' ~ constant('Search::CSV_OUTPUT') }}">
@@ -105,15 +105,15 @@
             {{ __('Current page in CSV') }}
          </a></li>
          <li><a class="dropdown-item" href="{{ exporthref ~ '&display_type=-' ~ constant('Search::PDF_OUTPUT_LANDSCAPE') }}">
-            <i class="fas fa-lg fa-file-pdf"></i>
+            <i class="far fa-lg fa-file-pdf"></i>
             {{ __('All pages in landscape PDF') }}
          </a></li>
          <li><a class="dropdown-item" href="{{ exporthref ~ '&display_type=-' ~ constant('Search::PDF_OUTPUT_PORTRAIT') }}">
-            <i class="fas fa-lg fa-file-pdf"></i>
+            <i class="far fa-lg fa-file-pdf"></i>
             {{ __('All pages in portrait PDF') }}
          </a></li>
          <li><a class="dropdown-item" href="{{ exporthref ~ '&display_type=-' ~ constant('Search::SYLK_OUTPUT') }}">
-            <i class="fas fa-lg fa-file-excel"></i>
+            <i class="far fa-lg fa-file-excel"></i>
             {{ __('All pages in SLK') }}
          </a></li>
          <li><a class="dropdown-item" href="{{ exporthref ~ '&display_type=-' ~ constant('Search::CSV_OUTPUT') }}">
@@ -122,7 +122,7 @@
          </a></li>
          {% if itemtype != 'Stat' %}
          <li id="copy_names_to_clipboard"><a class="dropdown-item" href="{{ exporthref ~ '&display_type=-' ~ constant('Search::NAMES_OUTPUT') }}">
-            <i class="fas fa-lg fa-copy"></i>
+            <i class="far fa-lg fa-copy"></i>
             {{ __('Copy names to clipboard') }}
          </a></li>
          {% endif %}

--- a/templates/components/user/link_with_tooltip.html.twig
+++ b/templates/components/user/link_with_tooltip.html.twig
@@ -32,7 +32,7 @@
 {% set rand = random() %}
 
 <span id="user_{{ rand }}">
-   <i class="far fa-user ms-1"></i>
+   <i class="ti ti-user ms-1"></i>
    {{ get_item_link('User', users_id, {
       'enable_anonymization': enable_anonymization
    })|raw }}

--- a/templates/install/blocks/requirements_table.html.twig
+++ b/templates/install/blocks/requirements_table.html.twig
@@ -55,7 +55,7 @@
                         data-bs-html="true"
                         data-bs-custom-class="validation-messages"
                         data-bs-content="{{ requirement.getValidationMessages()|join('<br />') }}">
-                     <i class="fas {{ requirement.isValidated() ? 'fa-check' : (requirement.isOptional() ? 'fa-exclamation-triangle' : 'fa-times') }}"></i>
+                     <i class="{{ requirement.isValidated() ? 'fa-check' : (requirement.isOptional() ? 'fas fa-exclamation-triangle' : 'ti ti-x') }}"></i>
                   </span>
                </td>
             </tr>

--- a/templates/layout/parts/breadcrumbs.html.twig
+++ b/templates/layout/parts/breadcrumbs.html.twig
@@ -32,7 +32,7 @@
 <ol class="breadcrumb breadcrumb-alternate pe-1 pe-sm-3" aria-label="breadcrumbs">
    <li class="breadcrumb-item text-truncate">
       <a href="{{ index_path() }}" title="{{ __('Home') }}">
-         <i class="fas fa-home"></i>
+         <i class="ti ti-home-2"></i>
          {{ __('Home') }}
       </a>
    </li>

--- a/templates/layout/parts/context_links.html.twig
+++ b/templates/layout/parts/context_links.html.twig
@@ -37,7 +37,7 @@
 {% if links['add'] is defined %}
 <li class="nav-item">
    <a href="{{ path(links['add']) }}" class="btn btn-icon btn-sm btn-outline-secondary me-1 pe-2" title="{{ __('Add') }}">
-      <i class="fas fa-plus"></i>
+      <i class="ti ti-plus"></i>
       <span class="d-none d-xxl-block">{{ __('Add') }}</span>
    </a>
 </li>
@@ -46,7 +46,7 @@
 {% if links['search'] is defined %}
 <li class="nav-item">
    <a href="{{ path(links['search']) }}" class="btn btn-icon btn-sm btn-outline-secondary me-1 pe-2" title="{{ __('Search') }}">
-      <i class="fas fa-search"></i>
+      <i class="ti ti-search"></i>
       <span class="d-none d-xxl-block">{{ __('Search') }}</span>
    </a>
 </li>
@@ -56,7 +56,7 @@
 <li class="nav-item">
    <a href="#" class="btn btn-icon btn-sm btn-outline-secondary me-1 pe-2 show-saved-searches"
       data-itemtype="{{ item }}" title="{{ __('Lists') }}">
-      <i class="fas fa-star"></i>
+      <i class="ti ti-star"></i>
       <span class="d-none d-xxl-block">{{ __('Lists') }}</span>
    </a>
 </li>
@@ -67,17 +67,14 @@
    {% elseif type == 'template' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" class="btn btn-icon btn-sm btn-outline-secondary me-1 pe-2" title="{{ __('Manage templates...') }}">
-            <i class="fas fa-layer-group"></i>
+            <i class="ti ti-template"></i>
             <span class="d-none d-xxl-block">{{ __('Templates') }}</span>
          </a>
       </li>
    {% elseif type == 'showall' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" class="btn btn-icon btn-sm btn-outline-secondary me-1 pe-2" title="{{ __('Show all') }}">
-            <span class="fa-stack">
-               <i class="fas fa-check fa-stack-1x" style="top: 1px; left: -2px; font-size: 1.2em"></i>
-               <i class="far fa-clock fa-stack-1x" style="top: 6px; left: 1px"></i>
-            </span>
+            <i class="ti ti-eye-check"></i>
             <span class="d-none d-xxl-block">{{ __('Show all') }}</span>
          </a>
       </li>

--- a/templates/layout/parts/global_search_form.html.twig
+++ b/templates/layout/parts/global_search_form.html.twig
@@ -34,7 +34,7 @@
    <div class="input-group">
       <input type="text" class="form-control" name="globalsearch" placeholder="{{ __('Search…') }}" />
       <button type="submit" class="btn btn-outline-secondary" title="{{ __('Search…') }}">
-         <span class="fas fa-search" aria-hidden="true"></span>
+         <span class="ti ti-search" aria-hidden="true"></span>
       </button>
    </div>
 </form>

--- a/templates/layout/parts/menu.html.twig
+++ b/templates/layout/parts/menu.html.twig
@@ -55,7 +55,7 @@
             {% if has_dashboard %}
                <a class="dropdown-item"
                   href="{{ path(firstlevel['default_dashboard']) }}">
-                  <i class="fas fa-fw fa-border-all"></i>
+                  <i class="ti ti-dashboard"></i>
                   {{ __('Dashboard') }}
                </a>
             {% endif %}

--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -34,7 +34,7 @@
 <div class="dropdown dropstart">
    <button class="dropdown-item dropdown-toggle" type="button" data-bs-toggle="dropdown"
            aria-haspopup="true" aria-expanded="false">
-      <i class="fas fa-user-check"></i>
+      <i class="ti ti-user-check"></i>
       {{ (session('glpiactiveprofile')['name'] ?? '')|verbatim_value }}
    </button>
    <div class="dropdown-menu" data-bs-popper="none">
@@ -42,7 +42,7 @@
       {% for profile_id, profile in session('glpiprofiles') %}
       <a class="dropdown-item {{ profile_id == (session('glpiactiveprofile')['id'] ?? 0) ? 'active' : '' }}"
          href="{{ index_path() }}?newprofile={{ profile_id }}">
-         <i class="fas fa-user-check"></i>{{ profile['name']|verbatim_value }}
+         <i class="ti ti-user-check"></i>{{ profile['name']|verbatim_value }}
       </a>
       {% endfor %}
    </div>
@@ -55,13 +55,13 @@
 
 {% if session('glpi_multientitiesmode') == 0 %}
    <span class="dropdown-item dropdown-item-text">
-      <i class="fa-fw fas fa-layer-group"></i>
+      <i class="fa-fw ti ti-stack"></i>
       {{ session('glpiactive_entity_name')|verbatim_value|u.truncate(35, '...') }}
    </span>
 {% else %}
    <div class="dropdown dropstart">
       <a href="#" class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside">
-         <i class="fa-fw fas fa-layer-group"></i>
+         <i class="fa-fw ti ti-stack"></i>
          {{ session('glpiactive_entity_name')|verbatim_value|u.truncate(35, '...') }}
       </a>
       <div class="dropdown-menu p-3">
@@ -83,7 +83,7 @@
                      placeholder="{{ __('Search entity') }}" autocomplete="off">
                <button type="submit" class="btn btn-icon btn-primary" title="{{ __('Search') }}"
                      data-bs-toggle="tooltip" data-bs-placement="top">
-                  <i class="fas fa-search"></i>
+                  <i class="ti ti-search"></i>
                </button>
                <a class="btn btn-icon btn-outline-secondary" href="#" id="entsearchtext{{ rand }}_clear"
                   title="{{ __("Clear search") }}" data-bs-toggle="tooltip" data-bs-placement="top">

--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -87,11 +87,11 @@
                </button>
                <a class="btn btn-icon btn-outline-secondary" href="#" id="entsearchtext{{ rand }}_clear"
                   title="{{ __("Clear search") }}" data-bs-toggle="tooltip" data-bs-placement="top">
-                     <i class="fas fa-times"></i>
+                     <i class="ti ti-x"></i>
                </a>
                <a href="{{ target }}?active_entity=all" class="btn btn-secondary"
                   title="{{ __('Select all') }}" data-bs-toggle="tooltip" data-bs-placement="top">
-                  <i class="fas fa-eye"></i>
+                  <i class="ti ti-eye"></i>
                </a>
             </div>
          </form>

--- a/templates/layout/parts/saved_searches.html.twig
+++ b/templates/layout/parts/saved_searches.html.twig
@@ -37,19 +37,19 @@
 <div class="card col-2 d-flex flex-column responsive-toggle {{ pinned ? 'pinned' : 'd-none' }} saved-searches-panel {{ itemtype_cls }}"
      id="saved-searches-panel-{{ rand }}">
    <div class="card-header d-flex flex-nowrap pe-0 align-items-center text-muted">
-      <i class="fas fa-star"></i>&nbsp;
+      <i class="ti ti-star"></i>&nbsp;
       {{ _n('Saved search', 'Saved searches', 2) }}
 
       <li class="ms-auto btn-list me-1">
          <a href="{{ path('front/savedsearch.php') }}" class="btn btn-sm btn-icon btn-ghost-secondary"
             data-bs-toggle="tooltip" data-bs-placement="bottom"
             title="{{ __('Manage all saved searches') }}">
-            <i class="fas fa-cog"></i>
+            <i class="ti ti-settings"></i>
          </a>
          <button class="btn btn-sm btn-icon btn-ghost-secondary ms-1 d-none d-md-block pin-saved-searches-panel"
                  data-bs-toggle="tooltip" data-bs-placement="bottom"
                  title="{{ __('Pin this panel for the current page') }}">
-            <i class="fas fa-thumbtack"></i>
+            <i class="ti ti-pinned"></i>
          </button>
          <button class="btn btn-sm btn-icon btn-ghost-secondary ms-1 close-saved-searches-panel"
                  data-bs-toggle="tooltip" data-bs-placement="bottom"

--- a/templates/layout/parts/saved_searches.html.twig
+++ b/templates/layout/parts/saved_searches.html.twig
@@ -54,7 +54,7 @@
          <button class="btn btn-sm btn-icon btn-ghost-secondary ms-1 close-saved-searches-panel"
                  data-bs-toggle="tooltip" data-bs-placement="bottom"
                  title="{{ __('Close the panel') }}">
-            <i class="fas fa-times"></i>
+            <i class="ti ti-x"></i>
          </button>
       </li>
    </div>
@@ -91,7 +91,7 @@
                 placeholder="{{ __('Filter list') }}" />
          <span class="input-group-text">
             <a href="#" class="link-secondary clear-text" role="button" title="Clear search">
-               <i class="fa fa-times fa-xs"></i>
+               <i class="ti ti-x fa-xs"></i>
             </a>
          </span>
       </div>

--- a/templates/layout/parts/saved_searches_list.html.twig
+++ b/templates/layout/parts/saved_searches_list.html.twig
@@ -50,7 +50,7 @@
       </div>
       <div class="d-flex flex-nowrap align-items-center">
          {% if search['is_private'] == 1 %}
-         <i class="fas fa-lock fa-xs text-muted me-1" title="{{ __('private') }}"
+         <i class="ti ti-lock fa-xs text-muted me-1" title="{{ __('private') }}"
             data-bs-toggle="tooltip" data-bs-placement="right"></i>
          {% endif %}
          <span class="badge">

--- a/templates/layout/parts/user_header.html.twig
+++ b/templates/layout/parts/user_header.html.twig
@@ -34,7 +34,7 @@
 <div class="btn-group">
    {% if is_debug_active %}
       <button class="btn btn-outline-danger d-none d-md-block see_debug" role="button">
-         <i class="fas fa-bug fa-lg mt-1" title=" {{ __('Display GLPI debug informations') }}">
+         <i class="ti ti-bug fa-lg mt-1" title=" {{ __('Display GLPI debug informations') }}">
             <span class="visually-hidden">{{ __('Display GLPI debug informations') }}</span>
          </i>
       </button>
@@ -62,7 +62,7 @@
                   <a href="{{ path('/ajax/switchdebug.php') }}"
                      class="dropdown-item {% if is_debug_active %}bg-red-lt{% endif %}"
                      title="{{ __('Change mode') }}">
-                     <i class="fas fa-fw fa-bug debug"></i>
+                     <i class="ti fa-fw ti-bug debug"></i>
                      {{ is_debug_active ? __('Debug mode enabled') : __('Debug mode disabled') }}
                   </a>
                {% endif %}
@@ -70,20 +70,20 @@
                {# @TODO Saved searches panel #}
 
                <div class="dropdown-item">
-                  <i class="fas fa-fw fa-language"></i>
+                  <i class="ti fa-fw ti-language"></i>
                   {{ call('User::showSwitchLangForm')|raw }}
                </div>
 
                <div class="dropdown-divider"></div>
 
                <a href="{{ help_url }}" class="dropdown-item" title="{{ __('Help') }}">
-                  <i class="fas fa-fw fa-question"></i>
+                  <i class="ti fa-fw ti-help"></i>
                   {{ __('Help') }}
                </a>
 
                <a href="#" class="dropdown-item" title="{{ __('About') }}"
                   id="show_about_modal_{{ rand_header }}">
-                  <i class="fas fa-fw fa-info"></i>
+                  <i class="ti fa-fw ti-info-circle"></i>
                   {{ __('About') }}
                   {% if founded_new_version is not null %}
                      <span class="badge bg-info text-dark ms-2">
@@ -95,11 +95,11 @@
                <div class="dropdown-divider"></div>
 
                <a href="{{ path('/front/preference.php') }}" class="dropdown-item" title="{{ __('My settings') }}">
-                  <i class="fas fa-fw fa-user-cog"></i>
+                  <i class="ti fa-fw ti-adjustments-alt"></i>
                   {{ __('My settings') }}
                </a>
                <a href="{{ path('/front/logout.php' ~ ((session('glpiextauth') ?: false) ? '?noAUTO=1' : '')) }}" class="dropdown-item" title="{{ __('Logout') }}">
-                  <i class="fas fa-fw fa-sign-out-alt"></i>
+                  <i class="ti fa-fw ti-logout"></i>
                   {{ __('Logout') }}
                </a>
             </div>

--- a/templates/pages/setup/authentication.html.twig
+++ b/templates/pages/setup/authentication.html.twig
@@ -39,20 +39,20 @@
             <div class="list-group list-group-flush">
                {% if has_profile_right('config', constant('UPDATE')) %}
                   <a class="list-group-item list-group-item-action" href="{{ path('front/auth.settings.php') }}">
-                     <i class="fas fa-fw fa-cogs me-1"></i>
+                     <i class="fa-fw ti ti-adjustments me-1"></i>
                      <span>{{ __('Setup') }}</span>
                   </a>
                {% endif %}
 
                {% if can_use_ldap %}
                   <a class="list-group-item list-group-item-action" href="{{ path('front/authldap.php') }}">
-                     <i class="far fa-fw fa-address-book me-1"></i>
+                     <i class="fa-fw far fa-address-book me-1"></i>
                      <span>{{ 'AuthLDAP'|itemtype_name }}</span>
                   </a>
                {% else %}
                   <div class="list-group-item">
                      <div class="list-group-item alert alert-important alert-warning m-3">
-                        <i class="fa fa-exclamation-triangle me-2"></i>
+                        <i class="fa-fw fa fa-exclamation-triangle me-2"></i>
                         {{ __('The LDAP extension of your PHP parser isn’t installed') }}
                      </div>
                   </div>
@@ -64,7 +64,7 @@
                </a>
 
                <a class="list-group-item list-group-item-action" href="{{ path('front/auth.others.php') }}">
-                  <i class="fas fa-fw fa-sign-in-alt me-1"></i>
+                  <i class="fa-fw ti ti-login me-1"></i>
                   <span>{{ __('Others authentication methods') }}</span>
                </a>
             </div>

--- a/templates/pages/setup/setup_notifications.html.twig
+++ b/templates/pages/setup/setup_notifications.html.twig
@@ -77,7 +77,7 @@
 
                <div class="card-footer">
                   <button type="submit" class="btn btn-primary">
-                     <i class="fas fa-save"></i>
+                     <i class="far fa-save"></i>
                      <span>{{ __('Save') }}</span>
                   </button>
                </div>

--- a/templates/pages/setup/setup_notifications.html.twig
+++ b/templates/pages/setup/setup_notifications.html.twig
@@ -96,20 +96,20 @@
             <div class="list-group list-group-flush">
                {% if has_profile_right('config', constant('READ')) %}
                   <a href="{{ path('front/notificationtemplate.php') }}" class="list-group-item list-group-item-action">
-                     <i class="fa-fw fas fa-layer-group"></i>
+                     <i class="fa-fw ti ti-template"></i>
                      <span>{{ _n('Notification template', 'Notification templates', get_plural_number()) }}</span>
                   </a>
                {% endif %}
 
                {% if has_profile_right('notification', constant('READ')) %}
                   <a href="{{ path('front/notification.php') }}" class="list-group-item list-group-item-action">
-                     <i class="fa-fw fas fa-bell "></i>
+                     <i class="fa-fw ti ti-bell "></i>
                      <span>{{ _n('Notification', 'Notifications', get_plural_number()) }}</span>
                   </a>
                {% else %}
                   <div class="list-group-item">
                      <div class="alert alert-important alert-warning m-3">
-                        <i class="fa fa-exclamation-triangle me-2"></i>
+                        <i class="fa-fw ti ti-alert-triangle me-2"></i>
                         {{ __('Unable to configure notifications: please configure at least one followup type using the above configuration.') }}
                      </div>
                   </div>

--- a/templates/password_form.html.twig
+++ b/templates/password_form.html.twig
@@ -69,7 +69,7 @@
                </div>
             {% endif %}
 
-            {% set save_button = '<i class="fas fa-save"></i><span>' ~ __('Save new password') ~ '<span>' %}
+            {% set save_button = '<i class="far fa-save"></i><span>' ~ __('Save new password') ~ '<span>' %}
 
          {% else %}
             <p class="text-muted mb-4">

--- a/tests/units/Glpi/Features/Dcbreadcrumb.php
+++ b/tests/units/Glpi/Features/Dcbreadcrumb.php
@@ -117,7 +117,7 @@ class DCBreadcrumb extends \DbTestCase {
       $DCBreadcrumb = \Computer::getDcBreadcrumbSpecificValueToDisplay($computer1->getID());
       $this->string($DCBreadcrumb)->isIdenticalTo(
          sprintf(
-            "<i class='ti ti-building-warehouse'></i> %s &gt; <i class='fas fa-building'></i> %s &gt; <i class='ti ti-server'></i> %s&nbsp;(U%d)",
+            "<i class='ti ti-building-warehouse'></i> %s &gt; <i class='ti ti-building'></i> %s &gt; <i class='ti ti-server'></i> %s&nbsp;(U%d)",
             $datacenter_name,
             $DCroom_name,
             $rack_name,

--- a/tests/units/Glpi/Features/Dcbreadcrumb.php
+++ b/tests/units/Glpi/Features/Dcbreadcrumb.php
@@ -117,7 +117,7 @@ class DCBreadcrumb extends \DbTestCase {
       $DCBreadcrumb = \Computer::getDcBreadcrumbSpecificValueToDisplay($computer1->getID());
       $this->string($DCBreadcrumb)->isIdenticalTo(
          sprintf(
-            "<i class='fas fa-warehouse'></i> %s &gt; <i class='fas fa-building'></i> %s &gt; <i class='fas fa-server'></i> %s&nbsp;(U%d)",
+            "<i class='ti ti-building-warehouse'></i> %s &gt; <i class='fas fa-building'></i> %s &gt; <i class='ti ti-server'></i> %s&nbsp;(U%d)",
             $datacenter_name,
             $DCroom_name,
             $rack_name,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

testing style after @AdrienClairembault remarks on icons
still wip, i want to pass on more icons

I'm in pain with following itemtypes : 

* Supplier
* Contact
* NetworkEquipment
* Simcard
* Domain

Check https://tabler-icons.io/ for list
To note, tabler author seems to add icons on request pretty oftenly

Screen of current work:

![image](https://user-images.githubusercontent.com/418844/143470708-31502fff-3f94-4805-bf16-fe832558a3cb.png)

