### PR TITLE
Fix wrong WAKEONLAN_TASK constant usage

### DIFF
--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -478,7 +478,7 @@ class Request extends AbstractRequest
     {
         $params = Plugin::doHookFunction(Hooks::HANDLE_WAKEONLAN_TASK, $params);
 
-        return $params['options']['response'][self::WAKEONLAN_TASK] ?? [];
+        return $params['options']['response'][self::WOL_TASK] ?? [];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix wrong constant usage introduced in #10316