### PR TITLE
Improve plugin support for Kanban

### DIFF
--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -2251,7 +2251,10 @@ class GLPIKanbanRights {
             }
          });
 
-         $(self.element).trigger('kanban:filter', self.filters);
+         $(self.element).trigger('kanban:filter', {
+            filters: self.filters,
+            kanban_element: self.element
+         });
 
          // Update column counters
          $(self.element + ' .kanban-column').each(function(i, column) {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8226,12 +8226,6 @@ abstract class CommonITILObject extends CommonDBTM
             'create_card_limited_columns'    => []
         ];
 
-        $plugin_filters = [];
-        Plugin::doHook(Hooks::KANBAN_FILTERS, [
-            'itemtype' => static::getType(),
-            'filters' => &$plugin_filters
-        ]);
-
         TemplateRenderer::getInstance()->display('components/kanban/kanban.html.twig', [
             'kanban_id'                   => 'kanban',
             'rights'                      => $rights,

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8149,7 +8149,11 @@ abstract class CommonITILObject extends CommonDBTM
             } else {
                 $card['_metadata']['content'] = '';
             }
-
+            $card['_metadata'] = Plugin::doHookFunction(Hooks::KANBAN_ITEM_METADATA, [
+                'itemtype' => $itemtype,
+                'items_id' => $item['id'],
+                'metadata' => $card['_metadata']
+            ])['metadata'];
             $columns[$item[$column_field]]['items'][] = $card;
         }
 
@@ -8214,54 +8218,60 @@ abstract class CommonITILObject extends CommonDBTM
 
         $itemtype = static::class;
         $rights = [
-         'create_item'                    => self::canCreate(),
-         'delete_item'                    => self::canDelete(),
-         'create_column'                  => false,
-         'modify_view'                    => true,
-         'order_card'                     => true,
-         'create_card_limited_columns'    => []
+            'create_item'                    => self::canCreate(),
+            'delete_item'                    => self::canDelete(),
+            'create_column'                  => false,
+            'modify_view'                    => true,
+            'order_card'                     => true,
+            'create_card_limited_columns'    => []
         ];
 
+        $plugin_filters = [];
+        Plugin::doHook(Hooks::KANBAN_FILTERS, [
+            'itemtype' => static::getType(),
+            'filters' => &$plugin_filters
+        ]);
+
         TemplateRenderer::getInstance()->display('components/kanban/kanban.html.twig', [
-         'kanban_id'                   => 'kanban',
-         'rights'                      => $rights,
-         'supported_itemtypes'         => $supported_itemtypes,
-         'max_team_images'             => 3,
-         'column_field'                => $column_field,
-         'item'                        => [
-            'itemtype'  => $itemtype,
-            'items_id'  => $ID
-         ],
-         'supported_filters'           => [
-            'title' => [
-               'description' => _x('filters', 'The title of the item'),
-               'supported_prefixes' => ['!', '#'] // Support exclusions and regex
+            'kanban_id'                   => 'kanban',
+            'rights'                      => $rights,
+            'supported_itemtypes'         => $supported_itemtypes,
+            'max_team_images'             => 3,
+            'column_field'                => $column_field,
+            'item'                        => [
+                'itemtype'  => $itemtype,
+                'items_id'  => $ID
             ],
-            'type' => [
-               'description' => _x('filters', 'The type of the item'),
-               'supported_prefixes' => ['!']
-            ],
-            'content' => [
-               'description' => _x('filters', 'The content of the item'),
-               'supported_prefixes' => ['!', '#'] // Support exclusions and regex
-            ],
-            'team' => [
-               'description' => _x('filters', 'A team member for the item'),
-               'supported_prefixes' => ['!']
-            ],
-            'user' => [
-               'description' => _x('filters', 'A user in the team of the item'),
-               'supported_prefixes' => ['!']
-            ],
-            'group' => [
-               'description' => _x('filters', 'A group in the team of the item'),
-               'supported_prefixes' => ['!']
-            ],
-            'supplier' => [
-               'description' => _x('filters', 'A supplier in the team of the item'),
-               'supported_prefixes' => ['!']
-            ],
-         ],
+            'supported_filters'           => [
+                'title' => [
+                    'description' => _x('filters', 'The title of the item'),
+                    'supported_prefixes' => ['!', '#'] // Support exclusions and regex
+                ],
+                'type' => [
+                    'description' => _x('filters', 'The type of the item'),
+                    'supported_prefixes' => ['!']
+                ],
+                'content' => [
+                    'description' => _x('filters', 'The content of the item'),
+                    'supported_prefixes' => ['!', '#'] // Support exclusions and regex
+                ],
+                'team' => [
+                    'description' => _x('filters', 'A team member for the item'),
+                    'supported_prefixes' => ['!']
+                ],
+                'user' => [
+                    'description' => _x('filters', 'A user in the team of the item'),
+                    'supported_prefixes' => ['!']
+                ],
+                'group' => [
+                    'description' => _x('filters', 'A group in the team of the item'),
+                    'supported_prefixes' => ['!']
+                ],
+                'supplier' => [
+                    'description' => _x('filters', 'A supplier in the team of the item'),
+                    'supported_prefixes' => ['!']
+                ],
+            ] + self::getKanbanPluginFilters(static::getType()),
         ]);
     }
 

--- a/src/Features/Kanban.php
+++ b/src/Features/Kanban.php
@@ -33,6 +33,9 @@
 
 namespace Glpi\Features;
 
+use Glpi\Plugin\Hooks;
+use Plugin;
+
 /**
  * Trait Kanban.
  * @since 9.5.0
@@ -137,5 +140,18 @@ trait Kanban
     public function canOrderKanbanCard($ID)
     {
         return true;
+    }
+
+    public static function getKanbanPluginFilters($itemtype)
+    {
+        global $PLUGIN_HOOKS;
+        $filters = [];
+
+        if (isset($PLUGIN_HOOKS[Hooks::KANBAN_FILTERS])) {
+            foreach ($PLUGIN_HOOKS[Hooks::KANBAN_FILTERS] as $plugin => $itemtype_filters) {
+                $filters = array_merge($filters, $itemtype_filters[$itemtype] ?? []);
+            }
+        }
+        return $filters;
     }
 }

--- a/src/Plugin/Hooks.php
+++ b/src/Plugin/Hooks.php
@@ -59,6 +59,8 @@ class Hooks
     const MIGRATE_TYPES                 = 'migratetypes';
     const POST_KANBAN_CONTENT           = 'post_kanban_content';
     const PRE_KANBAN_CONTENT            = 'pre_kanban_content';
+    const KANBAN_ITEM_METADATA          = 'kanban_item_metadata';
+    const KANBAN_FILTERS                = 'kanban_filters';
     const REDEFINE_MENUS                = 'redefine_menus';
     const RETRIEVE_MORE_DATA_FROM_LDAP  = 'retrieve_more_data_from_ldap';
     const RETRIEVE_MORE_FIELD_FROM_LDAP = 'retrieve_more_field_from_ldap';

--- a/src/Project.php
+++ b/src/Project.php
@@ -2355,6 +2355,11 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             } else {
                 $card['_metadata']['content'] = '';
             }
+            $card['_metadata'] = Plugin::doHookFunction(Hooks::KANBAN_ITEM_METADATA, [
+                'itemtype' => $itemtype,
+                'items_id' => $item['id'],
+                'metadata' => $card['_metadata']
+            ])['metadata'];
             $columns[$item['projectstates_id']]['items'][] = $card;
         }
 
@@ -2514,54 +2519,60 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
          'create_card_limited_columns'    => $canmodify_view ? [] : [0]
         ];
 
+        $plugin_filters = [];
+        Plugin::doHook(Hooks::KANBAN_FILTERS, [
+            'itemtype' => static::getType(),
+            'filters' => &$plugin_filters
+        ]);
+
         TemplateRenderer::getInstance()->display('components/kanban/kanban.html.twig', [
-         'kanban_id'                   => 'kanban',
-         'rights'                      => $rights,
-         'supported_itemtypes'         => $supported_itemtypes,
-         'max_team_images'             => 3,
-         'column_field'                => $column_field,
-         'item'                        => [
-            'itemtype'  => 'Project',
-            'items_id'  => $ID
-         ],
-         'supported_filters'           => [
-            'title' => [
-               'description' => _x('filters', 'The title of the item'),
-               'supported_prefixes' => ['!', '#'] // Support exclusions and regex
+            'kanban_id'                   => 'kanban',
+            'rights'                      => $rights,
+            'supported_itemtypes'         => $supported_itemtypes,
+            'max_team_images'             => 3,
+            'column_field'                => $column_field,
+            'item'                        => [
+                'itemtype'  => 'Project',
+                'items_id'  => $ID
             ],
-            'type' => [
-               'description' => _x('filters', 'The type of the item'),
-               'supported_prefixes' => ['!'] // Support exclusions only
-            ],
-            'milestone' => [
-               'description' => _x('filters', 'If the item represents a milestone or not'),
-               'supported_prefixes' => ['!']
-            ],
-            'content' => [
-               'description' => _x('filters', 'The content of the item'),
-               'supported_prefixes' => ['!', '#']
-            ],
-            'team' => [
-               'description' => _x('filters', 'A team member for the item'),
-               'supported_prefixes' => ['!']
-            ],
-            'user' => [
-               'description' => _x('filters', 'A user in the team of the item'),
-               'supported_prefixes' => ['!']
-            ],
-            'group' => [
-               'description' => _x('filters', 'A group in the team of the item'),
-               'supported_prefixes' => ['!']
-            ],
-            'supplier' => [
-               'description' => _x('filters', 'A supplier in the team of the item'),
-               'supported_prefixes' => ['!']
-            ],
-            'contact' => [
-               'description' => _x('filters', 'A contact in the team of the item'),
-               'supported_prefixes' => ['!']
-            ],
-         ],
+            'supported_filters'           => [
+                'title' => [
+                    'description' => _x('filters', 'The title of the item'),
+                    'supported_prefixes' => ['!', '#'] // Support exclusions and regex
+                ],
+                'type' => [
+                    'description' => _x('filters', 'The type of the item'),
+                    'supported_prefixes' => ['!'] // Support exclusions only
+                ],
+                'milestone' => [
+                    'description' => _x('filters', 'If the item represents a milestone or not'),
+                    'supported_prefixes' => ['!']
+                ],
+                'content' => [
+                    'description' => _x('filters', 'The content of the item'),
+                    'supported_prefixes' => ['!', '#']
+                ],
+                'team' => [
+                    'description' => _x('filters', 'A team member for the item'),
+                    'supported_prefixes' => ['!']
+                ],
+                'user' => [
+                    'description' => _x('filters', 'A user in the team of the item'),
+                    'supported_prefixes' => ['!']
+                ],
+                'group' => [
+                    'description' => _x('filters', 'A group in the team of the item'),
+                    'supported_prefixes' => ['!']
+                ],
+                'supplier' => [
+                    'description' => _x('filters', 'A supplier in the team of the item'),
+                    'supported_prefixes' => ['!']
+                ],
+                'contact' => [
+                    'description' => _x('filters', 'A contact in the team of the item'),
+                    'supported_prefixes' => ['!']
+                ],
+            ] + self::getKanbanPluginFilters(static::getType())
         ]);
     }
 

--- a/src/Project.php
+++ b/src/Project.php
@@ -2519,12 +2519,6 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
          'create_card_limited_columns'    => $canmodify_view ? [] : [0]
         ];
 
-        $plugin_filters = [];
-        Plugin::doHook(Hooks::KANBAN_FILTERS, [
-            'itemtype' => static::getType(),
-            'filters' => &$plugin_filters
-        ]);
-
         TemplateRenderer::getInstance()->display('components/kanban/kanban.html.twig', [
             'kanban_id'                   => 'kanban',
             'rights'                      => $rights,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add missing support for plugins to hook into the new Kanban filtering feature.

Two new PHP hooks were added:

- kanban_item_metadata: Used to inject metadata values into the displayed cards that will be used later for filtering
- kanban_filters: Add new filters for different item types

The JS-side event `kanban:filter` was changed to pass the kanban element selector in addition to the filters. This is not strictly needed for core Kanbans since they all use `#kanban` but this isn't a restriction for Kanban's added elsewhere.