### PR TITLE
remove link always pointing to "denied access" for self service profile

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -7448,9 +7448,11 @@ abstract class CommonITILObject extends CommonDBTM {
                );
             }
             echo "<span class='buttons'>";
-            echo "<a href='".Document::getFormURLWithID($item_i['id'])."' class='edit_document fa fa-eye pointer' title='".
-                   _sx("button", "Show")."'>";
-            echo "<span class='sr-only'>" . _sx('button', 'Show') . "</span></a>";
+            if (Session::getCurrentInterface() != 'helpdesk') {
+               echo "<a href='".Document::getFormURLWithID($item_i['id'])."' class='edit_document fa fa-eye pointer' title='".
+                     _sx("button", "Show")."'>";
+               echo "<span class='sr-only'>" . _sx('button', 'Show') . "</span></a>";
+            }
 
             $doc = new Document();
             $doc->getFromDB($item_i['id']);


### PR DESCRIPTION
With a self service user, this button always leads to an "access denied page".

![image](https://user-images.githubusercontent.com/14139801/150318455-3bfb1ba4-d334-432a-83ab-973ce1a925fe.png)
