### PR TITLE
Fix document item buttons in timeline

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6760,6 +6760,7 @@ abstract class CommonITILObject extends CommonDBTM
                 $this->getAssociatedDocumentsCriteria($params['bypass_rights']),
                 'timeline_position'  => ['>', self::NO_TIMELINE]
             ]);
+            $can_view_documents = Document::canView();
             foreach ($document_items as $document_item) {
                 $document_obj->getFromDB($document_item['documents_id']);
 
@@ -6776,9 +6777,13 @@ abstract class CommonITILObject extends CommonDBTM
 
                 $timeline_key = $document_item['itemtype'] . "_" . $document_item['items_id'];
                 if ($document_item['itemtype'] == static::getType()) {
+                    $item['_can_edit'] = $can_view_documents && $document_obj->canUpdateItem();
+                    $item['_can_delete'] = $can_view_documents && $document_obj->canDeleteItem();
                   // document associated directly to itilobject
-                    $timeline["Document_" . $document_item['documents_id']]
-                     = ['type' => 'Document_Item', 'item' => $item];
+                    $timeline["Document_" . $document_item['documents_id']] = [
+                        'type' => 'Document_Item',
+                        'item' => $item
+                    ];
                 } else if (isset($timeline[$timeline_key])) {
                  // document associated to a sub item of itilobject
                     if (!isset($timeline[$timeline_key]['documents'])) {
@@ -6789,7 +6794,9 @@ abstract class CommonITILObject extends CommonDBTM
                     $is_image = Document::isImage($docpath);
                     $sub_document = [
                         'type' => 'Document_Item',
-                        'item' => $item
+                        'item' => $item,
+                        '_can_edit' => $can_view_documents && $document_obj->canUpdateItem(),
+                        '_can_delete' => $can_view_documents && $document_obj->canDeleteItem(),
                     ];
                     if ($is_image) {
                         $sub_document['_is_image'] = true;

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -36,9 +36,11 @@
       <div class="row align-items-center m-n2">
          {% set name     = entry_i['name'] ?? entry_i['filename'] %}
          {% set filename = entry_i['filename'] ?? entry_i['name'] %}
+         {% set fk = item.getForeignKeyField() %}
+         {% set delete_link = item.getFormURL() ~ '?delete_document&documents_id=' ~ entry_i['id'] ~ '&' ~ fk ~ '=' ~ item.fields['id'] %}
 
          {% if entry_i['filename'] %}
-            {% set docpath = path('front/document.send.php?docid=' ~ entry_i['id']) %}
+            {% set docpath = path('front/document.send.php?docid=' ~ entry_i['id'] ~ "&" ~ fk ~ "=" ~ item.fields["id"]) %}
             <div class="col text-truncate">
                <a href="{{ docpath }}" target="_blank">
                   <img src="{{ filename|document_icon }}" alt="{{ __('File extension') }}" />
@@ -62,18 +64,21 @@
 
          <div class="col-auto">
             <div class="list-group-item-actions">
-               <a href="{{ 'Document'|itemtype_form_path(entry_i['id']) }}"
-                  class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Edit') }}"
-                  data-bs-toggle="tooltip" data-bs-placement="top">
-                  <i class="ti ti-edit"></i>
-               </a>
+               {% if entry_i['_can_edit'] %}
+                  <a href="{{ 'Document'|itemtype_form_path(entry_i['id']) }}"
+                     class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Edit') }}"
+                     data-bs-toggle="tooltip" data-bs-placement="top">
+                     <i class="ti ti-edit"></i>
+                  </a>
+               {% endif %}
 
-               {% set fk = item.getForeignKeyField() %}
-               <a href="{{ item.getFormURL() }}?delete_document&amp;documents_id={{ entry_i['id'] }}&amp;{{ fk }}={{ item.fields['id'] }}"
-                  class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Delete permanently') }}"
-                  data-bs-toggle="tooltip" data-bs-placement="top">
-                  <i class="ti ti-trash"></i>
-               </a>
+               {% if entry_i['_can_edit'] %}
+                  <a href="{{ delete_link }}"
+                     class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Delete permanently') }}"
+                     data-bs-toggle="tooltip" data-bs-placement="top">
+                     <i class="ti ti-trash"></i>
+                  </a>
+               {% endif %}
             </div>
          </div>
       </div>

--- a/templates/components/itilobject/timeline/sub_documents.html.twig
+++ b/templates/components/itilobject/timeline/sub_documents.html.twig
@@ -37,25 +37,28 @@
    {% if media_docs|length > 0 %}
       {% set imgs = [] %}
       {% for document in media_docs %}
-         {% set docpath = path('front/document.send.php?docid=' ~ document['item']['id']) %}
          {% set fk = item.getForeignKeyField() %}
+         {% set docpath = path('front/document.send.php?docid=' ~ document['item']['id'] ~ '&' ~ fk ~ '=' ~ item.fields['id']) %}
          {% set delete_link = item.getFormURL() ~ '?delete_document&documents_id=' ~ document['item']['id'] ~ '&' ~ fk ~ '=' ~ item.fields['id'] %}
 
          {% set post_figure_content %}
             <div class="col-auto">
                <div class="list-group-item-actions d-flex flex-column">
-                  <a href="{{ 'Document'|itemtype_form_path(document['item']['id']) }}"
-                     class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Edit') }}"
-                     data-bs-toggle="tooltip" data-bs-placement="top">
-                     <i class="ti ti-edit"></i>
-                  </a>
+                  {% if document['_can_edit'] %}
+                     <a href="{{ 'Document'|itemtype_form_path(document['item']['id']) }}"
+                        class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Edit') }}"
+                        data-bs-toggle="tooltip" data-bs-placement="top">
+                        <i class="ti ti-edit"></i>
+                     </a>
+                  {% endif %}
 
-                  {% set fk = item.getForeignKeyField() %}
-                  <a href="{{ delete_link }}"
-                     class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Delete permanently') }}"
-                     data-bs-toggle="tooltip" data-bs-placement="top">
-                     <i class="ti ti-trash"></i>
-                  </a>
+                  {% if document['_can_delete'] %}
+                     <a href="{{ delete_link }}"
+                        class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Delete permanently') }}"
+                        data-bs-toggle="tooltip" data-bs-placement="top">
+                        <i class="ti ti-trash"></i>
+                     </a>
+                  {% endif %}
                </div>
             </div>
          {% endset %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Edit and delete buttons for documents listed in timeline were always shown even if the user doesn't have permission to edit or delete it. This fixes them for standalone documents and sub-documents for Followups, Tasks, etc.
Reported in https://github.com/cconard96/glpi-screenshot-plugin/issues/30