### PR TITLE
Handle templates at child-item level

### DIFF
--- a/src/AbstractITILChildTemplate.php
+++ b/src/AbstractITILChildTemplate.php
@@ -117,6 +117,10 @@ abstract class AbstractITILChildTemplate extends CommonDropdown
      */
     public function getRenderedContent(CommonITILObject $itil_item): string
     {
+        if (empty($this->fields['content'])) {
+            return '';
+        }
+
         $html = TemplateManager::renderContentForCommonITIL(
             $itil_item,
             $this->fields['content']

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7653,8 +7653,7 @@ abstract class CommonITILObject extends CommonDBTM
         $itiltask   = new $itiltask_class();
         foreach ($this->input['_tasktemplates_id'] as $tasktemplates_id) {
             $itiltask->add([
-                'tasktemplates_id'            => $tasktemplates_id,
-                '_templates_id'               => $tasktemplates_id,
+                '_tasktemplates_id'           => $tasktemplates_id,
                 $this->getForeignKeyField()   => $this->fields['id'],
                 'date'                        => $this->fields['date'],
                 '_disablenotif'               => true
@@ -7681,9 +7680,9 @@ abstract class CommonITILObject extends CommonDBTM
            // Insert new followup from template
             $fup = new ITILFollowup();
             $fup->add([
+                '_itilfollowuptemplates_id' => $fup_templates_id,
                 'itemtype'                  => $this->getType(),
                 'items_id'                  => $this->getID(),
-                '_templates_id'             => $fup_templates_id,
                 '_disablenotif'             => true,
             ]);
         }
@@ -7701,9 +7700,9 @@ abstract class CommonITILObject extends CommonDBTM
 
         $solution = new ITILSolution();
         $solution->add([
-            'itemtype'          => static::getType(),
-            'status'            => CommonITILValidation::WAITING,
-            'items_id'          => $this->fields['id']
+            '_solutiontemplates_id' => $this->input['_solutiontemplates_id'],
+            'itemtype'              => static::getType(),
+            'items_id'              => $this->fields['id'],
         ]);
     }
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7649,29 +7649,14 @@ abstract class CommonITILObject extends CommonDBTM
         }
 
        // Add tasks in tasktemplates if defined in itiltemplate
-        $tasktemplate = new TaskTemplate();
         $itiltask_class = $this->getType() . 'Task';
         $itiltask   = new $itiltask_class();
         foreach ($this->input['_tasktemplates_id'] as $tasktemplates_id) {
-            $tasktemplate->getFromDB($tasktemplates_id);
-
-           // Parse twig template
-            $tasktemplate_content = $tasktemplate->getRenderedContent($this);
-
-           // Sanitize generated HTML before adding it in DB
-            $tasktemplate_content = Sanitizer::sanitize($tasktemplate_content);
-
             $itiltask->add([
                 'tasktemplates_id'            => $tasktemplates_id,
-                'content'                     => $tasktemplate_content,
-                'taskcategories_id'           => $tasktemplate->fields['taskcategories_id'],
-                'actiontime'                  => $tasktemplate->fields['actiontime'],
-                'state'                       => $tasktemplate->fields['state'],
+                '_templates_id'               => $tasktemplates_id,
                 $this->getForeignKeyField()   => $this->fields['id'],
                 'date'                        => $this->fields['date'],
-                'is_private'                  => $tasktemplate->fields['is_private'],
-                'users_id_tech'               => $tasktemplate->fields['users_id_tech'],
-                'groups_id_tech'              => $tasktemplate->fields['groups_id_tech'],
                 '_disablenotif'               => true
             ]);
         }
@@ -7693,28 +7678,13 @@ abstract class CommonITILObject extends CommonDBTM
 
        // Add tasks in itilfollowup template if defined in itiltemplate
         foreach ($this->input['_itilfollowuptemplates_id'] as $fup_templates_id) {
-           // Get template
-            $fup_template = new ITILFollowupTemplate();
-            if (!$fup_template->getFromDB($fup_templates_id)) {
-               // Ingore if unable to load
-                continue;
-            };
-
-           // Parse twig template
-            $new_fup_content = $fup_template->getRenderedContent($this);
-
-           // Sanitize generated HTML before adding it in DB
-            $new_fup_content = Sanitizer::sanitize($new_fup_content);
-
            // Insert new followup from template
             $fup = new ITILFollowup();
             $fup->add([
-                'itemtype'        => $this->getType(),
-                'items_id'        => $this->getID(),
-                'content'         => $new_fup_content,
-                'is_private'      => $fup_template->fields['is_private'],
-                'requesttypes_id' => $fup_template->fields['requesttypes_id'],
-                '_disablenotif'   => true,
+                'itemtype'                  => $this->getType(),
+                'items_id'                  => $this->getID(),
+                '_templates_id'             => $fup_templates_id,
+                '_disablenotif'             => true,
             ]);
         }
     }
@@ -7729,23 +7699,12 @@ abstract class CommonITILObject extends CommonDBTM
             return;
         }
 
