### PR TITLE
Add data attribs to search criteria input

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -3150,13 +3150,13 @@ JAVASCRIPT;
             $searchtype_name = "{$fieldname}{$prefix}[$num][searchtype]";
             echo "<div class='col-auto'>";
             $rands = Dropdown::showFromArray($searchtype_name, $actions, [
-            'value' => $request["searchtype"],
+                'value' => $request["searchtype"],
             ]);
             echo "</div>";
             $fieldsearch_id = Html::cleanId("dropdown_$searchtype_name$rands");
         }
 
-        echo "<div class='col-auto' id='$dropdownname'>";
+        echo "<div class='col-auto' id='$dropdownname' data-itemtype='{$request["itemtype"]}' data-fieldname='$fieldname' data-prefix='$prefix' data-num='$num'>";
         $params = [
          'value'       => rawurlencode(stripslashes($request['value'])),
          'searchopt'   => $searchopt,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | Back-end change only
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add some data attributes to the div surrounding the search criteria input to help identify if in JS.
The input field itself doesn't have any generalized identifier like a class and neither does the wrapper currently.

This is needed for the camerainput plugin to know where to inject the camera search button.
This would allow scanning a barcode as a data input method when searching.