### PR TITLE
fix(right): add dedicated right for followup template

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -5074,6 +5074,10 @@ $tables['glpi_profilerights'] = [
         'name'        => 'solutiontemplate',
         'rights'      => '23',
     ], [
+        'profiles_id' => '7',
+        'name'        => 'itilfollowuptemplate',
+        'rights'      => '23',
+    ], [
         'profiles_id' => '1',
         'name'        => 'calendar',
         'rights'      => '0',
@@ -5350,8 +5354,16 @@ $tables['glpi_profilerights'] = [
         'name'        => 'solutiontemplate',
         'rights'      => '0',
     ], [
+        'profiles_id' => '5',
+        'name'        => 'itilfollowuptemplate',
+        'rights'      => '0',
+    ], [
         'profiles_id' => '6',
         'name'        => 'solutiontemplate',
+        'rights'      => '0',
+    ], [
+        'profiles_id' => '6',
+        'name'        => 'itilfollowuptemplate',
         'rights'      => '0',
     ], [
         'profiles_id' => '2',
@@ -5637,9 +5649,17 @@ $tables['glpi_profilerights'] = [
         'profiles_id' => '3',
         'name'        => 'solutiontemplate',
         'rights'      => '23',
+    ],  [
+        'profiles_id' => '3',
+        'name'        => 'itilfollowuptemplate',
+        'rights'      => '23',
     ], [
         'profiles_id' => '4',
         'name'        => 'solutiontemplate',
+        'rights'      => '23',
+    ], [
+        'profiles_id' => '4',
+        'name'        => 'itilfollowuptemplate',
         'rights'      => '23',
     ], [
         'profiles_id' => '3',
@@ -5918,8 +5938,16 @@ $tables['glpi_profilerights'] = [
         'name'        => 'solutiontemplate',
         'rights'      => '0',
     ], [
+        'profiles_id' => '1',
+        'name'        => 'itilfollowuptemplate',
+        'rights'      => '0',
+    ], [
         'profiles_id' => '2',
         'name'        => 'solutiontemplate',
+        'rights'      => '0',
+    ], [
+        'profiles_id' => '2',
+        'name'        => 'itilfollowuptemplate',
         'rights'      => '0',
     ], [
         'profiles_id' => '4',
@@ -7048,6 +7076,10 @@ $tables['glpi_profilerights'] = [
     ], [
         'profiles_id' => '8',
         'name'        => 'solutiontemplate',
+        'rights'      => '1',
+    ], [
+        'profiles_id' => '8',
+        'name'        => 'itilfollowuptemplate',
         'rights'      => '1',
     ], [
         'profiles_id' => '8',

--- a/install/migrations/update_9.5.x_to_10.0.0/ticket.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/ticket.php
@@ -48,3 +48,7 @@ foreach (['glpi_tickettemplatemandatoryfields', 'glpi_tickettemplatepredefinedfi
     );
 }
 /* /Remove global_validation field from templates (should not be defined manually). */
+
+/* Add dedicated right for ITILFollowupTemplate */
+$migration->addRight('itilfollowuptemplate', ALLSTANDARDRIGHT, ['dropdown' => UPDATE]);
+/* Add dedicated right for ITILFollowupTemplate */

--- a/src/ITILFollowupTemplate.php
+++ b/src/ITILFollowupTemplate.php
@@ -41,7 +41,7 @@ class ITILFollowupTemplate extends AbstractITILChildTemplate
     public $dohistory          = true;
     public $can_be_translated  = true;
 
-    static $rightname          = 'itilfollowuptemplate';
+    public static $rightname          = 'itilfollowuptemplate';
 
     public static function getTypeName($nb = 0)
     {

--- a/src/ITILFollowupTemplate.php
+++ b/src/ITILFollowupTemplate.php
@@ -41,6 +41,7 @@ class ITILFollowupTemplate extends AbstractITILChildTemplate
     public $dohistory          = true;
     public $can_be_translated  = true;
 
+    static $rightname          = 'itilfollowuptemplate';
 
     public static function getTypeName($nb = 0)
     {

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1911,7 +1911,7 @@ class Profile extends CommonDBTM
                 'itemtype'  => 'ITILFollowupTemplate',
                 'label'     => _n('Followup template', 'Followup templates', Session::getPluralNumber()),
                 'field'     => 'itilfollowuptemplate'
-             ],
+            ],
             [
                 'itemtype'  => 'SolutionTemplate',
                 'label'     => _n('Solution template', 'Solution templates', Session::getPluralNumber()),

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1908,6 +1908,11 @@ class Profile extends CommonDBTM
                 'field'     => 'state'
             ],
             [
+                'itemtype'  => 'ITILFollowupTemplate',
+                'label'     => _n('Followup template', 'Followup templates', Session::getPluralNumber()),
+                'field'     => 'itilfollowuptemplate'
+             ],
+            [
                 'itemtype'  => 'SolutionTemplate',
                 'label'     => _n('Solution template', 'Solution templates', Session::getPluralNumber()),
                 'field'     => 'solutiontemplate'


### PR DESCRIPTION
add dedicated right for followup 
instead of global dropdown right

![image](https://user-images.githubusercontent.com/7335054/151790683-de736323-bae4-476d-a72c-0d63a0136377.png)




| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23298
