### PR TITLE
Prevent external calendars issues to break planning; fixes #10352

### DIFF
--- a/src/Application/ErrorHandler.php
+++ b/src/Application/ErrorHandler.php
@@ -116,6 +116,13 @@ class ErrorHandler
     private $output_disabled = false;
 
    /**
+    * Indicates wether output is suspended (temporarly disabled).
+    *
+    * @var bool
+    */
+    private $output_suspended = false;
+
+   /**
     * Output handler to use. If not set, output will be directly echoed on a format depending on
     * execution context (Web VS CLI).
     *
@@ -173,6 +180,26 @@ class ErrorHandler
     public function disableOutput(): void
     {
         $this->output_disabled = true;
+    }
+
+    /**
+     * Suspend output.
+     *
+     * @return void
+     */
+    public function suspendOutput(): void
+    {
+        $this->output_suspended = true;
+    }
+
+    /**
+     * Take away output suspension.
+     *
+     * @return void
+     */
+    public function unsuspendOutput(): void
+    {
+        $this->output_suspended = false;
     }
 
    /**
@@ -455,7 +482,7 @@ class ErrorHandler
     private function outputDebugMessage(string $error_type, string $message, string $log_level, bool $force = false): void
     {
 
-        if ($this->output_disabled) {
+        if ($this->output_disabled || $this->output_suspended) {
             return;
         }
 

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -31,6 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\ErrorHandler;
 use Glpi\RichText\RichText;
 use RRule\RRule;
 use Sabre\VObject\Component\VCalendar;
@@ -2109,6 +2110,8 @@ class Planning extends CommonGLPI
     */
     private static function getExternalCalendarRawEvents(string $limit_begin, string $limit_end): array
     {
+        ErrorHandler::getInstance()->suspendOutput(); // Suspend error output to prevent warnings to corrupr JSON output
+
         $raw_events = [];
 
         foreach ($_SESSION['glpi_plannings']['plannings'] as $planning_id => $planning_params) {
@@ -2180,6 +2183,8 @@ class Planning extends CommonGLPI
                 ];
             }
         }
+
+        ErrorHandler::getInstance()->unsuspendOutput(); // Restore error output state
 
         return $raw_events;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10352

New `ErrorHandler` methods will permit to temporarly suspend the output, but messages will still be sent to the error log. This is a good alternative to usage of `@` operator.