### PR TITLE
Ensure CommonGLPI constructor overrides have no params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The present file will list all changes made to the project; according to the
 - Added `CommonDBTM::showForm()` to have a generic showForm for asset (based on a twig template).
 
 #### Changes
+- `CommonGLPI` constructor signature has been declared in an interface (`CommonGLPIInterface`).
 - `DBmysqlIterator` class compliancy with `Iterator` has been fixed (i.e. `DBmysqlIterator::next()` does not return current row anymore).
 - `showForm()` method of all classes inheriting `CommonDBTM` have been changed to match `CommonDBTM::showForm()` signature.
 - Format of `Message-Id` header sent in Tickets notifications changed to match format used by other items.

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -174,12 +174,6 @@ class CommonDBTM extends CommonGLPI {
     */
    static $undisclosedFields = [];
 
-   /**
-    * Constructor
-   **/
-   function __construct () {
-   }
-
 
    /**
     * Return the table used to store this object

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -40,7 +40,7 @@ if (!defined('GLPI_ROOT')) {
 /**
  *  Common GLPI object
 **/
-class CommonGLPI {
+class CommonGLPI implements CommonGLPIInterface {
 
    /// GLPI Item type cache : set dynamically calling getType
    protected $type                 = -1;
@@ -73,6 +73,9 @@ class CommonGLPI {
    public $get_item_to_display_tab = false;
    static protected $othertabs     = [];
 
+
+   public function __construct() {
+   }
 
    /**
     * Return the localized name of the current Type

--- a/src/CommonGLPIInterface.php
+++ b/src/CommonGLPIInterface.php
@@ -30,11 +30,20 @@
  * ---------------------------------------------------------------------
  */
 
-namespace GlpiPlugin\Bar;
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
 
-class Something extends \CommonDBTM {
+/**
+ * CommonGLPI interface.
+ */
+interface CommonGLPIInterface {
 
-   public function __construct(array $param) {
-
-   }
+   /**
+    * Constructor.
+    *
+    * Declared in interface to ensure that `getItemForItemtype()` will be able to create an instance of CommonGLPI without
+    * having to pass any parameter.
+    */
+   public function __construct();
 }

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -424,18 +424,6 @@ final class DbUtils {
          return false;
       }
 
-      if (($constructor = $item_class->getConstructor()) !== null) {
-         foreach ($constructor->getParameters() as $parameter) {
-            if (!$parameter->isOptional()) {
-               trigger_error(
-                  sprintf('Cannot instanciate "%s" as its constructor has non optionnal parameters.', $itemtype),
-                  E_USER_WARNING
-               );
-               return false;
-            }
-         }
-      }
-
       return new $itemtype();
    }
 

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -245,21 +245,6 @@ class DbUtils extends DbTestCase {
             ->exists();
    }
 
-   public function testGetItemForItemtypeHavingConstructorWithMandatoryParameters() {
-      require_once __DIR__ . '/../fixtures/pluginbarsomething.php';
-
-      $this
-         ->if($this->newTestedInstance)
-         ->when(
-            function () {
-               $this->boolean($this->testedInstance->getItemForItemtype('GlpiPlugin\Bar\Something'))->isFalse();
-            }
-         )->error
-            ->withType(E_USER_WARNING)
-            ->withMessage('Cannot instanciate "GlpiPlugin\Bar\Something" as its constructor has non optionnal parameters.')
-            ->exists();
-   }
-
    public function dataPlural() {
 
       return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

We have some `new static()` in code, and some `new $itemtype()` also. If anyone overrides an itemtype constructor and defines some params in it, it will not work. Forcing lack of constructor arguments using an interface will prevent this kind of override.

See https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static