### PR TITLE
Fix form footer option

### DIFF
--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -564,14 +564,7 @@
    {{ include('components/form/buttons.html.twig') }}
    {{ include('components/form/inventory_info.html.twig') }}
 
-
    {% if params['formfooter'] is null or params['formfooter'] == true %}
-      {% set show_formfooter = true %}
-   {% else %}
-      {% set show_formfooter = false %}
-   {% endif %}
-
-   {% if show_formfooter %}
       <div class="card-footer mx-n2 mb-n2 mt-4">
          {{ include('components/form/dates.html.twig') }}
       </div>

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -565,7 +565,13 @@
    {{ include('components/form/inventory_info.html.twig') }}
 
 
-   {% if params['formfooter'] == null %}
+   {% if params['formfooter'] is null or params['formfooter'] == true %}
+      {% set show_formfooter = true %}
+   {% else %}
+      {% set show_formfooter = false %}
+   {% endif %}
+
+   {% if show_formfooter %}
       <div class="card-footer mx-n2 mb-n2 mt-4">
          {{ include('components/form/dates.html.twig') }}
       </div>


### PR DESCRIPTION
For some items you need to disable the form footer as you have no relevant dates or template to display, for example:

![image](https://user-images.githubusercontent.com/42734840/148400614-66760a8c-9682-4cf6-b33c-7498c3777647.png)

There seems to be an option "formfooter" that can be used to disable this footer but it's a bit weird to use.
`$options['formfooter'] = false;`  wont work, you need to set a "truthy" value to disable it because of the non strict check.
This is not very intuitive, you would not expect the footer to be disabled if you set formfooter to `true`.

These change allow the footer to be disabled with `$options['formfooter'] = false;` while still keeping the default behavior of showing the footer if the option is null (= not specified).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
