### PR TITLE
fix button alignement in legacy timeline actions

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -531,11 +531,12 @@ ul.legacy-timeline-actions {
     list-style: none;
     display: inline-flex;
     margin-bottom: 0;
+    position: relative;
+    top: -3px;
 
     li {
         display: inline;
         margin-left: 5px;
-        border: $input-border-width solid $input-border-color;
         border-radius: 5px;
         padding: 5px;
 


### PR DESCRIPTION
Seen with Formcreator, which adds a timeline action

### before 
![image](https://user-images.githubusercontent.com/14139801/151166191-2c614bfb-3e5b-4244-af30-e05868f8a117.png)

### intermediate (without change in Formcreator)

![image](https://user-images.githubusercontent.com/14139801/151168973-a2d9e4c3-ba57-4ea2-bae6-642ef68c3009.png)

### after (with change in Formcreator)

To have a consistent height of the button I replaced the HTML I tag with a BUTTON tag. I think this is acceptable to switch to GLPI 10,

![image](https://user-images.githubusercontent.com/14139801/151168345-498d715a-32e8-4a97-9f9a-4f76d73618a4.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
