### PR TITLE
Fix FAQ anchors

### DIFF
--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -1960,7 +1960,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
 
          return $title;
       };
-      $pattern = '|<(h[1-6]{1})(.?[^>])?>(.+)</h[1-6]{1}>|';
+      $pattern = '|<(h[1-6]{1})(.?[^>])?>(.+?)</h[1-6]{1}>|';
       $answer = preg_replace_callback($pattern, $callback, $answer);
 
       return $answer;

--- a/tests/functionnal/KnowbaseItem.php
+++ b/tests/functionnal/KnowbaseItem.php
@@ -360,4 +360,34 @@ class KnowbaseItem extends DbTestCase {
       // Check that the request is valid
       $DB->request($criteria);
    }
+
+   public function testGetAnswerAnchors(): void {
+      // Create test KB with multiple headers
+      $kb_name = 'Test testGetAnswerAnchors' . mt_rand();
+      $input = [
+         'name' => $kb_name,
+         // Answer :
+         // <h1>title 1a</h1>
+         // <h2>title2</h2>
+         // <h1>title 1b</h1>
+         // <h1>title 1c</h1>
+         'answer' => '&lt;h1&gt;title 1a&lt;/h1&gt;&lt;h2&gt;title2&lt;/h2&gt;&lt;h1&gt;title 1b&lt;/h1&gt;&lt;h1&gt;title 1c&lt;/h1&gt;'
+      ];
+      $this->createItems('KnowbaseItem', [$input]);
+
+      // Load KB
+      /** @var \KnowbaseItem */
+      $kbi = getItemByTypeName("KnowbaseItem", $kb_name);
+      $answer = $kbi->getAnswer();
+
+      // Test anchors, there should be one per header
+      $this->string($answer)->contains('<h1 id="title-1a">');
+      $this->string($answer)->contains('<a href="#title-1a">');
+      $this->string($answer)->contains('<h2 id="title2">');
+      $this->string($answer)->contains('<a href="#title2">');
+      $this->string($answer)->contains('<h1 id="title-1b">');
+      $this->string($answer)->contains('<a href="#title-1b">');
+      $this->string($answer)->contains('<h1 id="title-1c">');
+      $this->string($answer)->contains('<a href="#title-1c">');
+   }
 }


### PR DESCRIPTION
Anchors for FAQ headers are broken:

![image](https://user-images.githubusercontent.com/42734840/143863253-5845a359-a3cd-4b5c-939e-69d8b9f6b071.png)

Despite having 4 headers in my content I only have one anchor that I can hover.
As you can see in the bottom left corner, its URL also seems to be malformed as it contains extra chars (it should only contain the header name). 

It turns out one of the regex we use was too greedy and matched too much chars.
After fixing the regex:

![image](https://user-images.githubusercontent.com/42734840/143863670-f7554cfb-312b-46db-acce-08163db0ae5f.png)
  
![image](https://user-images.githubusercontent.com/42734840/143863720-e213791f-e117-4af3-ba44-06e7b64a65d2.png)

I've also added a functional test to check if the headers are properly formed.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !22988
