### PR TITLE
Drop unused transfers_id_auto config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ The present file will list all changes made to the project; according to the
 - Usage of `GLPI_PREVER` constant
 - Support of `doc_types`, `helpdesk_types` and `netport_types` keys in `Plugin::registerClass()`
 - `$CFG_GLPI['layout_excluded_pages']` entry
+- `$CFG_GLPI['transfers_id_auto']` entry
 - `$CFG_GLPI['use_ajax_autocompletion']` entry
 - `$DEBUG_AUTOLOAD` global variable
 - `$LOADED_PLUGINS` global variable

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -183,7 +183,6 @@ $default_prefs = [
     'use_slave_for_search'                    => '0',
     'proxy_passwd'                            => '',
     'smtp_passwd'                             => '',
-    'transfers_id_auto'                       => '0',
     'show_count_on_tabs'                      => '1',
     'refresh_views'                           => '0',
     'set_default_tech'                        => '1',

--- a/install/migrations/update_9.5.x_to_10.0.0/configs.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/configs.php
@@ -67,3 +67,6 @@ Config::setConfigurationValues('core', ['user_restored_ldap' => 0]);
 
 Config::setConfigurationValues('core', ['timeline_order' => 'natural']);
 $migration->addField("glpi_users", "timeline_order", "char(20) DEFAULT NULL", ['after' => 'savedsearches_pinned']);
+
+$migration->displayMessage('Drop obsolete automatic transfer configuration');
+Config::deleteConfigurationValues('core', ['transfers_id_auto']);

--- a/src/Config.php
+++ b/src/Config.php
@@ -636,24 +636,6 @@ class Config extends CommonDBTM
 
         echo "</table>";
 
-        if (
-            Session::haveRightsOr("transfer", [CREATE, UPDATE])
-            && Session::isMultiEntitiesMode()
-        ) {
-            echo "<br><table class='tab_cadre_fixe'>";
-            echo "<tr><th colspan='2'>" . __('Automatic transfer of computers') . "</th></tr>";
-            echo "<tr class='tab_bg_2'>";
-            echo "<td><label for='dropdown_transfers_id_auto$rand'>" . __('Template for the automatic transfer of computers in another entity') .
-              "</label></td><td>";
-            Transfer::dropdown(['value'      => $CFG_GLPI["transfers_id_auto"],
-                'name'       => "transfers_id_auto",
-                'emptylabel' => __('No automatic transfer'),
-                'rand'       => $rand
-            ]);
-            echo "</td></tr>";
-            echo "</table>";
-        }
-
         echo "<br><table class='tab_cadre_fixe'>";
         echo "<tr>";
         echo "<th colspan='4'>" . __('Automatically update of the elements related to the computers');

--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -4106,38 +4106,6 @@ class Transfer extends CommonDBTM
         }
     }
 
-
-    public function cleanRelationData()
-    {
-
-        parent::cleanRelationData();
-
-        if ($this->isUsedAsAutomaticTransferModel()) {
-            Config::setConfigurationValues(
-                'core',
-                [
-                    'transfers_id_auto' => 0,
-                ]
-            );
-        }
-    }
-
-
-    /**
-     * Check if used as automatic transfer model.
-     *
-     * @return boolean
-     */
-    private function isUsedAsAutomaticTransferModel()
-    {
-
-        $config_values = Config::getConfigurationValues('core', ['transfers_id_auto']);
-
-        return array_key_exists('transfers_id_auto', $config_values)
-         && $config_values['transfers_id_auto'] == $this->fields['id'];
-    }
-
-
     public static function getIcon()
     {
         return "fas fa-level-up-alt";

--- a/tests/functionnal/Config.php
+++ b/tests/functionnal/Config.php
@@ -552,10 +552,6 @@ class Config extends DbTestCase
                 'key'      => 'ssovariables_id',
                 'itemtype' => 'SsoVariable',
             ],
-            [
-                'key'      => 'transfers_id_auto',
-                'itemtype' => 'Transfer',
-            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This config is not used anymore (probably replaced by `glpi_entities_transfers_id`).