### PR TITLE
Fix unused timeline item templates

### DIFF
--- a/templates/components/itilobject/answer.html.twig
+++ b/templates/components/itilobject/answer.html.twig
@@ -49,6 +49,12 @@
                      </div>
                      <div>
                         {% if timeline_itemtype.template is defined %}
+                           {{ include(timeline_itemtype.template, {
+                              'item': item,
+                              'subitem': timeline_itemtype.item,
+                              'kb_id_toload': show_kb_sol
+                           }) }}
+                        {% else %}
                            {% set sf_options = {'parent': item} %}
                            {% if show_kb_sol %}
                               {% set sf_options = sf_options|merge({

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -139,16 +139,14 @@
                   <div class="card-body">
                      {{ include('components/itilobject/timeline/timeline_item_header.html.twig') }}
 
-                     {% if itiltype is same as 'ITILValidation' %}
-                        {{ include('components/itilobject/timeline/form_validation.html.twig', {'form_mode': 'view'}) }}
-                     {% elseif itiltype is same as 'ITILTask' %}
-                        {{ include('components/itilobject/timeline/form_task.html.twig', {'form_mode': 'view'}) }}
-                     {% elseif itiltype is same as 'ITILFollowup' %}
-                        {{ include('components/itilobject/timeline/form_followup.html.twig', {'form_mode': 'view'}) }}
-                     {% elseif itiltype is same as 'ITILSolution' %}
-                        {{ include('components/itilobject/timeline/form_solution.html.twig', {'form_mode': 'view'}) }}
-                     {% elseif itiltype is same as 'Document_Item' %}
-                        {{ include('components/itilobject/timeline/form_document_item.html.twig', {'form_mode': 'view'}) }}
+                     {% if itiltype in timeline_itemtypes|column('type') %}
+                        {% set matching_types = timeline_itemtypes|filter((v) => v.type == itiltype) %}
+                        {% if matching_types|length > 0 %}
+                           {% set timeline_itemtype = matching_types|first %}
+                           {% if timeline_itemtype.template is defined %}
+                              {{ include(timeline_itemtype.template, {'form_mode': 'view'}) }}
+                           {% endif %}
+                        {% endif %}
                      {% else %}
                         <div class="read-only-content">
                            {{ entry_i['content']|safe_html }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The `template` property for timeline itemtypes is only checked if it is defined and then the `showForm` method is always called on the `item` instead of just directly including the defined template. It seems like the template should be used directly if defined, otherwise it should fall back on `showForm`.