### PR TITLE
Fix guess  IP from Agent

### DIFF
--- a/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
@@ -134,19 +134,16 @@ if (!$DB->tableExists('glpi_agents')) {
          'comment' => 'Network Inventory task timeout (disabled by default)'
         ]
     );
-
     $migration->addField(
         'glpi_agents',
         'ip_binary',
         "varbinary(16) NOT NULL DEFAULT '0'"
     );
-
     $migration->addField(
         'glpi_agents',
         'ip_protocol',
         "varchar(5) DEFAULT NULL"
     );
-
 }
 $ADDTODISPLAYPREF['Agent'] = [2, 4, 10, 8, 11, 6];
 

--- a/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
@@ -80,6 +80,8 @@ if (!$DB->tableExists('glpi_agents')) {
          `threads_networkinventory` int NOT NULL DEFAULT '1' COMMENT 'Number of threads for Network Inventory',
          `timeout_networkdiscovery` int NOT NULL DEFAULT '0' COMMENT 'Network Discovery task timeout (disabled by default)',
          `timeout_networkinventory` int NOT NULL DEFAULT '0' COMMENT 'Network Inventory task timeout (disabled by default)',
+         `ip_binary` varbinary(16) NOT NULL DEFAULT '0',
+         `ip_protocol` varchar(5) DEFAULT NULL,
          PRIMARY KEY (`id`),
          KEY `name` (`name`),
          KEY `entities_id` (`entities_id`),
@@ -87,6 +89,8 @@ if (!$DB->tableExists('glpi_agents')) {
          KEY `item` (`itemtype`,`items_id`),
          UNIQUE KEY `deviceid` (`deviceid`),
          KEY `agenttypes_id` (`agenttypes_id`),
+         KEY `ip_binary` (`ip_binary`),
+         KEY `ip_protocol` (`ip_protocol`),
          CONSTRAINT `agenttypes_id` FOREIGN KEY (`agenttypes_id`) REFERENCES `glpi_agenttypes` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
    ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
     $DB->queryOrDie($query, "10.0 add table glpi_agents");
@@ -130,6 +134,19 @@ if (!$DB->tableExists('glpi_agents')) {
          'comment' => 'Network Inventory task timeout (disabled by default)'
         ]
     );
+
+    $migration->addField(
+        'glpi_agents',
+        'ip_binary',
+        "varbinary(16) NOT NULL DEFAULT '0'"
+    );
+
+    $migration->addField(
+        'glpi_agents',
+        'ip_protocol',
+        "varchar(5) DEFAULT NULL"
+    );
+
 }
 $ADDTODISPLAYPREF['Agent'] = [2, 4, 10, 8, 11, 6];
 

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8718,6 +8718,8 @@ CREATE TABLE `glpi_agents` (
   `threads_networkinventory` int NOT NULL DEFAULT '1' COMMENT 'Number of threads for Network inventory',
   `timeout_networkdiscovery` int NOT NULL DEFAULT '0' COMMENT 'Network Discovery task timeout (disabled by default)',
   `timeout_networkinventory` int NOT NULL DEFAULT '0' COMMENT 'Network Inventory task timeout (disabled by default)',
+  `ip_binary` varbinary(16) NOT NULL DEFAULT '0',
+  `ip_protocol` varchar(5) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `deviceid` (`deviceid`),
   KEY `name` (`name`),
@@ -8725,6 +8727,8 @@ CREATE TABLE `glpi_agents` (
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
   KEY `item` (`itemtype`,`items_id`),
+  KEY `ip_binary` (`ip_binary`),
+  KEY `ip_protocol` (`ip_protocol`),
   CONSTRAINT `agenttypes_id` FOREIGN KEY (`agenttypes_id`) REFERENCES `glpi_agenttypes` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -166,18 +166,18 @@ class Agent extends CommonDBTM
         return $ong;
     }
 
-    static function getSpecificValueToDisplay($field, $values, array $options = []) 
+    public static function getSpecificValueToDisplay($field, $values, array $options = [])
     {
         if (!is_array($values)) {
-           $values = [$field => $values];
+            $values = [$field => $values];
         }
         switch ($field) {
-           case 'ip_binary':
-              if ($ipadress = inet_ntop($values[$field])) {
-                 return $ipadress;
-              } else {
-                 return __('IP address not properly formatted');
-              }
+            case 'ip_binary':
+                if ($ipadress = inet_ntop($values[$field])) {
+                    return $ipadress;
+                } else {
+                    return __('IP address not properly formatted');
+                }
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }
@@ -482,7 +482,6 @@ class Agent extends CommonDBTM
 
         trigger_error(__('Agent IP address not properly formatted'));
         return false;
-
     }
 
    /**
@@ -505,9 +504,9 @@ class Agent extends CommonDBTM
         // add proxy string if configured in glpi
         if (!empty($CFG_GLPI["proxy_name"])) {
             $proxy_creds      = !empty($CFG_GLPI["proxy_user"])
-              ? $CFG_GLPI["proxy_user"].":".Toolbox::sodiumDecrypt($CFG_GLPI["proxy_passwd"])."@"
+              ? $CFG_GLPI["proxy_user"] . ":" . Toolbox::sodiumDecrypt($CFG_GLPI["proxy_passwd"]) . "@"
               : "";
-            $proxy_string     = "http://{$proxy_creds}".$CFG_GLPI['proxy_name'].":".$CFG_GLPI['proxy_port'];
+            $proxy_string     = "http://{$proxy_creds}" . $CFG_GLPI['proxy_name'] . ":" . $CFG_GLPI['proxy_port'];
             $options['proxy'] = $proxy_string;
         }
 


### PR DESCRIPTION
Actually, GLPI try to get all addresses from computer to request a remote inventory / status

from a standard inventory GLPI return three addresses (or more depending of inventory) (```NetworkPortLocal``` are excluded)
```https://192.168.1.24:62354/status``` (by ipv4)
```https://2a01:e0a:87c:4ea0:f178:597:e709:8aea:62354/status``` (by ipv6)
```https://Desktop:62354/status``` (by name)



As discuss with @g-bougard 

When agent contact GLPI save into ```glpi_agents``` table two new informations

- IP ```$_SERVER['REMOTE_ADDR']``` use by agent to contact GLPI (store as binary with ```inet_pton```)
- Protocol : ```http``` by default , ```https``` if plugin ```ssl``` is active agent side 

When user request ```/status```, ```/now``` (or other from plugins)
GLPI use this IP and make only one call.


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
