### PR TITLE
use_bind should be set to yes by default; see #10135

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -164,6 +164,7 @@ class AuthLDAP extends CommonDBTM
         $this->fields['comment_field']               = '';
         $this->fields['title_field']                 = '';
         $this->fields['use_dn']                      = 0;
+        $this->fields['use_bind']                    = 1;
         $this->fields['picture_field']               = '';
         $this->fields['responsible_field']           = '';
     }

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -127,7 +127,7 @@ class AuthLDAP extends DbTestCase
     {
         $ldap = new \AuthLDAP();
         $ldap->post_getEmpty();
-        $this->array($ldap->fields)->hasSize(24);
+        $this->array($ldap->fields)->hasSize(25);
     }
 
     public function testUnsetUndisclosedFields()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10135
