### PR TITLE
Do not check migrations by default on db:check

### DIFF
--- a/.github/actions/test_update-from-9.5.sh
+++ b/.github/actions/test_update-from-9.5.sh
@@ -19,12 +19,9 @@ bin/console glpi:database:update --config-dir=./tests/config --ansi --no-interac
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:database:update command FAILED" && exit 1;
 fi
-## Check DB
+## Check DB schema integrity (do not check additionnal migrations)
 bin/console glpi:database:check_schema_integrity \
-  --config-dir=./tests/config --ansi --no-interaction \
-  --ignore-dynamic-row-format-migration \
-  --ignore-utf8mb4-migration \
-  --ignore-unsigned-keys-migration
+  --config-dir=./tests/config --ansi --no-interaction
 
 # Execute myisam_to_innodb migration
 ## First run should do nothing.
@@ -32,6 +29,10 @@ bin/console glpi:migration:myisam_to_innodb --config-dir=./tests/config --ansi -
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:myisam_to_innodb command FAILED" && exit 1;
 fi
+## Check DB schema integrity (including myisam_to_innodb migration)
+bin/console glpi:database:check_schema_integrity \
+  --config-dir=./tests/config --ansi --no-interaction \
+  --check-innodb-migration
 
 # Execute timestamps migration
 ## First run should do nothing.
@@ -39,15 +40,18 @@ bin/console glpi:migration:timestamps --config-dir=./tests/config --ansi --no-in
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:timestamps command FAILED" && exit 1;
 fi
+## Check DB schema integrity (including timestamps migration)
+bin/console glpi:database:check_schema_integrity \
+  --config-dir=./tests/config --ansi --no-interaction \
+  --check-timestamps-migration
 
 # Execute dynamic_row_format migration
 ## Result will depend on DB server/version, we just expect that command will not fail.
 bin/console glpi:migration:dynamic_row_format --config-dir=./tests/config --ansi --no-interaction
-## Check DB
+## Check DB schema integrity (including dynamic_row_format migration)
 bin/console glpi:database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
-  --ignore-utf8mb4-migration \
-  --ignore-unsigned-keys-migration
+  --check-dynamic-row-format-migration
 
 # Execute utf8mb4 migration
 ## First run should do the migration (with no warnings).
@@ -60,10 +64,10 @@ bin/console glpi:migration:utf8mb4 --config-dir=./tests/config --ansi --no-inter
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:utf8mb4 command FAILED" && exit 1;
 fi
-# Check DB
+## Check DB schema integrity (including utf8mb4 migration)
 bin/console glpi:database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
-  --ignore-unsigned-keys-migration
+  --check-utf8mb4-migration
 
 # Execute unsigned keys migration
 ## First run should do the migration (with no warnings).
@@ -76,8 +80,15 @@ bin/console glpi:migration:unsigned_keys --config-dir=./tests/config --ansi --no
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:unsigned_keys command FAILED" && exit 1;
 fi
-# Check DB
-bin/console glpi:database:check_schema_integrity --config-dir=./tests/config --ansi --no-interaction
+## Check DB schema integrity (including unsigned keys migration)
+bin/console glpi:database:check_schema_integrity \
+  --config-dir=./tests/config --ansi --no-interaction \
+  --check-unsigned-keys-migration
+
+# Complete DB check
+bin/console glpi:database:check_schema_integrity \
+  --config-dir=./tests/config --ansi --no-interaction \
+  --check-all-migrations
 tests/bin/test-data-sanitization --ansi --no-interaction
 
 # Check updated data

--- a/.github/actions/test_update-from-older-version.sh
+++ b/.github/actions/test_update-from-older-version.sh
@@ -19,14 +19,9 @@ bin/console glpi:database:update --config-dir=./tests/config --ansi --no-interac
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:database:update command FAILED" && exit 1;
 fi
-## Check DB
+## Check DB schema integrity (do not check additionnal migrations)
 bin/console glpi:database:check_schema_integrity \
