### PR TITLE
Allow usage of npm v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
             },
             "engines": {
                 "node": ">= 16.0",
-                "npm": ">= 8.0"
+                "npm": ">= 7.0"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "GPL-2.0",
     "engines": {
         "node": ">= 16.0",
-        "npm": ">= 8.0"
+        "npm": ">= 7.0"
     },
     "dependencies": {
         "@eastdesire/jscolor": "^2.4.6",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Dependabot is using `npm` v7 (see https://github.com/dependabot/dependabot-core/blob/36c45ff2717f77bfab7eb2f71c58e66aec260835/Dockerfile#L101), so we need to allow usage of this version to be able to use this service.

Differences between v7 and v8 are minimal. Usage of a new major version number is related to drop of old node version support (see https://nodesource.com/blog/whats-new-in-npm-8).