### PR TITLE
fix php warning on device_simcard display

### DIFF
--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -1513,7 +1513,7 @@ class Item_Devices extends CommonDBRelation
                             $out .= Html::input(
                                 $field,
                                 [
-                                'value' => $this->fields['name'],
+                                'value' => $value,
                                 'id'    => "textfield_$field$rand",
                                 'size'  => $attributs['size'],
                                 ]


### PR DESCRIPTION
Looks like an error was introduced in UI refurbish, here (inc/item_devices.class.php line 1395) : https://github.com/glpi-project/glpi/commit/0aec396494ef38c781633f4abe6b07295014cd40#diff-fee44d53676e1f4f83896aa4ee32e3c6a885cfdca359cb684f1ee57c7c602479R1395

![image](https://user-images.githubusercontent.com/14139801/147539344-c47b0a46-c83f-41b0-bc1f-119d1e2dd674.png)


![image](https://user-images.githubusercontent.com/14139801/147538938-2eb71723-1263-4b39-82c3-7592bd21ad7c.png)


[Tue Dec 28 08:13:29 2021] PHP Notice:  Undefined index: name in /home/bugier/public_html/glpi-master/src/Item_Devices.php on line 1516
[Tue Dec 28 08:13:29 2021] PHP Stack trace:
[Tue Dec 28 08:13:29 2021] PHP   1. {main}() /ajax/common.tabs.php:0
[Tue Dec 28 08:13:29 2021] PHP   2. CommonGLPI::displayStandardTab($item = *uninitialized*, $tab = *uninitialized*, $withtemplate = *uninitialized*, $options = *uninitialized*) /ajax/common.tabs.php:107
[Tue Dec 28 08:13:29 2021] PHP   3. Item_DeviceSimcard->showForm($ID = *uninitialized*, $options = *uninitialized*) /home/bugier/public_html/glpi-master/src/CommonGLPI.php:655



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
