### PR TITLE
fix(twig): hook at the end of the display

### DIFF
--- a/templates/components/form/inventory_info.html.twig
+++ b/templates/components/form/inventory_info.html.twig
@@ -53,11 +53,6 @@
          </span>
       {% endif %}
    </div>
-   {% if item.fields['id'] > 0 and item.isField('is_dynamic') %}
-      <div class="card-body row">
-         {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::AUTOINVENTORY_INFORMATION'), item) }}
-      </div>
-   {% endif %}
    {% set agent = item is usingtrait('Glpi\\Features\\Inventoriable') ? item.getInventoryAgent() : null %}
    {% if agent is not null %}
       <div class="card-body row">
@@ -99,6 +94,11 @@
             </label>
             <span id='inventory_status'>{{ __('Unknown') }}</span>
          </div>
+
+         {% if item.fields['id'] > 0 and item.isField('is_dynamic') %}
+            {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::AUTOINVENTORY_INFORMATION'), item) }}
+         {% endif %}
+
       </div>
 
       <script>


### PR DESCRIPTION
Display hook after core

Before

![image](https://user-images.githubusercontent.com/7335054/151338846-aa065358-2991-4c5d-b4a0-b0654e4f3fff.png)

After

![image](https://user-images.githubusercontent.com/7335054/151338871-aac4ce97-bb35-4064-9137-82e15b89bf1f.png)



| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
