### PR TITLE
Improve SNMP credentials form

### DIFF
--- a/src/SNMPCredential.php
+++ b/src/SNMPCredential.php
@@ -174,6 +174,8 @@ class SNMPCredential extends CommonDBTM
                 return false;
             }
         }
+
+        return true;
     }
 
     public function prepareInputForAdd($input)

--- a/src/SNMPCredential.php
+++ b/src/SNMPCredential.php
@@ -159,15 +159,38 @@ class SNMPCredential extends CommonDBTM
         return $input;
     }
 
+    private function checkRequiredFields($input): bool
+    {
+        // Require a snmpversion
+        if (!isset($input['snmpversion']) || $input['snmpversion'] == '0') {
+            Session::addMessageAfterRedirect(__('You must select an SNMP version'), false, ERROR);
+            return false;
+        }
+
+        // Require username if using version 3
+        if ($input['snmpversion'] == 3) {
+            if (empty($input['username'])) {
+                Session::addMessageAfterRedirect(__('You must enter a username'), false, ERROR);
+                return false;
+            }
+        }
+    }
+
     public function prepareInputForAdd($input)
     {
         $input = parent::prepareInputForAdd($input);
+        if (!$this->checkRequiredFields($input)) {
+            return false;
+        }
         return $this->prepareInputs($input);
     }
 
     public function prepareInputForUpdate($input)
     {
         $input = parent::prepareInputForUpdate($input);
+        if (!$this->checkRequiredFields($input)) {
+            return false;
+        }
         return $this->prepareInputs($input);
     }
 

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -714,6 +714,7 @@
       'label_class': 'col-xxl-5',
       'input_class': 'col-xxl-7',
       'add_field_class': '',
+      'add_field_attribs': {},
       'center': false,
    }|merge(options) %}
 
@@ -743,7 +744,13 @@
       }) %}
    {% endif %}
 
-   <div class="form-field row {{ options.field_class }} {{ options.add_field_class }} {{ options.mb }}">
+   {% if options.add_field_attribs is not empty %}
+      {% set extra_attribs = call('Html::parseAttributes', {options: options.add_field_attribs}) %}
+   {% else %}
+      {% set extra_attribs = '' %}
+   {% endif %}
+
+   <div class="form-field row {{ options.field_class }} {{ options.add_field_class }} {{ options.mb }}" {{ extra_attribs|raw }}>
       {{ _self.label(label, id, options, 'col-form-label ' ~ options.label_class) }}
       {% if options.center %}
          {% set flex_class = "d-flex align-items-center" %}
@@ -762,6 +769,7 @@
       'mb': 'mb-2',
       'field_class': 'col-12 col-sm-6',
       'add_field_class': '',
+      'add_field_attribs': {},
    }|merge(options) %}
 
    {% if options.full_width %}
@@ -770,7 +778,13 @@
       }) %}
    {% endif %}
 
-   <div class="form-field {{ options.field_class }} {{ options.add_field_class }} {{ options.mb }}">
+   {% if options.add_field_attribs is not empty %}
+      {% set extra_attribs = call('Html::parseAttributes', {options: options.add_field_attribs}) %}
+   {% else %}
+      {% set extra_attribs = '' %}
+   {% endif %}
+
+   <div class="form-field {{ options.field_class }} {{ options.add_field_class }} {{ options.mb }}" {{ extra_attribs|raw }}>
       {{ _self.label(label, id, options, 'col-form-label ' ~ options.label_class) }}
       <div class="{{ options.input_class }} field-container">
          {{ field|raw }}

--- a/templates/components/form/snmpcredential.html.twig
+++ b/templates/components/form/snmpcredential.html.twig
@@ -62,7 +62,8 @@
       {
          add_field_attribs: {
             'data-snmp-version': '3'
-         }
+         },
+         required: true
       },
    ) }}
 

--- a/templates/components/form/snmpcredential.html.twig
+++ b/templates/components/form/snmpcredential.html.twig
@@ -62,8 +62,7 @@
       {
          add_field_attribs: {
             'data-snmp-version': '3'
-         },
-         required: true
+         }
       },
    ) }}
 

--- a/templates/components/form/snmpcredential.html.twig
+++ b/templates/components/form/snmpcredential.html.twig
@@ -39,27 +39,31 @@
       item.fields['snmpversion'],
       {0: '-----', 1: '1', 2: '2c', 3: '3'},
       __('SNMP version'),
-   ) }}
-
-   {{ fields.htmlField(
-      '',
-      '<h3 class="card-header">v 1 & v 2c</h3>',
-   ) }}
-   {{ fields.htmlField(
-      '',
-      '<h3 class="card-header">v 3</h3>',
+      {
+         required: true
+      }
    ) }}
 
    {{ fields.textField(
       'community',
       item.fields['community'],
       __('Community'),
+      {
+         add_field_attribs: {
+            'data-snmp-version': '1'
+         }
+      },
    ) }}
 
    {{ fields.textField(
       'username',
       item.fields['username'],
       _n('User', 'Users', get_plural_number()),
+      {
+         add_field_attribs: {
+            'data-snmp-version': '3'
+         }
+      },
    ) }}
 
    {{ fields.nullField() }}
@@ -69,6 +73,11 @@
       item.fields['authentication'],
       {0: '-----', 1: 'MD5', 2: 'SHA'},
       __('Encryption protocol for authentication '),
+      {
+         add_field_attribs: {
+            'data-snmp-version': '3'
+         }
+      },
    ) }}
 
    {{ fields.nullField() }}
@@ -77,6 +86,11 @@
       'auth_passphrase',
       item.fields['auth_passphrase'],
       __('Password'),
+      {
+         add_field_attribs: {
+            'data-snmp-version': '3'
+         }
+      },
    ) }}
 
    {{ fields.nullField() }}
@@ -86,6 +100,11 @@
       item.fields['encryption'],
       {0: '-----', 1: 'DES', 2: 'AES128', 3: 'Triple-DES'},
       __('Encryption protocol for data'),
+      {
+         add_field_attribs: {
+            'data-snmp-version': '3'
+         }
+      },
    ) }}
 
    {{ fields.nullField() }}
@@ -94,5 +113,29 @@
       'priv_passphrase',
       item.fields['priv_passphrase'],
       __('Password'),
+      {
+         add_field_attribs: {
+            'data-snmp-version': '3'
+         }
+      },
    ) }}
+
+   <script>
+
+      const filterFormForSNMPVersion = (version) => {
+         // Hide all elements with data-snmp-version attribute by default
+         $('.form-field[data-snmp-version]').hide();
+         if (version === '1' || version === '2') {
+            $('.form-field[data-snmp-version="1"]').show();
+         } else if (version === '3') {
+            $('.form-field[data-snmp-version="3"]').show();
+         }
+      }
+      filterFormForSNMPVersion($('select[name="snmpversion"]').val());
+      // If there is already a snmpversion selected, show the corresponding elements
+      $('select[name="snmpversion"]').on('change', (e) => {
+         const selection = $(e.currentTarget).val();
+         filterFormForSNMPVersion(selection);
+      });
+   </script>
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10150

- Show only relevant fields based on the selected SNMP version.
- Added required marker to snmpversion field (Checked server-side. Client-side validates OK for empty choice; not a big deal).
- Added check that the username field is set if using v3.
- Added ability to specify additional attributes on form fields. Used in this PR to add a data attribute to each field to specify which SNMP version they are used for.
- Removed redundant card headers for SNMP versions.