### PR TITLE
Simplify/enhance handling of unstable versions in update process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The present file will list all changes made to the project; according to the
 - Usage of `$order` parameter in `getAllDataFromTable()` (`DbUtils::getAllDataFromTable()`)
 - Usage of `table` parameter in requests made to `ajax/comments.php`
 - Usage of `GLPI_FORCE_EMPTY_SQL_MODE` constant
+- Usage of `GLPI_PREVER` constant
 - Support of `doc_types`, `helpdesk_types` and `netport_types` keys in `Plugin::registerClass()`
 - `$CFG_GLPI['layout_excluded_pages']` entry
 - `$CFG_GLPI['use_ajax_autocompletion']` entry
@@ -128,6 +129,7 @@ The present file will list all changes made to the project; according to the
 - `Contract::cloneItem()`
 - `Contract_Item::cloneItem()`
 - `ContractCost::cloneContract()`
+- `Config::agreeDevMessage()`
 - `Config::checkWriteAccessToDirs()`
 - `Config::displayCheckExtensions()`
 - `Config::getCache()`
@@ -192,6 +194,8 @@ The present file will list all changes made to the project; according to the
 - `NetworkPort::cloneItem()`
 - `Notepad::cloneItem()`
 - `NotificationTargetTicket::isAuthorMailingActivatedForHelpdesk()`
+- `Plugin::getGlpiPrever()`
+- `Plugin::isGlpiPrever()`
 - `Plugin::setLoaded()`
 - `Plugin::setUnloaded()`
 - `Plugin::setUnloadedByName()`

--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -87,8 +87,6 @@ include_once (GLPI_ROOT . "/inc/autoload.function.php");
       'GLPI_NETWORK_SERVICES'             => 'https://services.glpi-network.com', // GLPI Network services project URL
       'GLPI_NETWORK_REGISTRATION_API_URL' => '{GLPI_NETWORK_SERVICES}/api/registration/',
       'GLPI_MARKETPLACE_PLUGINS_API_URI'  => '{GLPI_NETWORK_SERVICES}/api/glpi-plugins/',
-      // TODO set false before final release of 9.5.0 and remove this comment
-      'GLPI_MARKETPLACE_PRERELEASES'      => false, // display pre-releases of plugins in marketplace
       'GLPI_MARKETPLACE_ALLOW_OVERRIDE'   => true, // allow marketplace to override a plugin found outside GLPI_MARKETPLACE_DIR
       'GLPI_MARKETPLACE_MANUAL_DOWNLOADS' => true, // propose manual download link of plugins which cannot be installed/updated by marketplace
       'GLPI_USER_AGENT_EXTRA_COMMENTS'    => '', // Extra comment to add to GLPI User-Agent

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2839,32 +2839,36 @@ HTML;
    }
 
    /**
-    * Get message that informs the user he's using a development version
+    * Get message that informs the user he is using an unstable version.
     *
-    * @param boolean $bg Display a background
+    * @param bool $is_dev
     *
     * @return void
     */
