### PR TITLE
fix contrast ratio warning on auror dark

### DIFF
--- a/css/palettes/auror_dark.scss
+++ b/css/palettes/auror_dark.scss
@@ -34,7 +34,7 @@ $primary: #fec95c;
 $primary-fg: #644e21;
 $secondary: #b0bbd4;
 $secondary-fg: #262d3d;
-$min-contrast-ratio: 5;
+$min-contrast-ratio: 3;
 
 .btn-primary,
 .btn-outline-primary,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Fix `WARNING: Found no color leading to 5:1 contrast ratio against...`
