### PR TITLE
avoid dc breadcrumb to wrap icon and text

### DIFF
--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -118,7 +118,7 @@
                         {% set dc_breadcrumbs %}
                            <ol class="breadcrumb breadcrumb-arrows" aria-label="breadcrumbs">
                               {% for dc_item in dc_breadcrumbs|reverse %}
-                                 <li class="breadcrumb-item">{{ dc_item|raw }}</li>
+                                 <li class="breadcrumb-item text-nowrap">{{ dc_item|raw }}</li>
                               {% endfor %}
                            </ol>
                         {% endset %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

before:
![image](https://user-images.githubusercontent.com/418844/145198839-8d7e9a80-b0ba-4995-9b63-26619bcc01fb.png)

After:
![image](https://user-images.githubusercontent.com/418844/145198799-d88cc833-51e0-49d9-8f01-30634ce5f407.png)

