### PR TITLE
Fix self-service form display

### DIFF
--- a/templates/components/itilobject/selfservice.html.twig
+++ b/templates/components/itilobject/selfservice.html.twig
@@ -63,8 +63,8 @@
       </div>
 
       <div class="card-body pb-3">
-         <div class="row">
-            <div class="col-12 col-sm-5">
+         <div class="row justify-content-around">
+            <div class="col-12">
 
                {% if delegating|length %}
                   {% set actor_add_form %}


### PR DESCRIPTION
Current self-service form has a huge left margin, I don't think it's on purpose.

Before:

![image](https://user-images.githubusercontent.com/42734840/147911877-929e2d85-2d23-47d3-9307-73eea3aac889.png)

After:

![image](https://user-images.githubusercontent.com/42734840/147911890-ff977e0a-2729-4106-ac1a-0818a20d188b.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
