### PR TITLE
Fix Object Locks UI

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -5871,10 +5871,10 @@ JAVASCRIPT
         return "glpi_confirm({
          title: '" . Toolbox::addslashes_deep($title) . "',
          message: '" . Toolbox::addslashes_deep($msg) . "',
-         confirm_event: function() {
+         confirm_callback: function() {
             " . ($yesCallback !== null ? '(' . $yesCallback . ')()' : '') . "
          },
-         cancel_event: function() {
+         cancel_callback: function() {
             " . ($noCallback !== null ? '(' . $noCallback . ')()' : '') . "
          },
       });

--- a/src/ObjectLock.php
+++ b/src/ObjectLock.php
@@ -544,16 +544,9 @@ class ObjectLock extends CommonDBTM
      **/
     private function displayLockMessage($msg, $title = '')
     {
-
-        echo "<div id='message_after_lock' class='objectlockmessage' style='display:inline-block;' >";
-        echo $msg;
-        echo "</div>";
-        echo Html::scriptBlock("$('#message_after_lock').hide();");
-
         echo Html::scriptBlock("
          $(function() {
-            $('#message_after_lock').insertAfter('.navigationheader');
-            $('#message_after_lock').show('slide', {direction: 'up'}, 1000);
+            $(`<div id='message_after_lock' class='objectlockmessage' style='display: inline-block;'>$msg</div>`).insertAfter('.navigationheader');
          });
       ");
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Only applies to GLPI 10.

First commit fixes invalid option names for JS `glpi_confirm` function that caused the Object Lock unlock dialog to not work.

Second commit fixes an issue with a jQuery animation trying to be applied to an element that doesn't exist yet. It doesn't spam the console with undefined property values if the show call is done within a 100ms timeout, but I don't notice the animation either in v9.5 or v10 so I just removed it. I also simplified the injection of the element instead of adding it, hiding it, moving it, and then showing it.