### PR TITLE
Fix validation notice for self-services

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4159,13 +4159,13 @@ JAVASCRIPT;
         }
 
         TemplateRenderer::getInstance()->display('components/itilobject/selfservice.html.twig', [
-         'nb_tic_to_validate' => TicketValidation::getNumberToValidate(Session::getLoginUserID()) > 0,
-         'url_validate'       => $url_validate,
-         'selfservice'        => true,
-         'item'               => $this,
-         'params'             => $options,
-         'itiltemplate'       => $tt,
-         'delegating'         => $delegating,
+         'has_tickets_to_validate' => TicketValidation::getNumberToValidate(Session::getLoginUserID()) > 0,
+         'url_validate'            => $url_validate,
+         'selfservice'             => true,
+         'item'                    => $this,
+         'params'                  => $options,
+         'itiltemplate'            => $tt,
+         'delegating'              => $delegating,
         ]);
     }
 

--- a/templates/components/itilobject/selfservice.html.twig
+++ b/templates/components/itilobject/selfservice.html.twig
@@ -47,9 +47,9 @@
 
 <div class="container-lg">
 
-   {% if nb_tic_to_validate > 0 %}
+   {% if has_tickets_to_validate and not url_validate is empty %}
       <div class="alert alert-warning" role="alert">
-      {{ __('There is some tickets awaiting approval') }} — <a href="{{ url_validate }}" class="alert-link">{{ __('check it out!') }}</a>
+      {{ __('There are some tickets awaiting approval') }} — <a href="{{ url_validate }}" class="alert-link">{{ __('check it out!') }}</a>
       </div>
    {% endif %}
 


### PR DESCRIPTION
I've found that, as a self service user, I can see the validation notice but the "Check it out" link redirect me to the current page:

![image](https://user-images.githubusercontent.com/42734840/147932988-68984a39-d857-4a60-b55d-95f7a0a71925.png)

This is because while I do have some tickets waiting for my validation (which trigger the notice to appear) I do not have the rights to validate tickets (which prevent the correct link from being set).

I've added an empty check on the link to prevent this (now the notice isn't show at all for my user).

A few others changes:
- `nb_tic_to_validate` -> `has_tickets_to_validate` since the var is actually a boolean and does not contains the numbers of tickets
- There **is** some tickets -> There **are** some tickets ("there is"  is for singular or uncountable items, "there are" for plural)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
