### PR TITLE
Automatically open language switcher

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -581,6 +581,11 @@ var langSwitch = function(elt) {
          $('#language_link')
             .html(html);
          $('#debugajax').remove();
+
+         window.setTimeout(() => {
+            // focus and open new select2. In a timeout because select2 takes a while to load
+            $('#language_link select[name="language"]').select2('open');
+         }, 100);
       }
    });
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Not sure how much it affects regular users but I find it awkward switching languages during development. Clicking the language link in the top bar once just loads the dropdown. It requires a second click to then open the dropdown to change the language.