-   public static function agreeDevMessage($bg = false) {
-      $msg = '<div class="'.($bg ? 'alert-important' : '') .' alert alert-warning">
-         <strong>' . __('You are using a development version, be careful!') . '</strong>
+   public static function agreeUnstableMessage(bool $is_dev) {
+      $msg = $is_dev
+         ? __('You are using a development version, be careful!')
+         : __('You are using a pre-release version, be careful!');
+
+      $out = '<div class="alert alert-warning">
+         <strong>' . $msg . '</strong>
          <br/>';
-      $msg .= "<div class='form-check'>
-         <input type='checkbox' class='form-check-input' required='required' id='agree_dev' name='agree_dev'>
-         <label for='agree_dev' class='form-check-label'>" . __('I know I am using a unstable version.') . "</label>
+      $out .= "<div class='form-check'>
+         <input type='checkbox' class='form-check-input' required='required' id='agree_unstable' name='agree_unstable'>
+         <label for='agree_unstable' class='form-check-label'>" . __('I know I am using a unstable version.') . "</label>
       </div>
       </div>";
-      $msg .= "<script type=text/javascript>
+      $out .= "<script type=text/javascript>
             $(function() {
                $('[name=from_update]').on('click', function(event){
-                  if(!$('#agree_dev').is(':checked')) {
+                  if(!$('#agree_unstable').is(':checked')) {
                      event.preventDefault();
                      alert('" . __('Please check the unstable version checkbox.') . "');
                   }
                });
             });
             </script>";
-      return $msg;
+      return $out;
    }
 
    /**

--- a/inc/define.php
+++ b/inc/define.php
@@ -33,17 +33,12 @@
 
 // Current version of GLPI
 define('GLPI_VERSION', '10.0.0-dev');
-if (substr(GLPI_VERSION, -4) === '-dev') {
-   //for dev version
-   define('GLPI_PREVER', str_replace('-dev', '', GLPI_VERSION));
-   define(
-      'GLPI_SCHEMA_VERSION',
-      GLPI_PREVER . '@' . sha1_file(GLPI_ROOT . '/install/mysql/glpi-empty.sql')
-   );
-} else {
-   //for stable version
-   define("GLPI_SCHEMA_VERSION", '10.0.0');
+define("GLPI_SCHEMA_VERSION", GLPI_VERSION . '@' . sha1_file(GLPI_ROOT . '/install/mysql/glpi-empty.sql'));
+
+if (!defined('GLPI_MARKETPLACE_PRERELEASES')) {
+   define('GLPI_MARKETPLACE_PRERELEASES', preg_match('/-(dev|alpha\d*|beta\d*|rc\d*)$/', GLPI_VERSION) === 1);
 }
+
 define('GLPI_MIN_PHP', '7.4.0'); // Must also be changed in top of index.php
 define('GLPI_YEAR', '2021');
 

--- a/inc/glpinetwork.class.php
+++ b/inc/glpinetwork.class.php
@@ -34,6 +34,8 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use Glpi\Toolbox\VersionParser;
+
 class GLPINetwork extends CommonGLPI {
 
    public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
@@ -134,7 +136,7 @@ class GLPINetwork extends CommonGLPI {
     * @return string
     */
    public static function getGlpiUserAgent(): string {
-      $version = defined('GLPI_PREVER') ? GLPI_PREVER : GLPI_VERSION;
+      $version = VersionParser::getNormalizedVersion(GLPI_VERSION, false);
       $comments = sprintf('installation-mode:%s', GLPI_INSTALL_MODE);
       if (!empty(GLPI_USER_AGENT_EXTRA_COMMENTS)) {
          // append extra comments (remove '(' and ')' chars to not break UA string)

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -6474,7 +6474,7 @@ HTML;
       }
 
       $ckey = 'css_';
-      $ckey .= isset($args['v']) ? $args['v'] : GLPI_SCHEMA_VERSION;
+      $ckey .= isset($args['v']) ? $args['v'] : GLPI_VERSION;
 
       $scss = new Compiler();
       if (isset($args['debug'])) {

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -42,6 +42,7 @@ use Glpi\Cache\CacheManager;
 use Glpi\Marketplace\Controller as MarketplaceController;
 use Glpi\Marketplace\View as MarketplaceView;
 use Glpi\Plugin\Hooks;
+use Glpi\Toolbox\VersionParser;
 
 class Plugin extends CommonDBTM {
 
@@ -1789,7 +1790,7 @@ class Plugin extends CommonDBTM {
          throw new \LogicException('Either "min" or "max" is required for GLPI requirements!');
       }
 
-      $glpiVersion = $this->isGlpiPrever() ? $this->getGlpiPrever() : $this->getGlpiVersion();
+      $glpiVersion = $this->getGlpiVersion();
 
       $compat = true;
       if (isset($infos['min']) && !version_compare($glpiVersion, $infos['min'], '>=')) {
@@ -1945,30 +1946,7 @@ class Plugin extends CommonDBTM {
     * @return string
     */
    public function getGlpiVersion() {
-      return GLPI_VERSION;
-   }
-
-   /**
-    * Get GLPI pre version
-    * Used from unit tests to mock.
-    *
-    * @since 9.2
-    *
-    * @return string
-    */
-   public function getGlpiPrever() {
-      return GLPI_PREVER;
-   }
-
-   /**
-    * Check if GLPI version is a pre version
-    *
-    * @since 9.3
-    *
-    * @return string
-    */
-   public function isGlpiPrever() {
-      return defined('GLPI_PREVER');
+      return VersionParser::getNormalizedVersion(GLPI_VERSION, false);
    }
 
    /**

--- a/inc/toolbox/versionparser.class.php
+++ b/inc/toolbox/versionparser.class.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Toolbox;
+
+class VersionParser {
+
+   /**
+    * Pattern used to detect/extract unstable flag.
+    * @var string
+    */
+   private const UNSTABLE_FLAG_PATTERN = '(dev|alpha\d*|beta\d*|rc\d*)';
+
+   /**
+    * Normalize version number.
+    *
+    * @param string $version
+    * @param bool $keep_stability_flag
+    *
+    * @return string
+    */
+   public static function getNormalizedVersion(string $version, bool $keep_stability_flag = true): string {
+      $version_pattern = implode(
+         '',
+         [
+            '/^',
+            '(?<major>\d+)', // Major release numero, always present
+            '\.(?<minor>\d+)', // Minor release numero, always present
+            '(\.(?<bugfix>\d+))?', // Bugfix numero, not always present (e.g. GLPI 9.2)
+            '(\.(?<tag_fail>\d+))?', // Redo tag operation numero, rarely present (e.g. GLPI 9.4.1.1)
+            '(?<stability_flag>-' . self::UNSTABLE_FLAG_PATTERN . ')?', // Stability flag, optional
+            '$/'
+         ]
+      );
+      $version_matches = [];
+      if (preg_match($version_pattern, $version, $version_matches) === 1) {
+         $version = $version_matches['major']
+            . '.' . $version_matches['minor']
+            . '.' . ($version_matches['bugfix'] ?? 0)
+            . ($keep_stability_flag && array_key_exists('stability_flag', $version_matches) ? $version_matches['stability_flag'] : '');
+      }
+
+      return $version;
+   }
+
+   /**
+    * Check if given version is a stable release (i.e. does not contains a stability flag refering to unstable state).
+    *
+    * @param string $version
+    *
+    * @return bool
+    */
+   public static function isStableRelease(string $version): bool {
+      return preg_match('/-' . self::UNSTABLE_FLAG_PATTERN . '$/', $version) !== 1;
+   }
+
+   /**
+    * Check if given version is a dev version (i.e. ends with `-dev`).
+    *
+    * @param string $version
+    *
+    * @return bool
+    */
+   public static function isDevVersion(string $version): bool {
+      return preg_match('/-dev$/', $version) === 1;
+   }
+}

--- a/inc/update.class.php
+++ b/inc/update.class.php
@@ -34,6 +34,8 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+use Glpi\Toolbox\VersionParser;
+
 /**
  *  Update class
 **/
@@ -296,15 +298,7 @@ class Update {
    public function getMigrationsToDo(string $current_version, bool $force_latest = false): array {
       $migrations = [];
 
-      // Normalize version to 'x.y.z-suffix'
-      $version_pattern = '/^(?<major>\d+)\.(?<minor>\d+)(\.(?<bugfix>\d+))?(\.(?<tag_fail>\d+))?(?<suffix>-dev)?$/';
-      $current_version_matches = [];
-      if (preg_match($version_pattern, $current_version, $current_version_matches) === 1) {
-         $current_version = $current_version_matches['major']
-            . '.' . $current_version_matches['minor']
-            . '.' . ($current_version_matches['bugfix'] ?? 0)
-            . ($current_version_matches['suffix'] ?? '');
-      }
+      $current_version = VersionParser::getNormalizedVersion($current_version);
 
       $pattern = '/^update_(?<source_version>\d+\.\d+\.(?:\d+|x))_to_(?<target_version>\d+\.\d+\.(?:\d+|x))\.php$/';
       $migration_iterator = new DirectoryIterator(GLPI_ROOT . '/install/migrations/');

--- a/install/update.php
+++ b/install/update.php
@@ -32,6 +32,7 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Cache\CacheManager;
+use Glpi\Toolbox\VersionParser;
 
 if (!defined('GLPI_ROOT')) {
    define('GLPI_ROOT', realpath('..'));
@@ -120,13 +121,12 @@ function doUpdateDb() {
    $current_version     = $currents['version'];
    $current_db_version  = $currents['dbversion'];
 
-   $migration = new Migration(GLPI_SCHEMA_VERSION);
+   $migration = new Migration(GLPI_VERSION);
    $update->setMigration($migration);
 
-   if (defined('GLPI_PREVER')) {
-      if ($current_db_version != GLPI_SCHEMA_VERSION && !isset($_POST['agree_dev'])) {
-         return;
-      }
+   if (!VersionParser::isStableRelease(GLPI_VERSION)
+       && $current_db_version != GLPI_SCHEMA_VERSION && !isset($_POST['agree_unstable'])) {
+      return;
    }
 
    $update->doUpdates($current_version);
@@ -208,8 +208,8 @@ if (empty($_POST["continuer"]) && empty($_POST["from_update"])) {
       echo "<h3 class='my-4'><span class='migred p-2'>".sprintf(__('Caution! You will update the GLPI database named: %s'), $DB->dbdefault) ."</h3>";
 
       echo "<form action='update.php' method='post'>";
-      if (strlen(GLPI_SCHEMA_VERSION) > 40) {
-         echo Config::agreeDevMessage();
+      if (!VersionParser::isStableRelease(GLPI_VERSION)) {
+         echo Config::agreeUnstableMessage(VersionParser::isDevVersion(GLPI_VERSION));
       }
       echo "<button type='submit' class='btn btn-primary' name='continuer' value='1'>
          ".__('Continue')."

--- a/tests/functionnal/Update.php
+++ b/tests/functionnal/Update.php
@@ -175,6 +175,54 @@ class Update extends \GLPITestCase {
             ],
          ],
          [
+            // Alpha versions always triggger latest migration
+            'current_version'     => '10.0.0-alpha',
+            'force_latest'        => false,
+            'expected_migrations' => [
+               $path . '/update_9.5.x_to_10.0.0.php' => 'update95xto1000',
+            ],
+         ],
+         [
+            // AlphaX versions always triggger latest migration
+            'current_version'     => '10.0.0-alpha3',
+            'force_latest'        => false,
+            'expected_migrations' => [
+               $path . '/update_9.5.x_to_10.0.0.php' => 'update95xto1000',
+            ],
+         ],
+         [
+            // Beta versions always triggger latest migration
+            'current_version'     => '10.0.0-beta',
+            'force_latest'        => false,
+            'expected_migrations' => [
+               $path . '/update_9.5.x_to_10.0.0.php' => 'update95xto1000',
+            ],
+         ],
+         [
+            // BetaX versions always triggger latest migration
+            'current_version'     => '10.0.0-beta1',
+            'force_latest'        => false,
+            'expected_migrations' => [
+               $path . '/update_9.5.x_to_10.0.0.php' => 'update95xto1000',
+            ],
+         ],
+         [
+            // RC versions always triggger latest migration
+            'current_version'     => '10.0.0-rc',
+            'force_latest'        => false,
+            'expected_migrations' => [
+               $path . '/update_9.5.x_to_10.0.0.php' => 'update95xto1000',
+            ],
+         ],
+         [
+            // RCX versions always triggger latest migration
+            'current_version'     => '10.0.0-rc2',
+            'force_latest'        => false,
+            'expected_migrations' => [
+               $path . '/update_9.5.x_to_10.0.0.php' => 'update95xto1000',
+            ],
+         ],
+         [
             // Force latests does not duplicate latest in list
             'current_version'     => '10.0.0-dev',
             'force_latest'        => true,

--- a/tests/units/Glpi/Toolbox/VersionParser.php
+++ b/tests/units/Glpi/Toolbox/VersionParser.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Toolbox;
+
+/**
+ * Test class for src/Glpi/Toolbox/versionparser.class.php
+ */
+class VersionParser extends \GLPITestCase {
+
+   protected function versionsProvider() {
+      return [
+         [
+            'version'             => '',
+            'keep_stability_flag' => false,
+            'normalized'          => '',
+            'stable'              => true,
+            'dev'                 => false,
+         ],
+         [
+            'version'             => '9.5+2.0',
+            'keep_stability_flag' => false,
+            'normalized'          => '9.5+2.0', // not semver compatible, cannot be normalized
+            'stable'              => true,
+            'dev'                 => false,
+         ],
+         [
+            'version'             => '0.89',
+            'keep_stability_flag' => false,
+            'normalized'          => '0.89.0',
+            'stable'              => true,
+            'dev'                 => false,
+         ],
+         [
+            'version'             => '9.2',
+            'keep_stability_flag' => false,
+            'normalized'          => '9.2.0',
+            'stable'              => true,
+            'dev'                 => false,
+         ],
+         [
+            'version'             => '9.2',
+            'keep_stability_flag' => true, // should have no effect
+            'normalized'          => '9.2.0',
+            'stable'              => true,
+            'dev'                 => false,
+         ],
+         [
+            'version'             => '9.4.1.1',
+            'keep_stability_flag' => false,
+            'normalized'          => '9.4.1',
+            'stable'              => true,
+            'dev'                 => false,
+         ],
+         [
+            'version'             => '10.0.0-dev',
+            'keep_stability_flag' => false,
+            'normalized'          => '10.0.0',
+            'stable'              => false,
+            'dev'                 => true,
+         ],
+         [
+            'version'             => '10.0.0-dev',
+            'keep_stability_flag' => true,
+            'normalized'          => '10.0.0-dev',
+            'stable'              => false,
+            'dev'                 => true,
+         ],
+         [
+            'version'             => '10.0.0-alpha',
+            'keep_stability_flag' => false,
+            'normalized'          => '10.0.0',
+            'stable'              => false,
+            'dev'                 => false,
+         ],
+         [
+            'version'             => '10.0.0-alpha2',
+            'keep_stability_flag' => true,
+            'normalized'          => '10.0.0-alpha2',
+            'stable'              => false,
+            'dev'                 => false,
+         ],
+         [
+            'version'             => '10.0.0-beta1',
+            'keep_stability_flag' => false,
+            'normalized'          => '10.0.0',
+            'stable'              => false,
+            'dev'                 => false,
+         ],
+         [
+            'version'             => '10.0.0-beta1',
+            'keep_stability_flag' => true,
+            'normalized'          => '10.0.0-beta1',
+            'stable'              => false,
+            'dev'                 => false,
+         ],
+         [
+            'version'             => '10.0.0-rc3',
+            'keep_stability_flag' => false,
+            'normalized'          => '10.0.0',
+            'stable'              => false,
+            'dev'                 => false,
+         ],
+         [
+            'version'             => '10.0.0-rc',
+            'keep_stability_flag' => true,
+            'normalized'          => '10.0.0-rc',
+            'stable'              => false,
+            'dev'                 => false,
+         ],
+         [
+            'version'             => '10.0.3',
+            'keep_stability_flag' => true,
+            'normalized'          => '10.0.3',
+            'stable'              => true,
+            'dev'                 => false,
+         ],
+      ];
+   }
+
+   /**
+    * @dataProvider versionsProvider
+    */
+   public function testGetNormalizeVersion(string $version, bool $keep_stability_flag, string $normalized, bool $stable, bool $dev): void {
+      $version_parser = $this->newTestedInstance();
+      $this->string($version_parser->getNormalizedVersion($version, $keep_stability_flag))->isEqualTo($normalized);
+   }
+
+   /**
+    * @dataProvider versionsProvider
+    */
+   public function testIsStableRelease(string $version, bool $keep_stability_flag, string $normalized, bool $stable, bool $dev): void {
+      $version_parser = $this->newTestedInstance();
+      $this->boolean($version_parser->isStableRelease($version))->isEqualTo($stable);
+   }
+
+   /**
+    * @dataProvider versionsProvider
+    */
+   public function testIsDevVersion(string $version, bool $keep_stability_flag, string $normalized, bool $stable, bool $dev): void {
+      $version_parser = $this->newTestedInstance();
+      $this->boolean($version_parser->isDevVersion($version))->isEqualTo($dev);
+   }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While analysing how pre-releases are handled, I figured out that it was quiet complex and was only handling `-dev` suffix in GLPI version. I tried to simplify this and add a correct handling of `-alphaX`, `-betaX`, `-rcX` suffixes.

- Permit upgrade from dev to dev version from UI
- Display "unstable" agreement when installing alpha/beta/rc versions
- Always add SQL init file hash in GLPI_SCHEMA_VERSION, as it will ensure update is always trigerred when file change and it will permit corrupted file detection
- Permit to install unstable plugins releases when using an unstable GLPI version