### PR TITLE
deep control of itil object layout

### DIFF
--- a/ajax/itillayout.php
+++ b/ajax/itillayout.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+include('../inc/includes.php');
+
+header('Content-Type: application/json; charset=UTF-8');
+Html::header_nocache();
+
+Session::checkLoginUser();
+
+$itillayout = json_encode($_POST['itil_layout']);
+if (json_last_error() !== JSON_ERROR_NONE) {
+    exit;
+}
+
+$user = new User();
+$success = $user->update(
+    [
+        'id' => Session::getLoginUserID(),
+        'itil_layout' => $itillayout,
+    ]
+);
+echo json_encode(['success' => $success]);

--- a/ajax/itillayout.php
+++ b/ajax/itillayout.php
@@ -39,7 +39,7 @@ Html::header_nocache();
 Session::checkLoginUser();
 
 $itillayout = json_encode($_POST['itil_layout']);
-if (json_last_error() !== JSON_ERROR_NONE) {
+if ($itillayout !== false) {
     exit;
 }
 

--- a/css/includes/components/itilobject/_layout.scss
+++ b/css/includes/components/itilobject/_layout.scss
@@ -109,8 +109,8 @@
                 }
             }
         }
-        &.right-collapsed {
 
+        &.right-collapsed {
             .itil-left-side {
                 width: calc(100% - 90px);
             }

--- a/css/includes/components/itilobject/_layout.scss
+++ b/css/includes/components/itilobject/_layout.scss
@@ -63,7 +63,7 @@
                 }
             }
 
-            #heading-main-item .accordion-button.collapsed  {
+            #heading-main-item .accordion-button.collapsed {
                 .status-recall {
                     display: inline-block;
                 }
@@ -76,7 +76,6 @@
             .switch-panel-width {
                 display: none;
             }
-
         }
     }
 
@@ -111,6 +110,7 @@
             }
         }
         &.right-collapsed {
+
             .itil-left-side {
                 width: calc(100% - 90px);
             }
@@ -119,7 +119,7 @@
                 overflow: hidden;
                 width: 90px;
 
-                #itil-data { //accordion
+                #itil-data { // accordion
                     .item-title {
                         display: none;
                     }
@@ -142,10 +142,13 @@
                 .timeline-buttons {
                     flex: 1 1 auto;
                 }
+
                 .form-buttons {
                     flex: inherit;
                 }
-                .switch-panel-width, .collapse-panel {
+
+                .switch-panel-width,
+                .collapse-panel {
                     display: none;
                 }
             }

--- a/css/includes/components/itilobject/_layout.scss
+++ b/css/includes/components/itilobject/_layout.scss
@@ -30,8 +30,12 @@
  */
 
 .itil-object {
+    .status-recall {
+        display: none;
+    }
+
     @include media-breakpoint-up(sm) {
-        height: calc(100vh - 178px);
+        height: calc(100vh - 187px);
 
         .itil-left-side,
         .itil-right-side {
@@ -58,6 +62,21 @@
                     background-color: $accordion-button-bg;
                 }
             }
+
+            #heading-main-item .accordion-button.collapsed  {
+                .status-recall {
+                    display: inline-block;
+                }
+
+                .item-icon {
+                    display: none;
+                }
+            }
+
+            .switch-panel-width {
+                display: none;
+            }
+
         }
     }
 
@@ -78,6 +97,56 @@
         .badge {
             text-transform: none;
             margin: calc(-0.25rem + 1px) -0.25rem;
+        }
+    }
+}
+
+#itil-object-container {
+    &.right-expanded {
+        .itil-footer {
+            .collapse-panel {
+                display: none;
+            }
+        }
+    }
+    &.right-collapsed {
+        .itil-left-side {
+            width: calc(100% - 90px);
+        }
+
+        .itil-right-side {
+            overflow: hidden;
+            width: 90px;
+
+            #itil-data { //accordion
+                .item-title {
+                    display: none;
+                }
+
+                .accordion-collapse {
+                    display: none;
+                }
+
+                .accordion-button::after {
+                    display: none;
+                }
+            }
+
+            .switch-panel-width {
+                display: inline-block;
+            }
+        }
+
+        .itil-footer {
+            .timeline-buttons {
+                flex: 1 1 auto;
+            }
+            .form-buttons {
+                flex: inherit;
+            }
+            .switch-panel-width, .collapse-panel {
+                display: none;
+            }
         }
     }
 }

