### PR TITLE
Central counter links fix

### DIFF
--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1498,8 +1498,8 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                } else if ($itemtype == "ProblemTask") {
                   $title = __("Problem tasks to do");
                }
-               $itemtype_url = strtolower(str_replace("Task","",$itemtype));
-               echo "<a href=\"".$CFG_GLPI["root_doc"]."/front/".$itemtype_url.".php?".
+               $linked_itemtype = str_replace("Task","",$itemtype);
+               echo "<a href=\"".$linked_itemtype::getSearchURL()."?".
                       Toolbox::append_params($options, '&amp;')."\">".
                       Html::makeTitle($title, $displayed_row_count, $total_row_count)."</a>";
                break;

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1498,7 +1498,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                } else if ($itemtype == "ProblemTask") {
                   $title = __("Problem tasks to do");
                }
-               $linked_itemtype = str_replace("Task","",$itemtype);
+               $linked_itemtype = str_replace("Task", "", $itemtype);
                echo "<a href=\"".$linked_itemtype::getSearchURL()."?".
                       Toolbox::append_params($options, '&amp;')."\">".
                       Html::makeTitle($title, $displayed_row_count, $total_row_count)."</a>";

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1498,7 +1498,8 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                } else if ($itemtype == "ProblemTask") {
                   $title = __("Problem tasks to do");
                }
-               echo "<a href=\"".$CFG_GLPI["root_doc"]."/front/ticket.php?".
+               $itemtype_url = strtolower(str_replace("Task","",$itemtype));
+               echo "<a href=\"".$CFG_GLPI["root_doc"]."/front/".$itemtype_url.".php?".
                       Toolbox::append_params($options, '&amp;')."\">".
                       Html::makeTitle($title, $displayed_row_count, $total_row_count)."</a>";
                break;


### PR DESCRIPTION
When clicking on the counters next to "Problems tasks to do", the link would send user to "Tickets" section instead of "Problem" section. I noted this when I was adding "Changes" information on central screen.

I tested it and now the link is sending user to correct place. I did with a variable because in my instance I'm adding "Changes" info on central too. I would send a pull request for it too, but I've seen it was already implemented.

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | don't know what that means
