### PR TITLE
Fix db:configure command when using a db that does not yet exists

### DIFF
--- a/src/Console/Database/AbstractConfigureCommand.php
+++ b/src/Console/Database/AbstractConfigureCommand.php
@@ -233,6 +233,7 @@ abstract class AbstractConfigureCommand extends AbstractCommand implements Force
             return self::ABORTED_BY_USER;
         }
 
+        mysqli_report(MYSQLI_REPORT_OFF);
         $mysqli = new mysqli();
         if (intval($db_port) > 0) {
             // Network port
@@ -252,6 +253,8 @@ abstract class AbstractConfigureCommand extends AbstractCommand implements Force
             return self::ERROR_DB_CONNECTION_FAILED;
         }
 
+        $db_exists = @$mysqli->select_db($db_name);
+
         ob_start();
         $db_version_data = $mysqli->query('SELECT version()')->fetch_array();
         $checkdb = Config::displayCheckDbEngine(false, $db_version_data[0]);
@@ -261,7 +264,7 @@ abstract class AbstractConfigureCommand extends AbstractCommand implements Force
             return self::ERROR_DB_ENGINE_UNSUPPORTED;
         }
 
-        if ($strict_configuration || !$compute_flags_from_db) {
+        if (!$db_exists || $strict_configuration || !$compute_flags_from_db) {
             // Force strict configuration
             $use_utf8mb4 = true;
             $allow_myisam = false;
@@ -361,8 +364,6 @@ abstract class AbstractConfigureCommand extends AbstractCommand implements Force
                   $this->log_deprecation_warnings = $log_deprecation_warnings;
 
                   $this->clearSchemaCache();
-
-                  parent::__construct();
             }
         };
 

--- a/src/Console/Database/InstallCommand.php
+++ b/src/Console/Database/InstallCommand.php
@@ -172,6 +172,10 @@ class InstallCommand extends AbstractConfigureCommand
         if (!$this->isDbAlreadyConfigured() || $input->getOption('reconfigure')) {
             $result = $this->configureDatabase($input, $output, false, true, false, false, false);
 
+            // Ensure global $DB is updated (used by GLPIKey)
+            global $DB;
+            $DB = $this->db;
+
             if (self::ABORTED_BY_USER === $result) {
                 return 0; // Considered as success
             } else if (self::SUCCESS !== $result) {
@@ -310,6 +314,7 @@ class InstallCommand extends AbstractConfigureCommand
         );
        // TODO Get rid of output buffering
         ob_start();
+        $this->db->connect(); // Reconnect DB to ensure it uses update configuration (see `self::configureDatabase()`)
         Toolbox::createSchema($default_language, $this->db);
         $message = ob_get_clean();
         if (!empty($message)) {

--- a/src/GLPIKey.php
+++ b/src/GLPIKey.php
@@ -174,7 +174,7 @@ class GLPIKey
 
        // Fetch old key before generating the new one (but only if DB exists and there is something to migrate)
         $previous_key = null;
-        if ($DB instanceof DBmysql) {
+        if ($DB instanceof DBmysql && $DB->connected) {
             if ($this->keyExists()) {
                 $previous_key = $this->get();
                 if ($previous_key === null) {
@@ -192,7 +192,7 @@ class GLPIKey
             return false;
         }
 
-        if ($DB instanceof DBmysql) {
+        if ($DB instanceof DBmysql && $DB->connected) {
             if (!$this->migrateFieldsInDb($previous_key) || !$this->migrateConfigsInDb($previous_key)) {
                 trigger_error('Error during encrypted data update in database.', E_USER_WARNING);
                 return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The `AbstractConfigureCommand::configureDatabase()` method can be used to create a configuration file that targets the database that will be created later by the `db:install` command. The call to `DBmysql::connect()` must be done after the creation of this new database.