### PR TITLE
Fix status field alignement when readonly

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -694,6 +694,7 @@
       'label_class': 'col-xxl-5',
       'input_class': 'col-xxl-7',
       'add_field_class': '',
+      'center': false,
    }|merge(options) %}
 
    {% if options.full_width %}
@@ -724,7 +725,10 @@
 
    <div class="form-field row {{ options.field_class }} {{ options.add_field_class }} {{ options.mb }}">
       {{ _self.label(label, id, options, 'col-form-label ' ~ options.label_class) }}
-      <div class="{{ options.input_class }} field-container">
+      {% if options.center %}
+         {% set flex_class = "d-flex align-items-center" %}
+      {% endif %}
+      <div class="{{ options.input_class }} {{ flex_class }} field-container">
          {{ field|raw }}
          {{ add_field_html|raw }}
       </div>

--- a/templates/components/itilobject/fields/status.html.twig
+++ b/templates/components/itilobject/fields/status.html.twig
@@ -46,6 +46,7 @@
       {% endif %}
    {% endset %}
 {% else %}
+   {% set field_options = field_options|merge({'center': true}) %}
    {% set status_field %}
       {{ item.getStatusIcon(item.fields['status'])|raw }}
       {{ item.getStatus(item.fields['status']) }}


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/42734840/147911091-08f7e384-0987-4d82-bc14-6059cb20af99.png)

![image](https://user-images.githubusercontent.com/42734840/147911190-7a1fde8b-193e-44de-95f0-31a4ea1ca32f.png)


After;

![image](https://user-images.githubusercontent.com/42734840/147911136-a5f95d2f-ede7-4c7a-bf6c-e8a6571e3734.png)

![image](https://user-images.githubusercontent.com/42734840/147911149-13df56dc-aaa8-4ecd-a47b-81c9b88ca78e.png)




| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
