### PR TITLE
fix horizontal tabs responsive

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -309,7 +309,7 @@ JAVASCRIPT;
             $nav_width      = "style='min-width: 200px'";
             if ($orientation == "horizontal") {
                 $flex_container = "flex-column";
-                $flex_tab       = "flex-row";
+                $flex_tab       = "flex-row d-none d-md-block";
                 $border         = "";
                 $navitemml      = "";
                 $navlinkp       = "";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Horizontal tabs (like central or preferences) display both controls : tabpanel and tabselect

![image](https://user-images.githubusercontent.com/418844/146349234-809c3a70-65f8-41bd-814d-35a66e5a2c11.png)

