### PR TITLE
Change Hook Inventory Information block location

### DIFF
--- a/templates/components/form/inventory_info.html.twig
+++ b/templates/components/form/inventory_info.html.twig
@@ -53,11 +53,13 @@
          </span>
       {% endif %}
    </div>
-
+   {% if item.fields['id'] > 0 and item.isField('is_dynamic') %}
+      <div class="card-body row">
+         {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::AUTOINVENTORY_INFORMATION'), item) }}
+      </div>
+   {% endif %}
    {% set agent = item is usingtrait('Glpi\\Features\\Inventoriable') ? item.getInventoryAgent() : null %}
-   {% if agent is null %}
-      {{ __('No agent has been linked.') }}
-   {% else %}
+   {% if agent is not null %}
       <div class="card-body row">
          <div class="mb-3 col-12 col-sm-6">
             <label class="form-label" >{{ agent.getTypeName() }}</label>

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -531,12 +531,6 @@
 
                      {% block more_fields %}
                      {% endblock %}
-
-                     {% if item.fields['id'] > 0 and item.isField('is_dynamic') %}
-                        <div class="mb-3 col-12 col-sm-6">
-                           {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::AUTOINVENTORY_INFORMATION'), item) }}
-                        </div>
-                     {% endif %}
                   {% endblock %}
                </div> {# .row #}
             </div> {# .row #}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #none

Use same block than GLPI inventory agent for plugins
