### PR TITLE
compact a little the display of search results on medium screens

### DIFF
--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -125,6 +125,14 @@
                     }
                 }
 
+                @media (max-width: 1899.98px) {
+                    font-size: 0.75rem;
+
+                    & > :not(caption) > * > * {
+                        padding: 0.25rem 0.25rem
+                    }
+                }
+
                 &.deleted-results {
                     color: rgb(56, 13, 13);
                 }

--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -129,7 +129,7 @@
                     font-size: 0.75rem;
 
                     & > :not(caption) > * > * {
-                        padding: 0.25rem 0.25rem
+                        padding: 0.25rem;
                     }
                 }
 

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -32,7 +32,7 @@
 {% set searchform_id = data['searchform_id']|default('search_' ~ rand) %}
 
 <div class="table-responsive-md">
-   <table class="search-results table  card-table table-hover {{ data['search']['is_deleted'] ? "table-danger deleted-results" : "table-striped" }}"
+   <table class="search-results table card-table table-hover {{ data['search']['is_deleted'] ? "table-danger deleted-results" : "table-striped" }}"
           id="{{ searchform_id }}">
       <thead>
          <tr {% if count == 0 %}style="display: none;"{% endif %}>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Last point of the previously mentionned meeting on glpi10.
On medium screens (we talked about a 22" with 1680*1050 resolution), the search results could be very big.
So on a 1900px breakpoint, i condensed a little the table.

Before (notice the horizontal scrollbar): 
![image](https://user-images.githubusercontent.com/418844/151562989-e3e95e17-b133-4bfa-93f6-552f1427ebcb.png)

After:
![image](https://user-images.githubusercontent.com/418844/151563030-f09d2d9b-cdc3-40ae-9c9c-91bde66a5c7f.png)

