### PR TITLE
Improve forgotten email edge case

### DIFF
--- a/front/lostpassword.php
+++ b/front/lostpassword.php
@@ -46,7 +46,7 @@ Html::simpleHeader(__('Forgotten password?'));
 // REQUEST needed : GET on first access / POST on submit form
 if (isset($_REQUEST['password_forget_token'])) {
 
-   if (isset($_POST['email'])) {
+   if (isset($_POST['password'])) {
       $user->showUpdateForgottenPassword($_REQUEST);
    } else {
       User::showPasswordForgetChangeForm($_REQUEST['password_forget_token']);

--- a/inc/api/api.class.php
+++ b/inc/api/api.class.php
@@ -2161,7 +2161,7 @@ abstract class API extends CommonGLPI {
          return $this->returnError(__("Email notifications are disabled"));
       }
 
-      if (!isset($params['email'])) {
+      if (!isset($params['email']) && !$params['password_forget_token']) {
          return $this->returnError(__("email parameter missing"));
       }
 
@@ -2183,7 +2183,6 @@ abstract class API extends CommonGLPI {
       } else {
          $password = isset($params['password']) ? $params['password'] : '';
          $input = [
-            'email'                    => Toolbox::addslashes_deep($params['email']),
             'password_forget_token'    => Toolbox::addslashes_deep($params['password_forget_token']),
             'password'                 => Toolbox::addslashes_deep($password),
             'password2'                => Toolbox::addslashes_deep($password),

--- a/inc/api/api.class.php
+++ b/inc/api/api.class.php
@@ -2178,7 +2178,7 @@ abstract class API extends CommonGLPI {
             return $this->returnError($e->getMessage());
          }
          return $this->returnResponse([
-            __("An email has been sent to your email address. The email contains information for reset your password.")
+            __('If the given email address match an exisiting GLPI user, you will receive an email containing the informations required to reset your password. Please contact your administrator if you do not receive any email.')
          ]);
       } else {
          $password = isset($params['password']) ? $params['password'] : '';

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1447,6 +1447,11 @@ class Config extends CommonDBTM {
       Html::closeForm();
    }
 
+   /**
+    * Check if the "use_password_security" parameter is enabled
+    *
+    * @return bool
+    */
    public static function arePasswordSecurityChecksEnabled(): bool {
       global $CFG_GLPI;
 

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1447,6 +1447,11 @@ class Config extends CommonDBTM {
       Html::closeForm();
    }
 
+   public static function arePasswordSecurityChecksEnabled(): bool {
+      global $CFG_GLPI;
+
+      return $CFG_GLPI["use_password_security"];
+   }
 
    /**
     * Display security checks on password

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -810,8 +810,7 @@ class User extends CommonDBTM {
                        // Permit to change password with token and email
                        || (($input['password_forget_token'] == $this->fields['password_forget_token'])
                            && (abs(strtotime($_SESSION["glpi_currenttime"])
-                               -strtotime($this->fields['password_forget_token_date'])) < DAY_TIMESTAMP)
-                           && $this->isEmail($input['email'])))) {
+                               -strtotime($this->fields['password_forget_token_date'])) < DAY_TIMESTAMP)))) {
                   $input["password"]
                      = Auth::getPasswordHash(Toolbox::unclean_cross_side_scripting_deep(stripslashes($input["password"])));
 
@@ -4884,6 +4883,8 @@ JAVASCRIPT;
          'password_forget_token_date' => 'NULL',
       ]);
 
+      $this->getFromDB($user->fields['id']);
+
       return true;
    }
 
@@ -5738,7 +5739,9 @@ JAVASCRIPT;
          return null;
       }
 
-      $data = array_pop(iterator_to_array($iterator));
+      // Get first row, should use current() when updated to GLPI 10
+      $data = iterator_to_array($iterator);
+      $data = array_pop($data);
 
       // Try to load the user
       $user = new self();

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -466,7 +466,7 @@ class User extends CommonDBTM {
       ];
 
       $data = iterator_to_array($DB->request($query));
-      return array_column($data, self::getTable() . '.id');
+      return array_column($data, 'id');
    }
 
    /**
@@ -4740,61 +4740,48 @@ JAVASCRIPT;
     * @return void
     */
    static function showPasswordForgetChangeForm($token) {
-      global $CFG_GLPI, $DB;
+      global $CFG_GLPI;
 
-      // Verif token.
-      $token_ok = false;
-      $iterator = $DB->request([
-         'FROM'   => self::getTable(),
-         'WHERE'  => [
-            'password_forget_token'       => $token,
-            new \QueryExpression('NOW() < ADDDATE(' . $DB->quoteName('password_forget_token_date') . ', INTERVAL 1 DAY)')
-         ]
-      ]);
+      if (!User::getUserByForgottenPasswordToken($token)) {
+         echo "<div class='center'>";
+         echo __('Your password reset request has expired or is invalid. Please renew it.');
+         echo "</div>";
 
-      if (count($iterator) == 1) {
-         $token_ok = true;
+         return;
       }
+
       echo "<div class='center'>";
+      echo "<form method='post' name='forgetpassword' action='".$CFG_GLPI['root_doc'].
+               "/front/lostpassword.php'>";
+      echo "<table class='tab_cadre'>";
+      echo "<tr><th colspan='2'>" . __('Forgotten password?')."</th></tr>";
 
-      if ($token_ok) {
-         echo "<form method='post' name='forgetpassword' action='".$CFG_GLPI['root_doc'].
-                "/front/lostpassword.php'>";
-         echo "<table class='tab_cadre'>";
-         echo "<tr><th colspan='2'>" . __('Forgotten password?')."</th></tr>";
+      echo "<tr class='tab_bg_1'>";
+      echo "<td colspan='2'>". __('Please enter your new password.')."</td></tr>";
 
-         echo "<tr class='tab_bg_1'>";
-         echo "<td colspan='2'>". __('Please confirm your email address and enter your new password.').
-              "</td></tr>";
+      echo "<tr class='tab_bg_1'><td>" . __('Password')."</td>";
+      echo "<td><input id='password' type='password' name='password' value='' size='20'
+                  autocomplete='new-password' onkeyup=\"return passwordCheck();\">";
+      echo "</td></tr>";
 
-         echo "<tr class='tab_bg_1'><td>" . _n('Email', 'Emails', 1)."</td>";
-         echo "<td><input type='text' name='email' value='' size='60'></td></tr>";
+      echo "<tr class='tab_bg_1'><td>" . __('Password confirmation')."</td>";
+      echo "<td><input type='password' name='password2' value='' size='20' autocomplete='new-password'>";
+      echo "</td></tr>";
 
-         echo "<tr class='tab_bg_1'><td>" . __('Password')."</td>";
-         echo "<td><input id='password' type='password' name='password' value='' size='20'
-                    autocomplete='new-password' onkeyup=\"return passwordCheck();\">";
-         echo "</td></tr>";
-
-         echo "<tr class='tab_bg_1'><td>" . __('Password confirmation')."</td>";
-         echo "<td><input type='password' name='password2' value='' size='20' autocomplete='new-password'>";
-         echo "</td></tr>";
-
+      if (Config::arePasswordSecurityChecksEnabled()) {
          echo "<tr class='tab_bg_1'><td>".__('Password security policy')."</td>";
          echo "<td>";
          Config::displayPasswordSecurityChecks();
          echo "</td></tr>";
-
-         echo "<tr class='tab_bg_2 center'><td colspan='2'>";
-         echo "<input type='hidden' name='password_forget_token' value='$token'>";
-         echo "<input type='submit' name='update' value=\"".__s('Save')."\" class='submit'>";
-         echo "</td></tr>";
-
-         echo "</table>";
-         Html::closeForm();
-
-      } else {
-         echo __('Your password reset request has expired or is invalid. Please renew it.');
       }
+
+      echo "<tr class='tab_bg_2 center'><td colspan='2'>";
+      echo "<input type='hidden' name='password_forget_token' value='$token'>";
+      echo "<input type='submit' name='update' value=\"".__s('Save')."\" class='submit'>";
+      echo "</td></tr>";
+
+      echo "</table>";
+      Html::closeForm();
       echo "</div>";
    }
 
@@ -4831,65 +4818,73 @@ JAVASCRIPT;
    /**
     * Handle password recovery form submission.
     *
-    * @param array $input
+    * @param array $input Submitted HTML form content
     *
-    * @throws ForgetPasswordException when requirements are not met
+    * @throws ForgetPasswordException  When the password reset request is invalid
+    * @throws PasswordTooWeakException When the new password does not comply
+    *                                  with the security checks
     *
-    * @return boolean true if password successfully changed, false otherwise
+    * @return boolean True if the password was successfully changed, false otherwise
     */
    public function updateForgottenPassword(array $input) {
-      $condition = [
-         'glpi_users.is_active'  => 1,
-         'glpi_users.is_deleted' => 0, [
-            'OR' => [
-               ['glpi_users.begin_date' => null],
-               ['glpi_users.begin_date' => ['<', new QueryExpression('NOW()')]]
-            ],
-         ], [
-            'OR'  => [
-               ['glpi_users.end_date'   => null],
-               ['glpi_users.end_date'   => ['>', new QueryExpression('NOW()')]]
-            ]
-         ]
-      ];
-      if ($this->getFromDBbyEmail($input['email'], $condition)) {
-         if (($this->fields["authtype"] == Auth::DB_GLPI)
-             || !Auth::useAuthExt()) {
+      // Get user by token
+      $token = $input['password_forget_token'] ?? "";
+      $user = self::getUserByForgottenPasswordToken($token);
 
-            if (($input['password_forget_token'] == $this->fields['password_forget_token'])
-                && (abs(strtotime($_SESSION["glpi_currenttime"])
-                        -strtotime($this->fields['password_forget_token_date'])) < DAY_TIMESTAMP)) {
-
-               $input['id'] = $this->fields['id'];
-               Config::validatePassword($input["password"], false); // Throws exception if password is invalid
-               if (!$this->update($input)) {
-                  return false;
-               }
-               $input2 = [
-                  'password_forget_token'      => '',
-                  'password_forget_token_date' => 'NULL',
-                  'id'                         => $this->fields['id']
-               ];
-               $this->update($input2);
-               return true;
-
-            } else {
-               throw new ForgetPasswordException(__('Your password reset request has expired or is invalid. Please renew it.'));
-            }
-
-         } else {
-            throw new ForgetPasswordException(__("The authentication method configuration doesn't allow you to change your password."));
-         }
-
-      } else {
-         if (self::countUsersByEmail($input['email'], $condition) > 1) {
-            throw new ForgetPasswordException(__('Multiple users were found for this email address. Please contact your administrator.'));
-         } else {
-            throw new ForgetPasswordException(__('Email address not found.'));
-         }
+      // Invalid token
+      if (!$user) {
+         throw new ForgetPasswordException(
+            __('Your password reset request has expired or is invalid. Please renew it.')
+         );
       }
 
-      return false;
+      // Check if the user is no longer active, it might happen if for some
+      // reasons the user is disabled manually after requesting a password reset
+      if ($user->fields['is_active'] == 0 || $user->fields['is_deleted'] == 1) {
+         throw new ForgetPasswordException(
+            __("Unable to reset password, please contact your administrator")
+         );
+      }
+
+      // Same check but for the account activation dates
+      if ((
+            $user->fields['begin_date'] !== null
+            && $user->fields['begin_date'] < $_SESSION['glpi_currenttime']
+         ) || (
+            $user->fields['end_date'] !== null
+            && $user->fields['end_date'] > $_SESSION['glpi_currenttime']
+         )
+      ) {
+         throw new ForgetPasswordException(
+            __("Unable to reset password, please contact your administrator")
+         );
+      }
+
+      // Safety check that the user authentication method support passwords changes
+      if ($user->fields["authtype"] !== Auth::DB_GLPI && Auth::useAuthExt()) {
+         throw new ForgetPasswordException(
+            __("The authentication method configuration doesn't allow you to change your password.")
+         );
+      }
+
+      $input['id'] = $user->fields['id'];
+
+      // Check new password validity, throws exception on failure
+      Config::validatePassword($input["password"], false);
+
+      // Try to set new password
+      if (!$user->update($input)) {
+         return false;
+      }
+
+      // Clear password reset token data
+      $user->update([
+         'id'                         => $user->fields['id'],
+         'password_forget_token'      => '',
+         'password_forget_token_date' => 'NULL',
+      ]);
+
+      return true;
    }
 
 
@@ -4942,7 +4937,7 @@ JAVASCRIPT;
          echo $e->getMessage();
          return;
       }
-      echo __('An email has been sent to your email address. The email contains information for reset your password.');
+      echo __('If the given email address match an exisiting GLPI user, you will receive an email containing the informations required to reset your password. Please contact your administrator if you do not receive any email.');
    }
 
    /**
@@ -4950,11 +4945,15 @@ JAVASCRIPT;
     *
     * @param string $email
     *
-    * @throws ForgetPasswordException when requirements are not met
+    * @throws ForgetPasswordException If the process failed and the user should
+    *                                 be aware of it (e.g. incorrect email)
     *
-    * @return boolean true if notification successfully created, false if user not found
+    * @return bool Return true if the password reset notification was sent,
+    *              false if the process failed but the user should not be aware
+    *              of it to avoid exposing whether or not the given email exist
+    *              in our database.
     */
-   public function forgetPassword($email) {
+   public function forgetPassword(string $email): bool {
       $condition = [
          'glpi_users.is_active'  => 1,
          'glpi_users.is_deleted' => 0, [
@@ -4970,38 +4969,45 @@ JAVASCRIPT;
          ]
       ];
 
-      if ($this->getFromDBbyEmail($email, $condition)) {
+      // Try to find a single user matching the given email
+      if (!$this->getFromDBbyEmail($email, $condition)) {
+         $count = self::countUsersByEmail($email, $condition);
+         trigger_error(
+            "Failed to find a single user for '$email', $count user(s) found.",
+            E_USER_WARNING
+         );
 
-         // Send token if auth DB or not external auth defined
-         if (($this->fields["authtype"] == Auth::DB_GLPI)
-             || !Auth::useAuthExt()) {
-
-            if (NotificationMailing::isUserAddressValid($email)) {
-               $input = [
-                  'password_forget_token'      => sha1(Toolbox::getRandomString(30)),
-                  'password_forget_token_date' => $_SESSION["glpi_currenttime"],
-                  'id'                         => $this->fields['id'],
-               ];
-               $this->update($input);
-               // Notication on root entity (glpi_users.entities_id is only a pref)
-               NotificationEvent::raiseEvent('passwordforget', $this, ['entities_id' => 0]);
-               QueuedNotification::forceSendFor($this->getType(), $this->fields['id']);
-               return true;
-            } else {
-               throw new ForgetPasswordException(__('Invalid email address'));
-            }
-
-         } else {
-            throw new ForgetPasswordException(__("The authentication method configuration doesn't allow you to change your password."));
-         }
-
+         return false;
       }
 
-      if (self::countUsersByEmail($email, $condition) > 1) {
-         throw new ForgetPasswordException(__('Multiple users were found for this email address. Please contact your administrator.'));
-      } else {
-         throw new ForgetPasswordException(__('Email address not found.'));
+      // Check that the configuration allow this user to change his password
+      if ($this->fields["authtype"] !== Auth::DB_GLPI && Auth::useAuthExt()) {
+         trigger_error(
+            __("The authentication method configuration doesn't allow the user '$email' to change his password."),
+            E_USER_WARNING
+         );
+
+         return false;
       }
+
+      // Check that the given email is valid
+      if (!NotificationMailing::isUserAddressValid($email)) {
+         throw new ForgetPasswordException(__('Invalid email address'));
+      }
+
+      // Store password reset token and date
+      $input = [
+         'password_forget_token'      => sha1(Toolbox::getRandomString(30)),
+         'password_forget_token_date' => $_SESSION["glpi_currenttime"],
+         'id'                         => $this->fields['id'],
+      ];
+      $this->update($input);
+
+      // Notication on root entity (glpi_users.entities_id is only a pref)
+      NotificationEvent::raiseEvent('passwordforget', $this, ['entities_id' => 0]);
+      QueuedNotification::forceSendFor($this->getType(), $this->fields['id']);
+
+      return true;
    }
 
 
@@ -5696,5 +5702,50 @@ JAVASCRIPT;
          }
 
       }
+   }
+
+   /**
+    * Find one user which match the given token and asked for a password reset
+    * less than one day ago
+    *
+    * @param string $token password_forget_token
+    *
+    * @return User|null The matching user or null if zero or more than one user
+    *                   were found
+    */
+   public static function getUserByForgottenPasswordToken(
+      string $token
+   ): ?User {
+      global $DB;
+
+      if (empty($token)) {
+         return null;
+      }
+
+      // Find users which match the given token and asked for a password reset
+      // less than one day ago
+      $iterator = $DB->request([
+         'SELECT' => 'id',
+         'FROM'   => self::getTable(),
+         'WHERE'  => [
+            'password_forget_token'       => $token,
+            new \QueryExpression('NOW() < ADDDATE(' . $DB->quoteName('password_forget_token_date') . ', INTERVAL 1 DAY)')
+         ]
+      ]);
+
+      // Check that we found exactly one user
+      if (count($iterator) !== 1) {
+         return null;
+      }
+
+      $data = array_pop(iterator_to_array($iterator));
+
+      // Try to load the user
+      $user = new self();
+      if (!$user->getFromDB($data['id'])) {
+         return null;
+      }
+
+      return $user;
    }
 }

--- a/tests/APIBaseClass.php
+++ b/tests/APIBaseClass.php
@@ -1427,7 +1427,7 @@ abstract class APIBaseClass extends atoum {
             'email'  => 'nonexistent@localhost.local'
          ],
          'server_errors' => [
-            "PHP Warning:  Failed to find a single user for 'nonexistent@localhost.local', 0 user(s) found."
+            "Failed to find a single user for 'nonexistent@localhost.local', 0 user(s) found."
          ]
       ], 200);
 

--- a/tests/APIBaseClass.php
+++ b/tests/APIBaseClass.php
@@ -1377,21 +1377,21 @@ abstract class APIBaseClass extends atoum {
       $user = getItemByTypeName('User', TU_USER);
       $email = $user->getDefaultEmail();
 
-      // Test the verb POST is not alloxed
+      // Check that the POST method is not allowed
       $res = $this->query('lostPassword',
                           ['verb'    => 'POST',
                           ],
                           400,
                           'ERROR');
 
-      // Test the verb GET is not alloxed
+      // Check that the GET method is not allowed
       $res = $this->query('lostPassword',
                           ['verb'    => 'GET',
                           ],
                           400,
                           'ERROR');
 
-      // Test the verb DELETE is not allowed
+      // Check that the DELETE method is not allowed
       $res = $this->query('lostPassword',
                           ['verb'    => 'DELETE',
                           ],
@@ -1402,7 +1402,7 @@ abstract class APIBaseClass extends atoum {
          ->variable['use_notifications']->isEqualTo(0)
          ->variable['notifications_mailing']->isEqualTo(0);
 
-      // Test disabled notifications make this fail
+      // Check that disabled notifications prevent password changes
       $res = $this->query('lostPassword',
                           ['verb'    => 'PUT',
                            'json'    => [
@@ -1412,21 +1412,24 @@ abstract class APIBaseClass extends atoum {
                           400,
                           'ERROR');
 
-      //enable notifications
+      // Enable notifications
       Config::setConfigurationValues('core', [
          'use_notifications' => '1',
          'notifications_mailing' => '1'
       ]);
 
-      // Test an unknown email is rejected
-      $res = $this->query('lostPassword',
-                          ['verb'    => 'PUT',
-                           'json'    => [
-                            'email'  => 'nonexistent@localhost.local'
-                           ]
-                          ],
-                          400,
-                          'ERROR');
+      // Test an unknown email, query will succeed to avoid exposing whether or
+      // not the email actually exist in our database but there will be a
+      // warning in the server logs
+      $this->query('lostPassword', [
+         'verb'    => 'PUT',
+         'json'    => [
+            'email'  => 'nonexistent@localhost.local'
+         ],
+         'server_errors' => [
+            "PHP Warning:  Failed to find a single user for 'nonexistent@localhost.local', 0 user(s) found."
+         ]
+      ], 200);
 
       // Test a valid email is accepted
       $res = $this->query('lostPassword',
@@ -1436,7 +1439,6 @@ abstract class APIBaseClass extends atoum {
                            ]
                           ],
                           200);
-
       // get the password recovery token
       $user = getItemByTypeName('User', TU_USER);
       $token = $user->getField('password_forget_token');
@@ -1445,7 +1447,6 @@ abstract class APIBaseClass extends atoum {
       $res = $this->query('lostPassword',
                           ['verb'    => 'PUT',
                            'json'    => [
-                            'email'                 => $email,
                             'password_forget_token' => $token . 'bad',
                             'password'              => 'NewPassword',
                            ]
@@ -1457,7 +1458,6 @@ abstract class APIBaseClass extends atoum {
       $res = $this->query('lostPassword',
                         ['verb'    => 'PATCH',
                          'json'    => [
-                          'email'                 => $email,
                           'password_forget_token' => $token,
                           'password'              => 'NewPassword',
                          ]

--- a/tests/functionnal/User.php
+++ b/tests/functionnal/User.php
@@ -53,17 +53,19 @@ class User extends \DbTestCase {
     *
     */
    public function testLostPassword() {
-      //would not be logical to login here
+      // would not be logical to login here
       $_SESSION['glpicronuserrunning'] = "cron_phpunit";
       $user = getItemByTypeName('User', TU_USER);
 
       // Test request for a password with invalid email
-      $this->exception(
+      $this->when(
          function() use ($user) {
             $user->forgetPassword('this-email-does-not-exists@example.com');
          }
-      )
-         ->isInstanceOf(\Glpi\Exception\ForgetPasswordException::class);
+      )->error()
+         ->withType(E_USER_WARNING)
+         ->withMessage("Failed to find a single user for 'this-email-does-not-exists@example.com', 0 user(s) found.")
+         ->exists();
 
       // Test request for a password
       $result = $user->forgetPassword($user->getDefaultEmail());
@@ -72,7 +74,6 @@ class User extends \DbTestCase {
       // Test reset password with a bad token
       $token = $user->getField('password_forget_token');
       $input = [
-         'email' => $user->getDefaultEmail(),
          'password_forget_token' => $token . 'bad',
          'password'  => TU_PASS,
          'password2' => TU_PASS
@@ -90,7 +91,6 @@ class User extends \DbTestCase {
 
       // 2 - Set a new password
       $input = [
-         'email' => $user->getDefaultEmail(),
          'password_forget_token' => $token,
          'password'  => 'NewPassword',
          'password2' => 'NewPassword'
@@ -101,7 +101,7 @@ class User extends \DbTestCase {
       $this->boolean($result)->isTrue();
       $newHash = $user->getField('password');
 
-      // 4 - Restore the initial password in the DB before checking he updated password
+      // 4 - Restore the initial password in the DB before checking the updated password
       // This ensure the original password is restored even if the next test fails
       $updateSuccess = $user->update([
          'id'        => $user->getID(),

--- a/tests/router.php
+++ b/tests/router.php
@@ -47,6 +47,6 @@ $DEBUG_SQL = [
     'times'   => [],
 ];
 
-ini_set("error_log", "tests/web/error.log");
+ini_set("log_error", 1);
 
 return false;

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -63,10 +63,27 @@ class APIRest extends APIBaseClass {
    }
 
    public function afterTestMethod($method) {
-      global $CFG_GLPI;
-
       // Check that no errors occured on the test server
       $this->string(file_get_contents(__DIR__ . '/error.log'))->isEmpty();
+   }
+
+   /**
+    * Check errors that are expected to happen on the API server side and thus
+    * can't be caught directly from the unit tests
+    *
+    * @param array $expected_errors
+    *
+    * @return void
+    */
+   protected function checkServerSideError(array $expected_errors): void {
+      $errors = file_get_contents(__DIR__ . '/error.log');
+
+      foreach ($expected_errors as $error) {
+         $this->string($errors)->contains($error);
+      }
+
+      // Clear error file
+      file_put_contents(__DIR__ . '/error.log', "");
    }
 
    protected function doHttpRequest($verb = "get", $relative_uri = "", $params = []) {
@@ -125,11 +142,18 @@ class APIRest extends APIBaseClass {
                       (!empty($resource_query)
                          ? '?' . $resource_query
                          : '');
-      unset($params['itemtype'],
-            $params['id'],
-            $params['parent_itemtype'],
-            $params['parent_id'],
-            $params['verb']);
+
+      $expected_errors = $params['server_errors'] ?? [];
+
+      unset(
+         $params['itemtype'],
+         $params['id'],
+         $params['parent_itemtype'],
+         $params['parent_id'],
+         $params['verb'],
+         $params['server_errors']
+      );
+
       // launch query
       try {
          $res = $this->doHttpRequest($verb, $relative_uri, $params);
@@ -162,6 +186,7 @@ class APIRest extends APIBaseClass {
       // common tests
       $this->variable($res)->isNotNull();
       $this->array($expected_codes)->contains($res->getStatusCode());
+      $this->checkServerSideError($expected_errors);
       return $data;
    }
 

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -52,9 +52,11 @@ class APIRest extends APIBaseClass {
 
       // Clear test server log
       if (!file_exists(__DIR__ . '/error.log')) {
-         touch(__DIR__ . '/error.log');
+         $file_created = touch(__DIR__ . '/error.log');
+         $this->boolean($file_created)->isTrue();
       }
-      file_put_contents(__DIR__ . '/error.log', "");
+      $file_updated = file_put_contents(__DIR__ . '/error.log', "");
+      $this->variable($file_updated)->isNotIdenticalTo(false);
 
       $this->http_client = new GuzzleHttp\Client();
       $this->base_uri    = trim($CFG_GLPI['url_base_api'], "/")."/";


### PR DESCRIPTION
There may be multiple users in GLPI with the same email (there is no unique email constraint).
If one of these users forget his password, the password recovery process fails with "Email address not found" which is confusing as the email address does in fact exist.
This may lead the user (and his administrator) to lose time trying to understand the real issue.

These changes add a different error message for this edge case.

Suggested by @Pieurre

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
