### PR TITLE
Fix edit saved search icon color

### DIFF
--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -1163,6 +1163,12 @@
       width: 1%;
    }
 
+   .bookmark_record {
+      .active {
+         color: #fed175 !important;
+      }
+   }
+
    .fa {
       &.bookmark_record, &.reset-search, &.fold-search {
          font-size: 1.5em;
@@ -1171,10 +1177,6 @@
          &:link {
             font-size: 1.5em;
             color: #ccc !important;
-         }
-
-         &.active {
-            color: #fed175 !important;
          }
       }
 
@@ -1190,10 +1192,6 @@
 
       &.reset-search:hover, &.bookmark_record.save:hover, &.fold-search:hover {
          color: #999 !important;
-
-         &.active {
-            color: #feb010 !important;
-         }
       }
    }
 


### PR DESCRIPTION
This icon is supposed to be yellow when viewing a saved search.

![image](https://user-images.githubusercontent.com/42734840/153433364-c2475314-d77c-438e-82da-09f44261b965.png)

Probably broken by some HTML change when switching to tabler.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
