### PR TITLE
Fix self-service followups actions

### DIFF
--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -35,14 +35,21 @@
          <div class="col-md-8 ps-3 timeline-buttons">
             {% set default_action_data = timeline_itemtypes|first %}
             {% if item.isNotSolved() and default_action_data != false %}
-               <div class="btn-group me-2 main-actions" style="{{ load_kb_sol > 0 ? 'display:none;' : '' }}">
+               {% if timeline_itemtypes|length > 1 %}
+                  <div class="btn-group me-2 main-actions" style="{{ load_kb_sol > 0 ? 'display:none;' : '' }}">
+               {% else %}
+                  {# Don't use d-inline-flex class as it add an '!important' tag that mess with our javascript that will hide this div #}
+                  <div class="main-actions" style="display:inline-flex">
+               {% endif %}
                   <button class="btn btn-primary answer-action" data-bs-toggle="collapse" data-bs-target="#new-{{ default_action_data.class }}-block">
                      <i class="{{ default_action_data.icon }}"></i>
                      <span>{{ default_action_data.label }}</span>
                   </button>
-                  <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
-                     <span class="visually-hidden">{{ __('View other actions') }}</span>
-                  </button>
+                  {% if timeline_itemtypes|length > 1 %}
+                     <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                        <span class="visually-hidden">{{ __('View other actions') }}</span>
+                     </button>
+                  {% endif %}
                   <ul class="dropdown-menu">
                      {% for action, timeline_itemtype in timeline_itemtypes %}
                         {% if loop.index0 > 0 %}

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -90,7 +90,8 @@
             {% endif %}
 
             <div class="row">
-               <div class="col-12 col-md-9">
+               {% set col_md = get_current_interface() == 'central' ? 'col-md-9' : 'col-md-12' %}
+               <div class="col-12 {{ col_md }}">
                   {{ fields.textareaField(
                      'content',
                      subitem.fields['content'],
@@ -105,92 +106,94 @@
                      }
                   ) }}
                </div>
-               <div class="col-12 col-md-3 order-first order-md-last">
-                  <div class="row">
+               {% if get_current_interface() == 'central' %}
+                  <div class="col-12 col-md-3 order-first order-md-last">
+                     <div class="row">
 
-                     {% set fup_template_lbl %}
-                        <i class="fas fa-reply fa-fw me-1"
-                           title="{{ _n('Followup template', 'Followup templates', get_plural_number()) }}"></i>
-                     {% endset %}
-                     {{ fields.dropdownField(
-                        'ITILFollowupTemplate',
-                        'itilfollowuptemplates_id',
-                        subitem.fields['itilfollowuptemplates_id'],
-                        fup_template_lbl,
-                        {
-                           'full_width': true,
-                           'icon_label': true,
-                           'on_change': 'itilfollowuptemplate_update' ~ rand ~ '(this.value)',
-                           'rand': rand,
-                        }
-                     ) }}
+                        {% set fup_template_lbl %}
+                           <i class="fas fa-reply fa-fw me-1"
+                              title="{{ _n('Followup template', 'Followup templates', get_plural_number()) }}"></i>
+                        {% endset %}
+                        {{ fields.dropdownField(
+                           'ITILFollowupTemplate',
+                           'itilfollowuptemplates_id',
+                           subitem.fields['itilfollowuptemplates_id'],
+                           fup_template_lbl,
+                           {
+                              'full_width': true,
+                              'icon_label': true,
+                              'on_change': 'itilfollowuptemplate_update' ~ rand ~ '(this.value)',
+                              'rand': rand,
+                           }
+                        ) }}
 
-                     {% set fup_source_lbl %}
-                        <i class="fas fa-inbox fa-fw me-1" title="{{ __('Source of followup') }}"></i>
-                     {% endset %}
-                     {{ fields.dropdownField(
-                        'RequestType',
-                        'requesttypes_id',
-                        subitem.fields['requesttypes_id'],
-                        fup_source_lbl,
-                        {
-                           'full_width': true,
-                           'icon_label': true,
-                           'is_active': 1,
-                           'is_itilfollowup': 1,
-                           'rand': rand,
-                        }
-                     ) }}
+                        {% set fup_source_lbl %}
+                           <i class="fas fa-inbox fa-fw me-1" title="{{ __('Source of followup') }}"></i>
+                        {% endset %}
+                        {{ fields.dropdownField(
+                           'RequestType',
+                           'requesttypes_id',
+                           subitem.fields['requesttypes_id'],
+                           fup_source_lbl,
+                           {
+                              'full_width': true,
+                              'icon_label': true,
+                              'is_active': 1,
+                              'is_itilfollowup': 1,
+                              'rand': rand,
+                           }
+                        ) }}
 
-                     {% set fup_private_lbl %}
-                        <i class="ti ti-lock fa-fw me-1" title="{{ __('Private') }}"></i>
-                     {% endset %}
-                     {{ fields.sliderField(
-                        'is_private',
-                        subitem.fields['is_private'],
-                        fup_private_lbl,
-                        {
-                           'full_width': true,
-                           'icon_label': true,
-                           'rand': rand,
-                        }
-                     ) }}
-
-                     {% if can_read_kb and kb_id_toload > 0 %}
-                        {% set link_kb_lbl %}
-                           <i class="fas fa-link fa-fw me-1" data-bs-toggle="tooltip" data-bs-placement="top"
-                              title="{{ __('Link to knowledge base entry #%id')|format('TODO kb id') }}"></i>
+                        {% set fup_private_lbl %}
+                           <i class="ti ti-lock fa-fw me-1" title="{{ __('Private') }}"></i>
                         {% endset %}
                         {{ fields.sliderField(
-                           'kb_linked_id',
-                           kb_id_toload,
-                           link_kb_lbl,
+                           'is_private',
+                           subitem.fields['is_private'],
+                           fup_private_lbl,
                            {
                               'full_width': true,
                               'icon_label': true,
                               'rand': rand,
                            }
                         ) }}
