### PR TITLE
Fix project clone

### DIFF
--- a/inc/features/clonable.class.php
+++ b/inc/features/clonable.class.php
@@ -56,6 +56,8 @@ trait Clonable {
 
       $clone_relations = $this->getCloneRelations();
       foreach ($clone_relations as $classname) {
+         $override_input = [];
+
          if (!is_a($classname, CommonDBConnexity::class, true)) {
             Toolbox::logWarning(
                sprintf(

--- a/tests/functionnal/Project.php
+++ b/tests/functionnal/Project.php
@@ -33,6 +33,7 @@ namespace tests\units;
 
 use DbTestCase;
 use ProjectTask;
+use ProjectTeam;
 
 /* Test for inc/project.class.php */
 class Project extends DbTestCase {
@@ -186,5 +187,79 @@ class Project extends DbTestCase {
          $this->integer($task_data['entities_id'])->isEqualTo($entity_id);
          $this->integer($task_data['is_recursive'])->isEqualTo(0);
       }
+   }
+
+   public function testClone() {
+      // Create a basic project
+      $project_name = 'Project testClone' . mt_rand();
+      $project_input = [
+         'name'     => $project_name,
+         'priority' => 5,
+      ];
+      $this->createItems('Project', [$project_input]);
+      $projects_id = getItemByTypeName("Project", $project_name, true);
+
+      // Create a user
+      $user_name = 'Project testClone - User' . mt_rand();
+      $this->createItems('User', [['name' => $user_name]]);
+      $users_id = getItemByTypeName("User", $user_name, true);
+
+      // Create a group
+      $group_name = 'Project testClone - Group' . mt_rand();
+      $this->createItems('Group', [['name' => $group_name]]);
+      $groups_id = getItemByTypeName("Group", $group_name, true);
+
+      // Add team to project
+      $this->createItems('ProjectTeam', [
+         [
+            'projects_id' => $projects_id,
+            'itemtype'    => 'User',
+            'items_id'    => $users_id,
+         ],
+         [
+            'projects_id' => $projects_id,
+            'itemtype'    => 'Group',
+            'items_id'    => $groups_id,
+         ],
+      ]);
+
+      // Load current project
+      $project = new \Project();
+      $this->boolean($project->getFromDB($projects_id))->isTrue();
+
+      // Clone project
+      $projects_id_clone = $project->clone();
+      $this->integer($projects_id_clone)->isGreaterThan(0);
+
+      // Load clone
+      $project_clone = new \Project();
+      $this->boolean($project_clone->getFromDB($projects_id_clone))->isTrue();
+
+      // Check basics fields
+      foreach (array_keys($project_input) as $field) {
+         $this->variable($project_clone->fields[$field])->isEqualTo($project->fields[$field]);
+      }
+
+      // Load project team
+      $project_team = new ProjectTeam();
+      $team = [];
+      foreach ($project_team->find(['projects_id' => $projects_id]) as $row) {
+         $team[] = [
+            'itemtype' => $row['itemtype'],
+            'items_id' => $row['items_id'],
+         ];
+      }
+
+      // Load clone team
+      $team_clone = [];
+      foreach ($project_team->find(['projects_id' => $projects_id_clone]) as $row) {
+         $team_clone[] = [
+            'itemtype' => $row['itemtype'],
+            'items_id' => $row['items_id'],
+         ];
+      }
+
+      // Compare teams
+      $this->array($team_clone)->isEqualTo($team);
    }
 }


### PR DESCRIPTION
When cloning a project, the "Project Team" data was not copied correctly:

![image](https://user-images.githubusercontent.com/42734840/143853631-5be57aeb-83cc-427e-a598-4fb510369db0.png)

1 -> My "original" team with one group (id =1) and one user (id = 3).
2 -> The incorrect data over multiple clone tests, you can see the project id was used instead of the correct user/group ids.
3 -> One more clone test after fix -> OK.

Seem like the `override_input` variable used wasn't reinitialized for each itemtype so some data was overlapping when it shouldn't.
Here I guess `items_id` was set from one of the previous clone relation (`Document_Item` or `ProjectTask`).

I've also added a new test to check that projects are cloned correctly.
Before fix:
![image](https://user-images.githubusercontent.com/42734840/143855651-3e83efd9-5760-4a6c-9b99-02166e4420e8.png)

After fix:
![image](https://user-images.githubusercontent.com/42734840/143855679-c1661dd6-52f0-414c-9f6f-79361edafcbe.png)



|  Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22986
