### PR TITLE
Harmonize showForm() signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,12 @@ The present file will list all changes made to the project; according to the
 ### API changes
 
 #### Added
-- Added `DBMysql::setSavepoint` to create savepoints within a transaction.
-- Added `CommonDBTM::showForm` to have a generic showForm for asset (based on a twig template).
+- Added `DBMysql::setSavepoint()` to create savepoints within a transaction.
+- Added `CommonDBTM::showForm()` to have a generic showForm for asset (based on a twig template).
 
 #### Changes
 - `DBmysqlIterator` class compliancy with `Iterator` has been fixed (i.e. `DBmysqlIterator::next()` does not return current row anymore).
+- `showForm()` method of all classes inheriting `CommonDBTM` have been changed to match `CommonDBTM::showForm()` signature.
 - Format of `Message-Id` header sent in Tickets notifications changed to match format used by other items.
 - Added `DB::truncate()` to replace raw SQL queries
 - Impact context `positions` field type changed from `TEXT` to `MEDIUMTEXT`

--- a/inc/abstractitilchildtemplate.class.php
+++ b/inc/abstractitilchildtemplate.class.php
@@ -44,7 +44,7 @@ if (!defined('GLPI_ROOT')) {
  */
 abstract class AbstractITILChildTemplate extends CommonDropdown
 {
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       parent::showForm($ID, $options);
 
       // Add autocompletion for ticket properties (twig templates)

--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -168,7 +168,7 @@ class Agent extends CommonDBTM {
     *
     * @return boolean
     */
-   function showForm($id, $options = []) {
+   function showForm($id, array $options = []) {
       global $CFG_GLPI;
 
       if (!empty($id)) {

--- a/inc/authldap.class.php
+++ b/inc/authldap.class.php
@@ -334,7 +334,7 @@ class AuthLDAP extends CommonDBTM {
     *
     * @return void|boolean (display) Returns false if there is a rights error.
     */
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       if (!Config::canUpdate()) {
          return false;

--- a/inc/authmail.class.php
+++ b/inc/authmail.class.php
@@ -158,7 +158,7 @@ class AuthMail extends CommonDBTM {
     *
     * @return void|boolean (display) Returns false if there is a rights error.
     */
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       if (!Config::canUpdate()) {
          return false;

--- a/inc/budget.class.php
+++ b/inc/budget.class.php
@@ -114,7 +114,7 @@ class Budget extends CommonDropdown{
     *
     * @return void|boolean (display) Returns false if there is a rights error.
     **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       $rowspan = 3;
       if ($ID > 0) {

--- a/inc/cable.class.php
+++ b/inc/cable.class.php
@@ -388,7 +388,7 @@ class Cable extends CommonDBTM {
    *
    * @return void|boolean (display) Returns false if there is a rights error.
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       $this->initForm($ID, $options);
       TemplateRenderer::getInstance()->display('pages/assets/cable.html.twig', [
          'item'   => $this,

--- a/inc/cartridge.class.php
+++ b/inc/cartridge.class.php
@@ -1164,7 +1164,7 @@ class Cartridge extends CommonDBRelation {
     *
     * @return boolean False if there was a rights issue. Otherwise, returns true.
     */
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       if (isset($options['parent']) && !empty($options['parent'])) {
          $printer = $options['parent'];

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -630,7 +630,7 @@ class Change extends CommonITILObject {
    }
 
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       if (!static::canView()) {
          return false;

--- a/inc/commondropdown.class.php
+++ b/inc/commondropdown.class.php
@@ -309,7 +309,7 @@ abstract class CommonDropdown extends CommonDBTM {
    }
 
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       if (!$this->isNewID($ID)) {
          $this->check($ID, READ);

--- a/inc/commonitilcost.class.php
+++ b/inc/commonitilcost.class.php
@@ -378,7 +378,7 @@ abstract class CommonITILCost extends CommonDBChild {
     * @param $ID        integer  ID of the item
     * @param $options   array    options used
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       if (isset($options['parent']) && !empty($options['parent'])) {
          $item = $options['parent'];

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1312,7 +1312,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
     * @param $options   array
     *     -  parent Object : the object
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       TemplateRenderer::getInstance()->display('components/itilobject/timeline/form_task.html.twig', [
          'item'      => $options['parent'],
          'subitem'   => $this

--- a/inc/commonitilvalidation.class.php
+++ b/inc/commonitilvalidation.class.php
@@ -944,7 +944,7 @@ abstract class CommonITILValidation  extends CommonDBChild {
     * @param $ID        integer  ID of the item
     * @param $options   array    options used
     **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       if ($ID > 0) {
          $this->canEdit($ID);

--- a/inc/computerantivirus.class.php
+++ b/inc/computerantivirus.class.php
@@ -226,7 +226,7 @@ class ComputerAntivirus extends CommonDBChild {
     *
     * @return boolean TRUE if form is ok
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       if (!Session::haveRight("computer", READ)) {
          return false;

--- a/inc/computervirtualmachine.class.php
+++ b/inc/computervirtualmachine.class.php
@@ -106,7 +106,7 @@ class ComputerVirtualMachine extends CommonDBChild {
     *
     * @return true if displayed  false if item not found or not right to display
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       if (!Session::haveRight("computer", UPDATE)) {
          return false;

--- a/inc/contact.class.php
+++ b/inc/contact.class.php
@@ -159,7 +159,7 @@ class Contact extends CommonDBTM{
    }
 
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       $this->initForm($ID, $options);
       $vcard_url = $this->getFormURL().'?getvcard=1&id='.$ID;

--- a/inc/contractcost.class.php
+++ b/inc/contractcost.class.php
@@ -233,7 +233,7 @@ class ContractCost extends CommonDBChild {
     * @param $ID        integer  ID of the item
     * @param $options   array    options used
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       if ($ID > 0) {
          $this->check($ID, READ);

--- a/inc/crontask.class.php
+++ b/inc/crontask.class.php
@@ -538,7 +538,7 @@ class CronTask extends CommonDBTM{
     *
     * @return boolean
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       if (!Config::canView() || !$this->getFromDB($ID)) {

--- a/inc/database.class.php
+++ b/inc/database.class.php
@@ -68,7 +68,7 @@ class Database extends CommonDBChild {
    }
 
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       $rand = mt_rand();
       $this->initForm($ID, $options);
       $this->showFormHeader($options);

--- a/inc/databaseinstance.class.php
+++ b/inc/databaseinstance.class.php
@@ -106,7 +106,7 @@ class DatabaseInstance extends CommonDBTM {
       return $dbs;
    }
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       $rand = mt_rand();

--- a/inc/dcroom.class.php
+++ b/inc/dcroom.class.php
@@ -67,7 +67,7 @@ class DCRoom extends CommonDBTM {
       return $ong;
    }
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $DB, $CFG_GLPI;
       $rand = mt_rand();
 

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -369,7 +369,7 @@ class Document extends CommonDBTM {
     *
     * @return void
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       $this->initForm($ID, $options);
       // $options['formoptions'] = " enctype='multipart/form-data'";
       $this->showFormHeader($options);

--- a/inc/domainrecord.class.php
+++ b/inc/domainrecord.class.php
@@ -309,7 +309,7 @@ class DomainRecord extends CommonDBChild {
       }
    }
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       $rand = mt_rand();

--- a/inc/domainrelation.class.php
+++ b/inc/domainrelation.class.php
@@ -77,7 +77,7 @@ class DomainRelation extends CommonDropdown {
     *
     * @return void|boolean (display) Returns false if there is a rights error.
     **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       $rowspan = 3;
       if ($ID > 0) {

--- a/inc/dropdowntranslation.class.php
+++ b/inc/dropdowntranslation.class.php
@@ -422,7 +422,7 @@ class DropdownTranslation extends CommonDBChild {
     * @param integer $ID       field (default -1)
     * @param array   $options
     */
-   function showForm($ID = -1, $options = []) {
+   function showForm($ID = -1, array $options = []) {
       global $CFG_GLPI;
 
       if (isset($options['parent']) && !empty($options['parent'])) {

--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -207,7 +207,7 @@ class Group extends CommonTreeDropdown {
    *
    * @return void|boolean (display) Returns false if there is a rights error.
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       $this->initForm($ID, $options);
       $this->showFormHeader($options);

--- a/inc/item_cluster.class.php
+++ b/inc/item_cluster.class.php
@@ -170,7 +170,7 @@ class Item_Cluster extends CommonDBRelation {
       }
    }
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $DB, $CFG_GLPI;
 
       echo "<div class='center'>";

--- a/inc/item_devices.class.php
+++ b/inc/item_devices.class.php
@@ -1267,7 +1267,7 @@ class Item_Devices extends CommonDBRelation {
    /**
     * @since 0.85
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       if (!$this->isNewID($ID)) {
          $this->check($ID, READ);
       } else {

--- a/inc/item_disk.class.php
+++ b/inc/item_disk.class.php
@@ -112,7 +112,7 @@ class Item_Disk extends CommonDBChild {
     *
     * @return true if displayed  false if item not found or not right to display
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       $itemtype = null;
       if (isset($options['itemtype']) && !empty($options['itemtype'])) {
          $itemtype = $options['itemtype'];

--- a/inc/item_enclosure.class.php
+++ b/inc/item_enclosure.class.php
@@ -163,7 +163,7 @@ class Item_Enclosure extends CommonDBRelation {
       }
    }
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $DB, $CFG_GLPI;
 
       echo "<div class='center'>";

--- a/inc/item_operatingsystem.class.php
+++ b/inc/item_operatingsystem.class.php
@@ -280,7 +280,7 @@ class Item_OperatingSystem extends CommonDBRelation {
       return parent::getConnexityItem($itemtype, $items_id, $getFromDB, $getEmpty, $getFromDBOrEmpty);
    }
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       $colspan = 4;
 
       echo "<div class='center'>";

--- a/inc/item_rack.class.php
+++ b/inc/item_rack.class.php
@@ -484,7 +484,7 @@ JAVASCRIPT;
       echo "</div>";
    }
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $DB, $CFG_GLPI;
 
       $colspan = 4;

--- a/inc/item_remotemanagement.class.php
+++ b/inc/item_remotemanagement.class.php
@@ -286,7 +286,7 @@ class Item_RemoteManagement extends CommonDBChild {
    }
 
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       $itemtype = null;
       if (isset($options['itemtype']) && !empty($options['itemtype'])) {
          $itemtype = $options['itemtype'];

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -761,7 +761,7 @@ class ITILFollowup  extends CommonDBChild {
     *@param $options array of possible options:
     *     - item Object : the ITILObject parent
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       if ($this->isNewItem()) {
          $this->getEmpty();
       }

--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -117,7 +117,7 @@ class ITILSolution extends CommonDBChild {
     *
     * @return boolean item found
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       if ($this->isNewItem()) {
          $this->getEmpty();
       }

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -709,7 +709,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria {
     *
     * @return void
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       // show kb item form

--- a/inc/knowbaseitemtranslation.class.php
+++ b/inc/knowbaseitemtranslation.class.php
@@ -265,7 +265,7 @@ class KnowbaseItemTranslation extends CommonDBChild {
     * @param integer $ID
     * @param array   $options
     */
-   function showForm($ID = -1, $options = []) {
+   function showForm($ID = -1, array $options = []) {
       if (isset($options['parent']) && !empty($options['parent'])) {
          $item = $options['parent'];
       }

--- a/inc/levelagreement.class.php
+++ b/inc/levelagreement.class.php
@@ -141,7 +141,7 @@ abstract class LevelAgreement extends CommonDBChild {
     *
     *@return boolean item found
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       $rowspan = 3;
       if ($ID > 0) {
          $rowspan = 5;

--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -139,7 +139,7 @@ class Link extends CommonDBTM {
    *
    * @return void
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       $this->initForm($ID, $options);
       $this->showFormHeader($options);

--- a/inc/mailcollector.class.php
+++ b/inc/mailcollector.class.php
@@ -216,7 +216,7 @@ class MailCollector  extends CommonDBTM {
     *
     * @return boolean item found
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       $this->initForm($ID, $options);

--- a/inc/manuallink.class.php
+++ b/inc/manuallink.class.php
@@ -86,7 +86,7 @@ class ManualLink extends CommonDBChild {
       return true;
    }
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       $this->initForm($ID, $options);
       $this->showFormHeader($options);

--- a/inc/networkname.class.php
+++ b/inc/networkname.class.php
@@ -89,7 +89,7 @@ class NetworkName extends FQDNLabel {
     *
     *@return void
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       $this->initForm($ID, $options);
 
       $recursiveItems = $this->recursivelyGetItems();

--- a/inc/networkport.class.php
+++ b/inc/networkport.class.php
@@ -1172,7 +1172,7 @@ class NetworkPort extends CommonDBChild {
       return $icon . $device_link;
    }
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       if (!isset($options['several'])) {
          $options['several'] = false;
       }

--- a/inc/networkportmigration.class.php
+++ b/inc/networkportmigration.class.php
@@ -113,7 +113,7 @@ class NetworkPortMigration extends CommonDBChild {
    }
 
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $DB;
 
       if (!self::canView()) {

--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -194,7 +194,7 @@ class Notification extends CommonDBTM {
    }
 
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       $this->initForm($ID, $options);

--- a/inc/notification_notificationtemplate.class.php
+++ b/inc/notification_notificationtemplate.class.php
@@ -299,7 +299,7 @@ class Notification_NotificationTemplate extends CommonDBRelation {
     *
     * @return true if displayed  false if item not found or not right to display
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       if (!Session::haveRight("notification", UPDATE)) {
          return false;
       }

--- a/inc/notificationtemplate.class.php
+++ b/inc/notificationtemplate.class.php
@@ -98,7 +98,7 @@ class NotificationTemplate extends CommonDBTM {
    }
 
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       if (!Config::canUpdate()) {

--- a/inc/notificationtemplatetranslation.class.php
+++ b/inc/notificationtemplatetranslation.class.php
@@ -88,7 +88,7 @@ class NotificationTemplateTranslation extends CommonDBChild {
    }
 
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       if (!Config::canUpdate()) {

--- a/inc/olalevel.class.php
+++ b/inc/olalevel.class.php
@@ -217,7 +217,7 @@ class OlaLevel extends LevelAgreementLevel {
     *
     * @return void
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       $this->initForm($ID, $options);
       $this->showFormHeader($options);

--- a/inc/pdu_rack.class.php
+++ b/inc/pdu_rack.class.php
@@ -202,7 +202,7 @@ class PDU_Rack extends CommonDBRelation {
       return $filled;
    }
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $DB;
 
       // search used racked (or sided mounted) pdus

--- a/inc/planningexternalevent.class.php
+++ b/inc/planningexternalevent.class.php
@@ -125,7 +125,7 @@ class PlanningExternalEvent extends CommonDBTM implements CalDAVCompatibleItemIn
    }
 
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       $canedit    = $this->can($ID, UPDATE);

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -1270,7 +1270,7 @@ class Problem extends CommonITILObject {
     * @param $ID
     * @param $options   array
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       if (!static::canView()) {

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -628,7 +628,7 @@ class Profile extends CommonDBTM {
     *
     * @return boolean item found
     **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       $onfocus = "";
       $new     = false;

--- a/inc/project.class.php
+++ b/inc/project.class.php
@@ -1424,7 +1424,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria {
     *
     *@return void
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       $this->initForm($ID, $options);
       $this->showFormHeader($options);
 

--- a/inc/projectcost.class.php
+++ b/inc/projectcost.class.php
@@ -244,7 +244,7 @@ class ProjectCost extends CommonDBChild {
     * @param $ID        integer  ID of the item
     * @param $options   array    options used
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       if ($ID > 0) {
          $this->check($ID, READ);

--- a/inc/projecttask.class.php
+++ b/inc/projecttask.class.php
@@ -529,7 +529,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
     *
     * @return true if displayed  false if item not found or not right to display
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       $rand_template           = mt_rand();

--- a/inc/queuednotification.class.php
+++ b/inc/queuednotification.class.php
@@ -649,7 +649,7 @@ class QueuedNotification extends CommonDBTM {
     *
     * @return true if displayed  false if item not found or not right to display
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       if (!Session::haveRight("queuednotification", READ)) {
          return false;
       }

--- a/inc/refusedequipment.class.php
+++ b/inc/refusedequipment.class.php
@@ -164,7 +164,7 @@ class RefusedEquipment extends CommonDBTM {
       return "fas fa-times";
    }
 
-   public function showForm($ID, $options = []) {
+   public function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       $this->initForm($ID, $options);

--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -569,7 +569,7 @@ class Reminder extends CommonDBVisible implements
     *     - target filename : where to go when done.
     *     - from_planning_ajax : set to disable planning form part
     **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       $this->initForm($ID, $options);

--- a/inc/remindertranslation.class.php
+++ b/inc/remindertranslation.class.php
@@ -201,7 +201,7 @@ class ReminderTranslation extends CommonDBChild {
     * @param integer $ID
     * @param array   $options
     */
-   function showForm($ID = -1, $options = []) {
+   function showForm($ID = -1, array $options = []) {
 
       if ($ID > 0) {
          $this->check($ID, READ);

--- a/inc/reservation.class.php
+++ b/inc/reservation.class.php
@@ -619,7 +619,7 @@ JAVASCRIPT;
     *     - item  reservation items ID for creation process
     *     - date date for creation process
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       if (!Session::haveRight("reservation", ReservationItem::RESERVEANITEM)) {

--- a/inc/reservationitem.class.php
+++ b/inc/reservationitem.class.php
@@ -361,7 +361,7 @@ class ReservationItem extends CommonDBChild {
    }
 
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       if (!self::canView()) {
          return false;

--- a/inc/rssfeed.class.php
+++ b/inc/rssfeed.class.php
@@ -648,7 +648,7 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria {
     * @param $options   array    of possible options:
     *     - target filename : where to go when done.
     **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       // Test _rss cache directory. I permission trouble : unable to edit
       if (Toolbox::testWriteAccessToDirectory(GLPI_RSS_DIR) > 0) {
          echo "<div class='center'>";

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -847,7 +847,7 @@ class Rule extends CommonDBTM {
     *
     * @return void
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
       if (!$this->isNewID($ID)) {
          $this->check($ID, READ);

--- a/inc/ruleaction.class.php
+++ b/inc/ruleaction.class.php
@@ -660,7 +660,7 @@ class RuleAction extends CommonDBChild {
     * @param $options array of possible options:
     *     - rule Object : the rule
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       // Yllen: you always have parent for action

--- a/inc/rulecriteria.class.php
+++ b/inc/rulecriteria.class.php
@@ -581,7 +581,7 @@ class RuleCriteria extends CommonDBChild {
     * @param $options array    of possible options:
     *     - rule Object : the rule
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $CFG_GLPI;
 
       // Yllen: you always have parent for criteria

--- a/inc/savedsearch.class.php
+++ b/inc/savedsearch.class.php
@@ -365,7 +365,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria {
     *
     * @return void
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       // Try to load id from fields if not specified
       if ($ID == 0) {

--- a/inc/savedsearch_alert.class.php
+++ b/inc/savedsearch_alert.class.php
@@ -102,7 +102,7 @@ class SavedSearch_Alert extends CommonDBChild {
     *
     * @return true if displayed  false if item not found or not right to display
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       /*if (!Session::haveRight("savedsearch", UPDATE)) {
          return false;

--- a/inc/slalevel.class.php
+++ b/inc/slalevel.class.php
@@ -215,7 +215,7 @@ class SlaLevel extends LevelAgreementLevel {
     *
     * @return void
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       $canedit = $this->can('sla', UPDATE);
 

--- a/inc/slm.class.php
+++ b/inc/slm.class.php
@@ -101,7 +101,7 @@ class SLM extends CommonDBTM {
     *
     * @return boolean item found
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       $rowspan = 2;
 

--- a/inc/snmpcredential.class.php
+++ b/inc/snmpcredential.class.php
@@ -79,7 +79,7 @@ class SNMPCredential extends CommonDBTM {
       return $ong;
    }
 
-   public function showForm($ID, $options = []) {
+   public function showForm($ID, array $options = []) {
       $this->initForm($ID, $options);
       TemplateRenderer::getInstance()->display('components/form/snmpcredential.html.twig', [
          'item'   => $this,

--- a/inc/socket.class.php
+++ b/inc/socket.class.php
@@ -174,7 +174,7 @@ class Socket extends CommonDBChild {
     *
     * @return true if displayed  false if item not found or not right to display
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
 
       $itemtype = null;
       if (isset($options['itemtype']) && !empty($options['itemtype'])) {

--- a/inc/softwarelicense.class.php
+++ b/inc/softwarelicense.class.php
@@ -255,7 +255,7 @@ class SoftwareLicense extends CommonTreeDropdown {
    }
 
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       $softwares_id = -1;
       if (isset($options['softwares_id'])) {
          $softwares_id = $options['softwares_id'];

--- a/inc/softwareversion.class.php
+++ b/inc/softwareversion.class.php
@@ -99,7 +99,7 @@ class SoftwareVersion extends CommonDBChild {
     * @return true if displayed  false if item not found or not right to display
     *
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       if ($ID > 0) {
          $this->check($ID, READ);
          $softwares_id = $this->fields['softwares_id'];

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -4085,7 +4085,7 @@ JAVASCRIPT;
    }
 
 
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       global $PLUGIN_HOOKS;
 
       // show full create form only to tech users

--- a/inc/transfer.class.php
+++ b/inc/transfer.class.php
@@ -3688,7 +3688,7 @@ class Transfer extends CommonDBTM {
     *
     * @return boolean item found
    **/
-   function showForm($ID, $options = []) {
+   function showForm($ID, array $options = []) {
       $edit_form = true;
       if (strpos($_SERVER['HTTP_REFERER'], "transfer.form.php") === false) {
          $edit_form = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This is valid:
```php
class A {
    function showForm($ID, array $options = []) {}
}
class B extends A {
    function showForm($ID, $options = []) {}
}
```

This is invalid:
```php
class A {
    function showForm($ID, $options = []) {}
}
class B extends A {
    function showForm($ID, array $options = []) {}
}
// Declaration of B::showForm($ID, array $options = []) must be compatible with A::showForm($ID, $options = [])
```


I propose to harmonize all signatures in core to  `function showForm($ID, array $options = []) {}`, so plugins may override it using both `function showForm($ID, $options = []) {}` and `function showForm($ID, array $options = []) {}` signatures without errors.