### PR TITLE
Verify unRecurs possible with massive actions

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -2345,6 +2345,12 @@ class CommonDBTM extends CommonGLPI {
     * @return boolean
    **/
    function canMassiveAction($action, $field, $value) {
+
+      if (static::maybeRecursive()) {
+         if ($field === 'is_recursive' && (int) $value === 0) {
+            return $this->canUnrecurs();
+         }
+      }
       return true;
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2549

When updating `is_recursive` via massive actions, `$this->canUnrecurs` wasn't checked when it should have been.