### PR TITLE
Better handling of /install directory removal; see #10132

### DIFF
--- a/front/locale.php
+++ b/front/locale.php
@@ -39,7 +39,7 @@ include('../inc/includes.php');
 header("Content-Type: application/json; charset=UTF-8");
 
 $is_cacheable = !isset($_GET['debug']);
-if (!isset($CFG_GLPI['dbversion']) || trim($CFG_GLPI['dbversion']) != GLPI_SCHEMA_VERSION) {
+if (!Update::isDbUpToDate()) {
    // Make sure to not cache if in the middle of a GLPI update
     $is_cacheable = false;
 }

--- a/inc/config.php
+++ b/inc/config.php
@@ -176,18 +176,7 @@ if (!isset($skip_db_check) && !file_exists(GLPI_CONFIG_DIR . "/config_db.php")) 
         }
     }
     // Check version
-    $skip_version_checks = isset($_GET["donotcheckversion"]);
-    $has_known_version   = isset($CFG_GLPI['dbversion']);
-    $can_check_version   = is_readable(GLPI_ROOT . '/install/mysql/glpi-empty.sql');
-    if (!$skip_version_checks && $has_known_version && !$can_check_version) {
-        trigger_error(
-            sprintf(
-                'Databse schema file "%s" is not readable. Cannot check if GLPI installation is up-to-date.',
-                GLPI_ROOT . '/install/mysql/glpi-empty.sql'
-            ),
-            E_USER_WARNING
-        );
-    } elseif (!$skip_version_checks && (!$has_known_version || trim($CFG_GLPI["dbversion"]) != GLPI_SCHEMA_VERSION)) {
+    if (!isset($_GET["donotcheckversion"]) && !Update::isDbUpToDate()) {
         Session::loadLanguage('', false);
 
         if (isCommandLine()) {

--- a/inc/define.php
+++ b/inc/define.php
@@ -37,10 +37,10 @@ use Glpi\SocketModel;
 define('GLPI_VERSION', '10.0.0-dev');
 define(
     "GLPI_SCHEMA_VERSION",
-    GLPI_VERSION . '@' . (
+    GLPI_VERSION . (
         is_readable(GLPI_ROOT . '/install/mysql/glpi-empty.sql')
-        ? sha1_file(GLPI_ROOT . '/install/mysql/glpi-empty.sql')
-        : 'unnown'
+        ? '@' . sha1_file(GLPI_ROOT . '/install/mysql/glpi-empty.sql')
+        : ''
     )
 );
 

--- a/inc/define.php
+++ b/inc/define.php
@@ -35,7 +35,14 @@ use Glpi\SocketModel;
 
 // Current version of GLPI
 define('GLPI_VERSION', '10.0.0-dev');
-define("GLPI_SCHEMA_VERSION", GLPI_VERSION . '@' . sha1_file(GLPI_ROOT . '/install/mysql/glpi-empty.sql'));
+define(
+    "GLPI_SCHEMA_VERSION",
+    GLPI_VERSION . '@' . (
+        is_readable(GLPI_ROOT . '/install/mysql/glpi-empty.sql')
+        ? sha1_file(GLPI_ROOT . '/install/mysql/glpi-empty.sql')
+        : 'unnown'
+    )
+);
 
 if (!defined('GLPI_MARKETPLACE_PRERELEASES')) {
     define('GLPI_MARKETPLACE_PRERELEASES', preg_match('/-(dev|alpha\d*|beta\d*|rc\d*)$/', GLPI_VERSION) === 1);

--- a/index.php
+++ b/index.php
@@ -48,7 +48,36 @@ define('DO_NOT_CHECK_HTTP_REFERER', 1);
 
 // If config_db doesn't exist -> start installation
 if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
-    Html::redirect("install/install.php");
+    if (file_exists(GLPI_ROOT . '/install/install.php')) {
+        Html::redirect("install/install.php");
+    } else {
+        // Init session (required by header display logic)
+        Session::setPath();
+        Session::start();
+        Session::loadLanguage('', false);
+        // Prevent inclusion of debug informations in footer, as they are based on vars that are not initialized here.
+        $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
+
+        // no translation
+        $title_text        = 'GLPI seems to not be configured properly.';
+        $missing_conf_text = sprintf('Database configuration file "%s" is missing.', GLPI_CONFIG_DIR . '/config_db.php');
+        $hint_text         = 'You have to either restart the install process, either restore this file.';
+
+        Html::nullHeader('Missing configuration');
+        echo '<div class="container-fluid mb-4">';
+        echo '<div class="row justify-content-center">';
+        echo '<div class="col-xl-6 col-lg-7 col-md-9 col-sm-12">';
+        echo '<h2>' . $title_text . '</h2>';
+        echo '<p class="mt-2 mb-n2 alert alert-warning">';
+        echo $missing_conf_text;
+        echo ' ';
+        echo $hint_text;
+        echo '</p>';
+        echo '</div>';
+        echo '</div>';
+        echo '</div>';
+        Html::nullFooter();
+    }
     die();
 } else {
     include(GLPI_ROOT . "/inc/includes.php");

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -232,16 +232,25 @@ class Application extends BaseApplication
 
         $begin_time = microtime(true);
 
-        if (
-            $command instanceof GlpiCommandInterface && $command->requiresUpToDateDb()
-            && (!array_key_exists('dbversion', $this->config) || (trim($this->config['dbversion']) != GLPI_SCHEMA_VERSION))
-        ) {
-            $output->writeln(
-                '<error>'
-                . __('The version of the database is not compatible with the version of the installed files. An update is necessary.')
-                . '</error>'
-            );
-            return self::ERROR_DB_OUTDATED;
+        if ($command instanceof GlpiCommandInterface && $command->requiresUpToDateDb()) {
+            $has_known_version = array_key_exists('dbversion', $this->config);
+            $can_check_version = is_readable(GLPI_ROOT . '/install/mysql/glpi-empty.sql');
+
+            if ($has_known_version && !$can_check_version) {
+                $msg = sprintf(
+                    'Databse schema file "%s" is not readable. Cannot check if GLPI installation is up-to-date.',
+                    GLPI_ROOT . '/install/mysql/glpi-empty.sql'
+                );
+                $output->writeln('<comment>' . $msg . '</comment>', OutputInterface::VERBOSITY_QUIET);
+            } elseif (!$has_known_version || (trim($this->config['dbversion']) != GLPI_SCHEMA_VERSION)) {
+                $output->writeln(
+                    '<error>'
+                    . __('The version of the database is not compatible with the version of the installed files. An update is necessary.')
+                    . '</error>',
+                    OutputInterface::VERBOSITY_QUIET
+                );
+                return self::ERROR_DB_OUTDATED;
+            }
         }
 
         if (

--- a/src/Console/Database/UpdateCommand.php
+++ b/src/Console/Database/UpdateCommand.php
@@ -138,7 +138,7 @@ class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionComma
         $informations->addRow([__('GLPI database version'), $current_db_version, GLPI_SCHEMA_VERSION]);
         $informations->render();
 
-        if (version_compare($current_db_version, GLPI_SCHEMA_VERSION, 'eq') && !$force) {
+        if (Update::isDbUpToDate() && !$force) {
             $output->writeln('<info>' . __('No migration needed.') . '</info>');
             return 0;
         }

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -1845,7 +1845,7 @@ final class DbUtils
         global $DB;
 
        // Case of not init $DB object
-        if (method_exists($DB, "close")) {
+        if ($DB !== null && method_exists($DB, "close")) {
             $DB->close();
         }
     }

--- a/src/Html.php
+++ b/src/Html.php
@@ -1633,7 +1633,7 @@ HTML;
    **/
     public static function footer($keepDB = false)
     {
-        global $CFG_GLPI, $FOOTER_LOADED, $TIMER_DEBUG, $PLUGIN_HOOKS;
+        global $CFG_GLPI, $FOOTER_LOADED, $PLUGIN_HOOKS;
 
        // If in modal : display popFooter
         if (isset($_REQUEST['_in_modal']) && $_REQUEST['_in_modal']) {
@@ -1649,9 +1649,7 @@ HTML;
         echo self::getCoreVariablesForJavascript(true);
 
         $tpl_vars = [
-         'execution_time'      => $TIMER_DEBUG->getTime(),
-         'memory_usage'        => memory_get_usage(),
-         'js_files'            => [],
+         'js_files' => [],
         ];
 
        // On demand scripts
@@ -1726,7 +1724,7 @@ HTML;
 
         self::displayDebugInfos();
 
-        if (!$keepDB) {
+        if (!$keepDB && function_exists('closeDBConnections')) {
             closeDBConnections();
         }
     }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2846,7 +2846,7 @@ class Toolbox
     public static function getDateFormat($type)
     {
         $formats = self::getDateFormats($type);
-        $format = $formats[$_SESSION["glpidate_format"]];
+        $format = $formats[$_SESSION["glpidate_format"] ?? 0];
         return $format;
     }
 

--- a/src/Update.php
+++ b/src/Update.php
@@ -358,7 +358,6 @@ class Update
             // Hash is removed from both to do a simple version comparison.
             $installed_version = preg_replace('/@.+$/', '', $installed_version);
             $defined_version   = preg_replace('/@.+$/', '', $defined_version);
-            return version_compare($installed_version, $defined_version, 'eq');
         }
 
         return $installed_version === $defined_version;

--- a/src/Update.php
+++ b/src/Update.php
@@ -336,4 +336,31 @@ class Update
 
         return $migrations;
     }
+
+    /**
+     * Check if database is up-to-date.
+     *
+     * @return bool
+     */
+    public static function isDbUpToDate(): bool
+    {
+        global $CFG_GLPI;
+
+        if (!array_key_exists('dbversion', $CFG_GLPI)) {
+            return false; // Considered as outdated if installed version is unknown.
+        }
+
+        $installed_version = trim($CFG_GLPI['dbversion']);
+        $defined_version   = GLPI_SCHEMA_VERSION;
+
+        if (!str_contains($installed_version, '@') || !str_contains($defined_version, '@')) {
+            // Either installed or defined version is not containing schema hash.
+            // Hash is removed from both to do a simple version comparison.
+            $installed_version = preg_replace('/@.+$/', '', $installed_version);
+            $defined_version   = preg_replace('/@.+$/', '', $defined_version);
+            return version_compare($installed_version, $defined_version, 'eq');
+        }
+
+        return $installed_version === $defined_version;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10132

1. When calling directly the root path of GLPI `/` or `/index.php`, if DB config file is missing and `/install/install.php` file has been removed, following page is displayed, instead of redirecting to a 404.
![image](https://user-images.githubusercontent.com/33253653/146349329-f8a02ccf-d2f8-49a8-af9d-9fa13a6f1f50.png)

2. Page displayed when DB config file is missing during call to any front PHP file is now displayed properly. Also, the `Go to install` button will be displayed only if the install page is available.
![image](https://user-images.githubusercontent.com/33253653/146350335-76078098-e0cb-43b6-b435-eefd745b373f.png)

~~3. When `/install/mysql/glpi-empty.sql` is missing, `GLPI_SCHEMA_VERSION` will be suffixed by `@unknown`. Checks done to ensure DB is up to date will trigger a warning in this case, but update page will not be displayed.
It will be considered as a non-blocking issue.
On CLI mode, warning will be displayed too.~~

3. When `/install/mysql/glpi-empty.sql` is missing, `GLPI_SCHEMA_VERSION` will cannot be suffixed by `@xxx` hash. In this case, the comparison is done ignoring this hash suffix, to prevent any issues on edge case.