### PR TITLE
fix(js): better way to get last clicked submit

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -5757,7 +5757,7 @@ JAVASCRIPT
          var lastClicked = null;
          $('input[type=submit], button[type=submit]').click(function(e) {
             e = e || event;
-            lastClicked = e.target || e.srcElement;
+            lastClicked = e.currentTarget || e.srcElement;
          });
 
          $('$selector').on('submit', function(e) {


### PR DESCRIPTION
Update an external event from calendar is partially break

If I click in the yellow (from submit button) -> update is OK
If I click on the label or on the icon (from submit button) -> update is KO

I think it's since the introduction of twig, where we added a ```<span>``` and ```<i>``` (for icon and label)

This Pr fix this

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal 23111
