### PR TITLE
do not display status border for new itilsolution form

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -327,6 +327,12 @@
 
     .timeline-item {
         min-width: 100%;
+
+        &.ITILSolution {
+            .timeline-content {
+                border-left: 1px solid transparent;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10546

The original bug reported is due to solutions in timeline have a 1em border with a status color (green = accepted, orange = wainting, etc).
For the new solution form, this border doesn't make any sense.
