### PR TITLE
fix empty display_onlogin hook displaying an empty  right column

### DIFF
--- a/templates/pages/login.html.twig
+++ b/templates/pages/login.html.twig
@@ -98,7 +98,7 @@
          </div>
 
          {% if right_panel %}
-            <div class="col offset-md-1 p-2 text-center">
+            <div class="col-auto offset-md-1 p-2 text-center">
                {% if text_login|length > 0 %}
                   <div class="rich_text_container">
                      {{ text_login|safe_html }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

When a plugin (like alerts or branding) use the`display_onlogin` but don't display anything, login screen show an empty right column.

Before:
![image](https://user-images.githubusercontent.com/418844/146740474-3278d83c-d14d-431c-883c-2783c3bb38e9.png)


After:
![image](https://user-images.githubusercontent.com/418844/146740558-712b8c2d-4588-4ad0-a40f-796b082fb362.png)

