### PR TITLE
Fix DB ssl_set

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -211,7 +211,6 @@ class DBmysql {
       $this->dbh = @new mysqli();
       if ($this->dbssl) {
           $this->dbh->ssl_set(
-             $this->dbh,
              $this->dbsslkey,
              $this->dbsslcert,
              $this->dbsslca,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

#9766 Changed ssl_set call from procedural style to object oriented. The parameters are different between the two versions as the mysqli parameter is no longer needed.
https://www.php.net/manual/en/mysqli.ssl-set.php