### PR TITLE
Fix DBmysqlIterator usage

### DIFF
--- a/inc/cartridge.class.php
+++ b/inc/cartridge.class.php
@@ -615,7 +615,7 @@ class Cartridge extends CommonDBRelation {
          ]
       ]);
       if ($it->count()) {
-         return $it->next()['stock_target'];
+         return $it->current()['stock_target'];
       }
       return 0;
    }
@@ -637,7 +637,7 @@ class Cartridge extends CommonDBRelation {
          ]
       ]);
       if ($it->count()) {
-         return $it->next()['stock_target'];
+         return $it->current()['stock_target'];
       }
       return 0;
    }

--- a/inc/consumable.class.php
+++ b/inc/consumable.class.php
@@ -337,7 +337,7 @@ class Consumable extends CommonDBChild {
          ]
       ]);
       if ($it->count()) {
-         return $it->next()['stock_target'];
+         return $it->current()['stock_target'];
       }
       return 0;
    }
@@ -359,7 +359,7 @@ class Consumable extends CommonDBChild {
          ]
       ]);
       if ($it->count()) {
-         return $it->next()['stock_target'];
+         return $it->current()['stock_target'];
       }
       return 0;
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since #9683, `$iterator->next()` must be replaced by `$iterator->current()`.