### PR TITLE
Ensure resize image height is greater than zero

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -1335,7 +1335,7 @@ class Toolbox {
                $new_height = $max_size;
             } else {
                $new_width  = $max_size;
-               $new_height = $max_size / $source_aspect_ratio;
+               $new_height = ceil($max_size / $source_aspect_ratio);
             }
          }
       }

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -1331,7 +1331,7 @@ class Toolbox {
             || ($img_height > $max_size)) {
             $source_aspect_ratio = $img_width / $img_height;
             if ($source_aspect_ratio < 1) {
-               $new_width  = $max_size * $source_aspect_ratio;
+               $new_width  = ceil($max_size * $source_aspect_ratio);
                $new_height = $max_size;
             } else {
                $new_width  = $max_size;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10109 

In some cases an image's resized height can be rounded down to zero which isn't valid (example image was 3px high by 449px wide).
Wrapping the division in `ceil` should make images at least 1px high.