### PR TITLE
fix false to array conversion with php8.1

### DIFF
--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -102,7 +102,9 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
 
    static function getMenuContent() {
       $menu = parent::getMenuContent();
-      unset($menu['links']['lists']);
+      if (isset($menu['links']['lists'])) {
+         unset($menu['links']['lists']);
+      }
 
       return $menu;
    }

--- a/inc/reservationitem.class.php
+++ b/inc/reservationitem.class.php
@@ -104,7 +104,9 @@ class ReservationItem extends CommonDBChild {
 
    static function getMenuContent() {
       $menu = parent::getMenuContent();
-      unset($menu['links']['lists']);
+      if (isset($menu['links']['lists'])) {
+         unset($menu['links']['lists']);
+      }
 
       return $menu;
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

follow #9972, in self-service mode, the unset array doesn't exist
