### PR TITLE
Remove fallback to active entity in Entity::getUsedConfig()

### DIFF
--- a/src/Application/View/Extension/ConfigExtension.php
+++ b/src/Application/View/Extension/ConfigExtension.php
@@ -68,13 +68,13 @@ class ConfigExtension extends AbstractExtension
      * Get entity configuration value.
      *
      * @param string        $key              Configuration key.
-     * @param null|int      $entity_id        Entity ID, defaults to current entity.
+     * @param int           $entity_id        Entity ID.
      * @param mixed         $default_value    Default value.
      * @param null|string   $inheritence_key  Key to use for inheritence check if different than key used to get value.
      *
      * @return mixed
      */
-    public function getEntityConfig(string $key, ?int $entity_id = null, $default_value = -2, ?string $inheritence_key = null)
+    public function getEntityConfig(string $key, int $entity_id, $default_value = -2, ?string $inheritence_key = null)
     {
         if ($inheritence_key === null) {
             $inheritence_key = $key;

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -3050,7 +3050,7 @@ class Entity extends CommonTreeDropdown
      * @param string  $fieldval       name of the field that we want value (default '')
      * @param mixed   $default_value  value to return (default -2)
      **/
-    public static function getUsedConfig($fieldref, $entities_id = null, $fieldval = '', $default_value = -2)
+    public static function getUsedConfig($fieldref, $entities_id, $fieldval = '', $default_value = -2)
     {
         $id_using_strategy = [
             'calendars_id',
@@ -3072,11 +3072,6 @@ class Entity extends CommonTreeDropdown
                     $fieldref
                 )
             );
-        }
-
-       // Get for current entity
-        if ($entities_id === null) {
-            $entities_id = Session::getActiveEntity();
         }
 
        // for calendar
@@ -3739,6 +3734,9 @@ class Entity extends CommonTreeDropdown
 
     public static function getAnonymizeConfig(?int $entities_id = null)
     {
+        if ($entities_id === null) {
+            $entities_id = Session::getActiveEntity();
+        }
         return Entity::getUsedConfig('anonymize_support_agents', $entities_id);
     }
 

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -61,7 +61,7 @@
             {% if entry_i['users_id_tech'] %}
                <span class="badge bg-orange-lt">
                   {% set is_current_tech = (entry_i['users_id_tech'] == session('glpiID')) %}
-                  {% set anonym_tech = (get_current_interface() == 'helpdesk' and not is_current_tech and entity_config('anonymize_support_agents') != constant('Entity::ANONYMIZE_DISABLED')) %}
+                  {% set anonym_tech = (get_current_interface() == 'helpdesk' and not is_current_tech and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED')) %}
                   {{ include('components/user/link_with_tooltip.html.twig', {
                      'users_id': entry_i['users_id_tech'],
                      'enable_anonymization': anonym_tech

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -46,7 +46,7 @@
       {% set date_mod = entry_i['date_mod'] %}
       {% set entry_rand = random() %}
       {% set is_current_user = users_id == session('glpiID') %}
-      {% set anonym_user = (get_current_interface() == 'helpdesk' and not is_current_user and entity_config('anonymize_support_agents') != constant('Entity::ANONYMIZE_DISABLED')) %}
+      {% set anonym_user = (get_current_interface() == 'helpdesk' and not is_current_user and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED')) %}
 
       {# Fix solution type #}
       {% if entry['type'] is same as 'Solution' %}

--- a/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
@@ -61,7 +61,7 @@
       {% endset %}
 
       {% set is_current_editor = (users_id_editor == session('glpiID')) %}
-      {% set anonym_editor = (get_current_interface() == 'helpdesk' and not is_current_editor and entity_config('anonymize_support_agents') != constant('Entity::ANONYMIZE_DISABLED')) %}
+      {% set anonym_editor = (get_current_interface() == 'helpdesk' and not is_current_editor and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED')) %}
       {% set editor_span %}
          {{ include('components/user/link_with_tooltip.html.twig', {
             'users_id': users_id_editor,

--- a/templates/components/user/picture.html.twig
+++ b/templates/components/user/picture.html.twig
@@ -31,7 +31,7 @@
 
 {% set enable_anonymization = enable_anonymization ?? false %}
 {% set avatar_size = avatar_size ?? "avatar-md" %}
-{% set anonymized = enable_anonymization and entity_config('anonymize_support_agents') != constant('Entity::ANONYMIZE_DISABLED') %}
+{% set anonymized = enable_anonymization and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED') %}
 {% set user = get_item('User', users_id) %}
 {% set user_thumbnail = user.getThumbnailPicturePath(enable_anonymization) %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fallback to active entity is dangerous in `Entity::getUsedConfig()` as, most of the time, this method is used in a cron context (active entity = root) and the config should be related to the processed object (e.g, the entity of a ticket). I do not see any usage of this fallback, so I propose to remove it.

This usage was introduced in https://github.com/glpi-project/glpi/pull/7015/files#diff-f2baa5b27a17ff7ea8035b11b6933f05a1ed3aa1ea898344284fd73d6dc4e9cfR1238 , but was almost removed in https://github.com/glpi-project/glpi/pull/7374.