### PR TITLE
Fix inheritence value for transfers_id entity config

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -1808,7 +1808,7 @@ class Entity extends CommonTreeDropdown
           'emptylabel' => __('No automatic transfer')
         ];
         if ($entity->fields['id'] > 0) {
-            $params['toadd'] = ['-1' => __('Inheritance of the parent entity')];
+            $params['toadd'] = [self::CONFIG_PARENT => __('Inheritance of the parent entity')];
         }
         Dropdown::show('Transfer', $params);
         echo "</td>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`Entity::getUsedConfig()` will not compute inheritence properly if value is `-1`.