### PR TITLE
Fix creating personal display preference when global is missing/unset

### DIFF
--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -179,7 +179,8 @@ class DisplayPreference extends CommonDBTM
 
                 foreach ($searchopt as $key => $val) {
                     if (
-                        is_array($val)
+                        is_int($key)
+                        && is_array($val)
                         && ($key != 1)
                         && !$done
                     ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Noticed with Database Instances. If there is no global display preferences set, the fallback for default personal preferences mistakenly tries processing the search option group strings returned by `Search::getOptions` like `'common' => ['name' => 'Characteristics']`