### PR TITLE
php warning with users_id_validate

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -4104,7 +4104,7 @@ class CommonDBTM extends CommonGLPI
                         case 'email':
                         case 'string':
                         case 'itemlink':
-                            if (strlen($value) > 255) {
+                            if (is_string($value) && strlen($value) > 255) {
                                 trigger_error(
                                     "$value exceed 255 characters long (" . strlen($value) . "), it will be truncated.",
                                     E_USER_WARNING


### PR DESCRIPTION
When adding a ticket with a validator user, a PHP warning occurs, while checking a string lenght. Actually, the validator is sent as an array

Found in unit tests of Formcreator, when creating a ticket from a target
https://github.com/pluginsGLPI/formcreator/runs/5138373153?check_suite_focus=true#step:8:953


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10602
