### PR TITLE
prevent overlap of state switch with ul>li in tasks

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -53,26 +53,33 @@
         }
     }
 
-    .state {
-        float: left;
-        width: 20px;
-        height: 20px;
-        margin-right: 3px;
-        background-repeat: no-repeat;
-        vertical-align: middle;
+    .todo-list-state {
+        display: inline-block !important;
+        margin-top: 1.5rem;
+        margin-left: 0.5rem;
+        margin-right: -0.5rem;
 
-        &.state_0 {
-            background-image: url("../pics/timeline/information.png");
-        }
+        .state {
+            display: inline-block;
+            width: 20px;
+            height: 20px;
+            margin-right: 3px;
+            background-repeat: no-repeat;
+            vertical-align: middle;
 
-        &.state_1 {
-            cursor: pointer;
-            background-image: url("../pics/timeline/todo.png");
-        }
+            &.state_0 {
+                background-image: url("../pics/timeline/information.png");
+            }
 
-        &.state_2 {
-            cursor: pointer;
-            background-image: url("../pics/timeline/done.png");
+            &.state_1 {
+                cursor: pointer;
+                background-image: url("../pics/timeline/todo.png");
+            }
+
+            &.state_2 {
+                cursor: pointer;
+                background-image: url("../pics/timeline/done.png");
+            }
         }
     }
 
@@ -444,9 +451,8 @@
             transition: all 200ms ease;
 
             .todo-list-state {
-                display: inline-block !important;
-                margin-top: 1.5rem;
-                margin-left: 0.5rem;
+                order: inherit !important;
+                margin-left: 0.5rem !important;
             }
 
             .creator,

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -43,12 +43,6 @@
 {% block timeline_card %}
    {% if form_mode == 'view' %}
       <div class="read-only-content {{ entry_i['state'] is constant('Planning::DONE') ? 'done' : '' }}">
-         {% if entry_i['state'] is constant('Planning::TODO') %}
-            <span class="state state_1" onclick="change_task_state({{ entry_i['id'] }}, this)" title="{{ __('To do') }}"></span>
-         {% elseif entry_i['state'] is constant('Planning::DONE') %}
-            <span class="state state_2" onclick="change_task_state({{ entry_i['id'] }}, this)" title="{{ __('Done') }}"></span>
-         {% endif %}
-
          <div class="text-content" data-bs-html="true" data-bs-custom-class="todo-list-tooltip"
               title="{{ entry_i['content']|html_to_text }}" data-bs-toggle="tooltip">
             {{ entry_i['content']|enhanced_html({

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -99,7 +99,7 @@
             data-itemtype="{{ entry['type'] }}" data-items-id="{{ entry_i['id'] }}"
             {% if entry['item_action'] is defined %}data-item-action="{{ entry['item_action'] }}"{% endif %}>
          <div class="row">
-            <div class="col-auto todo-list-state d-none">
+            <div class="col-auto todo-list-state {{ 'left' in item_position ? 'ms-auto ms-0 order-sm-last' : '' }}">
                {% if entry_i['state'] is constant('Planning::TODO') %}
                   <span class="state state_1" onclick="change_task_state({{ entry_i['id'] }}, this)" title="{{ __('To do') }}"></span>
                {% elseif entry_i['state'] is constant('Planning::DONE') %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Prevent this:
![image](https://user-images.githubusercontent.com/418844/151984373-580e3f1c-7563-4c61-bd19-31011a60727f.png)

By moving state checkbox outside of content:
![image](https://user-images.githubusercontent.com/418844/151984466-ae1934a7-fbae-43c6-857a-6320869b4e11.png)