-                     {% endif %}
 
-                     {% if candedit and can_update_kb and not nokb %}
-                        {% set fup_to_kb_lbl %}
-                           <i class="far fa-save fa-fw me-1" title="{{ __('Save and add to the knowledge base') }}"
-                              data-bs-toggle="tooltip" data-bs-placement="top"></i>
-                        {% endset %}
-                        {{ fields.sliderField(
-                           '_fup_to_kb',
-                           0,
-                           fup_to_kb_lbl,
-                           {
-                              'full_width': true,
-                              'icon_label': true,
-                              'rand': rand,
-                           }
-                        ) }}
-                     {% endif %}
+                        {% if can_read_kb and kb_id_toload > 0 %}
+                           {% set link_kb_lbl %}
+                              <i class="fas fa-link fa-fw me-1" data-bs-toggle="tooltip" data-bs-placement="top"
+                                 title="{{ __('Link to knowledge base entry #%id')|format('TODO kb id') }}"></i>
+                           {% endset %}
+                           {{ fields.sliderField(
+                              'kb_linked_id',
+                              kb_id_toload,
+                              link_kb_lbl,
+                              {
+                                 'full_width': true,
+                                 'icon_label': true,
+                                 'rand': rand,
+                              }
+                           ) }}
+                        {% endif %}
+
+                        {% if candedit and can_update_kb and not nokb %}
+                           {% set fup_to_kb_lbl %}
+                              <i class="far fa-save fa-fw me-1" title="{{ __('Save and add to the knowledge base') }}"
+                                 data-bs-toggle="tooltip" data-bs-placement="top"></i>
+                           {% endset %}
+                           {{ fields.sliderField(
+                              '_fup_to_kb',
+                              0,
+                              fup_to_kb_lbl,
+                              {
+                                 'full_width': true,
+                                 'icon_label': true,
+                                 'rand': rand,
+                              }
+                           ) }}
+                        {% endif %}
+                     </div>
                   </div>
-               </div>
+               {% endif %}
             </div>
 
             {{ call_plugin_hook('post_item_form', {"item": subitem, 'options': params}) }}
@@ -201,23 +204,25 @@
                         <i class="fas fa-plus"></i>
                         <span>{{ _x('button', 'Add') }}</span>
                      </button>
-                     <span class="input-group-text bg-yellow-lt py-0 pe-0" id="pending-reasons-control-{{ rand }}">
-                        <span class="d-inline-flex align-items-center" title="{{ __("Set the status to pending") }}"
-                              data-bs-toggle="tooltip" data-bs-placement="top" role="button">
-                           <i class="fas fa-pause me-2"></i>
-                           <label class="form-check form-switch pt-2">
-                              <input type="hidden"   name="pending" value="0" />
-                              <input type="checkbox" name="pending" value="1" class="form-check-input"
-                                    id="enable-pending-reasons-{{ rand }}"
-                                    role="button"
-                                    data-bs-toggle="collapse" data-bs-target="#pending-reasons-setup-{{ rand }}" />
-                           </label>
-                        </span>
+                     {% if get_current_interface() == 'central' %}
+                        <span class="input-group-text bg-yellow-lt py-0 pe-0" id="pending-reasons-control-{{ rand }}">
+                           <span class="d-inline-flex align-items-center" title="{{ __("Set the status to pending") }}"
+                                 data-bs-toggle="tooltip" data-bs-placement="top" role="button">
+                              <i class="fas fa-pause me-2"></i>
+                              <label class="form-check form-switch pt-2">
+                                 <input type="hidden"   name="pending" value="0" />
+                                 <input type="checkbox" name="pending" value="1" class="form-check-input"
+                                       id="enable-pending-reasons-{{ rand }}"
+                                       role="button"
+                                       data-bs-toggle="collapse" data-bs-target="#pending-reasons-setup-{{ rand }}" />
+                              </label>
+                           </span>
 
-                        <div class="collapse ps-2 py-1 flex-fill" id="pending-reasons-setup-{{ rand }}">
-                           {{ include('components/itilobject/timeline/pending_reasons.html.twig') }}
-                        </div>
-                     </span>
+                           <div class="collapse ps-2 py-1 flex-fill" id="pending-reasons-setup-{{ rand }}">
+                              {{ include('components/itilobject/timeline/pending_reasons.html.twig') }}
+                           </div>
+                        </span>
+                     {% endif %}
                   </div>
                {% else %}
                   <input type="hidden" name="id" value="{{ subitem.fields['id'] }}" />


### PR DESCRIPTION
Self-service users have access to too much information:
![image](https://user-images.githubusercontent.com/42734840/147922599-f7c6139a-2082-4917-8f62-919eb9ad49da.png)

Also the 'btn-group' dropdown shouldn't be displayed if there is only one possible action

![image](https://user-images.githubusercontent.com/42734840/147922653-4f4224a7-9207-47d4-9a1d-0532077098ad.png)

After changes:

![image](https://user-images.githubusercontent.com/42734840/147922736-62253c11-b87b-44a0-bb44-877bcd284932.png)

![image](https://user-images.githubusercontent.com/42734840/147923546-1b49d959-ee08-43f0-9810-bfec8777f1c8.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |