### PR TITLE
Fix dark theme detection in Kanban

### DIFF
--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -349,7 +349,7 @@ class GLPIKanbanRights {
             'allow_delete_item', 'supported_filters'
          ];
          // Use CSS variable check for dark theme detection by default
-         self.dark_theme = $('html').css('--is-dark').trim() === true;
+         self.dark_theme = $('html').css('--is-dark').trim() === 'true';
 
          if (args.length === 1) {
             for (let i = 0; i < overridableParams.length; i++) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

CSS variable is returned as a string, not a boolean.