### PR TITLE
Fix rules depending on category completename

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1104,6 +1104,11 @@ class Ticket extends CommonITILObject {
             $changes[]                             = '_groups_id_of_requester';
          }
 
+         // Special case to make sure rule depending on category completename are also executed
+         if (in_array('itilcategories_id', $changes)) {
+            $changes[] = 'itilcategories_id_cn';
+         }
+
          $input = $rules->processAllRules($input,
                                           $input,
                                           ['recursive'   => true,


### PR DESCRIPTION
This rule was never executed on update, even if the category was modified: 

![image](https://user-images.githubusercontent.com/42734840/145413981-22724792-b2f0-498b-80d1-f823643d3d08.png)

This is because the input contains a change for `itilcategories_id` while the rule field is defined as `itilcategories_id_cn`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
