### PR TITLE
fix(dashboard): cache issue with advanceddashboard

### DIFF
--- a/inc/dashboard/grid.class.php
+++ b/inc/dashboard/grid.class.php
@@ -957,6 +957,10 @@ HTML;
       }
       $card  = $cards[$card_id];
 
+      if (isset($card['keywords'])) {
+         $card_options['keywords'] = $card['keywords'];
+      }
+
       // manage cache
       $options_footprint = sha1(serialize($card_options).
          ($_SESSION['glpiactiveentities_string'] ?? "").

--- a/inc/dashboard/grid.class.php
+++ b/inc/dashboard/grid.class.php
@@ -957,8 +957,9 @@ HTML;
       }
       $card  = $cards[$card_id];
 
-      if (isset($card['keywords'])) {
-         $card_options['keywords'] = $card['keywords'];
+      // allows plugins to control uniqueness of its cards in cache system
+      if (isset($card['custom_hash'])) {
+         $card_options['custom_hash'] = $card['custom_hash'];
       }
 
       // manage cache


### PR DESCRIPTION
When we use, for example, the variable {{glpiID}} (=> GLPI user) in an advanceddashboard card, we sometimes get the result of another user. This happens when there are many simultaneous users.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23029
