### PR TITLE
Fix headers for new items

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -322,9 +322,13 @@ JAVASCRIPT;
             $html_sele = "";
             $i = 0;
 
-            // Hide tabs on item creation
+            // Hide tabs if only one single tab on item creation form
             $display_class = "";
-            if (is_a($type, CommonDBTM::class, true) && $type::isNewId($ID)) {
+            if (
+                is_a($type, CommonDBTM::class, true)
+                && $type::isNewId($ID)
+                && count($tabs) == 1
+            ) {
                 $display_class = "d-none";
             }
 

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -333,7 +333,6 @@ JAVASCRIPT;
             }
 
             foreach ($tabs as $val) {
-
                 $target = str_replace('\\', '_', $val['id']);
                 $html_tabs .= "<li class='nav-item $navitemml'>
                <a class='nav-link justify-content-between $navlinkp $display_class' data-bs-toggle='tab' title='" . strip_tags($val['title']) . "' ";

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -321,10 +321,18 @@ JAVASCRIPT;
             $html_tabs = "";
             $html_sele = "";
             $i = 0;
+
+            // Hide tabs on item creation
+            $display_class = "";
+            if (is_a($type, CommonDBTM::class, true) && $type::isNewId($ID)) {
+                $display_class = "d-none";
+            }
+
             foreach ($tabs as $val) {
+
                 $target = str_replace('\\', '_', $val['id']);
                 $html_tabs .= "<li class='nav-item $navitemml'>
-               <a class='nav-link justify-content-between $navlinkp' data-bs-toggle='tab' title='" . strip_tags($val['title']) . "' ";
+               <a class='nav-link justify-content-between $navlinkp $display_class' data-bs-toggle='tab' title='" . strip_tags($val['title']) . "' ";
                 $html_tabs .= " href='" . $val['url'] . (isset($val['params']) ? '?' . $val['params'] : '') . "' data-bs-target='#{$target}'>";
                 $html_tabs .= $val['title'] . "</a></li>";
 

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -87,7 +87,11 @@
                   </div>
                {% endif %}
                <span>
-               {{ nametype }} - {{ friendlyname }}
+               {% if item.id > 0 %}
+                  {{ nametype }} - {{ friendlyname }}
+               {% else %}
+                  {{ nametype }}
+               {% endif %}
                </span>
                {% if header_toolbar %}
                   <div class="d-inline-block toolbar ms-2">


### PR DESCRIPTION
Following #10098, a little fix + another improvement:
* Do not show item name on creation form
* Hide tab above creation form

Before:

![image](https://user-images.githubusercontent.com/42734840/146171997-95fe32bb-3dd4-47fd-872e-0d303a1cccae.png)

After:

![image](https://user-images.githubusercontent.com/42734840/146172042-67b02d70-43ff-4408-b599-b9191dc9a2ec.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
