### PR TITLE
Fix plugins autoloader and reports

### DIFF
--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -290,7 +290,7 @@ function glpi_autoload($classname)
         return true;
     }
 
-   // Deprecation warn for RuleImportComputer* classes
+    // Deprecation warn for RuleImportComputer* classes
     if (in_array($classname, ['RuleImportComputer', 'RuleImportComputerCollection'])) {
         Toolbox::deprecated(
             sprintf(
@@ -307,11 +307,19 @@ function glpi_autoload($classname)
     }
 
     $plugname = strtolower($plug['plugin']);
-    $dir      = GLPI_ROOT . "/plugins/$plugname/inc/";
+    $dir      = null;
     $item     = str_replace('\\', '/', strtolower($plug['class']));
 
     if (!Plugin::isPluginLoaded($plugname)) {
         return false;
+    }
+
+    foreach (PLUGINS_DIRECTORIES as $plugins_dir) {
+        $dir_to_check = "{$plugins_dir}/$plugname/inc/";
+        if (is_dir($dir_to_check)) {
+            $dir = $dir_to_check;
+            break;
+        }
     }
 
     if (file_exists("$dir$item.class.php")) {

--- a/src/Report.php
+++ b/src/Report.php
@@ -145,7 +145,14 @@ class Report extends CommonGLPI
             $group = $title;
             foreach ($names as $key => $val) {
                 if ($opt == $val["plug"]) {
-                    $file                  = $CFG_GLPI["root_doc"] . "/plugins/" . $key;
+                    $path = null;
+                    foreach (PLUGINS_DIRECTORIES as $plugins_dir) {
+                        if (is_dir($plugins_dir . '/' . $val['plug'])) {
+                            $path = $CFG_GLPI['root_doc'] . '/' . basename($plugins_dir);
+                            break;
+                        }
+                    }
+                    $file                  = $path . '/' . $key;
                     $values[$group][$file] = $val["name"];
                     if (stripos($_SERVER['REQUEST_URI'], $file) !== false) {
                         $selected = $file;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Marketplace directory was not evaluated during autoload since #9704 .
2. Custome plugins reports were always pointing to `plugins` directory.