### PR TITLE
Fix PHP 8.1 deprecation errors on empty dates rendering

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -4303,7 +4303,7 @@ class CommonDBTM extends CommonGLPI {
                                                                         'with_future' => true]);
                      return $dates[$value];
                   }
-                  return Html::convDate(Html::computeGenericDateTimeSearch($value, true));
+                  return empty($value) ? $value : Html::convDate(Html::computeGenericDateTimeSearch($value, true));
 
                case "datetime" :
                   if (isset($options['relative_dates']) && $options['relative_dates']) {
@@ -4311,7 +4311,7 @@ class CommonDBTM extends CommonGLPI {
                                                                         'with_future' => true]);
                      return $dates[$value];
                   }
-                  return Html::convDateTime(Html::computeGenericDateTimeSearch($value, false));
+                  return empty($value) ? $value : Html::convDateTime(Html::computeGenericDateTimeSearch($value, false));
 
                case "timestamp" :
                   if (($value == 0)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes following issue

```
*** PHP Deprecated function (8192): preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /var/www/glpi/src/Html.php at line 3205
  Backtrace :
  src/Html.php:3205                                  preg_match()
  src/CommonDBTM.php:4314                            Html::computeGenericDateTimeSearch()
  src/Log.php:659                                    CommonDBTM->getValueToDisplay()
  src/NotificationTargetCommonITILObject.php:1342    Log::getHistoryData()
  src/NotificationTargetTicket.php:151               NotificationTargetCommonITILObject->getDataForObject()
  src/NotificationTargetCommonITILObject.php:973     NotificationTargetTicket->getDataForObject()
  src/NotificationTarget.php:1270                    NotificationTargetCommonITILObject->addDataForTemplate()
  src/NotificationTemplate.php:255                   NotificationTarget->getForTemplate()
  src/NotificationEventAbstract.php:117              NotificationTemplate->getTemplateByLanguage()
  src/NotificationEvent.php:180                      NotificationEventAbstract::raise()
  src/ITILFollowup.php:337                           NotificationEvent::raiseEvent()
  src/CommonDBTM.php:1202                            ITILFollowup->post_addItem()
```