-  --config-dir=./tests/config --ansi --no-interaction \
-  --ignore-innodb-migration \
-  --ignore-timestamps-migration \
-  --ignore-dynamic-row-format-migration \
-  --ignore-utf8mb4-migration \
-  --ignore-unsigned-keys-migration
+  --config-dir=./tests/config --ansi --no-interaction
 
 # Execute myisam_to_innodb migration
 ## First run should do the migration (with no warnings).
@@ -39,13 +34,10 @@ bin/console glpi:migration:myisam_to_innodb --config-dir=./tests/config --ansi -
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:myisam_to_innodb command FAILED" && exit 1;
 fi
-## Check DB
+## Check DB schema integrity (including myisam_to_innodb migration)
 bin/console glpi:database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
-  --ignore-timestamps-migration \
-  --ignore-dynamic-row-format-migration \
-  --ignore-utf8mb4-migration \
-  --ignore-unsigned-keys-migration
+  --check-innodb-migration
 
 # Execute timestamps migration
 ## First run should do the migration (with no warnings).
@@ -58,21 +50,18 @@ bin/console glpi:migration:timestamps --config-dir=./tests/config --ansi --no-in
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:timestamps command FAILED" && exit 1;
 fi
-## Check DB
+## Check DB schema integrity (including timestamps migration)
 bin/console glpi:database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
-  --ignore-dynamic-row-format-migration \
-  --ignore-utf8mb4-migration \
-  --ignore-unsigned-keys-migration
+  --check-timestamps-migration
 
 # Execute dynamic_row_format migration
 ## Result will depend on DB server/version, we just expect that command will not fail.
 bin/console glpi:migration:dynamic_row_format --config-dir=./tests/config --ansi --no-interaction
-## Check DB
+## Check DB schema integrity (including dynamic_row_format migration)
 bin/console glpi:database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
-  --ignore-utf8mb4-migration \
-  --ignore-unsigned-keys-migration
+  --check-dynamic-row-format-migration
 
 # Execute utf8mb4 migration
 ## First run should do the migration (with no warnings).
@@ -85,10 +74,10 @@ bin/console glpi:migration:utf8mb4 --config-dir=./tests/config --ansi --no-inter
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:utf8mb4 command FAILED" && exit 1;
 fi
-## Check DB
+## Check DB schema integrity (including utf8mb4 migration)
 bin/console glpi:database:check_schema_integrity \
   --config-dir=./tests/config --ansi --no-interaction \
-  --ignore-unsigned-keys-migration
+  --check-utf8mb4-migration
 
 # Execute unsigned keys migration
 ## First run should do the migration (with no warnings).
@@ -101,8 +90,15 @@ bin/console glpi:migration:unsigned_keys --config-dir=./tests/config --ansi --no
 if [[ -z $(grep "No migration needed." $LOG_FILE) ]];
   then echo "bin/console glpi:migration:unsigned_keys command FAILED" && exit 1;
 fi
-# Check DB
-bin/console glpi:database:check_schema_integrity --config-dir=./tests/config --ansi --no-interaction
+## Check DB schema integrity (including unsigned keys migration)
+bin/console glpi:database:check_schema_integrity \
+  --config-dir=./tests/config --ansi --no-interaction \
+  --check-unsigned-keys-migration
+
+# Complete DB check
+bin/console glpi:database:check_schema_integrity \
+  --config-dir=./tests/config --ansi --no-interaction \
+  --check-all-migrations
 tests/bin/test-data-sanitization --ansi --no-interaction
 
 # Check updated data

--- a/src/Console/Database/CheckSchemaIntegrityCommand.php
+++ b/src/Console/Database/CheckSchemaIntegrityCommand.php
@@ -62,9 +62,9 @@ class CheckSchemaIntegrityCommand extends AbstractCommand
         $this->setName('glpi:database:check_schema_integrity');
         $this->setAliases(
             [
-            'db:check_schema_integrity',
-            'glpi:database:check', // old name
-            'db:check', // old alias
+                'db:check_schema_integrity',
+                'glpi:database:check', // old name
+                'db:check', // old alias
             ]
         );
         $this->setDescription(__('Check for schema differences between current database and installation file.'));
