### PR TITLE
Fix device number fields

### DIFF
--- a/src/DeviceBattery.php
+++ b/src/DeviceBattery.php
@@ -46,23 +46,25 @@ class DeviceBattery extends CommonDevice
         return array_merge(
             parent::getAdditionalFields(),
             [
-            [
-               'name'  => 'devicebatterytypes_id',
-               'label' => _n('Type', 'Types', 1),
-               'type'  => 'dropdownValue'
-            ],
-            [
-               'name'   => 'capacity',
-               'label'  => __('Capacity'),
-               'type'   => 'text',
-               'unit'   => __('mWh')
-            ],
-            [
-               'name'   => 'voltage',
-               'label'  => __('Voltage'),
-               'type'   => 'text',
-               'unit'   => __('mV')
-            ]
+                [
+                    'name'  => 'devicebatterytypes_id',
+                    'label' => _n('Type', 'Types', 1),
+                    'type'  => 'dropdownValue'
+                ],
+                [
+                    'name'   => 'capacity',
+                    'label'  => __('Capacity'),
+                    'type'   => 'integer',
+                    'min'    => 0,
+                    'unit'   => __('mWh')
+                ],
+                [
+                    'name'   => 'voltage',
+                    'label'  => __('Voltage'),
+                    'type'   => 'integer',
+                    'min'    => 0,
+                    'unit'   => __('mV')
+                ]
             ]
         );
     }

--- a/src/DeviceGraphicCard.php
+++ b/src/DeviceGraphicCard.php
@@ -67,8 +67,8 @@ class DeviceGraphicCard extends CommonDevice
                 ],
                 [
                     'name'  => 'none',
-                    'label' => RegisteredID::getTypeName(Session::getPluralNumber()) . RegisteredID::showAddChildButtonForItemForm(
-                        $this, '_registeredID', null, false),
+                    'label' => RegisteredID::getTypeName(Session::getPluralNumber())
+                        . RegisteredID::showAddChildButtonForItemForm($this, '_registeredID', null, false),
                     'type'  => 'registeredIDChooser'
                 ],
                 [

--- a/src/DeviceGraphicCard.php
+++ b/src/DeviceGraphicCard.php
@@ -47,28 +47,36 @@ class DeviceGraphicCard extends CommonDevice
 
         return array_merge(
             parent::getAdditionalFields(),
-            [['name'  => 'chipset',
-                                     'label' => __('Chipset'),
-                                     'type'  => 'text'],
-                               ['name'  => 'memory_default',
-                                     'label' => __('Memory by default'),
-                                     'type'  => 'text',
-                                     'unit'  => __('Mio')],
-                               ['name'  => 'interfacetypes_id',
-                                     'label' => __('Interface'),
-                                     'type'  => 'dropdownValue'],
-                               ['name'  => 'none',
-                                     'label' => RegisteredID::getTypeName(Session::getPluralNumber()) .
-                                        RegisteredID::showAddChildButtonForItemForm(
-                                            $this,
-                                            '_registeredID',
-                                            null,
-                                            false
-                                        ),
-                                     'type'  => 'registeredIDChooser'],
-                               ['name'  => 'devicegraphiccardmodels_id',
-                                     'label' => _n('Model', 'Models', 1),
-            'type'  => 'dropdownValue']]
+            [
+                [
+                    'name'  => 'chipset',
+                    'label' => __('Chipset'),
+                    'type'  => 'text'
+                ],
+                [
+                    'name'  => 'memory_default',
+                    'label' => __('Memory by default'),
+                    'type'  => 'integer',
+                    'min'  => 0,
+                    'unit'  => __('Mio')
+                ],
+                [
+                    'name'  => 'interfacetypes_id',
+                    'label' => __('Interface'),
+                    'type'  => 'dropdownValue'
+                ],
+                [
+                    'name'  => 'none',
+                    'label' => RegisteredID::getTypeName(Session::getPluralNumber()) . RegisteredID::showAddChildButtonForItemForm(
+                        $this, '_registeredID', null, false),
+                    'type'  => 'registeredIDChooser'
+                ],
+                [
+                    'name'  => 'devicegraphiccardmodels_id',
+                    'label' => _n('Model', 'Models', 1),
+                    'type'  => 'dropdownValue'
+                ]
+            ]
         );
     }
 

--- a/src/DeviceHardDrive.php
+++ b/src/DeviceHardDrive.php
@@ -47,23 +47,36 @@ class DeviceHardDrive extends CommonDevice
 
         return array_merge(
             parent::getAdditionalFields(),
-            [['name'  => 'capacity_default',
-                                     'label' => __('Capacity by default'),
-                                     'type'  => 'text',
-                                     'unit'  => __('Mio')],
-                               ['name'  => 'rpm',
-                                     'label' => __('Rpm'),
-                                     'type'  => 'text'],
-                               ['name'  => 'cache',
-                                     'label' => __('Cache'),
-                                     'type'  => 'text',
-                                     'unit'  => __('Mio')],
-                               ['name'  => 'deviceharddrivemodels_id',
-                                     'label' => _n('Model', 'Models', 1),
-                                     'type'  => 'dropdownValue'],
-                               ['name'  => 'interfacetypes_id',
-                                     'label' => __('Interface'),
-            'type'  => 'dropdownValue']]
+            [
+                [
+                    'name'  => 'capacity_default',
+                    'label' => __('Capacity by default'),
+                    'type'  => 'integer',
+                    'min'   => 0,
+                    'unit'  => __('Mio')
+                ],
+                [
+                    'name'  => 'rpm',
+                    'label' => __('Rpm'),
+                    'type'  => 'text'
+                ],
+                [
+                    'name'  => 'cache',
+                    'label' => __('Cache'),
+                    'type'  => 'text',
+                    'unit'  => __('Mio')
+                ],
+                [
+                    'name'  => 'deviceharddrivemodels_id',
+                    'label' => _n('Model', 'Models', 1),
+                    'type'  => 'dropdownValue'
+                ],
+                [
+                    'name'  => 'interfacetypes_id',
+                    'label' => __('Interface'),
+                    'type'  => 'dropdownValue'
+                ]
+            ]
         );
     }
 

