### PR TITLE
Expose forcedisplay parameter in Search::showList()

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -104,14 +104,17 @@ class Search
     /**
      * Display result table for search engine for an type
      *
-     * @param string $itemtype Item type to manage
-     * @param array  $params   Search params passed to prepareDatasForSearch function
+     * @param string $itemtype     Item type to manage
+     * @param array  $params       Search params passed to
+     *                             prepareDatasForSearch function
+     * @param array  $forcedisplay Array of columns to display (default empty
+     *                             = use display pref and search criteria)
      *
      * @return void
      **/
-    public static function showList($itemtype, $params)
+    public static function showList($itemtype, $params, $forcedisplay = [])
     {
-        $data = self::getDatas($itemtype, $params);
+        $data = self::getDatas($itemtype, $params, $forcedisplay);
 
         switch ($data['display_type']) {
             case self::CSV_OUTPUT:

--- a/src/Search.php
+++ b/src/Search.php
@@ -112,8 +112,11 @@ class Search
      *
      * @return void
      **/
-    public static function showList($itemtype, $params, $forcedisplay = [])
-    {
+    public static function showList(
+        $itemtype,
+        $params,
+        array $forcedisplay = []
+    ) {
         $data = self::getDatas($itemtype, $params, $forcedisplay);
 
         switch ($data['display_type']) {


### PR DESCRIPTION
Allow to specify the "forcedisplay" search parameter when calling `Search::showList()`.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
