### PR TITLE
force disposal of tooltips when removing criteria in search form

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -2331,7 +2331,7 @@ JAVASCRIPT;
          $(document).on("click", ".remove-search-criteria", function() {
             // force removal of tooltip
             var tooltip = bootstrap.Tooltip.getInstance($(this)[0]);
-            if (!!tooltip) {
+            if (tooltip !== null) {
                tooltip.dispose();
             }
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -2329,6 +2329,12 @@ JAVASCRIPT;
          }
 
          $(document).on("click", ".remove-search-criteria", function() {
+            // force removal of tooltip
+            var tooltip = bootstrap.Tooltip.getInstance($(this)[0]);
+            if (!!tooltip) {
+               tooltip.dispose();
+            }
+
             var rowID = $(this).data('rowid');
             $('#' + rowID).remove();
             $('#searchcriteria{$rand_criteria} .criteria-list .list-group-item:first-child').addClass('headerRow').show();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Honnestly, i don't know why tooltip are keeped after criteria removal, so i force the disposable when clicking on remove button
