### PR TITLE
permits to disable display of initials in timeline

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -2178,6 +2178,7 @@ $tables['glpi_entities'] = [
         'suppliers_as_private'                 => 0,
         'enable_custom_css'                    => 0,
         'anonymize_support_agents'             => 0,
+        'display_users_initials'               => 1,
         'contracts_strategy_default'           => 0,
         'transfers_strategy'                   => 0,
     ],

--- a/install/migrations/update_9.4.x_to_9.5.0.php
+++ b/install/migrations/update_9.4.x_to_9.5.0.php
@@ -1897,7 +1897,7 @@ HTML
         )
     );
 
-   // Add anonymize_support_agents to entity
+    // Add anonymize_support_agents to entity
     if (!$DB->fieldExists("glpi_entities", "anonymize_support_agents")) {
         $migration->addField(
             "glpi_entities",

--- a/install/migrations/update_9.5.x_to_10.0.0/entity.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/entity.php
@@ -112,5 +112,20 @@ foreach ($fkey_config_fields as $fkey_config_field) {
         // 'contracts_id_default' and 'transfers_id' fields will only exist if a previous dev install exists
         $migration->changeField('glpi_entities', $fkey_config_field, $fkey_config_field, "int {$default_key_sign} NOT NULL DEFAULT 0");
     }
+
+    // Add display_users_initials to entity
+    if (!$DB->fieldExists("glpi_entities", "display_users_initials")) {
+        $migration->addField(
+            "glpi_entities",
+            "display_users_initials",
+            "integer",
+            [
+                'after'     => "anonymize_support_agents",
+                'value'     => -2,               // Inherit as default value
+                'update'    => '1',              // Enabled for root entity
+                'condition' => 'WHERE `id` = 0'
+            ]
+        );
+    }
 }
 /** /Replace negative values for config foreign keys */

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -2759,6 +2759,7 @@ CREATE TABLE `glpi_entities` (
   `autofill_decommission_date` varchar(255) NOT NULL DEFAULT '-2',
   `suppliers_as_private` int NOT NULL DEFAULT '-2',
   `anonymize_support_agents` int NOT NULL DEFAULT '-2',
+  `display_users_initials` int NOT NULL DEFAULT '-2',
   `contracts_strategy_default` tinyint NOT NULL DEFAULT '-2',
   `contracts_id_default` int unsigned NOT NULL DEFAULT '0',
   `enable_custom_css` int NOT NULL DEFAULT '-2',

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -120,7 +120,7 @@ class Entity extends CommonTreeDropdown
             'inquest_duration','inquest_URL',
             'max_closedate', 'tickettemplates_strategy', 'tickettemplates_id',
             'changetemplates_strategy', 'changetemplates_id', 'problemtemplates_strategy', 'problemtemplates_id',
-            'suppliers_as_private', 'autopurge_delay', 'anonymize_support_agents',
+            'suppliers_as_private', 'autopurge_delay', 'anonymize_support_agents', 'display_users_initials',
             'contracts_strategy_default', 'contracts_id_default'
         ],
       // Configuration
@@ -2781,6 +2781,31 @@ class Entity extends CommonTreeDropdown
         }
         echo "</td></tr>";
 
+        echo "<tr class='tab_bg_1'><td  colspan='2'>" . __("Display initials for users without pictures") . "</td>";
+        echo "<td colspan='2'>";
+        $initialsValues = self::getDisplayUsersInitialsValues();
+        $currentInitialsValue = $entity->fields['display_users_initials'];
+
+        if ($ID == 0) { // Remove parent option for root entity
+            unset($initialsValues[self::CONFIG_PARENT]);
+        }
+
+        Dropdown::showFromArray(
+            'display_users_initials',
+            $initialsValues,
+            ['value' => $currentInitialsValue]
+        );
+
+       // If the entity is using it's parent value, print it
+        if ($currentInitialsValue == self::CONFIG_PARENT && $ID != 0) {
+            $parentSupplierValue = self::getUsedConfig(
+                'display_users_initials',
+                $entity->fields['entities_id']
+            );
+            self::inheritedValue($initialsValues[$parentSupplierValue], true);
+        }
+        echo "</td></tr>";
+
         echo "<tr class='tab_bg_1'><td  colspan='2'>" . __('Default contract') . "</td>";
         echo "<td colspan='2'>";
         $current_default_contract_value = $entity->fields['contracts_id_default'];
@@ -3291,6 +3316,26 @@ class Entity extends CommonTreeDropdown
         }
         return NOT_AVAILABLE;
     }
+
+    /**
+     * get value for display_users_initials
+     *
+     * @since 10.0.0
+     *
+     * @param integer|null $val if not set, ask for all values, else for 1 value (default NULL)
+     *
+     * @return string|array
+     **/
+    public static function getDisplayUsersInitialsValues()
+    {
+
+        return [
+            self::CONFIG_PARENT => __('Inheritance of the parent entity'),
+            0                   => __('No'),
+            1                   => __('Yes'),
+        ];
+    }
+
 
     /**
      * get value for suppliers_as_private

--- a/src/User.php
+++ b/src/User.php
@@ -6298,9 +6298,10 @@ JAVASCRIPT;
      */
     public function getPicturePath(bool $enable_anonymization = false): string
     {
+        global $CFG_GLPI;
 
         if ($enable_anonymization && Session::getCurrentInterface() == 'helpdesk' && Entity::getAnonymizeConfig() !== Entity::ANONYMIZE_DISABLED) {
-            return '/pics/picture.png';
+            return $CFG_GLPI["root_doc"] . '/pics/picture.png';
         }
 
         $path = Toolbox::getPictureUrl($this->fields['picture'], false);
@@ -6308,7 +6309,7 @@ JAVASCRIPT;
             return $path;
         }
 
-        return '/pics/picture.png';
+        return $CFG_GLPI["root_doc"] . '/pics/picture.png';
     }
 
     /**

--- a/templates/components/user/picture.html.twig
+++ b/templates/components/user/picture.html.twig
@@ -34,6 +34,9 @@
 {% set anonymized = enable_anonymization and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED') %}
 {% set user = get_item('User', users_id) %}
 {% set user_thumbnail = user.getThumbnailPicturePath(enable_anonymization) %}
+{% if user_thumbnail == null and not entity_config('display_users_initials', session('glpiactive_entity')) %}
+    {% set user_thumbnail = user.getPicturePath(enable_anonymization) %}
+{% endif %}
 
 {% if not anonymized %}
    <a href="{{ user.getLinkURL() }}" class="d-flex align-items-center">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Again, following a meeting about glpi 10 with Nicolas, he says me one of its colleagues initials is a bad idea to display (in France context)  in the timeline.

So here is a config to disable display of initials in timeline.
When set to no, user avatar will display a generic picture (the same used for anonymous heldesk):

![image](https://user-images.githubusercontent.com/418844/151558790-49bf9079-0146-47bb-991b-5e0eeb6fef3a.png)

