### PR TITLE
Differentiate GLPI debug alerts

### DIFF
--- a/src/Application/ErrorHandler.php
+++ b/src/Application/ErrorHandler.php
@@ -494,7 +494,7 @@ class ErrorHandler
             }
             $this->output_handler->writeln($message, $verbosity);
         } else if (!isCommandLine()) {
-            echo '<div class="alert alert-important alert-danger" style="z-index:10000">'
+            echo '<div class="alert alert-important alert-danger glpi-debug-alert" style="z-index:10000">'
             . '<span class="b">' . $error_type . ': </span>' . $message . '</div>';
         } else {
             echo $error_type . ': ' . $message . "\n";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

No real purpose inside GLPI itself right now.
I've been experimenting with an end-to-end test framework and wanted to test that no alerts show when in debug mode (PHP warnings, etc).
In most cases just looking for `alert-danger` is enough, but it is nice to be able to tell the difference between debug alerts and application alerts especially if an application alert is expected, but not a debug alert.