### PR TITLE
Fix ticket escalation status

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -1064,6 +1064,12 @@ abstract class CommonITILObject extends CommonDBTM {
                      if (isset($input['_auto_update'])
                          || $groupactors->can(-1, CREATE, $input['_itil_assign'])) {
                         $groupactors->add($input['_itil_assign']);
+
+                        // Reload object, needed as adding a group may trigger
+                        // some plugins hooks thay will update our current
+                        // object.
+                        $this->getFromDB($input["id"]);
+
                         $input['_forcenotif']                  = true;
                         if (((!isset($input['status'])
                              && (in_array($this->fields['status'], $this->getNewStatusArray())))


### PR DESCRIPTION
This issue affect the escalade plugin but need to be fixed in GLPI core unless I'm mistaken.

The issue is simple to reproduce.
I'm using the following escalade plugin configuration:
![image](https://user-images.githubusercontent.com/42734840/153172947-f20c9ef0-3be4-4b52-a2aa-f0616dd85a69.png)
I believe only the highlighted parameter is needed to reproduce this issue.

I have a ongoing ticket with an assigned user:
![image](https://user-images.githubusercontent.com/42734840/153173926-3b2af782-4e2f-4629-ad25-43572bfb762d.png)

I assign a new group to the ticket:
![image](https://user-images.githubusercontent.com/42734840/153174555-ed2a783d-9744-45fb-9b87-e0157dd7a169.png)

After hitting submit, the group replaced the user (as expected from my escalade plugin configuration) but the ticket status is now "New" instead of "Assigned":
![image](https://user-images.githubusercontent.com/42734840/153177317-fa1a630a-64b6-4e1c-8845-293f4ac1631a.png)

The technical causes are a bit harder to explain, to keep things short I found out that the following steps happens:
- `prepareInputForUpdate` in `CommonITIL` trigger the process of adding a new group to the ticket
- This trigger the `plugin_escalade_pre_item_add_group_ticket` hook that will remove the current assigned user of the ticket, setting it's status to "New"
- After the hook is done, the group is finally added, which trigger another update to the ticket to restore the "Assigned" status
- However, the update is never executed because the "in memory" ticket values still contains the "Assigned status" (our original value before going to "New" as the assigned user was deleted) -> GLPI think there is no status update needed and do nothing

I've fixed this by forcing a reload of the ticket values after the group is added.
GLPI is now aware that the status is "New" and that the update to "Assigned" must not be ignored.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23398