### PR TITLE
Cleanup inventory temp files

### DIFF
--- a/src/Inventory/Inventory.php
+++ b/src/Inventory/Inventory.php
@@ -416,6 +416,21 @@ class Inventory
     }
 
    /**
+    * Clenup temporary file
+    *
+    * @return void
+    */
+    public function cleanTempFile()
+    {
+        $ext = (Request::XML_MODE === $this->inventory_format ? 'xml' : 'json');
+        $tmpfile = sprintf('%s/%s.%s', GLPI_INVENTORY_DIR, $this->inventory_id, $ext);
+
+        if (file_exists($tmpfile)) {
+            unlink($tmpfile);
+        }
+    }
+
+   /**
     * Get error
     *
     * @return array

--- a/src/Inventory/Inventory.php
+++ b/src/Inventory/Inventory.php
@@ -333,6 +333,7 @@ class Inventory
             }
         } catch (\Exception $e) {
             $DB->rollback();
+            $this->cleanTempFile();
             throw $e;
         } finally {
             unset($_SESSION['glpiinventoryuserrunning']);

--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -259,6 +259,7 @@ class Request extends AbstractRequest
                //nothing expected happens; this is an error
                 $this->addError("Query '" . $this->query . "' is not supported.", 400);
             }
+            $this->inventory->cleanTempFile();
         }
     }
 
@@ -302,6 +303,7 @@ class Request extends AbstractRequest
                //nothing expected happens; this is an error
                 $this->addError("Query '" . $this->query . "' is not supported.", 400);
             }
+            $this->inventory->cleanTempFile();
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add API to clean up temporary file created during XML conversion.
Use it to cleanup netdiscovery and netinventory tasks handling XML messages.
Use it when import is failing.