-        $template = new SolutionTemplate();
-        if ($template->getFromDB($this->input['_solutiontemplates_id'])) {
-            // Parse twig template
-            $solution_content = $template->getRenderedContent($this);
-
-            // Sanitize generated HTML before adding it in DB
-            $solution_content = Sanitizer::sanitize($solution_content);
-
-            $solution = new ITILSolution();
-            $solution->add([
-                'itemtype'          => static::getType(),
-                'solutiontypes_id'  => $template->fields['solutiontypes_id'],
-                'content'           => $solution_content,
-                'status'            => CommonITILValidation::WAITING,
-                'items_id'          => $this->fields['id']
-            ]);
-        }
+        $solution = new ITILSolution();
+        $solution->add([
+            'itemtype'          => static::getType(),
+            'status'            => CommonITILValidation::WAITING,
+            'items_id'          => $this->fields['id']
+        ]);
     }
 
     /**

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -471,16 +471,16 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         $itemtype = $this->getItilObjectItemType();
 
         // Handle template
-        if (isset($input['_templates_id'])) {
+        if (isset($input['_tasktemplates_id'])) {
             $template = new TaskTemplate();
             $parent_item = new $itemtype();
             if (
-                !$template->getFromDB($input['_templates_id'])
+                !$template->getFromDB($input['_tasktemplates_id'])
                 || !$parent_item->getFromDB($input[$parent_item->getForeignKeyField()])
             ) {
                 return false;
             }
-            $input['tasktemplates_id']  = $input['_templates_id'];
+            $input['tasktemplates_id']  = $input['_tasktemplates_id'];
             $input = array_replace(
                 [
                     'content'           => Sanitizer::sanitize($template->getRenderedContent($parent_item)),

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -471,15 +471,18 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         $itemtype = $this->getItilObjectItemType();
 
         // Handle template
-        if (isset($input['_tasktemplates_id'])) {
+        if (isset($input['_templates_id'])) {
             $tasktemplate = new TaskTemplate;
-            $tasktemplate->getFromDB($input['_tasktemplates_id']);
+            $result = $tasktemplate->getFromDB($input['_templates_id']);
+            if (!$result) {
+                return false;
+            }
             $template_fields = $tasktemplate->fields;
             unset($template_fields['id']);
             if (isset($template_fields['content'])) {
                 $parent_item = new $itemtype;
                 $parent_item->getFromDB($input[$parent_item->getForeignKeyField()]);
-                $template_fields['content'] = $tasktemplate->getRenderedContent($parent_item);
+                $template_fields['content'] = Sanitizer::sanitize($tasktemplate->getRenderedContent($parent_item));
             }
             $input = array_replace($template_fields, $input);
         }

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -470,6 +470,20 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
         $itemtype = $this->getItilObjectItemType();
 
+        // Handle template
+        if (isset($input['_tasktemplates_id'])) {
+            $tasktemplate = new TaskTemplate;
+            $tasktemplate->getFromDB($input['_tasktemplates_id']);
+            $template_fields = $tasktemplate->fields;
+            unset($template_fields['id']);
+            if (isset($template_fields['content'])) {
+                $parent_item = new $itemtype;
+                $parent_item->getFromDB($input[$parent_item->getForeignKeyField()]);
+                $template_fields['content'] = $tasktemplate->getRenderedContent($parent_item);
+            }
+            $input = array_replace($template_fields, $input);
+        }
+
         if (empty($input['content'])) {
             Session::addMessageAfterRedirect(
                 __("You can't add a task without description."),

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -422,6 +422,20 @@ class ITILFollowup extends CommonDBChild
 
     public function prepareInputForAdd($input)
     {
+        //Handle template
+        if (isset($input['_itilfollowuptemplates_id'])) {
+            $fuptemplate = new ITILFollowupTemplate();
+            $fuptemplate->getFromDB($input['_itilfollowuptemplates_id']);
+            $template_fields = $fuptemplate->fields;
+            unset($template_fields['id']);
+            if (isset($template_fields['content'])) {
+                $parent_item = new $input['itemtype'];
+                $parent_item->getFromDB($input['items_id']);
+                $template_fields['content'] = $fuptemplate->getRenderedContent($parent_item);
+            }
+            $input = array_replace($template_fields, $input);
+        }
+
         $input["_job"] = new $input['itemtype']();
 
         if (

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -423,9 +423,12 @@ class ITILFollowup extends CommonDBChild
     public function prepareInputForAdd($input)
     {
         //Handle template
-        if (isset($input['_itilfollowuptemplates_id'])) {
+        if (isset($input['_templates_id'])) {
             $fuptemplate = new ITILFollowupTemplate();
-            $fuptemplate->getFromDB($input['_itilfollowuptemplates_id']);
+            $result = $fuptemplate->getFromDB($input['_templates_id']);
+            if (!$result) {
+                return false;
+            }
             $template_fields = $fuptemplate->fields;
             unset($template_fields['id']);
             if (isset($template_fields['content'])) {

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -33,6 +33,7 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\ContentTemplates\TemplateManager;
+use Glpi\Toolbox\Sanitizer;
 
 /**
  * ITILSolution Class
@@ -176,6 +177,23 @@ class ITILSolution extends CommonDBChild
         ) {
             $this->item = new $input['itemtype']();
             $this->item->getFromDB($input['items_id']);
+        }
+
+        // Handle template
+        if (isset($input['_templates_id'])) {
+            $template = new SolutionTemplate;
+            $result = $template->getFromDB($input['_templates_id']);
+            if (!$result) {
+                return false;
+            }
+            $template_fields = $template->fields;
+            unset($template_fields['id']);
+            if (isset($template_fields['content'])) {
+                $parent_item = new $input['itemtype'];
+                $parent_item->getFromDB($input[$parent_item->getForeignKeyField()]);
+                $template_fields['content'] = Sanitizer::sanitize($template->getRenderedContent($parent_item));
+            }
+            $input = array_replace($template_fields, $input);
         }
 
        // check itil object is not already solved

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -190,7 +190,7 @@ class ITILSolution extends CommonDBChild
             unset($template_fields['id']);
             if (isset($template_fields['content'])) {
                 $parent_item = new $input['itemtype'];
-                $parent_item->getFromDB($input[$parent_item->getForeignKeyField()]);
+                $parent_item->getFromDB($input['items_id']);
                 $template_fields['content'] = Sanitizer::sanitize($template->getRenderedContent($parent_item));
             }
             $input = array_replace($template_fields, $input);

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -180,8 +180,27 @@ class ITILSolution extends CommonDBChild
         }
 
         // Handle template
+        if (isset($input['_solutiontemplates_id'])) {
+            $template = new SolutionTemplate();
+            $parent_item = new $input['itemtype']();
+            if (
+                !$template->getFromDB($input['_solutiontemplates_id'])
+                || !$parent_item->getFromDB($input['items_id'])
+            ) {
+                return false;
+            }
+            $input = array_replace(
+                [
+                    'content'           => Sanitizer::sanitize($template->getRenderedContent($parent_item)),
+                    'solutiontypes_id'  => $template->fields['solutiontypes_id'],
+                    'status'            => CommonITILValidation::WAITING,
+                ],
+                $input
+            );
+        }
+
         if (isset($input['_templates_id'])) {
-            $template = new SolutionTemplate;
+            $template = new SolutionTemplate();
             $result = $template->getFromDB($input['_templates_id']);
             if (!$result) {
                 return false;
@@ -189,7 +208,7 @@ class ITILSolution extends CommonDBChild
             $template_fields = $template->fields;
             unset($template_fields['id']);
             if (isset($template_fields['content'])) {
-                $parent_item = new $input['itemtype'];
+                $parent_item = new $input['itemtype']();
                 $parent_item->getFromDB($input['items_id']);
                 $template_fields['content'] = Sanitizer::sanitize($template->getRenderedContent($parent_item));
             }

--- a/tests/functionnal/ITILFollowup.php
+++ b/tests/functionnal/ITILFollowup.php
@@ -45,12 +45,13 @@ use User;
 class ITILFollowup extends DbTestCase
 {
     /**
-     * Create a new ITILObject and return its id
+     * Create a new ITILObject and return its id or the object
      *
      * @param string $itemtype ITILObject parent to test followups on
-     * @return integer
+     * @param bool   $as_object
+     * @return integer|\CommonDBTM
      */
