### PR TITLE
Fix anonymous ticket creation

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1708,7 +1708,7 @@ class Ticket extends CommonITILObject
        // We condition the check with a bool flag set in front/tracking.injector.php (self-service ticket controller).
        // This to avoid plugins having their process broken.
         if (
-            isset($input['check_delegatee'])
+            isset($input['check_delegatee'], $input['_users_id_requester'])
             && $input['check_delegatee']
             && !self::canDelegateeCreateTicket($input['_users_id_requester'], ($input['entities_id'] ?? -2))
         ) {

--- a/templates/anonymous_helpdesk.html.twig
+++ b/templates/anonymous_helpdesk.html.twig
@@ -64,7 +64,7 @@
       </fieldset>
 
       <div class="form-footer">
-         <button class="btn btn-icon btn-primary w-100" name="update">
+         <button class="btn btn-icon btn-primary w-100" name="add">
             <i class="fas fa-envelope"></i>
             <span>{{ __('Send') }}</span>
          </button>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When trying to create a ticket using `helpdesk.public.php` you get redirected to a blank page and the ticket isn't created because the `add` parameter is missing in the POST.