### PR TITLE
Fix/10597

### DIFF
--- a/front/tracking.injector.php
+++ b/front/tracking.injector.php
@@ -92,11 +92,7 @@ if (isset($_POST['add'])) {
             echo "</div>";
         }
     } else {
-        echo "<div class='center'>";
-        echo "<img src='" . $CFG_GLPI["root_doc"] . "/pics/warning.png' alt='" . __s('Warning') . "'><br>";
-        Html::displayMessageAfterRedirect();
-        echo "<a href='" . $CFG_GLPI["root_doc"] . "/front/helpdesk.public.php?create_ticket=1'>" .
-            __('Back') . "</a></div>";
+        Html::back();
     }
     Html::nullFooter();
 } else { // reload display form

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4197,6 +4197,7 @@ JAVASCRIPT;
             'selfservice'             => true,
             'item'                    => $this,
             'params'                  => $options,
+            'itiltemplate_key'        => self::getTemplateFormFieldName(),
             'itiltemplate'            => $tt,
             'delegating'              => $delegating,
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10597

Add missing template field.
Removes confusing page that gets shown after an issue with adding tickets from simplified interface. It shows just a warning picture/icon with a Back link. It would be a better user experience to just take them back to the form instead of making them click the link.