### PR TITLE
Show only ongoing problems for "Link to a problem" massive action

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2857,7 +2857,10 @@ class Ticket extends CommonITILObject
                 return true;
 
             case 'link_to_problem':
-                Problem::dropdown(['name' => 'problems_id']);
+                Problem::dropdown([
+                    'name'      => 'problems_id',
+                    'condition' => Problem::getOpenCriteria()
+                ]);
                 echo '<br><br>';
                 echo Html::submit(_x('button', 'Link'), [
                     'name'      => 'link'


### PR DESCRIPTION
This is to avoid having too many values in the dropdown, as it makes it hard to find the correct one even with text filtering.

![image](https://user-images.githubusercontent.com/42734840/152993985-6860d05d-9ef4-432d-918e-9feedfc596ff.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23391