-    private function getNewITILObject($itemtype)
+    private function getNewITILObject($itemtype, bool $as_object = false)
     {
        //create reference ITILObject
         $itilobject = new $itemtype();
@@ -63,7 +64,7 @@ class ITILFollowup extends DbTestCase
 
         $this->boolean($itilobject->isNewItem())->isFalse();
         $this->boolean($itilobject->can($itilobject->getID(), \READ))->isTrue();
-        return (int)$itilobject->getID();
+        return $as_object ? $itilobject : (int)$itilobject->getID();
     }
 
     public function testACL()
@@ -520,5 +521,41 @@ class ITILFollowup extends DbTestCase
             'items_id' => $instance->getID(),
         ]);
         $this->integer($count)->isEqualTo(2);
+    }
+
+    public function testAddFromTemplate()
+    {
+        $this->login();
+
+        $ticket = $this->getNewITILObject('Ticket', true);
+        $template = new \ITILFollowupTemplate();
+        $templates_id = $template->add([
+            'name'               => 'test template',
+            'content'            => 'test template',
+            'is_private'         => 1,
+        ]);
+        $this->integer($templates_id)->isGreaterThan(0);
+        $fup = new \ITILFollowup();
+        $fups_id = $fup->add([
+            '_templates_id'      => $templates_id,
+            'itemtype'           => 'Ticket',
+            'items_id'           => $ticket->fields['id'],
+        ]);
+        $this->integer($fups_id)->isGreaterThan(0);
+
+        $this->string($fup->fields['content'])->isEqualTo('<p>test template</p>');
+        $this->integer($fup->fields['is_private'])->isEqualTo(1);
+
+        $fups_id = $fup->add([
+            '_templates_id'      => $templates_id,
+            'itemtype'           => 'Ticket',
+            'items_id'           => $ticket->fields['id'],
+            'content'            => 'test template2',
+            'is_private'         => 0,
+        ]);
+        $this->integer($fups_id)->isGreaterThan(0);
+
+        $this->string($fup->fields['content'])->isEqualTo('test template2');
+        $this->integer($fup->fields['is_private'])->isEqualTo(0);
     }
 }

