### PR TITLE
Fix/devices links

### DIFF
--- a/front/item_device.common.form.php
+++ b/front/item_device.common.form.php
@@ -106,7 +106,7 @@ if (isset($_POST["add"])) {
     if (in_array($item_device->getType(), $CFG_GLPI['devices_in_menu'])) {
         $menus = ["assets", strtolower($item_device->getType())];
     } else {
-        $menus = ["config", "commondevice", $item_device->getDeviceType()];
+        $menus = ["config", "commondevice", $item_device->getType()];
     }
 
     if (!isset($options)) {

--- a/front/item_device.common.form.php
+++ b/front/item_device.common.form.php
@@ -113,5 +113,5 @@ if (isset($_POST["add"])) {
         $options = [];
     }
 
-    Item_Devices::displayFullPageForItem($_GET["id"], $menus, $options ?? []);
+    $item_device::displayFullPageForItem($_GET["id"], $menus, $options ?? []);
 }

--- a/front/item_device.php
+++ b/front/item_device.php
@@ -48,7 +48,7 @@ if (!$itemDevice->canView()) {
 if (in_array($itemDevice->getType(), $CFG_GLPI['devices_in_menu'])) {
     Html::header($itemDevice->getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", strtolower($itemDevice->getType()));
 } else {
-    Html::header($itemDevice->getTypeName(Session::getPluralNumber()), '', "config", "commondevice", $itemDevice->getDeviceType());
+    Html::header($itemDevice->getTypeName(Session::getPluralNumber()), '', "config", "commondevice", $itemDevice->getType());
 }
 
 Search::show($_GET['itemtype']);

--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -110,18 +110,39 @@ abstract class CommonDevice extends CommonDropdown
             foreach ($dps as $tab) {
                 foreach ($tab as $key => $val) {
                     if ($tmp = getItemForItemtype($key)) {
-                        $menu['options'][$key]['title']           = $val;
-                        $menu['options'][$key]['page']            = $tmp->getSearchURL(false);
-                        $menu['options'][$key]['links']['search'] = $tmp->getSearchURL(false);
+                        $menu['options'][$key] = [
+                            'title' => $val,
+                            'page'  => $tmp->getSearchURL(false),
+                            'links' => [
+                                'search' => $tmp->getSearchURL(false),
+                                'lists'  => "",
+                            ]
+                        ];
                         if ($tmp->canCreate()) {
                             $menu['options'][$key]['links']['add'] = $tmp->getFormURL(false);
                         }
+
                         if ($itemClass = getItemForItemtype(self::getItem_DeviceType($key))) {
                             $itemTypeName = sprintf(__('%1$s items'), $key::getTypeName(1));
 
                             $listLabel = '<i class="fa fa-list pointer" title="' . $itemTypeName . '"></i>'
                             . '<span class="sr-only">' . $itemTypeName . '</span>';
                             $menu['options'][$key]['links'][$listLabel] = $itemClass->getSearchURL(false);
+
+                            // item device self links
+                            $item_device_key = $itemClass->getType();
+                            $item_device_search_url = $itemClass->getSearchURL(false);
+                            $menu['options'][$item_device_key] = [
+                                'title' => $itemTypeName,
+                                'page'  => $item_device_search_url,
+                                'links' => [
+                                    'search' => $item_device_search_url,
+                                    'lists'  => "",
+                                ],
+                            ];
+                            if ($itemClass->canCreate()) {
+                                $menu['options'][$item_device_key]['links']['add'] = $itemClass->getFormURL(false);
+                            }
                         }
                     }
                 }

--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -115,7 +115,6 @@ abstract class CommonDevice extends CommonDropdown
                             'page'  => $tmp->getSearchURL(false),
                             'links' => [
                                 'search' => $tmp->getSearchURL(false),
-                                'lists'  => "",
                             ]
                         ];
                         if ($tmp->canCreate()) {
@@ -137,7 +136,6 @@ abstract class CommonDevice extends CommonDropdown
                                 'page'  => $item_device_search_url,
                                 'links' => [
                                     'search' => $item_device_search_url,
-                                    'lists'  => "",
                                 ],
                             ];
                             if ($itemClass->canCreate()) {

--- a/templates/pages/setup/dropdowns_list.html.twig
+++ b/templates/pages/setup/dropdowns_list.html.twig
@@ -31,6 +31,7 @@
 
 {% set grid_items = [] %}
 
+{% set nb_opt = optgroup|length %}
 {% for label, dropdown in optgroup %}
    {% set card_id = 'dropdowns_list_' ~ random() %}
    {% set card_html %}
@@ -38,12 +39,12 @@
          <div class="accordion accordion-flush">
             <div class="accordion-item">
                <h2 class="accordion-header">
-                  <button class="accordion-button collapsed" type="button"
+                  <button class="accordion-button {{ nb_opt > 1 ? "collapsed" : "" }}" type="button"
                      data-bs-toggle="collapse" data-bs-target="#{{ card_id }}" aria-expanded="true" aria-controls="collapseOne">
                      {{ label }}
                   </button>
                </h2>
-               <div id="{{ card_id }}" class="accordion-collapse collapse" style="transition: none">
+               <div id="{{ card_id }}" class="accordion-collapse {{ nb_opt > 1 ? "collapse" : "" }}" style="transition: none">
                   <div class="list-group list-group-flush list-group-hoverable">
                      {% for itemtype, dropdown_label in dropdown %}
                         {% set is_entity_assign = itemtype|itemtype_class.isEntityAssign() %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10552

Fix several issues with devices:

- There was no links for creating a "device item", you can create a device (the main class) but not a relative item (the instance)
- item devices header was broken with #10114
- list of components was collapsed when only one was displayed (in oposition of dropdown lists)
