### PR TITLE
feat(ticket): KB order for associated items

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1462,6 +1462,9 @@ JAVASCRIPT;
                         KnowbaseItem::getTable()      => 'id'
                     ]
                 ]
+            ],
+            'ORDER' => [
+                KnowbaseItem::getTable()      => 'name'
             ]
         ]);
 


### PR DESCRIPTION
The KB item displayed by default was not the 1st in the list (which is sorted alphabetically), but the 1st ID

![image](https://user-images.githubusercontent.com/8530352/147078445-60542e31-12f8-4df8-9bef-45ddd699b369.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23109
