### PR TITLE
Smarter decimal contains search

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -4501,6 +4501,15 @@ JAVASCRIPT;
                 $nott = !$nott;
                //negated, use contains case
             case "contains":
+                if ($searchopt[$ID]["datatype"] === 'decimal') {
+                    $matches = [];
+                    preg_match('/^(\d+.?\d?)/', $val, $matches);
+                    $val = $matches[1];
+                    if (!str_contains($val, '.')) {
+                        $val .= '.';
+                    }
+                    $val = $val . "%";
+                }
                 $SEARCH = self::makeTextSearch($val, $nott);
                 break;
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -4501,7 +4501,7 @@ JAVASCRIPT;
                 $nott = !$nott;
                //negated, use contains case
             case "contains":
-                if ($searchopt[$ID]["datatype"] === 'decimal') {
+                if (isset($searchopt[$ID]["datatype"]) && ($searchopt[$ID]["datatype"] === 'decimal')) {
                     $matches = [];
                     preg_match('/^(\d+.?\d?)/', $val, $matches);
                     $val = $matches[1];

--- a/src/Search.php
+++ b/src/Search.php
@@ -4508,7 +4508,6 @@ JAVASCRIPT;
                     if (!str_contains($val, '.')) {
                         $val .= '.';
                     }
-                    $val = $val . "%";
                 }
                 $SEARCH = self::makeTextSearch($val, $nott);
                 break;
@@ -5010,6 +5009,7 @@ JAVASCRIPT;
                 case "decimal":
                 case "timestamp":
                 case "progressbar":
+                    $decimal_contains = $searchopt[$ID]["datatype"] === 'decimal' && $searchtype === 'contains';
                     $search  = ["/\&lt;/", "/\&gt;/"];
                     $replace = ["<", ">"];
                     $val     = preg_replace($search, $replace, $val);
@@ -5029,7 +5029,7 @@ JAVASCRIPT;
                         return $link . " ($tocompute " . $regs[1] . " " . $regs[3] . ") ";
                     }
 
-                    if (is_numeric($val)) {
+                    if (is_numeric($val) && !$decimal_contains) {
                         $numeric_val = floatval($val);
 
                         if (in_array($searchtype, ["notequals", "notcontains"])) {

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1633,6 +1633,36 @@ class Search extends DbTestCase
                 'meta' => false,
                 'expected' => "  AND  (`glpi_users_users_id_tech`.`id` = '2') ",
             ],
+            [
+                'link' => ' AND ',
+                'nott' => 0,
+                'itemtype' => \Monitor::class,
+                'ID' => 11, // Search ID 11 (size field)
+                'searchtype' => 'contains',
+                'val' => '70',
+                'meta' => false,
+                'expected' => "  AND  (`glpi_monitors`.`size` LIKE '70.%') ",
+            ],
+            [
+                'link' => ' AND ',
+                'nott' => 0,
+                'itemtype' => \Monitor::class,
+                'ID' => 11, // Search ID 11 (size field)
+                'searchtype' => 'contains',
+                'val' => '70.5',
+                'meta' => false,
+                'expected' => "  AND  (`glpi_monitors`.`size` LIKE '70.5%') ",
+            ],
+            [
+                'link' => ' AND ',
+                'nott' => 0,
+                'itemtype' => \Monitor::class,
+                'ID' => 11, // Search ID 11 (size field)
+                'searchtype' => 'contains',
+                'val' => '70.5%',
+                'meta' => false,
+                'expected' => "  AND  (`glpi_monitors`.`size` LIKE '70.5%') ",
+            ]
         ];
     }
 

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1641,7 +1641,7 @@ class Search extends DbTestCase
                 'searchtype' => 'contains',
                 'val' => '70',
                 'meta' => false,
-                'expected' => "  AND  (`glpi_monitors`.`size`  LIKE '%70.%%'  ) ",
+                'expected' => "  AND  (`glpi_monitors`.`size`  LIKE '%70.%'  )",
             ],
             [
                 'link' => ' AND ',
@@ -1651,7 +1651,7 @@ class Search extends DbTestCase
                 'searchtype' => 'contains',
                 'val' => '70.5',
                 'meta' => false,
-                'expected' => "  AND  (`glpi_monitors`.`size`  LIKE '%70.5%%'  ) ",
+                'expected' => "  AND  (`glpi_monitors`.`size`  LIKE '%70.5%'  )",
             ],
             [
                 'link' => ' AND ',
@@ -1661,7 +1661,7 @@ class Search extends DbTestCase
                 'searchtype' => 'contains',
                 'val' => '70.5%',
                 'meta' => false,
-                'expected' => "  AND  (`glpi_monitors`.`size`  LIKE '%70.5%%'  ) ",
+                'expected' => "  AND  (`glpi_monitors`.`size`  LIKE '%70.5%'  )",
             ]
         ];
     }

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1641,7 +1641,7 @@ class Search extends DbTestCase
                 'searchtype' => 'contains',
                 'val' => '70',
                 'meta' => false,
-                'expected' => "  AND  (`glpi_monitors`.`size` LIKE '70.%') ",
+                'expected' => "  AND  (`glpi_monitors`.`size`  LIKE '%70.%%'  ) ",
             ],
             [
                 'link' => ' AND ',
@@ -1651,7 +1651,7 @@ class Search extends DbTestCase
                 'searchtype' => 'contains',
                 'val' => '70.5',
                 'meta' => false,
-                'expected' => "  AND  (`glpi_monitors`.`size` LIKE '70.5%') ",
+                'expected' => "  AND  (`glpi_monitors`.`size`  LIKE '%70.5%%'  ) ",
             ],
             [
                 'link' => ' AND ',
@@ -1661,7 +1661,7 @@ class Search extends DbTestCase
                 'searchtype' => 'contains',
                 'val' => '70.5%',
                 'meta' => false,
-                'expected' => "  AND  (`glpi_monitors`.`size` LIKE '70.5%') ",
+                'expected' => "  AND  (`glpi_monitors`.`size`  LIKE '%70.5%%'  ) ",
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1508

Example search on Monitors:
Size CONTAINS 70

Example results:
- 70
- 70.5
- 70.55
- 70.05

Example search on Monitors:
Size CONTAINS 70.5

Example results:
- 70.5
- 70.55