### PR TITLE
Fix submit button for ticket forms

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1424,3 +1424,14 @@ $(document.body).on('submit', 'form[data-submit-once]', (e) => {
       blockFormSubmit(form, e);
    }
 });
+
+/**
+ * Strip html tags from a string
+ *
+ * @param {String} html_string
+ * @returns {String}
+ */
+function strip_tags(html_string) {
+   var dom = new DOMParser().parseFromString(html_string, 'text/html');
+   return dom.body.textContent;
+}

--- a/src/Html.php
+++ b/src/Html.php
@@ -3744,6 +3744,10 @@ JS;
                         if ($('#$name').val() == '') {
                            alert(__('The description field is mandatory'));
                            e.preventDefault();
+
+                           // Prevent other events to run
+                           // Needed to not break single submit forms
+                           e.stopPropagation();
                         }
                      });
                      editor.on('keyup', function (e) {
@@ -3755,7 +3759,7 @@ JS;
                         }
                      });
                      editor.on('init', function (e) {
-                        if ($('#$name').val() == '') {
+                        if (strip_tags($('#$name').val()) == '') {
                            $(editor.container).addClass('required');
                         }
                      });


### PR DESCRIPTION
Two fixes:

#### 1\) Fix submit button

If you forgot a mandatory tinymce field (e.g. ticket's description) then you can never submit your form again:

![image](https://user-images.githubusercontent.com/42734840/147942491-afd7091d-9b80-45f1-97fc-999e41f6d4b8.png)

-> Fixed by not triggering the "one time submit" code on failed tinymce validation.

#### 2\) Fix mandatory check on firefox

Firefox seems to save the content of all textareas on a page and rewrite them on a soft reload.
This caused an unexpected issue:

![image](https://user-images.githubusercontent.com/42734840/147942812-72326c03-c5af-42f5-9e1d-4c2c13b951f4.png)

If you refresh this page, the tinymce input is no longer required and you can submit an empty form:

![image](https://user-images.githubusercontent.com/42734840/147942904-0724286d-31aa-43ec-a2b1-d1a139cd89d6.png)

The browse save the HTML content of the tinymce textarea, which for some reason contains `<p><br></p>` for an empty textarea.
So when you refresh the page, the `$('#$name').val() == ''` check that add the required tag fails as `val` contains `<p><br></p>`.

-> Fixed by stripping all html tags before checking if `val` is empty.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
