### PR TITLE
Fix state dropdown

### DIFF
--- a/src/TaskTemplate.php
+++ b/src/TaskTemplate.php
@@ -186,7 +186,7 @@ class TaskTemplate extends AbstractITILChildTemplate
 
         switch ($field['type']) {
             case 'state':
-                Planning::dropdownState("state", $this->fields["state"], false, [
+                Planning::dropdownState("state", $this->fields["state"], true, [
                  'width'     => '100%',
                 ]);
                 break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

State dropdown in the Task Template form was missing.