### PR TITLE
Fix SLA and OLA class references

### DIFF
--- a/src/OLA.php
+++ b/src/OLA.php
@@ -39,9 +39,9 @@ class OLA extends LevelAgreement
 {
     protected static $prefix            = 'ola';
     protected static $prefixticket      = 'internal_';
-    protected static $levelclass        = 'OLALevel';
+    protected static $levelclass        = 'OlaLevel';
     protected static $levelticketclass  = 'OlaLevel_Ticket';
-    protected static $forward_entity_to = ['OLALevel'];
+    protected static $forward_entity_to = ['OlaLevel'];
 
     public static function getTypeName($nb = 0)
     {

--- a/src/SLA.php
+++ b/src/SLA.php
@@ -43,9 +43,9 @@ class SLA extends LevelAgreement
 {
     protected static $prefix            = 'sla';
     protected static $prefixticket      = '';
-    protected static $levelclass        = 'SLALevel';
+    protected static $levelclass        = 'SlaLevel';
     protected static $levelticketclass  = 'SlaLevel_Ticket';
-    protected static $forward_entity_to = ['SLALevel'];
+    protected static $forward_entity_to = ['SlaLevel'];
 
     public static function getTypeName($nb = 0)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Class names are case sensitive and these references didn't match the class name exactly.