### PR TITLE
Add problems to impact "status" badge

### DIFF
--- a/js/impact.js
+++ b/js/impact.js
@@ -2659,7 +2659,7 @@ var GLPIImpact = {
             hit = true;
 
             if (trigger) {
-               var target = badgeHitboxDetails.target + "?is_deleted=0&as_map=0&search=Search&itemtype=Ticket";
+               var target = badgeHitboxDetails.target;
 
                // Add items_id criteria
                target += "&criteria[0][link]=AND&criteria[0][field]=13&criteria[0][searchtype]=contains&criteria[0][value]=" + badgeHitboxDetails.id;


### PR DESCRIPTION
This "status badge" count the number of ongoing incidents for an item:

![image](https://user-images.githubusercontent.com/42734840/148198237-a54dcd70-cf03-4b09-9e04-cfdeffaaa91b.png)

With these changes, it also take into account ongoing problems.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23130
