### PR TITLE
Fix nightly build

### DIFF
--- a/.github/workflows/branch_build.yml
+++ b/.github/workflows/branch_build.yml
@@ -29,7 +29,7 @@ jobs:
           docker exec ${{ job.services.app.id }} composer install --optimize-autoloader --prefer-dist --no-interaction --no-progress --no-suggest
       - name: "Define release name"
         run: |
-          REF_NAME=$(echo ${{ matrix.branch }} | sed -E 's|/|-|')
+          REF_NAME=$(echo ${{ github.ref_name }} | sed -E 's|/|-|')
           SHA=$(git rev-parse --short HEAD)
           echo "release_name=$REF_NAME.$SHA" >> $GITHUB_ENV
       - name: "Build"

--- a/.github/workflows/branch_build.yml
+++ b/.github/workflows/branch_build.yml
@@ -34,7 +34,7 @@ jobs:
           echo "release_name=$REF_NAME.$SHA" >> $GITHUB_ENV
       - name: "Build"
         run: |
-          echo "Y" | docker exec --interactive ${{ job.services.app.id }} tools/make_release.sh . ${{ env.release_name }}
+          docker exec --interactive ${{ job.services.app.id }} tools/make_release.sh -y . ${{ env.release_name }}
           docker cp ${{ job.services.app.id }}:/tmp/glpi-${{ env.release_name }}.tgz ${{ github.workspace }}/${{ env.release_name }}.tar.gz
       - name: "Store archive"
         uses: actions/upload-artifact@v2

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -59,7 +59,7 @@ jobs:
       - name: "Build"
         if: ${{ steps.updated.outputs.build == 'yes' }}
         run: |
-          echo "Y" | docker exec --interactive ${{ job.services.app.id }} tools/make_release.sh . ${{ env.release_name }}
+          docker exec --interactive ${{ job.services.app.id }} tools/make_release.sh -y . ${{ env.release_name }}
           docker cp ${{ job.services.app.id }}:/tmp/glpi-${{ env.release_name }}.tgz ${{ github.workspace }}/${{ env.release_name }}.tar.gz
       - uses: actions/checkout@v2
         if: ${{ steps.updated.outputs.build == 'yes' }}

--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -30,12 +30,36 @@
 #  * ---------------------------------------------------------------------
 # */
 
+# Extract options and args (see https://stackoverflow.com/a/14203146)
+ASSUME_YES=0;
+POSITIONAL_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -y)
+            ASSUME_YES=1;
+            shift
+            ;;
+        -*|--*)
+            echo "Unknown option $1"
+            exit 1
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${POSITIONAL_ARGS[@]}"
+
 # Check arguments
 if [ ! "$#" -eq 2 ]
 then
     echo "This script builds a release archive based on Git index of given directory."
     echo ""
-    echo "Usage $0 /path/to/glpi-git-dir release-name"
+    echo "Usage $0 [-y] /path/to/glpi-git-dir release-name"
+    echo ""
+    echo "Options:"
+    echo "y     Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactively."
     exit
 fi
 
@@ -46,15 +70,18 @@ TARBALL_PATH=/tmp/glpi-$RELEASE.tgz
 
 if [ ! -e $SOURCE_DIR ] || [ ! -e $SOURCE_DIR/.git ]
 then
- echo "$SOURCE_DIR is not a valid Git repository"
- exit
+    echo "$SOURCE_DIR is not a valid Git repository"
+    exit
 fi
 
-read -p "Are translations up to date? [Y/n] " -n 1 -r
-echo # (optional) move to a new line
-if [[ ! $REPLY =~ ^[Yy]$ ]]
+if [[ ! $ASSUME_YES = 1 ]]
 then
-    [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
+    read -p "Are translations up to date? [Y/n] " -n 1 -r
+    echo # (optional) move to a new line
+    if [[ ! $REPLY =~ ^[Yy]$ ]]
+    then
+        [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
+    fi
 fi
 
 echo "Copying to $WORKING_DIR directory"
@@ -63,6 +90,20 @@ then
     rm -rf $WORKING_DIR
 fi
 git --git-dir="$SOURCE_DIR/.git" checkout-index --all --force --prefix="$WORKING_DIR/glpi/"
+
+if [[ ! $ASSUME_YES = 1 ]]
+then
+    FOUND_VERSION=$(grep -Eo "define\('GLPI_VERSION', '[^']+'\);" $WORKING_DIR/glpi/inc/define.php | sed "s/define('GLPI_VERSION', '\([^)]*\)');/\1/")
+    if [[ ! "$RELEASE" = "$FOUND_VERSION" ]]
+    then
+        read -p "$RELEASE does not match version $FOUND_VERSION declared in inc/define.php. Do you want to continue? [Y/n] " -n 1 -r
+        echo # (optional) move to a new line
+        if [[ ! $REPLY =~ ^[Yy]$ ]]
+        then
+            [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
+        fi
+    fi
+fi
 
 echo "Building application"
 $WORKING_DIR/glpi/tools/build_glpi.sh


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

- Backport release/version check from master branch
- Do not use `-P` option to grep as it is not available on Alpine linux
- Permit to bypass release/version check
- Add `-y` option
- Fix branch build archive name