--- a/tests/functionnal/ITILFollowup.php
+++ b/tests/functionnal/ITILFollowup.php
@@ -35,6 +35,7 @@ namespace tests\units;
 
 use CommonITILActor;
 use DbTestCase;
+use Glpi\Toolbox\Sanitizer;
 use ITILFollowup as CoreITILFollowup;
 use Ticket;
 use Ticket_User;
@@ -537,21 +538,21 @@ class ITILFollowup extends DbTestCase
         $this->integer($templates_id)->isGreaterThan(0);
         $fup = new \ITILFollowup();
         $fups_id = $fup->add([
-            '_templates_id'      => $templates_id,
-            'itemtype'           => 'Ticket',
-            'items_id'           => $ticket->fields['id'],
+            '_itilfollowuptemplates_id' => $templates_id,
+            'itemtype'                  => 'Ticket',
+            'items_id'                  => $ticket->fields['id'],
         ]);
         $this->integer($fups_id)->isGreaterThan(0);
 
-        $this->string($fup->fields['content'])->isEqualTo('<p>test template</p>');
+        $this->string($fup->fields['content'])->isEqualTo(Sanitizer::sanitize('<p>test template</p>', false));
         $this->integer($fup->fields['is_private'])->isEqualTo(1);
 
         $fups_id = $fup->add([
-            '_templates_id'      => $templates_id,
-            'itemtype'           => 'Ticket',
-            'items_id'           => $ticket->fields['id'],
-            'content'            => 'test template2',
-            'is_private'         => 0,
+            '_itilfollowuptemplates_id' => $templates_id,
+            'itemtype'                  => 'Ticket',
+            'items_id'                  => $ticket->fields['id'],
+            'content'                   => 'test template2',
+            'is_private'                => 0,
         ]);
         $this->integer($fups_id)->isGreaterThan(0);
 

