### PR TITLE
Fix rules count

### DIFF
--- a/inc/rulecollection.class.php
+++ b/inc/rulecollection.class.php
@@ -91,15 +91,22 @@ class RuleCollection extends CommonDBTM {
     *
     * @param boolean $recursive (true by default)
     * @param integer $condition (0 by default)
+    * @param integer $children (0 by default)
     *
     * @return : number of rules
    **/
-   function getCollectionSize($recursive = true, $condition = 0) {
+   function getCollectionSize(
+      $recursive = true,
+      $condition = 0,
+      $children = 0
+   ) {
       global $DB;
 
       $restrict = $this->getRuleListCriteria([
          'condition' => $condition,
-         'active'    => false
+         'active'    => false,
+         'inherited' => $recursive,
+         'childrens' => $children,
       ]);
 
       $iterator = $DB->request($restrict);
@@ -115,7 +122,6 @@ class RuleCollection extends CommonDBTM {
     * @return array
    **/
    function getRuleListCriteria($options = []) {
-
       $p['active']    = true;
       $p['start']     = 0;
       $p['limit']     = 0;
@@ -448,7 +454,7 @@ class RuleCollection extends CommonDBTM {
          echo "</td></tr></table>";
       }
 
-      $nb         = $this->getCollectionSize($p['inherited'], $p['condition']);
+      $nb         = $this->getCollectionSize($p['inherited'], $p['condition'], $p['childrens']);
       $p['start'] = (isset($options["start"]) ? $options["start"] : 0);
 
       if ($p['start'] >= $nb) {


### PR DESCRIPTION
The number of rules displayed in the pager doesn't match the results:

![image](https://user-images.githubusercontent.com/42734840/145216786-0321549d-13d8-42fc-bb64-d65d59a00874.png)

The count request is built using `getRuleListCriteria`.

![image](https://user-images.githubusercontent.com/42734840/145217708-fd090f5c-55e0-4595-b104-a8a740105ec2.png)

This function support `inherited` and `childrens` params but they weren't being set when called from `getCollectionSize`.



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23047
