### PR TITLE
Show only one instance of Users in actor dropdown

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -4147,7 +4147,8 @@ JAVASCRIPT;
                 'glpi_useremails'       => [
                     'ON' => [
                         'glpi_useremails' => 'users_id',
-                        'glpi_users'      => 'id'
+                        'glpi_users'      => 'id',
+                        ['AND' => ['glpi_useremails.is_default' => 1]]
                     ]
                 ],
                 'glpi_profiles_users'   => [
@@ -4221,7 +4222,6 @@ JAVASCRIPT;
                     'glpi_users.realname ASC',
                     'glpi_users.firstname ASC',
                     'glpi_users.name ASC',
-                    'glpi_useremails.is_default DESC'
                 ];
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10413

Only show the instance using the default email if a user has more than one email.
fixes #10413