### PR TITLE
prevent overflow of plan button when creating task

### DIFF
--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -345,7 +345,7 @@
                            });
                         }
                      </script>
-                     <button id="plan{{ rand }}" class="btn btn-outline-secondary d-block mb-2" onclick="showPlanUpdate{{ rand }}()" type="button">
+                     <button id="plan{{ rand }}" class="btn btn-outline-secondary d-block mb-2 text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
                         <i class="fas fa-calendar"></i>
                         <span>{{ __('Plan this task') }}</span>
                      </button>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Prevent "Plan this task" button to overflow with small screen

