### PR TITLE
Fix Ticket status change

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1531,27 +1531,6 @@ abstract class CommonITILObject extends CommonDBTM
         }
 
         if (isset($this->input["status"])) {
-            if (
-                ($this->input["status"] != self::WAITING)
-                && ($this->countSuppliers(CommonITILActor::ASSIGN) == 0)
-                && ($this->countUsers(CommonITILActor::ASSIGN) == 0)
-                && ($this->countGroups(CommonITILActor::ASSIGN) == 0)
-                && !$this->isNotSolved()
-            ) {
-                if (!in_array('status', $this->updates)) {
-                    $this->oldvalues['status'] = $this->fields['status'];
-                    $this->updates[] = 'status';
-                }
-
-               // $this->fields['status'] = self::INCOMING;
-               // Don't change status if it's a new status allow
-                if (
-                    in_array($this->oldvalues['status'], $this->getNewStatusArray())
-                    && !in_array($this->input['status'], $this->getNewStatusArray())
-                ) {
-                    $this->fields['status'] = $this->oldvalues['status'];
-                }
-            }
 
             if (
                 in_array("status", $this->updates)

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1531,7 +1531,6 @@ abstract class CommonITILObject extends CommonDBTM
         }
 
         if (isset($this->input["status"])) {
-
             if (
                 in_array("status", $this->updates)
                 && in_array($this->input["status"], $this->getSolvedStatusArray())

--- a/tests/functionnal/Change.php
+++ b/tests/functionnal/Change.php
@@ -196,7 +196,7 @@ class Change extends DbTestCase
     {
         $this->login();
         // Create a change
-        $change = new \Change;
+        $change = new \Change();
         $changes_id = $change->add([
             'name' => "test automatic status change",
             'content' => "test automatic status change",

--- a/tests/functionnal/Change.php
+++ b/tests/functionnal/Change.php
@@ -204,7 +204,7 @@ class Change extends DbTestCase
         ]);
 
         // Initial status is new (incoming)
-        $this->integer($change->fields['status'])->isIdenticalTo(CommonITILObject::INCOMING);
+        $this->integer($change->fields['status'])->isIdenticalTo(\CommonITILObject::INCOMING);
 
         $change->update([
             'id' => $changes_id,
@@ -218,23 +218,23 @@ class Change extends DbTestCase
 
         // Verify user was assigned and status doesn't change
         $change->loadActors();
-        $this->integer($change->countUsers(CommonITILActor::ASSIGN))->isIdenticalTo(1);
-        $this->integer($change->fields['status'])->isIdenticalTo(CommonITILObject::INCOMING);
+        $this->integer($change->countUsers(\CommonITILActor::ASSIGN))->isIdenticalTo(1);
+        $this->integer($change->fields['status'])->isIdenticalTo(\CommonITILObject::INCOMING);
 
         // Change status to accepted
         $change->update([
             'id' => $changes_id,
-            'status' => CommonITILObject::ACCEPTED,
+            'status' => \CommonITILObject::ACCEPTED,
         ]);
         // Unassign change and expect the status to stay accepted
-        $change_user = new Change_User();
+        $change_user = new \Change_User();
         $change_user->deleteByCriteria([
             'changes_id' => $changes_id,
-            'type' => CommonITILActor::ASSIGN,
+            'type' => \CommonITILActor::ASSIGN,
             'users_id' => getItemByTypeName('User', TU_USER, true),
         ]);
         $change->getFromDB($changes_id);
-        $this->integer($change->countUsers(CommonITILActor::ASSIGN))->isIdenticalTo(0);
-        $this->integer($change->fields['status'])->isIdenticalTo(CommonITILObject::ACCEPTED);
+        $this->integer($change->countUsers(\CommonITILActor::ASSIGN))->isIdenticalTo(0);
+        $this->integer($change->fields['status'])->isIdenticalTo(\CommonITILObject::ACCEPTED);
     }
 }

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -4024,40 +4024,40 @@ HTML
 
         // Check ticket status is new
         $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
-        $this->integer($ticket->countUsers(CommonITILActor::ASSIGN))->isEqualTo(0);
-        $this->integer($ticket->fields['status'])->isEqualTo(CommonITILObject::INCOMING);
+        $this->integer($ticket->countUsers(\CommonITILActor::ASSIGN))->isEqualTo(0);
+        $this->integer($ticket->fields['status'])->isEqualTo(\CommonITILObject::INCOMING);
 
         // Set status to solved
         $this->boolean($ticket->update([
             'id' => $tickets_id,
-            'status' => CommonITILObject::SOLVED,
+            'status' => \CommonITILObject::SOLVED,
             '_skip_auto_assign' => true,
         ]))->isTrue();
 
         // Check ticket status is solved
         $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
-        $this->integer($ticket->fields['status'])->isEqualTo(CommonITILObject::SOLVED);
+        $this->integer($ticket->fields['status'])->isEqualTo(\CommonITILObject::SOLVED);
 
         // Set status to new
         $this->boolean($ticket->update([
             'id' => $tickets_id,
-            'status' => CommonITILObject::INCOMING,
+            'status' => \CommonITILObject::INCOMING,
             '_skip_auto_assign' => true,
         ]))->isTrue();
 
         // Check ticket status is new
         $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
-        $this->integer($ticket->fields['status'])->isEqualTo(CommonITILObject::INCOMING);
+        $this->integer($ticket->fields['status'])->isEqualTo(\CommonITILObject::INCOMING);
 
         // Set status to closed
         $this->boolean($ticket->update([
             'id' => $tickets_id,
-            'status' => CommonITILObject::CLOSED,
+            'status' => \CommonITILObject::CLOSED,
             '_skip_auto_assign' => true,
         ]))->isTrue();
 
         // Check ticket status is closed
         $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
-        $this->integer($ticket->fields['status'])->isEqualTo(CommonITILObject::CLOSED);
+        $this->integer($ticket->fields['status'])->isEqualTo(\CommonITILObject::CLOSED);
     }
 }

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -3985,7 +3985,8 @@ HTML
         string $commondb_relation,
         string $field,
         array $extra_input
-    ): void {
+    ): void
+    {
         // Keep track of the linked items
         $linked = $item->input[$field];
         $this->array($linked);
@@ -4007,5 +4008,56 @@ HTML
 
         // Compare values
         $this->array($item->fields[$field])->isEqualTo($linked);
+    }
+
+    public function testNewToSolvedUnassigned()
+    {
+        $this->login();
+        // Create ticket without automatic assignment
+        $ticket = new \Ticket();
+        $tickets_id = $ticket->add([
+            'name' => 'testNewToSolvedUnassigned',
+            'content' => 'testNewToSolvedUnassigned',
+            '_skip_auto_assign' => true,
+        ]);
+        $this->integer($tickets_id)->isGreaterThan(0);
+
+        // Check ticket status is new
+        $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
+        $this->integer($ticket->countUsers(CommonITILActor::ASSIGN))->isEqualTo(0);
+        $this->integer($ticket->fields['status'])->isEqualTo(CommonITILObject::INCOMING);
+
+        // Set status to solved
+        $this->boolean($ticket->update([
+            'id' => $tickets_id,
+            'status' => CommonITILObject::SOLVED,
+            '_skip_auto_assign' => true,
+        ]))->isTrue();
+
+        // Check ticket status is solved
+        $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
+        $this->integer($ticket->fields['status'])->isEqualTo(CommonITILObject::SOLVED);
+
+        // Set status to new
+        $this->boolean($ticket->update([
+            'id' => $tickets_id,
+            'status' => CommonITILObject::INCOMING,
+            '_skip_auto_assign' => true,
+        ]))->isTrue();
+
+        // Check ticket status is new
+        $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
+        $this->integer($ticket->fields['status'])->isEqualTo(CommonITILObject::INCOMING);
+
+        // Set status to closed
+        $this->boolean($ticket->update([
+            'id' => $tickets_id,
+            'status' => CommonITILObject::CLOSED,
+            '_skip_auto_assign' => true,
+        ]))->isTrue();
+
+        // Check ticket status is closed
+        $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
+        $this->integer($ticket->fields['status'])->isEqualTo(CommonITILObject::CLOSED);
     }
 }

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -3985,8 +3985,7 @@ HTML
         string $commondb_relation,
         string $field,
         array $extra_input
-    ): void
-    {
+    ): void {
         // Keep track of the linked items
         $linked = $item->input[$field];
         $this->array($linked);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes (change in behavior)
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10299

Before GLPI 10 it seemed like you could change a ticket's status from New directly to Solved or Closed without having anyone assigned to it. The behavior that blocked it was not called at least for tickets, but it is now.

I don't understand the purpose of this forced behavior and don't think it is wanted for Tickets, Changes, or Problems.
If it is wanted, I think it would be best to have this be a configurable behavior somewhere else.
