### PR TITLE
Fix marketplace download icons

### DIFF
--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -672,7 +672,7 @@ HTML;
                <button class='modify_plugin'
                      data-action='download_plugin'
                      title='".__s("Download again")."'>
-                  <i class='fas fa-cloud-download-alt'></i>
+                  <i class='ti ti-cloud-download'></i>
                </button>";
          }
       } else if (!$is_available) {
@@ -715,7 +715,7 @@ HTML;
             $buttons .="<button class='modify_plugin'
                                 data-action='download_plugin'
                                 title='".__s("Download")."'>
-               <i class='ti ti-alert-triangle'></i>
+               <i class='ti ti-cloud-download'></i>
             </button>";
          } else if ($can_be_updated) {
             $update_title = sprintf(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Download icon was using an alert icon instead of the download one. The download again button was using the FontAwesome icon still so I changed it to Tabler since that icon was already replaced other places.