### PR TITLE
Fix lost hover with gap with collapsed left menu

### DIFF
--- a/css/includes/components/_global-menu.scss
+++ b/css/includes/components/_global-menu.scss
@@ -206,7 +206,7 @@
                   z-index: 1060;
 
                   & + .dropdown-menu {
-                     &.animate__fadeInLeft:before {
+                     &.animate__fadeInLeft::before {
                         left: -2px;
                         height: 100%;
                         width: 4px;
@@ -214,6 +214,7 @@
                         position: absolute;
                         background: transparent;
                      }
+
                      background-color: $mainmenu-fg;
                      color: $mainmenu-bg;
                      top: 0;

--- a/css/includes/components/_global-menu.scss
+++ b/css/includes/components/_global-menu.scss
@@ -206,6 +206,14 @@
                   z-index: 1060;
 
                   & + .dropdown-menu {
+                     &.animate__fadeInLeft:before {
+                        left: -2px;
+                        height: 100%;
+                        width: 4px;
+                        content: " ";
+                        position: absolute;
+                        background: transparent;
+                     }
                      background-color: $mainmenu-fg;
                      color: $mainmenu-bg;
                      top: 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

There is a 1px gap between the collapsed navigation menu and the panel with the sub-items that show up when hovering. Trying to move the mouse from the collapsed menu over to the sub-items causes the hover to be lost and the menu to close.

By using the before pseudo-element the sub-items panel is stretched over the collapsed menu for the hover to work while keeping it the same visually (gap still shows).