### PR TITLE
Add migration to use usigned int for primary/foreign keys; see #10262

### DIFF
--- a/front/pluginimage.send.php
+++ b/front/pluginimage.send.php
@@ -44,7 +44,7 @@ use Glpi\Event;
 include ('../inc/includes.php');
 
 if (!isset($_GET["name"]) || !isset($_GET["plugin"]) || !Plugin::isPluginActive($_GET["plugin"])) {
-   Event::log("-1", "system", 2, "security",
+   Event::log(0, "system", 2, "security",
               //TRANS: %s is user name
               sprintf(__('%s makes a bad usage.'), $_SESSION["glpiname"]));
    die("security");
@@ -58,7 +58,7 @@ if ((basename($_GET["name"]) != $_GET["name"])
     || !Toolbox::startsWith(realpath($filepath), realpath(GLPI_PLUGIN_DOC_DIR))
     || !Document::isImage($filepath)) {
 
-   Event::log("-1", "system", 1, "security",
+   Event::log(0, "system", 1, "security",
               sprintf(__('%s tries to use a non standard path.'), $_SESSION["glpiname"]));
    die("security");
 }

--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -940,20 +940,20 @@ class Auth extends CommonGLPI {
          if ($this->auth_succeded) {
             if (GLPI_DEMO_MODE) {
                // not translation in GLPI_DEMO_MODE
-               Event::log(-1, "system", 3, "login", $login_name." log in from ".$ip);
+               Event::log(0, "system", 3, "login", $login_name." log in from ".$ip);
             } else {
                //TRANS: %1$s is the login of the user and %2$s its IP address
-               Event::log(-1, "system", 3, "login", sprintf(__('%1$s log in from IP %2$s'),
+               Event::log(0, "system", 3, "login", sprintf(__('%1$s log in from IP %2$s'),
                                                             $login_name, $ip));
             }
 
          } else {
             if (GLPI_DEMO_MODE) {
-               Event::log(-1, "system", 3, "login", "login",
+               Event::log(0, "system", 3, "login", "login",
                           "Connection failed for " . $login_name . " ($ip)");
             } else {
                //TRANS: %1$s is the login of the user and %2$s its IP address
-               Event::log(-1, "system", 3, "login", sprintf(__('Failed login for %1$s from IP %2$s'),
+               Event::log(0, "system", 3, "login", sprintf(__('Failed login for %1$s from IP %2$s'),
                                                             $login_name, $ip));
             }
          }

--- a/inc/console/migration/unsignedkeyscommand.class.php
+++ b/inc/console/migration/unsignedkeyscommand.class.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Migration;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+use Glpi\Console\AbstractCommand;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class UnsignedKeysCommand extends AbstractCommand {
+
+   /**
+    * Error code returned when failed to migrate one column.
+    *
+    * @var int
+    */
+   const ERROR_COLUMN_MIGRATION_FAILED = 1;
+
+   protected function configure() {
+      parent::configure();
+
+      $this->setName('glpi:migration:unsigned_keys');
+      $this->setDescription(__('Migrate primary/foreign keys to unsigned integers'));
+   }
+
+   protected function execute(InputInterface $input, OutputInterface $output) {
+
+      $no_interaction = $input->getOption('no-interaction');
+
+      $columns = $this->db->getSignedKeysColumns();
+
+      $output->writeln(
+         sprintf(
+            '<info>' . __('Found %s primary/foreign key columns(s) using signed integers.') . '</info>',
+            $columns->count()
+         )
+      );
+
+      if ($columns->count() === 0) {
+         $output->writeln('<info>' . __('No migration needed.') . '</info>');
+         return 0;
+      }
+
+      if (!$no_interaction) {
+         // Ask for confirmation (unless --no-interaction)
+         /** @var QuestionHelper $question_helper */
+         $question_helper = $this->getHelper('question');
+         $run = $question_helper->ask(
+            $input,
+            $output,
+            new ConfirmationQuestion(__('Do you want to continue ?') . ' [Yes/no]', true)
+         );
+         if (!$run) {
+            $output->writeln(
+               '<comment>' . __('Migration aborted.') . '</comment>',
+               OutputInterface::VERBOSITY_VERBOSE
+            );
+            return 0;
+         }
+      }
+
+      $foreign_keys = $this->db->getForeignKeysContraints();
+
+      $progress_bar = new ProgressBar($output);
+      $errors = 0;
+
+      foreach ($progress_bar->iterate($columns) as $column) {
+         $table_name  = $column['TABLE_NAME'];
+         $column_name = $column['COLUMN_NAME'];
+         $data_type   = $column['DATA_TYPE'];
+         $nullable    = $column['IS_NULLABLE'] === 'YES';
+         $default     = $column['COLUMN_DEFAULT'];
+         $extra       = $column['EXTRA'];
+
+         $min = $this->db
+            ->request(['SELECT' => ['MIN' => sprintf('%s AS min', $column_name)], 'FROM' => $table_name])
+            ->next()['min'];
+
+         if (($min !== null && $min < 0) || ($default !== null && $default < 0)) {
+            $message = sprintf(
+               __('Migration of column "%s.%s" cannot be done as it contains negative values.'),
+               $table_name,
+               $column_name
+            );
+            $this->writelnOutputWithProgressBar(
+                '<error>' . $message . '</error>',
+                $progress_bar,
+                OutputInterface::VERBOSITY_QUIET
+            );
+            $errors++;
+            continue; // Do not migrate this column
+         }
+
+         // Ensure that column is not referenced in a CONSTRAINT key.
+         foreach ($foreign_keys as $foreign_key) {
+            if (($foreign_key['TABLE_NAME'] === $table_name && $foreign_key['COLUMN_NAME'] === $column_name)
+                || ($foreign_key['REFERENCED_TABLE_NAME'] === $table_name && $foreign_key['REFERENCED_COLUMN_NAME'] === $column_name)) {
+               $message = sprintf(
+                  __('Migration of column "%s.%s" cannot be done as it is referenced in CONSTRAINT "%s" of table "%s.%s".'),
+                  $table_name,
+                  $column_name,
+                  $foreign_key['CONSTRAINT_NAME'],
+                  $foreign_key['TABLE_NAME'],
+                  $foreign_key['COLUMN_NAME']
+               );
+               $this->writelnOutputWithProgressBar(
+                   '<error>' . $message . '</error>',
+                   $progress_bar,
+                   OutputInterface::VERBOSITY_QUIET
+               );
+               $errors++;
+               continue 2; // Non blocking error, it should not prevent migration of other fields
+            }
+         }
+
+         $this->writelnOutputWithProgressBar(
+            '<comment>' . sprintf(__('Migrating column "%s.%s"...'), $table_name, $column_name) . '</comment>',
+             $progress_bar,
+             OutputInterface::VERBOSITY_VERBOSE
+         );
+
+         $query = sprintf(
+            'ALTER TABLE %s MODIFY COLUMN %s %s unsigned %s %s %s',
+            $this->db->quoteName($table_name),
+            $this->db->quoteName($column_name),
+            $data_type,
+            $nullable ? 'NULL' : 'NOT NULL',
+            $default !== null || $nullable ? sprintf('DEFAULT %s', $this->db->quoteValue($default)) : '',
+            $extra
+         );
+
+         $result = $this->db->query($query);
+
+         if ($result === false) {
+            $message = sprintf(
+               __('Migration of column "%s.%s" failed with message "(%s) %s".'),
+               $table_name,
+               $column_name,
+               $this->db->errno(),
+               $this->db->error()
+            );
+            $this->writelnOutputWithProgressBar(
+               '<error>' . $message . '</error>',
+                $progress_bar,
+                OutputInterface::VERBOSITY_QUIET
+            );
+            $errors++;
+            continue; // Go to next column
+         }
+      }
+
+      $this->output->write(PHP_EOL);
+
+      if ($errors) {
+         $output->writeln(
+            '<error>' . __('Errors occured during migration.') . '</error>',
+            OutputInterface::VERBOSITY_QUIET
+         );
+         return self::ERROR_COLUMN_MIGRATION_FAILED;
+      }
+
+      $output->writeln('<info>' . __('Migration done.') . '</info>');
+
+      return 0; // Success
+   }
+}

--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -41,6 +41,32 @@ use Glpi\Application\ErrorHandler;
 **/
 class DBmysql {
 
+   /**
+    * List of keys that are allowed to use signed integers.
+    *
+    * Elements contained in this list have to be fixed before being able to globally use foreign key contraints.
+    *
+    * @var array
+    */
+   private const ALLOWED_SIGNED_KEYS = [
+      // FIXME Entity preference `glpi_entities.calendars_id` inherit/never strategy should be stored in another field.
+      'glpi_calendars.id',
+      // FIXME Entity preference `glpi_entities.changetemplates_id` inherit/never strategy should be stored in another field.
+      'glpi_changetemplates.id',
+      // FIXME Entity preference `glpi_entities.contracts_id_default` inherit/never strategy should be stored in another field.
+      'glpi_contracts.id',
+      // FIXME root entity uses "-1" value for its parent (`glpi_entities.entities_id`), should be null
+      // FIXME some entities_id foreign keys are using "-1" as default value, should be null
+      // FIXME Entity preference `glpi_entities.entities_id_software` inherit/never strategy should be stored in another field.
+      'glpi_entities.id',
+      // FIXME Entity preference `glpi_entities.problemtemplates_id` inherit/never strategy should be stored in another field.
+      'glpi_problemtemplates.id',
+      // FIXME Entity preference `glpi_entities.tickettemplates_id` inherit/never strategy should be stored in another field.
+      'glpi_tickettemplates.id',
+      // FIXME Entity preference `glpi_entities.transfers_id` inherit/never strategy should be stored in another field.
+      'glpi_transfers.id',
+   ];
+
    //! Database Host - string or Array of string (round robin)
    public $dbhost             = "";
    //! Database User
@@ -1663,6 +1689,108 @@ class DBmysql {
            ]
        ])->next();
        return (int)$result['cpt'];
+   }
+
+   /**
+    * Returns columns that corresponds to signed primary/foreign keys.
+    *
+    * @return DBmysqlIterator
+    *
+    * @since 9.5.7
+    */
+   public function getSignedKeysColumns() {
+
+      $query = [
+         'SELECT'     => [
+            'information_schema.columns.table_name as TABLE_NAME',
+            'information_schema.columns.column_name as COLUMN_NAME',
+            'information_schema.columns.data_type as DATA_TYPE',
+            'information_schema.columns.column_default as COLUMN_DEFAULT',
+            'information_schema.columns.is_nullable as IS_NULLABLE',
+            'information_schema.columns.extra as EXTRA',
+         ],
+         'FROM'       => 'information_schema.columns',
+         'INNER JOIN' => [
+            'information_schema.tables' => [
+               'FKEY' => [
+                  'information_schema.tables'  => 'table_name',
+                  'information_schema.columns' => 'table_name',
+                  [
+                     'AND' => [
+                        'information_schema.tables.table_schema' => new QueryExpression(
+                            $this->quoteName('information_schema.columns.table_schema')
+                        ),
+                     ]
+                  ],
+               ]
+            ]
+         ],
+         'WHERE'      => [
+            'information_schema.tables.table_schema'  => $this->dbdefault,
+            'information_schema.tables.table_name'    => ['LIKE', 'glpi\_%'],
+            'information_schema.tables.table_type'    => 'BASE TABLE',
+            [
+               'OR' => [
+                  ['information_schema.columns.column_name' => 'id'],
+                  ['information_schema.columns.column_name' => ['LIKE', '%\_id']],
+                  ['information_schema.columns.column_name' => ['LIKE', '%\_id\_%']],
+               ],
+            ],
+            'information_schema.columns.data_type' => ['tinyint', 'smallint', 'mediumint', 'int', 'bigint'],
+            ['NOT' => ['information_schema.columns.column_type' => ['LIKE', '%unsigned%']]],
+         ],
+         'ORDER'      => ['TABLE_NAME']
+      ];
+      foreach (self::ALLOWED_SIGNED_KEYS as $allowed_signed_key) {
+         list($excluded_table, $excluded_field) = explode('.', $allowed_signed_key);
+         $excluded_fkey = getForeignKeyFieldForTable($excluded_table);
+         $query['WHERE'][] = [
+            [
+               'NOT' => [
+                  'information_schema.tables.table_name'   => $excluded_table,
+                  'information_schema.columns.column_name' => $excluded_field
+               ]
+            ],
+            ['NOT' => ['information_schema.columns.column_name' => $excluded_fkey]],
+            ['NOT' => ['information_schema.columns.column_name' => ['LIKE', str_replace('_', '\_', $excluded_fkey . '_%')]]],
+         ];
+      }
+
+      $iterator = $this->request($query);
+
+      return $iterator;
+   }
+
+   /**
+    * Returns foreign keys constraints.
+    *
+    * @return DBmysqlIterator
+    *
+    * @since 9.5.7
+    */
+   public function getForeignKeysContraints() {
+
+      $query = [
+         'SELECT' => [
+            'table_schema as TABLE_SCHEMA',
+            'table_name as TABLE_NAME',
+            'column_name as COLUMN_NAME',
+            'constraint_name as CONSTRAINT_NAME',
+            'referenced_table_name as REFERENCED_TABLE_NAME',
+            'referenced_column_name as REFERENCED_COLUMN_NAME',
+            'ordinal_position as ORDINAL_POSITION',
+         ],
+         'FROM'   => 'information_schema.key_column_usage',
+         'WHERE'  => [
+            'referenced_table_schema' => $this->dbdefault,
+            'referenced_table_name'   => ['LIKE', 'glpi\_%'],
+         ],
+         'ORDER'  => ['TABLE_NAME']
+      ];
+
+      $iterator = $this->request($query);
+
+      return $iterator;
    }
 
    /**

--- a/inc/event.class.php
+++ b/inc/event.class.php
@@ -179,7 +179,7 @@ class Event extends CommonDBTM {
    static function displayItemLogID($type, $items_id) {
       global $CFG_GLPI;
 
-      if (($items_id == "-1") || ($items_id == "0")) {
+      if ($items_id <= 0) {
          echo "&nbsp;";//$item;
       } else {
          switch ($type) {

--- a/inc/networkportinstantiation.class.php
+++ b/inc/networkportinstantiation.class.php
@@ -662,11 +662,11 @@ class NetworkPortInstantiation extends CommonDBChild {
 
       switch ($origin) {
          case 'NetworkPortAlias' :
-            $possible_ports[-1]         = Dropdown::EMPTY_VALUE;
-            $field_name                 = 'networkports_id_alias';
-            $selectOptions['multiple']  = false;
-            $selectOptions['on_change'] = 'updateForm(this.options[this.selectedIndex].value)';
-            $netport_types[]            = 'NetworkPortAggregate';
+            $field_name                           = 'networkports_id_alias';
+            $selectOptions['display_emptychoice'] = true;
+            $selectOptions['multiple']            = false;
+            $selectOptions['on_change']           = 'updateForm(this.options[this.selectedIndex].value)';
+            $netport_types[]                      = 'NetworkPortAggregate';
             break;
 
          case 'NetworkPortAggregate' :

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -1520,7 +1520,7 @@ class Session {
 
       $_SESSION['impersonator_id'] = $impersonator_id;
 
-      Event::log(-1, "system", 3, "Impersonate", sprintf(__('%1$s starts impersonating user %2$s'),
+      Event::log(0, "system", 3, "Impersonate", sprintf(__('%1$s starts impersonating user %2$s'),
                                                             $impersonator, $user->fields['name']));
 
       return true;
@@ -1550,7 +1550,7 @@ class Session {
       $auth->user = $user;
       Session::init($auth);
 
-      Event::log(-1, "system", 3, "Impersonate", sprintf(__('%1$s stops impersonating user %2$s'),
+      Event::log(0, "system", 3, "Impersonate", sprintf(__('%1$s stops impersonating user %2$s'),
       $user->fields['name'], $impersonate_user));
 
       return true;

--- a/install/update_956_957.php
+++ b/install/update_956_957.php
@@ -80,6 +80,18 @@ function update956to957() {
    );
    /** /Replace -1 values for glpi_networkportaliases.networkports_id_alias field */
 
+   /** Replace -1 values for glpi_items_operatingsystems table foreign key fields */
+   foreach (['operatingsystems_id', 'operatingsystemversions_id', 'operatingsystemservicepacks_id'] as $item_os_fkey) {
+      $migration->addPostQuery(
+          $DB->buildUpdate(
+              'glpi_items_operatingsystems',
+              [$item_os_fkey => '0'],
+              [$item_os_fkey => '-1']
+          )
+      );
+   }
+   /** /Replace -1 values for glpi_items_operatingsystems table foreign key fields */
+
    // ************ Keep it at the end **************
    $migration->executeMigration();
 

--- a/install/update_956_957.php
+++ b/install/update_956_957.php
@@ -68,7 +68,17 @@ function update956to957() {
            ['items_id' => '-1', 'type' => 'system']
        )
    );
-   /** /Replace -1 values for items_id field */
+   /** /Replace -1 values for glpi_events.items_id field */
+
+   /** Replace -1 values for glpi_networkportaliases.networkports_id_alias field */
+   $migration->addPostQuery(
+       $DB->buildUpdate(
+           'glpi_networkportaliases',
+           ['networkports_id_alias' => '0'],
+           ['networkports_id_alias' => '-1']
+       )
+   );
+   /** /Replace -1 values for glpi_networkportaliases.networkports_id_alias field */
 
    // ************ Keep it at the end **************
    $migration->executeMigration();

--- a/install/update_956_957.php
+++ b/install/update_956_957.php
@@ -60,6 +60,16 @@ function update956to957() {
    }
    /* /Fix null `date` in ITIL tables */
 
+   /** Replace -1 values for glpi_events.items_id field */
+   $migration->addPostQuery(
+       $DB->buildUpdate(
+           'glpi_events',
+           ['items_id' => '0'],
+           ['items_id' => '-1', 'type' => 'system']
+       )
+   );
+   /** /Replace -1 values for items_id field */
+
    // ************ Keep it at the end **************
    $migration->executeMigration();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Here is the first step of migration to unsigned integers for primary/foreign keys. Switching installation file to unsigned int is too impacting and would trigger too many conflicts to be done on 9.5 branch, but the migration command should be, IMHO, be available in 9.5 branch, as it will be usefull for people using behaviours plugin.