### PR TITLE
Adjust some 'unsanitize' logic

### DIFF
--- a/src/RichText/UserMention.php
+++ b/src/RichText/UserMention.php
@@ -86,14 +86,14 @@ final class UserMention
             if ($new_value !== null) {
                 $mentionned_actors_ids = array_merge(
                     $mentionned_actors_ids,
-                    self::getUserIdsFromUserMentions($new_value, true)
+                    self::getUserIdsFromUserMentions($new_value)
                 );
             }
 
             if ($previous_value !== null) {
                 $previously_mentionned_actors_ids = array_merge(
                     $previously_mentionned_actors_ids,
-                    self::getUserIdsFromUserMentions($previous_value, true)
+                    self::getUserIdsFromUserMentions($previous_value)
                 );
             }
         }
@@ -179,18 +179,15 @@ final class UserMention
     * Extract ids of mentioned users.
     *
     * @param string $content
-    * @param bool $sanitized
     *
     * @return int[]
     */
-    public static function getUserIdsFromUserMentions(string $content, bool $sanitized = false)
+    public static function getUserIdsFromUserMentions(string $content)
     {
         $ids = [];
 
         try {
-            if ($sanitized) {
-                $content = Sanitizer::unsanitize($content, true);
-            }
+            $content = Sanitizer::getVerbatimValue($content);
             libxml_use_internal_errors(true);
             $content_as_xml = new SimpleXMLElement('<div>' . $content . '</div>');
         } catch (\Throwable $e) {

--- a/src/Session.php
+++ b/src/Session.php
@@ -1508,7 +1508,7 @@ class Session
             };
 
             // Check also unsanitized data, as sanitizing process may alter expected data.
-            $unsanitized_data = Sanitizer::getVerbatimValue($data);
+            $unsanitized_data = Sanitizer::unsanitize($data);
 
             return $match_expected($idor_data, $data) || $match_expected($idor_data, $unsanitized_data);
         }

--- a/src/Session.php
+++ b/src/Session.php
@@ -35,6 +35,7 @@ use Glpi\Cache\CacheManager;
 use Glpi\Cache\I18nCache;
 use Glpi\Event;
 use Glpi\Plugin\Hooks;
+use Glpi\Toolbox\Sanitizer;
 
 /**
  * Session Class
@@ -1506,8 +1507,8 @@ class Session
                 }
             };
 
-           // Check also unsanitized data, as sanitizing process may alter expected data.
-            $unsanitized_data = Toolbox::stripslashes_deep($data);
+            // Check also unsanitized data, as sanitizing process may alter expected data.
+            $unsanitized_data = Sanitizer::getVerbatimValue($data);
 
             return $match_expected($idor_data, $data) || $match_expected($idor_data, $unsanitized_data);
         }

--- a/src/Stat/Data/Location/StatDataLocation.php
+++ b/src/Stat/Data/Location/StatDataLocation.php
@@ -64,7 +64,7 @@ abstract class StatDataLocation extends StatData
 
         foreach ($data[$data_key] as $key => $val) {
             if ($val > 0) {
-                $newkey = Toolbox::stripTags($key, true);
+                $newkey = Toolbox::stripTags($key);
                 $this->labels[] = $newkey;
                 $this->series[] = ['name' => $newkey, 'data' => $val];
                 $this->total += $val;

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2965,19 +2965,15 @@ class Toolbox
     *
     * @since 10.0.0
     *
-    * @param string  $str              String to strip tags on
-    * @param boolean $sanitized_input  Indicates whether the input has been transformed by GLPI sanitize process
+    * @param string  $str
     *
     * @return string
     *
     * @TODO Unit test
     */
-    public static function stripTags(string $str, bool $sanitized_input = false): string
+    public static function stripTags(string $str): string
     {
-
-        if ($sanitized_input) {
-            $str = Sanitizer::unsanitize($str);
-        }
+        $str = Sanitizer::getVerbatimValue($str);
 
         return strip_tags($str);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. `UserMention::getUserIdsFromUserMentions()` and `Toolbox::stripTags()` were still requiring an opt-in argument to handle unsanitization. This arg has been removed as `Sanitizer` is now able to handle it automatically.
2. IDOR token check was using `Toolbox::stripslashes_deep()`. I replaced it with `Sanitizer::getVerbatimValue()` as we may also face encoding issues with `<`, `>` or `&` chars.