### PR TITLE
Add Kanban class to kanban element

### DIFF
--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -2689,6 +2689,7 @@ class GLPIKanbanRights {
        * @since 9.5.0
        */
         this.init = function() {
+            $(self.element).data('js_class', self);
             $(self.element).trigger('kanban:pre_init');
             loadState(function() {
                 build();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Bind Kanban class to its Kanban element. This makes it easier for plugins to interact with the Kanban code when they register listeners from outside the core JS file since the Kanban instance(s) aren't bound to the window global.

Ping @tsmr 