### PR TITLE
Fix form control for adding user emails

### DIFF
--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -150,7 +150,7 @@ class UserEmail extends CommonDBChild
 
         return "<input title=\'" . __s('Default email') . "\' type=\'radio\' name=\'_default_email\'" .
              " value=\'-'+$child_count_js_var+'\'>&nbsp;" .
-             "<input type=\'text\' size=\'30\' class='form-control' " . "name=\'" . $field_name .
+             "<input type=\'text\' size=\'30\' class=\'form-control\' " . "name=\'" . $field_name .
              "[-'+$child_count_js_var+']\'>";
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Clicking the `+` button to add new emails to a user gives an `Uncaught SyntaxError: missing ) after argument list` error in the console because of unescaped quotes.