### PR TITLE
Fix form ribbon position in iframe

### DIFF
--- a/css/includes/components/_asset-form.scss
+++ b/css/includes/components/_asset-form.scss
@@ -67,3 +67,7 @@
       overflow-y: auto;
    }
 }
+
+#page > .asset {
+   margin-top: 15px; // Fix top of form when embedded in iframe (Usually positioned properly because of .tab-content)
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10269

Fix top of form when embedded in iframe (Usually positioned properly because of .tab-content).
Without it, the top of the card header is cut off.