### PR TITLE
Fix editing root entity main form

### DIFF
--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -42,7 +42,11 @@
 {% set entity_id = 0 %}
 {% set entity_name = '' %}
 {% if item.isEntityAssign() %}
-   {% set entity_id = params['entities_id'] ?? item.fields['entities_id'] ?? session('glpiactive_entity') %}
+   {% if item.getType() == 'Entity' and item.fields['id'] == 0 %}
+      {% set entity_id = null %}
+   {% else %}
+      {% set entity_id = params['entities_id'] ?? item.fields['entities_id'] ?? session('glpiactive_entity') %}
+   {%  endif %}
 
    {% if is_multi_entities_mode() %}
       {% set entity_name = get_item_name('Entity', item.fields['entities_id']) %}

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -46,7 +46,7 @@
       {% set entity_id = null %}
    {% else %}
       {% set entity_id = params['entities_id'] ?? item.fields['entities_id'] ?? session('glpiactive_entity') %}
-   {%  endif %}
+   {% endif %}
 
    {% if is_multi_entities_mode() %}
       {% set entity_name = get_item_name('Entity', item.fields['entities_id']) %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When changing anything on the root entity main form, the hidden `entities_id` field is set to 0 instead of null. This makes it seem like the root entity is a child of itself and the update will fail.