### PR TITLE
Json protocol support update

### DIFF
--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -148,7 +148,8 @@ abstract class AbstractRequest
     */
     private function guessMode($contents)
     {
-        if ($this->headers->hasHeader('GLPI-Agent-ID') && preg_match('/^{/', $contents)) {
+       // In the case handleContentType() didn't set mode, just check $contents first char
+        if ($contents[0] === '{') {
             $this->setMode(self::JSON_MODE);
         } else {
            //defaults to XML; whose validity is checked later.

--- a/src/Agent/Communication/AbstractRequest.php
+++ b/src/Agent/Communication/AbstractRequest.php
@@ -148,8 +148,7 @@ abstract class AbstractRequest
     */
     private function guessMode($contents)
     {
-        json_decode($contents);
-        if (json_last_error() === JSON_ERROR_NONE) {
+        if ($this->headers->hasHeader('GLPI-Agent-ID') && preg_match('/^{/', $contents)) {
             $this->setMode(self::JSON_MODE);
         } else {
            //defaults to XML; whose validity is checked later.
@@ -288,6 +287,12 @@ abstract class AbstractRequest
     public function handleJSONRequest($data): bool
     {
         $jdata = json_decode($data);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $this->addError('JSON not well formed!', 400);
+            return false;
+        }
+
         $this->deviceid = $jdata->deviceid;
         $action = self::INVENT_ACTION;
         if (property_exists($jdata, 'action')) {

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -4129,7 +4129,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->boolean($refused->getFromDB($result['id']))->isTrue();
 
         $inventory_request = new \Glpi\Inventory\Request();
-        $inventory_request->handleContentType(false);
+        $inventory_request->handleContentType('application/json');
         $contents = file_get_contents($refused->getInventoryFileName());
         $inventory_request->handleRequest($contents);
 

--- a/tests/web/Glpi/Inventory/Request.php
+++ b/tests/web/Glpi/Inventory/Request.php
@@ -108,6 +108,39 @@ class Request extends \GLPITestCase
         )->hasCode(400)->message->contains('<ERROR>XML not well formed!</ERROR>');
     }
 
+    public function testRequestInvalidJSONContent()
+    {
+        $this->exception(
+            function () {
+                $res = $this->http_client->request(
+                    'POST',
+                    $this->base_uri . 'front/inventory.php',
+                    [
+                        'headers' => [
+                            'Content-Type' => 'application/json'
+                        ]
+                    ]
+                );
+            }
+        )->hasCode(400)->message->contains('{"status":"error","message":"JSON not well formed!","expiration":24}');
+        $this->exception(
+            function () {
+                $res = $this->http_client->request(
+                    'POST',
+                    $this->base_uri . 'front/inventory.php',
+                    [
+                        'headers' => [
+                            'Content-Type' => 'application/x-compress-zlib',
+                            'GLPI-Agent-ID' => 'a31ff7b5-4d8d-4e39-891e-0cca91d9df13'
+                        ],
+                        'body'   => gzcompress('{ bad content')
+                        ]
+                    ]
+                );
+            }
+        )->hasCode(400)->message->contains(gzcompress('{"status":"error","message":"JSON not well formed!","expiration":24}'));
+    }
+
     public function testPrologRequest()
     {
         $res = $this->http_client->request(

--- a/tests/web/Glpi/Inventory/Request.php
+++ b/tests/web/Glpi/Inventory/Request.php
@@ -134,7 +134,6 @@ class Request extends \GLPITestCase
                             'GLPI-Agent-ID' => 'a31ff7b5-4d8d-4e39-891e-0cca91d9df13'
                         ],
                         'body'   => gzcompress('{ bad content')
-                        ]
                     ]
                 );
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This PR permits to avoid a double json decoding of submitted content. It also introduces a malformed JSON error handled with a 400 HTTP error.
This also prevents to see a PHP warning exception inphp-errors.log when submitting a not compressed and malformed json with such a request:
```
LANG=C curl http://glpi-server/front/inventory.php -v -X POST -H "Content-Type: application/json"
```
Here was the found warning for such request:
```
[2022-01-11 12:20:04] glpiphplog.WARNING:   *** PHP Warning (2): First parameter must either be an object or the name of an existing class in /srv/glpi/src/Agent/Communication/AbstractRequest.php at line 293
  Backtrace :
  src/Agent/Communication/AbstractRequest.php:293    property_exists()
  src/Agent/Communication/AbstractRequest.php:219    Glpi\Agent\Communication\AbstractRequest->handleJSONRequest()
  front/inventory.php:67                             Glpi\Agent\Communication\AbstractRequest->handleRequest()
```

PS: In that case, the HTTP error was also 500 in place of 400.