### PR TITLE
Use legacy headers to prevent json format to be used for plugins tasks

### DIFF
--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -546,7 +546,7 @@ abstract class AbstractRequest
      *
      * @return array
      */
-   public function getHeaders($legacy = false): array {
+   public function getHeaders($legacy = true): array {
        return $this->headers->getHeaders($legacy);
    }
 

--- a/src/Agent/Communication/Headers/Common.php
+++ b/src/Agent/Communication/Headers/Common.php
@@ -140,7 +140,7 @@ class Common {
     *
     * @return array
     */
-   public function getHeaders($legacy = false): array {
+   public function getHeaders($legacy = true): array {
       //parse class attributes and normalize key name
       $reflect = new ReflectionClass($this);
       $props   = $reflect->getProperties(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED);

--- a/tests/functionnal/Glpi/Agent/Communication/Headers/Common.php
+++ b/tests/functionnal/Glpi/Agent/Communication/Headers/Common.php
@@ -70,7 +70,8 @@ class Common extends GLPITestCase {
             ->isIdenticalTo($headername);
    }
 
-   public function testGetHeadersWException() {
+   /* Useful only when legacy will no longer be the default */
+   /*public function testGetHeadersWException() {
       $this
          ->exception(
             function() {
@@ -80,7 +81,7 @@ class Common extends GLPITestCase {
                   ->array($this->testedInstance->getHeaders());
             }
          )->hasMessage('Content-Type HTTP header is mandatory!');
-   }
+   }*/
 
    public function testGetHeaders() {
       $instance = $this->newTestedInstance;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
