### PR TITLE
Prevent deprecations to break file upload JSON response

### DIFF
--- a/ajax/fileupload.php
+++ b/ajax/fileupload.php
@@ -34,7 +34,13 @@
  * @since 9.2
  */
 
+use Glpi\Application\ErrorHandler;
+
 include ('../inc/includes.php');
 
 Session::checkLoginUser();
+
+// Ensure warnings will not break ajax output.
+ErrorHandler::getInstance()->disableOutput();
+
 GLPIUploadHandler::uploadFiles($_POST);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

There are some PHP 8.1 deprecation errors triggered in the file upload lib. In debug mode, it prevents to upload a file as javascript is not able to understand the response.