@@ -77,38 +77,45 @@ class CheckSchemaIntegrityCommand extends AbstractCommand
         );
 
         $this->addOption(
-            'ignore-innodb-migration',
+            'check-all-migrations',
             null,
             InputOption::VALUE_NONE,
-            __('Do not check tokens related to migration from "MyISAM" to "InnoDB".')
+            __('Check tokens related to all databases migrations.')
         );
 
         $this->addOption(
-            'ignore-timestamps-migration',
+            'check-innodb-migration',
             null,
             InputOption::VALUE_NONE,
-            __('Do not check tokens related to migration from "datetime" to "timestamp".')
+            __('Check tokens related to migration from "MyISAM" to "InnoDB".')
         );
 
         $this->addOption(
-            'ignore-utf8mb4-migration',
+            'check-timestamps-migration',
             null,
             InputOption::VALUE_NONE,
-            __('Do not check tokens related to migration from "utf8" to "utf8mb4".')
+            __('Check tokens related to migration from "datetime" to "timestamp".')
         );
 
         $this->addOption(
-            'ignore-dynamic-row-format-migration',
+            'check-utf8mb4-migration',
             null,
             InputOption::VALUE_NONE,
-            __('Do not check tokens related to "DYNAMIC" row format migration.')
+            __('Check tokens related to migration from "utf8" to "utf8mb4".')
         );
 
         $this->addOption(
-            'ignore-unsigned-keys-migration',
+            'check-dynamic-row-format-migration',
             null,
             InputOption::VALUE_NONE,
-            __('Do not check tokens related to migration from signed to unsigned integers in primary/foreign keys.')
+            __('Check tokens related to "DYNAMIC" row format migration.')
+        );
+
+        $this->addOption(
+            'check-unsigned-keys-migration',
+            null,
+            InputOption::VALUE_NONE,
+            __('Check tokens related to migration from signed to unsigned integers in primary/foreign keys.')
         );
     }
 
@@ -118,11 +125,11 @@ class CheckSchemaIntegrityCommand extends AbstractCommand
         $checker = new DatabaseSchemaIntegrityChecker(
             $this->db,
             $input->getOption('strict'),
-            $input->getOption('ignore-innodb-migration'),
-            $input->getOption('ignore-timestamps-migration'),
-            $input->getOption('ignore-utf8mb4-migration'),
-            $input->getOption('ignore-dynamic-row-format-migration'),
-            $input->getOption('ignore-unsigned-keys-migration')
+            !$input->getOption('check-innodb-migration'),
+            !$input->getOption('check-timestamps-migration'),
+            !$input->getOption('check-utf8mb4-migration'),
+            !$input->getOption('check-dynamic-row-format-migration'),
+            !$input->getOption('check-unsigned-keys-migration')
         );
 
         if (

--- a/src/Console/Database/CheckSchemaIntegrityCommand.php
+++ b/src/Console/Database/CheckSchemaIntegrityCommand.php
@@ -125,11 +125,11 @@ class CheckSchemaIntegrityCommand extends AbstractCommand
         $checker = new DatabaseSchemaIntegrityChecker(
             $this->db,
             $input->getOption('strict'),
-            !$input->getOption('check-innodb-migration'),
-            !$input->getOption('check-timestamps-migration'),
-            !$input->getOption('check-utf8mb4-migration'),
-            !$input->getOption('check-dynamic-row-format-migration'),
-            !$input->getOption('check-unsigned-keys-migration')
+            !$input->getOption('check-all-migrations') && !$input->getOption('check-innodb-migration'),
+            !$input->getOption('check-all-migrations') && !$input->getOption('check-timestamps-migration'),
+            !$input->getOption('check-all-migrations') && !$input->getOption('check-utf8mb4-migration'),
+            !$input->getOption('check-all-migrations') && !$input->getOption('check-dynamic-row-format-migration'),
+            !$input->getOption('check-all-migrations') && !$input->getOption('check-unsigned-keys-migration')
         );
 
         if (


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I figured out that checking tokens related to migration by default on `db:check` may pollute results and mays prevent detection of more important inconsistencies (like missing of a field, for instance). See discussion in #10171, user does not give the full result as it had too many differences.

I propose to use opt-in options instead of opt-out options.