### PR TITLE
Add context links for Tickets in simplified interface

### DIFF
--- a/front/helpdesk.faq.php
+++ b/front/helpdesk.faq.php
@@ -41,7 +41,7 @@ if (isset($_GET["redirect"])) {
 Session::checkFaqAccess();
 
 if (Session::getLoginUserID()) {
-    Html::helpHeader(__('FAQ'), $_SERVER['PHP_SELF'], $_SESSION["glpiname"]);
+    Html::helpHeader(__('FAQ'));
 } else {
     $_SESSION["glpilanguage"] = $_SESSION['glpilanguage'] ?? $CFG_GLPI['language'];
    // Anonymous FAQ

--- a/front/helpdesk.public.php
+++ b/front/helpdesk.public.php
@@ -91,11 +91,11 @@ if (
 Session::checkValidSessionId();
 
 if (isset($_GET['create_ticket'])) {
-    Html::helpHeader(__('New ticket'), $_SERVER['PHP_SELF'], $_SESSION["glpiname"]);
+    Html::helpHeader(__('New ticket'));
     $ticket = new Ticket();
     $ticket->showFormHelpdesk(Session::getLoginUserID());
 } else {
-    Html::helpHeader(__('Home'), $_SERVER['PHP_SELF'], $_SESSION["glpiname"]);
+    Html::helpHeader(__('Home'));
 
     $password_alert = "";
     $user = new User();

--- a/front/knowbaseitem.form.php
+++ b/front/knowbaseitem.form.php
@@ -182,7 +182,7 @@ if (isset($_POST["add"])) {
         if (Session::getCurrentInterface() == "central") {
             Html::header(KnowbaseItem::getTypeName(1), $_SERVER['PHP_SELF'], "tools", "knowbaseitem");
         } else {
-            Html::helpHeader(__('FAQ'), $_SERVER['PHP_SELF']);
+            Html::helpHeader(__('FAQ'));
         }
 
         $available_options = ['item_itemtype', 'item_items_id', 'id'];

--- a/front/knowbaseitemtranslation.form.php
+++ b/front/knowbaseitemtranslation.form.php
@@ -75,9 +75,9 @@ if (isset($_POST['add'])) {
         if (Session::getCurrentInterface() == "central") {
             Html::header(KnowbaseItem::getTypeName(1), $_SERVER['PHP_SELF'], "tools", "knowbaseitemtranslation");
         } else {
-            Html::helpHeader(__('FAQ'), $_SERVER['PHP_SELF']);
+            Html::helpHeader(__('FAQ'));
         }
-        Html::helpHeader(__('FAQ'), $_SERVER['PHP_SELF'], $_SESSION["glpiname"]);
+        Html::helpHeader(__('FAQ'));
     } else {
         $_SESSION["glpilanguage"] = $CFG_GLPI['language'];
        // Anonymous FAQ

--- a/front/preference.php
+++ b/front/preference.php
@@ -71,7 +71,7 @@ if (
     if (Session::getCurrentInterface() == "central") {
         Html::header(Preference::getTypeName(1), $_SERVER['PHP_SELF'], 'preference');
     } else {
-        Html::helpHeader(Preference::getTypeName(1), $_SERVER['PHP_SELF']);
+        Html::helpHeader(Preference::getTypeName(1));
     }
 
     $pref = new Preference();

--- a/front/reminder.form.php
+++ b/front/reminder.form.php
@@ -135,7 +135,7 @@ if (isset($_POST["add"])) {
     Html::back();
 } else {
     if (Session::getCurrentInterface() == "helpdesk") {
-        Html::helpHeader(Reminder::getTypeName(Session::getPluralNumber()), '', $_SESSION["glpiname"]);
+        Html::helpHeader(Reminder::getTypeName(Session::getPluralNumber()));
     } else {
         Html::header(Reminder::getTypeName(Session::getPluralNumber()), '', "tools", "reminder");
     }

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -48,7 +48,7 @@ if (isset($_REQUEST['ajax'])) {
     Html::header_nocache();
     Html::popHeader(__('Simplified interface'));
 } else if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(__('Simplified interface'), $_SERVER['PHP_SELF'], $_SESSION["glpiname"]);
+    Html::helpHeader(__('Simplified interface'));
 } else {
     Html::header(Reservation::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "reservationitem");
 }

--- a/front/reservation.php
+++ b/front/reservation.php
@@ -40,7 +40,7 @@ if (!isset($_GET["reservationitems_id"])) {
 }
 
 if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(__('Simplified interface'), $_SERVER['PHP_SELF'], $_SESSION["glpiname"]);
+    Html::helpHeader(__('Simplified interface'));
 } else {
     Html::header(Reservation::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "reservationitem");
 }

--- a/front/reservationitem.php
+++ b/front/reservationitem.php
@@ -36,7 +36,7 @@ include('../inc/includes.php');
 Session::checkRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM]);
 
 if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(__('Simplified interface'), $_SERVER['PHP_SELF'], $_SESSION["glpiname"]);
+    Html::helpHeader(__('Simplified interface'));
 } else {
     Html::header(Reservation::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "reservationitem");
 }

--- a/front/rssfeed.form.php
+++ b/front/rssfeed.form.php
@@ -135,7 +135,7 @@ if (isset($_POST["add"])) {
     Html::back();
 } else {
     if (Session::getCurrentInterface() == "helpdesk") {
-        Html::helpHeader(RSSFeed::getTypeName(Session::getPluralNumber()), '', $_SESSION["glpiname"]);
+        Html::helpHeader(RSSFeed::getTypeName(Session::getPluralNumber()));
     } else {
         Html::header(RSSFeed::getTypeName(Session::getPluralNumber()), '', "tools", "rssfeed");
     }

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -226,7 +226,7 @@ if (isset($_POST["add"])) {
 
 if (isset($_GET["id"]) && ($_GET["id"] > 0)) {
     if (Session::getCurrentInterface() == "helpdesk") {
-        Html::helpHeader(Ticket::getTypeName(Session::getPluralNumber()), '', $_SESSION["glpiname"]);
+        Html::helpHeader(Ticket::getTypeName(Session::getPluralNumber()), 'tickets', 'ticket');
     } else {
         Html::header(Ticket::getTypeName(Session::getPluralNumber()), '', "helpdesk", "ticket");
     }

--- a/front/ticket.php
+++ b/front/ticket.php
@@ -36,7 +36,7 @@ include('../inc/includes.php');
 Session::checkLoginUser();
 
 if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(Ticket::getTypeName(Session::getPluralNumber()), '', $_SESSION["glpiname"]);
+    Html::helpHeader(Ticket::getTypeName(Session::getPluralNumber()), 'tickets', 'ticket');
 } else {
     Html::header(Ticket::getTypeName(Session::getPluralNumber()), '', "helpdesk", "ticket");
 }

--- a/front/tracking.injector.php
+++ b/front/tracking.injector.php
@@ -51,7 +51,7 @@ if (empty($_POST) || (count($_POST) == 0)) {
 if (isset($_POST["_type"]) && ($_POST["_type"] == "Helpdesk")) {
     Html::nullHeader(Ticket::getTypeName(Session::getPluralNumber()));
 } else if ($_POST["_from_helpdesk"]) {
-    Html::helpHeader(__('Simplified interface'), '', $_SESSION["glpiname"]);
+    Html::helpHeader(__('Simplified interface'));
 } else {
     Html::header(__('Simplified interface'), '', $_SESSION["glpiname"], "helpdesk", "tracking");
 }

--- a/front/updatepassword.php
+++ b/front/updatepassword.php
@@ -41,7 +41,7 @@ switch (Session::getCurrentInterface()) {
         Html::header(__('Update password'), $_SERVER['PHP_SELF']);
         break;
     case 'helpdesk':
-        Html::helpHeader(__('Update password'), $_SERVER['PHP_SELF']);
+        Html::helpHeader(__('Update password'));
         break;
     default:
         Html::simpleHeader(__('Update password'));

--- a/src/Html.php
+++ b/src/Html.php
@@ -1868,8 +1868,9 @@ HTML;
                 'content' => [
                     'ticket' => [
                         'links' => [
+                            'add'       => '/front/helpdesk.public.php?create_ticket=1',
                             'search'    => Ticket::getSearchURL(),
-                            'lists'     => ''
+                            'lists'     => '',
                         ]
                     ]
                 ]

--- a/templates/layout/parts/menu.html.twig
+++ b/templates/layout/parts/menu.html.twig
@@ -38,7 +38,16 @@
 {% for firstlevel in menu %}
    {% set firstlevel_active = menu[sector]['title'] == firstlevel['title'] %}
    {% set firstlevel_shown = (menu[sector]['title'] == firstlevel['title'] and is_vertical and is_menu_folded == false) %}
+   {% set has_subitems = false %}
    {% if firstlevel['content'] is defined %}
+      {# Are there any items under contents with a page property? #}
+      {% for secondlevel in firstlevel['content'] %}
+         {% if secondlevel['page'] is defined %}
+            {% set has_subitems = true %}
+         {% endif %}
+      {% endfor %}
+   {% endif %}
+   {% if has_subitems %}
    <li class="nav-item dropdown {{ firstlevel_active ? 'active' : '' }}"
        title="{{ firstlevel['title'] }}">
       <a class="nav-link dropdown-toggle {{ firstlevel_active ? 'active' : '' }} {{ firstlevel_shown ? 'show' : '' }}"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10041

Previously `Html::helpHeader` didn't support any context links (buttons link add, search, lists, etc).
I added some basic support for them in the context of Tickets.

As a side-effect, the menu template mistakenly thought that the Tickets menu item had children when it only had those context links. I added an extra check in the template to see if there were any real sub-items.