### PR TITLE
Revert PSR-12 changes made to inline JS anon funcs

### DIFF
--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -410,14 +410,14 @@ class DomainRecord extends CommonDBChild
 
         $js = <<<JAVASCRIPT
          $(
-            public function () {
+            function () {
                $('#data{$rand}, #dropdown_domainrecordtypes_id{$rand}').change(
-                  public function (event) {
+                  function (event) {
                      $('#data_obj{$rand}').val(''); // empty "data_obj" value if "data" or "record type" changed
                   }
                );
                $('#data{$rand} + a').click(
-                  public function (event) {
+                  function (event) {
                      event.preventDefault();
 
                      var select = $(this).closest('form').find('[name="domainrecordtypes_id"]');

--- a/src/DomainRecordType.php
+++ b/src/DomainRecordType.php
@@ -411,13 +411,13 @@ class DomainRecordType extends CommonDropdown
 
         $js = <<<JAVASCRIPT
          $(
-            public function () {
+            function () {
                var form = $('#domain_record_data{$rand}');
 
                // Put existing data into fields
                var data_to_copy = $('#{$str_input_id}').val();
                form.find('input').each(
-                  public function () {
+                  function () {
                      var endoffset = 0;
                      if ($(this).data('quote-value')) {
                         // Search for closing quote (quote inside value are escaped by a \)
@@ -458,7 +458,7 @@ class DomainRecordType extends CommonDropdown
                      var data_tokens = [];
                      var data_obj = {};
                      $(this).find('input').each(
-                        public function () {
+                        function () {
                            var value = $(this).val();
                            data_obj[$(this).attr('name')] = value; // keep raw value
 

--- a/src/User.php
+++ b/src/User.php
@@ -2288,7 +2288,7 @@ class User extends CommonDBTM
                 $impersonate_js = <<<JAVASCRIPT
                (function($) {
                   $('button[type="button"][name="impersonate"]').click(
-                     public function () {
+                     function () {
                         $(this).attr('type', 'submit');
                      }
                   );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

#10095 had changed JS anonymous functions that were in PHP files to `public function` which is not valid JS.