### PR TITLE
Add missing quote that broke racks with background

### DIFF
--- a/src/Rack.php
+++ b/src/Rack.php
@@ -454,7 +454,7 @@ class Rack extends CommonDBTM
             $blueprint = "
             <div class='blueprint'
                  style='background: url({$blueprint_url}) no-repeat top left/100% 100%;
-                        height: " . $grid_h . "px;></div>";
+                        height: " . $grid_h . "px;'></div>";
             $blueprint_ctrl = "<span class='mini_toggle active'
                                   id='toggle_blueprint'>" . __('Blueprint') . "</span>";
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10179 

Missing quote to end `style` attribute caused some JS to display directly in the page, breaking the rack view in server rooms.