### PR TITLE
Prevent releasing a version without updating inc/define.php first

### DIFF
--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -46,8 +46,8 @@ TARBALL_PATH=/tmp/glpi-$RELEASE.tgz
 
 if [ ! -e $SOURCE_DIR ] || [ ! -e $SOURCE_DIR/.git ]
 then
- echo "$SOURCE_DIR is not a valid Git repository"
- exit
+    echo "$SOURCE_DIR is not a valid Git repository"
+    exit
 fi
 
 read -p "Are translations up to date? [Y/n] " -n 1 -r
@@ -63,6 +63,14 @@ then
     rm -rf $WORKING_DIR
 fi
 git --git-dir="$SOURCE_DIR/.git" checkout-index --all --force --prefix="$WORKING_DIR/glpi/"
+
+
+FOUND_VERSION=$(grep -Po "define\('GLPI_VERSION', '\K.*?(?=')" $WORKING_DIR/glpi//inc/define.php)
+if [[ ! "$RELEASE" = "$FOUND_VERSION" ]]
+then
+    echo "$RELEASE does not match version $FOUND_VERSION declared in inc/define.php"
+    exit
+fi
 
 echo "Building application"
 $WORKING_DIR/glpi/tools/build_glpi.sh


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

GLPI_VERSION has not been updated in `inc/define.php` during GLPI 10.0.0-beta release process. This check will prevent this kind omission.

![image](https://user-images.githubusercontent.com/33253653/146566224-7ef6b9ef-c7fa-4c3f-9710-cdaeb9d80e01.png)
