### PR TITLE
Fix Gannt for PHP 8.1

### DIFF
--- a/src/Gantt/Item.php
+++ b/src/Gantt/Item.php
@@ -33,6 +33,8 @@
 
 namespace Glpi\Gantt;
 
+use ReturnTypeWillChange;
+
 /**
  * Generic class for holding Gantt item details.
  * Used to exchange Json data between client-server functions with Ajax calls.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10436

Fix bad class reference for ReturnTypeWillChange attribute (not in current Glpi\Gantt namespace).