### PR TITLE
Update/inventory support

### DIFF
--- a/front/inventory.php
+++ b/front/inventory.php
@@ -46,7 +46,7 @@ if (isset($_GET['refused'])) {
     $refused->getFromDB($_GET['refused']);
     $contents = file_get_contents($refused->getInventoryFileName());
 } else if ($_SERVER['REQUEST_METHOD'] != 'POST') {
-    $inventory_request->addError('Method not allowed');
+    $inventory_request->addError('Method not allowed', 405);
     $handle = false;
 } else {
     $contents = file_get_contents("php://input");

--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -314,7 +314,7 @@ abstract class AbstractRequest
     public function addError($message, $code = 500)
     {
         $this->error = true;
-        $this->http_repsonse_code = $code;
+        $this->http_response_code = $code;
         if ($this->headers->hasHeader('GLPI-Agent-ID')) {
             $this->addToResponse([
             'status' => 'error',

--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -72,6 +72,8 @@ abstract class AbstractRequest
 
    //GLPI AGENT TASK
     const INVENT_TASK = 'inventory';
+    const NETDISCOVERY_TASK = 'netdiscovery';
+    const NETINV_TASK = 'netinventory';
 
     const COMPRESS_NONE = 0;
     const COMPRESS_ZLIB = 1;

--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -114,6 +114,12 @@ class Request extends AbstractRequest
             case self::INVENT_TASK:
                 return $this->handleInventoryTask();
             break;
+            case self::NETDISCOVERY_TASK:
+                return $this->handleNetDiscoveryTask();
+            break;
+            case self::NETINV_TASK:
+                return $this->handleNetInventoryTask();
+            break;
             default:
                 $this->addError("Task '$task' is not supported.", 400);
                 return [];
@@ -346,6 +352,36 @@ class Request extends AbstractRequest
         $params['options']['response'] = [];
         $params['item'] = $this->inventory->getAgent();
         $params = Plugin::doHookFunction("handle_inventory_task", $params);
+
+        return $params['options']['response'];
+    }
+
+   /**
+    * Handle agent netdiscovery task options
+    *
+    * @return array
+    */
+    public function handleNetDiscoveryTask()
+    {
+
+        $params['options']['response'] = [];
+        $params['item'] = $this->inventory->getAgent();
+        $params = Plugin::doHookFunction("handle_netdiscovery_task", $params);
+
+        return $params['options']['response'];
+    }
+
+   /**
+    * Handle agent netinventory task options
+    *
+    * @return array
+    */
+    public function handleNetInventoryTask()
+    {
+
+        $params['options']['response'] = [];
+        $params['item'] = $this->inventory->getAgent();
+        $params = Plugin::doHookFunction("handle_netinventory_task", $params);
 
         return $params['options']['response'];
     }

--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -121,7 +121,6 @@ class Request extends AbstractRequest
                 return $this->handleNetInventoryTask();
             break;
             default:
-                $this->addError("Task '$task' is not supported.", 400);
                 return [];
         }
         return [];

--- a/tests/web/Glpi/Inventory/Request.php
+++ b/tests/web/Glpi/Inventory/Request.php
@@ -60,7 +60,6 @@ class Request extends \GLPITestCase
     */
     private function checkResponse(GuzzleHttp\Psr7\Response $res, $reply)
     {
-        $this->integer($res->getStatusCode())->isIdenticalTo(200);
         $this->string($res->getHeader('content-type')[0])->isIdenticalTo('application/xml');
         $this->string((string)$res->getBody())
          ->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY>$reply</REPLY>\n");
@@ -68,29 +67,39 @@ class Request extends \GLPITestCase
 
     public function testWrongHttpMethod()
     {
-        $res = $this->http_client->request(
-            'GET',
-            $this->base_uri . 'front/inventory.php',
-            [
-            'headers' => [
-               'Content-Type' => 'application/xml'
-            ]
-            ]
-        );
+        try {
+            $res = $this->http_client->request(
+                'GET',
+                $this->base_uri . 'front/inventory.php',
+                [
+                'headers' => [
+                   'Content-Type' => 'application/xml'
+                ]
+                ]
+            );
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
+            $res = $e->getResponse();
+        }
+        $this->integer($res->getStatusCode())->isIdenticalTo(405);
         $this->checkResponse($res, '<ERROR>Method not allowed</ERROR>');
     }
 
     public function testRequestInvalidContent()
     {
-        $res = $this->http_client->request(
-            'POST',
-            $this->base_uri . 'front/inventory.php',
-            [
-            'headers' => [
-               'Content-Type' => 'application/xml'
-            ]
-            ]
-        );
+        try {
+            $res = $this->http_client->request(
+                'POST',
+                $this->base_uri . 'front/inventory.php',
+                [
+                'headers' => [
+                   'Content-Type' => 'application/xml'
+                ]
+                ]
+            );
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
+            $res = $e->getResponse();
+        }
+        $this->integer($res->getStatusCode())->isIdenticalTo(400);
         $this->checkResponse($res, '<ERROR>XML not well formed!</ERROR>');
     }
 
@@ -111,8 +120,6 @@ class Request extends \GLPITestCase
             ]
         );
         $this->integer($res->getStatusCode())->isIdenticalTo(200);
-        $this->string($res->getHeader('content-type')[0])->isIdenticalTo('application/xml');
-        $this->string((string)$res->getBody())
-         ->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><PROLOG_FREQ>24</PROLOG_FREQ><RESPONSE>SEND</RESPONSE></REPLY>\n");
+        $this->checkResponse($res, '<PROLOG_FREQ>24</PROLOG_FREQ><RESPONSE>SEND</RESPONSE>');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |

First this PR add netdiscovery and netinventory tasks hooks, so we can modify glpiinventory plugin to handle this tasks providing required information during glpi-agent contact.
Secondly, a typo was hiding error handling in request addError() API as the HTTP error code wasn't set so we always got a 200 http code, even on error on glpi-agent side.
This revealed the line 118 at src/Inventory/Request.php should be removed to not fail on contact as glpi-agent is providing all the tasks it supports for information.
Finally, the `Method not supported` handling should return 405 as error code and it does now the typo is fixed.