### PR TITLE
try to fix saving of search query in savedsearch; fix #10430

### DIFF
--- a/ajax/savedsearch.php
+++ b/ajax/savedsearch.php
@@ -122,7 +122,7 @@ if ($_GET['action'] == 'create') {
         $id,
         [
             'type'      => $_GET['type'],
-            'url'       => rawurldecode($_GET["url"]),
+            'url'       => $_GET["url"],
             'itemtype'  => $_GET["itemtype"],
             'ajax'      => true
         ]

--- a/js/modules/Search/GenericView.js
+++ b/js/modules/Search/GenericView.js
@@ -99,7 +99,7 @@ window.GLPI.Search.GenericView = class GenericView {
             `);
             const bs_modal = new bootstrap.Modal(modal.get(0), {show: false});
             modal.on('show.bs.modal', () => {
-                const url = modal.attr('data-url')+'&url=' + encodeURIComponent(window.location.pathname + decodeURI(window.location.search));
+                const url = modal.attr('data-url')+'&url=' + encodeURIComponent(window.location.pathname + window.location.search);
                 modal.find('.modal-body').load(url, {});
             });
             bs_modal.show();

--- a/js/modules/Search/GenericView.js
+++ b/js/modules/Search/GenericView.js
@@ -99,7 +99,7 @@ window.GLPI.Search.GenericView = class GenericView {
             `);
             const bs_modal = new bootstrap.Modal(modal.get(0), {show: false});
             modal.on('show.bs.modal', () => {
-                const url = modal.attr('data-url')+'&url=' + encodeURIComponent(window.location.pathname + window.location.search);
+                const url = modal.attr('data-url')+'&url=' + encodeURIComponent(window.location.pathname + decodeURI(window.location.search));
                 modal.find('.modal-body').load(url, {});
             });
             bs_modal.show();

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -302,7 +302,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
      */
     public function prepareSearchUrlForDB(array $input): array
     {
-        $taburl = parse_url(Sanitizer::unsanitize(rawurldecode($input['url'])));
+        $taburl = parse_url(Sanitizer::unsanitize($input['url']));
 
         $query_tab = [];
 
@@ -407,7 +407,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         }
 
         if (isset($options['url'])) {
-            echo Html::hidden('url', ['value' => rawurlencode($options['url'])]);
+            echo Html::hidden('url', ['value' => $options['url']]);
         }
 
         echo "<tr><th colspan='4'>";

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -302,7 +302,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
      */
     public function prepareSearchUrlForDB(array $input): array
     {
-        $taburl = parse_url(rawurldecode(Sanitizer::unsanitize($input['url'])));
+        $taburl = parse_url(Sanitizer::unsanitize(rawurldecode($input['url'])));
 
         $query_tab = [];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10430

Not sure to do the right thing to fix the mentionned issue but on my understanding, with new ajax view for search, there is some double encoding of the query and before the save a bad order of decoding/unscaping.

I'll try to check also #10009 also
