### PR TITLE
Safety checks

### DIFF
--- a/inc/change_item.class.php
+++ b/inc/change_item.class.php
@@ -250,8 +250,9 @@ class Change_Item extends CommonItilObject_Item {
                         foreach ($linkeditems as $type => $tab) {
                            foreach ($tab as $ID) {
                               $typeitem = new $type;
-                              $typeitem->getFromDB($ID);
-                              $nb += self::countForItem($typeitem);
+                              if ($typeitem->getFromDB($ID)) {
+                                 $nb += self::countForItem($typeitem);
+                              }
                            }
                         }
                      }

--- a/inc/item_problem.class.php
+++ b/inc/item_problem.class.php
@@ -246,8 +246,9 @@ class Item_Problem extends CommonItilObject_Item {
                         foreach ($linkeditems as $type => $tab) {
                            $typeitem = new $type;
                            foreach ($tab as $ID) {
-                              $typeitem->getFromDB($ID);
-                              $nb += self::countForItem($typeitem);
+                              if ($typeitem->getFromDB($ID)) {
+                                 $nb += self::countForItem($typeitem);
+                              }
                            }
                         }
                      }


### PR DESCRIPTION
I've found the following warnings when viewing a computer:

```sh
[2021-12-09 10:15:59] glpiphplog.NOTICE:   *** PHP Notice (8): Undefined index: id in /var/www/glpi/inc/commondbrelation.class.php at line 1577
  Backtrace :
  inc/commondbrelation.class.php:1785                CommonDBRelation::getListForItemParams()
  inc/item_problem.class.php:250                     CommonDBRelation::countForItem()
  inc/commonglpi.class.php:339                       Item_Problem->getTabNameForItem()
  inc/computer.class.php:108                         CommonGLPI->addStandardTab()
  inc/commonglpi.class.php:294                       Computer->defineTabs()
  inc/commonglpi.class.php:859                       CommonGLPI->defineAllTabs()
  inc/commonglpi.class.php:1230                      CommonGLPI->showTabsContent()
  front/computer.form.php:106                        CommonGLPI->display()
```


```sh
[2021-12-09 10:10:33] glpiphplog.NOTICE:   *** PHP Notice (8): Undefined index: id in /var/www/glpi/inc/commondbrelation.class.php at line 1577
  Backtrace :
  inc/commondbrelation.class.php:1785                CommonDBRelation::getListForItemParams()
  inc/change_item.class.php:254                      CommonDBRelation::countForItem()
  inc/commonglpi.class.php:339                       Change_Item->getTabNameForItem()
  inc/computer.class.php:109                         CommonGLPI->addStandardTab()
  inc/commonglpi.class.php:294                       Computer->defineTabs()
  inc/toolbox.class.php:3593                         CommonGLPI->defineAllTabs()
  ajax/common.tabs.php:90                            Toolbox::getAvailablesTabs()
```

What happened was that the computed had a linked peripheral that was marked as deleted + dynamic:

![image](https://user-images.githubusercontent.com/42734840/145370071-f58cd65f-a921-4f4d-833e-e6b1f7b7e7af.png)

This mean this peripheral does not exist in the `glpi_peripherals` table.

`Change_Item::getTabNameForItem` and `Item_Problem::getTabNameForItem` were trying to load this peripheral without checking the query success, thus sending invalid data to the next function.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23042
