### PR TITLE
Fix select2 rendering in multiple context; fixes #10470

### DIFF
--- a/css/includes/components/_select2.scss
+++ b/css/includes/components/_select2.scss
@@ -65,19 +65,6 @@
             cursor: not-allowed;
         }
 
-        .select2-selection__rendered {
-            direction: rtl; // ellipsis on left
-            text-align: left;
-
-            &::before {
-                content: "\200E"; // left-to-right mark: be sure that content is displayed in ltr way
-            }
-
-            > * {
-                unicode-bidi: plaintext;
-            }
-        }
-
         &.select2-selection--single {
             @include font-size($input-font-size);
 
@@ -90,6 +77,16 @@
 
             .select2-selection__rendered {
                 line-height: $input-height;
+                direction: rtl; // ellipsis on left
+                text-align: left;
+
+                &::before {
+                    content: "\200E"; // left-to-right mark: be sure that content is displayed in ltr way
+                }
+
+                > * {
+                    unicode-bidi: plaintext; // preserve text direction
+                }
 
                 @include dark-mode {
                     & {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Move the "ellipsis" hack into `.select2-selection--single` to ensure it is not applied in multiple selection context.