### PR TITLE
language dropdown twig macro

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -442,6 +442,27 @@
    {{ _self.field(name, field, label, options|merge({'id': 'dropdown_' ~ name ~ '_' ~ options.rand})) }}
 {% endmacro %}
 
+{% macro dropdownLanguageField(name, value, label = '', options = {}) %}
+   {% set options = {'rand': random()}|merge(options) %}
+
+   {% if options.disabled %}
+      {% set options = options|merge({specific_tags: {'disabled': 'disabled'}}) %}
+   {% endif %}
+   {% if options.fields_template.isMandatoryField(name) %}
+      {% set options = {'specific_tags': {'required': true}}|merge(options) %}
+   {% endif %}
+
+   {% set field %}
+      {% do call('Dropdown::showLanguages', [name, {
+         'value': value,
+         'rand': rand,
+         'width': '100%',
+      }|merge(options)]) %}
+   {% endset %}
+
+   {{ _self.field(name, field, label, options|merge({'id': 'dropdown_' ~ name ~ '_' ~ options.rand})) }}
+{% endmacro %}
+
 {% macro dropdownArrayField(name, value, elements, label = '', options = {}) %}
    {% set options = {'rand': random()}|merge(options) %}
 


### PR DESCRIPTION
Add a twig macro to build a languages dropdown. 

Required to convert Formcreator to Twig.

![image](https://user-images.githubusercontent.com/14139801/147355037-d87cda84-3a3f-42fb-8b32-1eba5f3d4cdf.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
