### PR TITLE
Fix empty in error in Entity Assets tab

### DIFF
--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -960,6 +960,9 @@ final class DbUtils
     {
         global $DB, $GLPI_CACHE;
 
+        if ($items_id === null) {
+            return [];
+        }
         $ckey = 'ancestors_cache_';
         if (is_array($items_id)) {
             $ckey .= $table . '_' . md5(implode('|', $items_id));

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -1813,16 +1813,16 @@ class Entity extends CommonTreeDropdown
         echo "<td>";
 
         $toadd = [self::CONFIG_NEVER => __('No change of entity')]; // Keep software in PC entity
+        $entities = [];
         if ($ID > 0) {
             $toadd[self::CONFIG_PARENT] = __('Inheritance of the parent entity');
-        }
-        $entities = [$entity->fields['entities_id']];
-        foreach (getAncestorsOf('glpi_entities', $entity->fields['entities_id']) as $ent) {
-            if (Session::haveAccessToEntity($ent)) {
-                $entities[] = $ent;
+            $entities = [$entity->fields['entities_id']];
+            foreach (getAncestorsOf('glpi_entities', $entity->fields['entities_id']) as $ent) {
+                if (Session::haveAccessToEntity($ent)) {
+                    $entities[] = $ent;
+                }
             }
         }
-
         self::dropdown(['name'     => 'entities_id_software',
             'value'    => $entity->fields['entities_id_software'],
             'toadd'    => $toadd,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10590

Fixes specific empty IN case for Entity > Assets tab. Also adds a safety type check to `DBUtils::getAncestorsOf`.