### PR TITLE
Fix 'zero_on_empty' checkbox option

### DIFF
--- a/ajax/massiveaction.php
+++ b/ajax/massiveaction.php
@@ -86,7 +86,5 @@ if (count($actions)) {
     echo "<span id='show_massiveaction$rand'>&nbsp;</span>\n";
 }
 
-// Force 'checkbox-zero-on-empty', because some massive actions can use checkboxes
-$CFG_GLPI['checkbox-zero-on-empty'] = true;
 Html::closeForm();
 echo "</div>";

--- a/js/common.js
+++ b/js/common.js
@@ -1435,3 +1435,29 @@ function strip_tags(html_string) {
    var dom = new DOMParser().parseFromString(html_string, 'text/html');
    return dom.body.textContent;
 }
+
+/*
+ * Handle checkboxes that requires to send a "0" value to server when they are unchecked.
+ */
+$(document.body).on(
+   'submit',
+   'form',
+   (evt) => {
+      const form = $(evt.target).closest('form');
+      form.find('input[type="checkbox"][data-glpicore-cb-zero-on-empty="1"]:not(:checked)').each(
+         function(){
+            // If the checkbox is not validated, we add a hidden field with '0' as value
+            if ($(this).attr('name')) {
+               const input = $('<input>').attr(
+                  {
+                     type: 'hidden',
+                     name: $(this).attr('name'),
+                     value: '0'
+                  }
+               );
+               input.insertAfter($(this));
+            }
+         }
+      );
+   }
+);

--- a/js/common.js
+++ b/js/common.js
@@ -1435,29 +1435,3 @@ function strip_tags(html_string) {
    var dom = new DOMParser().parseFromString(html_string, 'text/html');
    return dom.body.textContent;
 }
-
-/*
- * Handle checkboxes that requires to send a "0" value to server when they are unchecked.
- */
-$(document.body).on(
-   'submit',
-   'form',
-   (evt) => {
-      const form = $(evt.target).closest('form');
-      form.find('input[type="checkbox"][data-glpicore-cb-zero-on-empty="1"]:not(:checked)').each(
-         function(){
-            // If the checkbox is not validated, we add a hidden field with '0' as value
-            if ($(this).attr('name')) {
-               const input = $('<input>').attr(
-                  {
-                     type: 'hidden',
-                     name: $(this).attr('name'),
-                     value: '0'
-                  }
-               );
-               input.insertAfter($(this));
-            }
-         }
-      );
-   }
-);

--- a/src/Html.php
+++ b/src/Html.php
@@ -2311,8 +2311,7 @@ HTML;
         }
 
         if ($params['zero_on_empty']) {
-            $out                               .= " data-glpicore-cb-zero-on-empty='1'";
-            $CFG_GLPI['checkbox-zero-on-empty'] = true;
+            $out .= " data-glpicore-cb-zero-on-empty='1'";
         }
 
         if (!empty($params['massive_tags'])) {
@@ -4392,31 +4391,13 @@ JAVASCRIPT
    **/
     public static function closeForm($display = true)
     {
-        global $CFG_GLPI;
+        $out = '';
 
-        $out = "\n";
         if (GLPI_USE_CSRF_CHECK) {
-            $out .= Html::hidden('_glpi_csrf_token', ['value' => Session::getNewCSRFToken()]) . "\n";
+            $out .= Html::hidden('_glpi_csrf_token', ['value' => Session::getNewCSRFToken()]);
         }
 
-        if (isset($CFG_GLPI['checkbox-zero-on-empty']) && $CFG_GLPI['checkbox-zero-on-empty']) {
-            $js = "   $('form').submit(function() {
-         $('input[type=\"checkbox\"][data-glpicore-cb-zero-on-empty=\"1\"]:not(:checked)').each(function(index){
-            // If the checkbox is not validated, we add a hidden field with '0' as value
-            if ($(this).attr('name')) {
-               $('<input>').attr({
-                  type: 'hidden',
-                  name: $(this).attr('name'),
-                  value: '0'
-               }).insertAfter($(this));
-            }
-         });
-      });";
-            $out .= Html::scriptBlock($js) . "\n";
-            unset($CFG_GLPI['checkbox-zero-on-empty']);
-        }
-
-        $out .= "</form>\n";
+        $out .= "</form>";
         if ($display) {
             echo $out;
             return true;

--- a/src/Html.php
+++ b/src/Html.php
@@ -2293,6 +2293,11 @@ HTML;
         }
 
         $out = "";
+
+        if ($params['zero_on_empty']) {
+            $out .= '<input type="hidden" name="' . $params['name'] . '" value="0" />';
+        }
+
         $out .= "<input type='checkbox' class='form-check-input' title=\"" . $params['title'] . "\" ";
         if (isset($params['onclick'])) {
             $params['onclick'] = htmlspecialchars($params['onclick'], ENT_QUOTES);
@@ -2308,10 +2313,6 @@ HTML;
         $criterion = self::getCriterionForMassiveCheckboxes($params['criterion']);
         if (!empty($criterion)) {
             $out .= " onClick='massiveUpdateCheckbox(\"$criterion\", this)'";
-        }
-
-        if ($params['zero_on_empty']) {
-            $out .= " data-glpicore-cb-zero-on-empty='1'";
         }
 
         if (!empty($params['massive_tags'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This JS script was indirectly included via the `CommonDBTM::showFormButtons()` in GLPI 9.5, but is not included anymore. ~~I propose to move it directly in `common.js` file, which should be included almost everywhere, and remove the related `CFG_GLPI` volative entry.~~
There is no need for such a script. Prepending the checkbox with an hidden input having the `0` value does the job.