--- a/src/DeviceMemory.php
+++ b/src/DeviceMemory.php
@@ -47,20 +47,31 @@ class DeviceMemory extends CommonDevice
 
         return array_merge(
             parent::getAdditionalFields(),
-            [['name'  => 'size_default',
-                                     'label' => __('Size by default'),
-                                     'type'  => 'text',
-                                     'unit'  => __('Mio')],
-                               ['name'  => 'frequence',
-                                     'label' => __('Frequency'),
-                                     'type'  => 'text',
-                                     'unit'  => __('MHz')],
-                               ['name'  => 'devicememorytypes_id',
-                                     'label' => _n('Type', 'Types', 1),
-                                     'type'  => 'dropdownValue'],
-                               ['name'  => 'devicememorymodels_id',
-                                     'label' => _n('Model', 'Models', 1),
-            'type'  => 'dropdownValue']]
+            [
+                [
+                    'name'  => 'size_default',
+                    'label' => __('Size by default'),
+                    'type'  => 'integer',
+                    'min'   => 0,
+                    'unit'  => __('Mio')
+                ],
+                [
+                    'name'  => 'frequence',
+                    'label' => __('Frequency'),
+                    'type'  => 'text',
+                    'unit'  => __('MHz')
+                ],
+                [
+                    'name'  => 'devicememorytypes_id',
+                    'label' => _n('Type', 'Types', 1),
+                    'type'  => 'dropdownValue'
+                ],
+                [
+                    'name'  => 'devicememorymodels_id',
+                    'label' => _n('Model', 'Models', 1),
+                    'type'  => 'dropdownValue'
+                ]
+            ]
         );
     }
 

--- a/src/DeviceProcessor.php
+++ b/src/DeviceProcessor.php
@@ -47,23 +47,38 @@ class DeviceProcessor extends CommonDevice
 
         return array_merge(
             parent::getAdditionalFields(),
-            [['name'  => 'frequency_default',
-                                     'label' => __('Frequency by default'),
-                                     'type'  => 'text',
-                                     'unit'  => __('MHz')],
-                               ['name'  => 'frequence',
-                                     'label' => __('Frequency'),
-                                     'type'  => 'text',
-                                     'unit'  => __('MHz')],
-                               ['name'  => 'nbcores_default',
-                                     'label' => __('Number of cores'),
-                                     'type'  => 'integer'],
-                               ['name'  => 'nbthreads_default',
-                                     'label' => __('Number of threads'),
-                                     'type'  => 'integer'],
-                               ['name'  => 'deviceprocessormodels_id',
-                                     'label' => _n('Model', 'Models', 1),
-                                     'type'  => 'dropdownValue']
+            [
+                [
+                    'name'  => 'frequency_default',
+                    'label' => __('Frequency by default'),
+                    'type'  => 'integer',
+                    'min'   => 0,
+                    'unit'  => __('MHz'),
+                ],
+                [
+                    'name'  => 'frequence',
+                    'label' => __('Frequency'),
+                    'type'  => 'integer',
+                    'min'   => 0,
+                    'unit'  => __('MHz'),
+                ],
+                [
+                    'name'  => 'nbcores_default',
+                    'label' => __('Number of cores'),
+                    'type'  => 'integer',
+                    'min'   => 0,
+                ],
+                [
+                    'name'  => 'nbthreads_default',
+                    'label' => __('Number of threads'),
+                    'type'  => 'integer',
+                    'min'   => 0,
+                ],
+                [
+                    'name'  => 'deviceprocessormodels_id',
+                    'label' => _n('Model', 'Models', 1),
+                    'type'  => 'dropdownValue',
+                ]
             ]
         );
     }

--- a/src/DeviceSimcard.php
+++ b/src/DeviceSimcard.php
@@ -47,22 +47,23 @@ class DeviceSimcard extends CommonDevice
         return array_merge(
             parent::getAdditionalFields(),
             [
-            [
-               'name'  => 'devicesimcardtypes_id',
-               'label' => _n('Type', 'Types', 1),
-               'type'  => 'dropdownValue'
-            ],
-            [
-               'name'  => 'voltage',
-               'label' => __('Voltage'),
-               'type'  => 'text',
-               'unit'  => 'mV'
-            ],
-            [
-                  'name'  => 'allow_voip',
-                  'label' => __('Allow VOIP'),
-                  'type'  => 'bool'
-            ],
+                [
+                    'name'  => 'devicesimcardtypes_id',
+                    'label' => _n('Type', 'Types', 1),
+                    'type'  => 'dropdownValue'
+                ],
+                [
+                    'name'  => 'voltage',
+                    'label' => __('Voltage'),
+                    'type'  => 'integer',
+                    'min'   => 0,
+                    'unit'  => 'mV'
+                ],
+                [
+                    'name'  => 'allow_voip',
+                    'label' => __('Allow VOIP'),
+                    'type'  => 'bool'
+                ],
             ]
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Many components have fields that are `INT` in the DB but are presented as text fields in the UI.
This makes it very easy to accidentally try setting the fields to invalid values.
By default, if you didn't change the empty "number" text fields, it would fail because an empty string is not a valid integer.