### PR TITLE
missing field in license form, creation was impossible

### DIFF
--- a/templates/pages/management/softwarelicense.html.twig
+++ b/templates/pages/management/softwarelicense.html.twig
@@ -33,6 +33,26 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 {% set params  = params ?? [] %}
 
+{% block form_fields %}
+   {{ fields.dropdownField(
+      'Software',
+      'softwares_id',
+      item.fields['softwares_id'],
+      "Software"|itemtype_name,
+      {
+         'entity': item.fields['entities_id'],
+         'condition': {
+            'is_template': 0,
+            'is_deleted': 0,
+         },
+      }
+   ) }}
+
+   {{ fields.nullField() }}
+
+   {{ parent() }}
+{% endblock %}
+
 {% block more_fields %}
    {% set field %}
       {% do call('SoftwareVersion::dropdownForOneSoftware', [{


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Software fieds was missing in the twig form