--- a/css/includes/components/itilobject/_layout.scss
+++ b/css/includes/components/itilobject/_layout.scss
@@ -102,50 +102,52 @@
 }
 
 #itil-object-container {
-    &.right-expanded {
-        .itil-footer {
-            .collapse-panel {
-                display: none;
-            }
-        }
-    }
-    &.right-collapsed {
-        .itil-left-side {
-            width: calc(100% - 90px);
-        }
-
-        .itil-right-side {
-            overflow: hidden;
-            width: 90px;
-
-            #itil-data { //accordion
-                .item-title {
-                    display: none;
-                }
-
-                .accordion-collapse {
-                    display: none;
-                }
-
-                .accordion-button::after {
+    @include media-breakpoint-up(sm) {
+        &.right-expanded {
+            .itil-footer {
+                .collapse-panel {
                     display: none;
                 }
             }
-
-            .switch-panel-width {
-                display: inline-block;
-            }
         }
+        &.right-collapsed {
+            .itil-left-side {
+                width: calc(100% - 90px);
+            }
 
-        .itil-footer {
-            .timeline-buttons {
-                flex: 1 1 auto;
+            .itil-right-side {
+                overflow: hidden;
+                width: 90px;
+
+                #itil-data { //accordion
+                    .item-title {
+                        display: none;
+                    }
+
+                    .accordion-collapse {
+                        display: none;
+                    }
+
+                    .accordion-button::after {
+                        display: none;
+                    }
+                }
+
+                .switch-panel-width {
+                    display: inline-block;
+                }
             }
-            .form-buttons {
-                flex: inherit;
-            }
-            .switch-panel-width, .collapse-panel {
-                display: none;
+
+            .itil-footer {
+                .timeline-buttons {
+                    flex: 1 1 auto;
+                }
+                .form-buttons {
+                    flex: inherit;
+                }
+                .switch-panel-width, .collapse-panel {
+                    display: none;
+                }
             }
         }
     }

--- a/inc/define.php
+++ b/inc/define.php
@@ -460,7 +460,8 @@ $CFG_GLPI['user_pref_field'] = ['backcreated', 'csv_delimiter', 'date_format',
     'use_flat_dropdowntree', 'palette', 'page_layout',
     'highcontrast_css', 'default_dashboard_central', 'default_dashboard_assets',
     'default_dashboard_helpdesk', 'default_dashboard_mini_ticket', 'default_central_tab',
-    'fold_menu', 'fold_search', 'savedsearches_pinned', 'richtext_layout', 'timeline_order'
+    'fold_menu', 'fold_search', 'savedsearches_pinned', 'richtext_layout', 'timeline_order',
+    'itil_layout'
 ];
 
 $CFG_GLPI['lock_lockable_objects'] = ['Budget',  'Change', 'Contact', 'Contract', 'Document',

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -238,6 +238,7 @@ $default_prefs = [
     'fold_search'                             => '0',
     'savedsearches_pinned'                    => '0',
     'timeline_order'                          => 'natural',
+    'itil_layout'                             => '',
     'richtext_layout'                         => 'inline',
     'lock_use_lock_item'                      => '0',
     'lock_autolock_mode'                      => '1',

--- a/install/migrations/update_9.5.x_to_10.0.0/configs.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/configs.php
@@ -68,5 +68,8 @@ Config::setConfigurationValues('core', ['user_restored_ldap' => 0]);
 Config::setConfigurationValues('core', ['timeline_order' => 'natural']);
 $migration->addField("glpi_users", "timeline_order", "char(20) DEFAULT NULL", ['after' => 'savedsearches_pinned']);
 
+Config::setConfigurationValues('core', ['itil_layout' => 0]);
+$migration->addField('glpi_users', 'itil_layout', 'text', ['after' => 'timeline_order']);
+
 $migration->displayMessage('Drop obsolete automatic transfer configuration');
 Config::deleteConfigurationValues('core', ['transfers_id_auto']);

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -7581,6 +7581,7 @@ CREATE TABLE `glpi_users` (
   `fold_search` tinyint DEFAULT NULL,
   `savedsearches_pinned` text,
   `timeline_order` char(20) DEFAULT NULL,
+  `itil_layout` text,
   `richtext_layout` char(20) DEFAULT NULL,
   `set_default_requester` tinyint DEFAULT NULL,
   `lock_autolock_mode` tinyint DEFAULT NULL,

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -154,7 +154,7 @@
             }).done(function(number) {
                var badge = "";
                if (number.length > 0) {
-                  badge = `<span class="badge bg-secondary">
+                  badge = `<span class="badge bg-secondary-lt">
                      ${number}
                   </span>`;
                }

--- a/templates/components/itilobject/actors/main.html.twig
+++ b/templates/components/itilobject/actors/main.html.twig
@@ -38,7 +38,10 @@
    {% set display_labels = true %}
 {% endif %}
 
-{% set actor_options = field_options|merge({is_horizontal: false}) %}
+{% set actor_options = field_options|merge({
+    is_horizontal: false,
+    add_field_class: (is_expanded ? 'col-sm-4' : ''),
+}) %}
 {% set can_admin = item.canAdminActors() %}
 {% if item.isNewItem() %}
    {% set can_admin = true %}

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -33,18 +33,28 @@
 {% set field_options = {
    'full_width': true,
    'fields_template': itiltemplate,
-   'disabled': (not canupdate)
+   'disabled': (not canupdate),
+   'add_field_class': (is_expanded ? 'col-sm-6' : ''),
 } %}
 
+{% set itil_layout    = user_pref('itil_layout', true) %}
+{% set headers_states = itil_layout['items'] %}
+
 <div class="accordion open accordion-flush" id="itil-data">
+   {% set main_show = headers_states['item-main'] is not defined or headers_states['item-main'] == "true" ? true : false %}
    <div class="accordion-item">
-      <h2 class="accordion-header" id="heading-main-ticket">
-         <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#ticket-main" aria-expanded="true" aria-controls="ticket-main">
-            <i class="ti ti-alert-circle me-1"></i>
-            <span>{{ item.getTypeName(1) }}</span>
+      <h2 class="accordion-header" id="heading-main-item">
+         <button class="accordion-button {{ main_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#item-main" aria-expanded="true" aria-controls="ticket-main">
+            <i class="ti ti-alert-circle me-1 item-icon"></i>
+            <span class='status-recall'>
+                {{ item.getStatusIcon(item.fields['status'])|raw }}
+            </span>
+            <span class="item-title">
+                {{ item.getTypeName(1) }}
+            </span>
          </button>
       </h2>
-      <div id="ticket-main" class="accordion-collapse collapse show" aria-labelledby="heading-main-ticket">
+      <div id="item-main" class="accordion-collapse collapse {{ main_show ? "show" : "" }}" aria-labelledby="heading-main-item">
          <div class="accordion-body row m-0 mt-n2">
 
             {{ call_plugin_hook('pre_item_form', {"item": item, 'options': params}) }}
@@ -232,17 +242,20 @@
       </div>
    </div>
 
+   {% set actors_show = headers_states['actors'] is not defined or headers_states['actors'] == "true" ? true : false %}
    <div class="accordion-item">
-      <h2 class="accordion-header" id="heading-actor">
-         <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#actors" aria-expanded="true" aria-controls="actors">
+      <h2 class="accordion-header" id="heading-actor" title="{{ __('Actors') }}" data-bs-toggle="tooltip">
+         <button class="accordion-button {{ actors_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#actors" aria-expanded="true" aria-controls="actors">
             <i class="ti ti-users me-1"></i>
-            <span>{{ __('Actors') }}</span>
+            <span class="item-title">
+                {{ __('Actors') }}
+            </span>
             <span class="badge bg-secondary ms-2">
                {{ item.countActors() }}
             </span>
          </button>
       </h2>
-      <div id="actors" class="accordion-collapse collapse show" aria-labelledby="heading-actor">
+      <div id="actors" class="accordion-collapse collapse {{ actors_show ? "show" : "" }}" aria-labelledby="heading-actor">
          <div class="accordion-body accordion-actors row m-0 mt-n2">
             {{ include('components/itilobject/actors/main.html.twig') }}
          </div>
@@ -250,15 +263,18 @@
    </div>
 
    {% if item_ticket is defined and item_ticket is not null %}
+      {% set items_show = headers_states['items'] is not defined or headers_states['items'] == "true" ? true : false %}
       <div class="accordion-item">
-         <h2 class="accordion-header" id="items-heading">
-            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#items" aria-expanded="true" aria-controls="items">
+         <h2 class="accordion-header" id="items-heading" title="{{ _n('Item', 'Items', get_plural_number()) }}" data-bs-toggle="tooltip">
+            <button class="accordion-button {{ items_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#items" aria-expanded="true" aria-controls="items">
                <i class="ti ti-package me-1"></i>
-               <span>{{ _n('Item', 'Items', get_plural_number()) }}</span>
+               <span class="item-title">
+                    {{ _n('Item', 'Items', get_plural_number()) }}
+                </span>
                <span class="item-counter badge bg-secondary ms-2"></span>
             </button>
          </h2>
-         <div id="items" class="accordion-collapse collapse show" aria-labelledby="items-heading">
+         <div id="items" class="accordion-collapse collapse {{ items_show ? "show" : "" }}" aria-labelledby="items-heading">
             <div class="accordion-body accordion-items row m-0 mt-n2">
                {{ item_ticket.itemAddForm(item, params|default({})) }}
             </div>
@@ -268,17 +284,20 @@
 
    {% if item.getType() == 'Ticket' %}
       {% set nb_la = (item.fields['slas_id_tto'] > 0 ? 1 : 0) + (item.fields['slas_id_ttr'] > 0 ? 1 : 0) + (item.fields['olas_id_tto'] > 0 ? 1 : 0) + (item.fields['olas_id_ttr'] > 0 ? 1 : 0) %}
+      {% set servicelevels_show = headers_states['service-levels'] is defined and headers_states['service-levels'] == "true" ? true : false %}
       <div class="accordion-item">
-         <h2 class="accordion-header" id="service-levels-heading">
-            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#service-levels" aria-expanded="true" aria-controls="service-levels">
+         <h2 class="accordion-header" id="service-levels-heading" title="{{ _n('Service level', 'Service levels', get_plural_number()) }}" data-bs-toggle="tooltip">
+            <button class="accordion-button {{ servicelevels_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#service-levels" aria-expanded="true" aria-controls="service-levels">
                <i class="ti ti-alarm me-1"></i>
-               <span>{{ _n('Service level', 'Service levels', get_plural_number()) }}</span>
+               <span class="item-title">
+                    {{ _n('Service level', 'Service levels', get_plural_number()) }}
+               </span>
                {% if nb_la > 0 %}
                   <span class="badge bg-secondary ms-2">{{ nb_la }}</span>
                {% endif %}
             </button>
          </h2>
-         <div id="service-levels" class="accordion-collapse collapse" aria-labelledby="service-levels-heading">
+         <div id="service-levels" class="accordion-collapse collapse {{ servicelevels_show ? "show" : "" }}" aria-labelledby="service-levels-heading">
             <div class="accordion-body row m-0 mt-n2">
                {{ include('components/itilobject/service_levels.html.twig') }}
             </div>
@@ -300,17 +319,20 @@
             {% set nb_analysis = nb_analysis + 1 %}
          {% endif %}
       {% endfor %}
+      {% set analysis_show = headers_states['analysis'] is defined and headers_states['analysis'] == "true" ? true : false %}
       <div class="accordion-item">
-         <h2 class="accordion-header" id="analysis-heading">
-            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#analysis" aria-expanded="true" aria-controls="analysis">
+         <h2 class="accordion-header" id="analysis-heading" title="{{ __("Analysis") }}" data-bs-toggle="tooltip">
+            <button class="accordion-button {{ analysis_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#analysis" aria-expanded="true" aria-controls="analysis">
                <i class="ti ti-eyeglass me-1"></i>
-               <span>{{ __("Analysis") }}</span>
+               <span class="item-title">
+                    {{ __("Analysis") }}
+               </span>
                {% if nb_analysis > 0 %}
                   <span class="badge bg-secondary ms-2">{{ nb_analysis }}</span>
                {% endif %}
             </button>
          </h2>
-         <div id="analysis" class="accordion-collapse collapse" aria-labelledby="analysis-heading">
+         <div id="analysis" class="accordion-collapse collapse {{ analysis_show ? "show" : "" }}" aria-labelledby="analysis-heading">
             <div class="accordion-body row m-0 mt-n2">
                {% for analysis_field, label in analysis_fields %}
                   {% if item.isField(analysis_field) %}
@@ -344,17 +366,20 @@
          {% endif %}
       {% endfor %}
 
+      {% set plans_show = headers_states['plans'] is defined and headers_states['plans'] == "true" ? true : false %}
       <div class="accordion-item">
-         <h2 class="accordion-header" id="plans-heading">
-            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#plans" aria-expanded="true" aria-controls="plans">
+         <h2 class="accordion-header" id="plans-heading" title="{{ __("Plans") }}" data-bs-toggle="tooltip">
+            <button class="accordion-button {{ plans_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#plans" aria-expanded="true" aria-controls="plans">
                <i class="ti ti-checkup-list me-1"></i>
-               <span>{{ __("Plans") }}</span>
+               <span class="item-title">
+                    {{ __("Plans") }}
+               </span>
                {% if nb_plans > 0 %}
                   <span class="badge bg-secondary ms-2">{{ nb_plans }}</span>
                {% endif %}
             </button>
          </h2>
-         <div id="plans" class="accordion-collapse collapse" aria-labelledby="plans-heading">
+         <div id="plans" class="accordion-collapse collapse {{ plans_show ? "show" : "" }}" aria-labelledby="plans-heading">
             <div class="accordion-body row m-0 mt-n2">
                {% for plans_field, label in plans_fields %}
                   {% if item.isField(plans_field) %}
@@ -375,28 +400,35 @@
    {% endif %}
 
    {% if ticket_ticket %}
+      {% set linked_tickets_show = headers_states['linked_tickets'] is defined and headers_states['linked_tickets'] == "true" ? true : false %}
       <div class="accordion-item">
-         <h2 class="accordion-header" id="linked_tickets-heading">
-            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#linked_tickets" aria-expanded="true" aria-controls="linked_tickets">
+         <h2 class="accordion-header" id="linked_tickets-heading" title="{{ 'Ticket_Ticket'|itemtype_name(nb_linked_tickets) }}" data-bs-toggle="tooltip">
+            <button class="accordion-button {{ linked_tickets_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#linked_tickets" aria-expanded="true" aria-controls="linked_tickets">
                <i class="ti ti-link me-1"></i>
                {% set linked_tickets = ticket_ticket.getLinkedTicketsTo(item.fields['id']) %}
                {% set nb_linked_tickets = linked_tickets|length %}
                {% if item.isNewItem() and params['_link']['tickets_id_2']|length > 0 %}
                   {% set nb_linked_tickets = 1 %}
                {% endif %}
-               <span>{{ 'Ticket_Ticket'|itemtype_name(nb_linked_tickets) }}</span>
+               <span class="item-title">
+                    {{ 'Ticket_Ticket'|itemtype_name(nb_linked_tickets) }}
+               </span>
                {% if nb_linked_tickets > 0 %}
                   <span class="badge bg-secondary ms-2">{{ nb_linked_tickets }}</span>
                {% endif %}
             </button>
          </h2>
-         <div id="linked_tickets" class="accordion-collapse collapse" aria-labelledby="linked_tickets-heading">
+         <div id="linked_tickets" class="accordion-collapse collapse {{ linked_tickets_show ? "show" : "" }}" aria-labelledby="linked_tickets-heading">
             <div class="accordion-body">
                {{ include('components/itilobject/linked_tickets.html.twig') }}
             </div>
          </div>
       </div>
    {% endif %}
+
+    <button type="button" class="switch-panel-width btn btn-sm btn-square btn-icon btn-ghost-secondary position-absolute bottom-0 start-0 mb-2">
+        <i class="fas fa-caret-left"></i>
+    </button>
 </div>
 
 <script type="text/javascript">

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -29,10 +29,19 @@
  # ---------------------------------------------------------------------
  #}
 
+{% set timeline_btns_cls = "col-md-8" %}
+{% set form_btns_cls     = "col-md" %}
+{% set switch_btn_cls    = "fa-caret-left" %}
+{% if is_expanded %}
+    {% set timeline_btns_cls = "col-md-4" %}
+    {% set form_btns_cls     = "col-md-8" %}
+    {% set switch_btn_cls    = "fa-caret-right" %}
+{% endif %}
+
 <div class="mx-n2 mb-n2 itil-footer itil-footer p-0 border-top" id="itil-footer">
    <div class="buttons-bar d-flex py-2">
       {% if not item.isNewItem() %}
-         <div class="col-md-8 ps-3 timeline-buttons">
+         <div class="{{ timeline_btns_cls }} ps-3 timeline-buttons">
             {% set default_action_data = timeline_itemtypes|first %}
             {% if item.isNotSolved() and default_action_data != false %}
                {% if timeline_itemtypes|length > 1 %}
@@ -71,11 +80,14 @@
          </div>
       {% endif %}
 
-      <div class="form-buttons col-md d-flex justify-content-end ms-auto ms-md-0 my-n2 py-2 pe-3 card-footer border-top-0 position-relative">
+      <div class="form-buttons {{ form_btns_cls }} d-flex justify-content-end ms-auto ms-md-0 my-n2 py-2 pe-3 card-footer border-top-0 position-relative">
          <span class="d-none d-md-block position-absolute top-0 start-0"
                data-bs-toggle="tooltip" data-bs-placement="top" title="{{ __('Toggle panels width') }}">
             <button type="button" class="switch-panel-width btn btn-sm btn-square btn-icon btn-ghost-secondary">
-               <i class="fas fa-caret-left"></i>
+               <i class="fas {{ switch_btn_cls }}"></i>
+            </button>
+            <button type="button" class="collapse-panel btn btn-sm btn-square btn-icon btn-ghost-secondary">
+               <i class="fas fa-caret-right"></i>
             </button>
          </span>
 

--- a/templates/components/itilobject/layout.html.twig
+++ b/templates/components/itilobject/layout.html.twig
@@ -32,22 +32,36 @@
 {% set rand = random() %}
 {% set main_rand = rand %}
 
-<div class="mt-n1" id="itil-object-container">
+{% set itil_layout = user_pref('itil_layout', true) %}
+{% set is_collapsed = itil_layout['collapsed'] == "true" %}
+{% set is_expanded  = itil_layout['expanded'] == "true" %}
+{% set collapsed_cls = (is_collapsed ? "right-collapsed" : "") %}
+{% set expanded_cls  = (is_expanded == "true" ? "right-expanded" : "") %}
+
+{% set left_side_cls = "col-md-8" %}
+{% set right_side_cls = "col-md-4" %}
+{% if is_expanded %}
+    {% set left_side_cls = "col-md-4" %}
+    {% set right_side_cls = "col-md-8" %}
+{% endif %}
+
+
+<div id="itil-object-container" class="mt-n1 {{ collapsed_cls }} {{ expanded_cls }}">
 
    {% if item.isNewItem and not params['template_preview'] %}
       {{ include('components/itilobject/mainform_open.html.twig') }}
    {% endif %}
 
-   <div class="row d-flex flex-column align-items-stretch itil-object ">
-      {% set fl_direction = (item.isNewItem ? 'flex-column' : 'flex-column-reverse') %}
-      <div class="itil-left-side col-12 col-md-8 order-last order-md-first pt-2 pe-2 pe-md-4 d-flex {{ fl_direction }} border-top border-4">
+   <div class="row d-flex flex-column alin-items-stretch itil-object">
+      {% set fl_direction = (item.isNewItemg ? 'flex-column' : 'flex-column-reverse') %}
+      <div class="itil-left-side col-12 {{ left_side_cls }} order-last order-md-first pt-2 pe-2 pe-md-4 d-flex {{ fl_direction }} border-top border-4">
          {% if item.isNewItem() %}
             {{ include('components/itilobject/timeline/new_form.html.twig') }}
          {% else %}
             {{ include('components/itilobject/timeline/timeline.html.twig') }}
          {% endif %}
       </div>
-      <div class="itil-right-side col-12 col-md-4 mt-0 mt-md-n1 card-footer p-0 rounded-0">
+      <div class="itil-right-side col-12 {{ right_side_cls }} mt-0 mt-md-n1 card-footer p-0 rounded-0">
          {% if not item.isNewItem() %}
             {{ include('components/itilobject/mainform_open.html.twig') }}
          {% endif %}
@@ -95,23 +109,89 @@
 <script type="text/javascript">
 $(function() {
    $(document).on("click", ".switch-panel-width", function() {
-      if ($('.itil-left-side').hasClass('col-md-8')) {
+       if ($('#itil-object-container').hasClass('right-collapsed')) {
+           $('#itil-object-container').removeClass('right-collapsed');
+       } else if ($('.itil-left-side').hasClass('col-md-8')) {
+         $('#itil-object-container').addClass('right-expanded');
          $('.itil-left-side').removeClass('col-md-8').addClass('col-md-4');
          $('.itil-footer .timeline-buttons').removeClass('col-md-8').addClass('col-md-4');
          $('.itil-footer .form-buttons').removeClass('col-md').addClass('col-md-8');
          $('.itil-right-side').removeClass('col-md-4').addClass('col-md-8');
          $('.switch-panel-width i.fas').removeClass('fa-caret-left').addClass('fa-caret-right');
-         $('.itil-right-side .accordion-body:not(.accordion-actors).row .col-12').removeClass('col-12').addClass('col-6');
-         $('#actors .col-12').removeClass('col-12').addClass('col-4');
+         $('.itil-right-side .accordion-body:not(.accordion-actors).row .col-12').removeClass('col-12').addClass('col-sm-6');
+         $('#actors .col-12').removeClass('col-12').addClass('col-sm-4');
       } else {
+         $('#itil-object-container').removeClass('right-expanded');
          $('.itil-left-side').removeClass('col-md-4').addClass('col-md-8');
          $('.itil-right-side').removeClass('col-md-8').addClass('col-md-4');
          $('.itil-footer .timeline-buttons').removeClass('col-md-4').addClass('col-md-8');
          $('.itil-footer .form-buttons').removeClass('col-md-8').addClass('col-md');
          $('.switch-panel-width i.fas').removeClass('fa-caret-right').addClass('fa-caret-left');
-         $('.itil-right-side .accordion-body:not(.accordion-actors).row .col-6').removeClass('col-6').addClass('col-12');
-         $('#actors .col-4').removeClass('col-4').addClass('col-12');
+         $('.itil-right-side .accordion-body:not(.accordion-actors).row .col-sm-6').removeClass('col-sm-6').addClass('col-12');
+         $('#actors .col-sm-4').removeClass('col-sm-4').addClass('col-12');
       }
+
+      saveFieldPanelState();
    });
+
+    $(document).on("click", ".collapse-panel", function() {
+       $('#itil-object-container').addClass('right-collapsed');
+
+        // Hide all accordion item
+        $('#itil-data .accordion-collapse').removeClass('show');
+        $('#itil-data .accordion-button').addClass('collapsed');
+
+       saveFieldPanelState();
+    });
+
+    $(document).on("click", ".right-collapsed .itil-right-side", function(event) {
+        $('#itil-object-container').removeClass('right-collapsed');
+        saveFieldPanelState();
+    });
+
+    var myCollapsible = document.getElementById('itil-data')
+    myCollapsible.addEventListener('shown.bs.collapse', function () {
+        saveFieldPanelState();
+    });
+    myCollapsible.addEventListener('hidden.bs.collapse', function () {
+        saveFieldPanelState();
+    });
+
+    var itil_layout = {
+        collapsed: false,
+        expanded: false,
+        items: {}
+    };
+
+    var saveFieldPanelState = function() {
+        itil_layout.collapsed = $('#itil-object-container').hasClass('right-collapsed');
+        itil_layout.expanded  = $('#itil-object-container').hasClass('right-expanded');
+
+        $('#itil-data .accordion-collapse').each(function() {
+            var item_shown = $(this).hasClass('show');
+            var item_id    = $(this).attr('id');
+
+            itil_layout.items[item_id] = item_shown;
+        });
+
+        $.ajax({
+            url: CFG_GLPI.root_doc + '/ajax/itillayout.php',
+            type: 'POST',
+            datatype: "json",
+            data: {
+                'itil_layout': itil_layout
+            }
+        });
+    }
+
+    var restoreFieldPanelState = function() {
+        $.each(field_panel_state.items, function(item_id, item_shown) {
+            if (item_shown) {
+                $('#' + item_id).addClass('show');
+            } else {
+                $('#' + item_id).removeClass('show');
+            }
+        });
+    }
 });
 </script>

--- a/templates/components/itilobject/service_levels.html.twig
+++ b/templates/components/itilobject/service_levels.html.twig
@@ -171,6 +171,7 @@
                         'entity': item.fields['entities_id'],
                         'condition': {'type': la_field.type},
                         'disabled': (not canupdate),
+                        'add_field_class': (is_expanded ? 'col-sm-6' : ''),
                      }
                   ) }}
                </div>
@@ -222,7 +223,8 @@
          mb: 'mb-2',
          label_class: 'col-auto',
          full_width: true,
-         is_horizontal: false
+         is_horizontal: false,
+         add_field_class: (is_expanded ? 'col-sm-6' : ''),
       }
    ) }}
 {% endfor %}


### PR DESCRIPTION
|Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Following an internal conversation with Nicolas about layout of itil objects and his usage of GLPI.
So, here is a list of features provided by this PR:

- right panel can be collapsed
- any click on the collapsed state will expand it
- state of collapsed/full expand right panel and also state of accordion is saved into db by ajax query
- we restore the states when constructing html
- status icon is recalled in first accordion heading when status dropdown is considered as not displayed

![image](https://user-images.githubusercontent.com/418844/151163508-6963a217-eb7d-4ca1-bf65-97ba5e27100d.png)

![image](https://user-images.githubusercontent.com/418844/151163689-fc4146e0-bf9a-4717-8ef8-d1079f380942.png)

![image](https://user-images.githubusercontent.com/418844/151163481-32bc1195-3b62-4f2e-85f8-f45ca8083e7d.png)

