### PR TITLE
Show name without link in reservation UI without item rights

### DIFF
--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -676,12 +676,11 @@ class ReservationItem extends CommonDBChild
                         );
                     }
                 }
+                $item_link = sprintf(__('%1$s - %2$s'), $typename, $row["name"]);
                 if ($itemtype::canView()) {
                     $item_link = "<a href='" . $itemtype::getFormURLWithId($row['items_id']) . "&forcetab=Reservation$1'>" .
-                        sprintf(__('%1$s - %2$s'), $typename, $row["name"]) .
+                        $item_link .
                         "</a>";
-                } else {
-                    $item_link = sprintf(__('%1$s - %2$s'), $typename, $row["name"]);
                 }
                 echo "<td>$item_link</td>";
                 echo "<td>" . Dropdown::getDropdownName("glpi_locations", $row["location"]) . "</td>";

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -676,9 +676,14 @@ class ReservationItem extends CommonDBChild
                         );
                     }
                 }
-                echo "<td><a href='" . $itemtype::getFormURLWithId($row['items_id']) . "&forcetab=Reservation$1'>" .
-                sprintf(__('%1$s - %2$s'), $typename, $row["name"]) .
-                "</a></td>";
+                if ($itemtype::canView()) {
+                    $item_link = "<a href='" . $itemtype::getFormURLWithId($row['items_id']) . "&forcetab=Reservation$1'>" .
+                        sprintf(__('%1$s - %2$s'), $typename, $row["name"]) .
+                        "</a>";
+                } else {
+                    $item_link = sprintf(__('%1$s - %2$s'), $typename, $row["name"]);
+                }
+                echo "<td>$item_link</td>";
                 echo "<td>" . Dropdown::getDropdownName("glpi_locations", $row["location"]) . "</td>";
                 echo "<td>" . nl2br(($row["comment"] ?? "")) . "</td>";
                 if ($showentity) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When using the simplified interface, the reservable items list has links to the Reservation tab for the items even when the user doesn't have access to view those item types so they get a blank page with `You don't have permission to perform this action.`.

It would probably be a better user experience if there weren't links there at all in this case.