### PR TITLE
Improve browser tab names

### DIFF
--- a/front/agent.form.php
+++ b/front/agent.form.php
@@ -120,11 +120,9 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {//print agent information
-    Html::header(Agent::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "glpi\inventory\inventory", "agent");
-   //show agent form to add
-    $agent->display([
-        'id'           => $_GET["id"],
-        'withtemplate' => $_GET["withtemplate"]
+    $menus = ["admin", "glpi\inventory\inventory", "agent"];
+    Agent::displayFullPageForItem((int) $_GET['id'], $menus, [
+        'withtemplate' => $_GET["withtemplate"],
+        'formoptions'  => "data-track-changes=true",
     ]);
-    Html::footer();
 }

--- a/front/apiclient.form.php
+++ b/front/apiclient.form.php
@@ -51,7 +51,6 @@ if (isset($_POST["add"])) {
     $client->delete($_POST);
     Html::redirect($CFG_GLPI["root_doc"] . "/front/config.form.php");
 } else {
-    Html::header(APIClient::getTypeName(1), $_SERVER['PHP_SELF'], "config", "config", "apiclient");
-    $client->display(['id' => $_GET["id"]]);
-    Html::footer();
+    $menus = ["config", "config", "apiclient"];
+    APIClient::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/appliance.form.php
+++ b/front/appliance.form.php
@@ -115,11 +115,8 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(Appliance::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "appliance");
-    $options = [
-        'id'           => $_GET['id'],
+    $menus = ["management", "appliance"];
+    Appliance::displayFullPageForItem($_GET['id'], $menus, [
         'withtemplate' => $_GET['withtemplate']
-    ];
-    $app->display($options);
-    Html::footer();
+    ]);
 }

--- a/front/authldap.form.php
+++ b/front/authldap.form.php
@@ -119,7 +119,5 @@ if (isset($_POST["update"])) {
     Html::back();
 }
 
-Html::header(AuthLDAP::getTypeName(1), $_SERVER['PHP_SELF'], 'config', 'auth', 'ldap');
-$config_ldap->display($_GET);
-
-Html::footer();
+$menus = ['config', 'auth', 'ldap'];
+AuthLDAP::displayFullPageForItem($_GET['id'], $menus, $_GET);

--- a/front/authmail.form.php
+++ b/front/authmail.form.php
@@ -69,8 +69,5 @@ if (isset($_POST["update"])) {
     Html::back();
 }
 
-Html::header(AuthMail::getTypeName(1), $_SERVER['PHP_SELF'], "config", "auth", "imap");
-
-$config_mail->display(['id' => $_GET["id"]]);
-
-Html::footer();
+$menus = ["config", "auth", "imap"];
+AuthMail::displayFullPageForItem($_GET['id'], $menus);

--- a/front/budget.form.php
+++ b/front/budget.form.php
@@ -123,12 +123,9 @@ if (isset($_POST["add"])) {
       $budget->showForm($_GET["id"], ['withtemplate' => $_GET["withtemplate"]]);
       Html::popFooter();
 } else {
-    Html::header(Budget::getTypeName(1), $_SERVER['PHP_SELF'], "management", "budget");
-    $budget->display([
-        'id'           => $_GET["id"],
+    $menus = ["management", "budget"];
+    Budget::displayFullPageForItem($_GET['id'], $menus, [
         'withtemplate' => $_GET["withtemplate"],
         'formoptions'  => "data-track-changes=true"
     ]);
-
-    Html::footer();
 }

--- a/front/cable.form.php
+++ b/front/cable.form.php
@@ -95,12 +95,9 @@ if (isset($_POST["add"])) {
       $cable->showForm($_GET["id"], ['withtemplate' => $_GET["withtemplate"]]);
       Html::popFooter();
 } else {
-    Html::header(Cable::getTypeName(1), $_SERVER['PHP_SELF'], "assets", "cable");
-    $cable->display([
-        'id'           => $_GET["id"],
+    $menus = ["assets", "cable"];
+    Cable::displayFullPageForItem($_GET['id'], $menus, [
         'withtemplate' => $_GET["withtemplate"],
         'formoptions'  => "data-track-changes=true"
     ]);
-
-    Html::footer();
 }

--- a/front/cartridgeitem.form.php
+++ b/front/cartridgeitem.form.php
@@ -116,9 +116,8 @@ if (isset($_POST["add"])) {
     }
     Html::back();
 } else {
-    Html::header(Cartridge::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "cartridgeitem");
-    $cartype->display(['id' => $_GET["id"],
+    $menus = ["assets", "cartridgeitem"];
+    CartridgeItem::displayFullPageForItem($_GET["id"], $menus, [
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/certificate.form.php
+++ b/front/certificate.form.php
@@ -119,16 +119,9 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(
-        Certificate::getTypeName(Session::getPluralNumber()),
-        $_SERVER['PHP_SELF'],
-        'management',
-        'certificate'
-    );
-    $certificate->display([
-        'id'           => $_GET["id"],
+    $menus = ['management', 'certificate'];
+    Certificate::displayFullPageForItem($_GET["id"], $menus, [
         'withtemplate' => $_GET["withtemplate"],
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/change.form.php
+++ b/front/change.form.php
@@ -198,8 +198,8 @@ if (isset($_POST["add"])) {
         Html::header(sprintf(__('%s Kanban'), Change::getTypeName(1)), $_SERVER['PHP_SELF'], "helpdesk", "change");
         $change::showKanban(0);
     } else {
-        Html::header(Change::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "helpdesk", "change");
-        $change->display($_REQUEST);
+        $menus = ["helpdesk", "change"];
+        Change::displayFullPageForItem($_REQUEST['id'] ?? 0, $menus, $_REQUEST);
     }
 
     if (isset($_GET['id']) && ($_GET['id'] > 0)) {

--- a/front/cluster.form.php
+++ b/front/cluster.form.php
@@ -115,11 +115,9 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(Cluster::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "cluster");
     $options = [
-        'id'           => $_GET['id'],
         'withtemplate' => $_GET['withtemplate'],
-        'formoptions'  => "data-track-changes=true"
+        'formoptions'  => "data-track-changes=true",
     ];
     if (isset($_GET['position'])) {
         $options['position'] = $_GET['position'];
@@ -127,6 +125,6 @@ if (isset($_POST["add"])) {
     if (isset($_GET['room'])) {
         $options['room'] = $_GET['room'];
     }
-    $cluster->display($options);
-    Html::footer();
+    $menus = ["management", "cluster"];
+    Cluster::displayFullPageForItem($_GET['id'], $menus, $options);
 }

--- a/front/computer.form.php
+++ b/front/computer.form.php
@@ -122,12 +122,9 @@ if (isset($_POST["add"])) {
 
    // Disconnect a computer from a printer/monitor/phone/peripheral
 } else {//print computer information
-    Html::header(Computer::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "computer");
-   //show computer form to add
-    $computer->display([
-        'id'           => $_GET["id"],
+    $menus = ["assets", "computer"];
+    Computer::displayFullPageForItem($_GET['id'], $menus, [
         'withtemplate' => $_GET["withtemplate"],
-        'formoptions'  => "data-track-changes=true"
+        'formoptions'  => "data-track-changes=true",
     ]);
-    Html::footer();
 }

--- a/front/computerantivirus.form.php
+++ b/front/computerantivirus.form.php
@@ -94,9 +94,8 @@ if (isset($_POST["add"])) {
     }
     Html::back();
 } else {
-    Html::header(Computer::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "computer");
-    $antivirus->display(['id'           => $_GET["id"],
+    $menus = ["assets", "computer"];
+    ComputerAntivirus::displayFullPageForItem($_GET["id"], $menus, [
         'computers_id' => $_GET["computers_id"]
     ]);
-    Html::footer();
 }

--- a/front/computervirtualmachine.form.php
+++ b/front/computervirtualmachine.form.php
@@ -95,9 +95,8 @@ if (isset($_POST["add"])) {
     }
     Html::back();
 } else {
-    Html::header(Computer::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "computer");
-    $disk->display(['id'           => $_GET["id"],
+    $menus = ["assets", "computer"];
+    ComputerVirtualMachine::displayFullPageForItem($_GET["id"], $menus, [
         'computers_id' => $_GET["computers_id"]
     ]);
-    Html::footer();
 }

--- a/front/config.form.php
+++ b/front/config.form.php
@@ -87,9 +87,6 @@ if (!empty($_POST['reset_translation_cache'])) {
     Html::redirect(Toolbox::getItemTypeFormURL('Config'));
 }
 
-Html::header(Config::getTypeName(1), $_SERVER['PHP_SELF'], "config", "config");
-$config->display([
-    'id'           => 1,
+Config::displayFullPageForItem(1, ["config", "config"], [
     'formoptions'  => "data-track-changes=true"
 ]);
-Html::footer();

--- a/front/consumableitem.form.php
+++ b/front/consumableitem.form.php
@@ -116,9 +116,8 @@ if (isset($_POST["add"])) {
     }
     Html::back();
 } else {
-    Html::header(_n('Consumable', 'Consumables', Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "consumableitem");
-    $constype->display(['id' => $_GET["id"],
+    $menus = ["assets", "consumableitem"];
+    ConsumableItem::displayFullPageForItem($_GET["id"], $menus, [
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/contact.form.php
+++ b/front/contact.form.php
@@ -122,10 +122,8 @@ if (isset($_GET['getvcard'])) {
     }
     Html::back();
 } else {
-    Html::header(Contact::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "contact");
-    $contact->display([
-        'id'           => $_GET["id"],
+    $menus = ["management", "contact"];
+    Contact::displayFullPageForItem($_GET["id"], $menus, [
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/contract.form.php
+++ b/front/contract.form.php
@@ -120,11 +120,9 @@ if (isset($_POST["add"])) {
     }
     Html::back();
 } else {
-    Html::header(Contract::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "contract");
-    $contract->display([
-        'id'           => $_GET["id"],
+    $menus = ["management", "contract"];
+    Contract::displayFullPageForItem($_GET["id"], $menus, [
         'withtemplate' => $_GET["withtemplate"],
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/crontask.form.php
+++ b/front/crontask.form.php
@@ -80,7 +80,6 @@ if (isset($_POST['execute'])) {
     if (!isset($_GET["id"]) || empty($_GET["id"])) {
         exit();
     }
-    Html::header(CronTask::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'config', 'crontask');
-    $crontask->display(['id' => $_GET["id"]]);
-    Html::footer();
+    $menus = ['config', 'crontask'];
+    CronTask::displayFullPageForItem($_GET['id'], $menus);
 }

--- a/front/database.form.php
+++ b/front/database.form.php
@@ -115,11 +115,8 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(Database::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "database");
-    $options = [
-        'id'           => $_GET['id'],
+    $menus = ["management", "database"];
+    Database::displayFullPageForItem($_GET['id'], $menus, [
         'databaseinstances_id' => $_GET['databaseinstances_id']
-    ];
-    $database->display($options);
-    Html::footer();
+    ]);
 }

--- a/front/databaseinstance.form.php
+++ b/front/databaseinstance.form.php
@@ -118,11 +118,8 @@ if (isset($_POST["add"])) {
     }
     Html::back();
 } else {
-    Html::header(DatabaseInstance::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "database", "databaseinstance");
-    $options = [
-        'id'           => $_GET['id'],
+    $menus = ["database", "databaseinstance"];
+    DatabaseInstance::displayFullPageForItem($_GET['id'], $menus, [
         'withtemplate' => $_GET['withtemplate']
-    ];
-    $instance->display($options);
-    Html::footer();
+    ]);
 }

--- a/front/datacenter.form.php
+++ b/front/datacenter.form.php
@@ -115,10 +115,8 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(Datacenter::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "datacenter");
-    $datacenter->display([
-        'id'           => $_GET["id"],
+    $menus = ["management", "datacenter"];
+    Datacenter::displayFullPageForItem($_GET["id"], $menus, [
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/dcroom.form.php
+++ b/front/dcroom.form.php
@@ -115,7 +115,6 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(DCRoom::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "datacenter", "dcroom");
     $options = [
         'id' => $_GET["id"],
     ];
@@ -128,6 +127,6 @@ if (isset($_POST["add"])) {
         $datacenter->getFromDB($options['datacenters_id']);
         $options['locations_id'] = $datacenter->fields['locations_id'];
     }
-    $room->display($options);
-    Html::footer();
+    $menus = ["management", "datacenter", "dcroom"];
+    DCRoom::displayFullPageForItem($_GET["id"], $menus, $options);
 }

--- a/front/document.form.php
+++ b/front/document.form.php
@@ -138,10 +138,8 @@ if (isset($_POST["add"])) {
     }
     Html::back();
 } else {
-    Html::header(Document::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "document");
-    $doc->display([
-        'id'           => $_GET["id"],
+    $menus = ["management", "document"];
+    Document::displayFullPageForItem($_GET["id"], $menus, [
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/domain.form.php
+++ b/front/domain.form.php
@@ -96,12 +96,9 @@ if (isset($_POST["add"])) {
     $ditem->delete($input);
     Html::back();
 } else {
-    Html::header(Domain::getTypeName(1), $_SERVER['PHP_SELF'], "management", "domain");
-    $domain->display([
-        'id'           => $_GET["id"],
+    $menus = ["management", "domain"];
+    Domain::displayFullPageForItem($_GET["id"], $menus, [
         'withtemplate' => $_GET["withtemplate"],
         'formoptions'  => "data-track-changes=true"
     ]);
-
-    Html::footer();
 }

--- a/front/domainrecord.form.php
+++ b/front/domainrecord.form.php
@@ -72,12 +72,9 @@ if (isset($_POST["add"])) {
     $record->showForm($_GET["id"], ['domains_id' => $_GET['domains_id'] ?? null]);
     Html::popFooter();
 } else {
-    Html::header(DomainRecord::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "domain", "domainrecord");
-    $record->display([
-        'id'           => $_GET["id"],
+    $menus = ["management", "domain", "domainrecord"];
+    DomainRecord::displayFullPageForItem($_GET["id"], $menus, [
         'domains_id'   => $_GET['domains_id'] ?? null,
         'withtemplate' => $_GET["withtemplate"]
     ]);
-
-    Html::footer();
 }

--- a/front/dropdown.common.form.php
+++ b/front/dropdown.common.form.php
@@ -165,14 +165,15 @@ if (isset($_POST["add"])) {
     $dropdown->showForm($_GET["id"]);
     Html::popFooter();
 } else {
-    $dropdown->displayHeader();
-
     if (!isset($options)) {
         $options = [];
     }
-    $options['id'] = $_GET['id'];
-    $options['formoptions'] = ($options['formoptions'] ?? '') . ' data-track-changes=true';
-
-    $dropdown->display($options);
-    Html::footer();
+    $menus = [
+        $dropdown->first_level_menu,
+        $dropdown->second_level_menu,
+        $dropdown->third_level_menu,
+    ];
+    $dropdown::displayFullPageForItem($_GET['id'], $menus, [
+        'formoptions' => ($options['formoptions'] ?? '') . ' data-track-changes=true'
+    ]);
 }

--- a/front/enclosure.form.php
+++ b/front/enclosure.form.php
@@ -115,9 +115,7 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(Enclosure::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "enclosure");
     $options = [
-        'id'           => $_GET['id'],
         'withtemplate' => $_GET['withtemplate'],
         'formoptions'  => "data-track-changes=true"
     ];
@@ -127,6 +125,6 @@ if (isset($_POST["add"])) {
     if (isset($_GET['room'])) {
         $options['room'] = $_GET['room'];
     }
-    $enclosure->display($options);
-    Html::footer();
+    $menus = ["assets", "enclosure"];
+    Enclosure::displayFullPageForItem($_GET['id'], $menus, $options);
 }

--- a/front/group.form.php
+++ b/front/group.form.php
@@ -116,10 +116,8 @@ if (isset($_POST["add"])) {
     );
     $group->redirectToList();
 } else {
-    Html::header(Group::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "group");
-    $group->display([
-        'id'           => $_GET["id"],
+    $menus = ["admin", "group"];
+    Group::displayFullPageForItem($_GET["id"], $menus, [
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/item_cluster.form.php
+++ b/front/item_cluster.form.php
@@ -72,7 +72,5 @@ if (isset($_REQUEST['id'])) {
     ];
 }
 
-Html::header(Cluster::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "cluster");
-
-$icl->display($params);
-Html::footer();
+$menus = ["management", "cluster"];
+Item_Cluster::displayFullPageForItem($params['id'] ?? 0, $menus, $params);

--- a/front/item_device.common.form.php
+++ b/front/item_device.common.form.php
@@ -104,15 +104,14 @@ if (isset($_POST["add"])) {
     Html::back();
 } else {
     if (in_array($item_device->getType(), $CFG_GLPI['devices_in_menu'])) {
-        Html::header($item_device->getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", strtolower($item_device->getType()));
+        $menus = ["assets", strtolower($item_device->getType())];
     } else {
-        Html::header($item_device->getTypeName(Session::getPluralNumber()), '', "config", "commondevice", $item_device->getDeviceType());
+        $menus = ["config", "commondevice", $item_device->getDeviceType()];
     }
 
     if (!isset($options)) {
         $options = [];
     }
-    $options['id'] = $_GET["id"];
-    $item_device->display($options);
-    Html::footer();
+
+    Item_Devices::displayFullPageForItem($_GET["id"], $menus, $options ?? []);
 }

--- a/front/item_disk.form.php
+++ b/front/item_disk.form.php
@@ -107,11 +107,9 @@ if (isset($_POST["add"])) {
     } else if ($_GET['itemtype'] != '') {
         $itemtype = $_GET['itemtype'];
     }
-    Html::header(Item_Disk::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", $itemtype);
-    $disk->display([
-        'id'        => $_GET["id"],
+    $menus = ["assets", $itemtype];
+    Item_Disk::displayFullPageForItem($_GET["id"], $menus, [
         'items_id'  => $_GET["items_id"],
         'itemtype'  => $_GET['itemtype']
     ]);
-    Html::footer();
 }

--- a/front/item_enclosure.form.php
+++ b/front/item_enclosure.form.php
@@ -72,7 +72,5 @@ if (isset($_REQUEST['id'])) {
     ];
 }
 
-Html::header(Enclosure::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "enclosure");
-
-$ien->display($params);
-Html::footer();
+$menus = ["management", "enclosure"];
+Item_Enclosure::displayFullPageForItem($_REQUEST['id'] ?? 0, $menus, $params);

--- a/front/item_operatingsystem.form.php
+++ b/front/item_operatingsystem.form.php
@@ -75,7 +75,5 @@ if (isset($_GET['id'])) {
     ];
 }
 
-Html::header(Computer::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "computer");
-
-$ios->display($params);
-Html::footer();
+$menus = ["assets", "computer"];
+Item_OperatingSystem::displayFullPageForItem($params['id'] ?? 0, $menus, $params);

--- a/front/item_rack.form.php
+++ b/front/item_rack.form.php
@@ -78,10 +78,9 @@ if (isset($_GET['id'])) {
 }
 $ajax = isset($_REQUEST['ajax']) ? true : false;
 
-if (!$ajax) {
-    Html::header(Rack::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "rack");
-}
-$ira->display($params);
-if (!$ajax) {
-    Html::footer();
+if ($ajax) {
+    $ira->display($params);
+} else {
+    $menus = ["assets", "rack"];
+    Item_Rack::displayFullPageForItem($params['id'] ?? 0, $menus, $params);
 }

--- a/front/item_remotemanagement.form.php
+++ b/front/item_remotemanagement.form.php
@@ -107,11 +107,10 @@ if (isset($_POST["add"])) {
     } else if ($_GET['itemtype'] != '') {
         $itemtype = $_GET['itemtype'];
     }
-    Html::header(Item_RemoteManagement::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", $itemtype);
-    $mgmt->display([
-        'id'        => $_GET["id"],
+
+    $menus = ["assets", $itemtype];
+    Item_RemoteManagement::displayFullPageForItem($_GET["id"], $menus, [
         'items_id'  => $_GET["items_id"],
         'itemtype'  => $_GET['itemtype']
     ]);
-    Html::footer();
 }

--- a/front/knowbaseitem.form.php
+++ b/front/knowbaseitem.form.php
@@ -176,15 +176,6 @@ if (isset($_POST["add"])) {
         }
         Html::popFooter();
     } else {
-       // check we can read the article
-        $kb->check($_GET["id"], READ);
-
-        if (Session::getCurrentInterface() == "central") {
-            Html::header(KnowbaseItem::getTypeName(1), $_SERVER['PHP_SELF'], "tools", "knowbaseitem");
-        } else {
-            Html::helpHeader(__('FAQ'));
-        }
-
         $available_options = ['item_itemtype', 'item_items_id', 'id'];
         $options           = [];
         foreach ($available_options as $key) {
@@ -192,12 +183,10 @@ if (isset($_POST["add"])) {
                 $options[$key] = $_GET[$key];
             }
         }
-        $kb->display($options);
-
-        if (Session::getCurrentInterface() == "central") {
-            Html::footer();
-        } else {
-            Html::helpFooter();
-        }
+        $menus = [
+            'central'  => "tools", "knowbaseitem",
+            'helpdesk' => [],
+        ];
+        KnowbaseItem::displayFullPageForItem($_GET['id'], $menus, $options);
     }
 }

--- a/front/knowbaseitem.php
+++ b/front/knowbaseitem.php
@@ -41,9 +41,6 @@ if (isset($_GET["id"])) {
     Html::redirect(KnowbaseItem::getFormURLWithID($_GET["id"]));
 }
 
-Html::header(KnowbaseItem::getTypeName(1), $_SERVER['PHP_SELF'], "tools", "knowbaseitem");
-
-
 // Clean for search
 $_GET = Toolbox::stripslashes_deep($_GET);
 
@@ -66,8 +63,5 @@ if (isset($_GET['forcetab'])) {
     unset($_GET['forcetab']);
 }
 
-$kb = new Knowbase();
-$kb->display($_GET);
-
-
-Html::footer();
+$menus = ["tools", "knowbaseitem"];
+Knowbase::displayTabContentForItem($_GET["id"] ?? 0, $menus, $_GET);

--- a/front/line.form.php
+++ b/front/line.form.php
@@ -115,10 +115,8 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(Line::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "management", "line");
-    $line->display([
-        'id'           => $_GET["id"],
+    $menus = ["management", "line"];
+    Line::displayFullPageForItem($_GET["id"], $menus, [
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/link.form.php
+++ b/front/link.form.php
@@ -80,8 +80,6 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(Link::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "config", "link");
-
-    $link->display(['id' => $_GET["id"]]);
-    Html::footer();
+    $menus = ["config", "link"];
+    Link::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/mailcollector.form.php
+++ b/front/mailcollector.form.php
@@ -102,7 +102,6 @@ if (isset($_POST["add"])) {
 
     Html::back();
 } else {
-    Html::header(MailCollector::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "config", "mailcollector");
-    $mailgate->display(['id' => $_GET["id"]]);
-    Html::footer();
+    $menus = ["config", "mailcollector"];
+    MailCollector::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/manuallink.form.php
+++ b/front/manuallink.form.php
@@ -98,24 +98,12 @@ if (array_key_exists('purge', $_POST) || array_key_exists('delete', $_POST)) {
     $itemtype = $link->isNewItem() ? $_GET['itemtype'] : $link->fields['itemtype'];
     $items_id = $link->isNewItem() ? $_GET['items_id'] : $link->fields['items_id'];
 
-    Html::header(
-        ManualLink::getTypeName(Session::getPluralNumber()),
-        $_SERVER['PHP_SELF'],
-        Html::getMenuSectorForItemtype($itemtype),
-        $itemtype
-    );
-
-    $link->display(
-        [
-            'id'          => $id,
-            'formoptions' => 'data-track-changes=true',
-
-            'itemtype'    => $itemtype,
-            'items_id'    => $items_id
-        ]
-    );
-
-    Html::footer();
+    $menus = [Html::getMenuSectorForItemtype($itemtype), $itemtype];
+    ManualLink::displayFullPageForItem($id ?? 0, $menus, [
+        'formoptions' => 'data-track-changes=true',
+        'itemtype'    => $itemtype,
+        'items_id'    => $items_id
+    ]);
 } else {
     Html::displayErrorAndDie('lost');
 }

--- a/front/monitor.form.php
+++ b/front/monitor.form.php
@@ -129,11 +129,10 @@ if (isset($_POST["add"])) {
 
     Html::redirect($monitor->getFormURLWithID($_POST["id"]));
 } else {
-    Html::header(Monitor::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "monitor");
-    $monitor->display([
-        'id'           => $_GET["id"],
+    $menus = ["assets", "monitor"];
+    Monitor::displayFullPageForItem($_GET['id'], $menus, [
+        'loaded'       => true,
         'withtemplate' => $_GET["withtemplate"],
-        'formoptions'  => "data-track-changes=true"
+        'formoptions'  => "data-track-changes=true",
     ]);
-    Html::footer();
 }

--- a/front/networkalias.form.php
+++ b/front/networkalias.form.php
@@ -102,8 +102,7 @@ if (isset($_GET['_in_modal'])) {
     }
 
     Session::checkRight("internet", UPDATE);
-    Html::header(NetworkAlias::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'assets');
 
-    $alias->display($_GET);
-    Html::footer();
+    $menus = ['assets'];
+    NetworkAlias::displayFullPageForItem($_GET["id"], $menus, $_GET);
 }

--- a/front/networkequipment.form.php
+++ b/front/networkequipment.form.php
@@ -115,11 +115,9 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(NetworkEquipment::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "networkequipment");
-    $netdevice->display([
-        'id'           => $_GET["id"],
+    $menus = ["assets", "networkequipment"];
+    NetworkEquipment::displayFullPageForItem($_GET["id"], $menus, [
         'withtemplate' => $_GET["withtemplate"],
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/networkname.form.php
+++ b/front/networkname.form.php
@@ -131,15 +131,6 @@ if (isset($_POST["add"])) {
         $_GET["itemtype"] = "";
     }
 
-    Session::checkRight("internet", READ);
-    Html::header(
-        NetworkName::getTypeName(Session::getPluralNumber()),
-        $_SERVER['PHP_SELF'],
-        'config',
-        'commondropdown',
-        'NetworkName'
-    );
-
-    $nn->display($_GET);
-    Html::footer();
+    $menus = ['config', 'commondropdown', 'NetworkName'];
+    NetworkName::displayFullPageForItem($_GET["id"], $menus, $_GET);
 }

--- a/front/networkport.form.php
+++ b/front/networkport.form.php
@@ -148,9 +148,7 @@ if (isset($_POST["add"])) {
     if (empty($_GET["instantiation_type"])) {
         $_GET["instantiation_type"] = "";
     }
-    Session::checkRight("networking", READ);
-    Html::header(NetworkPort::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'assets');
 
-    $np->display($_GET);
-    Html::footer();
+    $menus = ['assets'];
+    NetworkPort::displayFullPageForItem($_GET["id"], $menus, $_GET);
 }

--- a/front/networkportmigration.form.php
+++ b/front/networkportmigration.form.php
@@ -101,15 +101,6 @@ if (isset($_POST["purge"])) {
 
     Html::redirect($CFG_GLPI["root_doc"] . "/front/networkportmigration.php");
 } else {
-    Session::checkRight("networking", UPDATE);
-    Html::header(
-        NetworkPort::getTypeName(Session::getPluralNumber()),
-        $_SERVER['PHP_SELF'],
-        "tools",
-        "migration",
-        "networkportmigration"
-    );
-
-    $np->display(['id' => $_GET["id"]]);
-    Html::footer();
+    $menus = ["tools", "migration", "networkportmigration"];
+    NetworkPort::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/notification.form.php
+++ b/front/notification.form.php
@@ -81,13 +81,6 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(
-        Notification::getTypeName(Session::getPluralNumber()),
-        $_SERVER['PHP_SELF'],
-        "config",
-        "notification",
-        "notification"
-    );
-    $notification->display(['id' => $_GET["id"]]);
-    Html::footer();
+    $menus = ["config", "notification", "notification"];
+    Notification::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/notification_notificationtemplate.form.php
+++ b/front/notification_notificationtemplate.form.php
@@ -61,19 +61,15 @@ if (isset($_POST["add"])) {
     $notiftpl->update($_POST);
     Html::back();
 } else {
-    Html::header(
-        Notification_NotificationTemplate::getTypeName(Session::getPluralNumber()),
-        $_SERVER['PHP_SELF'],
-        "config",
-        "notification",
-        "notifications_notificationtemplates"
-    );
-    $params = [
-        'id' => $_GET['id'],
-    ];
+    $params = [];
     if (isset($_GET['notifications_id'])) {
         $params['notifications_id'] = $_GET['notifications_id'];
     }
-    $notiftpl->display($params);
-    Html::footer();
+
+    $menus = ["config", "notification", "notifications_notificationtemplates"];
+    Notification_NotificationTemplate::displayFullPageForItem(
+        $_GET['id'],
+        $menus,
+        $params
+    );
 }

--- a/front/notificationajaxsetting.form.php
+++ b/front/notificationajaxsetting.form.php
@@ -45,8 +45,5 @@ if (!empty($_POST["test_ajax_send"])) {
     Html::back();
 }
 
-Html::header(Notification::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "config", "notification", "config");
-
-$notificationajax->display(['id' => 1]);
-
-Html::footer();
+$menus = ["config", "notification", "config"];
+NotificationAjaxSetting::displayFullPageForItem(1, $menus);

--- a/front/notificationmailingsetting.form.php
+++ b/front/notificationmailingsetting.form.php
@@ -45,8 +45,5 @@ if (isset($_POST["test_smtp_send"])) {
     Html::back();
 }
 
-Html::header(Notification::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "config", "notification", "config");
-
-$notificationmail->display(['id' => 1]);
-
-Html::footer();
+$menus = ["config", "notification", "config"];
+NotificationMailingSetting::displayFullPageForItem(1, $menus);

--- a/front/notificationtemplate.form.php
+++ b/front/notificationtemplate.form.php
@@ -84,13 +84,6 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(
-        NotificationTemplate::getTypeName(Session::getPluralNumber()),
-        $_SERVER['PHP_SELF'],
-        "config",
-        "notification",
-        "notificationtemplate"
-    );
-    $notificationtemplate->display(['id' => $_GET["id"]]);
-    Html::footer();
+    $menus = ["config", "notification", "notificationtemplate"];
+    NotificationTemplate::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/notificationtemplatetranslation.form.php
+++ b/front/notificationtemplatetranslation.form.php
@@ -81,20 +81,18 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(
-        NotificationTemplate::getTypeName(Session::getPluralNumber()),
-        $_SERVER['PHP_SELF'],
-        "config",
-        "notification",
-        "notificationtemplate"
-    );
-
     if ($_GET["id"] == '') {
-        $options = ["notificationtemplates_id" => $_GET["notificationtemplates_id"]];
+        $options = [
+            "notificationtemplates_id" => $_GET["notificationtemplates_id"]
+        ];
     } else {
         $options = [];
     }
-    $options['id'] = $_GET["id"];
-    $language->display($options);
-    Html::footer();
+
+    $menus = ["config", "notification", "notificationtemplate"];
+    NotificationTemplateTranslation::displayFullPageForItem(
+        $_GET["id"],
+        $menus,
+        $options
+    );
 }

--- a/front/ola.form.php
+++ b/front/ola.form.php
@@ -90,8 +90,6 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(OLA::getTypeName(1), $_SERVER['PHP_SELF'], "config", "slm", "ola");
-
-    $ola->display(['id' => $_GET["id"]]);
-    Html::footer();
+    $menus = ["config", "slm", "ola"];
+    OLA::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/olalevel.form.php
+++ b/front/olalevel.form.php
@@ -104,9 +104,7 @@ if (isset($_POST["update"])) {
     $criteria->add($_POST);
 
     Html::back();
-} else if (isset($_GET["id"]) && ($_GET["id"] > 0)) { //print computer information
-    Html::header(OlaLevel::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "config", "slm", "olalevel");
-   //show computer form to add
-    $item->display(['id' => $_GET["id"]]);
-    Html::footer();
+} else if (isset($_GET["id"]) && ($_GET["id"] > 0)) {
+    $menus = ["config", "slm", "olalevel"];
+    OlaLevel::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/passivedcequipment.form.php
+++ b/front/passivedcequipment.form.php
@@ -115,14 +115,7 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(
-        PassiveDCEquipment::getTypeName(Session::getPluralNumber()),
-        $_SERVER['PHP_SELF'],
-        "assets",
-        "passivedcequipment"
-    );
     $options = [
-        'id' => $_GET['id'],
         'withtemplate' => $_GET['withtemplate'],
         'formoptions'  => "data-track-changes=true"
     ];
@@ -132,6 +125,7 @@ if (isset($_POST["add"])) {
     if (isset($_GET['room'])) {
         $options['room'] = $_GET['room'];
     }
-    $passive_equip->display($options);
-    Html::footer();
+
+    $menus = ["assets", "passivedcequipment"];
+    PassiveDCEquipment::displayFullPageForItem($_GET['id'], $menus, $options);
 }

--- a/front/pdu.form.php
+++ b/front/pdu.form.php
@@ -115,11 +115,9 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(PDU::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "pdu");
-    $pdu->display([
-        'id'           => $_GET["id"],
+    $menus = ["assets", "pdu"];
+    PDU::displayFullPageForItem($_GET["id"], $menus, [
         'withtemplate' => $_GET["withtemplate"],
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/pdu_plug.form.php
+++ b/front/pdu_plug.form.php
@@ -75,10 +75,9 @@ if (isset($_GET['id'])) {
 }
 $ajax = isset($_REQUEST['ajax']) ? true : false;
 
-if (!$ajax) {
-    Html::header(Pdu_Plug::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "pdu");
-}
-$pdup->display($params);
-if (!$ajax) {
-    Html::footer();
+if ($ajax) {
+    $pdup->display($params);
+} else {
+    $menus = ["assets", "pdu"];
+    Pdu_Plug::displayFullPageForItem($_GET['id'] ?? 0, $menus, $params);
 }

--- a/front/pdu_rack.form.php
+++ b/front/pdu_rack.form.php
@@ -72,10 +72,9 @@ $_SESSION['glpilisturl'][PDU_Rack::getType()] = $rack->getSearchURL();
 
 $ajax = isset($_REQUEST['ajax']) ? true : false;
 
-if (!$ajax) {
-    Html::header(Rack::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "rack");
-}
-$pra->display($params);
-if (!$ajax) {
-    Html::footer();
+if ($ajax) {
+    $pra->display($params);
+} else {
+    $menus = ["assets", "rack"];
+    PDU_Rack::displayFullPageForItem($_GET['id'] ?? 0, $menus, $params);
 }

--- a/front/peripheral.form.php
+++ b/front/peripheral.form.php
@@ -129,11 +129,9 @@ if (isset($_POST["add"])) {
 
     Html::redirect($peripheral->getFormURLWithID($_POST["id"]));
 } else {
-    Html::header(Peripheral::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "peripheral");
-    $peripheral->display([
-        'id'           => $_GET["id"],
+    $menus = ["assets", "peripheral"];
+    Peripheral::displayFullPageForItem($_GET["id"], $menus, [
         'withtemplate' => $_GET["withtemplate"],
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/phone.form.php
+++ b/front/phone.form.php
@@ -129,11 +129,9 @@ if (isset($_POST["add"])) {
 
     Html::redirect($phone->getFormURLWithID($_POST["id"]));
 } else {
-    Html::header(Phone::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'assets', 'phone');
-    $phone->display([
-        'id'           => $_GET["id"],
+    $menus = ['assets', 'phone'];
+    Phone::displayFullPageForItem($_GET["id"], $menus, [
         'withtemplate' => $_GET["withtemplate"],
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/planningexternalevent.form.php
+++ b/front/planningexternalevent.form.php
@@ -71,13 +71,6 @@ if (isset($_POST["add"])) {
     $extevent->update($_POST);
     Html::back();
 } else {
-    Html::header(
-        PlanningExternalEvent::getTypeName(Session::getPluralNumber()),
-        $_SERVER['PHP_SELF'],
-        "helpdesk",
-        "planning",
-        "external"
-    );
-    $extevent->display(['id' => $_GET["id"]]);
-    Html::footer();
+    $menus = ["helpdesk", "planning", "external"];
+    PlanningExternalEvent::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/printer.form.php
+++ b/front/printer.form.php
@@ -127,11 +127,9 @@ if (isset($_POST["add"])) {
     );
     Html::redirect($print->getFormURLWithID($_POST["id"]));
 } else {
-    Html::header(Printer::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "printer");
-    $print->display([
-        'id'           => $_GET["id"],
+    $menus = ["assets", "printer"];
+    Printer::displayFullPageForItem($_GET["id"], $menus, [
         'withtemplate' => $_GET["withtemplate"],
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/problem.form.php
+++ b/front/problem.form.php
@@ -200,24 +200,27 @@ if (isset($_POST["add"])) {
     if (isset($_GET['showglobalkanban']) && $_GET['showglobalkanban']) {
         Html::header(sprintf(__('%s Kanban'), Problem::getTypeName(1)), $_SERVER['PHP_SELF'], "helpdesk", "problem");
         $problem::showKanban(0);
+        Html::footer();
     } else {
-        Html::header(Problem::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "helpdesk", "problem");
-        $problem->display($_REQUEST);
-    }
-
-    if (isset($_GET['id']) && ($_GET['id'] > 0)) {
-        $url = KnowbaseItem::getFormURLWithParam($_GET) . '&_in_modal=1&item_itemtype=Ticket&item_items_id=' . $_GET['id'];
-        if (strpos($url, '_to_kb=') !== false) {
-            Ajax::createIframeModalWindow(
-                'savetokb',
-                $url,
-                [
-                    'title'         => __('Save and add to the knowledge base'),
-                    'reloadonclose' => false,
-                    'autoopen'      => true,
-                ]
-            );
+        $options = $_REQUEST;
+        if (isset($_GET['id']) && ($_GET['id'] > 0)) {
+            $url = KnowbaseItem::getFormURLWithParam($_GET) . '&_in_modal=1&item_itemtype=Ticket&item_items_id=' . $_GET['id'];
+            if (strpos($url, '_to_kb=') !== false) {
+                $options['after_display'] = Ajax::createIframeModalWindow(
+                    'savetokb',
+                    $url,
+                    [
+                        'title'         => __('Save and add to the knowledge base'),
+                        'reloadonclose' => false,
+                        'autoopen'      => true,
+                        'display'       => false,
+                    ]
+                );
+            }
         }
+
+        $menus = ["helpdesk", "problem"];
+        Problem::displayFullPageForItem($_GET['id'] ?? 0, $menus, $options);
     }
 
     Html::footer();

--- a/front/profile.form.php
+++ b/front/profile.form.php
@@ -64,11 +64,7 @@ if (isset($_POST["add"])) {
     Html::back();
 }
 
-Html::header(Profile::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "profile");
-
-$prof->display([
-    'id'           => $_GET["id"],
+$menus = ["admin", "profile"];
+Profile::displayFullPageForItem($_GET["id"], $menus, [
     'formoptions'  => " data-track-changes='true'"
 ]);
-
-Html::footer();

--- a/front/project.form.php
+++ b/front/project.form.php
@@ -124,18 +124,19 @@ if (isset($_POST["add"])) {
     $project->showForm($_GET["id"], ['withtemplate' => $_GET["withtemplate"]]);
     Html::popFooter();
 } else {
-    Html::header(Project::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "project");
-
     if (isset($_GET['showglobalgantt']) && $_GET['showglobalgantt']) {
+        Html::header(Project::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "project");
         $project->showGantt(-1);
+        Html::footer();
     } else if (isset($_GET['showglobalkanban']) && $_GET['showglobalkanban']) {
+        Html::header(Project::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "project");
         $project->showKanban(0);
+        Html::footer();
     } else {
-        $project->display([
-            'id'           => $_GET["id"],
+        $menus = ["tools", "project"];
+        Project::displayFullPageForItem($_GET["id"], $menus, [
             'withtemplate' => $_GET["withtemplate"],
             'formoptions'  => "data-track-changes=true"
         ]);
     }
-    Html::footer();
 }

--- a/front/projecttask.form.php
+++ b/front/projecttask.form.php
@@ -100,7 +100,6 @@ if (isset($_POST["add"])) {
     $task->showForm($_GET["id"], ['withtemplate' => $_GET["withtemplate"]]);
     Html::popFooter();
 } else {
-    Html::header(ProjectTask::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "project");
-    $task->display($_GET);
-    Html::footer();
+    $menus = ["tools", "project"];
+    ProjectTask::displayFullPageForItem($_GET['id'], $menus, $_GET);
 }

--- a/front/queuednotification.form.php
+++ b/front/queuednotification.form.php
@@ -43,8 +43,5 @@ if (!isset($_GET["id"])) {
     $_GET["id"] = "";
 }
 
-$mail = new QueuedNotification();
-
-Html::header(QueuedNotification::getTypeName(), $_SERVER['PHP_SELF'], "admin", "queuednotification");
-$mail->display($_GET);
-Html::footer();
+$menus = ["admin", "queuednotification"];
+QueuedNotification::displayFullPageForItem($_GET["id"], $menus, $_GET);

--- a/front/rack.form.php
+++ b/front/rack.form.php
@@ -115,10 +115,6 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    $ajax = isset($_REQUEST['ajax']) ? true : false;
-    if (!$ajax) {
-        Html::header(Rack::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "rack");
-    }
     $options = [
         'id'           => $_GET['id'],
         'withtemplate' => $_GET['withtemplate'],
@@ -134,8 +130,11 @@ if (isset($_POST["add"])) {
             $options['locations_id'] = $room->fields['locations_id'];
         }
     }
-    $rack->display($options);
-    if (!$ajax) {
-        Html::footer();
+
+    if ($_REQUEST['ajax'] ?? false) {
+        $rack->display($options);
+    } else {
+        $menus = ["assets", "rack"];
+        Rack::displayFullPageForItem($_GET["id"], $menus, $options);
     }
 }

--- a/front/refusedequipment.form.php
+++ b/front/refusedequipment.form.php
@@ -59,9 +59,6 @@ if (isset($_POST['delete']) || isset($_POST["purge"])) {
     );
     $refused->redirectToList();
 } else {
-    Html::header(RefusedEquipment::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "glpi\inventory\inventory", "refusedequipment");
-    $refused->display([
-        'id'           => $_GET["id"]
-    ]);
-    Html::footer();
+    $menus = ["admin", "glpi\inventory\inventory", "refusedequipment"];
+    RefusedEquipment::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/reminder.form.php
+++ b/front/reminder.form.php
@@ -134,17 +134,9 @@ if (isset($_POST["add"])) {
     }
     Html::back();
 } else {
-    if (Session::getCurrentInterface() == "helpdesk") {
-        Html::helpHeader(Reminder::getTypeName(Session::getPluralNumber()));
-    } else {
-        Html::header(Reminder::getTypeName(Session::getPluralNumber()), '', "tools", "reminder");
-    }
-
-    $remind->display(['id' => $_GET["id"]]);
-
-    if (Session::getCurrentInterface() == "helpdesk") {
-        Html::helpFooter();
-    } else {
-        Html::footer();
-    }
+    $menus = [
+        'central'  => ["tools", "reminder"],
+        'helpdesk' => [],
+    ];
+    Reminder::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/remindertranslation.form.php
+++ b/front/remindertranslation.form.php
@@ -49,8 +49,6 @@ if (isset($_POST['add'])) {
     $translation->delete($_POST, true);
     Html::redirect(Reminder::getFormURLWithID($_POST['reminders_id']));
 } else if (isset($_GET["id"])) {
-    $translation->check($_GET["id"], READ);
-    Html::header(Reminder::getTypeName(1), $_SERVER['PHP_SELF'], "tools", "remindertranslation");
-    $translation->display(['id' => $_GET['id']]);
-    Html::footer();
+    $menus = ["tools", "remindertranslation"];
+    ReminderTranslation::displayFullPageForItem($_GET['id'], $menus);
 }

--- a/front/rssfeed.form.php
+++ b/front/rssfeed.form.php
@@ -134,17 +134,9 @@ if (isset($_POST["add"])) {
     }
     Html::back();
 } else {
-    if (Session::getCurrentInterface() == "helpdesk") {
-        Html::helpHeader(RSSFeed::getTypeName(Session::getPluralNumber()));
-    } else {
-        Html::header(RSSFeed::getTypeName(Session::getPluralNumber()), '', "tools", "rssfeed");
-    }
-
-    $rssfeed->display(['id' => $_GET["id"]]);
-
-    if (Session::getCurrentInterface() == "helpdesk") {
-        Html::helpFooter();
-    } else {
-        Html::footer();
-    }
+    $menus = [
+        'central'  => ["tools", "rssfeed"],
+        'helpdesk' => []
+    ];
+    RSSFeed::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/rule.common.form.php
+++ b/front/rule.common.form.php
@@ -96,16 +96,7 @@ if (isset($_POST["add_action"])) {
     $rule->redirectToList();
 }
 
-Html::header(
-    Rule::getTypeName(Session::getPluralNumber()),
-    $_SERVER['PHP_SELF'],
-    'admin',
-    $rulecollection->menu_type,
-    $rulecollection->menu_option
-);
-
-$rule->display([
-    'id'           => $_GET["id"],
+$menus = ['admin', $rulecollection->menu_type, $rulecollection->menu_option];
+$rule::displayFullPageForItem($_GET["id"], $menus, [
     'formoptions'  => " data-track-changes='true'"
 ]);
-Html::footer();

--- a/front/savedsearch.form.php
+++ b/front/savedsearch.form.php
@@ -65,13 +65,10 @@ if (isset($_POST["add"])) {
     $savedsearch->check($_GET['id'], UPDATE);
     $savedsearch->createNotif();
     Html::back();
-} else {//print computer information
-    if (Session::getCurrentInterface() == "helpdesk") {
-        Html::helpHeader(SavedSearch::getTypeName(Session::getPluralNumber()));
-    } else {
-        Html::header(SavedSearch::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'tools', 'savedsearch');
-    }
-   //show computer form to add
-    $savedsearch->display(['id' => $_GET["id"]]);
-    Html::footer();
+} else {
+    $menus = [
+        'central'  => ['tools', 'savedsearch'],
+        'helpdesk' => [],
+    ];
+    SavedSearch::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/savedsearch_alert.form.php
+++ b/front/savedsearch_alert.form.php
@@ -93,9 +93,8 @@ if (isset($_POST["add"])) {
     }
     Html::back();
 } else {
-    Html::header(SavedSearch::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "savedsearch");
-    $alert->display(['id'           => $_GET["id"],
+    $menu = ["tools", "savedsearch"];
+    SavedSearch_Alert::displayFullPageForItem($_GET["id"], $menu, [
         'savedsearches_id' => $_GET["savedsearches_id"]
     ]);
-    Html::footer();
 }

--- a/front/sla.form.php
+++ b/front/sla.form.php
@@ -86,8 +86,6 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(SLA::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "config", "slm", "sla");
-
-    $sla->display(['id' => $_GET["id"]]);
-    Html::footer();
+    $menus = ["config", "slm", "sla"];
+    SLA::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/slalevel.form.php
+++ b/front/slalevel.form.php
@@ -100,9 +100,7 @@ if (isset($_POST["update"])) {
     $criteria->add($_POST);
 
     Html::back();
-} else if (isset($_GET["id"]) && ($_GET["id"] > 0)) { //print computer information
-    Html::header(SlaLevel::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "config", "slm", "slalevel");
-   //show computer form to add
-    $item->display(['id' => $_GET["id"]]);
-    Html::footer();
+} else if (isset($_GET["id"]) && ($_GET["id"] > 0)) {
+    $menus = ["config", "slm", "slalevel"];
+    SlaLevel::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/slm.form.php
+++ b/front/slm.form.php
@@ -90,8 +90,6 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(SLM::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "config", "slm");
-
-    $slm->display(['id' => $_GET["id"]]);
-    Html::footer();
+    $menus = ["config", "slm"];
+    SLM::displayFullPageForItem($_GET["id"], $menus);
 }

--- a/front/snmpcredential.form.php
+++ b/front/snmpcredential.form.php
@@ -114,11 +114,9 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(SNMPCredential::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "glpi\inventory\inventory", "snmpcredential");
-    $cred->display([
-        'id'           => $_GET["id"],
+    $menus = ["admin", "glpi\inventory\inventory", "snmpcredential"];
+    SNMPCredential::displayFullPageForItem($_GET["id"], $menus, [
         'withtemplate' => $_GET["withtemplate"],
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/socket.form.php
+++ b/front/socket.form.php
@@ -163,7 +163,6 @@ if (isset($_POST["add"])) {
         ];
     }
 
-    Html::header(Socket::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "cable", "socket");
-    $socket->display($options);
-    Html::footer();
+    $menus = ["assets", "cable", "socket"];
+    Socket::displayFullPageForItem($_GET["id"], $menus, $options);
 }

--- a/front/software.form.php
+++ b/front/software.form.php
@@ -115,11 +115,9 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(Software::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "software");
-    $soft->display([
-        'id'           => $_GET["id"],
+    $menus = ["assets", "software"];
+    Software::displayFullPageForItem($_GET["id"], $menus, [
         'withtemplate' => $_GET["withtemplate"],
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/softwarelicense.form.php
+++ b/front/softwarelicense.form.php
@@ -115,12 +115,6 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(
-        SoftwareLicense::getTypeName(Session::getPluralNumber()),
-        $_SERVER['PHP_SELF'],
-        "management",
-        "softwarelicense"
-    );
-    $license->display($_REQUEST);
-    Html::footer();
+    $menus = ["management", "softwarelicense"];
+    SoftwareLicense::displayFullPageForItem($_REQUEST['id'], $menus);
 }

--- a/front/softwareversion.form.php
+++ b/front/softwareversion.form.php
@@ -87,9 +87,8 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(SoftwareVersion::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "software");
-    $version->display(['id'           => $_GET["id"],
+    $menus = ["assets", "software"];
+    SoftwareVersion::displayFullPageForItem($_GET["id"], $menus, [
         'softwares_id' => $_GET["softwares_id"]
     ]);
-    Html::footer();
 }

--- a/front/supplier.form.php
+++ b/front/supplier.form.php
@@ -111,10 +111,8 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(Supplier::getTypeName(Session::getPluralNumber()), '', "management", "supplier");
-    $ent->display([
-        'id'           => $_GET["id"],
+    $menus = ["management", "supplier"];
+    Supplier::displayFullPageForItem($_GET["id"], $menus, [
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/transfer.form.php
+++ b/front/transfer.form.php
@@ -83,10 +83,7 @@ if (isset($_POST["add"])) {
     Html::back();
 }
 
-Html::header(__('Transfer'), '', 'admin', 'rule', 'transfer');
-
-$transfer->display(['id'     => $_GET["id"],
+$menus = ['admin', 'rule', 'transfer'];
+Transfer::displayFullPageForItem($_GET["id"], $menus, [
     'target' => $transfer->getFormURL()
 ]);
-
-Html::footer();

--- a/front/unmanaged.form.php
+++ b/front/unmanaged.form.php
@@ -115,11 +115,9 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    Html::header(Unmanaged::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "unmanaged");
-    $unmanaged->display([
-        'id'           => $_GET["id"],
+    $menus = ["assets", "unmanaged"];
+    Unmanaged::displayFullPageForItem($_GET["id"], $menus, [
         'withtemplate' => $_GET["withtemplate"],
         'formoptions'  => "data-track-changes=true"
     ]);
-    Html::footer();
 }

--- a/front/user.form.php
+++ b/front/user.form.php
@@ -234,12 +234,9 @@ if (isset($_GET['getvcard'])) {
 
          Html::back();
     } else {
-        Session::checkRight("user", READ);
-        Html::header(User::getTypeName(Session::getPluralNumber()), '', "admin", "user");
-        $user->display([
-            'id'           => $_GET["id"],
+        $menus = ["admin", "user"];
+        User::displayFullPageForItem($_GET["id"], $menus, [
             'formoptions'  => "data-track-changes=true"
         ]);
-        Html::footer();
     }
 }

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1119,32 +1119,30 @@ JAVASCRIPT;
      * @param array $options Options
      *
      * @return void
-     **/
+     */
     public function display($options = [])
     {
-        global $CFG_GLPI;
-
-        if (
-            isset($options['id'])
-            && !$this->isNewID($options['id'])
-        ) {
-            if (!$this->getFromDB($options['id'])) {
-                Html::displayNotFoundError();
-            }
-        }
-
-       // in case of lefttab layout, we couldn't see "right error" message
-        if ($this->get_item_to_display_tab) {
-            if (isset($_GET["id"]) && $_GET["id"] && !$this->can($_GET["id"], READ)) {
-               // This triggers from a profile switch.
-               // If we don't have right, redirect instead to central page
-                if (
-                    isset($_SESSION['_redirected_from_profile_selector'])
-                    && $_SESSION['_redirected_from_profile_selector']
-                ) {
-                    unset($_SESSION['_redirected_from_profile_selector']);
-                    Html::redirect($CFG_GLPI['root_doc'] . "/front/central.php");
+        // Item might already be loaded, skip load and rights checks
+        $item_loaded = $options['loaded'] ?? false;
+        if (!$item_loaded) {
+            if (
+                isset($options['id'])
+                && !$this->isNewID($options['id'])
+            ) {
+                if (!$this->getFromDB($options['id'])) {
+                    Html::displayNotFoundError();
                 }
+            }
+            // in case of lefttab layout, we couldn't see "right error" message
+            if (
+                $this->get_item_to_display_tab
+                && isset($_GET["id"])
+                && $_GET["id"]
+                && !$this->can($_GET["id"], READ)
+            ) {
+                // This triggers from a profile switch.
+                // If we don't have right, redirect instead to central page
+                Toolbox::handleProfileChangeRedirect();
                 Html::displayRightError();
             }
         }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8524,4 +8524,20 @@ abstract class CommonITILObject extends CommonDBTM
         }
         return null;
     }
+
+    /**
+     * Instead of "{itemtype} - {name}" we will use {itemtype} ({id}) - {name}
+     * as the ID of a Ticket/Change/Problem is an important information
+     *
+     * @return string
+     */
+    public function getBrowserTabName(): string
+    {
+        return sprintf(
+            __('%1$s (%2$s) - %3$s'),
+            static::getTypeName(1),
+            $this->getID(),
+            $this->getHeaderName()
+        );
+    }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -3965,4 +3965,15 @@ HTML;
             'name'  => null,
         ];
     }
+
+    /**
+     * Override parent: "{itemtype} - {header name}" -> "{itemtype}"
+     * There is only one config, no need to display the item name
+     *
+     * @return string
+     */
+    public function getBrowserTabName(): string
+    {
+        return self::getTypeName(1);
+    }
 }

--- a/src/Html.php
+++ b/src/Html.php
@@ -1156,15 +1156,21 @@ HTML;
      * @param string $sector  sector in which the page displayed is
      * @param string $item    item corresponding to the page displayed
      * @param string $option  option corresponding to the page displayed
+     * @param bool   $add_id  add current item id to the title ?
      *
      * @return void
-     **/
-    public static function includeHeader($title = '', $sector = 'none', $item = 'none', $option = '')
-    {
+     */
+    public static function includeHeader(
+        $title = '',
+        $sector = 'none',
+        $item = 'none',
+        $option = '',
+        bool $add_id = true
+    ) {
         global $CFG_GLPI, $PLUGIN_HOOKS;
 
        // complete title with id if exist
-        if (isset($_GET['id']) && $_GET['id']) {
+        if ($add_id && isset($_GET['id']) && $_GET['id']) {
             $title = sprintf(__('%1$s - %2$s'), $title, $_GET['id']);
         }
 
@@ -1587,25 +1593,32 @@ HTML;
      * @param string $sector  sector in which the page displayed is
      * @param string $item    item corresponding to the page displayed
      * @param string $option  option corresponding to the page displayed
-     **/
-    public static function header($title, $url = '', $sector = "none", $item = "none", $option = "")
-    {
+     * @param bool   $add_id  add current item id to the title ?
+     */
+    public static function header(
+        $title,
+        $url = '',
+        $sector = "none",
+        $item = "none",
+        $option = "",
+        bool $add_id = true
+    ) {
         global $CFG_GLPI, $HEADER_LOADED, $DB;
 
-       // If in modal : display popHeader
+        // If in modal : display popHeader
         if (isset($_REQUEST['_in_modal']) && $_REQUEST['_in_modal']) {
             return self::popHeader($title, $url, false, $sector, $item, $option);
         }
-       // Print a nice HTML-head for every page
+        // Print a nice HTML-head for every page
         if ($HEADER_LOADED) {
             return;
         }
         $HEADER_LOADED = true;
-       // Force lower case for sector and item
+        // Force lower case for sector and item
         $sector = strtolower($sector);
         $item   = strtolower($item);
 
-        self::includeHeader($title, $sector, $item, $option);
+        self::includeHeader($title, $sector, $item, $option, $add_id);
 
         $tmp_active_item = explode("/", $item);
         $active_item     = array_pop($tmp_active_item);
@@ -1639,7 +1652,7 @@ HTML;
             echo "</div>";
         }
 
-       // call static function callcron() every 5min
+        // call static function callcron() every 5min
         CronTask::callCron();
     }
 
@@ -1827,18 +1840,24 @@ HTML;
      * @param string $sector  sector in which the page displayed is
      * @param string $item    item corresponding to the page displayed
      * @param string $option  option corresponding to the page displayed
-     **/
-    public static function helpHeader($title, string $sector = "self-service", string $item = "none", string $option = "")
-    {
+     * @param bool   $add_id  add current item id to the title ?
+     */
+    public static function helpHeader(
+        $title,
+        string $sector = "self-service",
+        string $item = "none",
+        string $option = "",
+        bool $add_id = true
+    ) {
         global $HEADER_LOADED, $PLUGIN_HOOKS;
 
-       // Print a nice HTML-head for help page
+        // Print a nice HTML-head for help page
         if ($HEADER_LOADED) {
             return;
         }
         $HEADER_LOADED = true;
 
-        self::includeHeader($title, $sector, $item, $option);
+        self::includeHeader($title, $sector, $item, $option, $add_id);
 
         $menu = [
             'home' => [
@@ -1943,7 +1962,7 @@ HTML;
 
         TemplateRenderer::getInstance()->display('layout/parts/page_header.html.twig', $tpl_vars);
 
-       // call static function callcron() every 5min
+        // call static function callcron() every 5min
         CronTask::callCron();
     }
 

--- a/src/Item_Cluster.php
+++ b/src/Item_Cluster.php
@@ -43,7 +43,7 @@ class Item_Cluster extends CommonDBRelation
 
     public static function getTypeName($nb = 0)
     {
-        return _n('Item', 'Item', $nb);
+        return _n('Cluster item', 'Cluster items', $nb);
     }
 
 
@@ -53,7 +53,7 @@ class Item_Cluster extends CommonDBRelation
         if ($_SESSION['glpishow_count_on_tabs']) {
             $nb = self::countForMainItem($item);
         }
-        return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb);
+        return self::createTabEntry(_n('Item', 'Items', $nb));
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -3407,4 +3407,20 @@ HTML;
 
         return $tabs;
     }
+
+    /**
+     * Handle redirect after a profile switch.
+     * Must be called after a right check failure.
+     */
+    public static function handleProfileChangeRedirect(): void
+    {
+        global $CFG_GLPI;
+
+        $redirect = $_SESSION['_redirected_from_profile_selector'] ?? false;
+
+        if ($redirect) {
+            unset($_SESSION['_redirected_from_profile_selector']);
+            Html::redirect($CFG_GLPI['root_doc'] . "/front/central.php");
+        }
+    }
 }

--- a/templates/layout/parts/head.html.twig
+++ b/templates/layout/parts/head.html.twig
@@ -32,7 +32,7 @@
 <!DOCTYPE html>
 <html lang="{{ lang }}" {% if high_contrast %}data-high-contrast="1"{% endif %}>
 <head>
-   <title>GLPI - {{ title }}</title>
+   <title>{{ title }} - GLPI</title>
 
    <meta charset="utf-8" />
 


### PR DESCRIPTION
Another UI proposal.

Two changes:

1\) Move "GLPI" to the end of the tab name.
Our tabs names are currently like this: "GLPI - XXXXX".
I've noticed that most website do the opposite and put the must important information first, for example :

![image](https://user-images.githubusercontent.com/42734840/146016368-f3fc4d2b-d688-40a8-b4c8-4b53d49c8c83.png)

The main advantage is that the information on the left is always shown while the information on the right side may be hidden if you have too many tabs and they start to shrink.
It makes sense to keep the most important information always visible.

2\) Remove ids and use objects name.
All commondbtm items tab are displayed as "GLPI - {itemtype plural} - {item id}".
This is not very helpful for the user as ids are more meant for database than for humans.
If you have multiple computer tabs open for example, it's not easy to remember which is which.
Also, using the plural here seems inaccurate since we are viewing a single item.

Before changes:

![image](https://user-images.githubusercontent.com/42734840/146017150-4dde3b05-e693-4e36-b78e-712a8ff9a0ac.png)


After changes:

![image](https://user-images.githubusercontent.com/42734840/146017179-f4231aab-0074-41cc-8728-0bdf6205879a.png)

This was only done on computers for now, I'll keep this PR as a draft and wait for validation before editing all ".form.php" files .

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
