### PR TITLE
Add emailField twig macro

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -91,6 +91,7 @@
              name="{{ name }}" value="{{ value|verbatim_value }}"
              {{ options.readonly ? 'readonly' : '' }}
              {{ options.disabled ? 'disabled' : '' }}
+             {{ options.multiple ? 'multiple' : '' }} {# Only for emailField #}
              {{ options.required ? 'required' : '' }} />
    {% endset %}
 

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -345,6 +345,11 @@
    {{ _self.field(name, field, label, options) }}
 {% endmacro %}
 
+{% macro emailField(name, value, label = '', options = {}) %}
+   {% set options = {'type': 'email'}|merge(options) %}
+   {{ _self.textField(name, value, label, options) }}
+{% endmacro %}
+
 {% macro fileField(name, value, label = '', options = {}) %}
    {% set options = {
       'rand': random(),


### PR DESCRIPTION
Add support for [\<input type="email"\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email).


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
