### PR TITLE
Remove global_validation field from ITIL forms

### DIFF
--- a/install/migrations/update_9.5.x_to_10.0.0/ticket.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/ticket.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+/* Remove global_validation field from templates (should not be defined manually). */
+foreach (['glpi_tickettemplatemandatoryfields', 'glpi_tickettemplatepredefinedfields'] as $table) {
+    $migration->addPostQuery(
+        $DB->buildDelete(
+            $table,
+            [
+                'num' => 52, // global_validation
+            ]
+        )
+    );
+}
+/* /Remove global_validation field from templates (should not be defined manually). */

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1024,16 +1024,10 @@ abstract class CommonITILObject extends CommonDBTM
                     $allowed_fields[] = 'status';
                     $allowed_fields[] = '_accepted';
                 }
-               // for post-only with validate right or validation created by rules
+               // for validation created by rules
                 $validation_class = static::getType() . 'Validation';
-                if (class_exists($validation_class)) {
-                    if (
-                        $validation_class::canValidate($this->fields['id'])
-                        || $validation_class::canCreate()
-                        || isset($input["_rule_process"])
-                    ) {
-                        $allowed_fields[] = 'global_validation';
-                    }
+                if (class_exists($validation_class) && isset($input["_rule_process"])) {
+                    $allowed_fields[] = 'global_validation';
                 }
                // Manage assign and steal right
                 if (static::getType() === Ticket::getType() && Session::haveRightsOr(static::$rightname, [Ticket::ASSIGN, Ticket::STEAL])) {

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -589,14 +589,34 @@ abstract class CommonITILValidation extends CommonDBChild
     /**
      * Get Ticket validation status Name
      *
-     * @param integer $value status ID
+     * @param integer   $value
+     * @param bool      $decorated
      **/
-    public static function getStatus($value)
+    public static function getStatus($value, bool $decorated = false)
     {
+        $statuses = self::getAllStatusArray(true, true);
 
-        $tab = self::getAllStatusArray(true, true);
-       // Return $value if not define
-        return (isset($tab[$value]) ? $tab[$value] : $value);
+        $label = $statuses[$value] ?? $value;
+
+        if ($decorated) {
+            $color   = self::getStatusColor($value);
+            $classes = null;
+            switch ($value) {
+                case self::WAITING:
+                    $classes = 'waiting far fa-clock';
+                    break;
+                case self::ACCEPTED:
+                    $classes = 'accepted fas fa-check';
+                    break;
+                case self::REFUSED:
+                    $classes = 'refused fas fa-times';
+                    break;
+            }
+
+            return sprintf('<span><i class="validationstatus %s"></i> %s</span>', $classes, $label);
+        }
+
+        return $label;
     }
 
 
@@ -850,14 +870,7 @@ abstract class CommonITILValidation extends CommonDBChild
         echo "<tr class='tab_bg_1'>";
         echo "<td>" . __('Global approval status') . "</td>";
         echo "<td colspan='2'>";
-        if (Session::haveRightsOr(static::$rightname, TicketValidation::getValidateRights())) {
-            self::dropdownStatus(
-                "global_validation",
-                ['value'    => $item->fields["global_validation"]]
-            );
-        } else {
-            echo TicketValidation::getStatus($item->fields["global_validation"]);
-        }
+        echo TicketValidation::getStatus($item->fields["global_validation"], true);
         echo "</td></tr>";
 
         echo "<tr>";

--- a/src/ITILTemplateMandatoryField.php
+++ b/src/ITILTemplateMandatoryField.php
@@ -141,6 +141,7 @@ abstract class ITILTemplateMandatoryField extends ITILTemplateField
     public static function getExcludedFields()
     {
         return [
+            52  => 52, // global_validation
             175 => 175, // ticket's tasks
         ];
     }

--- a/src/ITILTemplatePredefinedField.php
+++ b/src/ITILTemplatePredefinedField.php
@@ -223,6 +223,7 @@ abstract class ITILTemplatePredefinedField extends ITILTemplateField
     {
         return [
             -2 => -2, // validation request
+            52  => 52, // global_validation
         ];
     }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4113,7 +4113,6 @@ JAVASCRIPT;
             'items_id'                  => [],
             'entities_id'               => $_SESSION['glpiactive_entity'],
             'plan'                      => [],
-            'global_validation'         => CommonITILValidation::NONE,
             '_add_validation'           => 0,
             'type'                      => Entity::getUsedConfig(
                 'tickettype',

--- a/templates/components/itilobject/fields/global_validation.html.twig
+++ b/templates/components/itilobject/fields/global_validation.html.twig
@@ -64,23 +64,15 @@
 
       <input type="hidden" name="_add_validation" value="{{ params['_add_validation'] }}" />
    {% else %}
-      {% set required = {} %}
-      {% if field_options.fields_template.isMandatoryField('global_validation') %}
-         {% set required = {
-            'required': true,
-         } %}
-      {% endif %}
-
-      {{ fields.field(
-         'global_validation',
-         call('TicketValidation::dropdownStatus', ['global_validation', {
-            'global': true,
-            'value': item.fields['global_validation'],
-            'display': false,
-            'disabled': (not canupdate),
-         }|merge(required)]),
-         "CommonITILValidation"|itemtype_name,
-         field_options
-      ) }}
+        {% if not itiltemplate.isHiddenField('global_validation') %}
+            {{ fields.htmlField(
+                'global_validation',
+                call('TicketValidation::getStatus', [item.fields['global_validation'], true]),
+                "CommonITILValidation"|itemtype_name,
+                {
+                    'full_width': true,
+                }
+            ) }}
+        {% endif %}
    {% endif %}
 {% endif %}

--- a/tests/functionnal/ITILTemplate.php
+++ b/tests/functionnal/ITILTemplate.php
@@ -226,7 +226,6 @@ class ITILTemplate extends DbTestCase
                     180 => 'Internal time to resolve',
                     185 => 'Internal time to own',
                     45 => 'Total duration',
-                    52 => 'Approval',
                     193 => 'Contract',
                     14 => 'Type',
                 ]
@@ -286,7 +285,7 @@ class ITILTemplate extends DbTestCase
     /**
      * @dataProvider fieldsProvider
      * */
-    public function testGetFields($itemtype, $fields)
+    public function testGetMandatoryFields($itemtype, $fields)
     {
         $tpl_class = '\\' . $itemtype . 'Template';
         $tpl = new $tpl_class();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

For now, people which have `VALIDATEREQUEST` or `VALIDATEINCIDENT` rights are able to update the `global_validation` without any restriction. It means that, if many people already add a refusal on a ticket, anyone having this right can bypass this and set the `global_validation` to "Accepted".

1. `VALIDATEREQUEST` and `VALIDATEINCIDENT` should only means that a user is able to receive an approval request.
2. `global_validation` field value should be only computed based on approval requests results, or by business rules, but should not be updatable manually by anyone.