### PR TITLE
Fix group name when not anonymized

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -1031,7 +1031,7 @@ class Group extends CommonTreeDropdown
     {
         if (
             Session::getCurrentInterface() == 'helpdesk'
-            && ($anon = $this->getAnonymizedName()) !== null
+            && ($anon = $this->getAnonymizedName()) !== ""
         ) {
             return $anon;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10044

If you don't anonymize agent names, the group name would be empty. I tested all anonymize options after this change and they seem to work as expected now.