### PR TITLE
Allow custom Kanban URLs

### DIFF
--- a/ajax/kanban.php
+++ b/ajax/kanban.php
@@ -183,16 +183,11 @@ if (($_POST['action'] ?? null) === 'update') {
 } else if ($_REQUEST['action'] === 'get_url') {
     $checkParams(['items_id']);
     if ($_REQUEST['items_id'] == -1) {
-        echo $itemtype::getFormURL(true) . '?showglobalkanban=1';
+        echo $itemtype::getGlobalKanbanUrl(true);
         return;
     }
     $item->getFromDB($_REQUEST['items_id']);
-    $tabs = $item->defineTabs();
-    $tab_id = array_search(__('Kanban'), $tabs);
-    if (false === $tab_id || is_null($tab_id)) {
-        Response::sendError(400, "Itemtype does not have a Kanban tab!", Response::CONTENT_TYPE_TEXT_HTML);
-    }
-    echo $itemtype::getFormURLWithID($_REQUEST['items_id'], true) . "&forcetab={$tab_id}";
+    echo $item->getKanbanUrlWithID($_REQUEST['items_id'], true);
 } else if (($_POST['action'] ?? null) === 'create_column') {
     $checkParams(['column_field', 'items_id', 'column_name']);
     $column_field = $_POST['column_field'];

--- a/src/Features/Kanban.php
+++ b/src/Features/Kanban.php
@@ -156,21 +156,21 @@ trait Kanban
         return $filters;
     }
 
-   public static function getGlobalKanbanUrl(bool $full = true): string
-   {
-      if (method_exists(static::class, 'getFormUrl')) {
-         return static::getFormURL($full) . '?showglobalkanban=1';
-      }
-      return '';
-   }
+    public static function getGlobalKanbanUrl(bool $full = true): string
+    {
+        if (method_exists(static::class, 'getFormUrl')) {
+            return static::getFormURL($full) . '?showglobalkanban=1';
+        }
+        return '';
+    }
 
-   public function getKanbanUrlWithID(int $items_id, bool $full = true): string
-   {
-      $tabs = $this->defineTabs();
-      $tab_id = array_search(__('Kanban'), $tabs);
-      if (false === $tab_id || is_null($tab_id)) {
-         Response::sendError(400, "Itemtype does not have a Kanban tab!", Response::CONTENT_TYPE_TEXT_HTML);
-      }
-      return static::getFormURLWithID($items_id, $full) . "&forcetab={$tab_id}";
-   }
+    public function getKanbanUrlWithID(int $items_id, bool $full = true): string
+    {
+        $tabs = $this->defineTabs();
+        $tab_id = array_search(__('Kanban'), $tabs);
+        if (false === $tab_id || is_null($tab_id)) {
+            Response::sendError(400, "Itemtype does not have a Kanban tab!", Response::CONTENT_TYPE_TEXT_HTML);
+        }
+        return static::getFormURLWithID($items_id, $full) . "&forcetab={$tab_id}";
+    }
 }

--- a/src/Features/Kanban.php
+++ b/src/Features/Kanban.php
@@ -156,21 +156,21 @@ trait Kanban
         return $filters;
     }
 
-    public static function getGlobalKanbanUrl(bool $full = true): string
-    {
-       if (method_exists(static::class, 'getFormUrl')) {
-          return static::getFormURL($full) . '?showglobalkanban=1';
-       }
-       return '';
-    }
+   public static function getGlobalKanbanUrl(bool $full = true): string
+   {
+      if (method_exists(static::class, 'getFormUrl')) {
+         return static::getFormURL($full) . '?showglobalkanban=1';
+      }
+      return '';
+   }
 
-    public function getKanbanUrlWithID(int $items_id, bool $full = true): string
-    {
-       $tabs = $this->defineTabs();
-       $tab_id = array_search(__('Kanban'), $tabs);
-       if (false === $tab_id || is_null($tab_id)) {
-          Response::sendError(400, "Itemtype does not have a Kanban tab!", Response::CONTENT_TYPE_TEXT_HTML);
-       }
-       return static::getFormURLWithID($items_id, $full) . "&forcetab={$tab_id}";
-    }
+   public function getKanbanUrlWithID(int $items_id, bool $full = true): string
+   {
+      $tabs = $this->defineTabs();
+      $tab_id = array_search(__('Kanban'), $tabs);
+      if (false === $tab_id || is_null($tab_id)) {
+         Response::sendError(400, "Itemtype does not have a Kanban tab!", Response::CONTENT_TYPE_TEXT_HTML);
+      }
+      return static::getFormURLWithID($items_id, $full) . "&forcetab={$tab_id}";
+   }
 }

--- a/src/Features/Kanban.php
+++ b/src/Features/Kanban.php
@@ -33,6 +33,7 @@
 
 namespace Glpi\Features;
 
+use Glpi\Http\Response;
 use Glpi\Plugin\Hooks;
 use Plugin;
 
@@ -153,5 +154,23 @@ trait Kanban
             }
         }
         return $filters;
+    }
+
+    public static function getGlobalKanbanUrl(bool $full = true): string
+    {
+       if (method_exists(static::class, 'getFormUrl')) {
+          return static::getFormURL($full) . '?showglobalkanban=1';
+       }
+       return '';
+    }
+
+    public function getKanbanUrlWithID(int $items_id, bool $full = true): string
+    {
+       $tabs = $this->defineTabs();
+       $tab_id = array_search(__('Kanban'), $tabs);
+       if (false === $tab_id || is_null($tab_id)) {
+          Response::sendError(400, "Itemtype does not have a Kanban tab!", Response::CONTENT_TYPE_TEXT_HTML);
+       }
+       return static::getFormURLWithID($items_id, $full) . "&forcetab={$tab_id}";
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Tasklists plugin has custom URLs for the different contexts it uses in its Kanban. Currently, the URLs in the switcher are hard coded to the item's form URL with the Kanban tab. Same with the global Kanban for an itemtype.
This adds methods to the Kanban trait which can be overridden by different itemtypes to specify different URLs.