### PR TITLE
Json protocol contact support update

### DIFF
--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -105,35 +105,43 @@ class Request extends AbstractRequest
 
    /**
      * Handle Task
+     *
      * @param string $task  Task (one of self::*_TASK)
+     *
      * @return array
      */
     protected function handleTask($task): array
     {
+        $params = [
+           'options' => [
+               'response' => []
+           ],
+           'item' => $this->inventory->getAgent(),
+        ];
         switch ($task) {
             case self::INVENT_TASK:
-                return $this->handleInventoryTask();
+                return $this->handleInventoryTask($params);
                 break;
             case self::NETDISCOVERY_TASK:
-                return $this->handleNetDiscoveryTask();
+                return $this->handleNetDiscoveryTask($params);
                 break;
             case self::NETINV_TASK:
-                return $this->handleNetInventoryTask();
+                return $this->handleNetInventoryTask($params);
                 break;
             case self::ESX_TASK:
-                return $this->handleESXTask();
+                return $this->handleESXTask($params);
                 break;
             case self::COLLECT_TASK:
-                return $this->handleCollectTask();
+                return $this->handleCollectTask($params);
                 break;
             case self::DEPLOY_TASK:
-                return $this->handleDeployTask();
+                return $this->handleDeployTask($params);
                 break;
             case self::WOL_TASK:
-                return $this->handleWakeOnLanTask();
+                return $this->handleWakeOnLanTask($params);
                 break;
             case self::REMOTEINV_TASK:
-                return $this->handleRemoteInventoryTask();
+                return $this->handleRemoteInventoryTask($params);
                 break;
             default:
                 $this->addError("Task '$task' is not supported.", 400);
@@ -372,32 +380,32 @@ class Request extends AbstractRequest
    /**
     * Handle agent enabled inventory task support on contact request
     *
+    * @param array $params Required hooks params
+    *
     * @return array
     */
-    public function handleInventoryTask(): array
+    public function handleInventoryTask(array $params): array
     {
-
-        $params['options']['response'] = [];
-        $params['item'] = $this->inventory->getAgent();
-        $params = Plugin::doHookFunction(Hooks::HANDLE_INVENTORY_TASK, $params);
-
-       // Return inventory task support merging current server/version infos
-        return array_merge($params['options']['response'][self::INVENT_TASK] ?? [], [
+       // Preset response as glpi supports native inventory by default
+        $params['options']['response'][self::INVENT_TASK] = [
             'server' => 'glpi',
             'version' => GLPI_VERSION
-        ]);
+        ];
+        $params = Plugin::doHookFunction(Hooks::HANDLE_INVENTORY_TASK, $params);
+
+       // Return inventory task support
+        return $params['options']['response'][self::INVENT_TASK] ?? [];
     }
 
    /**
     * Handle agent enabled netdiscovery task support on contact request
     *
+    * @param array $params Required hooks params
+    *
     * @return array
     */
-    public function handleNetDiscoveryTask(): array
+    public function handleNetDiscoveryTask(array $params): array
     {
-
-        $params['options']['response'] = [];
-        $params['item'] = $this->inventory->getAgent();
         $params = Plugin::doHookFunction(Hooks::HANDLE_NETDISCOVERY_TASK, $params);
 
         return $params['options']['response'][self::NETDISCOVERY_TASK] ?? [];
@@ -406,13 +414,12 @@ class Request extends AbstractRequest
    /**
     * Handle agent enabled netinventory task support on contact request
     *
+    * @param array $params Required hooks params
+    *
     * @return array
     */
-    public function handleNetInventoryTask(): array
+    public function handleNetInventoryTask(array $params): array
     {
-
-        $params['options']['response'] = [];
-        $params['item'] = $this->inventory->getAgent();
         $params = Plugin::doHookFunction(Hooks::HANDLE_NETINVENTORY_TASK, $params);
 
         return $params['options']['response'][self::NETINV_TASK] ?? [];
@@ -421,13 +428,12 @@ class Request extends AbstractRequest
    /**
     * Handle agent enabled ESX task support on contact request
     *
+    * @param array $params Required hooks params
+    *
     * @return array
     */
-    public function handleESXTask(): array
+    public function handleESXTask(array $params): array
     {
-
-        $params['options']['response'] = [];
-        $params['item'] = $this->inventory->getAgent();
         $params = Plugin::doHookFunction(Hooks::HANDLE_ESX_TASK, $params);
 
         return $params['options']['response'][self::ESX_TASK] ?? [];
@@ -436,13 +442,12 @@ class Request extends AbstractRequest
    /**
     * Handle agent enabled collect task support on contact request
     *
+    * @param array $params Required hooks params
+    *
     * @return array
     */
-    public function handleCollectTask(): array
+    public function handleCollectTask(array $params): array
     {
-
-        $params['options']['response'] = [];
-        $params['item'] = $this->inventory->getAgent();
         $params = Plugin::doHookFunction(Hooks::HANDLE_COLLECT_TASK, $params);
 
         return $params['options']['response'][self::COLLECT_TASK] ?? [];
@@ -451,13 +456,12 @@ class Request extends AbstractRequest
    /**
     * Handle agent enabled deploy task support on contact request
     *
+    * @param array $params Required hooks params
+    *
     * @return array
     */
-    public function handleDeployTask(): array
+    public function handleDeployTask(array $params): array
     {
-
-        $params['options']['response'] = [];
-        $params['item'] = $this->inventory->getAgent();
         $params = Plugin::doHookFunction(Hooks::HANDLE_DEPLOY_TASK, $params);
 
         return $params['options']['response'][self::DEPLOY_TASK] ?? [];
@@ -466,13 +470,12 @@ class Request extends AbstractRequest
    /**
     * Handle agent enabled wakeonlan task support on contact request
     *
+    * @param array $params Required hooks params
+    *
     * @return array
     */
-    public function handleWakeOnLanTask(): array
+    public function handleWakeOnLanTask(array $params): array
     {
-
-        $params['options']['response'] = [];
-        $params['item'] = $this->inventory->getAgent();
         $params = Plugin::doHookFunction(Hooks::HANDLE_WAKEONLAN_TASK, $params);
 
         return $params['options']['response'][self::WAKEONLAN_TASK] ?? [];
@@ -481,15 +484,15 @@ class Request extends AbstractRequest
    /**
     * Handle agent enabled remoteinventory task support on contact request
     *
+    * @param array $params Required hooks params
+    *
     * @return array
     */
-    public function handleRemoteInventoryTask(): array
+    public function handleRemoteInventoryTask(array $params): array
     {
-       // Permit remoteinventory task as it could have been setup on agent side
-        return [
-            'server' => 'glpi',
-            'version' => GLPI_VERSION
-        ];
+        $params = Plugin::doHookFunction(Hooks::HANDLE_REMOTEINV_TASK, $params);
+
+        return $params['options']['response'][self::REMOTEINV_TASK] ?? [];
     }
 
    /**

--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -318,7 +318,8 @@ class Request extends AbstractRequest
        //For the moment it's the Agent who informs us about the active tasks
         if (property_exists($this->inventory->getRawData(), 'enabled-tasks')) {
             foreach ($this->inventory->getRawData()->{'enabled-tasks'} as $task) {
-                if ((!empty($handle = $this->handleTask($task)))) {
+                $handle = $this->handleTask($task);
+                if (is_array($handle) && count($handle)) {
                    // Insert related task information under tasks list property
                     $response['tasks'][$task] = $handle;
                 } else {

--- a/src/Plugin/Hooks.php
+++ b/src/Plugin/Hooks.php
@@ -113,6 +113,7 @@ class Hooks
     const NETWORK_DISCOVERY = 'network_discovery';
     const NETWORK_INVENTORY = 'network_inventory';
     const INVENTORY_GET_PARAMS = 'inventory_get_params';
+
    // Agent contact request related hooks
     const HANDLE_INVENTORY_TASK    = 'handle_inventory_task';
     const HANDLE_NETDISCOVERY_TASK = 'handle_netdiscovery_task';

--- a/src/Plugin/Hooks.php
+++ b/src/Plugin/Hooks.php
@@ -112,6 +112,15 @@ class Hooks
     const PROLOG_RESPONSE = 'prolog_response';
     const NETWORK_DISCOVERY = 'network_discovery';
     const NETWORK_INVENTORY = 'network_inventory';
+    const INVENTORY_GET_PARAMS = 'inventory_get_params';
+   // Agent contact request related hooks
+    const HANDLE_INVENTORY_TASK    = 'handle_inventory_task';
+    const HANDLE_NETDISCOVERY_TASK = 'handle_netdiscovery_task';
+    const HANDLE_NETINVENTORY_TASK = 'handle_netinventory_task';
+    const HANDLE_ESX_TASK          = 'handle_esx_task';
+    const HANDLE_COLLECT_TASK      = 'handle_collect_task';
+    const HANDLE_DEPLOY_TASK       = 'handle_deploy_task';
+    const HANDLE_WAKEONLAN_TASK    = 'handle_wakeonlan_task';
 
    // Debug / Development hooks
     const DEBUG_TABS = 'debug_tabs';

--- a/src/Plugin/Hooks.php
+++ b/src/Plugin/Hooks.php
@@ -122,6 +122,7 @@ class Hooks
     const HANDLE_COLLECT_TASK      = 'handle_collect_task';
     const HANDLE_DEPLOY_TASK       = 'handle_deploy_task';
     const HANDLE_WAKEONLAN_TASK    = 'handle_wakeonlan_task';
+    const HANDLE_REMOTEINV_TASK    = 'handle_remoteinventory_task';
 
    // Debug / Development hooks
     const DEBUG_TABS = 'debug_tabs';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In this PR, we:
* add hooks support for all tasks supported by GLPI-Agent
* disable not supported tasks in contact answer so agent has not have to run them
* enable inventory and remoteinventory tasks by default

The purpose of this PR is to enhance the JSON protocol related to the CONTACT request. Actually, the server will answer GLPI-Agent to disable all its tasks but `inventory` one. Now, `remoteinventory` task is also enabled by default as this task is only setup on the agent side. Also, any plugin, like [GlpiInventory plugin](https://github.com/glpi-project/glpi-inventory-plugin), can tell GLPI to answer it can handle tasks enabled on agent side, thanks to be hooks.

For instance, to such CONTACT request:
```
{
   "action": "contact",
   "deviceid": "agent-server-2021-11-30-09-57-34",
   "enabled-tasks": [
      "inventory",
      "netdiscovery",
      "netinventory",
      "remoteinventory"
   ],
   "installed-tasks": [
      "collect",
      "deploy",
      "esx",
      "inventory",
      "netdiscovery",
      "netinventory",
      "remoteinventory",
      "wakeonlan"
   ],
   "name": "GLPI-Agent",
   "version": "1.1-dev"
}
```

Glpi can answer:
```
{"message":"netdiscovery task not supported;netinventory task not supported","disabled":["netdiscovery","netinventory"],"expiration":24,"status":"ok","tasks":{"inventory":{"server":"glpi","version":"10.0.0-dev"},"remoteinventory":{"server":"glpi","version":"10.0.0-dev"}}}
```
Here, as no hook was setup to support `netdiscovery` and `netinventory`, Glpi tells the agent to disable them and the agent will just skip them logging "message" in debug mode.

A [GlpiInventory plugin](https://github.com/glpi-project/glpi-inventory-plugin) PR will follow so the answer could be something like:
```
{"expiration":24,"status":"ok","tasks":{"inventory":{"server":"glpi","version":"10.0.0-dev"},"remoteinventory":{"server":"glpi","version":"10.0.0-dev"},"netdiscovery":{"server":"glpi-inventory-plugin","version":"1.0.0-rc3"},"netinventory":{"server":"glpi-inventory-plugin","version":"1.0.0-rc3"}}}
```
So the agent can still run the expected tasks. It can even adapt its comportment checking "server" and "version" properties.