### PR TITLE
Fix handling of falsy properties in Plugin::registerClass()

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1337,10 +1337,13 @@ class Plugin extends CommonDBTM
 
         $blacklist = ['device_types'];
         foreach ($all_types as $att) {
-            if (!in_array($att, $blacklist) && isset($attrib[$att]) && $attrib[$att]) {
-                $CFG_GLPI[$att][] = $itemtype;
-                unset($attrib[$att]);
+            if (in_array($att, $blacklist) || !isset($attrib[$att])) {
+               continue;
             }
+            if ($attrib[$att]) {
+                $CFG_GLPI[$att][] = $itemtype;
+            }
+            unset($attrib[$att]);
         }
 
         if (

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1338,7 +1338,7 @@ class Plugin extends CommonDBTM
         $blacklist = ['device_types'];
         foreach ($all_types as $att) {
             if (in_array($att, $blacklist) || !isset($attrib[$att])) {
-               continue;
+                continue;
             }
             if ($attrib[$att]) {
                 $CFG_GLPI[$att][] = $itemtype;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a property with falsy value is passed to `Plugin::registerClass()` it should not trigger a warning.

```
[2021-12-15 10:11:27] glpiphplog.WARNING:   *** PHP User Warning (512): Unknown attributes "helpdesk_visible_types", "linkgroup_types", "linkuser_types", "linkgroup_tech_types", "linkuser_tech_types", "ticket_types", "infocom_types", "networkport_types", "reservation_types", "contract_types", "unicity_types", "location_types", "itemdevices_types" used in "PluginGenericobjectVoiture" class registration in /var/www/glpi/src/Plugin.php at line 1394
  Backtrace :
  src/Plugin.php:1394                                trigger_error()
  plugins/genericobject/inc/object.class.php:178     Plugin::registerClass()
  plugins/genericobject/setup.php:213                PluginGenericobjectObject::registerType()
  src/Plugin.php:1446                                plugin_post_init_genericobject()
  src/Plugin.php:236                                 Plugin::doHook()
  inc/includes.php:108                               Plugin->init()
  ajax/displayMessageAfterRedirect.php:35            include()
```

BC break introduced in da75443694574c8a66c1964c415a50c9387bf54b