### PR TITLE
Update hooks params setup in getParams

### DIFF
--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -148,13 +148,18 @@ class Request extends AbstractRequest
         $this->inventory->contact($data);
 
         $response = [
-         'expiration'  => self::DEFAULT_FREQUENCY,
-         'status'     => 'ok',
+            'expiration' => self::DEFAULT_FREQUENCY,
+            'status'     => 'ok'
         ];
 
-        $params['options']['content'] = $data;
-        $params['options']['response'] = $response;
-        $params['item'] = $this->inventory->getAgent();
+        $params = [
+           'options' => [
+                'content' => $data,
+                'response' => $response
+            ],
+            'item' => $this->inventory->getAgent()
+        ];
+
         $params = Plugin::doHookFunction("inventory_get_params", $params);
 
         $this->addToResponse($params['options']['response']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This little PR to follow one @orthagh suggestion on #10316 and to avoid a possible deprecated notation in future PHP versions.