### PR TITLE
Fix unavailable LDAP causing user deletion

### DIFF
--- a/inc/auth.class.php
+++ b/inc/auth.class.php
@@ -846,7 +846,7 @@ class Auth extends CommonGLPI {
                   if (Toolbox::canUseLdap()) {
                      AuthLDAP::tryLdapAuth($this, $login_name, $login_password,
                                              $this->user->fields["auths_id"]);
-                     if (!$this->auth_succeded && !$this->user_found) {
+                     if ($this->ldap_connection !== false && (!$this->auth_succeded && !$this->user_found)) {
                         $search_params = [
                            'name'     => addslashes($login_name),
                            'authtype' => $this::LDAP];

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -1898,6 +1898,14 @@ class AuthLDAP extends DbTestCase {
 
        $auth = $this->login('brazil5', 'password', false, false);
 
+       // Restore original port
+       $this->boolean(
+           $this->ldap->update([
+               'id'     => $this->ldap->getID(),
+               'port'   => $original_port,
+           ])
+       )->isTrue();
+
        $user->getFromDBbyName('brazil5');
        // Verify trying to log in while LDAP unavailable does not disable user's GLPI account
        $this->integer($user->fields['is_active'])->isEqualTo(1);

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -1872,4 +1872,35 @@ class AuthLDAP extends DbTestCase {
       ]);
       $this->array($gus)->hasSize(1);
    }
+
+   public function testLdapUnavailable()
+   {
+       //Import user that doesn't exist yet
+       $auth = $this->login('brazil5', 'password', false);
+
+       $user = new \User();
+       $user->getFromDBbyName('brazil5');
+       $this->array($user->fields)
+           ->string['name']->isIdenticalTo('brazil5')
+           ->string['user_dn']->isIdenticalTo('uid=brazil5,ou=people,ou=ldap3,dc=glpi,dc=org');
+       $this->boolean($auth->user_present)->isFalse();
+       $this->boolean($auth->user_dn)->isFalse();
+       $this->resource($auth->ldap_connection)->isOfType('ldap link');
+
+       // Get original LDAP server port
+       $original_port = $this->ldap->fields['port'];
+       // Update LDAP to have inaccessible server
+       $this->boolean(
+           $this->ldap->update([
+               'port' => '1234',
+           ])
+       )->isTrue();
+
+       $auth = $this->login('brazil5', 'password', false, false);
+
+       $user->getFromDBbyName('brazil5');
+       // Verify trying to log in while LDAP unavailable does not disable user's GLPI account
+       $this->integer($user->fields['is_active'])->isEqualTo(1);
+       $this->integer($user->fields['is_deleted_ldap'])->isEqualTo(0);
+   }
 }

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -1873,8 +1873,7 @@ class AuthLDAP extends DbTestCase {
       $this->array($gus)->hasSize(1);
    }
 
-   public function testLdapUnavailable()
-   {
+   public function testLdapUnavailable() {
        //Import user that doesn't exist yet
        $auth = $this->login('brazil5', 'password', false);
 
@@ -1892,7 +1891,8 @@ class AuthLDAP extends DbTestCase {
        // Update LDAP to have inaccessible server
        $this->boolean(
            $this->ldap->update([
-               'port' => '1234',
+               'id'     => $this->ldap->getID(),
+               'port'   => '1234',
            ])
        )->isTrue();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Replaces #10013

If you try to log in with a user account while their LDAP server is unavailable, the process for managing users deleted in the LDAP is triggered. I added a check here to ensure the deletion process only starts if there wasn't a connection made to the LDAP.

To recreate, you can change the port on an LDAP server configured in GLPI and then try logging in to a user that syncs with it.