### PR TITLE
fix(agent): try http first

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -552,7 +552,7 @@ class Agent extends CommonDBTM
     public function getAgentURLs(): array
     {
         $adresses = $this->guessAddresses();
-        $protocols = ['https', 'http'];
+        $protocols = ['http', 'https'];
         $port = (int)$this->fields['port'];
         if ($port === 0) {
             $port = self::DEFAULT_PORT;

--- a/tests/functionnal/Agent.php
+++ b/tests/functionnal/Agent.php
@@ -124,18 +124,18 @@ class Agent extends DbTestCase
         ]);
 
         $this->array($this->testedInstance->getAgentURLs())->isIdenticalTo([
-            'https://glpixps:62354',
-            'https://192.168.1.142:62354',
-            'https://[fe80::b283:4fa3:d3f2:96b1]:62354',
-            'https://192.168.1.118:62354',
-            'https://[fe80::92a4:26c6:99dd:2d60]:62354',
-            'https://192.168.122.1:62354',
             'http://glpixps:62354',
             'http://192.168.1.142:62354',
             'http://[fe80::b283:4fa3:d3f2:96b1]:62354',
             'http://192.168.1.118:62354',
             'http://[fe80::92a4:26c6:99dd:2d60]:62354',
-            'http://192.168.122.1:62354'
+            'http://192.168.122.1:62354',
+            'https://glpixps:62354',
+            'https://192.168.1.142:62354',
+            'https://[fe80::b283:4fa3:d3f2:96b1]:62354',
+            'https://192.168.1.118:62354',
+            'https://[fe80::92a4:26c6:99dd:2d60]:62354',
+            'https://192.168.122.1:62354'
         ]);
 
         //link a domain to item and see if adresses are still ok


### PR DESCRIPTION
The SSL module is not enabled by default on the agent.

GLPI should calculate URLs with HTTP first


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
