### PR TITLE
Fix Infocom Hook display for plugins

### DIFF
--- a/templates/components/infocom.html.twig
+++ b/templates/components/infocom.html.twig
@@ -324,7 +324,7 @@
          ) }}
       {% endif %}
 
-      {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::INFOCOM'), item) }}
+      {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::INFOCOM'), {'item': item}) }}
 
       <div class="card-body mx-n2 mb-4  border-top">
          {% if can_global_update %}

--- a/templates/components/infocom.html.twig
+++ b/templates/components/infocom.html.twig
@@ -324,7 +324,7 @@
          ) }}
       {% endif %}
 
-      {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::INFOCOM'), {'item': item}) }}
+      {% do call_plugin_hook_func(constant('Glpi\\Plugin\\Hooks::INFOCOM'), item) %}
 
       <div class="card-body mx-n2 mb-4  border-top">
          {% if can_global_update %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #none

The hook don't display plugins informations on infocom.

Needs to change plugin existant hooks  : 

Example : 

```
diff --git a/inc/order_item.class.php b/inc/order_item.class.php
index 1569d09..18a0339 100644
--- a/inc/order_item.class.php
+++ b/inc/order_item.class.php
@@ -2005,7 +2005,8 @@ class PluginOrderOrder_Item extends CommonDBRelation {
    }
 
 
-   public static function showForInfocom(CommonDBTM $item) {
+   public static function showForInfocom($params) {
+      $item = $params['item'];
       $order_item = new self();
       $order_item->showPluginFromItems(get_class($item), $item->getField('id'));
    } 
```
