### PR TITLE
Try fixing automatic unlocks

### DIFF
--- a/ajax/unlockobject.php
+++ b/ajax/unlockobject.php
@@ -50,7 +50,7 @@ if (!empty($fetch_data_raw)) {
    $fetch_data = json_decode($fetch_data_raw, true);
 }
 
-if (is_array($fetch_data)) {
+if (isset($fetch_data) && is_array($fetch_data)) {
    $fetch_data = Toolbox::sanitize($fetch_data);
    $_POST = array_merge($_POST, $fetch_data);
 }

--- a/ajax/unlockobject.php
+++ b/ajax/unlockobject.php
@@ -45,6 +45,16 @@ header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 Session::checkLoginUser();
 
+$fetch_data_raw = file_get_contents('php://input');
+if (!empty($fetch_data_raw)) {
+   $fetch_data = json_decode($fetch_data_raw, true);
+}
+
+if (is_array($fetch_data)) {
+   $fetch_data = Toolbox::sanitize($fetch_data);
+   $_POST = array_merge($_POST, $fetch_data);
+}
+
 $ret = 0;
 if (isset($_POST['unlock']) && isset($_POST["id"])) {
    // then we may have something to unlock

--- a/ajax/unlockobject.php
+++ b/ajax/unlockobject.php
@@ -45,16 +45,6 @@ header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 Session::checkLoginUser();
 
-$fetch_data_raw = file_get_contents('php://input');
-if (!empty($fetch_data_raw)) {
-   $fetch_data = json_decode($fetch_data_raw, true);
-}
-
-if (isset($fetch_data) && is_array($fetch_data)) {
-   $fetch_data = Toolbox::sanitize($fetch_data);
-   $_POST = array_merge($_POST, $fetch_data);
-}
-
 $ret = 0;
 if (isset($_POST['unlock']) && isset($_POST["id"])) {
    // then we may have something to unlock

--- a/inc/objectlock.class.php
+++ b/inc/objectlock.class.php
@@ -349,10 +349,10 @@ class ObjectLock extends CommonDBTM {
                      cache: 'no-cache',
                      headers: {
                         'Accept': 'application/json',
-                        'Content-Type': 'application/json',
-                        'X-Glpi-Csrf-Token': getAjaxCsrfToken()
+                        'Content-Type': 'application/x-www-form-urlencoded;',
+                        'X-Glpi-Csrf-Token': getAjaxCsrfToken(),
                      },
-                     body: JSON.stringify({unlock: 1, id: {$id}})
+                     body: 'unlock=1&id={$id}'
                   }).catch(function(error) {
                      //fallback if fetch fails
                      fallback_request();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #9555

Unlock request was recently change to be a fetch but the payload for this type of request isn't automatically put into the superglobal `$_POST` so not data is available to automatically unlock items.

Forced unlocks continued to work because they were not done via fetch.