### PR TITLE
do not send encoded html to ldap search; see #10135

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1966,7 +1966,7 @@ class AuthLDAP extends CommonDBTM
             if ($values['ldap_filter'] == '') {
                 $filter = "(" . $field_for_sync . "=*)";
                 if (!empty($config_ldap->fields['condition'])) {
-                    $filter = "(& $filter " . $config_ldap->fields['condition'] . ")";
+                    $filter = "(& $filter " . Sanitizer::unsanitize($config_ldap->fields['condition']) . ")";
                 }
             } else {
                 $filter = $values['ldap_filter'];
@@ -3323,7 +3323,7 @@ class AuthLDAP extends CommonDBTM
         $filter = "(" . $values['login_field'] . "=" . $filter_value . ")";
 
         if (!empty($values['condition'])) {
-            $filter = "(& $filter " . $values['condition'] . ")";
+            $filter = "(& $filter " . Sanitizer::unsanitize($values['condition']) . ")";
         }
 
         if ($result = @ldap_search($ds, $values['basedn'], $filter, $ldap_parameters)) {
@@ -3835,7 +3835,7 @@ class AuthLDAP extends CommonDBTM
                      && !empty($_SESSION['ldap_import']['end_date'])
                         ? $_SESSION['ldap_import']['end_date'] : null);
         $filter    .= self::addTimestampRestrictions($begin_date, $end_date);
-        $ldap_condition = $authldap->getField('condition');
+        $ldap_condition = Sanitizer::unsanitize($authldap->getField('condition'));
        //Add entity filter and filter filled in directory's configuration form
         return  "(&" . (isset($_SESSION['ldap_import']['entity_filter'])
                     ? $_SESSION['ldap_import']['entity_filter']

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1821,7 +1821,7 @@ class AuthLDAP extends CommonDBTM
                   ]
                  ]
                 ];
-                $sr = @ldap_search($ds, $values['basedn'], $filter, $attrs, 0, -1, -1, LDAP_DEREF_NEVER, $controls);
+                $sr = ldap_search($ds, $values['basedn'], $filter, $attrs, 0, -1, -1, LDAP_DEREF_NEVER, $controls);
                 ldap_parse_result($ds, $sr, $errcode, $matcheddn, $errmsg, $referrals, $controls);
                 if (isset($controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'])) {
                     $cookie = $controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'];
@@ -1829,7 +1829,7 @@ class AuthLDAP extends CommonDBTM
                     $cookie = '';
                 }
             } else {
-                $sr = @ldap_search($ds, $values['basedn'], $filter, $attrs);
+                $sr = ldap_search($ds, $values['basedn'], $filter, $attrs);
             }
 
             if ($sr) {
@@ -2473,7 +2473,7 @@ class AuthLDAP extends CommonDBTM
                   ]
                 ]
                 ];
-                $sr = @ldap_search($ldap_connection, $config_ldap->fields['basedn'], $filter, $attrs, 0, -1, -1, LDAP_DEREF_NEVER, $controls);
+                $sr = ldap_search($ldap_connection, $config_ldap->fields['basedn'], $filter, $attrs, 0, -1, -1, LDAP_DEREF_NEVER, $controls);
                 ldap_parse_result($ldap_connection, $sr, $errcode, $matcheddn, $errmsg, $referrals, $controls);
                 if (isset($controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'])) {
                     $cookie = $controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'];
@@ -2481,7 +2481,7 @@ class AuthLDAP extends CommonDBTM
                     $cookie = '';
                 }
             } else {
-                $sr = @ldap_search($ldap_connection, $config_ldap->fields['basedn'], $filter, $attrs);
+                $sr = ldap_search($ldap_connection, $config_ldap->fields['basedn'], $filter, $attrs);
             }
 
             if ($sr) {
@@ -3326,7 +3326,7 @@ class AuthLDAP extends CommonDBTM
             $filter = "(& $filter " . Sanitizer::unsanitize($values['condition']) . ")";
         }
 
-        if ($result = @ldap_search($ds, $values['basedn'], $filter, $ldap_parameters)) {
+        if ($result = ldap_search($ds, $values['basedn'], $filter, $ldap_parameters)) {
            //search has been done, let's check for found results
             $info = self::get_entries_clean($ds, $result);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10135

@cedric-anne opinion on this one would be required before merging i suppose
Original error was on `ldap_search` (but the `@` before https://github.com/glpi-project/glpi/blob/10.0.0-beta/src/AuthLDAP.php#L3329 hides completly the error for me, also in logs):

```
[2021-12-21 12:21:20] glpiphplog.WARNING:   *** PHP Warning (2): ldap_search(): Search: Bad search filter in /var/www/html/glpi/10.0-git/src/AuthLDAP.php at line 3331
  Backtrace :
  src/AuthLDAP.php:3331                              ldap_search()
  src/AuthLDAP.php:2732                              AuthLDAP::searchUserDn()
  src/AuthLDAP.php:352                               AuthLDAP::ldapImportUserByServerId()
  src/MassiveAction.php:1168                         AuthLDAP::processMassiveActionsForOneItemtype()
  src/MassiveAction.php:1146                         MassiveAction->processForSeveralItemtypes()
  front/massiveaction.php:59                         MassiveAction->process()
```

And the bad content was the `&` encode to `&#38;`, both in db and also in form data (you can change it live in import form)
