### PR TITLE
Fix dropdown results with translated field shown

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -4989,7 +4989,7 @@ JAVASCRIPT;
           && !$is_fkey_composite_on_self) {
          $transitemtype = getItemTypeForTable($new_table);
          if (Session::haveTranslations($transitemtype, $field)) {
-            $transAS            = $nt.'_trans';
+            $transAS            = $nt.'_trans_'.$field;
             return self::joinDropdownTranslations(
                $transAS,
                $nt,
@@ -5221,7 +5221,7 @@ JAVASCRIPT;
                                               $addcondition)";
                   $transitemtype = getItemTypeForTable($new_table);
                   if (Session::haveTranslations($transitemtype, $field)) {
-                     $transAS            = $nt.'_trans';
+                     $transAS            = $nt.'_trans'.$field;
                      $specific_leftjoin .= self::joinDropdownTranslations(
                         $transAS,
                         $nt,

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -3548,7 +3548,7 @@ JAVASCRIPT;
       $tocompute      = "`$table$addtable`.`$field`";
       $tocomputeid    = "`$table$addtable`.`id`";
 
-      $tocomputetrans = "IFNULL(`$table".$addtable."_trans`.`value`,'".self::NULLVALUE."') ";
+      $tocomputetrans = "IFNULL(`$table".$addtable."_trans_" . $field . "`.`value`,'".self::NULLVALUE."') ";
 
       $ADDITONALFIELDS = '';
       if (isset($searchopt[$ID]["additionalfields"])
@@ -3799,7 +3799,7 @@ JAVASCRIPT;
                       $TRANS = "GROUP_CONCAT(DISTINCT CONCAT(IFNULL($tocomputetrans, '".self::NULLVALUE."'),
                                                              '".self::SHORTSEP."',$tocomputeid) ORDER BY $tocomputeid
                                              SEPARATOR '".self::LONGSEP."')
-                                     AS `".$NAME."_trans`, ";
+                                     AS `".$NAME."_trans_" . $field . "`, ";
                   }
 
                   return " GROUP_CONCAT(DISTINCT CONCAT($tocompute, '".self::SHORTSEP."' ,
@@ -3824,7 +3824,7 @@ JAVASCRIPT;
          if (Session::haveTranslations(getItemTypeForTable($table), $field)) {
             $TRANS = "GROUP_CONCAT(DISTINCT CONCAT(IFNULL($tocomputetrans, '".self::NULLVALUE."'),
                                                    '".self::SHORTSEP."',$tocomputeid) ORDER BY $tocomputeid SEPARATOR '".self::LONGSEP."')
-                                  AS `".$NAME."_trans`, ";
+                                  AS `".$NAME."_trans_" . $field . "`, ";
 
          }
          return " GROUP_CONCAT(DISTINCT CONCAT(IFNULL($tocompute, '".self::NULLVALUE."'),
@@ -3835,7 +3835,7 @@ JAVASCRIPT;
       }
       $TRANS = '';
       if (Session::haveTranslations(getItemTypeForTable($table), $field)) {
-         $TRANS = $tocomputetrans." AS `".$NAME."_trans`, ";
+         $TRANS = $tocomputetrans." AS `".$NAME."_trans_" . $field . "`, ";
 
       }
       return "$tocompute AS `".$NAME."`, $TRANS $ADDITONALFIELDS";
@@ -4567,7 +4567,7 @@ JAVASCRIPT;
       }
 
       $tocompute      = "`$table`.`$field`";
-      $tocomputetrans = "`".$table."_trans`.`value`";
+      $tocomputetrans = "`".$table."_trans_" . $field . "`.`value`";
       if (isset($searchopt[$ID]["computation"])) {
          $tocompute = $searchopt[$ID]["computation"];
          $tocompute = str_replace($DB->quoteName('TABLE'), 'TABLE', $tocompute);
@@ -5221,7 +5221,7 @@ JAVASCRIPT;
                                               $addcondition)";
                   $transitemtype = getItemTypeForTable($new_table);
                   if (Session::haveTranslations($transitemtype, $field)) {
-                     $transAS            = $nt.'_trans'.$field;
+                     $transAS            = $nt.'_trans_'.$field;
                      $specific_leftjoin .= self::joinDropdownTranslations(
                         $transAS,
                         $nt,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8637 

I also noticed that when viewing the search list of dropdowns with translations, it uses the default translation only and not the one for the current language. Looking at the Search engine code, this seems intentional and only shows translations for meta criteria?