### PR TITLE
fix(database): fix SO to get DatabaseInstance from Database list

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -251,11 +251,11 @@ class Database extends CommonDBChild
             'usehaving'          => true,
             'massiveaction'      => false,
             'joinparams'         => [
-               'beforejoin'         => [
-                  'table'              => DatabaseInstance::getTable(),
-                  'joinparams'         => [
-                     'jointype'           => 'item_itemtype',
-                     'specific_itemtype'  => 'Computer'
+                'beforejoin'         => [
+                    'table'              => DatabaseInstance::getTable(),
+                    'joinparams'         => [
+                        'jointype'           => 'item_itemtype',
+                        'specific_itemtype'  => 'Computer'
                   ]
                ]
             ]

--- a/src/Database.php
+++ b/src/Database.php
@@ -256,10 +256,10 @@ class Database extends CommonDBChild
                     'joinparams'         => [
                         'jointype'           => 'item_itemtype',
                         'specific_itemtype'  => 'Computer'
-                  ]
-               ]
+                    ]
+                ]
             ]
-         ];
+        ];
 
         return $tab;
     }

--- a/src/Database.php
+++ b/src/Database.php
@@ -248,17 +248,18 @@ class Database extends CommonDBChild
             'linkfield'          => 'items_id',
             'name'               => Computer::getTypeName(0),
             'forcegroupby'       => true,
+            'usehaving'          => true,
             'massiveaction'      => false,
             'joinparams'         => [
-                'beforejoin'         => [
-                    'table'              => DatabaseInstance::getTable(),
-                    'joinparams'         => [
-                        'jointype'           => 'itemtype_item',
-                        'specific_itemtype'  => 'Computer'
-                    ]
-                ]
+               'beforejoin'         => [
+                  'table'              => DatabaseInstance::getTable(),
+                  'joinparams'         => [
+                     'jointype'           => 'item_itemtype',
+                     'specific_itemtype'  => 'Computer'
+                  ]
+               ]
             ]
-        ];
+         ];
 
         return $tab;
     }


### PR DESCRIPTION
 Fix SO to get ```DatabaseInstance``` from ```Database``` list

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
