### PR TITLE
fix(UI): get timeline position from parent

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5385,7 +5385,9 @@ class CommonDBTM extends CommonGLPI
                     $toadd['timeline_position'] = CommonITILObject::NO_TIMELINE;
                 } else {
                     //get timeline_position from parent (followup  / task / doc)
-                    $toadd['timeline_position'] = $input['timeline_position'];
+                    if (isset($input['timeline_position'])) {
+                        $toadd['timeline_position'] = $input['timeline_position'];
+                    }
                 }
 
                 $docitem->add($toadd);

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5383,7 +5383,7 @@ class CommonDBTM extends CommonGLPI
                 ) {
                     //do not display inline docs in timeline
                     $toadd['timeline_position'] = CommonITILObject::NO_TIMELINE;
-                }else {
+                } else {
                     //get timeline_position from parent (followup  / task / doc)
                     $toadd['timeline_position'] = $input['timeline_position'];
                 }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5381,8 +5381,11 @@ class CommonDBTM extends CommonGLPI
                     && strpos($input[$options['content_field']], $doc->fields["tag"]) !== false
                     && strpos($doc->fields['mime'], 'image/') !== false
                 ) {
-                   //do not display inline docs in timeline
+                    //do not display inline docs in timeline
                     $toadd['timeline_position'] = CommonITILObject::NO_TIMELINE;
+                }else {
+                    //get timeline_position from parent (followup  / task / doc)
+                    $toadd['timeline_position'] = $input['timeline_position'];
                 }
 
                 $docitem->add($toadd);


### PR DESCRIPTION
Timeline position for doc is never set or always to left.

This PR fix this



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23422
