### PR TITLE
fix(ticket): missing users_id_editor on solution update

### DIFF
--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -386,6 +386,11 @@ class ITILSolution extends CommonDBChild {
          return false;
       }
 
+      if (isset($input['update'])
+          && ($uid = Session::getLoginUserID())) {
+         $input["users_id_editor"] = $uid;
+      }
+
       return $input;
    }
 


### PR DESCRIPTION
'users_id_editor' value wasn't changed on solution update.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23128
