### PR TITLE
Fix image pasting in rich text

### DIFF
--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -70,6 +70,7 @@ var handleUploadedFile = function (files, files_data, input_name, container, edi
                   if (editor_id && Object.prototype.hasOwnProperty.call(insertIntoEditor, file.name) && insertIntoEditor[file.name]) {
                      editor = tinyMCE.get(editor_id);
                      insertImgFromFile(editor, file, tag_data.tag);
+                     input_name = editor.targetElm.name; // attach uploaded image to rich text field
                   }
 
                   displayUploadedFile(files_data[index], tag_data, editor, input_name, container);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a file is uploaded, hidden fields are created by JS to store filename / prefix / tag of uploaded file. These fields have to be attached to rich text field when the uploaded file is a pasted image.