### PR TITLE
replace log's date filter by flatpickr

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -258,7 +258,8 @@
 
 {% macro dateField(name, value, label = '', options = {}) %}
    {% set options = {'rand': random()}|merge(options) %}
-   {% set options = {'id': name ~ '_' ~ options.rand}|merge(options) %}
+   {% set valid_name_id = call("Toolbox::slugify", [name, '']) %}
+   {% set options = {'id': valid_name_id ~ '_' ~ options.rand}|merge(options) %}
    {% set locale = get_current_locale() %}
 
    {% set field %}
@@ -287,7 +288,8 @@
 
 {% macro datetimeField(name, value, label = '', options = {}) %}
    {% set options = {'rand': random()}|merge(options) %}
-   {% set options = {'id': name ~ '_' ~ options.rand}|merge(options) %}
+   {% set valid_name_id = call("Toolbox::slugify", [name, '']) %}
+   {% set options = {'id': valid_name_id ~ '_' ~ options.rand}|merge(options) %}
    {% set locale = get_current_locale() %}
 
    {% set field %}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -258,8 +258,7 @@
 
 {% macro dateField(name, value, label = '', options = {}) %}
    {% set options = {'rand': random()}|merge(options) %}
-   {% set valid_name_id = call("Toolbox::slugify", [name, '']) %}
-   {% set options = {'id': valid_name_id ~ '_' ~ options.rand}|merge(options) %}
+   {% set options = {'id': name|slug ~ '_' ~ options.rand}|merge(options) %}
    {% set locale = get_current_locale() %}
 
    {% set field %}
@@ -288,8 +287,7 @@
 
 {% macro datetimeField(name, value, label = '', options = {}) %}
    {% set options = {'rand': random()}|merge(options) %}
-   {% set valid_name_id = call("Toolbox::slugify", [name, '']) %}
-   {% set options = {'id': valid_name_id ~ '_' ~ options.rand}|merge(options) %}
+   {% set options = {'id': name|slug ~ '_' ~ options.rand}|merge(options) %}
    {% set locale = get_current_locale() %}
 
    {% set field %}

--- a/templates/components/logs.html.twig
+++ b/templates/components/logs.html.twig
@@ -74,6 +74,8 @@
                   '',
                   {
                      no_label: true,
+                     full_width: true,
+                     mb: '',
                   },
                ) }}
             </td>

--- a/templates/components/logs.html.twig
+++ b/templates/components/logs.html.twig
@@ -29,6 +29,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
 {% if total_number < 1 %}
    <div class="alert alert-info">
       {{ __('No historical') }}
@@ -66,7 +68,14 @@
                <input type="hidden" name="items_id" value="{{ items_id }}" />
             </td>
             <td>
-               <input type="date" class="form-control" name="filters[date]" value="{{ filters['date'] }}" />
+               {{ fields.dateField(
+                  'filters[date]',
+                  filters['date'],
+                  '',
+                  {
+                     no_label: true,
+                  },
+               ) }}
             </td>
             <td>
                <select name="filters[users_names][]" class="form-select logs-filter-select-mulitple" multiple>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

slugify is here to prevent bad dom id (`filters[date]_rand` ), squares are forbidden in id

