### PR TITLE
Update agent informations ajax requests

### DIFF
--- a/templates/components/form/inventory_info.html.twig
+++ b/templates/components/form/inventory_info.html.twig
@@ -109,15 +109,17 @@
             $.ajax({
                type: 'POST',
                url: '{{ path('/ajax/agent.php') }}',
-               timeout: 3000, //3 seconds timeout
+               timeout: 30000, // 30 seconds timeout
                dataType: 'json',
                data: {
                   action: '{{ constant('Agent::ACTION_STATUS') }}',
                   id: '{{ agent.fields['id'] }}'
                },
                success: function(json) {
-                  icon.removeClass('fa-spin');
                   $('#agent_status').html(json.answer);
+               },
+               complete: function() {
+                  icon.removeClass('fa-spin');
                }
             });
          });
@@ -128,15 +130,17 @@
             $.ajax({
                type: 'POST',
                url: '{{ path('/ajax/agent.php') }}',
-               timeout: 3000, //3 seconds timeout
+               timeout: 30000, // 30 seconds timeout
                dataType: 'json',
                data: {
                   action: '{{ constant('Agent::ACTION_INVENTORY') }}',
                   id: '{{ agent.fields['id'] }}'
                },
                success: function(json) {
-                  icon.removeClass('fa-spin');
                   $('#inventory_status').html(json.answer);
+               },
+               complete: function() {
+                  icon.removeClass('fa-spin');
                }
             });
          });


### PR DESCRIPTION
 * use larger timeout as server can try a lot of address to contact agent
 * remove fa-spin class in complete function so it is removed also on timeout

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This will make the feature more reliable and users will know they won't have anymore information when the icon is no more spinning.