### PR TITLE
Catch any Guzzle exception for unknown status

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -645,7 +645,7 @@ class Agent extends CommonDBTM
             ErrorHandler::getInstance()->handleException($e);
            //not authorized
             return ['answer' => __('Not allowed')];
-        } catch (\GuzzleHttp\Exception\ConnectException $e) {
+        } catch (Exception $e) {
            //no response
             return ['answer' => __('Unknown')];
         }
@@ -666,7 +666,7 @@ class Agent extends CommonDBTM
             ErrorHandler::getInstance()->handleException($e);
            //not authorized
             return ['answer' => __('Not allowed')];
-        } catch (\GuzzleHttp\Exception\ConnectException $e) {
+        } catch (Exception $e) {
            //no response
             return ['answer' => __('Unknown')];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Triggering the [SNMP inventory issue #52](https://github.com/glpi-project/glpi-inventory-plugin/issues/52) case, I tried to update the status of an agent from the agent page after a just imported a printer. As the agent "Item type" was changed to **Printer**, the guessed addresses was only set to the printer name which was including a space ("MP 3055"). After debugging, I saw the agent guessed address was `https://mr 3055:62354/`. As a space in a hostname is an error, Guzzle triggered the `\GuzzleHttp\Exception\RequestException` which is not handled at the moment and an exception was catched in `php-errors.log`:
```
[2022-02-09 16:20:12] glpiphplog.CRITICAL:   *** Uncaught Exception GuzzleHttp\Exception\RequestException: cURL error 3:  (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://mp 3055:62354/status in /srv/glpi/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php at line 211
  Backtrace :
  ...zzlehttp/guzzle/src/Handler/CurlFactory.php:158 GuzzleHttp\Handler\CurlFactory::createRejection()
  ...zzlehttp/guzzle/src/Handler/CurlFactory.php:110 GuzzleHttp\Handler\CurlFactory::finishError()
  ...uzzlehttp/guzzle/src/Handler/CurlHandler.php:47 GuzzleHttp\Handler\CurlFactory::finish()
  vendor/guzzlehttp/guzzle/src/Handler/Proxy.php:28  GuzzleHttp\Handler\CurlHandler->__invoke()
  vendor/guzzlehttp/guzzle/src/Handler/Proxy.php:48  GuzzleHttp\Handler\Proxy::GuzzleHttp\Handler\{closure}()
  ...zlehttp/guzzle/src/PrepareBodyMiddleware.php:35 GuzzleHttp\Handler\Proxy::GuzzleHttp\Handler\{closure}()
  vendor/guzzlehttp/guzzle/src/Middleware.php:31     GuzzleHttp\PrepareBodyMiddleware->__invoke()
  ...guzzlehttp/guzzle/src/RedirectMiddleware.php:71 GuzzleHttp\Middleware::GuzzleHttp\{closure}()
  vendor/guzzlehttp/guzzle/src/Middleware.php:63     GuzzleHttp\RedirectMiddleware->__invoke()
  vendor/guzzlehttp/guzzle/src/HandlerStack.php:75   GuzzleHttp\Middleware::GuzzleHttp\{closure}()
  vendor/guzzlehttp/guzzle/src/Client.php:331        GuzzleHttp\HandlerStack->__invoke()
  vendor/guzzlehttp/guzzle/src/Client.php:168        GuzzleHttp\Client->transfer()
  vendor/guzzlehttp/guzzle/src/Client.php:187        GuzzleHttp\Client->requestAsync()
  src/Agent.php:616                                  GuzzleHttp\Client->request()
  src/Agent.php:642                                  Agent->requestAgent()
  ajax/agent.php:58                                  Agent->requestStatus()
```