### PR TITLE
Support buttons in datetime and add today/now button

### DIFF
--- a/css/includes/components/_flatpickr.scss
+++ b/css/includes/components/_flatpickr.scss
@@ -247,9 +247,5 @@ body {
    .flatpickr-time .flatpickr-am-pm:focus {
       background: transparent;
    }
-
-   .flatpickr-custom-buttons {
-      text-align: left;
-   }
 }
 /* stylelint-enable property-no-vendor-prefix */

--- a/css/includes/components/_flatpickr.scss
+++ b/css/includes/components/_flatpickr.scss
@@ -247,5 +247,9 @@ body {
    .flatpickr-time .flatpickr-am-pm:focus {
       background: transparent;
    }
+
+   .flatpickr-custom-buttons {
+      text-align: left;
+   }
 }
 /* stylelint-enable property-no-vendor-prefix */

--- a/js/flatpickr_buttons_plugin.js
+++ b/js/flatpickr_buttons_plugin.js
@@ -1,0 +1,117 @@
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+window.CustomFlatpickrButtons = (config = {}) => {
+
+   if (config.buttons !== undefined && !Array.isArray(config.buttons)) {
+      config.buttons = [config.buttons];
+   }
+
+   return (fp) => {
+      let wrapper;
+
+      if (config.buttons === undefined) {
+         config.buttons = [{
+            label: fp.config.enableTime ? __('Now') : __("Today"),
+            attributes: {
+               'class': 'btn btn-outline-secondary'
+            },
+            onClick: (e, fp) => {
+               fp.setDate(new Date());
+            }
+         }];
+      }
+
+      return {
+         onReady: () => {
+            wrapper = `<div class="flatpickr-custom-buttons pb-1"><div class="buttons-container">`;
+
+            (config.buttons).forEach((b, index) => {
+               const button = document.createElement('button');
+               button.type = 'button';
+               button.classList.add('ms-2');
+               button.textContent = b.label;
+               button.setAttribute('btn-id', index);
+               if (typeof b.attributes !== 'undefined') {
+                  Object.keys(b.attributes).forEach((key) => {
+                     if (key === 'class') {
+                        button.classList.add(...b.attributes[key].split(' '));
+                        return;
+                     }
+
+                     button.setAttribute(key, b.attributes[key]);
+                  });
+               }
+
+               wrapper += button.outerHTML;
+
+               fp.pluginElements.push(button);
+            });
+            wrapper += '</div></div>';
+
+            fp.calendarContainer.appendChild($.parseHTML(wrapper)[0]);
+
+            $(fp.calendarContainer).on('click', '.flatpickr-custom-buttons button', (e) => {
+               e.stopPropagation();
+               e.preventDefault();
+
+               const btn = $(e.target);
+               const btn_id = btn.attr('btn-id');
+               const click_handler = config.buttons[btn_id].onClick;
+
+               if (typeof click_handler !== 'function') {
+                  return;
+               }
+
+               click_handler(e, fp);
+            });
+
+            $(fp.calendarContainer).on('keydown', '.flatpickr-custom-buttons', (e) => {
+               const target = e.target;
+               if (target.tagName.toLowerCase() !== 'button') {
+                  return;
+               }
+
+               if (e.key === 'Tab') {
+                  if ((e.shiftKey && !target.previousSibling) || (!e.shiftKey && !target.nextSibling)) {
+                     e.preventDefault();
+                     fp.element.focus();
+                  }
+               }
+            });
+         },
+
+         onDestroy: () => {
+            $(wrapper).remove();
+         },
+      };
+   };
+};

--- a/js/flatpickr_buttons_plugin.js
+++ b/js/flatpickr_buttons_plugin.js
@@ -31,10 +31,6 @@
 
 window.CustomFlatpickrButtons = (config = {}) => {
 
-   if (config.buttons !== undefined && !Array.isArray(config.buttons)) {
-      config.buttons = [config.buttons];
-   }
-
    return (fp) => {
       let wrapper;
 
@@ -52,7 +48,7 @@ window.CustomFlatpickrButtons = (config = {}) => {
 
       return {
          onReady: () => {
-            wrapper = `<div class="flatpickr-custom-buttons pb-1"><div class="buttons-container">`;
+            wrapper = `<div class="flatpickr-custom-buttons pb-1 text-start"><div class="buttons-container">`;
 
             (config.buttons).forEach((b, index) => {
                const button = document.createElement('button');
@@ -92,20 +88,6 @@ window.CustomFlatpickrButtons = (config = {}) => {
                }
 
                click_handler(e, fp);
-            });
-
-            $(fp.calendarContainer).on('keydown', '.flatpickr-custom-buttons', (e) => {
-               const target = e.target;
-               if (target.tagName.toLowerCase() !== 'button') {
-                  return;
-               }
-
-               if (e.key === 'Tab') {
-                  if ((e.shiftKey && !target.previousSibling) || (!e.shiftKey && !target.nextSibling)) {
-                     e.preventDefault();
-                     fp.element.focus();
-                  }
-               }
             });
          },
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -2744,7 +2744,10 @@ HTML;
             allowInput: true,
             onClose(dates, currentdatestring, picker){
                picker.setDate(picker.altInput.value, true, picker.config.altFormat)
-            }
+            },
+            plugins: [
+               CustomFlatpickrButtons()
+            ]
          });
       });
 JS;
@@ -2922,7 +2925,10 @@ HTML;
             allowInput: true,
             onClose(dates, currentdatestring, picker){
                picker.setDate(picker.altInput.value, true, picker.config.altFormat)
-            }
+            },
+            plugins: [
+               CustomFlatpickrButtons()
+            ]
          });
       });
 JS;
@@ -6064,6 +6070,7 @@ JAVASCRIPT
                 break;
             case 'flatpickr':
                 $_SESSION['glpi_js_toload'][$name][] = 'public/lib/flatpickr.js';
+                $_SESSION['glpi_js_toload'][$name][] = 'js/flatpickr_buttons_plugin.js';
                 if (isset($_SESSION['glpilanguage'])) {
                     $filename = "public/lib/flatpickr/l10n/" .
                     strtolower($CFG_GLPI["languages"][$_SESSION['glpilanguage']][3]) . ".js";

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -276,7 +276,10 @@
             locale: getFlatPickerLocale("{{ locale['language'] }}", "{{ locale['region'] }}"),
             onClose(dates, currentdatestring, picker) {
                picker.setDate(picker.altInput.value, true, picker.config.altFormat)
-            }
+            },
+            plugins: [
+               CustomFlatpickrButtons()
+            ]
          });
       });
       </script>
@@ -306,7 +309,10 @@
             locale: getFlatPickerLocale('{{ locale['language'] }}', '{{ locale['region'] }}'),
             onClose(dates, currentdatestring, picker) {
                picker.setDate(picker.altInput.value, true, picker.config.altFormat)
-            }
+            },
+            plugins: [
+               CustomFlatpickrButtons()
+            ]
          });
       });
       </script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In the jQuery UI date picker, we had a button to automatically set the date/time to the current date.
Beyond setting the initial value to now, having the ability to update the date/time to the current one is useful in some cases like updating the last physical inventory.

I made a custom plugin for flatpickr to allow adding buttons, with a Now/Today button (label changes depending on if time is enabled) being the default.

Related stale issues: #7780, #7858
I've also seen some forum topics concerning the lack of the button.
Most recent was: https://forum.glpi-project.org/viewtopic.php?id=282697