### PR TITLE
Link closed Ticket/Problems/Changes

### DIFF
--- a/inc/change_problem.class.php
+++ b/inc/change_problem.class.php
@@ -164,7 +164,6 @@ class Change_Problem extends CommonDBRelation{
             'used'        => $used,
             'entity'      => $problem->getEntityID(),
             'entity_sons' => $problem->isRecursive(),
-            'condition'   => Change::getOpenCriteria(),
          ]);
          echo "</td><td class='center'>";
          echo "<input type='submit' name='add' value=\""._sx('button', 'Add')."\" class='submit'>";

--- a/inc/change_ticket.class.php
+++ b/inc/change_ticket.class.php
@@ -251,9 +251,7 @@ class Change_Ticket extends CommonDBRelation{
          $used[$data['id']]    = $data['id'];
       }
 
-      if ($canedit
-          && !in_array($change->fields['status'], array_merge($change->getClosedStatusArray(),
-                                                              $change->getSolvedStatusArray()))) {
+      if ($canedit) {
          echo "<div class='firstbloc'>";
          echo "<form name='changeticket_form$rand' id='changeticket_form$rand' method='post'
                 action='".Toolbox::getItemTypeFormURL(__CLASS__)."'>";
@@ -380,9 +378,7 @@ class Change_Ticket extends CommonDBRelation{
          $used[$data['id']]    = $data['id'];
       }
 
-      if ($canedit
-          && !in_array($ticket->fields['status'], array_merge($ticket->getClosedStatusArray(),
-                                                              $ticket->getSolvedStatusArray()))) {
+      if ($canedit) {
          echo "<div class='firstbloc'>";
          echo "<form name='changeticket_form$rand' id='changeticket_form$rand' method='post'
                action='".Toolbox::getItemTypeFormURL(__CLASS__)."'>";

--- a/inc/problem_ticket.class.php
+++ b/inc/problem_ticket.class.php
@@ -292,7 +292,6 @@ class Problem_Ticket extends CommonDBRelation{
             'entity'      => $problem->getEntityID(),
             'entity_sons' => $problem->isRecursive(),
             'displaywith' => ['id'],
-            'condition'   => Ticket::getOpenCriteria()
          ]);
          echo "</td><td class='center'>";
          echo "<input type='submit' name='add' value=\""._sx('button', 'Add')."\" class='submit'>";

--- a/inc/problem_ticket.class.php
+++ b/inc/problem_ticket.class.php
@@ -277,9 +277,7 @@ class Problem_Ticket extends CommonDBRelation{
          $used[$ticket['id']] = $ticket['id'];
       }
 
-      if ($canedit
-          && !in_array($problem->fields['status'], array_merge($problem->getClosedStatusArray(),
-                                                               $problem->getSolvedStatusArray()))) {
+      if ($canedit) {
          echo "<div class='firstbloc'>";
          echo "<form name='changeticket_form$rand' id='changeticket_form$rand' method='post'
                action='".Toolbox::getItemTypeFormURL(__CLASS__)."'>";
@@ -382,9 +380,7 @@ class Problem_Ticket extends CommonDBRelation{
       foreach ($problems as $problem) {
          $used[$problem['id']] = $problem['id'];
       }
-      if ($canedit
-          && !in_array($ticket->fields['status'], array_merge($ticket->getClosedStatusArray(),
-                                                              $ticket->getSolvedStatusArray()))) {
+      if ($canedit) {
          echo "<div class='firstbloc'>";
          echo "<form name='problemticket_form$rand' id='problemticket_form$rand' method='post'
                 action='".Toolbox::getItemTypeFormURL(__CLASS__)."'>";


### PR DESCRIPTION
It's not currently possible to link a closed ticket/change/problem to another ticket/change/problem:

![image](https://user-images.githubusercontent.com/42734840/145000683-9b044e35-9976-4c58-a781-1a57cb6721a5.png)

As discussed, keeping this tab readonly on solved items can be troublesome for some use-case.

I've removed this restriction from `Change` <-> `Ticket` and `Ticket` <-> `Problem`.
`Change` <-> `Problem` didn't have this restriction so no changes needed here.

EDIT:
Second commit remove the "open items only" condition on Problems for the Ticket and Changes tabs.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23034
