### PR TITLE
Fix DomainRecord helper js errors

### DIFF
--- a/ajax/domainrecord_data_form.php
+++ b/ajax/domainrecord_data_form.php
@@ -44,8 +44,4 @@ if (
     $domainrecordtype->getEmpty();
 }
 
-Html::popHeader($domainrecordtype->fields['name']);
-
 $domainrecordtype->showDataAjaxForm($_REQUEST['str_input_id'] ?? '', $_REQUEST['obj_input_id'] ?? '');
-
-Html::popFooter();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This was trying to include headers in an AJAX modal when they were already included for the page, which meant it tried loading the scripts twice and would fail/break.