### PR TITLE
Fix BR for tickets for update

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1068,6 +1068,8 @@ class Ticket extends CommonITILObject {
                 || ($DB->escape($this->fields[$key]) != $input[$key])) {
                $changes[] = $key;
             }
+         } elseif(isset($this->fields[$key]) && !isset($input[$key])){
+            $input[$key] = $this->fields[$key];
          }
       }
 


### PR DESCRIPTION
Issue with BR for Tickets in case Ticket::update() is called just with essential fields like id,status (done on several places like ITILSolution).
BR works just with $input so they are not able to match criteria for the missing fields.
Some bugs still remain and I plan to fix that later ($changes are not propagated for delete of Actors for example)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #9907
