### PR TITLE
Use GET for ajax modal like previous versions

### DIFF
--- a/src/Rack.php
+++ b/src/Rack.php
@@ -613,6 +613,7 @@ class Rack extends CommonDBTM
 
                glpi_ajax_dialog({
                   url : "{$rack->getFormURL()}",
+                  method: 'GET',
                   params: {
                      room: $room_id,
                      position: _x + ',' + _y,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10179 

AJAX is POST by default which GLPI checks CSRF for, but this modal doesn't have a token. In previous versions it explicitly was a GET for the form contents. The retrieved form should still be submitted through a POST.