### PR TITLE
Fix KB profile visibility dropdown

### DIFF
--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -2206,6 +2206,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
     protected function getShowVisibilityDropdownParams()
     {
         $params = parent::getShowVisibilityDropdownParams();
+        $params['right'] = ($this->getField('is_faq') ? 'faq' : 'knowbase');
         $params['allusers'] = 1;
         return $params;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10172

The removal of the `right` property in #9898 broke the Profile dropdown in the KB visibility tab. I tested the category dropdown from the other commit and it still worked with the `right` property restored. I'm not quite sure why it was removed.