### PR TITLE
use ti icon for solution approbation

### DIFF
--- a/templates/components/itilobject/timeline/approbation_form.html.twig
+++ b/templates/components/itilobject/timeline/approbation_form.html.twig
@@ -72,7 +72,7 @@
                   </button>
 
                   <button class="btn btn-icon btn-outline-success" name="add_close">
-                     <i class="fas fa-check"></i>
+                     <i class="ti ti-check"></i>
                      <span>{{ __('Approve') }}</span>
                   </button>
                </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Usage of icons from tabler and fontawesome for the two buttons results in a different spacing.
So let's standardize they
