### PR TITLE
Fix bad actor format for helpdesk ticket form

### DIFF
--- a/front/tracking.injector.php
+++ b/front/tracking.injector.php
@@ -56,6 +56,13 @@ if (isset($_POST["_type"]) && ($_POST["_type"] == "Helpdesk")) {
     Html::header(__('Simplified interface'), '', $_SESSION["glpiname"], "helpdesk", "tracking");
 }
 
+if (isset($_POST['_actors']) && is_string($_POST['_actors'])) {
+    try {
+        $_POST['_actors'] = json_decode(stripslashes($_POST['_actors']), true, 512, JSON_THROW_ON_ERROR);
+    } catch (\JsonException $e) {
+        $_POST['_actors'] = [];
+    }
+}
 if (isset($_POST['add'])) {
     if (!$CFG_GLPI["use_anonymous_helpdesk"]) {
         $track->check(-1, CREATE, $_POST);

--- a/front/tracking.injector.php
+++ b/front/tracking.injector.php
@@ -58,7 +58,7 @@ if (isset($_POST["_type"]) && ($_POST["_type"] == "Helpdesk")) {
 
 if (isset($_POST['_actors']) && is_string($_POST['_actors'])) {
     try {
-        $_POST['_actors'] = json_decode(stripslashes($_POST['_actors']), true, 512, JSON_THROW_ON_ERROR);
+        $_POST['_actors'] = json_decode($_UPOST['_actors'], true, 512, JSON_THROW_ON_ERROR);
     } catch (\JsonException $e) {
         $_POST['_actors'] = [];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When using the helpdesk form to create tickets (simplified interface) and then doing something to trigger a page reload like changing the category, you would get the following error:
`Warning: Invalid argument supplied for foreach() in C:\xampp\htdocs\glpi\src\CommonITILObject.php on line 162`

The `_actors` parameter is a JSON string but is treated like an array.
When using the standard interface, this is an array as expected.