### PR TITLE
Fix guessed agent addresses when netports.instantiation_type is NULL

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -479,7 +479,12 @@ class Agent extends CommonDBTM
                     'netports.items_id'  => $item->getID(),
                     'NOT'       => [
                         'OR'  => [
-                            'netports.instantiation_type' => 'NetworkPortLocal',
+                            'AND' => [
+                                'NOT' => [
+                                    'netports.instantiation_type' => 'NULL'
+                                ],
+                                'netports.instantiation_type' => 'NetworkPortLocal'
+                            ],
                             'ips.name'                    => ['127.0.0.1', '::1']
                         ]
                     ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In some case, a netword card can be reported without a connection type. When this happens, related instantiation_type is not set in database and related ip won't be use to try to contact the agent when requested.

The case I discovered is in a win10 virtualbox vm which reported its emulated ethernet card with the following json:
```
         {
            "description": "Intel(R) PRO/1000 MT Desktop Adapter",
            "ipaddress": "192.168.122.4",
            "ipdhcp": "192.168.122.3",
            "ipgateway": "192.168.122.1",
            "ipmask": "255.255.255.0",
            "ipsubnet": "192.168.122.0",
            "mac": "08:00:27:A7:B5:3B",
            "pciid": "8086:100E:001E:8086",
            "pnpdeviceid": "PCI\\VEN_8086&DEV_100E&SUBSYS_001E8086&REV_02\\3&267a616a&0&18",
            "speed": "1000",
            "status": "up",
            "virtualdev": false
         }
```
There are also other cards for IPv6 addresses but none has `type` field set which is used to set `'netports.instantiation_type'` in this PR.

Without this PR, when requesting the agent status for example, the API will only return the agent hostname which is not known by the server and the request fails even if the agent is normally reachable.