### PR TITLE
hz tabs should be displayed as flex, not block

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -309,7 +309,7 @@ JAVASCRIPT;
             $nav_width      = "style='min-width: 200px'";
             if ($orientation == "horizontal") {
                 $flex_container = "flex-column";
-                $flex_tab       = "flex-row d-none d-md-block";
+                $flex_tab       = "flex-row d-none d-md-flex";
                 $border         = "";
                 $navitemml      = "";
                 $navlinkp       = "";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

issue with horizontal tabs after merging of 9b875a3de652885ea6de7624d79ae552a319a2ab
they should be displayed as flex (at least inline) not block


Before:
![image](https://user-images.githubusercontent.com/418844/146777066-ed66a7e1-b422-49d5-b33f-088d57756ebf.png)

After:
![image](https://user-images.githubusercontent.com/418844/146777115-54ecfb2b-5485-4e41-916a-ffb1a88bd690.png)