--- a/tests/functionnal/TicketTask.php
+++ b/tests/functionnal/TicketTask.php
@@ -381,7 +381,7 @@ class TicketTask extends DbTestCase
         $this->integer($templates_id)->isGreaterThan(0);
         $task = new \TicketTask();
         $tasks_id = $task->add([
-            '_templates_id'      => $templates_id,
+            '_tasktemplates_id'  => $templates_id,
             'itemtype'           => 'Ticket',
             'tickets_id'         => $ticket->fields['id'],
         ]);
@@ -393,7 +393,7 @@ class TicketTask extends DbTestCase
         $this->integer($task->fields['is_private'])->isEqualTo(1);
 
         $tasks_id = $task->add([
-            '_templates_id'      => $templates_id,
+            '_tasktemplates_id'  => $templates_id,
             'itemtype'           => 'Ticket',
             'tickets_id'         => $ticket->fields['id'],
             'state'              => \Planning::TODO,

--- a/tests/functionnal/TicketTask.php
+++ b/tests/functionnal/TicketTask.php
@@ -366,4 +366,44 @@ class TicketTask extends DbTestCase
             ]
         );
     }
+
+    public function testAddFromTemplate()
+    {
+        $ticket = $this->getNewTicket(true);
+        $template = new \TaskTemplate();
+        $templates_id = $template->add([
+            'name'               => 'test template',
+            'content'            => 'test template',
+            'users_id_tech'      => getItemByTypeName('User', TU_USER, true),
+            'state'              => \Planning::DONE,
+            'is_private'         => 1,
+        ]);
+        $this->integer($templates_id)->isGreaterThan(0);
+        $task = new \TicketTask();
+        $tasks_id = $task->add([
+            '_templates_id'      => $templates_id,
+            'itemtype'           => 'Ticket',
+            'tickets_id'         => $ticket->fields['id'],
+        ]);
+        $this->integer($tasks_id)->isGreaterThan(0);
+
+        $this->string($task->fields['content'])->isEqualTo('&#60;p&#62;test template&#60;/p&#62;');
+        $this->integer($task->fields['users_id_tech'])->isEqualTo(getItemByTypeName('User', TU_USER, true));
+        $this->integer($task->fields['state'])->isEqualTo(\Planning::DONE);
+        $this->integer($task->fields['is_private'])->isEqualTo(1);
+
+        $tasks_id = $task->add([
+            '_templates_id'      => $templates_id,
+            'itemtype'           => 'Ticket',
+            'tickets_id'         => $ticket->fields['id'],
+            'state'              => \Planning::TODO,
+            'is_private'         => 0,
+        ]);
+        $this->integer($tasks_id)->isGreaterThan(0);
+
+        $this->string($task->fields['content'])->isEqualTo('&#60;p&#62;test template&#60;/p&#62;');
+        $this->integer($task->fields['users_id_tech'])->isEqualTo(getItemByTypeName('User', TU_USER, true));
+        $this->integer($task->fields['state'])->isEqualTo(\Planning::TODO);
+        $this->integer($task->fields['is_private'])->isEqualTo(0);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Task and followup templates are handled at the ITILObject level on creation or in the UI by changing fields after selecting a template. However, there is no way to programmatically add a task or followup from a template.

This is needed for a plugin. Still a WIP.