### PR TITLE
Fix missing ID in logs for Root Entity

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -189,7 +189,7 @@ class Event extends CommonDBTM
         global $CFG_GLPI;
 
         // If ID less than or equal to 0 (or Entity with ID less than 0 since Root Entity is 0)
-        if (($items_id <= 0 && $type !== \Entity::class) || ($type === \Entity::class && $items_id < 0)) {
+        if ($items_id < 0 || ($type !== \Entity::class && $items_id == 0)) {
             echo "&nbsp;";//$item;
         } else {
             switch ($type) {

--- a/src/Event.php
+++ b/src/Event.php
@@ -188,7 +188,8 @@ class Event extends CommonDBTM
     {
         global $CFG_GLPI;
 
-        if ($items_id <= 0) {
+        // If ID less than or equal to 0 (or Entity with ID less than 0 since Root Entity is 0)
+        if (($items_id <= 0 && $type !== \Entity::class) || ($type === \Entity::class && $items_id < 0)) {
             echo "&nbsp;";//$item;
         } else {
             switch ($type) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Any log entries related to the Root Entity do not show an ID and therefore no item link because it ignores any ID of 0 or less. I added an exception for Entities.