### PR TITLE
Fix antivirus creation

### DIFF
--- a/src/ComputerAntivirus.php
+++ b/src/ComputerAntivirus.php
@@ -411,4 +411,16 @@ class ComputerAntivirus extends CommonDBChild
         echo "</table>";
         echo "</div>";
     }
+
+    public function prepareInputForAdd($input)
+    {
+        $input = parent::prepareInputForAdd($input);
+
+        // Clear date if empty to avoid SQL error
+        if (empty($input['date_expiration'])) {
+            unset($input['date_expiration']);
+        }
+
+        return $input;
+    }
 }


### PR DESCRIPTION
Fix the following error when trying to create a `ComputerAntivirus` item without specifying an expiration date:

```sql
*** MySQL query error:
  SQL: INSERT INTO `glpi_computerantiviruses` (`computers_id`, `name`, `is_active`, `manufacturers_id`, `is_uptodate`, `antivirus_version`, `signature_version`, `date_expiration`, `date_creation`, `date_mod`) VALUES ('6', 'grd', '0', '0', '0', '', '', '', '2022-02-02 16:35:50', '2022-02-02 16:35:50')
  Error: Incorrect datetime value: '' for column 'date_expiration' at row 1
  Backtrace :
  src/DBmysql.php:1277                               
  src/CommonDBTM.php:653                             DBmysql->insert()
  src/CommonDBTM.php:1247                            CommonDBTM->addToDB()
  front/computerantivirus.form.php:51                CommonDBTM->add()
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
