### PR TITLE
Remove MA modal on close

### DIFF
--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -1105,7 +1105,8 @@ class CommonGLPI {
                      width: 500,
                      height: 'auto',
                      modal: true,
-                     appendTo: '#dialog_container_$rand'
+                     appendTo: '#dialog_container_$rand',
+                     close: function() { $(this).remove(); },
                   }).load(
                      '".$CFG_GLPI['root_doc']. "/ajax/dropdownMassiveAction.php',
                      Object.assign(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10011

This is to prevent issues with closing and re-opening the modal without executing an action.
fixes #10011
replaces #10153

This PR only applies to 9.5 since v10 doesn't use jQuery UI for dialogs. There may be a similar fix needed for the Bootstrap modals in v10.