### PR TITLE
Fix incompatible return type declarations

### DIFF
--- a/src/NotificationTargetObjectLock.php
+++ b/src/NotificationTargetObjectLock.php
@@ -142,7 +142,7 @@ class NotificationTargetObjectLock extends NotificationTarget
     }
 
 
-    public function getSender()
+    public function getSender(): array
     {
 
         $mails = new UserEmail();
@@ -171,7 +171,7 @@ class NotificationTargetObjectLock extends NotificationTarget
     }
 
 
-    public function getReplyTo($options = [])
+    public function getReplyTo($options = []): array
     {
 
         return $this->getSender();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Return types don't match parent methods after recent changes on master branch.
Seen reported on #10497 but this probably doesn't fix the issue regarding certification expiration notifications.