### PR TITLE
Fix table name in unsigned key usage warning

### DIFF
--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1957,7 +1957,14 @@ class DBmysql
     private function checkForDeprecatedTableOptions(string $query): void
     {
         $table_matches = [];
-        if (preg_match('/(ALTER|CREATE)\s+TABLE\s*(\s|`)(?<table>[^`\s]+)(\s|`)/i', $query, $table_matches) !== 1) {
+        $table_pattern = '/'
+            . '(ALTER|CREATE)'
+            . '(\s+TEMPORARY)?'
+            . '\s+TABLE'
+            . '(\s+IF\s+NOT\s+EXISTS)?'
+            . '\s*(\s|`)(?<table>[^`\s]+)(\s|`)'
+            . '/i';
+        if (preg_match($table_pattern, $query, $table_matches) !== 1) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

On some plugins, the install SQL queries are using ``` CREATE TABLE IF NOT EXISTS `xxx` ``` queries. In this case, table name was incorrectly extracted and following warning was trigerred: ``` Usage of signed integers in primary or foreign keys is discouraged, please use unsigned integers instead in `IF`.`id`. ```