### PR TITLE
Fix/10591

### DIFF
--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -213,7 +213,7 @@
                   itiltemplate_class: '{{ itiltemplate.getType() }}',
                   itiltemplates_id: {{ itiltemplate.fields['id'] ?? 0 }},
                   itemtype: '{{ item.getType() }}',
-                  items_id: {{ item.fields['id'] }},
+                  items_id: {{ item.isNewItem() ? -1 : item.fields['id'] }},
                   item: {{ item.fields|json_encode|raw }},
                   returned_itemtypes: {{ (returned_itemtypes ?? ['User', 'Group', 'Supplier'])|json_encode()|raw }},
                };

--- a/templates/dropdown_form.html.twig
+++ b/templates/dropdown_form.html.twig
@@ -34,7 +34,7 @@
 <div class="asset">
     {{ include('components/form/header.html.twig') }}
     {% set rand          = random() %}
-    {% set fields_params = fields_params ?? [] %}
+    {% set base_fields_params = fields_params ?? [] %}
     {% set params        = params ?? [] %}
     {% set target        = params['target'] ?? item.getFormURL() %}
     {% set withtemplate  = params['withtemplate'] ?? '' %}
@@ -61,6 +61,7 @@
 
         {# Dynamically show additional fields unique to certain dropdowns #}
         {% for field in additional_fields %}
+            {% set fields_params = base_fields_params %}
             {% set type = field['type']|default('') %}
             {% set show_field = true %}
             {% if field['name'] == 'entities_id' and (type != 'parent' or item.fields['id'] == 0) %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10591

Fixed two issues noticed while testing issue reported in #10591.

First is a broken JS parameter for new tickets (empty string instead of -1).
Second is that the `fields_params` object was being shared between the different dropdown form fields. I noticed this when all the yes/no dropdowns on the ITIL Categories form only had the option "No". One of the other fields had set the dropdown `used` option and had `1` in the array.