### PR TITLE
Inventory - Fix Rule Asset Import Case

### DIFF
--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -907,7 +907,7 @@ class RuleImportAsset extends Rule {
                      }
                      return $output;
                   }
-               } else {
+               } elseif ($action->fields["value"] != self::RULE_ACTION_LINK_OR_NO_IMPORT) {
                   // Import into new equipment
                   if (count($this->criterias)) {
                      foreach ($this->criterias as $criterion) {

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -907,7 +907,7 @@ class RuleImportAsset extends Rule {
                      }
                      return $output;
                   }
-               } elseif ($action->fields["value"] != self::RULE_ACTION_LINK_OR_NO_IMPORT) {
+               } else if ($action->fields["value"] != self::RULE_ACTION_LINK_OR_NO_IMPORT) {
                   // Import into new equipment
                   if (count($this->criterias)) {
                      foreach ($this->criterias as $criterion) {

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -888,7 +888,8 @@ class RuleImportAsset extends Rule {
                return $output;
             }
 
-            if ($action->fields["value"] == self::RULE_ACTION_LINK_OR_IMPORT) {
+            if ($action->fields["value"] == self::RULE_ACTION_LINK_OR_IMPORT
+            || $action->fields["value"] == self::RULE_ACTION_LINK_OR_NO_IMPORT) {
                if (isset($this->criterias_results['found_inventories'])) {
                   foreach ($this->criterias_results['found_inventories'] as $itemtype => $inventory) {
                      $items_id = current($inventory);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #none

When you want to Link a agent on an existing item or no import agent like this

![image](https://user-images.githubusercontent.com/13178158/145386131-72b9da04-e9ef-4b4b-9553-02ca5b1ba0c3.png)

The result is not send to $output without this check