### PR TITLE
Prevent warnings to break CSS; replace deprecated usages

### DIFF
--- a/front/css.php
+++ b/front/css.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * ---------------------------------------------------------------------
  * GLPI - Gestionnaire Libre de Parc Informatique
@@ -35,6 +34,8 @@ if (!defined('GLPI_ROOT')) {
    define('GLPI_ROOT', dirname(__DIR__));
 }
 
+use Glpi\Application\ErrorHandler;
+
 $_GET["donotcheckversion"]   = true;
 $dont_check_maintenance_mode = true;
 $skip_db_check               = true;
@@ -42,6 +43,9 @@ $skip_db_check               = true;
 //std cache, with DB connection
 include_once GLPI_ROOT . "/inc/db.function.php";
 include_once GLPI_ROOT . '/inc/config.php';
+
+// Ensure warnings will not break CSS output.
+ErrorHandler::getInstance()->disableOutput();
 
 $css = Html::compileScss($_GET);
 

--- a/inc/dashboard/widget.class.php
+++ b/inc/dashboard/widget.class.php
@@ -1999,12 +1999,13 @@ JAVASCRIPT;
       $scss = new Compiler();
 
       $glpi_root = GLPI_ROOT;
-      $palette_css = $scss->compile("{$css_dom_parent} {
+      $result = $scss->compileString("{$css_dom_parent} {
          \$ct-series-names: ({$series_names});
          \$ct-series-colors: ({$series_colors});
 
          @import '{$glpi_root}/css/includes/components/chartist/generate';
       }");
+      $palette_css = $result->getCss();
 
       $GLPI_CACHE->set($hash, $palette_css);
 

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -6559,7 +6559,8 @@ HTML;
       } else {
          try {
             Toolbox::logDebug("Compile $file");
-            $css = $scss->compile($import);
+            $result = $scss->compileString($import, dirname($path));
+            $css = $result->getCss();
             if (!isset($args['nocache'])) {
                $GLPI_CACHE->set($ckey, $css);
                $GLPI_CACHE->set($fckey, $file_hash);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

On PHP 8.1, in debug mode, main scss compilation triggers PHP deprecation warnings, and compiled CSS syntax is invalid due as it contains these warnings messages.
I propose to disable error handler output to prevent this behaviour. Warnings will still be logged in errors log.

Triggered warnings:
```
glpiphplog.NOTICE:   *** PHP Deprecated function (8192): strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/glpi/vendor/scssphp/scssphp/src/SourceMap/SourceMapGenerator.php at line 350
  Backtrace :
  ...cssphp/src/SourceMap/SourceMapGenerator.php:350 strpos()
  ...cssphp/src/SourceMap/SourceMapGenerator.php:205 ScssPhp\ScssPhp\SourceMap\SourceMapGenerator->normalizeFilename()
  vendor/scssphp/scssphp/src/Compiler.php:533        ScssPhp\ScssPhp\SourceMap\SourceMapGenerator->generateJson()
  inc/html.class.php:6562                            ScssPhp\ScssPhp\Compiler->compileString()
  front/css.php:50                                   Html::compileScss()
```