### PR TITLE
Support 'multiple' option for item dropdowns

### DIFF
--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -633,7 +633,6 @@ abstract class CommonDBRelation extends CommonDBConnexity
    **/
     public function canCreateItem()
     {
-
         return $this->canRelationItem(
             'canUpdateItem',
             'canUpdate',
@@ -2118,5 +2117,34 @@ abstract class CommonDBRelation extends CommonDBConnexity
         $forbidden   = parent::getForbiddenStandardMassiveAction();
         $forbidden[] = 'clone';
         return $forbidden;
+    }
+
+    /**
+     * Check if the given class match $itemtype_1 or $itemtype_2
+     *
+     * @param string $class
+     *
+     * @return int 0 (not a part of the relation), 1 ($itemtype_1) or 2 ($itemtype_2)
+     */
+    public static function getMemberPosition(string $class): int
+    {
+        if ($class == static::$itemtype_1) {
+            return 1;
+        } elseif ($class == static::$itemtype_2) {
+            return 2;
+        } elseif (
+            preg_match('/^itemtype/', static::$itemtype_1) === 1
+            && preg_match('/^itemtype/', static::$itemtype_2) === 0
+        ) {
+            return 1;
+        } elseif (
+            preg_match('/^itemtype/', static::$itemtype_2) === 1
+            && preg_match('/^itemtype/', static::$itemtype_1) === 0
+        ) {
+            return 2;
+        } else {
+            // Not a member of this relation
+            return 0;
+        }
     }
 }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5948,7 +5948,7 @@ class CommonDBTM extends CommonGLPI
             $item_1_id = $this->getID();
             $item_2_fk = $commondb_relation::$items_id_1;
         } else {
-            $error = static::class . " is not part of the " . $commondb_relation::class . " relation";
+            $error = static::class . " is not part of the " . get_class($commondb_relation) . " relation";
             throw new InvalidArgumentException($error);
         }
 
@@ -6061,7 +6061,7 @@ class CommonDBTM extends CommonGLPI
             $item_1_id = $this->getID();
             $item_2_fk = $commondb_relation::$items_id_1;
         } else {
-            $error = static::class . " is not part of the " . $commondb_relation::class . " relation";
+            $error = static::class . " is not part of the " . get_class($commondb_relation) . " relation";
             throw new InvalidArgumentException($error);
         }
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5948,7 +5948,7 @@ class CommonDBTM extends CommonGLPI
             $item_1_id = $this->getID();
             $item_2_fk = $commondb_relation::$items_id_1;
         } else {
-            $error = static::class . " is not part of the " . commondb_relation::class . " relation";
+            $error = static::class . " is not part of the " . $commondb_relation::class . " relation";
             throw new InvalidArgumentException($error);
         }
 
