### PR TITLE
SocketModel should use same namespace as Socket

### DIFF
--- a/front/socketmodel.form.php
+++ b/front/socketmodel.form.php
@@ -31,6 +31,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\SocketModel;
+
 include('../inc/includes.php');
 
 $dropdown = new SocketModel();

--- a/front/socketmodel.php
+++ b/front/socketmodel.php
@@ -31,6 +31,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\SocketModel;
+
 include('../inc/includes.php');
 
 $dropdown = new SocketModel();

--- a/inc/define.php
+++ b/inc/define.php
@@ -31,6 +31,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\SocketModel;
+
 // Current version of GLPI
 define('GLPI_VERSION', '10.0.0-dev');
 define("GLPI_SCHEMA_VERSION", GLPI_VERSION . '@' . sha1_file(GLPI_ROOT . '/install/mysql/glpi-empty.sql'));
@@ -273,7 +275,7 @@ $CFG_GLPI["dictionnary_types"]            = ['ComputerModel', 'ComputerType', 'M
                                                   'Software', 'OperatingSystemArchitecture',
                                                   'OperatingSystemKernel', 'OperatingSystemKernelVersion',
                                                   'OperatingSystemEdition', 'ImageResolution', 'ImageFormat',
-                                                  'DatabaseInstanceType', 'SocketModel', 'CableType'];
+                                                  'DatabaseInstanceType', SocketModel::class, 'CableType'];
 
 $CFG_GLPI["helpdesk_visible_types"]       = ['Software', 'Appliance', 'Database'];
 

--- a/src/Cable.php
+++ b/src/Cable.php
@@ -33,6 +33,7 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Socket;
+use Glpi\SocketModel;
 
 /// Class Cable
 class Cable extends CommonDBTM

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -32,6 +32,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\SocketModel;
 use Glpi\Toolbox\Sanitizer;
 
 class Dropdown
@@ -1088,7 +1089,7 @@ class Dropdown
              __('Cable management') => [
                'CableType' => null,
                'CableStrand' => null,
-               'SocketModel' => null,
+               SocketModel::class => null,
              ],
 
              __('Internet') => [

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -47,7 +47,6 @@ use Location;
 use Log;
 use NetworkPort;
 use Session;
-use SocketModel;
 
 /// Socket class
 class Socket extends CommonDBChild

--- a/src/SocketModel.php
+++ b/src/SocketModel.php
@@ -31,6 +31,10 @@
  * ---------------------------------------------------------------------
  */
 
+namespace Glpi;
+
+use CommonDropdown;
+
 /// Class ConnectorModel
 class SocketModel extends CommonDropdown
 {

--- a/templates/pages/assets/cable.html.twig
+++ b/templates/pages/assets/cable.html.twig
@@ -118,7 +118,7 @@
                   ]) %}
 
                   {{ fields.dropdownField(
-                     'SocketModel',
+                     'Glpi\\SocketModel',
                      'socketmodels_id_endpoint_' ~ side,
                      item.fields['socketmodels_id_endpoint_' ~ side],
                      'SocketModel'|itemtype_name,

--- a/templates/pages/assets/socket.html.twig
+++ b/templates/pages/assets/socket.html.twig
@@ -46,10 +46,10 @@
    ) }}
 
    {{ fields.dropdownField(
-      'SocketModel',
+      'Glpi\\SocketModel',
       'socketmodels_id',
       item.fields['socketmodels_id'],
-      'SocketModel'|itemtype_name,
+      'Glpi\\SocketModel'|itemtype_name,
    ) }}
 
    {% set wiring_side %}

--- a/tests/functionnal/Cable.php
+++ b/tests/functionnal/Cable.php
@@ -35,6 +35,7 @@ namespace tests\units;
 
 use DbTestCase;
 use Glpi\Socket;
+use Glpi\SocketModel;
 
 /* Test for inc/networkport.class.php */
 
@@ -140,7 +141,7 @@ class Cable extends DbTestCase
 
        //Second step add socket
        //add socket model
-        $socketModel = new \SocketModel();
+        $socketModel = new SocketModel();
         $nb_log = (int)countElementsInTable('glpi_logs');
         $socketModel_id = $socketModel->add([
          'name' => 'socketModel1'
@@ -237,7 +238,7 @@ class Cable extends DbTestCase
         $this->integer((int)countElementsInTable('glpi_logs'))->isGreaterThan($nb_log);
 
        //add socket model
-        $socketModel1 = new \SocketModel();
+        $socketModel1 = new SocketModel();
         $nb_log = (int)countElementsInTable('glpi_logs');
         $socketModel1_id = $socketModel1->add([
          'name' => 'socketModel1'
@@ -301,7 +302,7 @@ class Cable extends DbTestCase
         $this->integer((int)countElementsInTable('glpi_logs'))->isGreaterThan($nb_log);
 
        //add socket model
-        $socketModel2 = new \SocketModel();
+        $socketModel2 = new SocketModel();
         $nb_log = (int)countElementsInTable('glpi_logs');
         $socketModel2_id = $socketModel2->add([
          'name' => 'socketModel2'

--- a/tests/functionnal/Cable.php
+++ b/tests/functionnal/Cable.php
@@ -86,7 +86,7 @@ class Cable extends DbTestCase
 
        //Second step add socket
        //add socket model
-        $socketModel = new \SocketModel();
+        $socketModel = new SocketModel();
         $nb_log = (int)countElementsInTable('glpi_logs');
         $socketModel_id = $socketModel->add([
          'name' => 'socketModel1'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Multiple places in the code expects an asset model class to be the fully qualified class of the asset followed by `Model`. For sockets, the `Socket` is in the Glpi namespace while the `SocketModel` is in the root so it cannot be automatically discovered.