### PR TITLE
Fix root_doc for cron

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2212,6 +2212,12 @@ class Config extends CommonDBTM {
                                    str_replace('\\', '/', $currentdir));
          chdir($currentdir);
          $globaldir  = Html::cleanParametersURL($_SERVER['REQUEST_URI']);
+
+         // cron exception (running in CLI. Expect front slash to be missing)
+         if (strpos($globaldir, 'front/cron.php') !== false) {
+            $globaldir = preg_replace("/front\/cron.php/", "", $globaldir);
+         }
+
          $globaldir  = preg_replace("/\/[0-9a-zA-Z\.\-\_]+\.php/", "", $globaldir);
 
          // api exception


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6458 

Running `front/cron.php` from command line results in a `REQUEST_URI` without a starting slash and causes the wrong root doc to be found.

Is there any case where `CFG_GLPI['root_doc']` is not supposed to not just be set to an empty string? This may be something we can add tests for.