@@ -6061,7 +6061,7 @@ class CommonDBTM extends CommonGLPI
             $item_1_id = $this->getID();
             $item_2_fk = $commondb_relation::$items_id_1;
         } else {
-            $error = static::class . " is not part of the " . commondb_relation::class . " relation";
+            $error = static::class . " is not part of the " . $commondb_relation::class . " relation";
             throw new InvalidArgumentException($error);
         }
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1521,7 +1521,7 @@ class CommonDBTM extends CommonGLPI
                 $this->oldvalues = [];
 
                 foreach (array_keys($this->input) as $key) {
-                    if (array_key_exists($key, $this->fields)) {
+                    if ($DB->fieldExists(static::getTable(), $key)) {
                       // Prevent history for date statement (for date for example)
                         if (
                             is_null($this->fields[$key])
@@ -5911,5 +5911,167 @@ class CommonDBTM extends CommonGLPI
         }
 
         return new MassiveAction($params, [], 'initial', true);
+    }
+
+    /**
+     * Automatically update 1-N links tables for the current item.
+     *
+     * @param string $commondb_relation Valid class extending CommonDBRelation
+     * @param string $field             Target field in the item input
+     * @param array  $extra_input       Fixed value to be used when searching
+     *                                  for existing values or inserting new ones
+     *
+     * @return void
+     */
+    protected function update1NTableData(
+        string $commondb_relation,
+        string $field,
+        array $extra_input
+    ): void {
+        // Check $commondb_connexity parameter
+        if (!is_a($commondb_relation, CommonDBRelation::class, true)) {
+            $error = "$commondb_relation is not a CommonDBRelation item";
+            throw new InvalidArgumentException($error);
+        }
+
+        /** @var CommonDBRelation */
+        $commondb_relation = new $commondb_relation();
+
+        // Compute which item is item_1 and item_2
+        $relation_position = $commondb_relation::getMemberPosition(static::class);
+        if ($relation_position == 1) {
+            $item_1_fk = $commondb_relation::$items_id_1;
+            $item_1_id = $this->getID();
+            $item_2_fk = $commondb_relation::$items_id_2;
+        } elseif ($relation_position == 2) {
+            $item_1_fk = $commondb_relation::$items_id_2;
+            $item_1_id = $this->getID();
+            $item_2_fk = $commondb_relation::$items_id_1;
+        } else {
+            $error = static::class . " is not part of the " . commondb_relation::class . " relation";
+            throw new InvalidArgumentException($error);
+        }
+
+        // Get input value
+        $input_value = $this->input[$field] ?? null;
+
+        // See dropdownField twig macro, needed for empty values as an empty
+        // array wont be sent in the HTML form
+        $input_defined = (bool) ($this->input["_{$field}_defined"] ?? false);
+
+        // Load existing value
+        $existing_relations = $commondb_relation->find(
+            array_merge($extra_input, [
+                $item_1_fk => $item_1_id,
+            ])
+        );
+
+        // Case 1: no updates -> do nothing
+        if ($input_value === null && !$input_defined) {
+            return;
+        }
+
+        // Case 2: input was emptied -> remove all values
+        if (
+            ($input_value === null && $input_defined)
+            || (is_array($input_value) && ! count($input_value))
+        ) {
+            foreach ($existing_relations as $relation) {
+                $success = $commondb_relation->delete([
+                    'id' => $relation['id']
+                ]);
+                if (!$success) {
+                    $warning = "Failed to delete " . get_class($commondb_relation);
+                    trigger_error($warning, E_USER_WARNING);
+                }
+            }
+            return;
+        }
+
+        // Case 3: input was maybe modified -> delete missing values and add new ones
+        foreach ($existing_relations as $relation) {
+            $item_2_id = $relation[$item_2_fk];
+            // Delete missing value
+            if (!in_array($item_2_id, $input_value)) {
+                $success = $commondb_relation->delete([
+                    'id' => $relation['id']
+                ]);
+                if (!$success) {
+                    $warning = "Failed to delete " . get_class($commondb_relation);
+                    trigger_error($warning, E_USER_WARNING);
+                }
+            }
+        }
+
+        // Get existing values
+        $item_2_ids_db = array_column($existing_relations, $item_2_fk);
+
+        // Add new values
+        foreach ($input_value as $item_2_id) {
+            if (in_array($item_2_id, $item_2_ids_db)) {
+                // Value exist
+                continue;
+            }
+
+            $success = $commondb_relation->add(array_merge($extra_input, [
+                $item_1_fk => $item_1_id,
+                $item_2_fk => $item_2_id
+            ]));
+            if (!$success) {
+                $warning = "Failed to add " . get_class($commondb_relation);
+                trigger_error($warning, E_USER_WARNING);
+            }
+        }
+
+        unset($this->input[$field]);
+    }
+
+    /**
+     * Automatically load 1-N links values for the current item.
+     *
+     * @param string $commondb_relation Valid class extending CommonDBRelation
+     * @param string $field             Target field in the item input
+     * @param array  $extra_input       Fixed value to be used when searching
+     *                                  for existing valuess
+     *
+     * @return void
+     */
+    protected function load1NTableData(
+        string $commondb_relation,
+        string $field,
+        array $extra_input
+    ): void {
+        // Check $commondb_connexity parameter
+        if (!is_a($commondb_relation, CommonDBRelation::class, true)) {
+            $error = "$commondb_relation is not a CommonDBRelation item";
+            throw new InvalidArgumentException($error);
+        }
+
+        /** @var CommonDBRelation */
+        $commondb_relation = new $commondb_relation();
+
+        // Compute which item is item_1 and item_2
+        $relation_position = $commondb_relation::getMemberPosition(static::class);
+        if ($relation_position == 1) {
+            $item_1_fk = $commondb_relation::$items_id_1;
+            $item_1_id = $this->getID();
+            $item_2_fk = $commondb_relation::$items_id_2;
+        } elseif ($relation_position == 2) {
+            $item_1_fk = $commondb_relation::$items_id_2;
+            $item_1_id = $this->getID();
+            $item_2_fk = $commondb_relation::$items_id_1;
+        } else {
+            $error = static::class . " is not part of the " . commondb_relation::class . " relation";
+            throw new InvalidArgumentException($error);
+        }
+
+        // Load existing value
+        $existing_relations = $commondb_relation->find(
+            array_merge($extra_input, [
+                $item_1_fk => $item_1_id,
+            ])
+        );
+
+        $this->fields[$field] = array_column($existing_relations, $item_2_fk);
     }
 }

--- a/src/Html.php
+++ b/src/Html.php
@@ -4664,6 +4664,7 @@ JAVASCRIPT
             'display_emptychoice' => false,
             'specific_tags'       => [],
             'parent_id_field'     => null,
+            'multiple'            => false,
         ];
         $params = array_merge($default_options, $params);
 
@@ -4672,6 +4673,7 @@ JAVASCRIPT
         $valuename = $params['valuename'];
         $on_change = $params["on_change"];
         $placeholder = $params['placeholder'] ?? '';
+        $multiple = $params['multiple'];
         unset($params["on_change"]);
         unset($params["width"]);
 
@@ -4728,6 +4730,7 @@ JAVASCRIPT
 
          const select2_el = $('#$field_id').select2({
             width: '$width',
+            multiple: '$multiple',
             placeholder: '$placeholder',
             allowClear: $allowclear,
             minimumInputLength: 0,

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1578,4 +1578,39 @@ class Migration
             }
         }
     }
