### PR TITLE
Do not set listurl to AJAX urls

### DIFF
--- a/ajax/search.php
+++ b/ajax/search.php
@@ -32,6 +32,7 @@
 
 // Direct access to file
 
+$AJAX_INCLUDE = 1;
 include ('../inc/includes.php');
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -297,7 +297,11 @@ class Session {
     * @param string $title    List title (default '')
    **/
    static function initNavigateListItems($itemtype, $title = "") {
+      global $AJAX_INCLUDE;
 
+      if (isset($AJAX_INCLUDE)) {
+         return;
+      }
       if (empty($title)) {
          $title = __('List');
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The search AJAX calls Search::displayData which tries initializing the navigation header and replaces the list URL with the AJAX URL.