### PR TITLE
remove donation links

### DIFF
--- a/src/GLPINetwork.php
+++ b/src/GLPINetwork.php
@@ -271,8 +271,7 @@ class GLPINetwork extends CommonGLPI
             __("You need help to integrate GLPI in your IT, have a bug fixed or benefit from pre-configured rules or dictionaries?\n\n" .
             "We provide the %s space for you.\n" .
             "GLPI-Network is a commercial product that includes a subscription for tier 3 support, ensuring the correction of bugs encountered with a commitment time.\n\n" .
-            "In this same space, you will be able to <b>contact an official partner</b> to help you with your GLPI integration.\n\n" .
-            "Or, support the GLPI development effort by <b>donating</b>."),
+            "In this same space, you will be able to <b>contact an official partner</b> to help you with your GLPI integration."),
             "<a href='" . GLPI_NETWORK_SERVICES . "' target='_blank'>" . GLPI_NETWORK_SERVICES . "</a>"
         ));
     }

--- a/templates/install/step7.html.twig
+++ b/templates/install/step7.html.twig
@@ -33,12 +33,6 @@
 
 <p>
    {{ glpinetwork|raw }}
-
-   <br>
-   <a href="{{ glpinetwork_url }}" target="_blank" class="btn btn-primary mt-2">
-      <i class="fas fa-donate me-1"></i>
-      {{ __('Donate') }}
-   </a>
 </p>
 
 <hr>

--- a/templates/install/update.html.twig
+++ b/templates/install/update.html.twig
@@ -35,14 +35,6 @@
 
 <p>
    {{ glpinetwork|raw }}
-
-   <br>
-   <div class="text-center">
-      <a href="{{ glpinetwork_url }}" target="_blank" class="btn btn-primary mt-2">
-         <i class="fas fa-donate me-1"></i>
-         {{ __("Donate") }}
-      </a>
-   </div>
 </p>
 
 {% if not telemetry_enabled %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

The donations since the introduction of these links doesn't match the cost of "repution".
So let's remove them.

A push to transifex is required.
