### PR TITLE
Fix editing task from planning

### DIFF
--- a/src/Planning.php
+++ b/src/Planning.php
@@ -1268,7 +1268,8 @@ class Planning extends CommonGLPI
                 $options['parent']->getFromDB($params['parentid']);
             }
             $item = getItemForItemtype($params['itemtype']);
-            $item->showForm(intval($params['id']), $options);
+            $item->getFromDB((int) $params['id']);
+            $item->showForm((int)$params['id'], $options);
             $callback = "glpi_close_all_dialogs();
                       GLPIPlanning.refresh();
                       displayAjaxMessageAfterRedirect();";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10139

While this fixes this one instance, there may be others. The `showForm` method has an ID parameter that is largely ignored now.

For example, the default CommonDBTM implementation:
```php
$this->initForm($ID, $options);
TemplateRenderer::getInstance()->display('generic_show_form.html.twig', [
     'item'   => $this,
     'params' => $options,
]);
return true;
```

The showForm function seems like it is more useful in a static context where it would load a specific item from the DB within the function. Instead, the implementation acts like a class instance method that expects the fields from the database to already be loaded into the current instance.

Even in previous versions, this behavior wasn't very clear. The ID parameter was not used to fetch the item from the database and could mostly be replaced with `$this->fields['id']` or `$this->getID()`.