+
+    /**
+     * Helper to create a simple link table between two itemtypes
+     * The table will contain 3 columns :
+     * - id (primary key)
+     * - foreign key 1 (first itemtype)
+     * - foreign key 2 (second itemtype)
+     *
+     * @param string $table Table name
+     * @param string $class_1 First itemtype (CommonDBTM)
+     * @param string $class_2 Second itemtype (CommonDBTM)
+     */
+    public function createLinkTable(
+        string $table,
+        string $class_1,
+        string $class_2
+    ) {
+        $fk_1 = $class_1::getForeignKeyField();
+        $fk_2 = $class_2::getForeignKeyField();
+
+        $default_charset = DBConnection::getDefaultCharset();
+        $default_collation = DBConnection::getDefaultCollation();
+        $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
+
+        $this->addPreQuery("
+            CREATE TABLE `$table` (
+                `id` int unsigned NOT NULL AUTO_INCREMENT,
+                `$fk_1` int {$default_key_sign} NOT NULL DEFAULT '0',
+                `$fk_2` int {$default_key_sign} NOT NULL DEFAULT '0',
+                PRIMARY KEY (`id`),
+                KEY `$fk_1` (`$fk_1`),
+                KEY `$fk_2` (`$fk_2`)
+            ) ENGINE=InnoDB DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation} ROW_FORMAT=DYNAMIC;
+        ", "Create link table between $class_1 and $class_2");
+    }
 }

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -595,6 +595,14 @@
 {% endmacro %}
 
 {% macro dropdownField(itemtype, name, value, label = '', options = {}) %}
+   {% if options.multiple %}
+      {# Needed for empty value as the input wont be sent in this case... we need something to know the input was displayed AND empty #}
+      {% set defined_input_name = "_#{name}_defined" %}
+      <input type="hidden" name="{{ defined_input_name }}" value="1"></input>
+
+      {# Multiple values will be set, input need to be an array #}
+      {% set name = "#{name}[]" %}
+   {% endif %}
    {% set options = {'rand': random()}|merge(options) %}
    {% if options.fields_template.isMandatoryField(name) %}
       {% set options = {'specific_tags': {'required': true}}|merge(options) %}


### PR DESCRIPTION
The `$itemtype::Dropdown()` method allow to easily display a simple dropdown allowing the user to pick an item from a given itemtype.
This kind of dropdowns sadly doesn't support the "multiple" option of select2 which we can use on others dropdown like `showDropdownFromArray()`.
Creating a field that allow the user to select multiple items of the same itemtype is thus painful as you need to use a "dropdown from array", load the values manually, update data in multiple tables, ...

These changes add the 'multiple' option to the `$itemtype::Dropdown()` method to make this kind of fields easier to create.
There is also a new `getFieldsFromLinkTables` method in `CommonDBTM` that can be used to register such "multiple items" fields to allow GLPI to update them and load their values in the current item without having to write any code.

#### Working example from a plugin:
![image](https://user-images.githubusercontent.com/42734840/148777336-a7854f28-9147-48b6-b3f5-9b505c989c91.png)

```php
$migration->createLinkTable("{$table}_users", EmailTarget::class, User::class);
$migration->addField("{$table}_users", "type", 'string');
$migration->createLinkTable("{$table}_groups", EmailTarget::class, Group::class);
$migration->addField("{$table}_groups", "type", 'string');
```

```php
public function getFieldsFromLinkTables(): array
{
   $base_table = self::getTable();
   $users_table = "{$base_table}_users";
   $groups_table = "{$base_table}_groups";

   return [
      "to_users"  => new FieldFromLinkTable(
         $users_table,
         User::class,
         ['type' => self::TARGET_TO]
      ),
      "to_groups" => new FieldFromLinkTable(
         $groups_table,
         Group::class,
         ['type' => self::TARGET_TO]
      ),
      "cc_users"  => new FieldFromLinkTable(
         $users_table,
         User::class,
         ['type' => self::TARGET_CC]
      ),
      "cc_groups" => new FieldFromLinkTable(
         $groups_table,
         Group::class,
         ['type' => self::TARGET_CC]
      ),
   ];
}
```
```twig
{{ fields.dropdownField(
   'User',
   'to_users',
   item.fields['to_users'],
   __('TO (users)'),
   {
      'right': 'all',
      'multiple' : true,
   }
) }}

{{ fields.dropdownField(
   'Group',
   'to_groups',
   item.fields['to_groups'],
   __('TO (groups)'),
   {
      'multiple' : true,
   }
) }}

{{ fields.dropdownField(
   'User',
   'cc_users',
   item.fields['cc_users'],
   __('CC (users)'),
   {
      'right': 'all',
      'multiple' : true,
   }
) }}

{{ fields.dropdownField(
   'Group',
   'cc_groups',
   item.fields['cc_groups'],
   __('CC (groups)'),
   {
      'multiple' : true,
   }
) }}
```

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
