### PR TITLE
Fix PHP 8.1 deprecation warning on search hooks

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3228,7 +3228,7 @@ JAVASCRIPT;
                'addOrderBy',
                $itemtype, $ID, $order, "{$itemtype}_{$ID}"
             );
-            $out = trim($out);
+            $out = $out !== null ? trim($out) : null;
             if (!empty($out)) {
                $out = preg_replace('/^ORDER BY /', '', $out);
                $criterion = $out;
@@ -3284,7 +3284,7 @@ JAVASCRIPT;
                   'addOrderBy',
                   $itemtype, $ID, $order, "{$itemtype}_{$ID}"
                );
-               $out = trim($out);
+               $out = $out !== null ? trim($out) : null;
                if (!empty($out)) {
                   $out = preg_replace('/^ORDER BY /', '', $out);
                   $criterion = $out;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix deprecated usage of `trim(null)`.