### PR TITLE
Fix text direction in select2

### DIFF
--- a/css/includes/components/_select2.scss
+++ b/css/includes/components/_select2.scss
@@ -72,6 +72,10 @@
             &::before {
                 content: "\200E"; // left-to-right mark: be sure that content is displayed in ltr way
             }
+
+            > * {
+                unicode-bidi: plaintext;
+            }
         }
 
         &.select2-selection--single {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

From https://developer.mozilla.org/en-US/docs/Web/CSS/unicode-bidi
> This keyword makes the elements directionality calculated without considering its parent bidirectional state or the value of the direction property. The directionality is calculated using the P2 and P3 rules of the Unicode Bidirectional Algorithm. This value allows the display of data that is already formatted using a tool following the Unicode Bidirectional Algorithm.

Before:
![image](https://user-images.githubusercontent.com/33253653/150528842-a6a1129e-f07c-4c21-982e-49718502e891.png)

After:
![image](https://user-images.githubusercontent.com/33253653/150528986-672d2255-2da4-43e0-9873-74505eee6e98.png)
