### PR TITLE
Add missing class causing JS errors on zoom

### DIFF
--- a/templates/pages/tools/project/gantt.html.twig
+++ b/templates/pages/tools/project/gantt.html.twig
@@ -47,19 +47,19 @@
                <span>{{ __('Zoom') }}</span>
             </span>
 
-            <input type="radio" id="scale1" class="btn-check" name="scale" value="day" checked />
+            <input type="radio" id="scale1" class="btn-check gantt_radio" name="scale" value="day" checked />
             <label class="btn btn-outline-secondary" for="scale1">{{ __('Days') }}</label>
 
-            <input type="radio" id="scale2" class="btn-check" name="scale" value="week" />
+            <input type="radio" id="scale2" class="btn-check gantt_radio" name="scale" value="week" />
             <label class="btn btn-outline-secondary" for="scale2">{{ __('Weeks') }}</label>
 
-            <input type="radio" id="scale3" class="btn-check" name="scale" value="month" checked />
+            <input type="radio" id="scale3" class="btn-check gantt_radio" name="scale" value="month" checked />
             <label class="btn btn-outline-secondary" for="scale3">{{ __('Months') }}</label>
 
-            <input type="radio" id="scale4" class="btn-check" name="scale" value="quarter" />
+            <input type="radio" id="scale4" class="btn-check gantt_radio" name="scale" value="quarter" />
             <label class="btn btn-outline-secondary" for="scale4">{{ __('Quarters') }}</label>
 
-            <input type="radio" id="scale5" class="btn-check" name="scale" value="year" />
+            <input type="radio" id="scale5" class="btn-check gantt_radio" name="scale" value="year" />
             <label class="btn btn-outline-secondary" for="scale5">{{ __('Years') }}</label>
          </div>
 
@@ -67,13 +67,13 @@
 
       <li class="gantt-menu-item gantt-menu-item-right">
          <div class="input-group" role="group">
-            <input type="radio" id="rb-find" class="btn-check rb-optype" name="rb-optype" checked />
+            <input type="radio" id="rb-find" class="btn-check rb-optype gantt_radio" name="rb-optype" checked />
             <label class="btn btn-outline-secondary" for="rb-find">
                <i class="fas fa-search"></i>
                <span>{{ __('Find') }}</span>
             </label>
 
-            <input type="radio" id="rb-filter" class="btn-check rb-optype" name="rb-optype" />
+            <input type="radio" id="rb-filter" class="btn-check rb-optype gantt_radio" name="rb-optype" />
             <label class="btn btn-outline-secondary" for="rb-filter">
                <i class="fas fa-filter"></i>
                <span>{{ __('Filter') }}</span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Clicking any of the zoom buttons show an error in the console even though they appear to work properly.
It expects a `gantt_radio` class on radio buttons but that class is missing.