### PR TITLE
Fix calendar active time when working in days

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -285,50 +285,45 @@ class Calendar extends CommonDropdown
 
         $activetime = 0;
 
-        $cache_duration = $this->getDurationsCache();
-
-        for ($actualtime = $timestart; $actualtime <= $timerealend; $actualtime += DAY_TIMESTAMP) {
-            $actualdate = date('Y-m-d', $actualtime);
-
-            if (!$this->isHoliday($actualdate)) {
-                $beginhour    = '00:00:00';
-                // Calendar segment work with '24:00:00' format for midnight
-                $endhour      = '24:00:00';
-                $dayofweek    = self::getDayNumberInWeek($actualtime);
-                $timeoftheday = 0;
-
-                if ($actualdate == $datestart) { // First day : cannot use cache
-                    $beginhour = date('H:i:s', $timestart);
-                }
-
-                if ($actualdate == $dateend) { // Last day : cannot use cache
-                    $endhour = date('H:i:s', $timeend);
-                }
-
-                if (
-                    (($actualdate == $datestart) || ($actualdate == $dateend))
-                    && ($cache_duration[$dayofweek] > 0)
-                ) {
-                     $timeoftheday = CalendarSegment::getActiveTimeBetween(
-                         $this->fields['id'],
-                         $dayofweek,
-                         $beginhour,
-                         $endhour
-                     );
-                } else {
-                    $cached_duration = $cache_duration[$dayofweek];
-                    if ($cached_duration > 0 && $work_in_days) {
-                        $timeoftheday = DAY_TIMESTAMP;
-                    } else {
-                        $timeoftheday = $cached_duration;
-                    }
-                }
-                $activetime += $timeoftheday;
-            }
-        }
-
         if ($work_in_days) {
-            $activetime = (int) ceil($activetime / DAY_TIMESTAMP) * DAY_TIMESTAMP;
+            $activetime = $timeend - $timestart;
+        } else {
+            $cache_duration = $this->getDurationsCache();
+
+            for ($actualtime = $timestart; $actualtime <= $timerealend; $actualtime += DAY_TIMESTAMP) {
+                $actualdate = date('Y-m-d', $actualtime);
+
+                if (!$this->isHoliday($actualdate)) {
+                    $beginhour    = '00:00:00';
+                    // Calendar segment work with '24:00:00' format for midnight
+                    $endhour      = '24:00:00';
+                    $dayofweek    = self::getDayNumberInWeek($actualtime);
+                    $timeoftheday = 0;
+
+                    if ($actualdate == $datestart) { // First day : cannot use cache
+                        $beginhour = date('H:i:s', $timestart);
+                    }
+
+                    if ($actualdate == $dateend) { // Last day : cannot use cache
+                        $endhour = date('H:i:s', $timeend);
+                    }
+
+                    if (
+                        (($actualdate == $datestart) || ($actualdate == $dateend))
+                        && ($cache_duration[$dayofweek] > 0)
+                    ) {
+                         $timeoftheday = CalendarSegment::getActiveTimeBetween(
+                             $this->fields['id'],
+                             $dayofweek,
+                             $beginhour,
+                             $endhour
+                         );
+                    } else {
+                        $timeoftheday = $cache_duration[$dayofweek];
+                    }
+                    $activetime += $timeoftheday;
+                }
+            }
         }
         return $activetime;
     }

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -285,45 +285,50 @@ class Calendar extends CommonDropdown
 
         $activetime = 0;
 
