### PR TITLE
fix glpi_close_all_dialogs js function

### DIFF
--- a/js/glpi_dialog.js
+++ b/js/glpi_dialog.js
@@ -306,7 +306,7 @@ var glpi_confirm = function({
  * Remove from dom all opened glpi dialog
  */
 var glpi_close_all_dialogs = function() {
-   $('.modal.show, .modal-backdrop.show').remove();
+   $('.modal.show').modal('hide').remove();
 };
 
 var toast_id = 0;

--- a/js/glpi_dialog.js
+++ b/js/glpi_dialog.js
@@ -303,13 +303,10 @@ var glpi_confirm = function({
 
 
 /**
- * Close and remove from dom all opened glpi dialog
+ * Remove from dom all opened glpi dialog
  */
 var glpi_close_all_dialogs = function() {
-   document.querySelectorAll('.modal').forEach(function(modalElem) {
-      const myModal = new bootstrap.Modal(modalElem);
-      myModal.hide();
-   });
+   $('.modal.show, .modal-backdrop.show').remove();
 };
 
 var toast_id = 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Don't know why, but modal.hide() (or dispose()) doesn't anymore.
