### PR TITLE
Fix decimal dropdown

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -349,6 +349,7 @@ class Config extends CommonDBTM {
       Dropdown::showNumber("decimal_number", ['value' => $CFG_GLPI["decimal_number"],
                                               'min'   => 1,
                                               'max'   => 4,
+                                              'step'   => 0.5,
                                               'rand'  => $rand]);
       echo "</td>";
       echo "<td colspan='2'></td>";

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -349,7 +349,6 @@ class Config extends CommonDBTM {
       Dropdown::showNumber("decimal_number", ['value' => $CFG_GLPI["decimal_number"],
                                               'min'   => 1,
                                               'max'   => 4,
-                                              'step'   => 0.5,
                                               'rand'  => $rand]);
       echo "</td>";
       echo "<td colspan='2'></td>";

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -1512,15 +1512,13 @@ class Dropdown {
     *
     * @since 0.84
     *
-    * @param integer  $value    numeric value
-    * @param string   $unit     unit (maybe year, month, day, hour, % for standard management)
-    * @param int|null $decimals number of decimal, null to not handle decimals at all
-    *
-    * @return string
-    */
-   static function getValueWithUnit($value, $unit, ?int $decimals = 0): string {
+    * @param integer $value numeric value
+    * @param string $unit unit (maybe year, month, day, hour, % for standard management)
+    * @param integer $decimals number of decimal
+    **/
+   static function getValueWithUnit($value, $unit, $decimals = 0) {
 
-      $formatted_number = !is_null($decimals) && is_numeric($value)
+      $formatted_number = is_numeric($value)
          ? Html::formatNumber($value, false, $decimals)
          : $value;
 

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -1512,10 +1512,10 @@ class Dropdown {
     *
     * @since 0.84
     *
-    * @param integer $value numeric value
-    * @param string $unit unit (maybe year, month, day, hour, % for standard management)
+    * @param integer $value    numeric value
+    * @param string  $unit     unit (maybe year, month, day, hour, % for standard management)
     * @param integer $decimals number of decimal
-    **/
+   **/
    static function getValueWithUnit($value, $unit, $decimals = 0) {
 
       $formatted_number = is_numeric($value)

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -1478,7 +1478,7 @@ class Dropdown {
 
       $field_id = Html::cleanId("dropdown_".$myname.$p['rand']);
       if (!isset($p['toadd'][$p['value']])) {
-         $decimals = Toolbox::isFloat($p['step']) ? null : 0;
+         $decimals = Toolbox::isFloat($p['value']) ? Toolbox::getDecimalNumbers($p['step']) : 0;
          $valuename = self::getValueWithUnit($p['value'], $p['unit'], $decimals);
       } else {
          $valuename = $p['toadd'][$p['value']];
@@ -3521,7 +3521,7 @@ class Dropdown {
          foreach ($tosend as $i) {
             $txt = $i;
             if (isset($post['unit'])) {
-               $decimals = Toolbox::isFloat($post['step']) ? null : 0;
+               $decimals = Toolbox::isFloat($i) ? Toolbox::getDecimalNumbers($post['step']) : 0;
                $txt = Dropdown::getValueWithUnit($i, $post['unit'], $decimals);
             }
             $data[] = ['id' => $i,
@@ -3539,7 +3539,7 @@ class Dropdown {
             }
 
             if (isset($post['unit'])) {
-               $decimals = Toolbox::isFloat($post['step']) ? null : 0;
+               $decimals = Toolbox::isFloat($value) ? Toolbox::getDecimalNumbers($post['step']) : 0;
                $txt = Dropdown::getValueWithUnit($value, $post['unit'], $decimals);
             }
             $data[] = [

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -1478,7 +1478,8 @@ class Dropdown {
 
       $field_id = Html::cleanId("dropdown_".$myname.$p['rand']);
       if (!isset($p['toadd'][$p['value']])) {
-         $valuename = self::getValueWithUnit($p['value'], $p['unit']);
+         $decimals = Toolbox::isFloat($p['step']) ? null : 0;
+         $valuename = self::getValueWithUnit($p['value'], $p['unit'], $decimals);
       } else {
          $valuename = $p['toadd'][$p['value']];
       }
@@ -1511,13 +1512,15 @@ class Dropdown {
     *
     * @since 0.84
     *
-    * @param integer $value    numeric value
-    * @param string  $unit     unit (maybe year, month, day, hour, % for standard management)
-    * @param integer $decimals number of decimal
-   **/
-   static function getValueWithUnit($value, $unit, $decimals = 0) {
+    * @param integer  $value    numeric value
+    * @param string   $unit     unit (maybe year, month, day, hour, % for standard management)
+    * @param int|null $decimals number of decimal, null to not handle decimals at all
+    *
+    * @return string
+    */
+   static function getValueWithUnit($value, $unit, ?int $decimals = 0): string {
 
-      $formatted_number = is_numeric($value)
+      $formatted_number = !is_null($decimals) && is_numeric($value)
          ? Html::formatNumber($value, false, $decimals)
          : $value;
 
@@ -3518,7 +3521,8 @@ class Dropdown {
          foreach ($tosend as $i) {
             $txt = $i;
             if (isset($post['unit'])) {
-               $txt = Dropdown::getValueWithUnit($i, $post['unit']);
+               $decimals = Toolbox::isFloat($post['step']) ? null : 0;
+               $txt = Dropdown::getValueWithUnit($i, $post['unit'], $decimals);
             }
             $data[] = ['id' => $i,
                'text' => (string)$txt];
@@ -3535,7 +3539,8 @@ class Dropdown {
             }
 
             if (isset($post['unit'])) {
-               $txt = Dropdown::getValueWithUnit($value, $post['unit']);
+               $decimals = Toolbox::isFloat($post['step']) ? null : 0;
+               $txt = Dropdown::getValueWithUnit($value, $post['unit'], $decimals);
             }
             $data[] = [
                'id' => $value,

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3626,7 +3626,7 @@ HTML;
     *
     * @param mixed $value A possible float
     *
-    * @return bool
+    * @return int
     */
    public static function getDecimalNumbers($value): int {
       if (!is_numeric($value)) {

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3603,11 +3603,46 @@ HTML;
    /**
     * Check if a mixed value (possibly a string) is an integer or a float
     *
-    * @param $value A possible float
+    * @param mixed $value A possible float
     *
     * @return bool
     */
-   public static function isFloat($value) {
+   public static function isFloat($value): bool {
+      if (!is_numeric($value)) {
+         $type = gettype($value);
+
+         trigger_error(
+            "Calling isFloat on $type",
+            E_USER_WARNING
+         );
+         return false;
+      }
+
       return (floatval($value) - intval($value)) > 0;
+   }
+
+   /**
+    * Get the number of decimals for a given value
+    *
+    * @param mixed $value A possible float
+    *
+    * @return bool
+    */
+   public static function getDecimalNumbers($value): int {
+      if (!is_numeric($value)) {
+         $type = gettype($value);
+
+         trigger_error(
+            "Calling getDecimalNumbers on $type",
+            E_USER_WARNING
+         );
+         return 0;
+      }
+
+      if (floatval($value) == intval($value)) {
+         return 0;
+      }
+
+      return strlen(preg_replace('/\d*\./', '', floatval($value)));
    }
 }

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3599,4 +3599,15 @@ HTML;
 
       return $tabs;
    }
+
+   /**
+    * Check if a mixed value (possibly a string) is an integer or a float
+    *
+    * @param $value A possible float
+    *
+    * @return bool
+    */
+   public static function isFloat($value) {
+      return (floatval($value) - intval($value)) > 0;
+   }
 }

--- a/tests/functionnal/Dropdown.php
+++ b/tests/functionnal/Dropdown.php
@@ -33,6 +33,7 @@
 namespace tests\units;
 
 use \DbTestCase;
+use Generator;
 
 /* Test for inc/dropdown.class.php */
 
@@ -1351,5 +1352,90 @@ class Dropdown extends DbTestCase {
          $idor_add_params['entity_restrict'] = $params['entity_restrict'];
       }
       return \Session::getNewIDORToken(($params['itemtype'] ?? ''), $idor_add_params);
+   }
+
+   /**
+    * Data provider for testDropdownNumber
+    *
+    * @return Generator
+    */
+   protected function testDropdownNumberProvider(): Generator {
+      yield [
+         'params' => [
+            'min'  => 1,
+            'max'  => 4,
+            'step' => 1,
+            'unit' => "",
+         ],
+         'expected' => [1, 2, 3, 4]
+      ];
+
+      yield [
+         'params' => [
+            'min'  => 1,
+            'max'  => 4,
+            'step' => 0.5,
+            'unit' => "",
+         ],
+         'expected' => [1, 1.5, 2, 2.5, 3, 3.5, 4]
+      ];
+
+      yield [
+         'params' => [
+            'min'  => 1,
+            'max'  => 4,
+            'step' => 2,
+            'unit' => "",
+         ],
+         'expected' => [1, 3]
+      ];
+
+      yield [
+         'params' => [
+            'min'  => 1,
+            'max'  => 4,
+            'step' => 2.5,
+            'unit' => "",
+         ],
+         'expected' => [1, 3.5]
+      ];
+
+      yield [
+         'params' => [
+            'min'  => 1,
+            'max'  => 4,
+            'step' => 5.5,
+            'unit' => "",
+         ],
+         'expected' => [1]
+      ];
+   }
+
+   /**
+    * Tests for Dropdown::DropdownNumber()
+    *
+    * @dataprovider testDropdownNumberProvider
+    *
+    * @param array $params
+    * @param array $expected
+    *
+    * @return void
+    */
+   public function testDropdownNumber(array $params, array $expected): void {
+      $params['display'] = false;
+
+      $data = \Dropdown::getDropdownNumber($params, false);
+      $this->array($data)->hasKey("results");
+      $this->array($data['results'])->hasSize(count($expected));
+      $this->integer($data['count'])->isEqualTo(count($expected));
+
+      foreach ($data['results'] as $key => $dropdown_entry) {
+         $this->array($dropdown_entry)->hasKeys(["id", "text"]);
+
+         $numeric_text_value = floatval($dropdown_entry['text']);
+         $this->variable($dropdown_entry['id'])->isEqualTo($numeric_text_value);
+
+         $this->variable($dropdown_entry['id'])->isEqualTo($expected[$key]);
+      }
    }
 }

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -35,6 +35,7 @@ namespace tests\units;
 use Generator;
 use Glpi\Api\Deprecated\TicketFollowup;
 use ITILFollowup;
+use stdClass;
 use Ticket;
 
 /* Test for inc/toolbox.class.php */
@@ -1128,6 +1129,24 @@ class Toolbox extends \GLPITestCase {
          'value'    => 3,
          'expected' => false,
       ];
+
+      yield [
+         'value'    => "not a float",
+         'expected' => false,
+         'warning'  => "Calling isFloat on string",
+      ];
+
+      yield [
+         'value'    => new stdClass(),
+         'expected' => false,
+         'warning'  => "Calling isFloat on object",
+      ];
+
+      yield [
+         'value'    => [],
+         'expected' => false,
+         'warning'  => "Calling isFloat on array",
+      ];
    }
 
    /**
@@ -1135,12 +1154,123 @@ class Toolbox extends \GLPITestCase {
     *
     * @dataprovider testIsFloatProvider
     *
-    * @param $value
-    * @param bool $expected
+    * @param mixed         $value
+    * @param bool          $expected
+    * @param string|null   $warning
     *
     * @return void
     */
-   public function testIsFloat($value, bool $expected): void {
-      $this->boolean(\Toolbox::isFloat($value))->isEqualTo($expected);
+   public function testIsFloat(
+      $value,
+      bool $expected,
+      ?string $warning = null
+   ): void {
+      $result = null;
+
+      if (!is_null($warning)) {
+         $this->when(function () use ($value, &$result) {
+            $result = \Toolbox::isFloat($value);
+         })->error()
+            ->withType(E_USER_WARNING)
+            ->withMessage($warning)
+            ->exists();
+      } else {
+         $result = \Toolbox::isFloat($value);
+      }
+
+      $this->boolean($result)->isEqualTo($expected);
+   }
+
+   /**
+    * Data provider for testgetDecimalNumbers
+    *
+    * @return Generator
+    */
+   protected function testgetDecimalNumbersProvider(): Generator {
+      yield [
+         'value'    => "1",
+         'decimals' => 0,
+      ];
+
+      yield [
+         'value'    => "1.5",
+         'decimals' => 1,
+      ];
+
+      yield [
+         'value'    => "7.5569569",
+         'decimals' => 7,
+      ];
+
+      yield [
+         'value'    => "0",
+         'decimals' => 0,
+      ];
+
+      yield [
+         'value'    => 3.4,
+         'decimals' => 1,
+      ];
+
+      yield [
+         'value'    => 3,
+         'decimals' => 0,
+      ];
+
+      yield [
+         'value'    => "not a float",
+         'decimals' => 0,
+         'warning'  => "Calling getDecimalNumbers on string",
+      ];
+
+      yield [
+         'value'    => new stdClass(),
+         'decimals' => 0,
+         'warning'  => "Calling getDecimalNumbers on object",
+      ];
+
+      yield [
+         'value'    => [],
+         'decimals' => 0,
+         'warning'  => "Calling getDecimalNumbers on array",
+      ];
+
+      yield [
+         'value'    => 3.141592653589791415926535897914159265358979,
+         'decimals' => 13, // floatval() round up after 13 decimals
+      ];
+
+   }
+
+   /**
+    * Tests for Toolbox::getDecimalNumbers()
+    *
+    * @dataprovider testgetDecimalNumbersProvider
+    *
+    * @param mixed         $value
+    * @param int           $decimals
+    * @param string|null   $warning
+    *
+    * @return void
+    */
+   public function testGetDecimalNumbers(
+      $value,
+      int $decimals,
+      ?string $warning = null
+   ): void {
+      $result = null;
+
+      if (!is_null($warning)) {
+         $this->when(function () use ($value, &$result) {
+            $result = \Toolbox::getDecimalNumbers($value);
+         })->error()
+            ->withType(E_USER_WARNING)
+            ->withMessage($warning)
+            ->exists();
+      } else {
+         $result = \Toolbox::getDecimalNumbers($value);
+      }
+
+      $this->integer($result)->isEqualTo($decimals);
    }
 }

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -32,6 +32,7 @@
 
 namespace tests\units;
 
+use Generator;
 use Glpi\Api\Deprecated\TicketFollowup;
 use ITILFollowup;
 use Ticket;
@@ -1090,5 +1091,56 @@ class Toolbox extends \GLPITestCase {
     */
    public function testDoubleEncodeEmails(string $source, string $result): void {
       $this->string(\Toolbox::doubleEncodeEmails($source))->isEqualTo($result);
+   }
+
+   /**
+    * Data provider for testIsFloat
+    *
+    * @return Generator
+    */
+   protected function testIsFloatProvider(): Generator {
+      yield [
+         'value'    => "1",
+         'expected' => false,
+      ];
+
+      yield [
+         'value'    => "1.5",
+         'expected' => true,
+      ];
+
+      yield [
+         'value'    => "7.5569569",
+         'expected' => true,
+      ];
+
+      yield [
+         'value'    => "0",
+         'expected' => false,
+      ];
+
+      yield [
+         'value'    => 3.4,
+         'expected' => true,
+      ];
+
+      yield [
+         'value'    => 3,
+         'expected' => false,
+      ];
+   }
+
+   /**
+    * Tests for Toolbox::IsFloat()
+    *
+    * @dataprovider testIsFloatProvider
+    *
+    * @param $value
+    * @param bool $expected
+    *
+    * @return void
+    */
+   public function testIsFloat($value, bool $expected): void {
+      $this->boolean(\Toolbox::isFloat($value))->isEqualTo($expected);
    }
 }


### PR DESCRIPTION
Dropdowns with a decimal step are not displayed correctly since b7457cbbba5d063a828502c099c2cff66068bc15.

![image](https://user-images.githubusercontent.com/42734840/151532951-c4255fc4-3985-4051-a4b2-099f02cf58f8.png)

After fix:

![image](https://user-images.githubusercontent.com/42734840/151533001-01962ba6-95bd-4505-a4ea-99428f65588a.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23325
