### PR TITLE
fix: task date before ticket creation date

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -1825,6 +1825,7 @@ abstract class CommonITILObject extends CommonDBTM {
                'actiontime'                  => $tasktemplate->fields['actiontime'],
                'state'                       => $tasktemplate->fields['state'],
                $this->getForeignKeyField()   => $this->fields['id'],
+               'date'                        => $this->fields['date'],
                'is_private'                  => $tasktemplate->fields['is_private'],
                'users_id_tech'               => $tasktemplate->fields['users_id_tech'],
                'groups_id_tech'              => $tasktemplate->fields['groups_id_tech'],


### PR DESCRIPTION
When scheduled the creation of a recurring ticket with the option "Preliminary creation". The task opens with the actual creation date of the ticket. So task date was before ticket date.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23092
