### PR TITLE
Hide single tab

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -326,7 +326,6 @@ JAVASCRIPT;
             $display_class = "";
             if (
                 is_a($type, CommonDBTM::class, true)
-                && $type::isNewId($ID)
                 && count($tabs) == 1
             ) {
                 $display_class = "d-none";


### PR DESCRIPTION
Following https://github.com/glpi-project/glpi/pull/10124.

The previous PR only targeted new items regarding this visual issue:
![image](https://user-images.githubusercontent.com/42734840/148388223-ca719aa8-2e60-4381-9e40-60244bb9c572.png)
![image](https://user-images.githubusercontent.com/42734840/148388303-b559add9-8912-4bc2-982f-8cb7910386e2.png)

These one extend it to all items: no point to display tabs list if there is only one tab ( + it's overlapping the "ribbon" thing containing the icon).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
