### PR TITLE
Move  NotificationTarget::getSender() to Config

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -3759,7 +3759,7 @@ HTML;
      *
      * @return array [email => sender address, name => sender name]
      */
-    public static function getSender(
+    public static function getAdminEmailSender(
         int $entities_id,
         bool $allow_response
     ): array {

--- a/src/Config.php
+++ b/src/Config.php
@@ -3781,7 +3781,8 @@ HTML;
      *
      * @return array [email => sender address, name => sender name]
      */
-    public static function getAdminEmail(int $entities_id): array{
+    public static function getAdminEmail(int $entities_id): array
+    {
         global $CFG_GLPI;
 
         // Read config data for generic from email

--- a/src/Config.php
+++ b/src/Config.php
@@ -3827,8 +3827,8 @@ HTML;
 
         // Final fallback, no valid values found
         return [
-            'email' => '',
-            'name'  => '',
+            'email' => null,
+            'name'  => null,
         ];
     }
 
@@ -3840,8 +3840,8 @@ HTML;
     public static function getNoReplyEmail(): array
     {
         // Read config data for noreply email
-        $noreply_email      = $CFG_GLPI['admin_email']      ?? "";
-        $noreply_email_name = $CFG_GLPI['admin_email_name'] ?? "";
+        $noreply_email      = $CFG_GLPI['admin_email_noreply']      ?? "";
+        $noreply_email_name = $CFG_GLPI['admin_email_noreply_name'] ?? "";
 
         // Check if noreply email is valid
         if (NotificationMailing::isUserAddressValid($noreply_email)) {
@@ -3853,8 +3853,8 @@ HTML;
 
         // No valid values found
         return [
-            'email' => '',
-            'name'  => '',
+            'email' => null,
+            'name'  => null,
         ];
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -3794,7 +3794,7 @@ HTML;
         }
 
         if (
-            !$allow_response()
+            !$allow_response
             && isset($CFG_GLPI['admin_email_noreply'])
             && !empty($CFG_GLPI['admin_email_noreply'])
         ) {

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1159,20 +1159,7 @@ class NotificationTarget extends CommonDBChild
      **/
     public function getReplyTo(): array
     {
-        $replyto = Config::getReplyToEmail($this->getEntity());
-        if ($replyto['email'] !== null) {
-            return $replyto;
-        } else {
-            trigger_error('Reply-To address is not defined in notifications configuration.', E_USER_WARNING);
-        }
-
-        // No replyto defined, try to use admin email as a replacement
-        $admin = Config::getAdminEmail($this->getEntity());
-        if ($admin['email'] === null) {
-            trigger_error('Admin email address is not defined in notifications configuration.', E_USER_WARNING);
-        }
-
-        return $admin;
+        return Config::getReplyToEmail($this->getEntity());
     }
 
 

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1136,7 +1136,7 @@ class NotificationTarget extends CommonDBChild
         // Compute config values
         return Config::getEmailSender(
             $this->getEntity(),
-            $this->allowResponse()
+            !$this->allowResponse()
         );
     }
 

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1133,7 +1133,7 @@ class NotificationTarget extends CommonDBChild
      */
     public function getSender()
     {
-        return Config::getSender(
+        return Config::getAdminEmailSender(
             $this->getEntity(),
             $this->allowResponse()
         );

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1130,57 +1130,13 @@ class NotificationTarget extends CommonDBChild
      * Get admin which sends the notification
      *
      * @return array [email => sender address, name => sender name]
-     **/
+     */
     public function getSender()
     {
-        global $CFG_GLPI;
-
-        $sender = [
-            'email'  => null,
-            'name'   => null
-        ];
-
-        if (
-            isset($CFG_GLPI['from_email'])
-            && !empty($CFG_GLPI['from_email'])
-            && NotificationMailing::isUserAddressValid($CFG_GLPI['from_email'])
-        ) {
-           //generic from, if defined
-            $sender['email'] = $CFG_GLPI['from_email'];
-            $sender['name']  = $CFG_GLPI['from_email_name'];
-        } else {
-            $admin_email      = trim(Entity::getUsedConfig('admin_email', $this->getEntity(), '', ''));
-            $admin_email_name = trim(Entity::getUsedConfig('admin_email_name', $this->getEntity(), '', ''));
-
-            if (NotificationMailing::isUserAddressValid($admin_email)) {
-               //If the entity administrator's address is defined, return it
-                $sender['email'] = $admin_email;
-                $sender['name']  = $admin_email_name;
-            } else {
-               //Entity admin is not defined, return the global admin's address
-                $sender['email'] = $CFG_GLPI['admin_email'];
-                $sender['name']  = $CFG_GLPI['admin_email_name'];
-            }
-        }
-
-        if (
-            !$this->allowResponse()
-            && isset($CFG_GLPI['admin_email_noreply'])
-            && !empty($CFG_GLPI['admin_email_noreply'])
-        ) {
-           // Override with no reply email if defined
-            $sender['email'] = $CFG_GLPI['admin_email_noreply'];
-
-            if (
-                isset($CFG_GLPI['admin_email_noreply_name'])
-                && !empty($CFG_GLPI['admin_email_noreply_name'])
-            ) {
-               // Override name with no replay name if defined
-                $sender['name']  = $CFG_GLPI['admin_email_noreply_name'];
-            }
-        }
-
-        return $sender;
+        return Config::getSender(
+            $this->getEntity(),
+            $this->allowResponse()
+        );
     }
 
 

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1127,28 +1127,17 @@ class NotificationTarget extends CommonDBChild
 
 
     /**
-     * Get admin which sends the notification
+     * Get email to use as a sender for the notifications
      *
      * @return array [email => sender address, name => sender name]
      */
     public function getSender(): array
     {
-        if (!$this->allowResponse()) {
-            $admin = Config::getNoReplyEmail();
-            if ($admin['email'] !== null) {
-                return $admin;
-            } else {
-                trigger_error('No-Reply address is not defined in notifications configuration.', E_USER_WARNING);
-            }
-        }
-
-        // No noreply defined, try to use admin email as a replacement
-        $admin = Config::getAdminEmail($this->getEntity());
-        if ($admin['email'] === null) {
-            trigger_error('Admin email address is not defined in notifications configuration.', E_USER_WARNING);
-        }
-
-        return $admin;
+        // Compute config values
+        return Config::getEmailSender(
+            $this->getEntity(),
+            $this->allowResponse()
+        );
     }
 
 
@@ -1159,7 +1148,7 @@ class NotificationTarget extends CommonDBChild
      **/
     public function getReplyTo(): array
     {
-        return Config::getReplyToEmail($this->getEntity());
+        return Config::getReplyToEmailSender($this->getEntity());
     }
 
 

--- a/src/NotificationTemplate.php
+++ b/src/NotificationTemplate.php
@@ -590,7 +590,7 @@ class NotificationTemplate extends CommonDBTM
         $user_name  = $user_infos['username'];
 
         $sender     = $target->getSender();
-        $replyto    = $target->getReplyTo($options);
+        $replyto    = $target->getReplyTo();
 
         $mailing_options['to']          = $to;
         $mailing_options['toname']      = $user_name;

--- a/tests/functionnal/NotificationTarget.php
+++ b/tests/functionnal/NotificationTarget.php
@@ -258,17 +258,7 @@ class NotificationTarget extends DbTestCase
             'name'           => "Global admin",
         ];
 
-        // Case 5: default post install values with global from config
-        $CFG_GLPI['from_email'] = "globalfrom@localhost";
-        $CFG_GLPI['from_email_name'] = "Global from";
-
-        yield [
-            'allow_response' => true,
-            'email'          => "globalfrom@localhost",
-            'name'           => "Global from",
-        ];
-
-        // Case 6: default post install values with specific entity config
+        // Case 5: default post install values with specific entity config
         $entity = new Entity();
         $this->boolean($entity->update([
             'id'               => Session::getActiveEntity(),
@@ -285,6 +275,16 @@ class NotificationTarget extends DbTestCase
             'allow_response' => true,
             'email'          => "specificadmin@localhost",
             'name'           => "Specific admin",
+        ];
+
+        // Case 6: default post install values with global from config
+        $CFG_GLPI['from_email'] = "globalfrom@localhost";
+        $CFG_GLPI['from_email_name'] = "Global from";
+
+        yield [
+            'allow_response' => true,
+            'email'          => "globalfrom@localhost",
+            'name'           => "Global from",
         ];
     }
 

--- a/tests/functionnal/NotificationTarget.php
+++ b/tests/functionnal/NotificationTarget.php
@@ -286,7 +286,6 @@ class NotificationTarget extends DbTestCase
             'email'          => "specificadmin@localhost",
             'name'           => "Specific admin",
         ];
-
     }
 
     /**
@@ -326,6 +325,5 @@ class NotificationTarget extends DbTestCase
                 ->withMessage($warning)
                 ->exists();
         }
-
     }
 }

--- a/tests/functionnal/NotificationTarget.php
+++ b/tests/functionnal/NotificationTarget.php
@@ -33,7 +33,6 @@
 
 namespace tests\units;
 
-use Config;
 use DbTestCase;
 use Entity;
 use Generator;

--- a/tests/functionnal/NotificationTarget.php
+++ b/tests/functionnal/NotificationTarget.php
@@ -228,7 +228,7 @@ class NotificationTarget extends DbTestCase
             'allow_response' => false,
             'email'          => "admsys@localhost",
             'name'           => "",
-            'warning'        => 'No-Reply address is not defined in notifications configuration.'
+            'warning'        => 'No-Reply address is not defined in configuration.'
         ];
 
         // Case 2: no reply with global config


### PR DESCRIPTION
Move `NotificationTarget::getSender()` code to a public static function in `Config`.

This allow plugins (or future new core features) to get the computed "From" configuration without having a `NotificationTarget` object.
This is useful if you need to send emails without the full GLPI notifications system.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
