### PR TITLE
Update http protocol error and inventory error support

### DIFF
--- a/front/inventory.php
+++ b/front/inventory.php
@@ -79,7 +79,5 @@ if (isset($_GET['refused'])) {
     foreach ($headers as $key => $value) {
         header(sprintf('%1$s: %2$s', $key, $value));
     }
-    if ($inventory_request->getHttpResponseCode() != 405) {
-        echo $inventory_request->getResponse();
-    }
+    echo $inventory_request->getResponse();
 }

--- a/front/inventory.php
+++ b/front/inventory.php
@@ -49,11 +49,13 @@ if (isset($_GET['refused'])) {
     if (isset($_GET['action']) && $_GET['action'] == 'getConfig') {
        /**
         * Even if Fusion protocol is not supported for getConfig requests, they
-        * should be handled and answered with a json
+        * should be handled and answered with a json content type
         */
+        $inventory_request->handleContentType('application/json');
         $inventory_request->addError('Protocol not supported', 400);
     } else {
-        $inventory_request->addError('Method not allowed', 405);
+        // Method not allowed answer without content
+        $inventory_request->addError(null, 405);
     }
     $handle = false;
 } else {

--- a/front/inventory.php
+++ b/front/inventory.php
@@ -77,5 +77,7 @@ if (isset($_GET['refused'])) {
     foreach ($headers as $key => $value) {
         header(sprintf('%1$s: %2$s', $key, $value));
     }
-    echo $inventory_request->getResponse();
+    if ($inventory_request->getHttpResponseCode() != 405) {
+        echo $inventory_request->getResponse();
+    }
 }

--- a/front/inventory.php
+++ b/front/inventory.php
@@ -46,7 +46,15 @@ if (isset($_GET['refused'])) {
     $refused->getFromDB($_GET['refused']);
     $contents = file_get_contents($refused->getInventoryFileName());
 } else if ($_SERVER['REQUEST_METHOD'] != 'POST') {
-    $inventory_request->addError('Method not allowed');
+    if (isset($_GET['action']) && $_GET['action'] == 'getConfig') {
+       /**
+        * Even if Fusion protocol is not supported for getConfig requests, they
+        * should be handled and answered with a json
+        */
+        $inventory_request->addError('Protocol not supported', 400);
+    } else {
+        $inventory_request->addError('Method not allowed', 405);
+    }
     $handle = false;
 } else {
     $contents = file_get_contents("php://input");

--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -314,25 +314,20 @@ abstract class AbstractRequest
     {
         $this->error = true;
         $this->http_response_code = $code;
-        if ($code == 400 && preg_match('/not supported/', $message)) {
-            $this->setMode(self::JSON_MODE);
-            $this->addToResponse([
-            'status' => 'error',
-            'message' => $message,
-            'expiration' => self::DEFAULT_FREQUENCY
-            ]);
-        } else if ($this->headers->hasHeader('GLPI-Agent-ID')) {
-            $this->addToResponse([
-            'status' => 'error',
-            'message' => preg_replace(
-                '|\$ref\[file~2//.*/vendor/glpi-project/inventory_format/inventory.schema.json\]|',
-                '$ref[inventory.schema.json]',
-                $message
-            ),
-            'expiration' => self::DEFAULT_FREQUENCY
-            ]);
-        } else if ($code != 405) { // No need to add content on 405 error
-            $this->addToResponse(['ERROR' => $message]);
+        if (!empty($message)) {
+            if ($this->mode === self::JSON_MODE) {
+                $this->addToResponse([
+                'status' => 'error',
+                'message' => preg_replace(
+                    '|\$ref\[file~2//.*/vendor/glpi-project/inventory_format/inventory.schema.json\]|',
+                    '$ref[inventory.schema.json]',
+                    $message
+                ),
+                'expiration' => self::DEFAULT_FREQUENCY
+                ]);
+            } else {
+                $this->addToResponse(['ERROR' => $message]);
+            }
         }
     }
 

--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -445,39 +445,45 @@ abstract class AbstractRequest
     */
     public function getResponse(): string
     {
-        if ($this->mode === null) {
-            throw new \RuntimeException("Mode has not been set");
-        }
+        // Default to return empty response on no response set
+        $data = "";
+        if ($this->response !== null) {
+            if ($this->mode === null) {
+                throw new \RuntimeException("Mode has not been set");
+            }
 
-        $data = null;
-        switch ($this->mode) {
-            case self::XML_MODE:
-                $data = $this->response->saveXML();
-                break;
-            case self::JSON_MODE:
-                $data = json_encode($this->response);
-                break;
-            default:
-                throw new \RuntimeException("Unknown mode " . $this->mode);
-            break;
-        }
-
-        if ($this->compression !== self::COMPRESS_NONE) {
-            switch ($this->compression) {
-                case self::COMPRESS_ZLIB:
-                    $data = gzcompress($data);
+            switch ($this->mode) {
+                case self::XML_MODE:
+                    $data = $this->response->saveXML();
                     break;
-                case self::COMPRESS_GZIP:
-                    $data = gzencode($data);
-                    break;
-                case self::COMPRESS_BR:
-                    $data = brotli_compress($data);
-                    break;
-                case self::COMPRESS_DEFLATE:
-                    $data = gzdeflate($data);
+                case self::JSON_MODE:
+                    $data = json_encode($this->response);
                     break;
                 default:
-                    throw new \UnexpectedValueException("Unknown compression mode" . $this->compression);
+                    throw new \UnexpectedValueException("Unknown mode " . $this->mode);
+            }
+
+            if ($this->compression === null) {
+                throw new \RuntimeException("Compression has not been set");
+            }
+
+            if ($this->compression !== self::COMPRESS_NONE) {
+                switch ($this->compression) {
+                    case self::COMPRESS_ZLIB:
+                        $data = gzcompress($data);
+                        break;
+                    case self::COMPRESS_GZIP:
+                        $data = gzencode($data);
+                        break;
+                    case self::COMPRESS_BR:
+                        $data = brotli_compress($data);
+                        break;
+                    case self::COMPRESS_DEFLATE:
+                        $data = gzdeflate($data);
+                        break;
+                    default:
+                        throw new \UnexpectedValueException("Unknown compression mode" . $this->compression);
+                }
             }
         }
 

--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -72,6 +72,13 @@ abstract class AbstractRequest
 
    //GLPI AGENT TASK
     const INVENT_TASK = 'inventory';
+    const NETDISCOVERY_TASK = 'netdiscovery';
+    const NETINV_TASK = 'netinventory';
+    const ESX_TASK = 'esx';
+    const COLLECT_TASK = 'collect';
+    const DEPLOY_TASK = 'deploy';
+    const WOL_TASK = 'wakeonlan';
+    const REMOTEINV_TASK = 'remoteinventory';
 
     const COMPRESS_NONE = 0;
     const COMPRESS_ZLIB = 1;

--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -318,11 +318,7 @@ abstract class AbstractRequest
             if ($this->mode === self::JSON_MODE) {
                 $this->addToResponse([
                 'status' => 'error',
-                'message' => preg_replace(
-                    '|\$ref\[file~2//.*/vendor/glpi-project/inventory_format/inventory.schema.json\]|',
-                    '$ref[inventory.schema.json]',
-                    $message
-                ),
+                'message' => $message,
                 'expiration' => self::DEFAULT_FREQUENCY
                 ]);
             } else {

--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -319,7 +319,9 @@ abstract class AbstractRequest
      */
     public function addError($message, $code = 500)
     {
-        $this->error = true;
+        if ($code >= 400) {
+            $this->error = true;
+        }
         $this->http_response_code = $code;
         if (!empty($message)) {
             if ($this->mode === self::JSON_MODE) {

--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -352,6 +352,8 @@ abstract class AbstractRequest
             foreach ($entries as $name => $content) {
                 if ($name == "message" && isset($this->response[$name])) {
                     $this->response[$name] .= ";$content";
+                } else if ($name == "disabled") {
+                    $this->response[$name][] = $content;
                 } else {
                     $this->response[$name] = $content;
                 }

--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -437,10 +437,6 @@ abstract class AbstractRequest
     */
     public function getResponse(): string
     {
-        if (!isset($this->response)) {
-            return null;
-        }
-
         if ($this->mode === null) {
             throw new \RuntimeException("Mode has not been set");
         }

--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -314,7 +314,7 @@ abstract class AbstractRequest
     {
         $this->error = true;
         $this->http_response_code = $code;
-        if ($code == 400 && preg_match('/not supported/', $message )) {
+        if ($code == 400 && preg_match('/not supported/', $message)) {
             $this->setMode(self::JSON_MODE);
             $this->addToResponse([
             'status' => 'error',

--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -349,7 +349,13 @@ abstract class AbstractRequest
                 $this->addNode($root, $name, $content);
             }
         } else {
-            $this->response = $entries;
+            foreach ($entries as $name => $content) {
+                if ($name == "message" && isset($this->response[$name])) {
+                    $this->response[$name] .= ";$content";
+                } else {
+                    $this->response[$name] = $content;
+                }
+            }
         }
     }
 

--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -343,7 +343,7 @@ abstract class AbstractRequest
     *
     * @return void
     */
-    protected function addToResponse(array $entries)
+    public function addToResponse(array $entries)
     {
         if ($this->mode === self::XML_MODE) {
             $root = $this->response->documentElement;

--- a/src/Inventory/Inventory.php
+++ b/src/Inventory/Inventory.php
@@ -133,7 +133,11 @@ class Inventory
         try {
             $converter->validate($data);
         } catch (\RuntimeException $e) {
-            $this->errors[] = $e->getMessage();
+            $this->errors[] = preg_replace(
+                '|\$ref\[file~2//.*/vendor/glpi-project/inventory_format/inventory.schema.json\]|',
+                '$ref[inventory.schema.json]',
+                $e->getMessage()
+            );
             return false;
         } finally {
             $this->raw_data = $data;

--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -121,8 +121,11 @@ class Request extends AbstractRequest
             case self::DEPLOY_TASK:
             case self::WOL_TASK:
             case self::REMOTEINV_TASK:
-               // Task is not supported, just put information as message in response
-                $this->addToResponse(["message" => "$task task not supported"]);
+               // Task is not supported, disable it and add unsupported message in response
+                $this->addToResponse([
+                    "message" => "$task task not supported",
+                    "disabled" => $task
+                ]);
                 break;
             default:
                 $this->addError("Task '$task' is not supported.", 400);

--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -97,7 +97,7 @@ class Request extends AbstractRequest
             case self::DEPLOY_ACTION:
             case self::WOL_ACTION:
             default:
-                $this->addError("Query '$query' is not supported.", 400);
+                $this->addError("Query '$query' is not supported.", 501);
                 return false;
         }
         return true;

--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -113,8 +113,18 @@ class Request extends AbstractRequest
         switch ($task) {
             case self::INVENT_TASK:
                 return $this->handleInventoryTask();
-            break;
+                break;
+            case self::NETDISCOVERY_TASK:
+            case self::NETINV_TASK:
+            case self::ESX_TASK:
+            case self::COLLECT_TASK:
+            case self::DEPLOY_TASK:
+            case self::WOL_TASK:
+            case self::REMOTEINV_TASK:
+               // Nothing to do when an agent is telling it supports these tasks
+                break;
             default:
+                $this->addError("Task '$task' is not supported.", 400);
                 return [];
         }
         return [];

--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -97,7 +97,6 @@ class Request extends AbstractRequest
             case self::DEPLOY_ACTION:
             case self::WOL_ACTION:
             default:
-                $this->addError("Query '$query' is not supported.", 400);
                 return false;
         }
         return true;
@@ -115,7 +114,6 @@ class Request extends AbstractRequest
                 return $this->handleInventoryTask();
             break;
             default:
-                $this->addError("Task '$task' is not supported.", 400);
                 return [];
         }
         return [];

--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -121,7 +121,8 @@ class Request extends AbstractRequest
             case self::DEPLOY_TASK:
             case self::WOL_TASK:
             case self::REMOTEINV_TASK:
-               // Nothing to do when an agent is telling it supports these tasks
+               // Task is not supported, just put information as message in response
+                $this->addToResponse(["message" => "$task task not supported"]);
                 break;
             default:
                 $this->addError("Task '$task' is not supported.", 400);

--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -97,6 +97,7 @@ class Request extends AbstractRequest
             case self::DEPLOY_ACTION:
             case self::WOL_ACTION:
             default:
+                $this->addError("Query '$query' is not supported.", 400);
                 return false;
         }
         return true;

--- a/tests/units/Glpi/Inventory/Request.php
+++ b/tests/units/Glpi/Inventory/Request.php
@@ -138,7 +138,8 @@ class Request extends \GLPITestCase
         $request = new \Glpi\Inventory\Request();
         $request->handleContentType('application/xml');
         $request->handleRequest($data);
-        $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY/>\n");
+        $this->integer($request->getStatusCode())->isIdenticalTo(501);
+        $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><ERROR>Query '$query' is not supported.</ERROR>\n");
     }
 
     public function testAddError()

--- a/tests/units/Glpi/Inventory/Request.php
+++ b/tests/units/Glpi/Inventory/Request.php
@@ -147,10 +147,13 @@ class Request extends \GLPITestCase
         $request->handleContentType('application/xml');
         $request->addError('Something went wrong.');
         $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><ERROR>Something went wrong.</ERROR></REPLY>\n");
+    }
 
+    public function testAddResponse()
+    {
         $request = new \Glpi\Inventory\Request();
         $request->handleContentType('application/xml');
-       //But test addResponse adding nodes with attributes
+       //to test nodes with attributes
         $request->addResponse([
          'OPTION' => [
             'NAME' => 'NETDISCOVERY',

--- a/tests/units/Glpi/Inventory/Request.php
+++ b/tests/units/Glpi/Inventory/Request.php
@@ -139,7 +139,7 @@ class Request extends \GLPITestCase
         $request->handleContentType('application/xml');
         $request->handleRequest($data);
         $this->integer($request->getHttpResponseCode())->isIdenticalTo(501);
-        $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><ERROR>Query '$query' is not supported.</ERROR>\n");
+        $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><ERROR>Query '$query' is not supported.</ERROR></REPLY>\n");
     }
 
     public function testAddError()

--- a/tests/units/Glpi/Inventory/Request.php
+++ b/tests/units/Glpi/Inventory/Request.php
@@ -43,7 +43,13 @@ class Request extends \GLPITestCase
        //no mode
         $request = new \Glpi\Inventory\Request();
         $this->variable($request->getMode())->isNull();
-        $this->variable($request->getResponse())->isNull();
+        $this->exception(
+            function () use ($request) {
+                $this->variable($request->getResponse())->isNull();
+            }
+        )
+         ->isInstanceOf('\RuntimeException')
+         ->hasMessage('Mode has not been set');
 
         $this->exception(
             function () use ($request) {
@@ -141,13 +147,10 @@ class Request extends \GLPITestCase
         $request->handleContentType('application/xml');
         $request->addError('Something went wrong.');
         $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><ERROR>Something went wrong.</ERROR></REPLY>\n");
-    }
 
-    public function testAddResponse()
-    {
         $request = new \Glpi\Inventory\Request();
         $request->handleContentType('application/xml');
-       //to test nodes with attributes
+       //But test addResponse adding nodes with attributes
         $request->addResponse([
          'OPTION' => [
             'NAME' => 'NETDISCOVERY',

--- a/tests/units/Glpi/Inventory/Request.php
+++ b/tests/units/Glpi/Inventory/Request.php
@@ -43,13 +43,7 @@ class Request extends \GLPITestCase
        //no mode
         $request = new \Glpi\Inventory\Request();
         $this->variable($request->getMode())->isNull();
-        $this->exception(
-            function () use ($request) {
-                $this->variable($request->getResponse())->isNull();
-            }
-        )
-         ->isInstanceOf('\RuntimeException')
-         ->hasMessage('Mode has not been set');
+        $this->variable($request->getResponse())->isNull();
 
         $this->exception(
             function () use ($request) {
@@ -138,7 +132,7 @@ class Request extends \GLPITestCase
         $request = new \Glpi\Inventory\Request();
         $request->handleContentType('application/xml');
         $request->handleRequest($data);
-        $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><ERROR>Query '" . strtolower($query) . "' is not supported.</ERROR></REPLY>\n");
+        $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY/>\n");
     }
 
     public function testAddError()
@@ -147,11 +141,14 @@ class Request extends \GLPITestCase
         $request->handleContentType('application/xml');
         $request->addError('Something went wrong.');
         $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><ERROR>Something went wrong.</ERROR></REPLY>\n");
+    }
 
+    public function testAddResponse()
+    {
         $request = new \Glpi\Inventory\Request();
         $request->handleContentType('application/xml');
        //to test nodes with attributes
-        $request->addError([
+        $request->addResponse([
          'OPTION' => [
             'NAME' => 'NETDISCOVERY',
             'PARAM' => [
@@ -203,7 +200,7 @@ class Request extends \GLPITestCase
          ]
         ]);
 
-        $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><ERROR><OPTION><NAME>NETDISCOVERY</NAME><PARAM THREADS_DISCOVERY=\"5\" TIMEOUT=\"1\" PID=\"16\"/><RANGEIP ID=\"1\" IPSTART=\"192.168.1.1\" IPEND=\"192.168.1.254\" ENTITY=\"0\"/><AUTHENTICATION ID=\"1\" COMMUNITY=\"public\" VERSION=\"1\" USERNAME=\"\" AUTHPROTOCOL=\"\" AUTHPASSPHRASE=\"\" PRIVPROTOCOL=\"\" PRIVPASSPHRASE=\"\"/><AUTHENTICATION ID=\"2\" COMMUNITY=\"public\" VERSION=\"2c\" USERNAME=\"\" AUTHPROTOCOL=\"\" AUTHPASSPHRASE=\"\" PRIVPROTOCOL=\"\" PRIVPASSPHRASE=\"\"/></OPTION></ERROR></REPLY>\n");
+        $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><OPTION><NAME>NETDISCOVERY</NAME><PARAM THREADS_DISCOVERY=\"5\" TIMEOUT=\"1\" PID=\"16\"/><RANGEIP ID=\"1\" IPSTART=\"192.168.1.1\" IPEND=\"192.168.1.254\" ENTITY=\"0\"/><AUTHENTICATION ID=\"1\" COMMUNITY=\"public\" VERSION=\"1\" USERNAME=\"\" AUTHPROTOCOL=\"\" AUTHPASSPHRASE=\"\" PRIVPROTOCOL=\"\" PRIVPASSPHRASE=\"\"/><AUTHENTICATION ID=\"2\" COMMUNITY=\"public\" VERSION=\"2c\" USERNAME=\"\" AUTHPROTOCOL=\"\" AUTHPASSPHRASE=\"\" PRIVPROTOCOL=\"\" PRIVPASSPHRASE=\"\"/></OPTION></REPLY>\n");
     }
 
     protected function compressionProvider(): array

--- a/tests/units/Glpi/Inventory/Request.php
+++ b/tests/units/Glpi/Inventory/Request.php
@@ -138,7 +138,7 @@ class Request extends \GLPITestCase
         $request = new \Glpi\Inventory\Request();
         $request->handleContentType('application/xml');
         $request->handleRequest($data);
-        $this->integer($request->getStatusCode())->isIdenticalTo(501);
+        $this->integer($request->getHttpResponseCode())->isIdenticalTo(501);
         $this->string($request->getResponse())->isIdenticalTo("<?xml version=\"1.0\"?>\n<REPLY><ERROR>Query '$query' is not supported.</ERROR>\n");
     }
 

--- a/tests/units/Glpi/Inventory/Request.php
+++ b/tests/units/Glpi/Inventory/Request.php
@@ -40,9 +40,13 @@ class Request extends \GLPITestCase
 {
     public function testConstructor()
     {
-       //no mode
+       //no mode without content
         $request = new \Glpi\Inventory\Request();
         $this->variable($request->getMode())->isNull();
+        $this->variable($request->getResponse())->isIdenticalTo("");
+
+       //no mode with content
+        $request->addToResponse(["something" => "some content"]);
         $this->exception(
             function () use ($request) {
                 $this->variable($request->getResponse())->isNull();

--- a/tests/units/Glpi/Inventory/Request.php
+++ b/tests/units/Glpi/Inventory/Request.php
@@ -119,11 +119,11 @@ class Request extends \GLPITestCase
         return [
          ['query' => 'register'], //Request::REGISTER_ACTION
          ['query' => 'configuration'], //Request::CONFIG_ACTION
-         ['query' => 'ESX'], //Request::ESX_ACTION
-         ['query' => 'COLLECT'], //Request::COLLECT_ACTION
-         ['query' => 'DEPLOY'], //Request:: DEPLOY_ACTION
+         ['query' => 'esx'], //Request::ESX_ACTION
+         ['query' => 'collect'], //Request::COLLECT_ACTION
+         ['query' => 'deploy'], //Request:: DEPLOY_ACTION
          ['query' => 'wakeonlan'], //Request::WOL_ACTION
-         ['query' => 'UNKNOWN'],
+         ['query' => 'unknown'],
         ];
     }
 

--- a/tests/units/Glpi/Inventory/Request.php
+++ b/tests/units/Glpi/Inventory/Request.php
@@ -154,7 +154,7 @@ class Request extends \GLPITestCase
         $request = new \Glpi\Inventory\Request();
         $request->handleContentType('application/xml');
        //to test nodes with attributes
-        $request->addResponse([
+        $request->addToResponse([
          'OPTION' => [
             'NAME' => 'NETDISCOVERY',
             'PARAM' => [

--- a/tests/web/Glpi/Inventory/Request.php
+++ b/tests/web/Glpi/Inventory/Request.php
@@ -69,22 +69,28 @@ class Request extends \GLPITestCase
 
     public function testUnsupportedHttpMethod()
     {
-        $res = $this->http_client->request(
-            'GET',
-            $this->base_uri . 'front/inventory.php',
-            ]
-        );
+        try {
+            $res = $this->http_client->request(
+                'GET',
+                $this->base_uri . 'front/inventory.php'
+            );
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
+            $res = $e->getResponse();
+        }
         $this->integer($res->getStatusCode())->isIdenticalTo(405);
         $this->integer($res->getHeader('content-length'))->isIdenticalTo(0);
     }
 
     public function testUnsupportedLegacyRequest()
     {
-        $res = $this->http_client->request(
-            'GET',
-            $this->base_uri . 'front/inventory.php?action=getConfig',
-            ]
-        );
+        try {
+            $res = $this->http_client->request(
+                'GET',
+                $this->base_uri . 'front/inventory.php?action=getConfig'
+            );
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
+            $res = $e->getResponse();
+        }
         $this->integer($res->getStatusCode())->isIdenticalTo(400);
         $this->string((string)$res->getBody())
          ->isIdenticalTo("{\"status\":\"error\",\"message\":\"Protocol not supported\",\"expiration\":24}");
@@ -92,15 +98,19 @@ class Request extends \GLPITestCase
 
     public function testRequestInvalidContent()
     {
-        $res = $this->http_client->request(
-            'POST',
-            $this->base_uri . 'front/inventory.php',
-            [
-            'headers' => [
-               'Content-Type' => 'application/xml'
-            ]
-            ]
-        );
+        try {
+            $res = $this->http_client->request(
+                'POST',
+                $this->base_uri . 'front/inventory.php',
+                [
+                'headers' => [
+                   'Content-Type' => 'application/xml'
+                ]
+                ]
+            );
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
+            $res = $e->getResponse();
+        }
         $this->checkXmlResponse($res, '<ERROR>XML not well formed!</ERROR>', 400);
     }
 

--- a/tests/web/Glpi/Inventory/Request.php
+++ b/tests/web/Glpi/Inventory/Request.php
@@ -69,31 +69,26 @@ class Request extends \GLPITestCase
 
     public function testUnsupportedHttpMethod()
     {
-        try {
-            $res = $this->http_client->request(
-                'GET',
-                $this->base_uri . 'front/inventory.php'
-            );
-        } catch (\GuzzleHttp\Exception\RequestException $e) {
-            $res = $e->getResponse();
-        }
-        $this->integer($res->getStatusCode())->isIdenticalTo(405);
-        $this->integer(strlen($res->getBody()))->isIdenticalTo(0);
+        $this->exception(
+            function () {
+                $res = $this->http_client->request(
+                    'GET',
+                    $this->base_uri . 'front/inventory.php'
+                );
+            }
+        )->hasCode(405)->message->contains('405 Method Not Allowed');
     }
 
     public function testUnsupportedLegacyRequest()
     {
-        try {
-            $res = $this->http_client->request(
-                'GET',
-                $this->base_uri . 'front/inventory.php?action=getConfig'
-            );
-        } catch (\GuzzleHttp\Exception\RequestException $e) {
-            $res = $e->getResponse();
-        }
-        $this->integer($res->getStatusCode())->isIdenticalTo(400);
-        $this->string((string)$res->getBody())
-         ->isIdenticalTo("{\"status\":\"error\",\"message\":\"Protocol not supported\",\"expiration\":24}");
+        $this->exception(
+            function () {
+                $res = $this->http_client->request(
+                    'GET',
+                    $this->base_uri . 'front/inventory.php?action=getConfig'
+                );
+            }
+        )->hasCode(400)->message->contains('{"status":"error","message":"Protocol not supported","expiration":24}');
     }
 
     public function testRequestInvalidContent()

--- a/tests/web/Glpi/Inventory/Request.php
+++ b/tests/web/Glpi/Inventory/Request.php
@@ -98,20 +98,19 @@ class Request extends \GLPITestCase
 
     public function testRequestInvalidContent()
     {
-        try {
-            $res = $this->http_client->request(
-                'POST',
-                $this->base_uri . 'front/inventory.php',
-                [
-                'headers' => [
-                   'Content-Type' => 'application/xml'
-                ]
-                ]
-            );
-        } catch (\GuzzleHttp\Exception\RequestException $e) {
-            $res = $e->getResponse();
-        }
-        $this->checkXmlResponse($res, '<ERROR>XML not well formed!</ERROR>', 400);
+        $this->exception(
+            function () {
+                $res = $this->http_client->request(
+                    'POST',
+                    $this->base_uri . 'front/inventory.php',
+                    [
+                        'headers' => [
+                            'Content-Type' => 'application/xml'
+                        ]
+                    ]
+                );
+            }
+        )->hasCode(400)->message->contains('<ERROR>XML not well formed!</ERROR>');
     }
 
     public function testPrologRequest()

--- a/tests/web/Glpi/Inventory/Request.php
+++ b/tests/web/Glpi/Inventory/Request.php
@@ -78,7 +78,7 @@ class Request extends \GLPITestCase
             $res = $e->getResponse();
         }
         $this->integer($res->getStatusCode())->isIdenticalTo(405);
-        $this->integer($res->getHeader('content-length'))->isIdenticalTo(0);
+        $this->integer($res->getHeader('content-length')[0])->isIdenticalTo(0);
     }
 
     public function testUnsupportedLegacyRequest()

--- a/tests/web/Glpi/Inventory/Request.php
+++ b/tests/web/Glpi/Inventory/Request.php
@@ -78,7 +78,7 @@ class Request extends \GLPITestCase
             $res = $e->getResponse();
         }
         $this->integer($res->getStatusCode())->isIdenticalTo(405);
-        $this->integer(strlen($res->getBody())->isIdenticalTo(0);
+        $this->integer(strlen($res->getBody()))->isIdenticalTo(0);
     }
 
     public function testUnsupportedLegacyRequest()

--- a/tests/web/Glpi/Inventory/Request.php
+++ b/tests/web/Glpi/Inventory/Request.php
@@ -78,7 +78,7 @@ class Request extends \GLPITestCase
             $res = $e->getResponse();
         }
         $this->integer($res->getStatusCode())->isIdenticalTo(405);
-        $this->integer($res->getHeader('content-length')[0])->isIdenticalTo(0);
+        $this->integer(intval($res->getHeader('content-length')[0]))->isIdenticalTo(0);
     }
 
     public function testUnsupportedLegacyRequest()

--- a/tests/web/Glpi/Inventory/Request.php
+++ b/tests/web/Glpi/Inventory/Request.php
@@ -78,7 +78,7 @@ class Request extends \GLPITestCase
             $res = $e->getResponse();
         }
         $this->integer($res->getStatusCode())->isIdenticalTo(405);
-        $this->integer(intval($res->getHeader('content-length')[0]))->isIdenticalTo(0);
+        $this->integer(strlen($res->getBody())->isIdenticalTo(0);
     }
 
     public function testUnsupportedLegacyRequest()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | partly #10162

It appeared glpi-agent and fusioninventory-agent can generate unexpected errors like "Uncaught Exception RuntimeException: Mode has not been set" in php-errors.log.
This was due to GET request generated by Collect, ESX & Deploy tasks requesting a config with the GET protocol.
First there was a typo preventing GLPI from setting the HTTP code on the response, so GLPI 10 was always returning 200 even on error.
The "Method not allowed" was configured to return a 400 HTTP code but this error should be returned as 405 and without content.
Also, in the case of GLPI-Agent communicating in json, the server would answer a 400 as the server does not support all the tasks the agent tells it supports. Here, the server should silently ignore the tasks and leave the agent handles an empty response on its own.