### PR TITLE
Fix handling of REST API payload

### DIFF
--- a/inc/api/apirest.class.php
+++ b/inc/api/apirest.class.php
@@ -453,7 +453,7 @@ class APIRest extends API {
          }
 
          // with this content_type, php://input is empty... (see http://php.net/manual/en/wrappers.php.php)
-         if (!$uploadManifest = json_decode(stripcslashes($_REQUEST['uploadManifest']))) {
+         if (!$uploadManifest = json_decode($_REQUEST['uploadManifest'])) {
             $this->returnError("JSON payload seems not valid", 400, "ERROR_JSON_PAYLOAD_INVALID",
                                false);
          }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since commit c811224616af91b7d9040826dd99bc3a461d754d, `APIRest::parseIncomingParams()` is called prior to sanitizing process (API is using unsanitized data and sanitizes it when it is necessary, see 9246382419e886a90e794226658c98c4ed5f9386).

If a payload containing unicode entities was sent, in a multipart request containing uploaded files, these unicode entities were broken by unnecessary call to `stripcslashes`. Thus, if an input field was containing a `"`, JSON decoding was failing, resulting in a `ERROR_JSON_PAYLOAD_INVALID` error.

Invalid JSON due to removal of backslash preceding a quote:
```diff
-{"input":{"name":"Name with a quote: \"","_filename":["image.png"]}}
+{"input":{"name":"Name with a quote: "","_filename":["image.png"]}}
```

Altered special char due to removal of backslash preceding a unicode entity:
```diff
-{"input":{"name":"Name with a special char: \u00e9","_filename":["image.png"]}}
+{"input":{"name":"Name with a special char: u00e9","_filename":["image.png"]}}
```