### PR TITLE
Replace user-facing master/slave DB usage with main/replica

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ The present file will list all changes made to the project; according to the
 - PDF export library has been changed from `TCPDF` to `mPDF`.
 - The search engine and search results page now support sorting by multiple fields.
 - The search result lists now refresh/update without triggering a full page reload.
+- Replaced user-facing cases of master/slave usage replaced with main/replica.
 
 ### Deprecated
 - Usage of XML-RPC API is deprecated.
+- The database "slaves" property in the status checker (/status.php and glpi:system:status) is deprecated. Use "replicas" instead,
+- The database "master" property in the status checker (/status.php and glpi:system:status) is deprecated. Use "main" instead,
 
 ### Removed
 - Autocomplete feature on text fields.

--- a/src/Config.php
+++ b/src/Config.php
@@ -799,7 +799,7 @@ class Config extends CommonDBTM
         echo "</td></tr>";
 
         echo "<tr class='tab_bg_2'>";
-        echo "<td>" . __('Use the slave for the search engine') . "</td><td>";
+        echo "<td>" . __('Use the replica for the search engine') . "</td><td>";
         $values = [0 => __('Never'),
             1 => __('If synced (all changes)'),
             2 => __('If synced (current user changes)'),

--- a/src/DBConnection.php
+++ b/src/DBConnection.php
@@ -613,7 +613,7 @@ class DBConnection extends CommonDBTM
     {
 
         return ['description' => __('Check the SQL replica'),
-            'parameter'   => __('Max delay between master and slave (minutes)')
+            'parameter'   => __('Max delay between main and replica (minutes)')
         ];
     }
 
@@ -650,7 +650,7 @@ class DBConnection extends CommonDBTM
                 } else {
                                   //TRANS: %1$s is the server name, %2$s is the time
                     $task->log(sprintf(
-                        __('SQL server: %1$s, difference between master and slave: %2$s'),
+                        __('SQL server: %1$s, difference between main and replica: %2$s'),
                         $name,
                         Html::timestampToString($diff, true)
                     ));
@@ -696,11 +696,11 @@ class DBConnection extends CommonDBTM
             } else if ($diff) {
                 printf(
                     __('%1$s: %2$s') . "<br>",
-                    __('Difference between master and slave'),
+                    __('Difference between main and replica'),
                     Html::timestampToString($diff, 1)
                 );
             } else {
-                printf(__('%1$s: %2$s') . "<br>", __('Difference between master and slave'), __('None'));
+                printf(__('%1$s: %2$s') . "<br>", __('Difference between main and replica'), __('None'));
             }
         }
     }

--- a/src/NotificationTargetDBConnection.php
+++ b/src/NotificationTargetDBConnection.php
@@ -76,7 +76,7 @@ class NotificationTargetDBConnection extends NotificationTarget
     public function getTags()
     {
 
-        $tags = ['dbconnection.delay' => __('Difference between master and slave')];
+        $tags = ['dbconnection.delay' => __('Difference between main and replica')];
 
         foreach ($tags as $tag => $label) {
             $this->addTagToList(['tag'   => $tag,
@@ -88,9 +88,9 @@ class NotificationTargetDBConnection extends NotificationTarget
 
        //Tags with just lang
         $tags = ['dbconnection.title'
-                                 => __('Slave database out of sync!'),
+                                 => __('Replica database out of sync!'),
             'dbconnection.delay'
-                                 => __('The slave database is desynchronized. The difference is of:')
+                                 => __('The replica database is desynchronized. The difference is of:')
         ];
 
         foreach ($tags as $tag => $label) {

--- a/src/System/Status/StatusChecker.php
+++ b/src/System/Status/StatusChecker.php
@@ -173,7 +173,7 @@ final class StatusChecker
                     'servers' => []
                 ]
             ];
-           // Check slave server connection
+           // Check replica SQL server connection
             if (DBConnection::isDBSlaveActive()) {
                 $DBslave = DBConnection::getDBSlaveConf();
                 if (is_array($DBslave->dbhost)) {
@@ -220,6 +220,10 @@ final class StatusChecker
             }
         }
 
+        // Set new properties. Master and slave are deprecated given their implications in English.
+        $status['main'] = $status['master'];
+        $status['replicas'] = $status['slaves'];
+
         return $status;
     }
 
@@ -229,7 +233,7 @@ final class StatusChecker
 
         if ($db_ok === null) {
             $status = self::getDBStatus();
-            $db_ok = ($status['master']['status'] === self::STATUS_OK || $status['slaves']['status'] === self::STATUS_OK);
+            $db_ok = ($status['main']['status'] === self::STATUS_OK || $status['replicas']['status'] === self::STATUS_OK);
         }
 
         return $db_ok;
@@ -560,7 +564,7 @@ final class StatusChecker
                 $output .= "GLPI_DBSLAVE_{$num}_{$slave_info['status']}\n";
             }
         } else {
-            $output .= "No slave DB\n";
+            $output .= "No slave DB\n"; // Leave as "slave" since plain text is already deprecated
         }
         $output .= "GLPI_DB_{$status['db']['master']['status']}\n";
         $output .= "GLPI_SESSION_DIR_{$status['filesystem']['session_dir']['status']}\n";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Using master/slave wording has bad connotations in English. I propose replacing the wording with main/replica.

Also, there was already multiple places where main/replica was used in the UI in addition to the other wording so this will also unify it more.

I left the config file name as "config_db_slave" for now.
For the status checker, I left the old properties in place to avoid causing issues with monitoring solutions and added the new properties (Not sure how bad it would be to remove the old ones without deprecation). The plain-text output was left as-is since it is already deprecated.