### PR TITLE
fix(savedsearch): typing error

### DIFF
--- a/src/SavedSearch_Alert.php
+++ b/src/SavedSearch_Alert.php
@@ -176,7 +176,7 @@ class SavedSearch_Alert extends CommonDBChild
         $alert = new Alert();
         $alert->getFromDBByCrit([
             'items_id'  => $this->fields['savedsearches_id'],
-            'itemptype' => SavedSearch::getType(),
+            'itemtype' => SavedSearch::getType(),
         ]);
         Dropdown::showFrequency('frequency', $this->fields["frequency"]);
         echo "</td></tr>";


### PR DESCRIPTION
"itemptype" instead of "itemtype"

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
