### PR TITLE
Use primary/foreign key default sign option in migrations

### DIFF
--- a/install/migrations/update_9.5.x_to_10.0.0/cable.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/cable.php
@@ -40,10 +40,11 @@ use Glpi\Socket;
 
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
 if (!$DB->tableExists('glpi_cabletypes')) {
     $query = "CREATE TABLE `glpi_cabletypes` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
       `name` varchar(255) DEFAULT NULL,
       `comment` text,
       `date_mod` timestamp NULL DEFAULT NULL,
@@ -58,7 +59,7 @@ if (!$DB->tableExists('glpi_cabletypes')) {
 
 if (!$DB->tableExists('glpi_cablestrands')) {
     $query = "CREATE TABLE `glpi_cablestrands` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
       `name` varchar(255) DEFAULT NULL,
       `comment` text,
       `date_mod` timestamp NULL DEFAULT NULL,
@@ -73,7 +74,7 @@ if (!$DB->tableExists('glpi_cablestrands')) {
 
 if (!$DB->tableExists('glpi_socketmodels')) {
     $query = "CREATE TABLE `glpi_socketmodels` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
       `name` varchar(255) DEFAULT NULL,
       `comment` text,
       `date_mod` timestamp NULL DEFAULT NULL,
@@ -88,24 +89,24 @@ if (!$DB->tableExists('glpi_socketmodels')) {
 
 if (!$DB->tableExists('glpi_cables')) {
     $query = "CREATE TABLE `glpi_cables` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
       `name` varchar(255) DEFAULT NULL,
-      `entities_id` int unsigned NOT NULL DEFAULT '0',
+      `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `is_recursive` tinyint NOT NULL DEFAULT '0',
       `itemtype_endpoint_a` varchar(255) DEFAULT NULL,
       `itemtype_endpoint_b` varchar(255) DEFAULT NULL,
-      `items_id_endpoint_a` int unsigned NOT NULL DEFAULT '0',
-      `items_id_endpoint_b` int unsigned NOT NULL DEFAULT '0',
-      `socketmodels_id_endpoint_a` int unsigned NOT NULL DEFAULT '0',
-      `socketmodels_id_endpoint_b` int unsigned NOT NULL DEFAULT '0',
-      `sockets_id_endpoint_a` int unsigned NOT NULL DEFAULT '0',
-      `sockets_id_endpoint_b` int unsigned NOT NULL DEFAULT '0',
-      `cablestrands_id` int unsigned NOT NULL DEFAULT '0',
+      `items_id_endpoint_a` int {$default_key_sign} NOT NULL DEFAULT '0',
+      `items_id_endpoint_b` int {$default_key_sign} NOT NULL DEFAULT '0',
+      `socketmodels_id_endpoint_a` int {$default_key_sign} NOT NULL DEFAULT '0',
+      `socketmodels_id_endpoint_b` int {$default_key_sign} NOT NULL DEFAULT '0',
+      `sockets_id_endpoint_a` int {$default_key_sign} NOT NULL DEFAULT '0',
+      `sockets_id_endpoint_b` int {$default_key_sign} NOT NULL DEFAULT '0',
+      `cablestrands_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `color` varchar(255) DEFAULT NULL,
       `otherserial` varchar(255) DEFAULT NULL,
-      `states_id` int unsigned NOT NULL DEFAULT '0',
-      `users_id_tech` int unsigned NOT NULL DEFAULT '0',
-      `cabletypes_id` int unsigned NOT NULL DEFAULT '0',
+      `states_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+      `users_id_tech` int {$default_key_sign} NOT NULL DEFAULT '0',
+      `cabletypes_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `comment` text,
       `date_mod` timestamp NULL DEFAULT NULL,
       `date_creation` timestamp NULL DEFAULT NULL,
@@ -140,15 +141,15 @@ if (!$DB->tableExists('glpi_cables')) {
 if (!$DB->tableExists('glpi_sockets')) {
    //create socket table
     $query = "CREATE TABLE `glpi_sockets` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
       `position` int NOT NULL DEFAULT '0',
-      `locations_id` int unsigned NOT NULL DEFAULT '0',
+      `locations_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `name` varchar(255) DEFAULT NULL,
-      `socketmodels_id` int unsigned NOT NULL DEFAULT '0',
+      `socketmodels_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `wiring_side` tinyint DEFAULT '1',
       `itemtype` varchar(255) DEFAULT NULL,
-      `items_id` int unsigned NOT NULL DEFAULT '0',
-      `networkports_id` int unsigned NOT NULL DEFAULT '0',
+      `items_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+      `networkports_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `comment` text,
       `date_mod` timestamp NULL DEFAULT NULL,
       `date_creation` timestamp NULL DEFAULT NULL,
@@ -231,7 +232,7 @@ $migration->dropTable('glpi_netpoints');
 
 if (!$DB->tableExists('glpi_networkportfiberchanneltypes')) {
     $query = "CREATE TABLE `glpi_networkportfiberchanneltypes` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
       `name` varchar(255) DEFAULT NULL,
       `comment` text,
       `date_mod` timestamp NULL DEFAULT NULL,
@@ -244,7 +245,7 @@ if (!$DB->tableExists('glpi_networkportfiberchanneltypes')) {
     $DB->queryOrDie($query, "10.0 add table glpi_networkportfiberchanneltypes");
 }
 
-$migration->addField('glpi_networkportfiberchannels', 'networkportfiberchanneltypes_id', "int unsigned NOT NULL DEFAULT '0'", ['after' => 'items_devicenetworkcards_id']);
+$migration->addField('glpi_networkportfiberchannels', 'networkportfiberchanneltypes_id', "int {$default_key_sign} NOT NULL DEFAULT '0'", ['after' => 'items_devicenetworkcards_id']);
 $migration->addKey('glpi_networkportfiberchannels', 'networkportfiberchanneltypes_id', 'type');
 
 $DELFROMDISPLAYPREF['Socket'] = [5, 6, 9, 8, 7]; // Remove display prefs generated in GLPI 10.0.0-beta1

--- a/install/migrations/update_9.5.x_to_10.0.0/cameras.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/cameras.php
@@ -31,12 +31,18 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
 if (!$DB->tableExists('glpi_devicecameras')) {
     $query = "CREATE TABLE `glpi_devicecameras` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
       `designation` varchar(255) DEFAULT NULL,
       `flashunit` tinyint NOT NULL DEFAULT '0',
       `lensfacing` varchar(255) DEFAULT NULL,
@@ -44,10 +50,10 @@ if (!$DB->tableExists('glpi_devicecameras')) {
       `focallength` varchar(255) DEFAULT NULL,
       `sensorsize` varchar(255) DEFAULT NULL,
       `comment` text,
-      `manufacturers_id` int unsigned NOT NULL DEFAULT '0',
-      `entities_id` int unsigned NOT NULL DEFAULT '0',
+      `manufacturers_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+      `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `is_recursive` tinyint NOT NULL DEFAULT '0',
-      `devicecameramodels_id` int unsigned DEFAULT NULL,
+      `devicecameramodels_id` int {$default_key_sign} DEFAULT NULL,
       `support` varchar(255) DEFAULT NULL,
       `date_mod` timestamp NULL DEFAULT NULL,
       `date_creation` timestamp NULL DEFAULT NULL,
@@ -68,7 +74,7 @@ if (!$DB->tableExists('glpi_devicecameras')) {
 
 if (!$DB->tableExists('glpi_devicecameramodels')) {
     $query = "CREATE TABLE `glpi_devicecameramodels` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
       `name` varchar(255) DEFAULT NULL,
       `comment` text,
       `product_number` varchar(255) DEFAULT NULL,
@@ -81,12 +87,12 @@ if (!$DB->tableExists('glpi_devicecameramodels')) {
 
 if (!$DB->tableExists('glpi_imageformats')) {
     $query = "CREATE TABLE `glpi_imageformats` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
       `name` varchar(255) DEFAULT NULL,
       `date_mod` timestamp NULL DEFAULT NULL,
       `comment` text,
       `date_creation` timestamp NULL DEFAULT NULL,
-      `entities_id` int unsigned NOT NULL DEFAULT '0',
+      `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `is_recursive` tinyint NOT NULL DEFAULT '0',
       PRIMARY KEY (`id`),
       UNIQUE KEY `unicity` (`name`),
@@ -100,13 +106,13 @@ if (!$DB->tableExists('glpi_imageformats')) {
 
 if (!$DB->tableExists('glpi_imageresolutions')) {
     $query = "CREATE TABLE `glpi_imageresolutions` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
       `name` varchar(255) DEFAULT NULL,
       `is_video` tinyint NOT NULL DEFAULT '0',
       `date_mod` timestamp NULL DEFAULT NULL,
       `comment` text,
       `date_creation` timestamp NULL DEFAULT NULL,
-      `entities_id` int unsigned NOT NULL DEFAULT '0',
+      `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `is_recursive` tinyint NOT NULL DEFAULT '0',
       PRIMARY KEY (`id`),
       UNIQUE KEY `unicity` (`name`),
@@ -121,13 +127,13 @@ if (!$DB->tableExists('glpi_imageresolutions')) {
 
 if (!$DB->tableExists('glpi_items_devicecameras')) {
     $query = "CREATE TABLE `glpi_items_devicecameras` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
-      `items_id` int unsigned NOT NULL DEFAULT '0',
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+      `items_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `itemtype` varchar(255) DEFAULT NULL,
-      `devicecameras_id` int unsigned NOT NULL DEFAULT '0',
+      `devicecameras_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `is_deleted` tinyint NOT NULL DEFAULT '0',
       `is_dynamic` tinyint NOT NULL DEFAULT '0',
-      `entities_id` int unsigned NOT NULL DEFAULT '0',
+      `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `is_recursive` tinyint NOT NULL DEFAULT '0',
       PRIMARY KEY (`id`),
       KEY `items_id` (`items_id`),
@@ -143,9 +149,9 @@ if (!$DB->tableExists('glpi_items_devicecameras')) {
 
 if (!$DB->tableExists('glpi_items_devicecameras_imageformats')) {
     $query = "CREATE TABLE `glpi_items_devicecameras_imageformats` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
-      `item_devicecameras_id` int unsigned NOT NULL DEFAULT '0',
-      `imageformats_id` int unsigned NOT NULL DEFAULT '0',
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+      `item_devicecameras_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+      `imageformats_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `is_dynamic` tinyint NOT NULL DEFAULT '0',
       PRIMARY KEY (`id`),
       KEY `item_devicecameras_id` (`item_devicecameras_id`),
@@ -157,9 +163,9 @@ if (!$DB->tableExists('glpi_items_devicecameras_imageformats')) {
 
 if (!$DB->tableExists('glpi_items_devicecameras_imageresolutions')) {
     $query = "CREATE TABLE `glpi_items_devicecameras_imageresolutions` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
-      `item_devicecameras_id` int unsigned NOT NULL DEFAULT '0',
-      `imageresolutions_id` int unsigned NOT NULL DEFAULT '0',
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+      `item_devicecameras_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+      `imageresolutions_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `is_dynamic` tinyint NOT NULL DEFAULT '0',
       PRIMARY KEY (`id`),
       KEY `item_devicecameras_id` (`item_devicecameras_id`),

--- a/install/migrations/update_9.5.x_to_10.0.0/dashboard_filters.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/dashboard_filters.php
@@ -38,15 +38,16 @@
 
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
 if (!$DB->tableExists('glpi_dashboards_filters')) {
-    $migration->addField('glpi_dashboards_dashboards', 'users_id', "int unsigned NOT NULL DEFAULT '0'", ['after' => 'context']);
+    $migration->addField('glpi_dashboards_dashboards', 'users_id', "int {$default_key_sign} NOT NULL DEFAULT '0'", ['after' => 'context']);
     $migration->addKey('glpi_dashboards_dashboards', 'users_id');
 
     $query = "CREATE TABLE `glpi_dashboards_filters` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
-         `dashboards_dashboards_id` int unsigned NOT NULL DEFAULT '0',
-         `users_id` int unsigned NOT NULL DEFAULT '0',
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+         `dashboards_dashboards_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `users_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `filter` longtext,
          PRIMARY KEY (`id`),
          KEY `dashboards_dashboards_id` (`dashboards_dashboards_id`),

--- a/install/migrations/update_9.5.x_to_10.0.0/databases.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/databases.php
@@ -39,10 +39,11 @@
 
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
 if (!$DB->tableExists('glpi_databaseinstancetypes')) {
     $query = "CREATE TABLE `glpi_databaseinstancetypes` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
          `name` varchar(255) DEFAULT NULL,
          `comment` text,
          `date_mod` timestamp NULL DEFAULT NULL,
@@ -57,7 +58,7 @@ if (!$DB->tableExists('glpi_databaseinstancetypes')) {
 
 if (!$DB->tableExists('glpi_databaseinstancecategories')) {
     $query = "CREATE TABLE `glpi_databaseinstancecategories` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
          `name` varchar(255) DEFAULT NULL,
          `comment` text,
          `date_mod` timestamp NULL DEFAULT NULL,
@@ -72,23 +73,23 @@ if (!$DB->tableExists('glpi_databaseinstancecategories')) {
 
 if (!$DB->tableExists('glpi_databaseinstances')) {
     $query = "CREATE TABLE `glpi_databaseinstances` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
-         `entities_id` int unsigned NOT NULL DEFAULT '0',
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+         `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `is_recursive` tinyint NOT NULL DEFAULT '0',
          `name` varchar(255) NOT NULL DEFAULT '',
          `version` varchar(255) NOT NULL DEFAULT '',
          `port` varchar(10) NOT NULL DEFAULT '',
          `path` varchar(255) NOT NULL DEFAULT '',
          `size` int NOT NULL DEFAULT '0',
-         `databaseinstancetypes_id` int unsigned NOT NULL DEFAULT '0',
-         `databaseinstancecategories_id` int unsigned NOT NULL DEFAULT '0',
-         `locations_id` int unsigned NOT NULL DEFAULT '0',
-         `manufacturers_id` int unsigned NOT NULL DEFAULT '0',
-         `users_id_tech` int unsigned NOT NULL DEFAULT '0',
-         `groups_id_tech` int unsigned NOT NULL DEFAULT '0',
-         `states_id` int unsigned NOT NULL DEFAULT '0',
+         `databaseinstancetypes_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `databaseinstancecategories_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `locations_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `manufacturers_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `users_id_tech` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `groups_id_tech` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `states_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `itemtype` varchar(100) NOT NULL DEFAULT '',
-         `items_id` int unsigned NOT NULL DEFAULT '0',
+         `items_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `is_onbackup` tinyint NOT NULL DEFAULT '0',
          `is_active` tinyint NOT NULL DEFAULT '0',
          `is_deleted` tinyint NOT NULL DEFAULT '0',
@@ -127,7 +128,7 @@ if (!$DB->fieldExists('glpi_databaseinstances', 'itemtype') || !$DB->fieldExists
     $migration->addField('glpi_databaseinstances', 'itemtype', 'string', [
       'after' => 'states_id'
     ]);
-    $migration->addField('glpi_databaseinstances', 'items_id', "int unsigned NOT NULL DEFAULT '0'", [
+    $migration->addField('glpi_databaseinstances', 'items_id', "int {$default_key_sign} NOT NULL DEFAULT '0'", [
       'after' => 'itemtype'
     ]);
     $migration->addKey('glpi_databaseinstances', ['itemtype', 'items_id'], 'item');
@@ -140,12 +141,12 @@ if ($DB->tableExists('glpi_databaseinstances_items')) {
 
 if (!$DB->tableExists('glpi_databases')) {
     $query = "CREATE TABLE `glpi_databases` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
-         `entities_id` int unsigned NOT NULL DEFAULT '0',
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+         `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `is_recursive` tinyint NOT NULL DEFAULT '0',
          `name` varchar(255) NOT NULL DEFAULT '',
          `size` int NOT NULL DEFAULT '0',
-         `databaseinstances_id` int unsigned NOT NULL DEFAULT '0',
+         `databaseinstances_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `is_onbackup` tinyint NOT NULL DEFAULT '0',
          `is_active` tinyint NOT NULL DEFAULT '0',
          `is_deleted` tinyint NOT NULL DEFAULT '0',

--- a/install/migrations/update_9.5.x_to_10.0.0/entity.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/entity.php
@@ -40,8 +40,7 @@ if (!defined('GLPI_ROOT')) {
  * @var Migration $migration
  */
 
-$default_charset = DBConnection::getDefaultCharset();
-$default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
 /** Create registration_number field */
 if (!$DB->fieldExists("glpi_entities", "registration_number")) {
@@ -58,7 +57,7 @@ if (!$DB->fieldExists("glpi_entities", "registration_number")) {
 
 /** Replace -1 value for entities_id field */
 $DB->updateOrDie('glpi_entities', ['entities_id' => '0'], ['id' => '0']); // Replace -1 value for root entity to be able to change type to unsigned
-$migration->changeField('glpi_entities', 'entities_id', 'entities_id', "int unsigned DEFAULT '0'");
+$migration->changeField('glpi_entities', 'entities_id', 'entities_id', "int {$default_key_sign} DEFAULT '0'");
 $migration->migrationOneTable('glpi_entities'); // Ensure 'entities_id' is nullable.
 $DB->updateOrDie('glpi_entities', ['entities_id' => 'NULL'], ['id' => '0']);
 /** /Replace -1 value for entities_id field */
@@ -106,7 +105,7 @@ foreach ($fkey_config_fields as $fkey_config_field) {
 
     if ($DB->fieldExists('glpi_entities', $fkey_config_field)) {
         // 'contracts_id_default' and 'transfers_id' fields will only exist if a previous dev install exists
-        $migration->changeField('glpi_entities', $fkey_config_field, $fkey_config_field, 'int unsigned NOT NULL DEFAULT 0');
+        $migration->changeField('glpi_entities', $fkey_config_field, $fkey_config_field, "int {$default_key_sign} NOT NULL DEFAULT 0");
     }
 }
 /** /Replace negative values for config foreign keys */

--- a/install/migrations/update_9.5.x_to_10.0.0/gantt.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/gantt.php
@@ -38,14 +38,15 @@
 
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
 // Create table for project task links
 if (!$DB->tableExists('glpi_projecttasklinks')) {
     $query = "CREATE TABLE `glpi_projecttasklinks` (
-       `id` int unsigned NOT NULL AUTO_INCREMENT,
-       `projecttasks_id_source` int unsigned NOT NULL,
+       `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+       `projecttasks_id_source` int {$default_key_sign} NOT NULL,
        `source_uuid` varchar(255) NOT NULL,
-       `projecttasks_id_target` int unsigned NOT NULL,
+       `projecttasks_id_target` int {$default_key_sign} NOT NULL,
        `target_uuid` varchar(255) NOT NULL,
        `type` tinyint NOT NULL DEFAULT '0',
        `lag` smallint DEFAULT '0',

--- a/install/migrations/update_9.5.x_to_10.0.0/inventory_management.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/inventory_management.php
@@ -39,12 +39,13 @@
 
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
 if (!$DB->tableExists('glpi_items_remotemanagements')) {
     $query = "CREATE TABLE `glpi_items_remotemanagements` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
          `itemtype` varchar(100) DEFAULT NULL,
-         `items_id` int unsigned NOT NULL DEFAULT '0',
+         `items_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `remoteid` varchar(255) DEFAULT NULL,
          `type` varchar(255) DEFAULT NULL,
          `is_dynamic` tinyint NOT NULL DEFAULT '0',

--- a/install/migrations/update_9.5.x_to_10.0.0/knowbaseitem_knowbaseitemcategory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/knowbaseitem_knowbaseitemcategory.php
@@ -32,18 +32,20 @@
  */
 
  /**
+ * @var DB $DB
  * @var Migration $migration
  */
 
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
 /* Update link KB_item-category from 1-1 to 1-n */
 if (!$DB->tableExists('glpi_knowbaseitems_knowbaseitemcategories')) {
     $query = "CREATE TABLE `glpi_knowbaseitems_knowbaseitemcategories` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
-      `knowbaseitems_id` int unsigned NOT NULL DEFAULT '0',
-      `knowbaseitemcategories_id` int unsigned NOT NULL DEFAULT '0',
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+      `knowbaseitems_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+      `knowbaseitemcategories_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       PRIMARY KEY (`id`),
       KEY `knowbaseitems_id` (`knowbaseitems_id`),
       KEY `knowbaseitemcategories_id` (`knowbaseitemcategories_id`)

--- a/install/migrations/update_9.5.x_to_10.0.0/manuallinks.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/manuallinks.php
@@ -38,16 +38,17 @@
 
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
 if (!$DB->tableExists('glpi_manuallinks')) {
     $query = "CREATE TABLE `glpi_manuallinks` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
       `name` varchar(255) DEFAULT NULL,
       `url` varchar(8096) NOT NULL,
       `open_window` tinyint NOT NULL DEFAULT '1',
       `icon` varchar(255) DEFAULT NULL,
       `comment` text,
-      `items_id` int unsigned NOT NULL DEFAULT '0',
+      `items_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       `itemtype` varchar(255) DEFAULT NULL,
       `date_creation` timestamp NULL DEFAULT NULL,
       `date_mod` timestamp NULL DEFAULT NULL,

--- a/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
@@ -43,10 +43,11 @@ $migration->addConfig(\Glpi\Inventory\Conf::$defaults, 'inventory');
 
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
 if (!$DB->tableExists('glpi_agenttypes')) {
     $query = "CREATE TABLE `glpi_agenttypes` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
          `name` varchar(255) DEFAULT NULL,
          PRIMARY KEY (`id`),
          KEY `name` (`name`)
@@ -64,17 +65,17 @@ if (!$DB->tableExists('glpi_agenttypes')) {
 }
 if (!$DB->tableExists('glpi_agents')) {
     $query = "CREATE TABLE `glpi_agents` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
          `deviceid` VARCHAR(255) NOT NULL,
-         `entities_id` int unsigned NOT NULL DEFAULT '0',
+         `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `is_recursive` tinyint NOT NULL DEFAULT '0',
          `name` varchar(255) DEFAULT NULL,
-         `agenttypes_id` int unsigned NOT NULL,
+         `agenttypes_id` int {$default_key_sign} NOT NULL,
          `last_contact` timestamp NULL DEFAULT NULL,
          `version` varchar(255) DEFAULT NULL,
          `locked` tinyint NOT NULL DEFAULT '0',
          `itemtype` varchar(100) NOT NULL,
-         `items_id` int unsigned NOT NULL,
+         `items_id` int {$default_key_sign} NOT NULL,
          `useragent` varchar(255) DEFAULT NULL,
          `tag` varchar(255) DEFAULT NULL,
          `port` varchar(6) DEFAULT NULL,
@@ -137,12 +138,12 @@ $ADDTODISPLAYPREF['Agent'] = [2, 4, 10, 8, 11, 6];
 
 if (!$DB->tableExists('glpi_rulematchedlogs')) {
     $query = "CREATE TABLE `glpi_rulematchedlogs` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
          `date` timestamp NULL DEFAULT NULL,
-         `items_id` int unsigned NOT NULL DEFAULT '0',
+         `items_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `itemtype` varchar(100) DEFAULT NULL,
-         `rules_id` int unsigned NULL DEFAULT NULL,
-         `agents_id` int unsigned NOT NULL DEFAULT '0',
+         `rules_id` int {$default_key_sign} NULL DEFAULT NULL,
+         `agents_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `method` varchar(255) DEFAULT NULL,
          PRIMARY KEY (`id`),
          KEY `item` (`itemtype`,`items_id`),
@@ -164,9 +165,9 @@ if (countElementsInTable(Rule::getTable(), ['sub_type' => 'RuleImportAsset']) ==
 //locked fields
 if (!$DB->tableExists('glpi_lockedfields')) {
     $query = "CREATE TABLE `glpi_lockedfields` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
          `itemtype` varchar(100) DEFAULT NULL,
-         `items_id` int unsigned NOT NULL DEFAULT '0',
+         `items_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `field` varchar(50) NOT NULL,
          `value` varchar(255) DEFAULT NULL,
          `date_creation` timestamp NULL DEFAULT NULL,
@@ -189,7 +190,7 @@ if (!$DB->fieldExists('glpi_entities', 'transfers_id')) {
     $migration->addField(
         'glpi_entities',
         'transfers_id',
-        'int unsigned NOT NULL DEFAULT 0',
+        "int {$default_key_sign} NOT NULL DEFAULT 0",
         [
             'value'     => -2,
             // 0 value for root entity
@@ -214,7 +215,7 @@ if (!$DB->fieldExists('glpi_networkequipments', 'autoupdatesystems_id')) {
     $migration->addField(
         'glpi_networkequipments',
         'autoupdatesystems_id',
-        "int unsigned NOT NULL DEFAULT '0'",
+        "int {$default_key_sign} NOT NULL DEFAULT '0'",
         [
          'after' => 'date_creation',
         ]
@@ -316,8 +317,8 @@ foreach ($netport_fields as $netport_field => $definition) {
 
 if (!$DB->tableExists('glpi_unmanageds')) {
     $query = "CREATE TABLE `glpi_unmanageds` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
-         `entities_id` int unsigned NOT NULL DEFAULT '0',
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+         `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `is_recursive` tinyint NOT NULL DEFAULT '0',
          `name` varchar(255) DEFAULT NULL,
          `serial` varchar(255) DEFAULT NULL,
@@ -326,24 +327,24 @@ if (!$DB->tableExists('glpi_unmanageds')) {
          `contact_num` varchar(255) DEFAULT NULL,
          `date_mod` timestamp NULL DEFAULT NULL,
          `comment` text,
-         `locations_id` int unsigned NOT NULL DEFAULT '0',
-         `networks_id` int unsigned NOT NULL DEFAULT '0',
-         `manufacturers_id` int unsigned NOT NULL DEFAULT '0',
+         `locations_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `networks_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `manufacturers_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `is_deleted` tinyint NOT NULL DEFAULT '0',
-         `users_id` int unsigned NOT NULL DEFAULT '0',
-         `groups_id` int unsigned NOT NULL DEFAULT '0',
-         `states_id` int unsigned NOT NULL DEFAULT '0',
+         `users_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `groups_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `states_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `is_dynamic` tinyint NOT NULL DEFAULT '0',
          `date_creation` timestamp NULL DEFAULT NULL,
-         `autoupdatesystems_id` int unsigned NOT NULL DEFAULT '0',
+         `autoupdatesystems_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `sysdescr` text,
-         `domains_id` int unsigned NOT NULL DEFAULT '0',
-         `agents_id` int unsigned NOT NULL DEFAULT '0',
+         `domains_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `agents_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `itemtype` varchar(100) NULL DEFAULT NULL,
          `accepted` tinyint NOT NULL DEFAULT '0',
          `hub` tinyint NOT NULL DEFAULT '0',
          `ip` varchar(255) DEFAULT NULL,
-         `snmpcredentials_id` int unsigned NOT NULL DEFAULT '0',
+         `snmpcredentials_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          PRIMARY KEY (`id`),
          KEY `name` (`name`),
          KEY `entities_id` (`entities_id`),
@@ -373,8 +374,8 @@ $ADDTODISPLAYPREF['Unmanaged'] = [2, 4, 3, 5, 7, 10, 18, 14, 15, 9];
 
 if (!$DB->tableExists('glpi_networkporttypes')) {
     $query = "CREATE TABLE `glpi_networkporttypes` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
-         `entities_id` int unsigned NOT NULL DEFAULT '0',
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+         `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `is_recursive` tinyint NOT NULL DEFAULT '0',
          `value_decimal` int NOT NULL,
          `name` varchar(255) DEFAULT NULL,
@@ -439,8 +440,8 @@ $ADDTODISPLAYPREF['NetworkPort'] = [3, 30, 31, 32, 33, 34, 35, 36, 38, 39, 40];
 
 if (!$DB->tableExists('glpi_printers_cartridgeinfos')) {
     $query = "CREATE TABLE `glpi_printers_cartridgeinfos` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
-         `printers_id` int unsigned NOT NULL,
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+         `printers_id` int {$default_key_sign} NOT NULL,
          `property` varchar(255)  NOT NULL,
          `value` varchar(255)  NOT NULL,
          `date_mod` timestamp NULL DEFAULT NULL,
@@ -455,8 +456,8 @@ if (!$DB->tableExists('glpi_printers_cartridgeinfos')) {
 
 if (!$DB->tableExists('glpi_printerlogs')) {
     $query = "CREATE TABLE `glpi_printerlogs` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
-         `printers_id` int unsigned NOT NULL,
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+         `printers_id` int {$default_key_sign} NOT NULL,
          `total_pages` int NOT NULL DEFAULT '0',
          `bw_pages` int NOT NULL DEFAULT '0',
          `color_pages` int NOT NULL DEFAULT '0',
@@ -479,11 +480,11 @@ if (!$DB->tableExists('glpi_printerlogs')) {
 
 if (!$DB->tableExists('glpi_networkportconnectionlogs')) {
     $query = "CREATE TABLE `glpi_networkportconnectionlogs` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
          `date` timestamp NULL DEFAULT NULL,
          `connected` tinyint NOT NULL DEFAULT '0',
-         `networkports_id_source` int unsigned NOT NULL DEFAULT '0',
-         `networkports_id_destination` int unsigned NOT NULL DEFAULT '0',
+         `networkports_id_source` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `networkports_id_destination` int {$default_key_sign} NOT NULL DEFAULT '0',
          PRIMARY KEY (`id`),
          KEY `date` (`date`),
          KEY `networkports_id_destination` (`networkports_id_destination`),
@@ -497,13 +498,13 @@ if (!$DB->tableExists('glpi_networkportconnectionlogs')) {
 
 if (!$DB->tableExists('glpi_networkportmetrics')) {
     $query = "CREATE TABLE `glpi_networkportmetrics` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
          `date` timestamp NULL DEFAULT NULL,
          `ifinbytes` bigint NOT NULL DEFAULT '0',
          `ifinerrors` bigint NOT NULL DEFAULT '0',
          `ifoutbytes` bigint NOT NULL DEFAULT '0',
          `ifouterrors` bigint NOT NULL DEFAULT '0',
-         `networkports_id` int unsigned NOT NULL DEFAULT '0',
+         `networkports_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          PRIMARY KEY (`id`),
          KEY `date` (`date`),
          KEY `networkports_id` (`networkports_id`)
@@ -513,18 +514,18 @@ if (!$DB->tableExists('glpi_networkportmetrics')) {
 
 if (!$DB->tableExists('glpi_refusedequipments')) {
     $query = "CREATE TABLE `glpi_refusedequipments` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
          `name` varchar(255) DEFAULT NULL,
          `itemtype` varchar(100) DEFAULT NULL,
-         `entities_id` int unsigned NOT NULL DEFAULT '0',
+         `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `ip` varchar(255) DEFAULT NULL,
          `mac` varchar(255) DEFAULT NULL,
-         `rules_id` int unsigned NOT NULL DEFAULT '0',
+         `rules_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `method` varchar(255) DEFAULT NULL,
          `serial` varchar(255) DEFAULT NULL,
          `uuid` varchar(255) DEFAULT NULL,
-         `agents_id` int unsigned NOT NULL DEFAULT '0',
-         `autoupdatesystems_id` int unsigned NOT NULL DEFAULT '0',
+         `agents_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `autoupdatesystems_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `date_creation` timestamp NULL DEFAULT NULL,
          `date_mod` timestamp NULL DEFAULT NULL,
          PRIMARY KEY (`id`),
@@ -546,7 +547,7 @@ if (!$DB->tableExists('glpi_refusedequipments')) {
         $migration->addField(
             'glpi_networkequipments',
             'autoupdatesystems_id',
-            "int unsigned NOT NULL DEFAULT '0'",
+            "int {$default_key_sign} NOT NULL DEFAULT '0'",
             [
             'after' => 'agents_id'
             ]
@@ -578,8 +579,8 @@ CronTask::Register(
 
 if (!$DB->tableExists('glpi_usbvendors')) {
     $query = "CREATE TABLE `glpi_usbvendors` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
-         `entities_id` int unsigned NOT NULL DEFAULT '0',
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+         `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `is_recursive` tinyint NOT NULL DEFAULT '0',
          `vendorid` varchar(4) NOT NULL,
          `deviceid` varchar(4) DEFAULT NULL,
@@ -606,8 +607,8 @@ $ADDTODISPLAYPREF['USBVendor'] = [10, 11];
 
 if (!$DB->tableExists('glpi_pcivendors')) {
     $query = "CREATE TABLE `glpi_pcivendors` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
-         `entities_id` int unsigned NOT NULL DEFAULT '0',
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+         `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `is_recursive` tinyint NOT NULL DEFAULT '0',
          `vendorid` varchar(4) NOT NULL,
          `deviceid` varchar(4) DEFAULT NULL,
@@ -634,7 +635,7 @@ $ADDTODISPLAYPREF['PCIVendor'] = [10, 11];
 
 if (!$DB->tableExists('glpi_snmpcredentials')) {
     $query = "CREATE TABLE `glpi_snmpcredentials` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
          `name` varchar(64) DEFAULT NULL,
          `snmpversion` varchar(8) NOT NULL DEFAULT '1',
          `community` varchar(255) DEFAULT NULL,
@@ -680,7 +681,7 @@ foreach ($cred_tables as $cred_table) {
         $migration->addField(
             $cred_table,
             'snmpcredentials_id',
-            "int unsigned NOT NULL DEFAULT '0'"
+            "int {$default_key_sign} NOT NULL DEFAULT '0'"
         );
         $migration->addKey($cred_table, 'snmpcredentials_id');
     }
@@ -690,7 +691,7 @@ if (!$DB->fieldExists('glpi_printers', 'autoupdatesystems_id')) {
     $migration->addField(
         'glpi_printers',
         'autoupdatesystems_id',
-        "int unsigned NOT NULL DEFAULT '0'",
+        "int {$default_key_sign} NOT NULL DEFAULT '0'",
         [
          'after' => 'snmpcredentials_id',
         ]

--- a/install/migrations/update_9.5.x_to_10.0.0/networknames.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/networknames.php
@@ -31,7 +31,13 @@
  * ---------------------------------------------------------------------
  */
 
-$migration->addField('glpi_networknames', 'ipnetworks_id', "int unsigned NOT NULL DEFAULT '0'", [
+ /**
+ * @var Migration $migration
+ */
+
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
+
+$migration->addField('glpi_networknames', 'ipnetworks_id', "int {$default_key_sign} NOT NULL DEFAULT '0'", [
    'after' => 'fqdns_id'
 ]);
 $migration->addKey('glpi_networknames', 'ipnetworks_id', 'ipnetworks_id');

--- a/install/migrations/update_9.5.x_to_10.0.0/pendingreason.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/pendingreason.php
@@ -38,18 +38,19 @@
 
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
 // Add pending reason table
 if (!$DB->tableExists('glpi_pendingreasons')) {
     $query = "CREATE TABLE `glpi_pendingreasons` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
-         `entities_id` int unsigned NOT NULL DEFAULT '0',
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+         `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `is_recursive` tinyint NOT NULL DEFAULT '0',
          `name` varchar(255) DEFAULT NULL,
          `followup_frequency` int NOT NULL DEFAULT '0',
          `followups_before_resolution` int NOT NULL DEFAULT '0',
-         `itilfollowuptemplates_id` int unsigned NOT NULL DEFAULT '0',
-         `solutiontemplates_id` int unsigned NOT NULL DEFAULT '0',
+         `itilfollowuptemplates_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `solutiontemplates_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `comment` text,
          PRIMARY KEY (`id`),
          KEY `name` (`name`),
@@ -64,9 +65,9 @@ if (!$DB->tableExists('glpi_pendingreasons')) {
 // Add pending reason items table
 if (!$DB->tableExists('glpi_pendingreasons_items')) {
     $query = "CREATE TABLE `glpi_pendingreasons_items` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
-         `pendingreasons_id` int unsigned NOT NULL DEFAULT '0',
-         `items_id` int unsigned NOT NULL DEFAULT '0',
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+         `pendingreasons_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+         `items_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `itemtype` varchar(100) NOT NULL DEFAULT '',
          `followup_frequency` int NOT NULL DEFAULT '0',
          `followups_before_resolution` int NOT NULL DEFAULT '0',

--- a/install/migrations/update_9.5.x_to_10.0.0/recurrentchange.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/recurrentchange.php
@@ -40,6 +40,7 @@ $migration->displayMessage("Adding recurrent changes");
 
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
 $DB->updateOrDie(
     'glpi_crontasks',
@@ -57,18 +58,18 @@ $DB->updateOrDie(
 $recurrent_change_table = 'glpi_recurrentchanges';
 if (!$DB->tableExists($recurrent_change_table)) {
     $DB->queryOrDie("CREATE TABLE `$recurrent_change_table` (
-         `id` int unsigned NOT NULL AUTO_INCREMENT,
+         `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
          `name` varchar(255) DEFAULT NULL,
          `comment` text,
-         `entities_id` int unsigned NOT NULL DEFAULT '0',
+         `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `is_recursive` tinyint NOT NULL DEFAULT '0',
          `is_active` tinyint NOT NULL DEFAULT '0',
-         `changetemplates_id` int unsigned NOT NULL DEFAULT '0',
+         `changetemplates_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `begin_date` timestamp NULL DEFAULT NULL,
          `periodicity` varchar(255) DEFAULT NULL,
          `create_before` int NOT NULL DEFAULT '0',
          `next_creation_date` timestamp NULL DEFAULT NULL,
-         `calendars_id` int unsigned NOT NULL DEFAULT '0',
+         `calendars_id` int {$default_key_sign} NOT NULL DEFAULT '0',
          `end_date` timestamp NULL DEFAULT NULL,
          PRIMARY KEY (`id`),
          KEY `entities_id` (`entities_id`),

--- a/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
@@ -36,6 +36,8 @@
  * @var Migration $migration
  */
 
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
+
 // Remove the `NOT NULL` flag of comment fields and fix collation
 $tables = [
    'glpi_apiclients',
@@ -753,7 +755,7 @@ foreach ($tables as $table) {
         ['entities_id' => 0, 'no_entity_restriction' => 1],
         ['entities_id' => -1]
     );
-    $migration->changeField($table, 'entities_id', 'entities_id', 'int unsigned DEFAULT NULL');
+    $migration->changeField($table, 'entities_id', 'entities_id', "int {$default_key_sign} DEFAULT NULL");
     $migration->migrationOneTable($table); // Ensure 'entities_id' is nullable
     $DB->updateOrDie(
         $table,
@@ -768,5 +770,5 @@ $tables = [
     'glpi_savedsearches',
 ];
 foreach ($tables as $table) {
-    $migration->changeField($table, 'entities_id', 'entities_id', 'int unsigned NOT NULL DEFAULT 0');
+    $migration->changeField($table, 'entities_id', 'entities_id', "int {$default_key_sign} NOT NULL DEFAULT 0");
 }

--- a/install/migrations/update_9.5.x_to_10.0.0/ticket_contract.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/ticket_contract.php
@@ -42,12 +42,13 @@ if (!defined('GLPI_ROOT')) {
 
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
 if (!$DB->tableExists('glpi_tickets_contracts')) {
     $query = "CREATE TABLE `glpi_tickets_contracts` (
-      `id` int unsigned NOT NULL AUTO_INCREMENT,
-      `tickets_id` int unsigned NOT NULL DEFAULT '0',
-      `contracts_id` int unsigned NOT NULL DEFAULT '0',
+      `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+      `tickets_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+      `contracts_id` int {$default_key_sign} NOT NULL DEFAULT '0',
       PRIMARY KEY (`id`),
       UNIQUE KEY `unicity` (`tickets_id`,`contracts_id`),
       KEY `contracts_id` (`contracts_id`)
@@ -59,7 +60,7 @@ if (!$DB->fieldExists("glpi_entities", "contracts_id_default")) {
     $migration->addField(
         "glpi_entities",
         "contracts_id_default",
-        "int unsigned NOT NULL DEFAULT 0",
+        "int {$default_key_sign} NOT NULL DEFAULT 0",
         [
          'after'     => "anonymize_support_agents",
          'value'     => -2,               // Inherit as default value

--- a/install/migrations/update_9.5.x_to_10.0.0/tickettask.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/tickettask.php
@@ -40,8 +40,10 @@ if (!defined('GLPI_ROOT')) {
  * @var Migration $migration
  */
 
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
+
  /* Add `sourceof_items_id` to some glpi_tickettasks */
 if (!$DB->fieldExists('glpi_tickettasks', 'sourceof_items_id')) {
-    $migration->addField('glpi_tickettasks', 'sourceof_items_id', "int unsigned NOT NULL DEFAULT '0'", ['value' => 0]);
+    $migration->addField('glpi_tickettasks', 'sourceof_items_id', "int {$default_key_sign} NOT NULL DEFAULT '0'", ['value' => 0]);
     $migration->addKey('glpi_tickettasks', 'sourceof_items_id');
 }

--- a/src/DBConnection.php
+++ b/src/DBConnection.php
@@ -810,4 +810,22 @@ class DBConnection extends CommonDBTM
 
         return 'utf8mb4_unicode_ci';
     }
+
+   /**
+    * Return default sign option to use for primary (and foreign) key fields.
+    *
+    * @return string
+    *
+    * @since 10.0.0
+    */
+    public static function getDefaultPrimaryKeySignOption(): string
+    {
+        global $DB;
+
+        if ($DB instanceof DBmysql && $DB->allow_signed_keys) {
+            return '';
+        }
+
+        return 'unsigned';
+    }
 }

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -366,7 +366,7 @@ class Migration
 
            // for plugins
             case 'autoincrement':
-                $format = "INT unsigned NOT NULL AUTO_INCREMENT";
+                $format = "INT " . DBConnection::getDefaultPrimaryKeySignOption() . " NOT NULL AUTO_INCREMENT";
                 break;
 
             default:
@@ -1432,7 +1432,7 @@ class Migration
                     $fkey_table,
                     $fkey_oldname,
                     $fkey_newname,
-                    "int unsigned NOT NULL DEFAULT '0'" // assume that foreign key always uses GLPI conventions
+                    "int " . DBConnection::getDefaultPrimaryKeySignOption() . " NOT NULL DEFAULT '0'" // assume that foreign key always uses GLPI conventions
                 );
             }
         }

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -344,26 +344,36 @@ class Migration extends \GLPITestCase
             'format'    => 'string',
             'options'   => [],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` VARCHAR(255) COLLATE utf8_unicode_ci DEFAULT NULL   ",
-            'utf8mb4'   => false,
+            'db_properties' => [
+                'use_utf8mb4' => false,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'string',
             'options'   => [],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` VARCHAR(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL   ",
+            'db_properties' => [
+                'use_utf8mb4' => true,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'string',
             'options'   => ['value' => 'a string'],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` VARCHAR(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'a string'   ",
-            'utf8mb4'   => false,
+            'db_properties' => [
+                'use_utf8mb4' => false,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'string',
             'options'   => ['value' => 'a string'],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` VARCHAR(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'a string'   ",
+            'db_properties' => [
+                'use_utf8mb4' => true,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
@@ -406,84 +416,126 @@ class Migration extends \GLPITestCase
             'format'    => 'text',
             'options'   => [],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` TEXT COLLATE utf8_unicode_ci DEFAULT NULL   ",
-            'utf8mb4'   => false,
+            'db_properties' => [
+                'use_utf8mb4' => false,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'text',
             'options'   => [],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` TEXT COLLATE utf8mb4_unicode_ci DEFAULT NULL   ",
+            'db_properties' => [
+                'use_utf8mb4' => true,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'text',
             'options'   => ['value' => 'A text'],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` TEXT COLLATE utf8_unicode_ci NOT NULL DEFAULT 'A text'   ",
-            'utf8mb4'   => false,
+            'db_properties' => [
+                'use_utf8mb4' => false,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'text',
             'options'   => ['value' => 'A text'],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` TEXT COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'A text'   ",
+            'db_properties' => [
+                'use_utf8mb4' => true,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'mediumtext',
             'options'   => [],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` MEDIUMTEXT COLLATE utf8_unicode_ci DEFAULT NULL   ",
-            'utf8mb4'   => false,
+            'db_properties' => [
+                'use_utf8mb4' => false,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'mediumtext',
             'options'   => [],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` MEDIUMTEXT COLLATE utf8mb4_unicode_ci DEFAULT NULL   ",
+            'db_properties' => [
+                'use_utf8mb4' => true,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'mediumtext',
             'options'   => ['value' => 'A medium text'],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` MEDIUMTEXT COLLATE utf8_unicode_ci NOT NULL DEFAULT 'A medium text'   ",
-            'utf8mb4'   => false,
+            'db_properties' => [
+                'use_utf8mb4' => false,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'mediumtext',
             'options'   => ['value' => 'A medium text'],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` MEDIUMTEXT COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'A medium text'   ",
+            'db_properties' => [
+                'use_utf8mb4' => true,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'longtext',
             'options'   => [],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` LONGTEXT COLLATE utf8_unicode_ci DEFAULT NULL   ",
-            'utf8mb4'   => false,
+            'db_properties' => [
+                'use_utf8mb4' => false,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'longtext',
             'options'   => [],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` LONGTEXT COLLATE utf8mb4_unicode_ci DEFAULT NULL   ",
+            'db_properties' => [
+                'use_utf8mb4' => true,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'longtext',
             'options'   => ['value' => 'A long text'],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` LONGTEXT COLLATE utf8_unicode_ci NOT NULL DEFAULT 'A long text'   ",
-            'utf8mb4'   => false,
+            'db_properties' => [
+                'use_utf8mb4' => false,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
             'format'    => 'longtext',
             'options'   => ['value' => 'A long text'],
             'sql'       => "ALTER TABLE `my_table` ADD `my_field` LONGTEXT COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'A long text'   ",
+            'db_properties' => [
+                'use_utf8mb4' => true,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'id',
             'format'    => 'autoincrement',
             'options'   => [],
-            'sql'       => "ALTER TABLE `my_table` ADD `id` INT unsigned NOT NULL AUTO_INCREMENT   "
+            'sql'       => "ALTER TABLE `my_table` ADD `id` INT  NOT NULL AUTO_INCREMENT   ",
+            'db_properties' => [
+                'allow_signed_keys' => true,
+            ],
+         ], [
+            'table'     => 'my_table',
+            'field'     => 'id',
+            'format'    => 'autoincrement',
+            'options'   => [],
+            'sql'       => "ALTER TABLE `my_table` ADD `id` INT unsigned NOT NULL AUTO_INCREMENT   ",
+            'db_properties' => [
+                'allow_signed_keys' => false,
+            ],
          ], [
             'table'     => 'my_table',
             'field'     => 'my_field',
@@ -525,11 +577,13 @@ class Migration extends \GLPITestCase
    /**
     * @dataProvider fieldsFormatsProvider
     */
-    public function testAddField($table, $field, $format, $options, $sql, bool $utf8mb4 = true)
+    public function testAddField($table, $field, $format, $options, $sql, array $db_properties = [])
     {
         global $DB;
         $DB = $this->db;
-        $DB->use_utf8mb4 = $utf8mb4;
+        foreach ($db_properties as $db_property => $value) {
+            $DB->$db_property = $value;
+        }
         $this->calling($this->db)->fieldExists = false;
         $this->queries = [];
 
@@ -807,6 +861,7 @@ class Migration extends \GLPITestCase
     {
         global $DB;
         $DB = $this->db;
+        $DB->allow_signed_keys = false;
 
         $this->calling($this->db)->tableExists = function ($table) {
             return $table === 'glpi_someoldtypes';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

~~Includes #10315 .~~

Working on plugins, I figured out that we should only use `unsigned` primary/foreign key when migration has been done in core (which can be verified using the `$DB->allow_signed_key` flag). Indeed, it could prevent unconsistency between keys types.

I implemented something similar as what we have already done for utf8 VS utf8mb4 handling.