### PR TITLE
Fix default SQL replica config

### DIFF
--- a/src/DBConnection.php
+++ b/src/DBConnection.php
@@ -274,7 +274,7 @@ class DBConnection extends CommonDBTM
             $properties[self::PROPERTY_ALLOW_DATETIME] = false;
         }
 
-        $config_str = '<?php' . "\n" . 'class DB extends DBmysql {' . "\n";
+        $config_str = '<?php' . "\n" . 'class DBSlave extends DBmysql {' . "\n";
         foreach ($properties as $name => $value) {
             $config_str .= sprintf('   public $%s = %s;', $name, var_export($value, true)) . "\n";
         }

--- a/tests/units/DBConnection.php
+++ b/tests/units/DBConnection.php
@@ -199,7 +199,7 @@ PHP
             'allow_datetime'           => true,
             'expected'                 => <<<'PHP'
 <?php
-class DB extends DBmysql {
+class DBSlave extends DBmysql {
    public $slave = true;
    public $dbhost = 'slave.db.domain.org';
    public $dbuser = 'glpi';
@@ -221,7 +221,7 @@ PHP
             'allow_datetime'           => false,
             'expected'                 => <<<'PHP'
 <?php
-class DB extends DBmysql {
+class DBSlave extends DBmysql {
    public $slave = true;
    public $dbhost = array (
   0 => 'slave1.db.domain.org',
@@ -251,7 +251,7 @@ PHP
             'allow_datetime'           => true,
             'expected'                 => <<<'PHP'
 <?php
-class DB extends DBmysql {
+class DBSlave extends DBmysql {
    public $slave = true;
    public $dbhost = '127.0.0.1';
    public $dbuser = 'root';
@@ -421,7 +421,7 @@ PHP
                ,
                'config_db_slave.php' => <<<PHP
 <?php
-class DB extends DBmysql {
+class DBSlave extends DBmysql {
    public \$dbhost      = 'slave.domain.org';
    public \$dbuser      = 'glpi';
    public \$dbdefault   = 'glpi';
@@ -448,7 +448,7 @@ PHP
                ,
                'config_db_slave.php' => <<<PHP
 <?php
-class DB extends DBmysql {
+class DBSlave extends DBmysql {
    public \$dbhost      = 'slave.domain.org';
    public \$dbuser      = 'glpi';
    public \$dbdefault   = 'glpi';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Working on user documentation, I found that the default SQL replica config that gets created when you enable it in the System tab uses the wrong class name.
The main DB config already defines the class `DB`. Looking at the code in GLPI, it looks like the replica config class is supposed to be `DBSlave`.

Without the change, the SQL Replica configuration tab fails to load because it tries autoloading `DB` twice.