### PR TITLE
use card_id to store/retrieve css cache entry for dashboard widgets

### DIFF
--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -2017,7 +2017,7 @@ JAVASCRIPT;
         $series_names  = implode(',', $palette['names']);
         $series_colors = implode(',', $palette['colors']);
 
-        $hash = sha1($series_names . $series_colors);
+        $hash = sha1($css_dom_parent . $series_names . $series_colors);
         if (($palette_css = $GLPI_CACHE->get($hash)) !== null) {
             return $palette_css;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