-        if ($work_in_days) {
-            $activetime = $timeend - $timestart;
-        } else {
-            $cache_duration = $this->getDurationsCache();
+        $cache_duration = $this->getDurationsCache();
 
-            for ($actualtime = $timestart; $actualtime <= $timerealend; $actualtime += DAY_TIMESTAMP) {
-                $actualdate = date('Y-m-d', $actualtime);
+        for ($actualtime = $timestart; $actualtime <= $timerealend; $actualtime += DAY_TIMESTAMP) {
+            $actualdate = date('Y-m-d', $actualtime);
 
-                if (!$this->isHoliday($actualdate)) {
-                    $beginhour    = '00:00:00';
-                    // Calendar segment work with '24:00:00' format for midnight
-                    $endhour      = '24:00:00';
-                    $dayofweek    = self::getDayNumberInWeek($actualtime);
-                    $timeoftheday = 0;
+            if (!$this->isHoliday($actualdate)) {
+                $beginhour    = '00:00:00';
+                // Calendar segment work with '24:00:00' format for midnight
+                $endhour      = '24:00:00';
+                $dayofweek    = self::getDayNumberInWeek($actualtime);
+                $timeoftheday = 0;
 
-                    if ($actualdate == $datestart) { // First day : cannot use cache
-                        $beginhour = date('H:i:s', $timestart);
-                    }
-
-                    if ($actualdate == $dateend) { // Last day : cannot use cache
-                        $endhour = date('H:i:s', $timeend);
-                    }
-
-                    if (
-                        (($actualdate == $datestart) || ($actualdate == $dateend))
-                        && ($cache_duration[$dayofweek] > 0)
-                    ) {
-                         $timeoftheday = CalendarSegment::getActiveTimeBetween(
-                             $this->fields['id'],
-                             $dayofweek,
-                             $beginhour,
-                             $endhour
-                         );
-                    } else {
-                        $timeoftheday = $cache_duration[$dayofweek];
-                    }
-                    $activetime += $timeoftheday;
+                if ($actualdate == $datestart) { // First day : cannot use cache
+                    $beginhour = date('H:i:s', $timestart);
                 }
+
+                if ($actualdate == $dateend) { // Last day : cannot use cache
+                    $endhour = date('H:i:s', $timeend);
+                }
+
+                if (
+                    (($actualdate == $datestart) || ($actualdate == $dateend))
+                    && ($cache_duration[$dayofweek] > 0)
+                ) {
+                     $timeoftheday = CalendarSegment::getActiveTimeBetween(
+                         $this->fields['id'],
+                         $dayofweek,
+                         $beginhour,
+                         $endhour
+                     );
+                } else {
+                    $cached_duration = $cache_duration[$dayofweek];
+                    if ($cached_duration > 0 && $work_in_days) {
+                        $timeoftheday = DAY_TIMESTAMP;
+                    } else {
+                        $timeoftheday = $cached_duration;
+                    }
+                }
+                $activetime += $timeoftheday;
             }
+        }
+
+        if ($work_in_days) {
+            $activetime = (int) ceil($activetime / DAY_TIMESTAMP) * DAY_TIMESTAMP;
         }
         return $activetime;
     }

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -261,7 +261,8 @@ class Calendar extends CommonDropdown
      *
      * @param $start           datetime begin
      * @param $end             datetime end
-     * @param $work_in_days    boolean  force working in days (false by default)
+     * @param $work_in_days    boolean  force working in days (false by default).
+     *      If set to true, non-working days and times are ignored and a simple time difference calculation is done.
      *
      * @return integer timestamp of delay
      */

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -799,19 +799,14 @@ abstract class LevelAgreement extends CommonDBChild
             return 0;
         }
 
+        $active_time = 0;
+
         if (isset($this->fields['id'])) {
             $cal          = new Calendar();
-            $work_in_days = ($this->fields['definition_time'] == 'day');
-
-           // Based on a calendar
-            if ($this->fields['calendars_id'] > 0) {
-                if ($cal->getFromDB($this->fields['calendars_id'])) {
-                    return $cal->getActiveTimeBetween($start, $end, $work_in_days);
-                }
-            } else { // No calendar
-                $timestart = strtotime($start);
-                $timeend   = strtotime($end);
-                return ($timeend - $timestart);
+            if ($this->fields['calendars_id'] > 0 && $cal->getFromDB($this->fields['calendars_id'])) {
+                $active_time = $cal->getActiveTimeBetween($start, $end);
+            } else {
+                $active_time = $cal->getActiveTimeBetween($start, $end, true);
             }
         }
         return 0;

--- a/tests/functionnal/Calendar.php
+++ b/tests/functionnal/Calendar.php
@@ -62,6 +62,18 @@ class Calendar extends DbTestCase
 
     protected function activeProvider()
     {
+        /**
+         * 2019-01-01 - Tuesday
+         * 2019-01-02 - Wednesday
+         * 2019-01-03 - Thursday
+         * 2019-01-04 - Friday
+         * 2019-01-05 - Saturday (Non-working day)
+         * 2019-01-06 - Sunday (Non-working day)
+         * 2019-01-07 - Monday
+         * 2019-01-08 - Tuesday
+         *
+         * Default calendar has 12-hour working day (8:00 - 20:00)
+         */
         return [
             [
                 'start'  => '2019-01-01 07:00:00',
@@ -72,22 +84,50 @@ class Calendar extends DbTestCase
                 'end'    => '2019-01-01 07:00:00',
                 'value'  => 0
             ], [
+                'start'  => '2019-01-01 06:00:00',
+                'end'    => '2019-01-01 09:00:00',
+                'value'  => HOUR_TIMESTAMP
+            ], [
+                'start'  => '2019-01-01 06:00:00',
+                'end'    => '2019-01-02 01:00:00',
+                'value'  => 12 * HOUR_TIMESTAMP
+            ], [
                 'start'  => '2019-01-01 00:00:00',
                 'end'    => '2019-01-08 00:00:00',
-                'value'  => 12 * HOUR_TIMESTAMP * 5
+                'value'  => 12 * HOUR_TIMESTAMP * 5 // 5 working days (7 days - 2 non-working days)
             ], [
                 'start'  => '2019-01-08 00:00:00',
                 'end'    => '2019-01-01 00:00:00',
-                'value'  => 0
+                'value'  => 0 // End date is before start date (No working hours)
             ], [
                 'start'  => '2019-01-01 07:00:00',
                 'end'    => '2019-01-01 09:00:00',
-                'value'  => HOUR_TIMESTAMP * 2,
+                'value'  => DAY_TIMESTAMP,
                 'days'   => true
             ], [
                 'start'  => '2019-01-01 00:00:00',
                 'end'    => '2019-01-08 00:00:00',
-                'value'  => WEEK_TIMESTAMP,
+                'value'  => 12 * HOUR_TIMESTAMP * 5,
+                'days'   => false
+            ], [
+                'start'  => '2019-01-01 00:00:00',
+                'end'    => '2019-01-08 00:00:00',
+                'value'  => 5 * DAY_TIMESTAMP,
+                'days'   => true
+            ], [
+                'start'  => '2019-01-01 00:00:00',
+                'end'    => '2019-01-04 00:00:00',
+                'value'  => 3 * DAY_TIMESTAMP,
+                'days'   => true
+            ], [
+                'start'  => '2019-01-05 00:00:00',
+                'end'    => '2019-01-07 00:00:00',
+                'value'  => 0,
+                'days'   => true
+            ], [
+                'start'  => '2019-01-01 00:19:50',
+                'end'    => '2019-01-02 00:18:00',
+                'value'  => DAY_TIMESTAMP,
                 'days'   => true
             ]
         ];

--- a/tests/functionnal/Calendar.php
+++ b/tests/functionnal/Calendar.php
@@ -62,18 +62,6 @@ class Calendar extends DbTestCase
 
     protected function activeProvider()
     {
-        /**
-         * 2019-01-01 - Tuesday
-         * 2019-01-02 - Wednesday
-         * 2019-01-03 - Thursday
-         * 2019-01-04 - Friday
-         * 2019-01-05 - Saturday (Non-working day)
-         * 2019-01-06 - Sunday (Non-working day)
-         * 2019-01-07 - Monday
-         * 2019-01-08 - Tuesday
-         *
-         * Default calendar has 12-hour working day (8:00 - 20:00)
-         */
         return [
             [
                 'start'  => '2019-01-01 07:00:00',
@@ -84,50 +72,22 @@ class Calendar extends DbTestCase
                 'end'    => '2019-01-01 07:00:00',
                 'value'  => 0
             ], [
-                'start'  => '2019-01-01 06:00:00',
-                'end'    => '2019-01-01 09:00:00',
-                'value'  => HOUR_TIMESTAMP
-            ], [
-                'start'  => '2019-01-01 06:00:00',
-                'end'    => '2019-01-02 01:00:00',
-                'value'  => 12 * HOUR_TIMESTAMP
-            ], [
                 'start'  => '2019-01-01 00:00:00',
                 'end'    => '2019-01-08 00:00:00',
-                'value'  => 12 * HOUR_TIMESTAMP * 5 // 5 working days (7 days - 2 non-working days)
+                'value'  => 12 * HOUR_TIMESTAMP * 5
             ], [
                 'start'  => '2019-01-08 00:00:00',
                 'end'    => '2019-01-01 00:00:00',
-                'value'  => 0 // End date is before start date (No working hours)
+                'value'  => 0
             ], [
                 'start'  => '2019-01-01 07:00:00',
                 'end'    => '2019-01-01 09:00:00',
-                'value'  => DAY_TIMESTAMP,
+                'value'  => HOUR_TIMESTAMP * 2,
                 'days'   => true
             ], [
                 'start'  => '2019-01-01 00:00:00',
                 'end'    => '2019-01-08 00:00:00',
-                'value'  => 12 * HOUR_TIMESTAMP * 5,
-                'days'   => false
-            ], [
-                'start'  => '2019-01-01 00:00:00',
-                'end'    => '2019-01-08 00:00:00',
-                'value'  => 5 * DAY_TIMESTAMP,
-                'days'   => true
-            ], [
-                'start'  => '2019-01-01 00:00:00',
-                'end'    => '2019-01-04 00:00:00',
-                'value'  => 3 * DAY_TIMESTAMP,
-                'days'   => true
-            ], [
-                'start'  => '2019-01-05 00:00:00',
-                'end'    => '2019-01-07 00:00:00',
-                'value'  => 0,
-                'days'   => true
-            ], [
-                'start'  => '2019-01-01 00:19:50',
-                'end'    => '2019-01-02 00:18:00',
-                'value'  => DAY_TIMESTAMP,
+                'value'  => WEEK_TIMESTAMP,
                 'days'   => true
             ]
         ];

--- a/tests/functionnal/LevelAgreement.php
+++ b/tests/functionnal/LevelAgreement.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+
+abstract class LevelAgreement extends DbTestCase
+{
+
+    protected $levelagreement_class = null;
+
+    public function __construct(string $levelagreement_class)
+    {
+        $this->levelagreement_class = $levelagreement_class;
+    }
+
+    protected function getLevelAgreementInstance(): \LevelAgreement
+    {
+        return new $this->levelagreement_class();
+    }
+
+    protected function getActiveTimeBetweeenProvider()
+    {
+        return [
+            [
+                'start'         => '2019-01-01 07:00:00',
+                'end'           => '2019-01-01 09:00:00',
+                'value'         => HOUR_TIMESTAMP,
+                'calendars_id'  => 1
+            ], [
+                'start'         => '2019-01-01 06:00:00',
+                'end'           => '2019-01-01 07:00:00',
+                'value'         => 0,
+                'calendars_id'  => 1
+            ], [
+                'start'         => '2019-01-01 00:00:00',
+                'end'           => '2019-01-08 00:00:00',
+                'value'         => 12 * HOUR_TIMESTAMP * 5,
+                'calendars_id'  => 1
+            ], [
+                'start'         => '2019-01-08 00:00:00',
+                'end'           => '2019-01-01 00:00:00',
+                'value'         => 0,
+                'calendars_id'  => 1
+            ], [
+                'start'         => '2019-01-01 07:00:00',
+                'end'           => '2019-01-01 09:00:00',
+                'value'         => HOUR_TIMESTAMP * 2,
+                'calendars_id'  => -1
+            ], [
+                'start'         => '2019-01-01 00:00:00',
+                'end'           => '2019-01-08 00:00:00',
+                'value'         => WEEK_TIMESTAMP,
+                'calendars_id'  => -1
+            ]
+        ];
+    }
+
+    public function testGetActiveTimeBetween($start, $end, $expected, $calendars_id)
+    {
+        $level_agreement = $this->getLevelAgreementInstance();
+        $level_agreement->fields['calendars_id'] = $calendars_id;
+        $this->boolean($level_agreement->getActiveTimeBetween($start, $end))->isIdenticalTo($expected);
+    }
+}

--- a/tests/functionnal/OLA.php
+++ b/tests/functionnal/OLA.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+require_once 'LevelAgreement.php';
+
+class OLA extends LevelAgreement
+{
+
+    public function __construct()
+    {
+        parent::__construct(\OLA::class);
+    }
+}

--- a/tests/functionnal/SLA.php
+++ b/tests/functionnal/SLA.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+require_once 'LevelAgreement.php';
+
+class SLA extends LevelAgreement
+{
+
+    public function __construct()
+    {
+        parent::__construct(\SLA::class);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes (time calculation change)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10594

I'm not quite sure this is the correct fix yet. The original logic had been unchanged for years.

To me it looks like it should return a timestamp in days (n * DAY_TIMESTAMP) for working time, but it doesn't. The behavior currently just ignores all non-working time and returns ($end - $start).

In the context of an SLA (with non 24/7 calendar):
Ticket created 10 minutes before end of day with TTR of 1 day (having Days in SLA sets work_in_days to true).

The current behavior gives technicians until 10 minutes before closing the next day regardless of working hours. If the next day is a holiday, it looks like it would give technicians 10 minutes to meet the SLA.