### PR TITLE
Remove usage of MySQL integer display width in migrations

### DIFF
--- a/install/migrations/update_0.80.0_to_0.80.1.php
+++ b/install/migrations/update_0.80.0_to_0.80.1.php
@@ -117,8 +117,8 @@ function update0800to0801() {
 
    $migration->addField("glpi_ocsservers", "ocs_version", "VARCHAR( 255 ) NULL");
 
-   if ($migration->addField("glpi_slalevels", "entities_id", "INT( 11 ) NOT NULL DEFAULT 0")) {
-      $migration->addField("glpi_slalevels", "is_recursive", "TINYINT( 1 ) NOT NULL DEFAULT 0");
+   if ($migration->addField("glpi_slalevels", "entities_id", "INT NOT NULL DEFAULT 0")) {
+      $migration->addField("glpi_slalevels", "is_recursive", "TINYINT NOT NULL DEFAULT 0");
       $migration->migrationOneTable('glpi_slalevels');
 
       $entities    = getAllDataFromTable('glpi_entities');

--- a/install/migrations/update_0.80.x_to_0.83.0.php
+++ b/install/migrations/update_0.80.x_to_0.83.0.php
@@ -84,11 +84,11 @@ function update080xto0830() {
    // Problems management
    if (!$DB->tableExists('glpi_problems')) {
       $query = "CREATE TABLE `glpi_problems` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) DEFAULT NULL,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `is_deleted` tinyint NOT NULL DEFAULT '0',
                   `status` varchar(255) DEFAULT NULL,
                   `content` longtext DEFAULT NULL,
                   `date_mod` DATETIME DEFAULT NULL,
@@ -96,23 +96,23 @@ function update080xto0830() {
                   `solvedate` DATETIME DEFAULT NULL,
                   `closedate` DATETIME DEFAULT NULL,
                   `due_date` DATETIME DEFAULT NULL,
-                  `users_id_recipient` int(11) NOT NULL DEFAULT '0',
-                  `users_id_lastupdater` int(11) NOT NULL DEFAULT '0',
-                  `suppliers_id_assign` int(11) NOT NULL DEFAULT '0',
-                  `urgency` int(11) NOT NULL DEFAULT '1',
-                  `impact` int(11) NOT NULL DEFAULT '1',
-                  `priority` int(11) NOT NULL DEFAULT '1',
-                  `itilcategories_id` int(11) NOT NULL DEFAULT '0',
+                  `users_id_recipient` int NOT NULL DEFAULT '0',
+                  `users_id_lastupdater` int NOT NULL DEFAULT '0',
+                  `suppliers_id_assign` int NOT NULL DEFAULT '0',
+                  `urgency` int NOT NULL DEFAULT '1',
+                  `impact` int NOT NULL DEFAULT '1',
+                  `priority` int NOT NULL DEFAULT '1',
+                  `itilcategories_id` int NOT NULL DEFAULT '0',
                   `impactcontent` longtext DEFAULT NULL,
                   `causecontent` longtext DEFAULT NULL,
                   `symptomcontent` longtext DEFAULT NULL,
-                  `solutiontypes_id` int(11) NOT NULL DEFAULT '0',
+                  `solutiontypes_id` int NOT NULL DEFAULT '0',
                   `solution` text COLLATE utf8_unicode_ci,
-                  `actiontime` int(11) NOT NULL DEFAULT '0',
+                  `actiontime` int NOT NULL DEFAULT '0',
                   `begin_waiting_date` datetime DEFAULT NULL,
-                  `waiting_duration` int(11) NOT NULL DEFAULT '0',
-                  `close_delay_stat` int(11) NOT NULL DEFAULT '0',
-                  `solve_delay_stat` int(11) NOT NULL DEFAULT '0',
+                  `waiting_duration` int NOT NULL DEFAULT '0',
+                  `close_delay_stat` int NOT NULL DEFAULT '0',
+                  `solve_delay_stat` int NOT NULL DEFAULT '0',
                   `notepad` LONGTEXT NULL,
                   PRIMARY KEY (`id`),
                   KEY `name` (`name`),
@@ -145,11 +145,11 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_problems_users')) {
       $query = "CREATE TABLE `glpi_problems_users` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `problems_id` int(11) NOT NULL DEFAULT '0',
-                  `users_id` int(11) NOT NULL DEFAULT '0',
-                  `type` int(11) NOT NULL DEFAULT '1',
-                  `use_notification` tinyint(1) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `problems_id` int NOT NULL DEFAULT '0',
+                  `users_id` int NOT NULL DEFAULT '0',
+                  `type` int NOT NULL DEFAULT '1',
+                  `use_notification` tinyint NOT NULL DEFAULT '0',
                   `alternative_email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`problems_id`,`type`,`users_id`,`alternative_email`),
@@ -160,10 +160,10 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_groups_problems')) {
       $query = "CREATE TABLE `glpi_groups_problems` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `problems_id` int(11) NOT NULL DEFAULT '0',
-                  `groups_id` int(11) NOT NULL DEFAULT '0',
-                  `type` int(11) NOT NULL DEFAULT '1',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `problems_id` int NOT NULL DEFAULT '0',
+                  `groups_id` int NOT NULL DEFAULT '0',
+                  `type` int NOT NULL DEFAULT '1',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`problems_id`,`type`,`groups_id`),
                   KEY `group` (`groups_id`,`type`)
@@ -173,10 +173,10 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_items_problems')) {
       $query = "CREATE TABLE `glpi_items_problems` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `problems_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `problems_id` int NOT NULL DEFAULT '0',
                   `itemtype` varchar(100) default NULL,
-                  `items_id` int(11) NOT NULL DEFAULT '0',
+                  `items_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`problems_id`,`itemtype`,`items_id`),
                   KEY `item` (`itemtype`,`items_id`)
@@ -186,9 +186,9 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_problems_tickets')) {
       $query = "CREATE TABLE `glpi_problems_tickets` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `problems_id` int(11) NOT NULL DEFAULT '0',
-                  `tickets_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `problems_id` int NOT NULL DEFAULT '0',
+                  `tickets_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`problems_id`,`tickets_id`),
                   KEY `tickets_id` (`tickets_id`)
@@ -198,17 +198,17 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_problemtasks')) {
       $query = "CREATE TABLE `glpi_problemtasks` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `problems_id` int(11) NOT NULL DEFAULT '0',
-                  `taskcategories_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `problems_id` int NOT NULL DEFAULT '0',
+                  `taskcategories_id` int NOT NULL DEFAULT '0',
                   `date` datetime DEFAULT NULL,
                   `begin` datetime DEFAULT NULL,
                   `end` datetime DEFAULT NULL,
-                  `users_id` int(11) NOT NULL DEFAULT '0',
-                  `users_id_tech` int(11) NOT NULL DEFAULT '0',
+                  `users_id` int NOT NULL DEFAULT '0',
+                  `users_id_tech` int NOT NULL DEFAULT '0',
                   `content` longtext COLLATE utf8_unicode_ci,
-                  `actiontime` int(11) NOT NULL DEFAULT '0',
-                  `state` int(11) NOT NULL DEFAULT '0',
+                  `actiontime` int NOT NULL DEFAULT '0',
+                  `state` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `problems_id` (`problems_id`),
                   KEY `users_id` (`users_id`),
@@ -545,15 +545,15 @@ function update080xto0830() {
 
    $migration->addField("glpi_configs", "show_count_on_tabs", "bool", ['value' => '1']);
 
-   $migration->addField("glpi_users", "show_count_on_tabs", "tinyint(1) NULL DEFAULT NULL");
+   $migration->addField("glpi_users", "show_count_on_tabs", "tinyint NULL DEFAULT NULL");
 
    $migration->addField("glpi_configs", "refresh_ticket_list", "integer");
 
-   $migration->addField("glpi_users", "refresh_ticket_list", "int(11) NULL DEFAULT NULL");
+   $migration->addField("glpi_users", "refresh_ticket_list", "int NULL DEFAULT NULL");
 
    $migration->addField("glpi_configs", "set_default_tech", "bool", ['value' => '1']);
 
-   $migration->addField("glpi_users", "set_default_tech", "tinyint(1) NULL DEFAULT NULL");
+   $migration->addField("glpi_users", "set_default_tech", "tinyint NULL DEFAULT NULL");
 
    $migration->addField("glpi_reservations", "group", "integer");
 
@@ -638,10 +638,10 @@ function update080xto0830() {
    // Several email per users
    if (!$DB->tableExists('glpi_useremails')) {
       $query = "CREATE TABLE `glpi_useremails` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `users_id` int(11) NOT NULL DEFAULT '0',
-                  `is_default` TINYINT( 1 ) NOT NULL DEFAULT 0,
-                  `is_dynamic` TINYINT( 1 ) NOT NULL DEFAULT 0,
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `users_id` int NOT NULL DEFAULT '0',
+                  `is_default` TINYINT NOT NULL DEFAULT 0,
+                  `is_dynamic` TINYINT NOT NULL DEFAULT 0,
                   `email` varchar( 255 ) NULL DEFAULT NULL,
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`users_id`,`email`),
@@ -817,10 +817,10 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_tickettemplates')) {
       $query = "CREATE TABLE `glpi_tickettemplates` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar( 255 ) NULL DEFAULT NULL,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` TINYINT( 1 ) NOT NULL DEFAULT 0,
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` TINYINT NOT NULL DEFAULT 0,
                   `comment` TEXT DEFAULT NULL,
                   PRIMARY KEY (`id`),
                   KEY `name` (`name`),
@@ -855,11 +855,11 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_tickettemplatehiddenfields')) {
       $query = "CREATE TABLE `glpi_tickettemplatehiddenfields` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `tickettemplates_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` TINYINT( 1 ) NOT NULL DEFAULT 0,
-                  `num` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `tickettemplates_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` TINYINT NOT NULL DEFAULT 0,
+                  `num` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `entities_id` (`entities_id`),
                   KEY `is_recursive` (`is_recursive`),
@@ -871,11 +871,11 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_tickettemplatepredefinedfields')) {
       $query = "CREATE TABLE `glpi_tickettemplatepredefinedfields` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `tickettemplates_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` TINYINT( 1 ) NOT NULL DEFAULT 0,
-                  `num` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `tickettemplates_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` TINYINT NOT NULL DEFAULT 0,
+                  `num` int NOT NULL DEFAULT '0',
                   `value` TEXT DEFAULT NULL,
                   PRIMARY KEY (`id`),
                   KEY `entities_id` (`entities_id`),
@@ -888,11 +888,11 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_tickettemplatemandatoryfields')) {
       $query = "CREATE TABLE `glpi_tickettemplatemandatoryfields` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `tickettemplates_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` TINYINT( 1 ) NOT NULL DEFAULT 0,
-                  `num` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `tickettemplates_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` TINYINT NOT NULL DEFAULT 0,
+                  `num` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `entities_id` (`entities_id`),
                   KEY `is_recursive` (`is_recursive`),
@@ -1006,16 +1006,16 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_ticketrecurrents')) {
       $query = "CREATE TABLE `glpi_ticketrecurrents` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar( 255 ) NULL DEFAULT NULL,
                   `comment` TEXT DEFAULT NULL,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` TINYINT( 1 ) NOT NULL DEFAULT 0,
-                  `is_active` TINYINT( 1 ) NOT NULL DEFAULT 0,
-                  `tickettemplates_id` int(11) NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` TINYINT NOT NULL DEFAULT 0,
+                  `is_active` TINYINT NOT NULL DEFAULT 0,
+                  `tickettemplates_id` int NOT NULL DEFAULT '0',
                   `begin_date` datetime DEFAULT NULL,
-                  `periodicity` int(11) NOT NULL DEFAULT '0',
-                  `create_before` int(11) NOT NULL DEFAULT '0',
+                  `periodicity` int NOT NULL DEFAULT '0',
+                  `create_before` int NOT NULL DEFAULT '0',
                   `next_creation_date` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
                   KEY `entities_id` (`entities_id`),
@@ -1242,9 +1242,9 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_reminders_users')) {
       $query = "CREATE TABLE `glpi_reminders_users` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `reminders_id` int(11) NOT NULL DEFAULT '0',
-                  `users_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `reminders_id` int NOT NULL DEFAULT '0',
+                  `users_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `reminders_id` (`reminders_id`),
                   KEY `users_id` (`users_id`)
@@ -1255,11 +1255,11 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_groups_reminders')) {
       $query = "CREATE TABLE `glpi_groups_reminders` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `reminders_id` int(11) NOT NULL DEFAULT '0',
-                  `groups_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '-1',
-                  `is_recursive` TINYINT( 1 ) NOT NULL DEFAULT 0,
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `reminders_id` int NOT NULL DEFAULT '0',
+                  `groups_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '-1',
+                  `is_recursive` TINYINT NOT NULL DEFAULT 0,
                   PRIMARY KEY (`id`),
                   KEY `reminders_id` (`reminders_id`),
                   KEY `groups_id` (`groups_id`),
@@ -1273,11 +1273,11 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_profiles_reminders')) {
       $query = "CREATE TABLE `glpi_profiles_reminders` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `reminders_id` int(11) NOT NULL DEFAULT '0',
-                  `profiles_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '-1',
-                  `is_recursive` TINYINT( 1 ) NOT NULL DEFAULT 0,
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `reminders_id` int NOT NULL DEFAULT '0',
+                  `profiles_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '-1',
+                  `is_recursive` TINYINT NOT NULL DEFAULT 0,
                   PRIMARY KEY (`id`),
                   KEY `reminders_id` (`reminders_id`),
                   KEY `profiles_id` (`profiles_id`),
@@ -1290,10 +1290,10 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_entities_reminders')) {
       $query = "CREATE TABLE `glpi_entities_reminders` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `reminders_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` TINYINT( 1 ) NOT NULL DEFAULT 0,
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `reminders_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` TINYINT NOT NULL DEFAULT 0,
                   PRIMARY KEY (`id`),
                   KEY `reminders_id` (`reminders_id`),
                   KEY `entities_id` (`entities_id`),
@@ -1364,9 +1364,9 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_knowbaseitems_users')) {
       $query = "CREATE TABLE `glpi_knowbaseitems_users` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `knowbaseitems_id` int(11) NOT NULL DEFAULT '0',
-                  `users_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `knowbaseitems_id` int NOT NULL DEFAULT '0',
+                  `users_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `knowbaseitems_id` (`knowbaseitems_id`),
                   KEY `users_id` (`users_id`)
@@ -1377,11 +1377,11 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_groups_knowbaseitems')) {
       $query = "CREATE TABLE `glpi_groups_knowbaseitems` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `knowbaseitems_id` int(11) NOT NULL DEFAULT '0',
-                  `groups_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '-1',
-                  `is_recursive` TINYINT( 1 ) NOT NULL DEFAULT 0,
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `knowbaseitems_id` int NOT NULL DEFAULT '0',
+                  `groups_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '-1',
+                  `is_recursive` TINYINT NOT NULL DEFAULT 0,
                   PRIMARY KEY (`id`),
                   KEY `knowbaseitems_id` (`knowbaseitems_id`),
                   KEY `groups_id` (`groups_id`),
@@ -1395,11 +1395,11 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_knowbaseitems_profiles')) {
       $query = "CREATE TABLE `glpi_knowbaseitems_profiles` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `knowbaseitems_id` int(11) NOT NULL DEFAULT '0',
-                  `profiles_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '-1',
-                  `is_recursive` TINYINT( 1 ) NOT NULL DEFAULT 0,
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `knowbaseitems_id` int NOT NULL DEFAULT '0',
+                  `profiles_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '-1',
+                  `is_recursive` TINYINT NOT NULL DEFAULT 0,
                   PRIMARY KEY (`id`),
                   KEY `knowbaseitems_id` (`knowbaseitems_id`),
                   KEY `profiles_id` (`profiles_id`),
@@ -1412,10 +1412,10 @@ function update080xto0830() {
 
    if (!$DB->tableExists('glpi_entities_knowbaseitems')) {
       $query = "CREATE TABLE `glpi_entities_knowbaseitems` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `knowbaseitems_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` TINYINT( 1 ) NOT NULL DEFAULT 0,
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `knowbaseitems_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` TINYINT NOT NULL DEFAULT 0,
                   PRIMARY KEY (`id`),
                   KEY `knowbaseitems_id` (`knowbaseitems_id`),
                   KEY `entities_id` (`entities_id`),
@@ -1529,15 +1529,15 @@ function update080xto0830() {
 
    // new default value
    $migration->changeField("glpi_entitydatas", "calendars_id", "calendars_id",
-                           "int(11) NOT NULL DEFAULT '-2'");
+                           "int NOT NULL DEFAULT '-2'");
    $migration->changeField("glpi_entitydatas", "tickettype", "tickettype",
-                           "int(11) NOT NULL DEFAULT '-2'");
+                           "int NOT NULL DEFAULT '-2'");
    $migration->changeField("glpi_entitydatas", "inquest_config", "inquest_config",
-                           "int(11) NOT NULL DEFAULT '-2'");
+                           "int NOT NULL DEFAULT '-2'");
    $migration->changeField("glpi_entitydatas", "inquest_rate", "inquest_rate",
-                           "int(11) NOT NULL DEFAULT '0'");
+                           "int NOT NULL DEFAULT '0'");
    $migration->changeField("glpi_entitydatas", "inquest_delay", "inquest_delay",
-                           "int(11) NOT NULL DEFAULT '-10'");
+                           "int NOT NULL DEFAULT '-10'");
 
    // migration to new values for inherit parent (-1 => -2)
    $fieldparent = ['autofill_buy_date', 'autofill_delivery_date', 'autofill_warranty_date',
@@ -1585,7 +1585,7 @@ function update080xto0830() {
                   $DB->queryOrDie($query, "0.83 migrate data from config to glpi_entitydatas");
 
                   $migration->changeField("glpi_entitydatas", "$field_config", "$field_config",
-                                          "int(11) NOT NULL DEFAULT '-2'");
+                                          "int NOT NULL DEFAULT '-2'");
 
                   $migration->dropField("glpi_configs", $field_config);
                }

--- a/install/migrations/update_0.83.0_to_0.83.1.php
+++ b/install/migrations/update_0.83.0_to_0.83.1.php
@@ -73,7 +73,7 @@ function update0830to0831() {
                               'condition' => " WHERE `config` = 'w'"]);
 
    $migration->addField("glpi_configs", "display_count_on_home", "integer", ['value' => 5]);
-   $migration->addField("glpi_users", "display_count_on_home", "int(11) NULL DEFAULT NULL");
+   $migration->addField("glpi_users", "display_count_on_home", "int NULL DEFAULT NULL");
 
    // ************ Keep it at the end **************
    $migration->displayMessage('Migration of glpi_displaypreferences');

--- a/install/migrations/update_0.83.x_to_0.84.0.php
+++ b/install/migrations/update_0.83.x_to_0.84.0.php
@@ -484,16 +484,16 @@ function update083xto0840() {
 
    if (!$DB->tableExists('glpi_contractcosts')) {
       $query = "CREATE TABLE `glpi_contractcosts` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `contracts_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `contracts_id` int NOT NULL DEFAULT '0',
                   `name` varchar(255) DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `begin_date` date DEFAULT NULL,
                   `end_date` date DEFAULT NULL,
                   `cost` decimal(20,4) NOT NULL DEFAULT '0.0000',
-                  `budgets_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+                  `budgets_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `name` (`name`),
                   KEY `contracts_id` (`contracts_id`),
@@ -535,18 +535,18 @@ function update083xto0840() {
 
    if (!$DB->tableExists('glpi_ticketcosts')) {
       $query = "CREATE TABLE `glpi_ticketcosts` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `tickets_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `tickets_id` int NOT NULL DEFAULT '0',
                   `name` varchar(255) DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `begin_date` date DEFAULT NULL,
                   `end_date` date DEFAULT NULL,
-                  `actiontime` int(11) NOT NULL DEFAULT '0',
+                  `actiontime` int NOT NULL DEFAULT '0',
                   `cost_time` decimal(20,4) NOT NULL DEFAULT '0.0000',
                   `cost_fixed` decimal(20,4) NOT NULL DEFAULT '0.0000',
                   `cost_material` decimal(20,4) NOT NULL DEFAULT '0.0000',
-                  `budgets_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
+                  `budgets_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `name` (`name`),
                   KEY `tickets_id` (`tickets_id`),
@@ -604,15 +604,15 @@ function update083xto0840() {
 
    if (!$DB->tableExists('glpi_rssfeeds')) {
       $query = "CREATE TABLE `glpi_rssfeeds` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) DEFAULT NULL,
-                  `users_id` int(11) NOT NULL DEFAULT '0',
+                  `users_id` int NOT NULL DEFAULT '0',
                   `comment` text COLLATE utf8_unicode_ci,
                   `url` text COLLATE utf8_unicode_ci,
-                  `refresh_rate` int(11) NOT NULL DEFAULT '86400',
-                  `max_items` int(11) NOT NULL DEFAULT '20',
-                  `have_error` TINYINT( 1 ) NOT NULL DEFAULT 0,
-                  `is_active` TINYINT( 1 ) NOT NULL DEFAULT 0,
+                  `refresh_rate` int NOT NULL DEFAULT '86400',
+                  `max_items` int NOT NULL DEFAULT '20',
+                  `have_error` TINYINT NOT NULL DEFAULT 0,
+                  `is_active` TINYINT NOT NULL DEFAULT 0,
                   `date_mod` DATETIME DEFAULT NULL,
                   PRIMARY KEY (`id`),
                   KEY `name` (`name`),
@@ -626,9 +626,9 @@ function update083xto0840() {
    }
    if (!$DB->tableExists('glpi_rssfeeds_users')) {
       $query = "CREATE TABLE `glpi_rssfeeds_users` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `rssfeeds_id` int(11) NOT NULL DEFAULT '0',
-                  `users_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `rssfeeds_id` int NOT NULL DEFAULT '0',
+                  `users_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `rssfeeds_id` (`rssfeeds_id`),
                   KEY `users_id` (`users_id`)
@@ -639,11 +639,11 @@ function update083xto0840() {
 
    if (!$DB->tableExists('glpi_groups_rssfeeds')) {
       $query = "CREATE TABLE `glpi_groups_rssfeeds` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `rssfeeds_id` int(11) NOT NULL DEFAULT '0',
-                  `groups_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '-1',
-                  `is_recursive` TINYINT( 1 ) NOT NULL DEFAULT 0,
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `rssfeeds_id` int NOT NULL DEFAULT '0',
+                  `groups_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '-1',
+                  `is_recursive` TINYINT NOT NULL DEFAULT 0,
                   PRIMARY KEY (`id`),
                   KEY `rssfeeds_id` (`rssfeeds_id`),
                   KEY `groups_id` (`groups_id`),
@@ -657,11 +657,11 @@ function update083xto0840() {
 
    if (!$DB->tableExists('glpi_profiles_rssfeeds')) {
       $query = "CREATE TABLE `glpi_profiles_rssfeeds` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `rssfeeds_id` int(11) NOT NULL DEFAULT '0',
-                  `profiles_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '-1',
-                  `is_recursive` TINYINT( 1 ) NOT NULL DEFAULT 0,
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `rssfeeds_id` int NOT NULL DEFAULT '0',
+                  `profiles_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '-1',
+                  `is_recursive` TINYINT NOT NULL DEFAULT 0,
                   PRIMARY KEY (`id`),
                   KEY `rssfeeds_id` (`rssfeeds_id`),
                   KEY `profiles_id` (`profiles_id`),
@@ -674,10 +674,10 @@ function update083xto0840() {
 
    if (!$DB->tableExists('glpi_entities_rssfeeds')) {
       $query = "CREATE TABLE `glpi_entities_rssfeeds` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `rssfeeds_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` TINYINT( 1 ) NOT NULL DEFAULT 0,
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `rssfeeds_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` TINYINT NOT NULL DEFAULT 0,
                   PRIMARY KEY (`id`),
                   KEY `rssfeeds_id` (`rssfeeds_id`),
                   KEY `entities_id` (`entities_id`),
@@ -691,11 +691,11 @@ function update083xto0840() {
 
    if (!$DB->tableExists('glpi_planningrecalls')) {
       $query = "CREATE TABLE `glpi_planningrecalls` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `items_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `items_id` int NOT NULL DEFAULT '0',
                   `itemtype` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
-                  `users_id` int(11) NOT NULL DEFAULT '0',
-                  `before_time` int(11) NOT NULL DEFAULT '-10',
+                  `users_id` int NOT NULL DEFAULT '0',
+                  `before_time` int NOT NULL DEFAULT '-10',
                   `when` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
                   KEY `users_id` (`users_id`),
@@ -824,12 +824,12 @@ function update083xto0840() {
    $migration->addField("glpi_configs", "entity_ssofield", "string");
    $migration->addField("glpi_configs", "registration_number_ssofield", "string");
 
-   $migration->addField("glpi_users", "notification_to_myself", "tinyint(1) DEFAULT NULL");
+   $migration->addField("glpi_users", "notification_to_myself", "tinyint DEFAULT NULL");
    $migration->addField("glpi_users", 'duedateok_color', "string");
    $migration->addField("glpi_users", 'duedatewarning_color', "string");
    $migration->addField("glpi_users", 'duedatecritical_color', "string");
-   $migration->addField("glpi_users", 'duedatewarning_less', "int(11) DEFAULT NULL");
-   $migration->addField("glpi_users", 'duedatecritical_less', "int(11) DEFAULT NULL");
+   $migration->addField("glpi_users", 'duedatewarning_less', "int DEFAULT NULL");
+   $migration->addField("glpi_users", 'duedatecritical_less', "int DEFAULT NULL");
    $migration->addField("glpi_users", 'duedatewarning_unit', "string");
    $migration->addField("glpi_users", 'duedatecritical_unit', "string");
 
@@ -865,10 +865,10 @@ function update083xto0840() {
 
    if (!$DB->tableExists('glpi_slalevelcriterias')) {
       $query = "CREATE TABLE `glpi_slalevelcriterias` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `slalevels_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `slalevels_id` int NOT NULL DEFAULT '0',
                   `criteria` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `condition` int(11) NOT NULL DEFAULT '0'
+                  `condition` int NOT NULL DEFAULT '0'
                               COMMENT 'see define.php PATTERN_* and REGEX_* constant',
                   `pattern` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   PRIMARY KEY (`id`),
@@ -914,8 +914,8 @@ function update083xto0840() {
 
    if (!$DB->tableExists('glpi_blacklists')) {
       $query = "CREATE TABLE `glpi_blacklists` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `type` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `type` int NOT NULL DEFAULT '0',
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `value` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
@@ -955,7 +955,7 @@ function update083xto0840() {
 
    if (!$DB->tableExists('glpi_ssovariables')) {
       $query = "CREATE TABLE `glpi_ssovariables` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci NOT NULL,
                   PRIMARY KEY (`id`)
@@ -1143,10 +1143,10 @@ function update083xto0840() {
    // Add multiple suppliers for itil objects
    if (!$DB->tableExists('glpi_problems_suppliers')) {
       $query = "CREATE TABLE `glpi_problems_suppliers` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `problems_id` int(11) NOT NULL DEFAULT '0',
-                  `suppliers_id` int(11) NOT NULL DEFAULT '0',
-                  `type` int(11) NOT NULL DEFAULT '1',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `problems_id` int NOT NULL DEFAULT '0',
+                  `suppliers_id` int NOT NULL DEFAULT '0',
+                  `type` int NOT NULL DEFAULT '1',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`problems_id`,`type`,`suppliers_id`),
                   KEY `group` (`suppliers_id`,`type`)
@@ -1166,10 +1166,10 @@ function update083xto0840() {
 
    if (!$DB->tableExists('glpi_suppliers_tickets')) {
       $query = "CREATE TABLE `glpi_suppliers_tickets` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `tickets_id` int(11) NOT NULL DEFAULT '0',
-                  `suppliers_id` int(11) NOT NULL DEFAULT '0',
-                  `type` int(11) NOT NULL DEFAULT '1',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `tickets_id` int NOT NULL DEFAULT '0',
+                  `suppliers_id` int NOT NULL DEFAULT '0',
+                  `type` int NOT NULL DEFAULT '1',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`tickets_id`,`type`,`suppliers_id`),
                   KEY `group` (`suppliers_id`,`type`)
@@ -1839,9 +1839,9 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
    // Adding FQDN table
    if (!$DB->tableExists('glpi_fqdns')) {
       $query = "CREATE TABLE `glpi_fqdns` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `fqdn` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
@@ -1877,9 +1877,9 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
    // Adding IPAddress table
    if (!$DB->tableExists('glpi_ipaddresses')) {
       $query = "CREATE TABLE `glpi_ipaddresses` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `items_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `items_id` int NOT NULL DEFAULT '0',
                   `itemtype` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
                   `version` tinyint unsigned DEFAULT '0',
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
@@ -1902,9 +1902,9 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
    // Adding WifiNetwork table
    if (!$DB->tableExists('glpi_wifinetworks')) {
       $query = "CREATE TABLE `glpi_wifinetworks` (
-                 `id` int(11) NOT NULL AUTO_INCREMENT,
-                 `entities_id` int(11) NOT NULL DEFAULT '0',
-                 `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+                 `id` int NOT NULL AUTO_INCREMENT,
+                 `entities_id` int NOT NULL DEFAULT '0',
+                 `is_recursive` tinyint NOT NULL DEFAULT '0',
                  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                  `essid` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                  `mode` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL
@@ -1924,15 +1924,15 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
    // Adding IPNetwork table
    if (!$DB->tableExists('glpi_ipnetworks')) {
       $query = "CREATE TABLE `glpi_ipnetworks` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `ipnetworks_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `ipnetworks_id` int NOT NULL DEFAULT '0',
                   `completename` text COLLATE utf8_unicode_ci,
-                  `level` int(11) NOT NULL DEFAULT '0',
+                  `level` int NOT NULL DEFAULT '0',
                   `ancestors_cache` longtext COLLATE utf8_unicode_ci,
                   `sons_cache` longtext COLLATE utf8_unicode_ci,
-                  `addressable` tinyint(1) NOT NULL DEFAULT '0',
+                  `addressable` tinyint NOT NULL DEFAULT '0',
                   `version` tinyint unsigned DEFAULT '0',
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `address` varchar(40) COLLATE utf8_unicode_ci DEFAULT NULL,
@@ -2043,9 +2043,9 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
    // Adding IPNetwork table
    if (!$DB->tableExists('glpi_ipnetworks_vlans')) {
       $query = "CREATE TABLE `glpi_ipnetworks_vlans` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `ipnetworks_id` int(11) NOT NULL DEFAULT '0',
-                  `vlans_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `ipnetworks_id` int NOT NULL DEFAULT '0',
+                  `vlans_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `link` (`ipnetworks_id`, `vlans_id`)
                 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
@@ -2058,15 +2058,15 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
    // Adding NetworkName table
    if (!$DB->tableExists('glpi_networknames')) {
       $query = "CREATE TABLE `glpi_networknames` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `items_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `items_id` int NOT NULL DEFAULT '0',
                   `itemtype` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
-                  `fqdns_id` int(11) NOT NULL DEFAULT '0',
-                  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-                  `is_dynamic` tinyint(1) NOT NULL DEFAULT '0',
+                  `fqdns_id` int NOT NULL DEFAULT '0',
+                  `is_deleted` tinyint NOT NULL DEFAULT '0',
+                  `is_dynamic` tinyint NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `entities_id` (`entities_id`),
                   KEY `FQDN` (`name`,`fqdns_id`),
@@ -2097,11 +2097,11 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
    // Adding NetworkAlias table
    if (!$DB->tableExists('glpi_networkaliases')) {
       $query = "CREATE TABLE `glpi_networkaliases` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `networknames_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `networknames_id` int NOT NULL DEFAULT '0',
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `fqdns_id` int(11) NOT NULL DEFAULT '0',
+                  `fqdns_id` int NOT NULL DEFAULT '0',
                   `comment` text COLLATE utf8_unicode_ci,
                   PRIMARY KEY (`id`),
                   KEY `entities_id` (`entities_id`),
@@ -2117,9 +2117,9 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
    // Adding IPAddress_IPNetwork table
    if (!$DB->tableExists('glpi_ipaddresses_ipnetworks')) {
       $query = "CREATE TABLE `glpi_ipaddresses_ipnetworks` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `ipaddresses_id` int(11) NOT NULL DEFAULT '0',
-                  `ipnetworks_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `ipaddresses_id` int NOT NULL DEFAULT '0',
+                  `ipnetworks_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`ipaddresses_id`,`ipnetworks_id`),
                   KEY `ipnetworks_id` (`ipnetworks_id`),
@@ -2219,12 +2219,12 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
    // Adding NetworkPortEthernet table
    if (!$DB->tableExists('glpi_networkportethernets')) {
       $query = "CREATE TABLE `glpi_networkportethernets` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `networkports_id` int(11) NOT NULL DEFAULT '0',
-                  `items_devicenetworkcards_id` int(11) NOT NULL DEFAULT '0',
-                  `netpoints_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `networkports_id` int NOT NULL DEFAULT '0',
+                  `items_devicenetworkcards_id` int NOT NULL DEFAULT '0',
+                  `netpoints_id` int NOT NULL DEFAULT '0',
                   `type` varchar(10) COLLATE utf8_unicode_ci DEFAULT '' COMMENT 'T, LX, SX',
-                  `speed` int(11) NOT NULL DEFAULT '10' COMMENT 'Mbit/s: 10, 100, 1000, 10000',
+                  `speed` int NOT NULL DEFAULT '10' COMMENT 'Mbit/s: 10, 100, 1000, 10000',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `networkports_id` (`networkports_id`),
                   KEY `card` (`items_devicenetworkcards_id`),
@@ -2244,11 +2244,11 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
    // Adding NetworkPortWifi table
    if (!$DB->tableExists('glpi_networkportwifis')) {
       $query = "CREATE TABLE `glpi_networkportwifis` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `networkports_id` int(11) NOT NULL DEFAULT '0',
-                  `items_devicenetworkcards_id` int(11) NOT NULL DEFAULT '0',
-                  `wifinetworks_id` int(11) NOT NULL DEFAULT '0',
-                  `networkportwifis_id` int(11) NOT NULL DEFAULT '0'
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `networkports_id` int NOT NULL DEFAULT '0',
+                  `items_devicenetworkcards_id` int NOT NULL DEFAULT '0',
+                  `wifinetworks_id` int NOT NULL DEFAULT '0',
+                  `networkportwifis_id` int NOT NULL DEFAULT '0'
                                         COMMENT 'only useful in case of Managed node',
                   `version` varchar(20) COLLATE utf8_unicode_ci DEFAULT NULL
                             COMMENT 'a, a/b, a/b/g, a/b/g/n, a/b/g/n/y',
@@ -2273,8 +2273,8 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
    // Adding NetworkPortLocal table
    if (!$DB->tableExists('glpi_networkportlocals')) {
       $query = "CREATE TABLE `glpi_networkportlocals` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `networkports_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `networkports_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `networkports_id` (`networkports_id`)
                 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
@@ -2290,8 +2290,8 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
    // Adding NetworkPortDialup table
    if (!$DB->tableExists('glpi_networkportdialups')) {
       $query = "CREATE TABLE `glpi_networkportdialups` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `networkports_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `networkports_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `networkports_id` (`networkports_id`)
                 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
@@ -2307,8 +2307,8 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
    // Adding NetworkPortAggregate table
    if (!$DB->tableExists('glpi_networkportaggregates')) {
       $query = "CREATE TABLE `glpi_networkportaggregates` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `networkports_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `networkports_id` int NOT NULL DEFAULT '0',
                   `networkports_id_list` TEXT DEFAULT NULL
                              COMMENT 'array of associated networkports_id',
                   PRIMARY KEY (`id`),
@@ -2391,9 +2391,9 @@ function updateNetworkFramework(&$ADDTODISPLAYPREF) {
    // Adding NetworkPortAlias table
    if (!$DB->tableExists('glpi_networkportaliases')) {
       $query = "CREATE TABLE `glpi_networkportaliases` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `networkports_id` int(11) NOT NULL DEFAULT '0',
-                  `networkports_id_alias` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `networkports_id` int NOT NULL DEFAULT '0',
+                  `networkports_id_alias` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `networkports_id` (`networkports_id`),
                   KEY `networkports_id_alias` (`networkports_id_alias`)

--- a/install/migrations/update_0.84.x_to_0.85.0.php
+++ b/install/migrations/update_0.84.x_to_0.85.0.php
@@ -133,10 +133,10 @@ function update084xto0850() {
       }
 
       $query = "CREATE TABLE `glpi_profilerights` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `profiles_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `profiles_id` int NOT NULL DEFAULT '0',
                   `name` varchar(255) DEFAULT NULL,
-                  `rights` int(11) NOT NULL DEFAULT '0',
+                  `rights` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`profiles_id`, `name`)
                 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
@@ -991,13 +991,13 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_queuedmails')) {
       $query = "CREATE TABLE `glpi_queuedmails` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `itemtype` varchar(100) default NULL,
-                  `items_id` int(11) NOT NULL DEFAULT '0',
-                  `notificationtemplates_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-                  `sent_try` int(11) NOT NULL DEFAULT '0',
+                  `items_id` int NOT NULL DEFAULT '0',
+                  `notificationtemplates_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_deleted` tinyint NOT NULL DEFAULT '0',
+                  `sent_try` int NOT NULL DEFAULT '0',
                   `create_time` datetime DEFAULT NULL,
                   `send_time` datetime DEFAULT NULL,
                   `sent_time` datetime DEFAULT NULL,
@@ -1077,38 +1077,38 @@ function update084xto0850() {
    // changes management
    if (!$DB->tableExists('glpi_changes')) {
       $query = "CREATE TABLE `glpi_changes` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) DEFAULT NULL,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-                  `status` int(11) NOT NULL DEFAULT '1',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `is_deleted` tinyint NOT NULL DEFAULT '0',
+                  `status` int NOT NULL DEFAULT '1',
                   `content` longtext DEFAULT NULL,
                   `date_mod` DATETIME DEFAULT NULL,
                   `date` DATETIME DEFAULT NULL,
                   `solvedate` DATETIME DEFAULT NULL,
                   `closedate` DATETIME DEFAULT NULL,
                   `due_date` DATETIME DEFAULT NULL,
-                  `users_id_recipient` int(11) NOT NULL DEFAULT '0',
-                  `users_id_lastupdater` int(11) NOT NULL DEFAULT '0',
-                  `urgency` int(11) NOT NULL DEFAULT '1',
-                  `impact` int(11) NOT NULL DEFAULT '1',
-                  `priority` int(11) NOT NULL DEFAULT '1',
-                  `itilcategories_id` int(11) NOT NULL DEFAULT '0',
+                  `users_id_recipient` int NOT NULL DEFAULT '0',
+                  `users_id_lastupdater` int NOT NULL DEFAULT '0',
+                  `urgency` int NOT NULL DEFAULT '1',
+                  `impact` int NOT NULL DEFAULT '1',
+                  `priority` int NOT NULL DEFAULT '1',
+                  `itilcategories_id` int NOT NULL DEFAULT '0',
                   `impactcontent` longtext DEFAULT NULL,
                   `controlistcontent` longtext DEFAULT NULL,
                   `rolloutplancontent` longtext DEFAULT NULL,
                   `backoutplancontent` longtext DEFAULT NULL,
                   `checklistcontent` longtext DEFAULT NULL,
                   `global_validation` varchar(255) COLLATE utf8_unicode_ci DEFAULT 'none',
-                  `validation_percent` int(11) NOT NULL DEFAULT '0',
-                  `solutiontypes_id` int(11) NOT NULL DEFAULT '0',
+                  `validation_percent` int NOT NULL DEFAULT '0',
+                  `solutiontypes_id` int NOT NULL DEFAULT '0',
                   `solution` text COLLATE utf8_unicode_ci,
-                  `actiontime` int(11) NOT NULL DEFAULT '0',
+                  `actiontime` int NOT NULL DEFAULT '0',
                   `begin_waiting_date` datetime DEFAULT NULL,
-                  `waiting_duration` int(11) NOT NULL DEFAULT '0',
-                  `close_delay_stat` int(11) NOT NULL DEFAULT '0',
-                  `solve_delay_stat` int(11) NOT NULL DEFAULT '0',
+                  `waiting_duration` int NOT NULL DEFAULT '0',
+                  `close_delay_stat` int NOT NULL DEFAULT '0',
+                  `solve_delay_stat` int NOT NULL DEFAULT '0',
                   `notepad` LONGTEXT NULL,
                   PRIMARY KEY (`id`),
                   KEY `name` (`name`),
@@ -1138,11 +1138,11 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_changes_users')) {
       $query = "CREATE TABLE `glpi_changes_users` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `changes_id` int(11) NOT NULL DEFAULT '0',
-                  `users_id` int(11) NOT NULL DEFAULT '0',
-                  `type` int(11) NOT NULL DEFAULT '1',
-                  `use_notification` tinyint(1) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `changes_id` int NOT NULL DEFAULT '0',
+                  `users_id` int NOT NULL DEFAULT '0',
+                  `type` int NOT NULL DEFAULT '1',
+                  `use_notification` tinyint NOT NULL DEFAULT '0',
                   `alternative_email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`changes_id`,`type`,`users_id`,`alternative_email`),
@@ -1153,10 +1153,10 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_changes_groups')) {
       $query = "CREATE TABLE `glpi_changes_groups` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `changes_id` int(11) NOT NULL DEFAULT '0',
-                  `groups_id` int(11) NOT NULL DEFAULT '0',
-                  `type` int(11) NOT NULL DEFAULT '1',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `changes_id` int NOT NULL DEFAULT '0',
+                  `groups_id` int NOT NULL DEFAULT '0',
+                  `type` int NOT NULL DEFAULT '1',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`changes_id`,`type`,`groups_id`),
                   KEY `group` (`groups_id`,`type`)
@@ -1166,10 +1166,10 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_changes_suppliers')) {
       $query = "CREATE TABLE `glpi_changes_suppliers` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `changes_id` int(11) NOT NULL DEFAULT '0',
-                  `suppliers_id` int(11) NOT NULL DEFAULT '0',
-                  `type` int(11) NOT NULL DEFAULT '1',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `changes_id` int NOT NULL DEFAULT '0',
+                  `suppliers_id` int NOT NULL DEFAULT '0',
+                  `type` int NOT NULL DEFAULT '1',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`changes_id`,`type`,`suppliers_id`),
                   KEY `group` (`suppliers_id`,`type`)
@@ -1179,10 +1179,10 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_changes_items')) {
       $query = "CREATE TABLE `glpi_changes_items` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `changes_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `changes_id` int NOT NULL DEFAULT '0',
                   `itemtype` varchar(100) default NULL,
-                  `items_id` int(11) NOT NULL DEFAULT '0',
+                  `items_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`changes_id`,`itemtype`,`items_id`),
                   KEY `item` (`itemtype`,`items_id`)
@@ -1192,9 +1192,9 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_changes_tickets')) {
       $query = "CREATE TABLE `glpi_changes_tickets` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `changes_id` int(11) NOT NULL DEFAULT '0',
-                  `tickets_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `changes_id` int NOT NULL DEFAULT '0',
+                  `tickets_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`changes_id`,`tickets_id`),
                   KEY `tickets_id` (`tickets_id`)
@@ -1204,9 +1204,9 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_changes_problems')) {
       $query = "CREATE TABLE `glpi_changes_problems` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `changes_id` int(11) NOT NULL DEFAULT '0',
-                  `problems_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `changes_id` int NOT NULL DEFAULT '0',
+                  `problems_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`changes_id`,`problems_id`),
                   KEY `problems_id` (`problems_id`)
@@ -1216,17 +1216,17 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_changetasks')) {
       $query = "CREATE TABLE `glpi_changetasks` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `changes_id` int(11) NOT NULL DEFAULT '0',
-                  `taskcategories_id` int(11) NOT NULL DEFAULT '0',
-                  `state` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `changes_id` int NOT NULL DEFAULT '0',
+                  `taskcategories_id` int NOT NULL DEFAULT '0',
+                  `state` int NOT NULL DEFAULT '0',
                   `date` datetime DEFAULT NULL,
                   `begin` datetime DEFAULT NULL,
                   `end` datetime DEFAULT NULL,
-                  `users_id` int(11) NOT NULL DEFAULT '0',
-                  `users_id_tech` int(11) NOT NULL DEFAULT '0',
+                  `users_id` int NOT NULL DEFAULT '0',
+                  `users_id_tech` int NOT NULL DEFAULT '0',
                   `content` longtext COLLATE utf8_unicode_ci,
-                  `actiontime` int(11) NOT NULL DEFAULT '0',
+                  `actiontime` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `changes_id` (`changes_id`),
                   KEY `state` (`state`),
@@ -1242,19 +1242,19 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_changecosts')) {
       $query = "CREATE TABLE `glpi_changecosts` (
-               `id` int(11) NOT NULL AUTO_INCREMENT,
-               `changes_id` int(11) NOT NULL DEFAULT '0',
+               `id` int NOT NULL AUTO_INCREMENT,
+               `changes_id` int NOT NULL DEFAULT '0',
                `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                `comment` text COLLATE utf8_unicode_ci,
                `begin_date` date DEFAULT NULL,
                `end_date` date DEFAULT NULL,
-               `actiontime` int(11) NOT NULL DEFAULT '0',
+               `actiontime` int NOT NULL DEFAULT '0',
                `cost_time` decimal(20,4) NOT NULL DEFAULT '0.0000',
                `cost_fixed` decimal(20,4) NOT NULL DEFAULT '0.0000',
                `cost_material` decimal(20,4) NOT NULL DEFAULT '0.0000',
-               `budgets_id` int(11) NOT NULL DEFAULT '0',
-               `entities_id` int(11) NOT NULL DEFAULT '0',
-               `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+               `budgets_id` int NOT NULL DEFAULT '0',
+               `entities_id` int NOT NULL DEFAULT '0',
+               `is_recursive` tinyint NOT NULL DEFAULT '0',
                PRIMARY KEY (`id`),
                KEY `name` (`name`),
                KEY `changes_id` (`changes_id`),
@@ -1269,15 +1269,15 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_changevalidations')) {
       $query = "CREATE TABLE `glpi_changevalidations` (
-            `id` int(11) NOT NULL AUTO_INCREMENT,
-            `entities_id` int(11) NOT NULL DEFAULT '0',
-            `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-            `users_id` int(11) NOT NULL DEFAULT '0',
-            `changes_id` int(11) NOT NULL DEFAULT '0',
-            `users_id_validate` int(11) NOT NULL DEFAULT '0',
+            `id` int NOT NULL AUTO_INCREMENT,
+            `entities_id` int NOT NULL DEFAULT '0',
+            `is_recursive` tinyint NOT NULL DEFAULT '0',
+            `users_id` int NOT NULL DEFAULT '0',
+            `changes_id` int NOT NULL DEFAULT '0',
+            `users_id_validate` int NOT NULL DEFAULT '0',
             `comment_submission` text COLLATE utf8_unicode_ci,
             `comment_validation` text COLLATE utf8_unicode_ci,
-            `status` int(11) NOT NULL DEFAULT '2',
+            `status` int NOT NULL DEFAULT '2',
             `submission_date` datetime DEFAULT NULL,
             `validation_date` datetime DEFAULT NULL,
             PRIMARY KEY (`id`),
@@ -1426,18 +1426,18 @@ function update084xto0850() {
    // Add problem costs
    if (!$DB->tableExists('glpi_problemcosts')) {
       $query = "CREATE TABLE `glpi_problemcosts` (
-               `id` int(11) NOT NULL AUTO_INCREMENT,
-               `problems_id` int(11) NOT NULL DEFAULT '0',
+               `id` int NOT NULL AUTO_INCREMENT,
+               `problems_id` int NOT NULL DEFAULT '0',
                `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                `comment` text COLLATE utf8_unicode_ci,
                `begin_date` date DEFAULT NULL,
                `end_date` date DEFAULT NULL,
-               `actiontime` int(11) NOT NULL DEFAULT '0',
+               `actiontime` int NOT NULL DEFAULT '0',
                `cost_time` decimal(20,4) NOT NULL DEFAULT '0.0000',
                `cost_fixed` decimal(20,4) NOT NULL DEFAULT '0.0000',
                `cost_material` decimal(20,4) NOT NULL DEFAULT '0.0000',
-               `budgets_id` int(11) NOT NULL DEFAULT '0',
-               `entities_id` int(11) NOT NULL DEFAULT '0',
+               `budgets_id` int NOT NULL DEFAULT '0',
+               `entities_id` int NOT NULL DEFAULT '0',
                PRIMARY KEY (`id`),
                KEY `name` (`name`),
                KEY `problems_id` (`problems_id`),
@@ -1483,8 +1483,8 @@ function update084xto0850() {
    Config::setConfigurationValues('core', ['translate_kb' => 0]);
    if (!$DB->tableExists("glpi_knowbaseitemtranslations")) {
       $query = "CREATE TABLE IF NOT EXISTS `glpi_knowbaseitemtranslations` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `knowbaseitems_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `knowbaseitems_id` int NOT NULL DEFAULT '0',
                   `language` varchar(5) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `name` text COLLATE utf8_unicode_ci,
                   `answer` longtext COLLATE utf8_unicode_ci,
@@ -1501,8 +1501,8 @@ function update084xto0850() {
    Config::setConfigurationValues('core', ['translate_dropdowns' => 0]);
    if (!$DB->tableExists("glpi_dropdowntranslations")) {
       $query = "CREATE TABLE IF NOT EXISTS `glpi_dropdowntranslations` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `items_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `items_id` int NOT NULL DEFAULT '0',
                   `itemtype` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `language` varchar(5) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `field` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
@@ -1600,7 +1600,7 @@ function update084xto0850() {
    $migration->dropField("glpi_users", 'is_not_categorized_soft_expanded');
 
    // Config::setConfigurationValues('core', array('use_unicodefont' => 0));
-   // $migration->addField("glpi_users", 'use_unicodefont', "int(11) DEFAULT NULL");
+   // $migration->addField("glpi_users", 'use_unicodefont', "int DEFAULT NULL");
    Config::deleteConfigurationValues('core', ['use_unicodefont']);
    $migration->dropField("glpi_users", 'use_unicodefont');
    Config::setConfigurationValues('core', ['pdffont' => 'helvetica']);
@@ -1751,7 +1751,7 @@ function update084xto0850() {
    }
 
    Config::setConfigurationValues('core', ['keep_devices_when_purging_item' => 0]);
-   $migration->addField("glpi_users", "keep_devices_when_purging_item", "int(11) DEFAULT NULL");
+   $migration->addField("glpi_users", "keep_devices_when_purging_item", "int DEFAULT NULL");
 
    Config::setConfigurationValues('core', ['maintenance_mode' => 0]);
    Config::setConfigurationValues('core', ['maintenance_text' => '']);
@@ -1823,7 +1823,7 @@ function update084xto0850() {
 
    if (!$DB->tableExists("glpi_blacklistedmailcontents")) {
       $query = "CREATE TABLE IF NOT EXISTS `glpi_blacklistedmailcontents` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) DEFAULT NULL,
                   `content` text COLLATE utf8_unicode_ci,
                   `comment` text COLLATE utf8_unicode_ci,
@@ -1882,7 +1882,7 @@ function update084xto0850() {
    $migration->addField('glpi_users', 'privatebookmarkorder', 'longtext');
 
    // Pref to comme back ticket created
-   if ($migration->addField('glpi_users', 'backcreated', 'TINYINT(1) DEFAULT NULL')) {
+   if ($migration->addField('glpi_users', 'backcreated', 'TINYINT DEFAULT NULL')) {
       $query = "INSERT INTO `glpi_configs`
                        (`context`, `name`, `value`)
                 VALUES ('core', 'backcreated', 0)";
@@ -1893,25 +1893,25 @@ function update084xto0850() {
 
    if (!$DB->tableExists("glpi_projects")) {
       $query = "CREATE TABLE IF NOT EXISTS `glpi_projects` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `code` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `priority` int(11) NOT NULL DEFAULT '1',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `projects_id` int(11) NOT NULL DEFAULT '0',
-                  `projectstates_id` int(11) NOT NULL DEFAULT '0',
-                  `projecttypes_id` int(11) NOT NULL DEFAULT '0',
+                  `priority` int NOT NULL DEFAULT '1',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `projects_id` int NOT NULL DEFAULT '0',
+                  `projectstates_id` int NOT NULL DEFAULT '0',
+                  `projecttypes_id` int NOT NULL DEFAULT '0',
                   `date` datetime DEFAULT NULL,
                   `date_mod` datetime DEFAULT NULL,
-                  `users_id` int(11) NOT NULL DEFAULT '0',
-                  `groups_id` int(11) NOT NULL DEFAULT '0',
+                  `users_id` int NOT NULL DEFAULT '0',
+                  `groups_id` int NOT NULL DEFAULT '0',
                   `plan_start_date` datetime DEFAULT NULL,
                   `plan_end_date` datetime DEFAULT NULL,
                   `real_start_date` datetime DEFAULT NULL,
                   `real_end_date` datetime DEFAULT NULL,
-                  `percent_done` int(11) NOT NULL DEFAULT '0',
-                  `show_on_global_gantt` tinyint(1) NOT NULL DEFAULT '0',
+                  `percent_done` int NOT NULL DEFAULT '0',
+                  `show_on_global_gantt` tinyint NOT NULL DEFAULT '0',
                   `content` longtext DEFAULT NULL,
                   `comment` longtext DEFAULT NULL,
                   `notepad` longtext DEFAULT NULL,
@@ -1969,16 +1969,16 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_projectcosts')) {
       $query = "CREATE TABLE `glpi_projectcosts` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `projects_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `projects_id` int NOT NULL DEFAULT '0',
                   `name` varchar(255) DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `begin_date` date DEFAULT NULL,
                   `end_date` date DEFAULT NULL,
                   `cost` decimal(20,4) NOT NULL DEFAULT '0.0000',
-                  `budgets_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+                  `budgets_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `name` (`name`),
                   KEY `projects_id` (`projects_id`),
@@ -1993,11 +1993,11 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_projectstates')) {
       $query = "CREATE TABLE `glpi_projectstates` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `color` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `is_finished` tinyint(1) NOT NULL DEFAULT '0',
+                  `is_finished` tinyint NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `name` (`name`),
                   KEY `is_finished` (`is_finished`)
@@ -2024,7 +2024,7 @@ function update084xto0850() {
    }
    if (!$DB->tableExists('glpi_projecttypes')) {
       $query = "CREATE TABLE `glpi_projecttypes` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   PRIMARY KEY (`id`),
@@ -2038,9 +2038,9 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_changes_projects')) {
       $query = "CREATE TABLE `glpi_changes_projects` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `changes_id` int(11) NOT NULL DEFAULT '0',
-                  `projects_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `changes_id` int NOT NULL DEFAULT '0',
+                  `projects_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`changes_id`,`projects_id`),
                   KEY `projects_id` (`projects_id`)
@@ -2050,10 +2050,10 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_projectteams')) {
       $query = "CREATE TABLE `glpi_projectteams` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `projects_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `projects_id` int NOT NULL DEFAULT '0',
                   `itemtype` varchar(100) default NULL,
-                  `items_id` int(11) NOT NULL DEFAULT '0',
+                  `items_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`projects_id`,`itemtype`,`items_id`),
                   KEY `item` (`itemtype`,`items_id`)
@@ -2063,10 +2063,10 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_items_projects')) {
       $query = "CREATE TABLE `glpi_items_projects` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `projects_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `projects_id` int NOT NULL DEFAULT '0',
                   `itemtype` varchar(100) default NULL,
-                  `items_id` int(11) NOT NULL DEFAULT '0',
+                  `items_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`projects_id`,`itemtype`,`items_id`),
                   KEY `item` (`itemtype`,`items_id`)
@@ -2076,26 +2076,26 @@ function update084xto0850() {
 
    if (!$DB->tableExists("glpi_projecttasks")) {
       $query = "CREATE TABLE IF NOT EXISTS `glpi_projecttasks` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `content` longtext DEFAULT NULL,
                   `comment` longtext DEFAULT NULL,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `projects_id` int(11) NOT NULL DEFAULT '0',
-                  `projecttasks_id` int(11) NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `projects_id` int NOT NULL DEFAULT '0',
+                  `projecttasks_id` int NOT NULL DEFAULT '0',
                   `date` datetime DEFAULT NULL,
                   `date_mod` datetime DEFAULT NULL,
                   `plan_start_date` datetime DEFAULT NULL,
                   `plan_end_date` datetime DEFAULT NULL,
                   `real_start_date` datetime DEFAULT NULL,
                   `real_end_date` datetime DEFAULT NULL,
-                  `planned_duration` int(11) NOT NULL DEFAULT '0',
-                  `effective_duration` int(11) NOT NULL DEFAULT '0',
-                  `projectstates_id` int(11) NOT NULL DEFAULT '0',
-                  `projecttasktypes_id` int(11) NOT NULL DEFAULT '0',
-                  `users_id` int(11) NOT NULL DEFAULT '0',
-                  `percent_done` int(11) NOT NULL DEFAULT '0',
+                  `planned_duration` int NOT NULL DEFAULT '0',
+                  `effective_duration` int NOT NULL DEFAULT '0',
+                  `projectstates_id` int NOT NULL DEFAULT '0',
+                  `projecttasktypes_id` int NOT NULL DEFAULT '0',
+                  `users_id` int NOT NULL DEFAULT '0',
+                  `percent_done` int NOT NULL DEFAULT '0',
                   `notepad` longtext DEFAULT NULL,
                   PRIMARY KEY (`id`),
                   KEY `name` (`name`),
@@ -2120,7 +2120,7 @@ function update084xto0850() {
    }
    if (!$DB->tableExists('glpi_projecttasktypes')) {
       $query = "CREATE TABLE `glpi_projecttasktypes` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   PRIMARY KEY (`id`),
@@ -2130,10 +2130,10 @@ function update084xto0850() {
    }
    if (!$DB->tableExists('glpi_projecttaskteams')) {
       $query = "CREATE TABLE `glpi_projecttaskteams` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `projecttasks_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `projecttasks_id` int NOT NULL DEFAULT '0',
                   `itemtype` varchar(100) default NULL,
-                  `items_id` int(11) NOT NULL DEFAULT '0',
+                  `items_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`projecttasks_id`,`itemtype`,`items_id`),
                   KEY `item` (`itemtype`,`items_id`)
@@ -2143,9 +2143,9 @@ function update084xto0850() {
 
    if (!$DB->tableExists('glpi_projecttasks_tickets')) {
       $query = "CREATE TABLE `glpi_projecttasks_tickets` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `tickets_id` int(11) NOT NULL DEFAULT '0',
-                  `projecttasks_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `tickets_id` int NOT NULL DEFAULT '0',
+                  `projecttasks_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`tickets_id`,`projecttasks_id`),
                   KEY `projects_id` (`projecttasks_id`)
@@ -2336,13 +2336,13 @@ function update084xto0850() {
    // Create new notepad table
    if (!$DB->tableExists('glpi_notepads')) {
       $query = "CREATE TABLE `glpi_notepads` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `itemtype` varchar(100) default NULL,
-                  `items_id` int(11) NOT NULL DEFAULT '0',
+                  `items_id` int NOT NULL DEFAULT '0',
                   `date` datetime DEFAULT NULL,
                   `date_mod` datetime DEFAULT NULL,
-                  `users_id` int(11) NOT NULL DEFAULT '0',
-                  `users_id_lastupdater` int(11) NOT NULL DEFAULT '0',
+                  `users_id` int NOT NULL DEFAULT '0',
+                  `users_id_lastupdater` int NOT NULL DEFAULT '0',
                   `content` LONGTEXT DEFAULT NULL,
                   PRIMARY KEY (`id`),
                   KEY `item` (`itemtype`,`items_id`),
@@ -2379,11 +2379,11 @@ function update084xto0850() {
       }
    }
 
-   $migration->addField('glpi_deviceprocessors', 'nbcores_default', 'int(11) DEFAULT NULL');
-   $migration->addField('glpi_deviceprocessors', 'nbthreads_default', 'int(11) DEFAULT NULL');
+   $migration->addField('glpi_deviceprocessors', 'nbcores_default', 'int DEFAULT NULL');
+   $migration->addField('glpi_deviceprocessors', 'nbthreads_default', 'int DEFAULT NULL');
 
-   $migration->addField('glpi_items_deviceprocessors', 'nbcores', 'int(11) DEFAULT NULL');
-   $migration->addField('glpi_items_deviceprocessors', 'nbthreads', 'int(11) DEFAULT NULL');
+   $migration->addField('glpi_items_deviceprocessors', 'nbcores', 'int DEFAULT NULL');
+   $migration->addField('glpi_items_deviceprocessors', 'nbthreads', 'int DEFAULT NULL');
    $migration->addKey('glpi_items_deviceprocessors', 'nbcores');
    $migration->addKey('glpi_items_deviceprocessors', 'nbthreads');
 
@@ -2548,9 +2548,9 @@ function update084xto0850() {
    // as well devices
    if (!$DB->tableExists('glpi_registeredids')) {
       $query = "CREATE TABLE `glpi_registeredids` (
-                 `id` int(11) NOT NULL AUTO_INCREMENT,
+                 `id` int NOT NULL AUTO_INCREMENT,
                  `name` varchar(255) DEFAULT NULL,
-                 `items_id` int(11) NOT NULL DEFAULT '0',
+                 `items_id` int NOT NULL DEFAULT '0',
                  `itemtype` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
                  `device_type` varchar(100) COLLATE utf8_unicode_ci NOT NULL COMMENT 'USB, PCI ...',
                  PRIMARY KEY (`id`),

--- a/install/migrations/update_0.85.0_to_0.85.3.php
+++ b/install/migrations/update_0.85.0_to_0.85.3.php
@@ -69,7 +69,7 @@ function update0850to0853() {
       Config::setConfigurationValues('core', ['cron_limit' => 5]);
    }
    Config::setConfigurationValues('core', ['task_state' => Planning::TODO]);
-   $migration->addField("glpi_users", "task_state", "int(11) DEFAULT NULL");
+   $migration->addField("glpi_users", "task_state", "int DEFAULT NULL");
 
    $migration->addField('glpi_projecttasks', 'is_milestone', 'bool');
    $migration->addKey('glpi_projecttasks', 'is_milestone');
@@ -78,10 +78,10 @@ function update0850to0853() {
    // Add glpi_items_tickets table for associated elements
    if (!$DB->tableExists('glpi_items_tickets')) {
       $query = "CREATE TABLE `glpi_items_tickets` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `itemtype` varchar(255) DEFAULT NULL,
-                  `items_id` int(11) NOT NULL DEFAULT '0',
-                  `tickets_id` int(11) NOT NULL DEFAULT '0',
+                  `items_id` int NOT NULL DEFAULT '0',
+                  `tickets_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`itemtype`, `items_id`, `tickets_id`),
                   KEY `tickets_id` (`tickets_id`)

--- a/install/migrations/update_0.85.x_to_0.90.0.php
+++ b/install/migrations/update_0.85.x_to_0.90.0.php
@@ -73,8 +73,8 @@ function update085xto0900() {
    // add timeline config
    Config::setConfigurationValues('core', ['ticket_timeline' => 1]);
    Config::setConfigurationValues('core', ['ticket_timeline_keep_replaced_tabs' => 0]);
-   $migration->addField("glpi_users", "ticket_timeline", "tinyint(1) DEFAULT NULL");
-   $migration->addField("glpi_users", "ticket_timeline_keep_replaced_tabs", "tinyint(1) DEFAULT NULL");
+   $migration->addField("glpi_users", "ticket_timeline", "tinyint DEFAULT NULL");
+   $migration->addField("glpi_users", "ticket_timeline_keep_replaced_tabs", "tinyint DEFAULT NULL");
 
    // clean unused parameter
    $migration->dropField("glpi_users", "dropdown_chars_limit");

--- a/install/migrations/update_0.90.x_to_9.1.0.php
+++ b/install/migrations/update_0.90.x_to_9.1.0.php
@@ -71,10 +71,10 @@ function update090xto910() {
    /************** Lock Objects *************/
    if (!$DB->tableExists('glpi_objectlocks')) {
       $query = "CREATE TABLE `glpi_objectlocks` (
-                 `id` INT(11) NOT NULL AUTO_INCREMENT,
+                 `id` INT NOT NULL AUTO_INCREMENT,
                  `itemtype` VARCHAR(100) NOT NULL COMMENT 'Type of locked object',
-                 `items_id` INT(11) NOT NULL COMMENT 'RELATION to various tables, according to itemtype (ID)',
-                 `users_id` INT(11) NOT NULL COMMENT 'id of the locker',
+                 `items_id` INT NOT NULL COMMENT 'RELATION to various tables, according to itemtype (ID)',
+                 `users_id` INT NOT NULL COMMENT 'id of the locker',
                  `date_mod` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Timestamp of the lock',
                  PRIMARY KEY (`id`),
                  UNIQUE INDEX `item` (`itemtype`, `items_id`)
@@ -297,22 +297,22 @@ function update090xto910() {
       );
    }
 
-   $migration->addField("glpi_users", "lock_autolock_mode", "tinyint(1) NULL DEFAULT NULL");
-   $migration->addField("glpi_users", "lock_directunlock_notification", "tinyint(1) NULL DEFAULT NULL");
+   $migration->addField("glpi_users", "lock_autolock_mode", "tinyint NULL DEFAULT NULL");
+   $migration->addField("glpi_users", "lock_directunlock_notification", "tinyint NULL DEFAULT NULL");
 
    /************** Default Requester *************/
    Config::setConfigurationValues('core', ['set_default_requester' => 1]);
-   $migration->addField("glpi_users", "set_default_requester", "tinyint(1) NULL DEFAULT NULL");
+   $migration->addField("glpi_users", "set_default_requester", "tinyint NULL DEFAULT NULL");
 
    // ************ NetworkPort ethernets **************
    if (!$DB->tableExists("glpi_networkportfiberchannels")) {
       $query = "CREATE TABLE `glpi_networkportfiberchannels` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `networkports_id` int(11) NOT NULL DEFAULT '0',
-                  `items_devicenetworkcards_id` int(11) NOT NULL DEFAULT '0',
-                  `netpoints_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `networkports_id` int NOT NULL DEFAULT '0',
+                  `items_devicenetworkcards_id` int NOT NULL DEFAULT '0',
+                  `netpoints_id` int NOT NULL DEFAULT '0',
                   `wwn` varchar(16) COLLATE utf8_unicode_ci DEFAULT '',
-                  `speed` int(11) NOT NULL DEFAULT '10' COMMENT 'Mbit/s: 10, 100, 1000, 10000',
+                  `speed` int NOT NULL DEFAULT '10' COMMENT 'Mbit/s: 10, 100, 1000, 10000',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `networkports_id` (`networkports_id`),
                   KEY `card` (`items_devicenetworkcards_id`),
@@ -332,7 +332,7 @@ function update090xto910() {
 
    if (!$DB->tableExists('glpi_operatingsystemarchitectures')) {
       $query = "CREATE TABLE `glpi_operatingsystemarchitectures` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `date_mod` datetime DEFAULT NULL,
@@ -348,13 +348,13 @@ function update090xto910() {
    /************** Task's templates *************/
    if (!$DB->tableExists('glpi_tasktemplates')) {
       $query = "CREATE TABLE `glpi_tasktemplates` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `content` text COLLATE utf8_unicode_ci,
-                  `taskcategories_id` int(11) NOT NULL DEFAULT '0',
-                  `actiontime` int(11) NOT NULL DEFAULT '0',
+                  `taskcategories_id` int NOT NULL DEFAULT '0',
+                  `actiontime` int NOT NULL DEFAULT '0',
                   `comment` text COLLATE utf8_unicode_ci,
                   PRIMARY KEY (`id`),
                   KEY `name` (`name`),
@@ -375,7 +375,7 @@ function update090xto910() {
 
    if (!$DB->tableExists('glpi_budgettypes')) {
       $query = "CREATE TABLE `glpi_budgettypes` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `date_mod` datetime DEFAULT NULL,
@@ -413,12 +413,12 @@ function update090xto910() {
    Config::setConfigurationValues('core', ['url_base_api' => trim($current_config['url_base'], "/")."/apirest.php/"]);
    if (!$DB->tableExists('glpi_apiclients')) {
       $query = "CREATE TABLE `glpi_apiclients` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `entities_id` INT NOT NULL DEFAULT '0',
-                  `is_recursive` TINYINT(1) NOT NULL DEFAULT '0',
+                  `is_recursive` TINYINT NOT NULL DEFAULT '0',
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `date_mod` DATETIME DEFAULT NULL,
-                  `is_active` TINYINT(1) NOT NULL DEFAULT '0',
+                  `is_active` TINYINT NOT NULL DEFAULT '0',
                   `ipv4_range_start` BIGINT NULL ,
                   `ipv4_range_end` BIGINT NULL ,
                   `ipv6` VARCHAR( 255 ) NULL,
@@ -648,16 +648,16 @@ function update090xto910() {
    /************* Add antivirus table */
    if (!$DB->tableExists('glpi_computerantiviruses')) {
       $query = "CREATE TABLE `glpi_computerantiviruses` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `computers_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `computers_id` int NOT NULL DEFAULT '0',
                   `name` varchar(255) DEFAULT NULL,
-                  `manufacturers_id` int(11) NOT NULL DEFAULT '0',
+                  `manufacturers_id` int NOT NULL DEFAULT '0',
                   `antivirus_version` varchar(255) DEFAULT NULL,
                   `signature_version` varchar(255) DEFAULT NULL,
-                  `is_active` tinyint(1) NOT NULL DEFAULT '0',
-                  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-                  `is_uptodate` tinyint(1) NOT NULL DEFAULT '0',
-                  `is_dynamic` tinyint(1) NOT NULL DEFAULT '0',
+                  `is_active` tinyint NOT NULL DEFAULT '0',
+                  `is_deleted` tinyint NOT NULL DEFAULT '0',
+                  `is_uptodate` tinyint NOT NULL DEFAULT '0',
+                  `is_dynamic` tinyint NOT NULL DEFAULT '0',
                   `date_expiration` datetime DEFAULT NULL,
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,
@@ -770,19 +770,19 @@ function update090xto910() {
    /** ************ New SLA structure ************ */
    if (!$DB->tableExists('glpi_slts')) {
       $query = "CREATE TABLE `glpi_slts` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `type` int(11) NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `type` int NOT NULL DEFAULT '0',
                   `comment` text COLLATE utf8_unicode_ci,
-                  `number_time` int(11) NOT NULL,
-                  `calendars_id` int(11) NOT NULL DEFAULT '0',
+                  `number_time` int NOT NULL,
+                  `calendars_id` int NOT NULL DEFAULT '0',
                   `date_mod` datetime DEFAULT NULL,
                   `definition_time` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `end_of_working_day` tinyint(1) NOT NULL DEFAULT '0',
+                  `end_of_working_day` tinyint NOT NULL DEFAULT '0',
                   `date_creation` datetime DEFAULT NULL,
-                  `slas_id` int(11) NOT NULL DEFAULT '0',
+                  `slas_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `name` (`name`),
                   KEY `calendars_id` (`calendars_id`),
@@ -888,7 +888,7 @@ function update090xto910() {
 
    /************** High contrast CSS **************/
    Config::setConfigurationValues('core', ['highcontrast_css' => 0]);
-   $migration->addField("glpi_users", "highcontrast_css", "tinyint(1) DEFAULT 0");
+   $migration->addField("glpi_users", "highcontrast_css", "tinyint DEFAULT 0");
 
    /************** SMTP option for self-signed certificates **************/
    Config::setConfigurationValues('core', ['smtp_check_certificate' => 1]);

--- a/install/migrations/update_9.1.x_to_9.2.0.php
+++ b/install/migrations/update_9.1.x_to_9.2.0.php
@@ -53,16 +53,16 @@ function update91xto920() {
 
    if (!$DB->tableExists("glpi_businesscriticities")) {
       $query = "CREATE TABLE `glpi_businesscriticities` (
-        `id` int(11) NOT NULL AUTO_INCREMENT,
+        `id` int NOT NULL AUTO_INCREMENT,
         `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-        `entities_id` int(11) NOT NULL DEFAULT '0',
-        `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+        `entities_id` int NOT NULL DEFAULT '0',
+        `is_recursive` tinyint NOT NULL DEFAULT '0',
         `comment` text COLLATE utf8_unicode_ci,
         `date_mod` datetime DEFAULT NULL,
         `date_creation` datetime DEFAULT NULL,
-        `businesscriticities_id` int(11) NOT NULL DEFAULT '0',
+        `businesscriticities_id` int NOT NULL DEFAULT '0',
         `completename` text COLLATE utf8_unicode_ci,
-        `level` int(11) NOT NULL DEFAULT '0',
+        `level` int NOT NULL DEFAULT '0',
         `ancestors_cache` longtext COLLATE utf8_unicode_ci,
         `sons_cache` longtext COLLATE utf8_unicode_ci,
         PRIMARY KEY (`id`),
@@ -112,10 +112,10 @@ function update91xto920() {
    $migration->displayMessage(sprintf(__('Add of - %s to database'), 'Knowbase item link to tickets'));
    if (!$DB->tableExists('glpi_knowbaseitems_items')) {
       $query = "CREATE TABLE `glpi_knowbaseitems_items` (
-                 `id` int(11) NOT NULL AUTO_INCREMENT,
-                 `knowbaseitems_id` int(11) NOT NULL,
+                 `id` int NOT NULL AUTO_INCREMENT,
+                 `knowbaseitems_id` int NOT NULL,
                  `itemtype` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
-                 `items_id` int(11) NOT NULL DEFAULT '0',
+                 `items_id` int NOT NULL DEFAULT '0',
                  `date_creation` datetime DEFAULT NULL,
                  `date_mod` datetime DEFAULT NULL,
                  PRIMARY KEY (`id`),
@@ -130,13 +130,13 @@ function update91xto920() {
    $migration->displayMessage(sprintf(__('Add of - %s to database'), 'Knowbase item revisions'));
    if (!$DB->tableExists('glpi_knowbaseitems_revisions')) {
       $query = "CREATE TABLE `glpi_knowbaseitems_revisions` (
-                 `id` int(11) NOT NULL AUTO_INCREMENT,
-                 `knowbaseitems_id` int(11) NOT NULL,
-                 `revision` int(11) NOT NULL,
+                 `id` int NOT NULL AUTO_INCREMENT,
+                 `knowbaseitems_id` int NOT NULL,
+                 `revision` int NOT NULL,
                  `name` text COLLATE utf8_unicode_ci,
                  `answer` longtext COLLATE utf8_unicode_ci,
                  `language` varchar(5) COLLATE utf8_unicode_ci DEFAULT NULL,
-                 `users_id` int(11) NOT NULL DEFAULT '0',
+                 `users_id` int NOT NULL DEFAULT '0',
                  `date_creation` datetime DEFAULT NULL,
                  PRIMARY KEY (`id`),
                  UNIQUE KEY `unicity` (`knowbaseitems_id`, `revision`, `language`),
@@ -170,12 +170,12 @@ function update91xto920() {
    $migration->displayMessage(sprintf(__('Add of - %s to database'), 'Knowbase item comments'));
    if (!$DB->tableExists('glpi_knowbaseitems_comments')) {
       $query = "CREATE TABLE `glpi_knowbaseitems_comments` (
-                 `id` int(11) NOT NULL AUTO_INCREMENT,
-                 `knowbaseitems_id` int(11) NOT NULL,
-                 `users_id` int(11) NOT NULL DEFAULT '0',
+                 `id` int NOT NULL AUTO_INCREMENT,
+                 `knowbaseitems_id` int NOT NULL,
+                 `users_id` int NOT NULL DEFAULT '0',
                  `language` varchar(5) COLLATE utf8_unicode_ci DEFAULT NULL,
                  `comment` text COLLATE utf8_unicode_ci NOT NULL,
-                 `parent_comment_id` int(11) DEFAULT NULL,
+                 `parent_comment_id` int DEFAULT NULL,
                  `date_creation` datetime DEFAULT NULL,
                  `date_mod` datetime DEFAULT NULL,
                  PRIMARY KEY (`id`)
@@ -242,8 +242,8 @@ function update91xto920() {
    //add serial, location and state on each devices items
    foreach ($tables as $table) {
       $migration->addField($table, "otherserial", "varchar(255) NULL DEFAULT NULL");
-      $migration->addField($table, "locations_id", "int(11) NOT NULL DEFAULT '0'");
-      $migration->addField($table, "states_id", "int(11) NOT NULL DEFAULT '0'");
+      $migration->addField($table, "locations_id", "int NOT NULL DEFAULT '0'");
+      $migration->addField($table, "states_id", "int NOT NULL DEFAULT '0'");
       $migration->migrationOneTable($table);
       $migration->addKey($table, 'otherserial');
       $migration->addKey($table, 'locations_id');
@@ -271,7 +271,7 @@ function update91xto920() {
    foreach ($tables as $table) {
       if (!$DB->tableExists($table)) {
          $query = "CREATE TABLE `$table` (
-                      `id` INT(11) NOT NULL AUTO_INCREMENT,
+                      `id` INT NOT NULL AUTO_INCREMENT,
                       `name` VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8_unicode_ci',
                       `comment` TEXT NULL COLLATE 'utf8_unicode_ci',
                       `product_number` VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8_unicode_ci',
@@ -298,23 +298,23 @@ function update91xto920() {
               'glpi_devicesoundcards'    => 'devicesoundcardmodels_id'];
 
    foreach ($tables as $table => $field) {
-      $migration->addField($table, $field, 'int(11) DEFAULT NULL', ['after' => 'is_recursive']);
+      $migration->addField($table, $field, 'int DEFAULT NULL', ['after' => 'is_recursive']);
       $migration->migrationOneTable($table);
       $migration->addKey($table, $field);
    }
 
    if (!$DB->tableExists('glpi_devicegenerics')) {
       $query = "CREATE TABLE `glpi_devicegenerics` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `designation` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `devicegenerictypes_id` int(11) NOT NULL DEFAULT '0',
+                  `devicegenerictypes_id` int NOT NULL DEFAULT '0',
                   `comment` text COLLATE utf8_unicode_ci,
-                  `manufacturers_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `locations_id` int(11) NOT NULL DEFAULT '0',
-                  `states_id` int(11) NOT NULL DEFAULT '0',
-                  `devicegenericmodels_id` int(11) DEFAULT NULL,
+                  `manufacturers_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `locations_id` int NOT NULL DEFAULT '0',
+                  `states_id` int NOT NULL DEFAULT '0',
+                  `devicegenericmodels_id` int DEFAULT NULL,
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
@@ -334,18 +334,18 @@ function update91xto920() {
 
    if (!$DB->tableExists('glpi_items_devicegenerics')) {
       $query = "CREATE TABLE `glpi_items_devicegenerics` (
-                   `id` INT(11) NOT NULL AUTO_INCREMENT,
-                   `items_id` INT(11) NOT NULL DEFAULT '0',
+                   `id` INT NOT NULL AUTO_INCREMENT,
+                   `items_id` INT NOT NULL DEFAULT '0',
                    `itemtype` VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8_unicode_ci',
-                   `devicegenerics_id` INT(11) NOT NULL DEFAULT '0',
-                   `is_deleted` TINYINT(1) NOT NULL DEFAULT '0',
-                   `is_dynamic` TINYINT(1) NOT NULL DEFAULT '0',
-                   `entities_id` INT(11) NOT NULL DEFAULT '0',
-                   `is_recursive` TINYINT(1) NOT NULL DEFAULT '0',
+                   `devicegenerics_id` INT NOT NULL DEFAULT '0',
+                   `is_deleted` TINYINT NOT NULL DEFAULT '0',
+                   `is_dynamic` TINYINT NOT NULL DEFAULT '0',
+                   `entities_id` INT NOT NULL DEFAULT '0',
+                   `is_recursive` TINYINT NOT NULL DEFAULT '0',
                    `serial` VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8_unicode_ci',
                    `otherserial` VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8_unicode_ci',
-                   `locations_id` INT(11) NOT NULL DEFAULT '0',
-                   `states_id` INT(11) NOT NULL DEFAULT '0',
+                   `locations_id` INT NOT NULL DEFAULT '0',
+                   `states_id` INT NOT NULL DEFAULT '0',
                    PRIMARY KEY (`id`),
                    INDEX `computers_id` (`items_id`),
                    INDEX `devicegenerics_id` (`devicegenerics_id`),
@@ -362,7 +362,7 @@ function update91xto920() {
 
    if (!$DB->tableExists('glpi_devicegenerictypes')) {
       $query = "CREATE TABLE `glpi_devicegenerictypes` (
-                  `id` INT(11) NOT NULL AUTO_INCREMENT,
+                  `id` INT NOT NULL AUTO_INCREMENT,
                   `name` VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8_unicode_ci',
                   `comment` TEXT NULL COLLATE 'utf8_unicode_ci',
                    PRIMARY KEY (`id`),
@@ -373,16 +373,16 @@ function update91xto920() {
 
    if (!$DB->tableExists('glpi_devicebatteries')) {
       $query = "CREATE TABLE `glpi_devicebatteries` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `designation` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
-                  `manufacturers_id` int(11) NOT NULL DEFAULT '0',
-                  `voltage` int(11) DEFAULT NULL,
-                  `capacity` int(11) DEFAULT NULL,
-                  `devicebatterytypes_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `devicebatterymodels_id` int(11) DEFAULT NULL,
+                  `manufacturers_id` int NOT NULL DEFAULT '0',
+                  `voltage` int DEFAULT NULL,
+                  `capacity` int DEFAULT NULL,
+                  `devicebatterytypes_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `devicebatterymodels_id` int DEFAULT NULL,
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
@@ -400,19 +400,19 @@ function update91xto920() {
 
    if (!$DB->tableExists('glpi_items_devicebatteries')) {
       $query = "CREATE TABLE `glpi_items_devicebatteries` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `items_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `items_id` int NOT NULL DEFAULT '0',
                   `itemtype` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `devicebatteries_id` int(11) NOT NULL DEFAULT '0',
+                  `devicebatteries_id` int NOT NULL DEFAULT '0',
                   `manufacturing_date` date DEFAULT NULL,
-                  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-                  `is_dynamic` tinyint(1) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+                  `is_deleted` tinyint NOT NULL DEFAULT '0',
+                  `is_dynamic` tinyint NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
                   `serial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `otherserial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `locations_id` int(11) NOT NULL DEFAULT '0',
-                  `states_id` int(11) NOT NULL DEFAULT '0',
+                  `locations_id` int NOT NULL DEFAULT '0',
+                  `states_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `computers_id` (`items_id`),
                   KEY `devicebatteries_id` (`devicebatteries_id`),
@@ -429,7 +429,7 @@ function update91xto920() {
 
    if (!$DB->tableExists('glpi_devicebatterytypes')) {
       $query = "CREATE TABLE `glpi_devicebatterytypes` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `date_mod` datetime DEFAULT NULL,
@@ -444,16 +444,16 @@ function update91xto920() {
 
    if (!$DB->tableExists('glpi_devicefirmwares')) {
       $query = "CREATE TABLE `glpi_devicefirmwares` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `designation` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
-                  `manufacturers_id` int(11) NOT NULL DEFAULT '0',
+                  `manufacturers_id` int NOT NULL DEFAULT '0',
                   `date` date DEFAULT NULL,
                   `version` varchar(255) DEFAULT NULL,
-                  `devicefirmwaretypes_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `devicefirmwaremodels_id` int(11) DEFAULT NULL,
+                  `devicefirmwaretypes_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `devicefirmwaremodels_id` int DEFAULT NULL,
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
@@ -470,18 +470,18 @@ function update91xto920() {
    }
    if (!$DB->tableExists('glpi_items_devicefirmwares')) {
       $query = "CREATE TABLE `glpi_items_devicefirmwares` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `items_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `items_id` int NOT NULL DEFAULT '0',
                   `itemtype` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `devicefirmwares_id` int(11) NOT NULL DEFAULT '0',
-                  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-                  `is_dynamic` tinyint(1) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+                  `devicefirmwares_id` int NOT NULL DEFAULT '0',
+                  `is_deleted` tinyint NOT NULL DEFAULT '0',
+                  `is_dynamic` tinyint NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
                   `serial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `otherserial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `locations_id` int(11) NOT NULL DEFAULT '0',
-                  `states_id` int(11) NOT NULL DEFAULT '0',
+                  `locations_id` int NOT NULL DEFAULT '0',
+                  `states_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `computers_id` (`items_id`),
                   KEY `devicefirmwares_id` (`devicefirmwares_id`),
@@ -497,7 +497,7 @@ function update91xto920() {
    }
    if (!$DB->tableExists('glpi_devicefirmwaretypes')) {
       $query = "CREATE TABLE `glpi_devicefirmwaretypes` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `date_mod` datetime DEFAULT NULL,
@@ -537,16 +537,16 @@ function update91xto920() {
    //Device sensors
    if (!$DB->tableExists('glpi_devicesensors')) {
       $query = "CREATE TABLE `glpi_devicesensors` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `designation` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `devicesensortypes_id` int(11) NOT NULL DEFAULT '0',
-                  `devicesensormodels_id` int(11) NOT NULL DEFAULT '0',
+                  `devicesensortypes_id` int NOT NULL DEFAULT '0',
+                  `devicesensormodels_id` int NOT NULL DEFAULT '0',
                   `comment` text COLLATE utf8_unicode_ci,
-                  `manufacturers_id` int(11) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `locations_id` int(11) NOT NULL DEFAULT '0',
-                  `states_id` int(11) NOT NULL DEFAULT '0',
+                  `manufacturers_id` int NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `locations_id` int NOT NULL DEFAULT '0',
+                  `states_id` int NOT NULL DEFAULT '0',
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
@@ -565,18 +565,18 @@ function update91xto920() {
 
    if (!$DB->tableExists('glpi_items_devicesensors')) {
       $query = "CREATE TABLE `glpi_items_devicesensors` (
-                   `id` INT(11) NOT NULL AUTO_INCREMENT,
-                   `items_id` INT(11) NOT NULL DEFAULT '0',
+                   `id` INT NOT NULL AUTO_INCREMENT,
+                   `items_id` INT NOT NULL DEFAULT '0',
                    `itemtype` VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8_unicode_ci',
-                   `devicesensors_id` INT(11) NOT NULL DEFAULT '0',
-                   `is_deleted` TINYINT(1) NOT NULL DEFAULT '0',
-                   `is_dynamic` TINYINT(1) NOT NULL DEFAULT '0',
-                   `entities_id` INT(11) NOT NULL DEFAULT '0',
-                   `is_recursive` TINYINT(1) NOT NULL DEFAULT '0',
+                   `devicesensors_id` INT NOT NULL DEFAULT '0',
+                   `is_deleted` TINYINT NOT NULL DEFAULT '0',
+                   `is_dynamic` TINYINT NOT NULL DEFAULT '0',
+                   `entities_id` INT NOT NULL DEFAULT '0',
+                   `is_recursive` TINYINT NOT NULL DEFAULT '0',
                    `serial` VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8_unicode_ci',
                    `otherserial` VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8_unicode_ci',
-                   `locations_id` INT(11) NOT NULL DEFAULT '0',
-                   `states_id` INT(11) NOT NULL DEFAULT '0',
+                   `locations_id` INT NOT NULL DEFAULT '0',
+                   `states_id` INT NOT NULL DEFAULT '0',
                    PRIMARY KEY (`id`),
                    INDEX `computers_id` (`items_id`),
                    INDEX `devicesensors_id` (`devicesensors_id`),
@@ -595,7 +595,7 @@ function update91xto920() {
 
    if (!$DB->tableExists('glpi_devicesensortypes')) {
       $query = "CREATE TABLE `glpi_devicesensortypes` (
-                  `id` INT(11) NOT NULL AUTO_INCREMENT,
+                  `id` INT NOT NULL AUTO_INCREMENT,
                   `name` VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8_unicode_ci',
                   `comment` TEXT NULL COLLATE 'utf8_unicode_ci',
                    PRIMARY KEY (`id`),
@@ -694,19 +694,19 @@ function update91xto920() {
    /** ************ New SLM structure ************ */
    if (!$DB->tableExists('glpi_olas')) {
       $query = "CREATE TABLE `glpi_olas` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `type` int(11) NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `type` int NOT NULL DEFAULT '0',
                   `comment` text COLLATE utf8_unicode_ci,
-                  `number_time` int(11) NOT NULL,
-                  `calendars_id` int(11) NOT NULL DEFAULT '0',
+                  `number_time` int NOT NULL,
+                  `calendars_id` int NOT NULL DEFAULT '0',
                   `date_mod` datetime DEFAULT NULL,
                   `definition_time` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `end_of_working_day` tinyint(1) NOT NULL DEFAULT '0',
+                  `end_of_working_day` tinyint NOT NULL DEFAULT '0',
                   `date_creation` datetime DEFAULT NULL,
-                  `slms_id` int(11) NOT NULL DEFAULT '0',
+                  `slms_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   KEY `name` (`name`),
                   KEY `calendars_id` (`calendars_id`),
@@ -719,8 +719,8 @@ function update91xto920() {
 
    if (!$DB->tableExists('glpi_olalevelactions')) {
       $query = "CREATE TABLE `glpi_olalevelactions` (
-               `id` int(11) NOT NULL AUTO_INCREMENT,
-               `olalevels_id` int(11) NOT NULL DEFAULT '0',
+               `id` int NOT NULL AUTO_INCREMENT,
+               `olalevels_id` int NOT NULL DEFAULT '0',
                `action_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                `field` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                `value` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
@@ -732,10 +732,10 @@ function update91xto920() {
 
    if (!$DB->tableExists('glpi_olalevelcriterias')) {
       $query = "CREATE TABLE `glpi_olalevelcriterias` (
-               `id` int(11) NOT NULL AUTO_INCREMENT,
-               `olalevels_id` int(11) NOT NULL DEFAULT '0',
+               `id` int NOT NULL AUTO_INCREMENT,
+               `olalevels_id` int NOT NULL DEFAULT '0',
                `criteria` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-               `condition` int(11) NOT NULL DEFAULT '0' COMMENT 'see define.php PATTERN_* and REGEX_* constant',
+               `condition` int NOT NULL DEFAULT '0' COMMENT 'see define.php PATTERN_* and REGEX_* constant',
                `pattern` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                PRIMARY KEY (`id`),
                KEY `olalevels_id` (`olalevels_id`),
@@ -746,13 +746,13 @@ function update91xto920() {
 
    if (!$DB->tableExists('glpi_olalevels')) {
       $query = "CREATE TABLE `glpi_olalevels` (
-               `id` int(11) NOT NULL AUTO_INCREMENT,
+               `id` int NOT NULL AUTO_INCREMENT,
                `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-               `olas_id` int(11) NOT NULL DEFAULT '0',
-               `execution_time` int(11) NOT NULL,
-               `is_active` tinyint(1) NOT NULL DEFAULT '1',
-               `entities_id` int(11) NOT NULL DEFAULT '0',
-               `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+               `olas_id` int NOT NULL DEFAULT '0',
+               `execution_time` int NOT NULL,
+               `is_active` tinyint NOT NULL DEFAULT '1',
+               `entities_id` int NOT NULL DEFAULT '0',
+               `is_recursive` tinyint NOT NULL DEFAULT '0',
                `match` char(10) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'see define.php *_MATCHING constant',
                `uuid` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                PRIMARY KEY (`id`),
@@ -765,9 +765,9 @@ function update91xto920() {
 
    if (!$DB->tableExists('glpi_olalevels_tickets')) {
       $query = "CREATE TABLE `glpi_olalevels_tickets` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `tickets_id` int(11) NOT NULL DEFAULT '0',
-                  `olalevels_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `tickets_id` int NOT NULL DEFAULT '0',
+                  `olalevels_id` int NOT NULL DEFAULT '0',
                   `date` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
                   KEY `tickets_id` (`tickets_id`),
@@ -934,12 +934,12 @@ function update91xto920() {
    if ($DB->tableExists('glpi_bookmarks')) {
       $migration->renameTable("glpi_bookmarks", "glpi_savedsearches");
 
-      $migration->addField("glpi_savedsearches", "last_execution_time", "int(11) NULL DEFAULT NULL");
+      $migration->addField("glpi_savedsearches", "last_execution_time", "int NULL DEFAULT NULL");
       $migration->addField("glpi_savedsearches", "do_count",
-                           "tinyint(1) NOT NULL DEFAULT '2' COMMENT 'Do or do not count results on list display; see SavedSearch::COUNT_* constants'");
+                           "tinyint NOT NULL DEFAULT '2' COMMENT 'Do or do not count results on list display; see SavedSearch::COUNT_* constants'");
       $migration->addField("glpi_savedsearches", "last_execution_date",
                            "DATETIME NULL DEFAULT NULL");
-      $migration->addField("glpi_savedsearches", "counter", "int(11) NOT NULL DEFAULT '0'");
+      $migration->addField("glpi_savedsearches", "counter", "int NOT NULL DEFAULT '0'");
       $migration->migrationOneTable("glpi_savedsearches");
       $migration->addKey("glpi_savedsearches", 'last_execution_time');
       $migration->addKey("glpi_savedsearches", 'do_count');
@@ -1031,10 +1031,10 @@ function update91xto920() {
 
    if (!$DB->tableExists('glpi_notifications_notificationtemplates')) {
       $query = "CREATE TABLE `glpi_notifications_notificationtemplates` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `notifications_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `mode` varchar(20) COLLATE utf8_unicode_ci NOT NULL COMMENT 'See Notification_NotificationTemplate::MODE_* constants',
-                  `notificationtemplates_id` int(11) NOT NULL DEFAULT '0',
+                  `notificationtemplates_id` int NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `unicity` (`notifications_id`, `mode`, `notificationtemplates_id`),
                   KEY `notifications_id` (`notifications_id`),
@@ -1084,17 +1084,17 @@ function update91xto920() {
    if ($DB->tableExists('glpi_bookmarks_users')) {
       $migration->renameTable("glpi_bookmarks_users", "glpi_savedsearches_users");
       $migration->changeField('glpi_savedsearches_users', 'bookmarks_id', 'savedsearches_id',
-                              'int(11) NOT NULL DEFAULT "0"');
+                              'int NOT NULL DEFAULT "0"');
    }
 
    if (!$DB->tableExists('glpi_savedsearches_alerts')) {
       $query = "CREATE TABLE `glpi_savedsearches_alerts` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `savedsearches_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `savedsearches_id` int NOT NULL DEFAULT '0',
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `is_active` tinyint(1) NOT NULL DEFAULT '0',
-                  `operator` tinyint(1) NOT NULL,
-                  `value` int(11) NOT NULL,
+                  `is_active` tinyint NOT NULL DEFAULT '0',
+                  `operator` tinyint NOT NULL,
+                  `value` int NOT NULL,
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
@@ -1269,17 +1269,17 @@ Regards,',
 
    if (!$DB->tableExists('glpi_items_operatingsystems')) {
       $query = "CREATE TABLE `glpi_items_operatingsystems` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `items_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `items_id` int NOT NULL DEFAULT '0',
                   `itemtype` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `operatingsystems_id` int(11) NOT NULL DEFAULT '0',
-                  `operatingsystemversions_id` int(11) NOT NULL DEFAULT '0',
-                  `operatingsystemservicepacks_id` int(11) NOT NULL DEFAULT '0',
-                  `operatingsystemarchitectures_id` int(11) NOT NULL DEFAULT '0',
-                  `operatingsystemkernelversions_id` int(11) NOT NULL DEFAULT '0',
+                  `operatingsystems_id` int NOT NULL DEFAULT '0',
+                  `operatingsystemversions_id` int NOT NULL DEFAULT '0',
+                  `operatingsystemservicepacks_id` int NOT NULL DEFAULT '0',
+                  `operatingsystemarchitectures_id` int NOT NULL DEFAULT '0',
+                  `operatingsystemkernelversions_id` int NOT NULL DEFAULT '0',
                   `license_number` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `license_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `operatingsystemeditions_id` int(11) NOT NULL DEFAULT '0',
+                  `operatingsystemeditions_id` int NOT NULL DEFAULT '0',
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
@@ -1299,7 +1299,7 @@ Regards,',
 
    if (!$DB->tableExists('glpi_operatingsystemkernels')) {
       $query = "CREATE TABLE `glpi_operatingsystemkernels` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `date_mod` datetime DEFAULT NULL,
@@ -1312,8 +1312,8 @@ Regards,',
 
    if (!$DB->tableExists('glpi_operatingsystemkernelversions')) {
       $query = "CREATE TABLE `glpi_operatingsystemkernelversions` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `operatingsystemkernels_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `operatingsystemkernels_id` int NOT NULL DEFAULT '0',
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `date_mod` datetime DEFAULT NULL,
@@ -1327,7 +1327,7 @@ Regards,',
 
    if (!$DB->tableExists('glpi_operatingsystemeditions')) {
       $query = "CREATE TABLE `glpi_operatingsystemeditions` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `date_mod` datetime DEFAULT NULL,
@@ -1400,7 +1400,7 @@ Regards,',
       $migration->addField(
          'glpi_items_operatingsystems',
          'is_deleted',
-         "tinyint(1) NOT NULL DEFAULT '0'"
+         "tinyint NOT NULL DEFAULT '0'"
       );
       $migration->addKey('glpi_items_operatingsystems', 'is_deleted');
    }
@@ -1409,7 +1409,7 @@ Regards,',
       $migration->addField(
          'glpi_items_operatingsystems',
          'is_dynamic',
-         "tinyint(1) NOT NULL DEFAULT '0'"
+         "tinyint NOT NULL DEFAULT '0'"
       );
       $migration->addKey('glpi_items_operatingsystems', 'is_dynamic');
    }
@@ -1418,7 +1418,7 @@ Regards,',
       $migration->addField(
          'glpi_items_operatingsystems',
          'entities_id',
-         "int(11) NOT NULL DEFAULT '0'"
+         "int NOT NULL DEFAULT '0'"
       );
       $migration->addKey('glpi_items_operatingsystems', 'entities_id');
    }
@@ -1429,28 +1429,28 @@ Regards,',
    // Add certificates management
    if (!$DB->tableExists('glpi_certificates')) {
       $query = "CREATE TABLE `glpi_certificates` (
-        `id` INT(11) NOT NULL AUTO_INCREMENT,
+        `id` INT NOT NULL AUTO_INCREMENT,
         `name` VARCHAR(255) COLLATE utf8_unicode_ci  DEFAULT NULL,
         `serial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
         `otherserial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-        `entities_id` INT(11) NOT NULL DEFAULT '0',
-        `is_recursive` TINYINT(1) NOT NULL DEFAULT '0',
+        `entities_id` INT NOT NULL DEFAULT '0',
+        `is_recursive` TINYINT NOT NULL DEFAULT '0',
         `comment` text COLLATE utf8_unicode_ci,
-        `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-        `is_template` tinyint(1) NOT NULL DEFAULT '0',
+        `is_deleted` tinyint NOT NULL DEFAULT '0',
+        `is_template` tinyint NOT NULL DEFAULT '0',
         `template_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-        `certificatetypes_id`  INT(11) NOT NULL DEFAULT '0' COMMENT 'RELATION to glpi_certificatetypes (id)',
+        `certificatetypes_id`  INT NOT NULL DEFAULT '0' COMMENT 'RELATION to glpi_certificatetypes (id)',
         `dns_name` VARCHAR(255) COLLATE utf8_unicode_ci  DEFAULT NULL,
         `dns_suffix` VARCHAR(255) COLLATE utf8_unicode_ci  DEFAULT NULL,
-        `users_id_tech` INT(11) NOT NULL DEFAULT '0' COMMENT 'RELATION to glpi_users (id)',
-        `groups_id_tech` INT(11) NOT NULL DEFAULT '0' COMMENT 'RELATION to glpi_groups (id)',
-        `locations_id` INT(11) NOT NULL DEFAULT '0' COMMENT 'RELATION to glpi_locations (id)',
-        `manufacturers_id` INT(11) NOT NULL DEFAULT '0' COMMENT 'RELATION to glpi_manufacturers (id)',
-        `users_id` int(11) NOT NULL DEFAULT '0',
-        `groups_id` int(11) NOT NULL DEFAULT '0',
-        `is_autosign` TINYINT(1) NOT NULL DEFAULT '0',
+        `users_id_tech` INT NOT NULL DEFAULT '0' COMMENT 'RELATION to glpi_users (id)',
+        `groups_id_tech` INT NOT NULL DEFAULT '0' COMMENT 'RELATION to glpi_groups (id)',
+        `locations_id` INT NOT NULL DEFAULT '0' COMMENT 'RELATION to glpi_locations (id)',
+        `manufacturers_id` INT NOT NULL DEFAULT '0' COMMENT 'RELATION to glpi_manufacturers (id)',
+        `users_id` int NOT NULL DEFAULT '0',
+        `groups_id` int NOT NULL DEFAULT '0',
+        `is_autosign` TINYINT NOT NULL DEFAULT '0',
         `date_expiration` DATE DEFAULT NULL,
-        `states_id` INT(11) NOT NULL DEFAULT '0' COMMENT 'RELATION to states (id)',
+        `states_id` INT NOT NULL DEFAULT '0' COMMENT 'RELATION to states (id)',
         `command` TEXT COLLATE utf8_unicode_ci,
         `certificate_request` TEXT COLLATE utf8_unicode_ci,
         `certificate_item` TEXT COLLATE utf8_unicode_ci,
@@ -1477,9 +1477,9 @@ Regards,',
 
    if (!$DB->tableExists('glpi_certificates_items')) {
       $query = "CREATE TABLE `glpi_certificates_items` (
-           `id` INT(11) NOT NULL AUTO_INCREMENT,
-           `certificates_id` INT(11) NOT NULL DEFAULT '0',
-           `items_id` INT(11) NOT NULL DEFAULT '0' COMMENT 'RELATION to various tables, according to itemtype (id)',
+           `id` INT NOT NULL AUTO_INCREMENT,
+           `certificates_id` INT NOT NULL DEFAULT '0',
+           `items_id` INT NOT NULL DEFAULT '0' COMMENT 'RELATION to various tables, according to itemtype (id)',
            `itemtype` VARCHAR(100) COLLATE utf8_unicode_ci NOT NULL COMMENT 'see .class.php file',
            `date_creation` DATETIME DEFAULT NULL,
            `date_mod` DATETIME DEFAULT NULL,
@@ -1495,9 +1495,9 @@ Regards,',
 
    if (!$DB->tableExists('glpi_certificatetypes')) {
       $query = "CREATE TABLE `glpi_certificatetypes` (
-           `id` INT(11) NOT NULL AUTO_INCREMENT,
-           `entities_id` INT(11) NOT NULL DEFAULT '0',
-           `is_recursive` TINYINT(1) NOT NULL DEFAULT '0',
+           `id` INT NOT NULL AUTO_INCREMENT,
+           `entities_id` INT NOT NULL DEFAULT '0',
+           `is_recursive` TINYINT NOT NULL DEFAULT '0',
            `name` VARCHAR(255) COLLATE utf8_unicode_ci DEFAULT NULL,
            `comment` TEXT COLLATE utf8_unicode_ci,
            `date_creation` DATETIME DEFAULT NULL,
@@ -1639,13 +1639,13 @@ Regards,',
 
    if (!$DB->tableExists('glpi_lineoperators')) {
       $query = "CREATE TABLE IF NOT EXISTS `glpi_lineoperators` (
-                   `id` int(11) NOT NULL AUTO_INCREMENT,
+                   `id` int NOT NULL AUTO_INCREMENT,
                    `name` varchar(255) NOT NULL DEFAULT '',
                    `comment` text COLLATE utf8_unicode_ci,
-                   `mcc` int(11) DEFAULT NULL,
-                   `mnc` int(11) DEFAULT NULL,
-                   `entities_id`      INT(11) NOT NULL DEFAULT 0,
-                   `is_recursive`     TINYINT(1) NOT NULL DEFAULT 0,
+                   `mcc` int DEFAULT NULL,
+                   `mnc` int DEFAULT NULL,
+                   `entities_id`      INT NOT NULL DEFAULT 0,
+                   `is_recursive`     TINYINT NOT NULL DEFAULT 0,
                    `date_mod` datetime DEFAULT NULL,
                    `date_creation` datetime DEFAULT NULL,
                    PRIMARY KEY (`id`),
@@ -1661,7 +1661,7 @@ Regards,',
 
    if (!$DB->tableExists('glpi_linetypes')) {
       $query = "CREATE TABLE IF NOT EXISTS `glpi_linetypes` (
-         `id` int(11) NOT NULL AUTO_INCREMENT,
+         `id` int NOT NULL AUTO_INCREMENT,
          `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
          `comment` text COLLATE utf8_unicode_ci,
          `date_mod` datetime DEFAULT NULL,
@@ -1676,19 +1676,19 @@ Regards,',
 
    if (!$DB->tableExists('glpi_lines')) {
       $query = "CREATE TABLE `glpi_lines` (
-            `id`                   INT(11) NOT NULL auto_increment,
+            `id`                   INT NOT NULL auto_increment,
             `name`                 VARCHAR(255) NOT NULL DEFAULT '',
-            `entities_id`          INT(11) NOT NULL DEFAULT 0,
-            `is_recursive`         TINYINT(1) NOT NULL DEFAULT 0,
-            `is_deleted`           TINYINT(1) NOT NULL DEFAULT 0,
+            `entities_id`          INT NOT NULL DEFAULT 0,
+            `is_recursive`         TINYINT NOT NULL DEFAULT 0,
+            `is_deleted`           TINYINT NOT NULL DEFAULT 0,
             `caller_num`           VARCHAR(255) NOT NULL DEFAULT '',
             `caller_name`          VARCHAR(255) NOT NULL DEFAULT '',
-            `users_id`             INT(11) NOT NULL DEFAULT 0,
-            `groups_id`            INT(11) NOT NULL DEFAULT 0,
-            `lineoperators_id`     INT(11) NOT NULL DEFAULT 0,
-            `locations_id`         INT(11) NOT NULL DEFAULT '0',
-            `states_id`            INT(11) NOT NULL DEFAULT '0',
-            `linetypes_id`         INT(11) NOT NULL DEFAULT '0',
+            `users_id`             INT NOT NULL DEFAULT 0,
+            `groups_id`            INT NOT NULL DEFAULT 0,
+            `lineoperators_id`     INT NOT NULL DEFAULT 0,
+            `locations_id`         INT NOT NULL DEFAULT '0',
+            `states_id`            INT NOT NULL DEFAULT '0',
+            `linetypes_id`         INT NOT NULL DEFAULT '0',
             `date_creation`        DATETIME DEFAULT NULL,
             `date_mod`             DATETIME DEFAULT NULL,
             `comment`              TEXT DEFAULT NULL,
@@ -1703,7 +1703,7 @@ Regards,',
 
    if (!$DB->tableExists('glpi_devicesimcardtypes')) {
       $query = "CREATE TABLE IF NOT EXISTS `glpi_devicesimcardtypes` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) NOT NULL DEFAULT '',
                   `comment` text COLLATE utf8_unicode_ci,
                   `date_mod` datetime DEFAULT NULL,
@@ -1755,17 +1755,17 @@ Regards,',
 
    if (!$DB->tableExists('glpi_devicesimcards')) {
       $query = "CREATE TABLE IF NOT EXISTS `glpi_devicesimcards` (
-               `id` int(11) NOT NULL AUTO_INCREMENT,
+               `id` int NOT NULL AUTO_INCREMENT,
                `designation` varchar(255) DEFAULT NULL,
                `comment` text CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL,
-               `entities_id` int(11) NOT NULL DEFAULT '0',
-               `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-               `manufacturers_id` int(11) NOT NULL DEFAULT '0',
-               `voltage` int(11) DEFAULT NULL,
-               `devicesimcardtypes_id` int(11) NOT NULL DEFAULT '0',
+               `entities_id` int NOT NULL DEFAULT '0',
+               `is_recursive` tinyint NOT NULL DEFAULT '0',
+               `manufacturers_id` int NOT NULL DEFAULT '0',
+               `voltage` int DEFAULT NULL,
+               `devicesimcardtypes_id` int NOT NULL DEFAULT '0',
                `date_mod` datetime DEFAULT NULL,
                `date_creation` datetime DEFAULT NULL,
-               `allow_voip` tinyint(1) NOT NULL DEFAULT '0',
+               `allow_voip` tinyint NOT NULL DEFAULT '0',
                PRIMARY KEY (`id`),
                KEY `designation` (`designation`),
                KEY `entities_id` (`entities_id`),
@@ -1780,18 +1780,18 @@ Regards,',
 
    if (!$DB->tableExists('glpi_items_devicesimcards')) {
       $query = "CREATE TABLE IF NOT EXISTS `glpi_items_devicesimcards` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `items_id` int(11) NOT NULL DEFAULT '0' COMMENT 'RELATION to various table, according to itemtype (id)',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `items_id` int NOT NULL DEFAULT '0' COMMENT 'RELATION to various table, according to itemtype (id)',
                   `itemtype` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
-                  `devicesimcards_id` int(11) NOT NULL DEFAULT '0',
-                  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-                  `is_dynamic` tinyint(1) NOT NULL DEFAULT '0',
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
+                  `devicesimcards_id` int NOT NULL DEFAULT '0',
+                  `is_deleted` tinyint NOT NULL DEFAULT '0',
+                  `is_dynamic` tinyint NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
                   `serial` varchar(255) NULL DEFAULT NULL,
                   `otherserial` varchar(255) NULL DEFAULT NULL,
-                  `states_id` int(11) NOT NULL DEFAULT '0',
-                  `locations_id` int(11) NOT NULL DEFAULT '0',
-                  `lines_id` int(11) NOT NULL DEFAULT '0',
+                  `states_id` int NOT NULL DEFAULT '0',
+                  `locations_id` int NOT NULL DEFAULT '0',
+                  `lines_id` int NOT NULL DEFAULT '0',
                   `pin` varchar(255) NOT NULL DEFAULT '',
                   `pin2` varchar(255) NOT NULL DEFAULT '',
                   `puk` varchar(255) NOT NULL DEFAULT '',
@@ -1956,25 +1956,25 @@ Regards,',
 
    if (!$DB->tableExists('glpi_projecttasktemplates')) {
       $query = "CREATE TABLE `glpi_projecttasktemplates` (
-                       `id` int(11) NOT NULL AUTO_INCREMENT,
-                       `entities_id` int(11) NOT NULL DEFAULT '0',
-                       `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+                       `id` int NOT NULL AUTO_INCREMENT,
+                       `entities_id` int NOT NULL DEFAULT '0',
+                       `is_recursive` tinyint NOT NULL DEFAULT '0',
                        `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                        `description` longtext COLLATE utf8_unicode_ci,
                        `comment` longtext COLLATE utf8_unicode_ci,
-                       `projects_id` int(11) NOT NULL DEFAULT '0',
-                       `projecttasks_id` int(11) NOT NULL DEFAULT '0',
+                       `projects_id` int NOT NULL DEFAULT '0',
+                       `projecttasks_id` int NOT NULL DEFAULT '0',
                        `plan_start_date` datetime DEFAULT NULL,
                        `plan_end_date` datetime DEFAULT NULL,
                        `real_start_date` datetime DEFAULT NULL,
                        `real_end_date` datetime DEFAULT NULL,
-                       `planned_duration` int(11) NOT NULL DEFAULT '0',
-                       `effective_duration` int(11) NOT NULL DEFAULT '0',
-                       `projectstates_id` int(11) NOT NULL DEFAULT '0',
-                       `projecttasktypes_id` int(11) NOT NULL DEFAULT '0',
-                       `users_id` int(11) NOT NULL DEFAULT '0',
-                       `percent_done` int(11) NOT NULL DEFAULT '0',
-                       `is_milestone` tinyint(1) NOT NULL DEFAULT '0',
+                       `planned_duration` int NOT NULL DEFAULT '0',
+                       `effective_duration` int NOT NULL DEFAULT '0',
+                       `projectstates_id` int NOT NULL DEFAULT '0',
+                       `projecttasktypes_id` int NOT NULL DEFAULT '0',
+                       `users_id` int NOT NULL DEFAULT '0',
+                       `percent_done` int NOT NULL DEFAULT '0',
+                       `is_milestone` tinyint NOT NULL DEFAULT '0',
                        `comments` text COLLATE utf8_unicode_ci,
                        `date_mod` datetime DEFAULT NULL,
                        `date_creation` datetime DEFAULT NULL,
@@ -2001,21 +2001,21 @@ Regards,',
 
    //add editor in followupps
    if (!$DB->fieldExists('glpi_ticketfollowups', 'users_id_editor')) {
-      $migration->addField("glpi_ticketfollowups", "users_id_editor", "int(11) NOT NULL DEFAULT '0'", ['after' => 'users_id']);
+      $migration->addField("glpi_ticketfollowups", "users_id_editor", "int NOT NULL DEFAULT '0'", ['after' => 'users_id']);
       $migration->addKey("glpi_ticketfollowups", "users_id_editor");
    }
 
    //add editor in *tasks
    if (!$DB->fieldExists('glpi_tickettasks', 'users_id_editor')) {
-      $migration->addField("glpi_tickettasks", "users_id_editor", "int(11) NOT NULL DEFAULT '0'", ['after' => 'users_id']);
+      $migration->addField("glpi_tickettasks", "users_id_editor", "int NOT NULL DEFAULT '0'", ['after' => 'users_id']);
       $migration->addKey("glpi_tickettasks", "users_id_editor");
    }
    if (!$DB->fieldExists('glpi_changetasks', 'users_id_editor')) {
-      $migration->addField("glpi_changetasks", "users_id_editor", "int(11) NOT NULL DEFAULT '0'", ['after' => 'users_id']);
+      $migration->addField("glpi_changetasks", "users_id_editor", "int NOT NULL DEFAULT '0'", ['after' => 'users_id']);
       $migration->addKey("glpi_changetasks", "users_id_editor");
    }
    if (!$DB->fieldExists('glpi_problemtasks', 'users_id_editor')) {
-      $migration->addField("glpi_problemtasks", "users_id_editor", "int(11) NOT NULL DEFAULT '0'", ['after' => 'users_id']);
+      $migration->addField("glpi_problemtasks", "users_id_editor", "int NOT NULL DEFAULT '0'", ['after' => 'users_id']);
       $migration->addKey("glpi_problemtasks", "users_id_editor");
    }
 
@@ -2061,26 +2061,26 @@ Regards,',
    //Fix some field order from old migrations
    $migration->migrationOneTable('glpi_states');
    $DB->queryOrDie("ALTER TABLE `glpi_budgets` CHANGE `date_creation` `date_creation` DATETIME NULL DEFAULT NULL AFTER `date_mod`");
-   $DB->queryOrDie("ALTER TABLE `glpi_changetasks` CHANGE `groups_id_tech` `groups_id_tech` INT(11) NOT NULL DEFAULT '0' AFTER `users_id_tech`");
-   $DB->queryOrDie("ALTER TABLE `glpi_problemtasks` CHANGE `groups_id_tech` `groups_id_tech` INT(11) NOT NULL DEFAULT '0' AFTER `users_id_tech`");
-   $DB->queryOrDie("ALTER TABLE `glpi_tickettasks` CHANGE `groups_id_tech` `groups_id_tech` INT(11) NOT NULL DEFAULT '0' AFTER `users_id_tech`");
+   $DB->queryOrDie("ALTER TABLE `glpi_changetasks` CHANGE `groups_id_tech` `groups_id_tech` INT NOT NULL DEFAULT '0' AFTER `users_id_tech`");
+   $DB->queryOrDie("ALTER TABLE `glpi_problemtasks` CHANGE `groups_id_tech` `groups_id_tech` INT NOT NULL DEFAULT '0' AFTER `users_id_tech`");
+   $DB->queryOrDie("ALTER TABLE `glpi_tickettasks` CHANGE `groups_id_tech` `groups_id_tech` INT NOT NULL DEFAULT '0' AFTER `users_id_tech`");
    $DB->queryOrDie("ALTER TABLE `glpi_knowbaseitemcategories` CHANGE `sons_cache` `sons_cache` LONGTEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL AFTER `level`");
-   $DB->queryOrDie("ALTER TABLE `glpi_requesttypes` CHANGE `is_followup_default` `is_followup_default` TINYINT(1) NOT NULL DEFAULT '0' AFTER `is_helpdesk_default`");
-   $DB->queryOrDie("ALTER TABLE `glpi_requesttypes` CHANGE `is_mailfollowup_default` `is_mailfollowup_default` TINYINT(1) NOT NULL DEFAULT '0' AFTER `is_mail_default`");
+   $DB->queryOrDie("ALTER TABLE `glpi_requesttypes` CHANGE `is_followup_default` `is_followup_default` TINYINT NOT NULL DEFAULT '0' AFTER `is_helpdesk_default`");
+   $DB->queryOrDie("ALTER TABLE `glpi_requesttypes` CHANGE `is_mailfollowup_default` `is_mailfollowup_default` TINYINT NOT NULL DEFAULT '0' AFTER `is_mail_default`");
    $DB->queryOrDie("ALTER TABLE `glpi_requesttypes` CHANGE `comment` `comment` TEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL AFTER `is_ticketfollowup`");
    $DB->queryOrDie("ALTER TABLE `glpi_requesttypes` CHANGE `date_mod` `date_mod` DATETIME NULL DEFAULT NULL AFTER `comment`");
    $DB->queryOrDie("ALTER TABLE `glpi_requesttypes` CHANGE `date_creation` `date_creation` DATETIME NULL DEFAULT NULL AFTER `date_mod`");
-   $DB->queryOrDie("ALTER TABLE `glpi_groups` CHANGE `is_task` `is_task` TINYINT(1) NOT NULL DEFAULT '1' AFTER `is_assign`");
+   $DB->queryOrDie("ALTER TABLE `glpi_groups` CHANGE `is_task` `is_task` TINYINT NOT NULL DEFAULT '1' AFTER `is_assign`");
    $DB->queryOrDie("ALTER TABLE `glpi_states` CHANGE `date_mod` `date_mod` DATETIME NULL DEFAULT NULL AFTER `is_visible_certificate`");
    $DB->queryOrDie("ALTER TABLE `glpi_states` CHANGE `date_creation` `date_creation` DATETIME NULL DEFAULT NULL AFTER `date_mod`");
-   $DB->queryOrDie("ALTER TABLE `glpi_taskcategories` CHANGE `is_active` `is_active` TINYINT(1) NOT NULL DEFAULT '1' AFTER `sons_cache`");
+   $DB->queryOrDie("ALTER TABLE `glpi_taskcategories` CHANGE `is_active` `is_active` TINYINT NOT NULL DEFAULT '1' AFTER `sons_cache`");
    $DB->queryOrDie("ALTER TABLE `glpi_users` CHANGE `palette` `palette` CHAR(20) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL AFTER `layout`");
-   $DB->queryOrDie("ALTER TABLE `glpi_users` CHANGE `set_default_requester` `set_default_requester` TINYINT(1) NULL DEFAULT NULL AFTER `ticket_timeline_keep_replaced_tabs`");
+   $DB->queryOrDie("ALTER TABLE `glpi_users` CHANGE `set_default_requester` `set_default_requester` TINYINT NULL DEFAULT NULL AFTER `ticket_timeline_keep_replaced_tabs`");
    $DB->queryOrDie("ALTER TABLE `glpi_users` CHANGE `plannings` `plannings` TEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL AFTER `highcontrast_css`");
 
    //Fix bad default values
-   $DB->queryOrDie("ALTER TABLE `glpi_states` CHANGE `is_visible_softwarelicense` `is_visible_softwarelicense` TINYINT(1) NOT NULL DEFAULT '1'");
-   $DB->queryOrDie("ALTER TABLE `glpi_states` CHANGE `is_visible_line` `is_visible_line` TINYINT(1) NOT NULL DEFAULT '1'");
+   $DB->queryOrDie("ALTER TABLE `glpi_states` CHANGE `is_visible_softwarelicense` `is_visible_softwarelicense` TINYINT NOT NULL DEFAULT '1'");
+   $DB->queryOrDie("ALTER TABLE `glpi_states` CHANGE `is_visible_line` `is_visible_line` TINYINT NOT NULL DEFAULT '1'");
 
    //Fields added in 0905_91 script but not in empty sql...
    if (!$DB->fieldExists('glpi_changetasks', 'date_creation', false)) {
@@ -2121,7 +2121,7 @@ Regards,',
    }
 
    //Fix comments...
-   $DB->queryOrDie("ALTER TABLE `glpi_savedsearches` CHANGE `type` `type` INT(11) NOT NULL DEFAULT '0' COMMENT 'see SavedSearch:: constants'");
+   $DB->queryOrDie("ALTER TABLE `glpi_savedsearches` CHANGE `type` `type` INT NOT NULL DEFAULT '0' COMMENT 'see SavedSearch:: constants'");
 
    //Fix unicity...
    $tables = [
@@ -2171,7 +2171,7 @@ Regards,',
    }
 
    //wrong type
-   $DB->queryOrDie("ALTER TABLE `glpi_users` CHANGE `keep_devices_when_purging_item` `keep_devices_when_purging_item` TINYINT(1) NULL DEFAULT NULL");
+   $DB->queryOrDie("ALTER TABLE `glpi_users` CHANGE `keep_devices_when_purging_item` `keep_devices_when_purging_item` TINYINT NULL DEFAULT NULL");
 
    //missing index
    $migration->addKey('glpi_networknames', 'is_deleted');
@@ -2197,7 +2197,7 @@ Regards,',
    foreach ($timeline_tables as $tl_table) {
       //add timeline_position in $tl_table
       if (!$DB->fieldExists($tl_table, 'timeline_position')) {
-         $migration->addField($tl_table, "timeline_position", "tinyint(1) NOT NULL DEFAULT '0'");
+         $migration->addField($tl_table, "timeline_position", "tinyint NOT NULL DEFAULT '0'");
          $where = [
             "$tl_table.tickets_id"  => new \QueryExpression(
                DBmysql::quoteName("glpi_tickets_users.tickets_id")

--- a/install/migrations/update_9.2.0_to_9.2.1.php
+++ b/install/migrations/update_9.2.0_to_9.2.1.php
@@ -99,8 +99,8 @@ function update920to921() {
    //see https://github.com/glpi-project/glpi/issues/2871
    if (!$DB->tableExists('glpi_olalevelactions')) {
       $query = "CREATE TABLE `glpi_olalevelactions` (
-               `id` int(11) NOT NULL AUTO_INCREMENT,
-               `olalevels_id` int(11) NOT NULL DEFAULT '0',
+               `id` int NOT NULL AUTO_INCREMENT,
+               `olalevels_id` int NOT NULL DEFAULT '0',
                `action_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                `field` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                `value` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
@@ -112,10 +112,10 @@ function update920to921() {
 
    if (!$DB->tableExists('glpi_olalevelcriterias')) {
       $query = "CREATE TABLE `glpi_olalevelcriterias` (
-               `id` int(11) NOT NULL AUTO_INCREMENT,
-               `olalevels_id` int(11) NOT NULL DEFAULT '0',
+               `id` int NOT NULL AUTO_INCREMENT,
+               `olalevels_id` int NOT NULL DEFAULT '0',
                `criteria` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-               `condition` int(11) NOT NULL DEFAULT '0' COMMENT 'see define.php PATTERN_* and REGEX_* constant',
+               `condition` int NOT NULL DEFAULT '0' COMMENT 'see define.php PATTERN_* and REGEX_* constant',
                `pattern` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                PRIMARY KEY (`id`),
                KEY `olalevels_id` (`olalevels_id`),
@@ -126,13 +126,13 @@ function update920to921() {
 
    if (!$DB->tableExists('glpi_olalevels')) {
       $query = "CREATE TABLE `glpi_olalevels` (
-               `id` int(11) NOT NULL AUTO_INCREMENT,
+               `id` int NOT NULL AUTO_INCREMENT,
                `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-               `olas_id` int(11) NOT NULL DEFAULT '0',
-               `execution_time` int(11) NOT NULL,
-               `is_active` tinyint(1) NOT NULL DEFAULT '1',
-               `entities_id` int(11) NOT NULL DEFAULT '0',
-               `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+               `olas_id` int NOT NULL DEFAULT '0',
+               `execution_time` int NOT NULL,
+               `is_active` tinyint NOT NULL DEFAULT '1',
+               `entities_id` int NOT NULL DEFAULT '0',
+               `is_recursive` tinyint NOT NULL DEFAULT '0',
                `match` char(10) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'see define.php *_MATCHING constant',
                `uuid` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                PRIMARY KEY (`id`),
@@ -145,9 +145,9 @@ function update920to921() {
 
    if (!$DB->tableExists('glpi_olalevels_tickets')) {
       $query = "CREATE TABLE `glpi_olalevels_tickets` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `tickets_id` int(11) NOT NULL DEFAULT '0',
-                  `olalevels_id` int(11) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `tickets_id` int NOT NULL DEFAULT '0',
+                  `olalevels_id` int NOT NULL DEFAULT '0',
                   `date` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
                   KEY `tickets_id` (`tickets_id`),
@@ -376,7 +376,7 @@ function update920to921() {
    $migration->addField('glpi_items_devicesimcards', 'is_recursive', 'bool', ['after' => 'entities_id', 'value' => '0']);
    $migration->addKey('glpi_items_devicesimcards', 'is_recursive');
 
-   $migration->addField('glpi_items_operatingsystems', 'is_recursive', "tinyint(1) NOT NULL DEFAULT '0'",
+   $migration->addField('glpi_items_operatingsystems', 'is_recursive', "tinyint NOT NULL DEFAULT '0'",
                         ['after' => 'entities_id']);
    $migration->addKey('glpi_items_operatingsystems', 'is_recursive');
    $migration->migrationOneTable('glpi_items_operatingsystems');

--- a/install/migrations/update_9.2.2_to_9.2.3.php
+++ b/install/migrations/update_9.2.2_to_9.2.3.php
@@ -55,7 +55,7 @@ function update922to923() {
       $migration->addField(
          "glpi_devicepcis",
          "devicenetworkcardmodels_id",
-         "int(11) NOT NULL DEFAULT '0'",
+         "int NOT NULL DEFAULT '0'",
          ['after' => 'manufacturers_id']
       );
       $migration->addKey('glpi_devicepcis', 'devicenetworkcardmodels_id');

--- a/install/migrations/update_9.2.x_to_9.3.0.php
+++ b/install/migrations/update_9.2.x_to_9.3.0.php
@@ -50,22 +50,22 @@ function update92xto930() {
    //Create solutions table
    if (!$DB->tableExists('glpi_itilsolutions')) {
       $query = "CREATE TABLE `glpi_itilsolutions` (
-         `id` int(11) NOT NULL AUTO_INCREMENT,
+         `id` int NOT NULL AUTO_INCREMENT,
          `itemtype` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
-         `items_id` int(11) NOT NULL DEFAULT '0',
-         `solutiontypes_id` int(11) NOT NULL DEFAULT '0',
+         `items_id` int NOT NULL DEFAULT '0',
+         `solutiontypes_id` int NOT NULL DEFAULT '0',
          `solutiontype_name` varchar(255) NULL DEFAULT NULL,
          `content` longtext COLLATE utf8_unicode_ci,
          `date_creation` datetime DEFAULT NULL,
          `date_mod` datetime DEFAULT NULL,
          `date_approval` datetime DEFAULT NULL,
-         `users_id` int(11) NOT NULL DEFAULT '0',
+         `users_id` int NOT NULL DEFAULT '0',
          `user_name` varchar(255) NULL DEFAULT NULL,
-         `users_id_editor` int(11) NOT NULL DEFAULT '0',
-         `users_id_approval` int(11) NOT NULL DEFAULT '0',
+         `users_id_editor` int NOT NULL DEFAULT '0',
+         `users_id_approval` int NOT NULL DEFAULT '0',
          `user_name_approval` varchar(255) NULL DEFAULT NULL,
-         `status` int(11) NOT NULL DEFAULT '1',
-         `ticketfollowups_id` int(11) DEFAULT NULL  COMMENT 'Followup reference on reject or approve a ticket solution',
+         `status` int NOT NULL DEFAULT '1',
+         `ticketfollowups_id` int DEFAULT NULL  COMMENT 'Followup reference on reject or approve a ticket solution',
          PRIMARY KEY (`id`),
          KEY `itemtype` (`itemtype`),
          KEY `item_id` (`items_id`),
@@ -203,12 +203,12 @@ function update92xto930() {
    /** Datacenters */
    if (!$DB->tableExists('glpi_datacenters')) {
       $query = "CREATE TABLE `glpi_datacenters` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `locations_id` int(11) NOT NULL DEFAULT '0',
-                  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `locations_id` int NOT NULL DEFAULT '0',
+                  `is_deleted` tinyint NOT NULL DEFAULT '0',
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
@@ -222,16 +222,16 @@ function update92xto930() {
 
    if (!$DB->tableExists('glpi_dcrooms')) {
       $query = "CREATE TABLE `glpi_dcrooms` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `locations_id` int(11) NOT NULL DEFAULT '0',
-                  `vis_cols` int(11) DEFAULT NULL,
-                  `vis_rows` int(11) DEFAULT NULL,
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `locations_id` int NOT NULL DEFAULT '0',
+                  `vis_cols` int DEFAULT NULL,
+                  `vis_rows` int DEFAULT NULL,
                   `blueprint` text COLLATE utf8_unicode_ci,
-                  `datacenters_id` int(11) NOT NULL DEFAULT '0',
-                  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
+                  `datacenters_id` int NOT NULL DEFAULT '0',
+                  `is_deleted` tinyint NOT NULL DEFAULT '0',
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
@@ -249,7 +249,7 @@ function update92xto930() {
 
    if (!$DB->tableExists('glpi_rackmodels')) {
       $query = "CREATE TABLE `glpi_rackmodels` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `product_number` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
@@ -264,9 +264,9 @@ function update92xto930() {
 
    if (!$DB->tableExists('glpi_racktypes')) {
       $query = "CREATE TABLE `glpi_racktypes` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `date_creation` datetime DEFAULT NULL,
@@ -283,34 +283,34 @@ function update92xto930() {
 
    if (!$DB->tableExists('glpi_racks')) {
       $query = "CREATE TABLE `glpi_racks` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `locations_id` int(11) NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `locations_id` int NOT NULL DEFAULT '0',
                   `serial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `otherserial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `rackmodels_id` int(11) DEFAULT NULL,
-                  `manufacturers_id` int(11) NOT NULL DEFAULT '0',
-                  `racktypes_id` int(11) NOT NULL DEFAULT '0',
-                  `states_id` int(11) NOT NULL DEFAULT '0',
-                  `users_id_tech` int(11) NOT NULL DEFAULT '0',
-                  `groups_id_tech` int(11) NOT NULL DEFAULT '0',
-                  `width` int(11) DEFAULT NULL,
-                  `height` int(11) DEFAULT NULL,
-                  `depth` int(11) DEFAULT NULL,
-                  `number_units` int(11) DEFAULT '0',
-                  `is_template` tinyint(1) NOT NULL DEFAULT '0',
+                  `rackmodels_id` int DEFAULT NULL,
+                  `manufacturers_id` int NOT NULL DEFAULT '0',
+                  `racktypes_id` int NOT NULL DEFAULT '0',
+                  `states_id` int NOT NULL DEFAULT '0',
+                  `users_id_tech` int NOT NULL DEFAULT '0',
+                  `groups_id_tech` int NOT NULL DEFAULT '0',
+                  `width` int DEFAULT NULL,
+                  `height` int DEFAULT NULL,
+                  `depth` int DEFAULT NULL,
+                  `number_units` int DEFAULT '0',
+                  `is_template` tinyint NOT NULL DEFAULT '0',
                   `template_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-                  `dcrooms_id` int(11) NOT NULL DEFAULT '0',
-                  `room_orientation` int(11) NOT NULL DEFAULT '0',
+                  `is_deleted` tinyint NOT NULL DEFAULT '0',
+                  `dcrooms_id` int NOT NULL DEFAULT '0',
+                  `room_orientation` int NOT NULL DEFAULT '0',
                   `position` varchar(50),
                   `bgcolor` varchar(7) DEFAULT NULL,
-                  `max_power` int(11) NOT NULL DEFAULT '0',
-                  `mesured_power` int(11) NOT NULL DEFAULT '0',
-                  `max_weight` int(11) NOT NULL DEFAULT '0',
+                  `max_power` int NOT NULL DEFAULT '0',
+                  `mesured_power` int NOT NULL DEFAULT '0',
+                  `max_weight` int NOT NULL DEFAULT '0',
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
@@ -332,15 +332,15 @@ function update92xto930() {
 
    if (!$DB->tableExists('glpi_items_racks')) {
       $query = "CREATE TABLE `glpi_items_racks` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `racks_id` int(11) NOT NULL,
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `racks_id` int NOT NULL,
                   `itemtype` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-                  `items_id` int(11) NOT NULL,
-                  `position` int(11) NOT NULL,
-                  `orientation` tinyint(1),
+                  `items_id` int NOT NULL,
+                  `position` int NOT NULL,
+                  `orientation` tinyint,
                   `bgcolor` varchar(7) DEFAULT NULL,
-                  `hpos` tinyint(1) NOT NULL DEFAULT '0',
-                  `is_reserved` tinyint(1) NOT NULL DEFAULT '0',
+                  `hpos` tinyint NOT NULL DEFAULT '0',
+                  `is_reserved` tinyint NOT NULL DEFAULT '0',
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `item` (`itemtype`,`items_id`, `is_reserved`),
                   KEY `relation` (`racks_id`,`itemtype`,`items_id`)
@@ -364,22 +364,22 @@ function update92xto930() {
    $models_fields = [
       [
          'name'   => 'weight',
-         'type'   => "int(11) NOT NULL DEFAULT '0'"
+         'type'   => "int NOT NULL DEFAULT '0'"
       ], [
          'name'   => 'required_units',
-         'type'   => "int(11) NOT NULL DEFAULT '1'"
+         'type'   => "int NOT NULL DEFAULT '1'"
       ], [
          'name'   => 'depth',
          'type'   => "float NOT NULL DEFAULT 1"
       ], [
          'name'   => 'power_connections',
-         'type'   => "int(11) NOT NULL DEFAULT '0'"
+         'type'   => "int NOT NULL DEFAULT '0'"
       ], [
          'name'   => 'power_consumption',
-         'type'   => "int(11) NOT NULL DEFAULT '0'"
+         'type'   => "int NOT NULL DEFAULT '0'"
       ], [
          'name'   => 'is_half_rack',
-         'type'   => "tinyint(1) NOT NULL DEFAULT '0'"
+         'type'   => "tinyint NOT NULL DEFAULT '0'"
       ], [
          'name'   => 'picture_front',
          'type'   => "text"
@@ -407,16 +407,16 @@ function update92xto930() {
 
    if (!$DB->tableExists('glpi_enclosuremodels')) {
       $query = "CREATE TABLE `glpi_enclosuremodels` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `product_number` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `weight` int(11) NOT NULL DEFAULT '0',
-                  `required_units` int(11) NOT NULL DEFAULT '1',
+                  `weight` int NOT NULL DEFAULT '0',
+                  `required_units` int NOT NULL DEFAULT '1',
                   `depth` float NOT NULL DEFAULT 1,
-                  `power_connections` int(11) NOT NULL DEFAULT '0',
-                  `power_consumption` int(11) NOT NULL DEFAULT '0',
-                  `is_half_rack` tinyint(1) NOT NULL DEFAULT '0',
+                  `power_connections` int NOT NULL DEFAULT '0',
+                  `power_consumption` int NOT NULL DEFAULT '0',
+                  `is_half_rack` tinyint NOT NULL DEFAULT '0',
                   `picture_front` text COLLATE utf8_unicode_ci,
                   `picture_rear` text COLLATE utf8_unicode_ci,
                   `date_mod` datetime DEFAULT NULL,
@@ -432,24 +432,24 @@ function update92xto930() {
 
    if (!$DB->tableExists('glpi_enclosures')) {
       $query = "CREATE TABLE `glpi_enclosures` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `locations_id` int(11) NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `locations_id` int NOT NULL DEFAULT '0',
                   `serial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `otherserial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `enclosuremodels_id` int(11) DEFAULT NULL,
-                  `users_id_tech` int(11) NOT NULL DEFAULT '0',
-                  `groups_id_tech` int(11) NOT NULL DEFAULT '0',
-                  `is_template` tinyint(1) NOT NULL DEFAULT '0',
+                  `enclosuremodels_id` int DEFAULT NULL,
+                  `users_id_tech` int NOT NULL DEFAULT '0',
+                  `groups_id_tech` int NOT NULL DEFAULT '0',
+                  `is_template` tinyint NOT NULL DEFAULT '0',
                   `template_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-                  `orientation` tinyint(1),
-                  `power_supplies` tinyint(1) NOT NULL DEFAULT '0',
-                  `states_id` int(11) NOT NULL DEFAULT '0' COMMENT 'RELATION to states (id)',
+                  `is_deleted` tinyint NOT NULL DEFAULT '0',
+                  `orientation` tinyint,
+                  `power_supplies` tinyint NOT NULL DEFAULT '0',
+                  `states_id` int NOT NULL DEFAULT '0' COMMENT 'RELATION to states (id)',
                   `comment` text COLLATE utf8_unicode_ci,
-                  `manufacturers_id` int(11) NOT NULL DEFAULT '0',
+                  `manufacturers_id` int NOT NULL DEFAULT '0',
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
@@ -469,11 +469,11 @@ function update92xto930() {
 
    if (!$DB->tableExists('glpi_items_enclosures')) {
       $query = "CREATE TABLE `glpi_items_enclosures` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `enclosures_id` int(11) NOT NULL,
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `enclosures_id` int NOT NULL,
                   `itemtype` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-                  `items_id` int(11) NOT NULL,
-                  `position` int(11) NOT NULL,
+                  `items_id` int NOT NULL,
+                  `position` int NOT NULL,
                   PRIMARY KEY (`id`),
                   UNIQUE KEY `item` (`itemtype`,`items_id`),
                   KEY `relation` (`enclosures_id`,`itemtype`,`items_id`)
@@ -483,19 +483,19 @@ function update92xto930() {
 
    if (!$DB->tableExists('glpi_pdumodels')) {
       $query = "CREATE TABLE `glpi_pdumodels` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `product_number` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `weight` int(11) NOT NULL DEFAULT '0',
-                  `required_units` int(11) NOT NULL DEFAULT '1',
+                  `weight` int NOT NULL DEFAULT '0',
+                  `required_units` int NOT NULL DEFAULT '1',
                   `depth` float NOT NULL DEFAULT 1,
-                  `power_connections` int(11) NOT NULL DEFAULT '0',
-                  `max_power` int(11) NOT NULL DEFAULT '0',
-                  `is_half_rack` tinyint(1) NOT NULL DEFAULT '0',
+                  `power_connections` int NOT NULL DEFAULT '0',
+                  `max_power` int NOT NULL DEFAULT '0',
+                  `is_half_rack` tinyint NOT NULL DEFAULT '0',
                   `picture_front` text COLLATE utf8_unicode_ci,
                   `picture_rear` text COLLATE utf8_unicode_ci,
-                  `is_rackable` tinyint(1) NOT NULL DEFAULT '0',
+                  `is_rackable` tinyint NOT NULL DEFAULT '0',
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
@@ -515,9 +515,9 @@ function update92xto930() {
 
    if (!$DB->tableExists('glpi_pdutypes')) {
       $query = "CREATE TABLE `glpi_pdutypes` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `date_creation` datetime DEFAULT NULL,
@@ -534,23 +534,23 @@ function update92xto930() {
 
    if (!$DB->tableExists('glpi_pdus')) {
       $query = "CREATE TABLE `glpi_pdus` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `entities_id` int(11) NOT NULL DEFAULT '0',
-                  `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-                  `locations_id` int(11) NOT NULL DEFAULT '0',
+                  `entities_id` int NOT NULL DEFAULT '0',
+                  `is_recursive` tinyint NOT NULL DEFAULT '0',
+                  `locations_id` int NOT NULL DEFAULT '0',
                   `serial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `otherserial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `pdumodels_id` int(11) DEFAULT NULL,
-                  `users_id_tech` int(11) NOT NULL DEFAULT '0',
-                  `groups_id_tech` int(11) NOT NULL DEFAULT '0',
-                  `is_template` tinyint(1) NOT NULL DEFAULT '0',
+                  `pdumodels_id` int DEFAULT NULL,
+                  `users_id_tech` int NOT NULL DEFAULT '0',
+                  `groups_id_tech` int NOT NULL DEFAULT '0',
+                  `is_template` tinyint NOT NULL DEFAULT '0',
                   `template_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-                  `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-                  `states_id` int(11) NOT NULL DEFAULT '0' COMMENT 'RELATION to states (id)',
+                  `is_deleted` tinyint NOT NULL DEFAULT '0',
+                  `states_id` int NOT NULL DEFAULT '0' COMMENT 'RELATION to states (id)',
                   `comment` text COLLATE utf8_unicode_ci,
-                  `manufacturers_id` int(11) NOT NULL DEFAULT '0',
-                  `pdutypes_id` int(11) NOT NULL DEFAULT '0',
+                  `manufacturers_id` int NOT NULL DEFAULT '0',
+                  `pdutypes_id` int NOT NULL DEFAULT '0',
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
@@ -571,7 +571,7 @@ function update92xto930() {
 
    if (!$DB->tableExists('glpi_plugs')) {
       $query = "CREATE TABLE `glpi_plugs` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
+                  `id` int NOT NULL AUTO_INCREMENT,
                   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                   `comment` text COLLATE utf8_unicode_ci,
                   `date_mod` datetime DEFAULT NULL,
@@ -586,10 +586,10 @@ function update92xto930() {
 
    if (!$DB->tableExists('glpi_pdus_plugs')) {
       $query = "CREATE TABLE `glpi_pdus_plugs` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `plugs_id` int(11) NOT NULL DEFAULT '0',
-                  `pdus_id` int(11) NOT NULL DEFAULT '0',
-                  `number_plugs` int(11) DEFAULT '0',
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `plugs_id` int NOT NULL DEFAULT '0',
+                  `pdus_id` int NOT NULL DEFAULT '0',
+                  `number_plugs` int DEFAULT '0',
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,
                   PRIMARY KEY (`id`),
@@ -610,11 +610,11 @@ function update92xto930() {
 
    if (!$DB->tableExists('glpi_pdus_racks')) {
       $query = "CREATE TABLE `glpi_pdus_racks` (
-                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                  `racks_id` int(11) NOT NULL DEFAULT '0',
-                  `pdus_id` int(11) NOT NULL DEFAULT '0',
-                  `side` int(11) DEFAULT '0',
-                  `position` int(11) NOT NULL,
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `racks_id` int NOT NULL DEFAULT '0',
+                  `pdus_id` int NOT NULL DEFAULT '0',
+                  `side` int DEFAULT '0',
+                  `position` int NOT NULL,
                   `bgcolor` varchar(7) DEFAULT NULL,
                   `date_mod` datetime DEFAULT NULL,
                   `date_creation` datetime DEFAULT NULL,

--- a/install/migrations/update_9.3.x_to_9.4.0.php
+++ b/install/migrations/update_9.3.x_to_9.4.0.php
@@ -164,7 +164,7 @@ function update93xto940() {
          'glpi_itils_projects',
          'changes_id',
          'items_id',
-         "int(11) NOT NULL DEFAULT '0'"
+         "int NOT NULL DEFAULT '0'"
       );
 
       $migration->addKey(
@@ -188,7 +188,7 @@ function update93xto940() {
 
    /** Add watcher visibility to groups */
    if (!$DB->fieldExists('glpi_groups', 'is_watcher')) {
-      if ($migration->addField('glpi_groups', 'is_watcher', "tinyint(1) NOT NULL DEFAULT '1'", ['after' => 'is_requester'])) {
+      if ($migration->addField('glpi_groups', 'is_watcher', "tinyint NOT NULL DEFAULT '1'", ['after' => 'is_requester'])) {
          $migration->addKey('glpi_groups', 'is_watcher');
          $migration->migrationOneTable('glpi_groups');
       }
@@ -261,7 +261,7 @@ function update93xto940() {
          'glpi_itilfollowups',
          'tickets_id',
          'items_id',
-         "int(11) NOT NULL DEFAULT '0'"
+         "int NOT NULL DEFAULT '0'"
       );
       $migration->addKey(
          'glpi_itilfollowups',
@@ -302,7 +302,7 @@ function update93xto940() {
          'glpi_itilsolutions',
          'ticketfollowups_id',
          'itilfollowups_id',
-         "int(11) DEFAULT NULL"
+         "int DEFAULT NULL"
       );
       $migration->dropKey(
          'glpi_itilsolutions',
@@ -315,9 +315,9 @@ function update93xto940() {
    }
 
    /** Add timeline_position to Change and Problem items */
-   $migration->addField("glpi_changetasks", "timeline_position", "tinyint(1) NOT NULL DEFAULT '0'");
-   $migration->addField("glpi_changevalidations", "timeline_position", "tinyint(1) NOT NULL DEFAULT '0'");
-   $migration->addField("glpi_problemtasks", "timeline_position", "tinyint(1) NOT NULL DEFAULT '0'");
+   $migration->addField("glpi_changetasks", "timeline_position", "tinyint NOT NULL DEFAULT '0'");
+   $migration->addField("glpi_changevalidations", "timeline_position", "tinyint NOT NULL DEFAULT '0'");
+   $migration->addField("glpi_problemtasks", "timeline_position", "tinyint NOT NULL DEFAULT '0'");
 
    /** Give all existing profiles access to personalizations for legacy functionality */
    $migration->addRight('personalization', READ | UPDATE, []);
@@ -396,14 +396,14 @@ function update93xto940() {
 
    /** Add source item id to ITILFollowups. Used by followups created by merging tickets */
    if (!$DB->fieldExists('glpi_itilfollowups', 'sourceitems_id')) {
-      if ($migration->addField('glpi_itilfollowups', 'sourceitems_id', "int(11) NOT NULL DEFAULT '0'")) {
+      if ($migration->addField('glpi_itilfollowups', 'sourceitems_id', "int NOT NULL DEFAULT '0'")) {
          $migration->addKey('glpi_itilfollowups', 'sourceitems_id');
       }
    }
 
    /** Add sourceof item id to ITILFollowups. Used to link to tickets created by promotion */
    if (!$DB->fieldExists('glpi_itilfollowups', 'sourceof_items_id')) {
-      if ($migration->addField('glpi_itilfollowups', 'sourceof_items_id', "int(11) NOT NULL DEFAULT '0'")) {
+      if ($migration->addField('glpi_itilfollowups', 'sourceof_items_id', "int NOT NULL DEFAULT '0'")) {
          $migration->addKey('glpi_itilfollowups', 'sourceof_items_id');
       }
    }

--- a/install/migrations/update_9.4.x_to_9.5.0.php
+++ b/install/migrations/update_9.4.x_to_9.5.0.php
@@ -151,9 +151,9 @@ function update94xto950() {
    /** Clusters */
    if (!$DB->tableExists('glpi_clustertypes')) {
       $query = "CREATE TABLE `glpi_clustertypes` (
-         `id` int(11) NOT NULL AUTO_INCREMENT,
-         `entities_id` int(11) NOT NULL DEFAULT '0',
-         `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+         `id` int NOT NULL AUTO_INCREMENT,
+         `entities_id` int NOT NULL DEFAULT '0',
+         `is_recursive` tinyint NOT NULL DEFAULT '0',
          `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
          `comment` text COLLATE utf8_unicode_ci,
          `date_creation` timestamp NULL DEFAULT NULL,
@@ -170,19 +170,19 @@ function update94xto950() {
 
    if (!$DB->tableExists('glpi_clusters')) {
       $query = "CREATE TABLE `glpi_clusters` (
-         `id` int(11) NOT NULL AUTO_INCREMENT,
-         `entities_id` int(11) NOT NULL DEFAULT '0',
-         `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+         `id` int NOT NULL AUTO_INCREMENT,
+         `entities_id` int NOT NULL DEFAULT '0',
+         `is_recursive` tinyint NOT NULL DEFAULT '0',
          `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
          `uuid` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
          `version` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-         `users_id_tech` int(11) NOT NULL DEFAULT '0',
-         `groups_id_tech` int(11) NOT NULL DEFAULT '0',
-         `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-         `states_id` int(11) NOT NULL DEFAULT '0' COMMENT 'RELATION to states (id)',
+         `users_id_tech` int NOT NULL DEFAULT '0',
+         `groups_id_tech` int NOT NULL DEFAULT '0',
+         `is_deleted` tinyint NOT NULL DEFAULT '0',
+         `states_id` int NOT NULL DEFAULT '0' COMMENT 'RELATION to states (id)',
          `comment` text COLLATE utf8_unicode_ci,
-         `clustertypes_id` int(11) NOT NULL DEFAULT '0',
-         `autoupdatesystems_id` int(11) NOT NULL DEFAULT '0',
+         `clustertypes_id` int NOT NULL DEFAULT '0',
+         `autoupdatesystems_id` int NOT NULL DEFAULT '0',
          `date_mod` timestamp NULL DEFAULT NULL,
          `date_creation` timestamp NULL DEFAULT NULL,
          PRIMARY KEY (`id`),
@@ -200,10 +200,10 @@ function update94xto950() {
 
    if (!$DB->tableExists('glpi_items_clusters')) {
       $query = "CREATE TABLE `glpi_items_clusters` (
-         `id` int(11) NOT NULL AUTO_INCREMENT,
-         `clusters_id` int(11) NOT NULL DEFAULT '0',
+         `id` int NOT NULL AUTO_INCREMENT,
+         `clusters_id` int NOT NULL DEFAULT '0',
          `itemtype` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
-         `items_id` int(11) NOT NULL DEFAULT '0',
+         `items_id` int NOT NULL DEFAULT '0',
          PRIMARY KEY (`id`),
          UNIQUE KEY `unicity` (`clusters_id`,`itemtype`,`items_id`),
          KEY `item` (`itemtype`,`items_id`)
@@ -263,10 +263,10 @@ function update94xto950() {
    foreach (['change', 'problem'] as $itiltype) {
       if (!$DB->tableExists("glpi_{$itiltype}templates")) {
          $query = "CREATE TABLE `glpi_{$itiltype}templates` (
-            `id` int(11) NOT NULL AUTO_INCREMENT,
+            `id` int NOT NULL AUTO_INCREMENT,
             `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-            `entities_id` int(11) NOT NULL DEFAULT '0',
-            `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+            `entities_id` int NOT NULL DEFAULT '0',
+            `is_recursive` tinyint NOT NULL DEFAULT '0',
             `comment` text COLLATE utf8_unicode_ci,
             PRIMARY KEY (`id`),
             KEY `name` (`name`),
@@ -288,9 +288,9 @@ function update94xto950() {
 
       if (!$DB->tableExists("glpi_{$itiltype}templatehiddenfields")) {
          $query = "CREATE TABLE `glpi_{$itiltype}templatehiddenfields` (
-            `id` int(11) NOT NULL AUTO_INCREMENT,
-            `{$itiltype}templates_id` int(11) NOT NULL DEFAULT '0',
-            `num` int(11) NOT NULL DEFAULT '0',
+            `id` int NOT NULL AUTO_INCREMENT,
+            `{$itiltype}templates_id` int NOT NULL DEFAULT '0',
+            `num` int NOT NULL DEFAULT '0',
             PRIMARY KEY (`id`),
             UNIQUE KEY `unicity` (`{$itiltype}templates_id`,`num`),
             KEY `{$itiltype}templates_id` (`{$itiltype}templates_id`)
@@ -300,9 +300,9 @@ function update94xto950() {
 
       if (!$DB->tableExists("glpi_{$itiltype}templatemandatoryfields")) {
          $query = "CREATE TABLE `glpi_{$itiltype}templatemandatoryfields` (
-            `id` int(11) NOT NULL AUTO_INCREMENT,
-            `{$itiltype}templates_id` int(11) NOT NULL DEFAULT '0',
-            `num` int(11) NOT NULL DEFAULT '0',
+            `id` int NOT NULL AUTO_INCREMENT,
+            `{$itiltype}templates_id` int NOT NULL DEFAULT '0',
+            `num` int NOT NULL DEFAULT '0',
             PRIMARY KEY (`id`),
             UNIQUE KEY `unicity` (`{$itiltype}templates_id`,`num`),
             KEY `{$itiltype}templates_id` (`{$itiltype}templates_id`)
@@ -322,9 +322,9 @@ function update94xto950() {
 
       if (!$DB->tableExists("glpi_{$itiltype}templatepredefinedfields")) {
          $query = "CREATE TABLE `glpi_{$itiltype}templatepredefinedfields` (
-            `id` int(11) NOT NULL AUTO_INCREMENT,
-            `{$itiltype}templates_id` int(11) NOT NULL DEFAULT '0',
-            `num` int(11) NOT NULL DEFAULT '0',
+            `id` int NOT NULL AUTO_INCREMENT,
+            `{$itiltype}templates_id` int NOT NULL DEFAULT '0',
+            `num` int NOT NULL DEFAULT '0',
             `value` text COLLATE utf8_unicode_ci,
             PRIMARY KEY (`id`),
             KEY `{$itiltype}templates_id` (`{$itiltype}templates_id`)
@@ -340,15 +340,15 @@ function update94xto950() {
    /** add templates for followups */
    if (!$DB->tableExists('glpi_itilfollowuptemplates')) {
       $query = "CREATE TABLE `glpi_itilfollowuptemplates` (
-         `id`              INT(11) NOT NULL AUTO_INCREMENT,
+         `id`              INT NOT NULL AUTO_INCREMENT,
          `date_creation`   TIMESTAMP NULL DEFAULT NULL,
          `date_mod`        TIMESTAMP NULL DEFAULT NULL,
-         `entities_id`     INT(11) NOT NULL DEFAULT '0',
-         `is_recursive`    TINYINT(1) NOT NULL DEFAULT '0',
+         `entities_id`     INT NOT NULL DEFAULT '0',
+         `is_recursive`    TINYINT NOT NULL DEFAULT '0',
          `name`            VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8_unicode_ci',
          `content`         TEXT NULL COLLATE 'utf8_unicode_ci',
-         `requesttypes_id` INT(11) NOT NULL DEFAULT '0',
-         `is_private`      TINYINT(1) NOT NULL DEFAULT '0',
+         `requesttypes_id` INT NOT NULL DEFAULT '0',
+         `is_private`      TINYINT NOT NULL DEFAULT '0',
          `comment`         TEXT NULL COLLATE 'utf8_unicode_ci',
          PRIMARY KEY (`id`),
          INDEX `name` (`name`),
@@ -458,22 +458,22 @@ function update94xto950() {
    /** /Add Externals events for planning */
    if (!$DB->tableExists('glpi_planningexternalevents')) {
       $query = "CREATE TABLE `glpi_planningexternalevents` (
-         `id` int(11) NOT NULL AUTO_INCREMENT,
-         `planningexternaleventtemplates_id` int(11) NOT NULL DEFAULT '0',
-         `entities_id` int(11) NOT NULL DEFAULT '0',
-         `is_recursive` TINYINT(1) NOT NULL DEFAULT '1',
+         `id` int NOT NULL AUTO_INCREMENT,
+         `planningexternaleventtemplates_id` int NOT NULL DEFAULT '0',
+         `entities_id` int NOT NULL DEFAULT '0',
+         `is_recursive` TINYINT NOT NULL DEFAULT '1',
          `date` timestamp NULL DEFAULT NULL,
-         `users_id` int(11) NOT NULL DEFAULT '0',
+         `users_id` int NOT NULL DEFAULT '0',
          `users_id_guests` text COLLATE utf8_unicode_ci,
-         `groups_id` int(11) NOT NULL DEFAULT '0',
+         `groups_id` int NOT NULL DEFAULT '0',
          `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
          `text` text COLLATE utf8_unicode_ci,
          `begin` timestamp NULL DEFAULT NULL,
          `end` timestamp NULL DEFAULT NULL,
          `rrule` text COLLATE utf8_unicode_ci,
-         `state` int(11) NOT NULL DEFAULT '0',
-         `planningeventcategories_id` int(11) NOT NULL DEFAULT '0',
-         `background` tinyint(1) NOT NULL DEFAULT '0',
+         `state` int NOT NULL DEFAULT '0',
+         `planningeventcategories_id` int NOT NULL DEFAULT '0',
+         `background` tinyint NOT NULL DEFAULT '0',
          `date_mod` timestamp NULL DEFAULT NULL,
          `date_creation` timestamp NULL DEFAULT NULL,
          PRIMARY KEY (`id`),
@@ -520,7 +520,7 @@ function update94xto950() {
 
    if (!$DB->tableExists('glpi_planningeventcategories')) {
       $query = "CREATE TABLE `glpi_planningeventcategories` (
-         `id` int(11) NOT NULL AUTO_INCREMENT,
+         `id` int NOT NULL AUTO_INCREMENT,
          `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
          `color` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
          `comment` text COLLATE utf8_unicode_ci,
@@ -544,17 +544,17 @@ function update94xto950() {
 
    if (!$DB->tableExists('glpi_planningexternaleventtemplates')) {
       $query = "CREATE TABLE `glpi_planningexternaleventtemplates` (
-         `id` int(11) NOT NULL AUTO_INCREMENT,
-         `entities_id` int(11) NOT NULL DEFAULT '0',
+         `id` int NOT NULL AUTO_INCREMENT,
+         `entities_id` int NOT NULL DEFAULT '0',
          `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
          `text` text COLLATE utf8_unicode_ci,
          `comment` text COLLATE utf8_unicode_ci,
-         `duration` int(11) NOT NULL DEFAULT '0',
-         `before_time` int(11) NOT NULL DEFAULT '0',
+         `duration` int NOT NULL DEFAULT '0',
+         `before_time` int NOT NULL DEFAULT '0',
          `rrule` text COLLATE utf8_unicode_ci,
-         `state` int(11) NOT NULL DEFAULT '0',
-         `planningeventcategories_id` int(11) NOT NULL DEFAULT '0',
-         `background` tinyint(1) NOT NULL DEFAULT '0',
+         `state` int NOT NULL DEFAULT '0',
+         `planningeventcategories_id` int NOT NULL DEFAULT '0',
+         `background` tinyint NOT NULL DEFAULT '0',
          `date_mod` timestamp NULL DEFAULT NULL,
          `date_creation` timestamp NULL DEFAULT NULL,
          PRIMARY KEY (`id`),
@@ -639,7 +639,7 @@ function update94xto950() {
          'glpi_items_softwareversions',
          'computers_id',
          'items_id',
-         "int(11) NOT NULL DEFAULT '0'"
+         "int NOT NULL DEFAULT '0'"
       );
       $migration->addField(
          'glpi_items_softwareversions',
@@ -674,7 +674,7 @@ function update94xto950() {
          'glpi_items_softwarelicenses',
          'computers_id',
          'items_id',
-         "int(11) NOT NULL DEFAULT '0'"
+         "int NOT NULL DEFAULT '0'"
       );
       $migration->addField(
          'glpi_items_softwarelicenses',
@@ -712,7 +712,7 @@ function update94xto950() {
 
    /** Add source item id to TicketTask. Used by tasks created by merging tickets */
    if (!$DB->fieldExists('glpi_tickettasks', 'sourceitems_id')) {
-      if ($migration->addField('glpi_tickettasks', 'sourceitems_id', "int(11) NOT NULL DEFAULT '0'")) {
+      if ($migration->addField('glpi_tickettasks', 'sourceitems_id', "int NOT NULL DEFAULT '0'")) {
          $migration->addKey('glpi_tickettasks', 'sourceitems_id');
       }
    }
@@ -725,11 +725,11 @@ function update94xto950() {
    // Impact dependencies
    if (!$DB->tableExists('glpi_impactrelations')) {
       $query = "CREATE TABLE `glpi_impactrelations` (
-         `id` INT(11) NOT NULL AUTO_INCREMENT,
+         `id` INT NOT NULL AUTO_INCREMENT,
          `itemtype_source` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
-         `items_id_source` INT(11) NOT NULL DEFAULT '0',
+         `items_id_source` INT NOT NULL DEFAULT '0',
          `itemtype_impacted` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
-         `items_id_impacted` INT(11) NOT NULL DEFAULT '0',
+         `items_id_impacted` INT NOT NULL DEFAULT '0',
          PRIMARY KEY (`id`),
          UNIQUE KEY `unicity` (
             `itemtype_source`,
@@ -746,7 +746,7 @@ function update94xto950() {
    // Impact compounds
    if (!$DB->tableExists('glpi_impactcompounds')) {
       $query = "CREATE TABLE `glpi_impactcompounds` (
-            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `id` INT NOT NULL AUTO_INCREMENT,
             `name` VARCHAR(255) NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
             `color` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
             PRIMARY KEY (`id`)
@@ -757,10 +757,10 @@ function update94xto950() {
    // Impact parents
    if (!$DB->tableExists('glpi_impactitems')) {
       $query = "CREATE TABLE `glpi_impactitems` (
-            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `id` INT NOT NULL AUTO_INCREMENT,
             `itemtype` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
-            `items_id` INT(11) NOT NULL DEFAULT '0',
-            `parent_id` INT(11) NOT NULL DEFAULT '0',
+            `items_id` INT NOT NULL DEFAULT '0',
+            `parent_id` INT NOT NULL DEFAULT '0',
             `zoom` FLOAT NOT NULL DEFAULT '0',
             `pan_x` FLOAT NOT NULL DEFAULT '0',
             `pan_y` FLOAT NOT NULL DEFAULT '0',
@@ -771,7 +771,7 @@ function update94xto950() {
             `position_y` FLOAT NOT NULL DEFAULT '0',
             `show_depends` TINYINT NOT NULL DEFAULT '1',
             `show_impact` TINYINT NOT NULL DEFAULT '1',
-            `max_depth` INT(11) NOT NULL DEFAULT '5',
+            `max_depth` INT NOT NULL DEFAULT '5',
             PRIMARY KEY (`id`),
             UNIQUE KEY `unicity` (
                `itemtype`,
@@ -853,10 +853,10 @@ function update94xto950() {
    /** Kanban */
    if (!$DB->tableExists('glpi_items_kanbans')) {
       $query = "CREATE TABLE `glpi_items_kanbans` (
-         `id` int(11) NOT NULL AUTO_INCREMENT,
+         `id` int NOT NULL AUTO_INCREMENT,
          `itemtype` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
-         `items_id` int(11) DEFAULT NULL,
-         `users_id` int(11) NOT NULL,
+         `items_id` int DEFAULT NULL,
+         `users_id` int NOT NULL,
          `state` text COLLATE utf8_unicode_ci,
          `date_mod` timestamp NULL DEFAULT NULL,
          `date_creation` timestamp NULL DEFAULT NULL,
@@ -866,7 +866,7 @@ function update94xto950() {
       $DB->queryOrDie($query, "add table glpi_kanbans");
    }
    if (!$DB->fieldExists('glpi_users', 'refresh_views')) {
-      $migration->changeField('glpi_users', 'refresh_ticket_list', 'refresh_views', 'int(11) DEFAULT NULL');
+      $migration->changeField('glpi_users', 'refresh_ticket_list', 'refresh_views', 'int DEFAULT NULL');
    }
    $migration->addPostQuery(
       $DB->buildUpdate(
@@ -915,9 +915,9 @@ function update94xto950() {
    /** Add glpi_vobjects table for CalDAV server */
    if (!$DB->tableExists('glpi_vobjects')) {
       $query = "CREATE TABLE `glpi_vobjects` (
-            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `id` INT NOT NULL AUTO_INCREMENT,
             `itemtype` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
-            `items_id` int(11) NOT NULL DEFAULT '0',
+            `items_id` int NOT NULL DEFAULT '0',
             `data` text COLLATE utf8_unicode_ci,
             `date_mod` timestamp NULL DEFAULT NULL,
             `date_creation` timestamp NULL DEFAULT NULL,
@@ -954,7 +954,7 @@ function update94xto950() {
    ]);
    if (!$DB->tableExists('glpi_dashboards_dashboards')) {
       $query = "CREATE TABLE `glpi_dashboards_dashboards` (
-         `id` int(11) NOT NULL AUTO_INCREMENT,
+         `id` int NOT NULL AUTO_INCREMENT,
          `key` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
          `name` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
          `context` varchar(100) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'core',
@@ -965,14 +965,14 @@ function update94xto950() {
    }
    if (!$DB->tableExists('glpi_dashboards_items')) {
       $query = "CREATE TABLE `glpi_dashboards_items` (
-        `id` int(11) NOT NULL AUTO_INCREMENT,
-        `dashboards_dashboards_id` int(11) NOT NULL,
+        `id` int NOT NULL AUTO_INCREMENT,
+        `dashboards_dashboards_id` int NOT NULL,
         `gridstack_id` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
         `card_id` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
-        `x` int(11) DEFAULT NULL,
-        `y` int(11) DEFAULT NULL,
-        `width` int(11) DEFAULT NULL,
-        `height` int(11) DEFAULT NULL,
+        `x` int DEFAULT NULL,
+        `y` int DEFAULT NULL,
+        `width` int DEFAULT NULL,
+        `height` int DEFAULT NULL,
         `card_options` text COLLATE utf8_unicode_ci,
         PRIMARY KEY (`id`),
         KEY `dashboards_dashboards_id` (`dashboards_dashboards_id`)
@@ -981,10 +981,10 @@ function update94xto950() {
    }
    if (!$DB->tableExists('glpi_dashboards_rights')) {
       $query = "CREATE TABLE `glpi_dashboards_rights` (
-         `id` int(11) NOT NULL AUTO_INCREMENT,
-         `dashboards_dashboards_id` int(11) NOT NULL,
+         `id` int NOT NULL AUTO_INCREMENT,
+         `dashboards_dashboards_id` int NOT NULL,
          `itemtype` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
-         `items_id` int(11) NOT NULL,
+         `items_id` int NOT NULL,
          PRIMARY KEY (`id`),
          KEY `dashboards_dashboards_id` (`dashboards_dashboards_id`),
          UNIQUE KEY `unicity` (`dashboards_dashboards_id`, `itemtype`,`items_id`)
@@ -1075,10 +1075,10 @@ function update94xto950() {
    /** Domains */
    if (!$DB->tableExists('glpi_domaintypes')) {
       $query = "CREATE TABLE `glpi_domaintypes` (
-            `id` int(11) NOT NULL        AUTO_INCREMENT,
+            `id` int NOT NULL        AUTO_INCREMENT,
             `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-            `entities_id` int(11) NOT NULL        DEFAULT '0',
-            `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+            `entities_id` int NOT NULL        DEFAULT '0',
+            `is_recursive` tinyint NOT NULL DEFAULT '0',
             `comment` text COLLATE utf8_unicode_ci,
             PRIMARY KEY (`id`),
             KEY `name` (`name`)
@@ -1115,9 +1115,9 @@ function update94xto950() {
 
    if (!$DB->tableExists('glpi_domains_items')) {
       $query = "CREATE TABLE `glpi_domains_items` (
-            `id` int(11) NOT NULL AUTO_INCREMENT,
-            `domains_id` int(11) NOT NULL DEFAULT '0',
-            `items_id` int(11) NOT NULL DEFAULT '0',
+            `id` int NOT NULL AUTO_INCREMENT,
+            `domains_id` int NOT NULL DEFAULT '0',
+            `items_id` int NOT NULL DEFAULT '0',
             `itemtype` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
             PRIMARY KEY (`id`),
             UNIQUE KEY `unicity` (`domains_id`, `itemtype`, `items_id`),
@@ -1197,10 +1197,10 @@ function update94xto950() {
    /** Domains relations */
    if (!$DB->tableExists('glpi_domainrelations')) {
       $query = "CREATE TABLE `glpi_domainrelations` (
-            `id` int(11) NOT NULL        AUTO_INCREMENT,
+            `id` int NOT NULL        AUTO_INCREMENT,
             `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-            `entities_id` int(11) NOT NULL        DEFAULT '0',
-            `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+            `entities_id` int NOT NULL        DEFAULT '0',
+            `is_recursive` tinyint NOT NULL DEFAULT '0',
             `comment` text COLLATE utf8_unicode_ci,
             PRIMARY KEY (`id`),
             KEY `name` (`name`)
@@ -1226,10 +1226,10 @@ function update94xto950() {
    /** Domain records */
    if (!$DB->tableExists('glpi_domainrecordtypes')) {
       $query = "CREATE TABLE `glpi_domainrecordtypes` (
-            `id` int(11) NOT NULL        AUTO_INCREMENT,
+            `id` int NOT NULL        AUTO_INCREMENT,
             `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-            `entities_id` int(11) NOT NULL        DEFAULT '0',
-            `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+            `entities_id` int NOT NULL        DEFAULT '0',
+            `is_recursive` tinyint NOT NULL DEFAULT '0',
             `comment` text COLLATE utf8_unicode_ci,
             PRIMARY KEY (`id`),
             KEY `name` (`name`)
@@ -1249,17 +1249,17 @@ function update94xto950() {
 
    if (!$DB->tableExists('glpi_domainrecords')) {
       $query = "CREATE TABLE `glpi_domainrecords` (
-            `id` int(11) NOT NULL AUTO_INCREMENT,
+            `id` int NOT NULL AUTO_INCREMENT,
             `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
             `data` text COLLATE utf8_unicode_ci DEFAULT NULL,
-            `entities_id` int(11) NOT NULL DEFAULT '0',
-            `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-            `domains_id` int(11) NOT NULL DEFAULT '0',
-            `domainrecordtypes_id` int(11) NOT NULL DEFAULT '0',
-            `ttl` int(11) NOT NULL,
-            `users_id_tech` int(11) NOT NULL DEFAULT '0',
-            `groups_id_tech` int(11) NOT NULL DEFAULT '0',
-            `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
+            `entities_id` int NOT NULL DEFAULT '0',
+            `is_recursive` tinyint NOT NULL DEFAULT '0',
+            `domains_id` int NOT NULL DEFAULT '0',
+            `domainrecordtypes_id` int NOT NULL DEFAULT '0',
+            `ttl` int NOT NULL,
+            `users_id_tech` int NOT NULL DEFAULT '0',
+            `groups_id_tech` int NOT NULL DEFAULT '0',
+            `is_deleted` tinyint NOT NULL DEFAULT '0',
             `comment` text COLLATE utf8_unicode_ci,
             `date_mod` timestamp NULL DEFAULT NULL,
             `date_creation` timestamp NULL DEFAULT NULL,
@@ -1386,7 +1386,7 @@ HTML
    // Create new impact_context table
    if (!$DB->tableExists('glpi_impactcontexts')) {
       $query = "CREATE TABLE `glpi_impactcontexts` (
-            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `id` INT NOT NULL AUTO_INCREMENT,
             `positions` TEXT NOT NULL COLLATE 'utf8_unicode_ci',
             `zoom` FLOAT NOT NULL DEFAULT '0',
             `pan_x` FLOAT NOT NULL DEFAULT '0',
@@ -1394,9 +1394,9 @@ HTML
             `impact_color` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
             `depends_color` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
             `impact_and_depends_color` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
-            `show_depends` TINYINT(1) NOT NULL DEFAULT '1',
-            `show_impact` TINYINT(1) NOT NULL DEFAULT '1',
-            `max_depth` INT(11) NOT NULL DEFAULT '5',
+            `show_depends` TINYINT NOT NULL DEFAULT '1',
+            `show_impact` TINYINT NOT NULL DEFAULT '1',
+            `max_depth` INT NOT NULL DEFAULT '5',
             PRIMARY KEY (`id`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
       $DB->queryOrDie($query, "add table glpi_impactcontexts");
@@ -1791,23 +1791,23 @@ HTML
    /** Passive Datacenter equipments */
    if (!$DB->tableExists('glpi_passivedcequipments')) {
       $query = "CREATE TABLE `glpi_passivedcequipments` (
-         `id` int(11) NOT NULL AUTO_INCREMENT,
+         `id` int NOT NULL AUTO_INCREMENT,
          `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-         `entities_id` int(11) NOT NULL DEFAULT '0',
-         `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-         `locations_id` int(11) NOT NULL DEFAULT '0',
+         `entities_id` int NOT NULL DEFAULT '0',
+         `is_recursive` tinyint NOT NULL DEFAULT '0',
+         `locations_id` int NOT NULL DEFAULT '0',
          `serial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
          `otherserial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-         `passivedcequipmentmodels_id` int(11) DEFAULT NULL,
-         `passivedcequipmenttypes_id` int(11) NOT NULL DEFAULT '0',
-         `users_id_tech` int(11) NOT NULL DEFAULT '0',
-         `groups_id_tech` int(11) NOT NULL DEFAULT '0',
-         `is_template` tinyint(1) NOT NULL DEFAULT '0',
+         `passivedcequipmentmodels_id` int DEFAULT NULL,
+         `passivedcequipmenttypes_id` int NOT NULL DEFAULT '0',
+         `users_id_tech` int NOT NULL DEFAULT '0',
+         `groups_id_tech` int NOT NULL DEFAULT '0',
+         `is_template` tinyint NOT NULL DEFAULT '0',
          `template_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-         `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-         `states_id` int(11) NOT NULL DEFAULT '0' COMMENT 'RELATION to states (id)',
+         `is_deleted` tinyint NOT NULL DEFAULT '0',
+         `states_id` int NOT NULL DEFAULT '0' COMMENT 'RELATION to states (id)',
          `comment` text COLLATE utf8_unicode_ci,
-         `manufacturers_id` int(11) NOT NULL DEFAULT '0',
+         `manufacturers_id` int NOT NULL DEFAULT '0',
          `date_mod` timestamp NULL DEFAULT NULL,
          `date_creation` timestamp NULL DEFAULT NULL,
          PRIMARY KEY (`id`),
@@ -1827,16 +1827,16 @@ HTML
    }
    if (!$DB->tableExists('glpi_passivedcequipmentmodels')) {
       $query = "CREATE TABLE `glpi_passivedcequipmentmodels` (
-         `id` int(11) NOT NULL AUTO_INCREMENT,
+         `id` int NOT NULL AUTO_INCREMENT,
          `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
          `comment` text COLLATE utf8_unicode_ci,
          `product_number` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-         `weight` int(11) NOT NULL DEFAULT '0',
-         `required_units` int(11) NOT NULL DEFAULT '1',
+         `weight` int NOT NULL DEFAULT '0',
+         `required_units` int NOT NULL DEFAULT '1',
          `depth` float NOT NULL DEFAULT 1,
-         `power_connections` int(11) NOT NULL DEFAULT '0',
-         `power_consumption` int(11) NOT NULL DEFAULT '0',
-         `is_half_rack` tinyint(1) NOT NULL DEFAULT '0',
+         `power_connections` int NOT NULL DEFAULT '0',
+         `power_consumption` int NOT NULL DEFAULT '0',
+         `is_half_rack` tinyint NOT NULL DEFAULT '0',
          `picture_front` text COLLATE utf8_unicode_ci,
          `picture_rear` text COLLATE utf8_unicode_ci,
          `date_mod` timestamp NULL DEFAULT NULL,
@@ -1851,7 +1851,7 @@ HTML
    }
    if (!$DB->tableExists('glpi_passivedcequipmenttypes')) {
       $query = "CREATE TABLE `glpi_passivedcequipmenttypes` (
-         `id` int(11) NOT NULL AUTO_INCREMENT,
+         `id` int NOT NULL AUTO_INCREMENT,
          `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
          `comment` text COLLATE utf8_unicode_ci,
          `date_mod` timestamp NULL DEFAULT NULL,
@@ -1913,12 +1913,12 @@ HTML
    //Create remindertranslations table
    if (!$DB->tableExists('glpi_remindertranslations')) {
       $query = "CREATE TABLE `glpi_remindertranslations` (
-                 `id` int(11) NOT NULL AUTO_INCREMENT,
-                 `reminders_id` int(11) NOT NULL DEFAULT '0',
+                 `id` int NOT NULL AUTO_INCREMENT,
+                 `reminders_id` int NOT NULL DEFAULT '0',
                  `language` varchar(5) COLLATE utf8_unicode_ci DEFAULT NULL,
                  `name` text COLLATE utf8_unicode_ci,
                  `text` longtext COLLATE utf8_unicode_ci,
-                 `users_id` int(11) NOT NULL DEFAULT '0',
+                 `users_id` int NOT NULL DEFAULT '0',
                  `date_mod` timestamp NULL DEFAULT NULL,
                  `date_creation` timestamp NULL DEFAULT NULL,
                  PRIMARY KEY (`id`),

--- a/install/migrations/update_9.4.x_to_9.5.0/appliances.php
+++ b/install/migrations/update_9.4.x_to_9.5.0/appliances.php
@@ -32,23 +32,23 @@
 
 if (!$DB->tableExists('glpi_appliances')) {
    $query = "CREATE TABLE `glpi_appliances` (
-         `id` int(11) NOT NULL auto_increment,
-         `entities_id` int(11) NOT NULL DEFAULT '0',
-         `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
+         `id` int NOT NULL auto_increment,
+         `entities_id` int NOT NULL DEFAULT '0',
+         `is_recursive` tinyint NOT NULL DEFAULT '0',
          `name` varchar(255) NOT NULL DEFAULT '',
-         `is_deleted` tinyint(1) NOT NULL DEFAULT '0',
-         `appliancetypes_id` int(11) NOT NULL DEFAULT '0',
+         `is_deleted` tinyint NOT NULL DEFAULT '0',
+         `appliancetypes_id` int NOT NULL DEFAULT '0',
          `comment` text,
-         `locations_id` int(11) NOT NULL DEFAULT '0',
-         `manufacturers_id` int(11) NOT NULL DEFAULT '0',
-         `applianceenvironments_id` int(11) NOT NULL DEFAULT '0',
-         `users_id` int(11) NOT NULL DEFAULT '0',
-         `users_id_tech` int(11) NOT NULL DEFAULT '0',
-         `groups_id` int(11) NOT NULL DEFAULT '0',
-         `groups_id_tech` int(11) NOT NULL DEFAULT '0',
-         `relationtype` int(11) NOT NULL DEFAULT '0',
+         `locations_id` int NOT NULL DEFAULT '0',
+         `manufacturers_id` int NOT NULL DEFAULT '0',
+         `applianceenvironments_id` int NOT NULL DEFAULT '0',
+         `users_id` int NOT NULL DEFAULT '0',
+         `users_id_tech` int NOT NULL DEFAULT '0',
+         `groups_id` int NOT NULL DEFAULT '0',
+         `groups_id_tech` int NOT NULL DEFAULT '0',
+         `relationtype` int NOT NULL DEFAULT '0',
          `date_mod` timestamp NULL DEFAULT NULL,
-         `states_id` int(11) NOT NULL DEFAULT '0',
+         `states_id` int NOT NULL DEFAULT '0',
          `externalidentifier` varchar(255) DEFAULT NULL,
          `serial` varchar(255) DEFAULT NULL,
          `otherserial` varchar(255) DEFAULT NULL,
@@ -74,9 +74,9 @@ if (!$DB->tableExists('glpi_appliances')) {
 
 if (!$DB->tableExists('glpi_appliances_items')) {
    $query = "CREATE TABLE `glpi_appliances_items` (
-         `id` int(11) NOT NULL auto_increment,
-         `appliances_id` int(11) NOT NULL default '0',
-         `items_id` int(11) NOT NULL default '0',
+         `id` int NOT NULL auto_increment,
+         `appliances_id` int NOT NULL default '0',
+         `items_id` int NOT NULL default '0',
          `itemtype` VARCHAR(100) NOT NULL default '',
          PRIMARY KEY (`id`),
          UNIQUE `unicity` (`appliances_id`,`items_id`,`itemtype`),
@@ -88,9 +88,9 @@ if (!$DB->tableExists('glpi_appliances_items')) {
 
 if (!$DB->tableExists('glpi_appliancetypes')) {
    $query = "CREATE TABLE `glpi_appliancetypes` (
-         `id` int(11) NOT NULL auto_increment,
-         `entities_id` int(11) NOT NULL default '0',
-         `is_recursive` tinyint(1) NOT NULL default '0',
+         `id` int NOT NULL auto_increment,
+         `entities_id` int NOT NULL default '0',
+         `is_recursive` tinyint NOT NULL default '0',
          `name` varchar(255) NOT NULL default '',
          `comment` text,
          `externalidentifier` varchar(255) NULL,
@@ -104,7 +104,7 @@ if (!$DB->tableExists('glpi_appliancetypes')) {
 
 if (!$DB->tableExists('glpi_applianceenvironments')) {
    $query = "CREATE TABLE `glpi_applianceenvironments` (
-         `id` int(11) NOT NULL auto_increment,
+         `id` int NOT NULL auto_increment,
          `name` varchar(255) default NULL,
          `comment` text,
          PRIMARY KEY (`id`),
@@ -115,9 +115,9 @@ if (!$DB->tableExists('glpi_applianceenvironments')) {
 
 if (!$DB->tableExists('glpi_appliancerelations')) {
    $query = "CREATE TABLE `glpi_appliancerelations` (
-         `id` int(11) NOT NULL auto_increment,
-         `appliances_items_id` int(11) NOT NULL default '0',
-         `relations_id` int(11) NOT NULL default '0' comment 'locations_id,domains_id or networks_id',
+         `id` int NOT NULL auto_increment,
+         `appliances_items_id` int NOT NULL default '0',
+         `relations_id` int NOT NULL default '0' comment 'locations_id,domains_id or networks_id',
          PRIMARY KEY (`id`),
          KEY `appliances_items_id` (`appliances_items_id`),
          KEY `relations_id` (`relations_id`)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Integer display width is deprecated in MySQL 8.x and will probably be removed in a future major version.
We already remove its usage in GLPI 9.5.x->10.0.0 migrations and in `glpi-empty.sql` DB init script.