### PR TITLE
fix(cable): remove duplicate dropdown (type)

### DIFF
--- a/templates/pages/assets/cable.html.twig
+++ b/templates/pages/assets/cable.html.twig
@@ -35,13 +35,6 @@
 
 {% block more_fields %}
    {{ fields.dropdownField(
-      'CableType',
-      'cabletypes_id',
-      item.fields['cabletypes_id'],
-      'CableType'|itemtype_name,
-   ) }}
-
-   {{ fields.dropdownField(
       'CableStrand',
       'cablestrands_id',
       item.fields['cablestrands_id'],


### PR DESCRIPTION
Remove duplicate dropdown type

Before

![image](https://user-images.githubusercontent.com/7335054/152118606-7a7e5399-9747-4ae6-abc3-853a0da3af80.png)


After

![image](https://user-images.githubusercontent.com/7335054/152118617-d46bd1bb-3ce3-4f2c-8921-8a1ad1be3c0c.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
