### PR TITLE
fix field without label ignoring field class

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -672,7 +672,7 @@
       'mb': 'mb-3',
    }|merge(options) %}
 
-   {% set class = 'col-12 col-sm-6' %}
+   {% set class = options.field_class ?? 'col-12 col-sm-6' %}
    {% if options.full_width %}
       {% set class = 'col-12' %}
    {% endif %}


### PR DESCRIPTION
Using Twig to generate fields with alternate field_class and no_label, field_class is ignored.


Below the condition form for a section, in Formcreator. The 4 last fields should be on the same line, they use in order the following field_class
'field_class': 'col-12 col-sm-1',
'field_class': 'col-12 col-sm-5',
'field_class': 'col-12 col-sm-1',
'field_class': 'col-12 col-sm-5',

Sum of col-sm-xx is 12 and matches col-12. 

No_label is set for all these fields

![image](https://user-images.githubusercontent.com/14139801/147656659-cc2070a2-477a-4a01-9cb5-de53e9fd6d21.png)

Expected rendering, obtained with this patch

![image](https://user-images.githubusercontent.com/14139801/147657403-e46637df-58a5-452d-9279-e4424fbc8cb1.png)


However, if full_widh is enabled, col-sm-xx is deleted as expected, but col-12 will be used instead of a col-xx defind in field_class. This pach does not addresses this case.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
