### PR TITLE
Allow adding child-entity connection to Computers

### DIFF
--- a/inc/computer_item.class.php
+++ b/inc/computer_item.class.php
@@ -326,8 +326,11 @@ class Computer_Item extends CommonDBRelation{
          if (!empty($withtemplate)) {
             echo "<input type='hidden' name='_no_history' value='1'>";
          }
-         self::dropdownAllConnect('Computer', "items_id", $comp->fields["entities_id"],
-                                  $withtemplate, $used);
+         $entities = $comp->fields["entities_id"];
+         if ($comp->isRecursive()) {
+            $entities = getSonsOf("glpi_entities", $comp->getEntityID());
+         }
+         self::dropdownAllConnect('Computer', "items_id", $entities, $withtemplate, $used);
          echo "</td><td class='center' width='20%'>";
          echo "<input type='submit' name='add' value=\""._sx('button', 'Connect')."\" class='submit'>";
          echo "<input type='hidden' name='computers_id' value='".$comp->fields['id']."'>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix ability to add connections to a computer that exist in a child of the computer's entity when the computer is set to be recursive.