### PR TITLE
Restore actors after incomplete form reload

### DIFF
--- a/src/Change.php
+++ b/src/Change.php
@@ -1116,7 +1116,7 @@ class Change extends CommonITILObject
              'backoutplancontent'         => '',
              'checklistcontent'           => '',
              'items_id'                   => 0,
-            '_actors'                     => [],
+             '_actors'                     => [],
         ];
     }
 

--- a/src/Change.php
+++ b/src/Change.php
@@ -1077,45 +1077,46 @@ class Change extends CommonITILObject
     {
         $default_use_notif = Entity::getUsedConfig('is_notif_enable_default', $_SESSION['glpiactive_entity'], '', 1);
         return [
-         '_users_id_requester'        => Session::getLoginUserID(),
-         '_users_id_requester_notif'  => [
-            'use_notification'  => $default_use_notif,
-            'alternative_email' => ''
-         ],
-         '_groups_id_requester'       => 0,
-         '_users_id_assign'           => 0,
-         '_users_id_assign_notif'     => [
-            'use_notification'  => $default_use_notif,
-            'alternative_email' => ''],
-         '_groups_id_assign'          => 0,
-         '_users_id_observer'         => 0,
-         '_users_id_observer_notif'   => [
-            'use_notification'  => $default_use_notif,
-            'alternative_email' => ''
-         ],
-         '_suppliers_id_assign_notif' => [
-            'use_notification'  => $default_use_notif,
-            'alternative_email' => ''
-         ],
-         '_groups_id_observer'        => 0,
-         '_suppliers_id_assign'       => 0,
-         'priority'                   => 3,
-         'urgency'                    => 3,
-         'impact'                     => 3,
-         'content'                    => '',
-         'entities_id'                => $_SESSION['glpiactive_entity'],
-         'name'                       => '',
-         'itilcategories_id'          => 0,
-         'actiontime'                 => 0,
-         '_add_validation'            => 0,
-         'users_id_validate'          => [],
-         '_tasktemplates_id'          => [],
-         'controlistcontent'          => '',
-         'impactcontent'              => '',
-         'rolloutplancontent'         => '',
-         'backoutplancontent'         => '',
-         'checklistcontent'           => '',
-         'items_id'                   => 0,
+            '_users_id_requester'        => Session::getLoginUserID(),
+            '_users_id_requester_notif'  => [
+                'use_notification'  => $default_use_notif,
+                'alternative_email' => ''
+            ],
+            '_groups_id_requester'       => 0,
+            '_users_id_assign'           => 0,
+            '_users_id_assign_notif'     => [
+                'use_notification'  => $default_use_notif,
+                'alternative_email' => ''],
+            '_groups_id_assign'          => 0,
+            '_users_id_observer'         => 0,
+            '_users_id_observer_notif'   => [
+                'use_notification'  => $default_use_notif,
+                'alternative_email' => ''
+            ],
+            '_suppliers_id_assign_notif' => [
+                'use_notification'  => $default_use_notif,
+                'alternative_email' => ''
+            ],
+            '_groups_id_observer'        => 0,
+             '_suppliers_id_assign'       => 0,
+             'priority'                   => 3,
+             'urgency'                    => 3,
+             'impact'                     => 3,
+             'content'                    => '',
+             'entities_id'                => $_SESSION['glpiactive_entity'],
+             'name'                       => '',
+             'itilcategories_id'          => 0,
+             'actiontime'                 => 0,
+             '_add_validation'            => 0,
+             'users_id_validate'          => [],
+             '_tasktemplates_id'          => [],
+             'controlistcontent'          => '',
+             'impactcontent'              => '',
+             'rolloutplancontent'         => '',
+             'backoutplancontent'         => '',
+             'checklistcontent'           => '',
+             'items_id'                   => 0,
+            '_actors'                     => [],
         ];
     }
 

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -1721,40 +1721,41 @@ class Problem extends CommonITILObject
     {
         $default_use_notif = Entity::getUsedConfig('is_notif_enable_default', $_SESSION['glpiactive_entity'], '', 1);
         return [
-         '_users_id_requester'        => Session::getLoginUserID(),
-         '_users_id_requester_notif'  => [
-            'use_notification'  => $default_use_notif,
-            'alternative_email' => ''
-         ],
-         '_groups_id_requester'       => 0,
-         '_users_id_assign'           => 0,
-         '_users_id_assign_notif'     => [
-            'use_notification'  => $default_use_notif,
-            'alternative_email' => ''],
-         '_groups_id_assign'          => 0,
-         '_users_id_observer'         => 0,
-         '_users_id_observer_notif'   => [
-            'use_notification'  => $default_use_notif,
-            'alternative_email' => ''
-         ],
-         '_suppliers_id_assign_notif' => [
-            'use_notification'  => $default_use_notif,
-            'alternative_email' => ''
-         ],
-         '_groups_id_observer'        => 0,
-         '_suppliers_id_assign'       => 0,
-         'priority'                   => 3,
-         'urgency'                    => 3,
-         'impact'                     => 3,
-         'content'                    => '',
-         'name'                       => '',
-         'entities_id'                => $_SESSION['glpiactive_entity'],
-         'itilcategories_id'          => 0,
-         'actiontime'                 => 0,
-         '_add_validation'            => 0,
-         'users_id_validate'          => [],
-         '_tasktemplates_id'          => [],
-         'items_id'                   => 0,
+             '_users_id_requester'        => Session::getLoginUserID(),
+             '_users_id_requester_notif'  => [
+                'use_notification'  => $default_use_notif,
+                'alternative_email' => ''
+             ],
+             '_groups_id_requester'       => 0,
+             '_users_id_assign'           => 0,
+             '_users_id_assign_notif'     => [
+                'use_notification'  => $default_use_notif,
+                'alternative_email' => ''],
+             '_groups_id_assign'          => 0,
+             '_users_id_observer'         => 0,
+             '_users_id_observer_notif'   => [
+                'use_notification'  => $default_use_notif,
+                'alternative_email' => ''
+             ],
+             '_suppliers_id_assign_notif' => [
+                'use_notification'  => $default_use_notif,
+                'alternative_email' => ''
+             ],
+             '_groups_id_observer'        => 0,
+             '_suppliers_id_assign'       => 0,
+             'priority'                   => 3,
+             'urgency'                    => 3,
+             'impact'                     => 3,
+             'content'                    => '',
+             'name'                       => '',
+             'entities_id'                => $_SESSION['glpiactive_entity'],
+             'itilcategories_id'          => 0,
+             'actiontime'                 => 0,
+             '_add_validation'            => 0,
+             'users_id_validate'          => [],
+             '_tasktemplates_id'          => [],
+             'items_id'                   => 0,
+            '_actors'                     => [],
         ];
     }
 

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -1755,7 +1755,7 @@ class Problem extends CommonITILObject
              'users_id_validate'          => [],
              '_tasktemplates_id'          => [],
              'items_id'                   => 0,
-            '_actors'                     => [],
+             '_actors'                     => [],
         ];
     }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4327,7 +4327,9 @@ JAVASCRIPT;
                '_content'                  => [],
                '_tag_content'              => [],
                '_filename'                 => [],
-               '_tag_filename'             => []];
+               '_tag_filename'             => [],
+               '_actors'                   => [],
+            ];
     }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While looking at a different issue, I noticed that in some cases the actors would disappear before I submit the final form.
To recreate:
1. Have category a mandatory field
2. Create ticket with actors and everything required except category
3. Try adding ticket and get error saying category is required and see actors are missing
This doesn't seem to happen when adding other actors or changing fields that cause the form to reload.