### PR TITLE
Prevent fatal error when searching 'event' or 'socket'; fixes #10528

### DIFF
--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -32,6 +32,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Toolbox\ClassHandler;
 use Glpi\Toolbox\Sanitizer;
 
 /**
@@ -242,13 +243,11 @@ final class DbUtils
             $inittable = $table;
             $table     = str_replace("glpi_", "", $table);
             $prefix    = "";
-            $pref2     = NS_GLPI;
 
             $matches = [];
             if (preg_match('/^plugin_([a-z0-9]+)_/', $table, $matches)) {
                 $table  = preg_replace('/^plugin_[a-z0-9]+_/', '', $table);
                 $prefix = "Plugin" . Toolbox::ucfirst($matches[1]);
-                $pref2  = NS_PLUG . ucfirst($matches[1]) . '\\';
             }
 
             if (strstr($table, '_')) {
@@ -262,36 +261,7 @@ final class DbUtils
                 $table = Toolbox::ucfirst($this->getSingular($table));
             }
 
-            $base_itemtype = $this->fixItemtypeCase($prefix . $table);
-            $namespaced_itemtype = $this->fixItemtypeCase($pref2 . str_replace('_', '\\', $table));
-
-           // Both potential itemtype (with or without namespace) are pointing to the same file, so it will trigger a
-           // "Cannot declare class XXX, because the name is already in use" error if the "wrong" version is
-           // required by the autoloader when the good version is already loaded.
-           // i.e. `class_exists('Glpi\Computer')` will load `src/Computer.php` which may redeclare the `Computer class`
-           //
-           // To prevent this, we check existence of both without allowing the autoloader to be used.
-           // If none exists yet, we trigger the autoloader to ensure the class file is loaded and the class is defined.
-           //
-           // Then we check again existence of both without allowing the autoloader to be used,
-           // in order to find the good class to use.
-            if (!class_exists($base_itemtype, false) && !class_exists($namespaced_itemtype, false)) {
-                // Try to trigger loading of base itemtype
-                class_exists($base_itemtype);
-                if (!class_exists($namespaced_itemtype, false) && !class_exists($base_itemtype, false)) {
-                    // Namespace itemtype file will not be loaded by call to `class_exists($base_itemtype)`:
-                    // - if namespace has more than one level (i.e. "Glpi\Dashboard\Dashboard")
-                    // - if clanname without namespace already exists (i.e. `Socket` from `sockets` extension, `Event` from `event` extension, ...)
-                    class_exists($namespaced_itemtype); // Try to trigger loading of namespaced itemtype
-                }
-            }
-
-            $itemtype = null;
-            if (class_exists($base_itemtype, false)) {
-                $itemtype = $base_itemtype;
-            } else if (class_exists($namespaced_itemtype, false)) {
-                $itemtype = $namespaced_itemtype;
-            }
+            $itemtype = ClassHandler::getProperClassname($prefix . $table);
 
             if ($itemtype !== null && $item = $this->getItemForItemtype($itemtype)) {
                 $itemtype                                   = get_class($item);
@@ -302,84 +272,6 @@ final class DbUtils
 
             return "UNKNOWN";
         }
-    }
-
-    /**
-     * Try to fix itemtype case.
-     * PSR-4 loading requires classnames to be used with their correct case.
-     *
-     * @param string $itemtype
-     * @param string $root_dir
-     *
-     * @return string
-     */
-    public function fixItemtypeCase(string $itemtype, $root_dir = GLPI_ROOT)
-    {
-
-       // If a class exists for this itemtype, just return the declared class name.
-        $matches = preg_grep('/^' . preg_quote($itemtype) . '$/i', get_declared_classes());
-        if (count($matches) === 1) {
-            return current($matches);
-        }
-
-        static $files = [];
-
-        $context = 'glpi-core';
-        $plugin_matches = [];
-        if (preg_match('/^Plugin(?<plugin>[A-Z][a-z]+)(?<class>[A-Z][a-z]+)/', $itemtype, $plugin_matches)) {
-           // Nota: plugin classes that does not use any namespace cannot be completely case insensitive
-           // indeed, we must be able to separate plugin name (directory) from class name (file)
-           // so pattern must be the one provided by getItemTypeForTable: PluginDirectorynameClassname
-            $context = strtolower($plugin_matches['plugin']);
-        } else if (preg_match('/^' . preg_quote(NS_PLUG) . '(?<plugin>[a-z]+)\\\/i', $itemtype, $plugin_matches)) {
-            $context = strtolower($plugin_matches['plugin']);
-        }
-
-        if (!array_key_exists($context, $files)) {
-           // Fetch filenames from "src" directory of context (GLPI core or given plugin).
-            $files[$context] = [];
-
-            $srcdir = $root_dir . ($context === 'glpi-core' ? '' : '/plugins/' . $context) . '/src';
-            if (!is_dir($srcdir)) {
-               // Cannot search in files if dir not exists (can correspond to a deleted plugin)
-                return $itemtype;
-            }
-            $files_iterator = new RecursiveIteratorIterator(
-                new RecursiveDirectoryIterator($srcdir),
-                RecursiveIteratorIterator::SELF_FIRST
-            );
-            /** @var SplFileInfo $file */
-            foreach ($files_iterator as $file) {
-                if (!$file->isReadable() || !$file->isFile() || '.php' === !$file->getExtension()) {
-                    continue;
-                }
-                $relative_path = str_replace($srcdir . DIRECTORY_SEPARATOR, '', $file->getPathname());
-
-                // Sore into files list:
-                // - key is the lowercased filename;
-                // - value is the classname with correct case.
-                $files[$context][strtolower($relative_path)] = str_replace(
-                    [DIRECTORY_SEPARATOR, '.php'],
-                    ['\\',                ''],
-                    $relative_path
-                );
-            }
-        }
-
-        $namespace      = $context === 'glpi-core' ? NS_GLPI : NS_PLUG . ucfirst($context) . '\\';
-        $uses_namespace = preg_match('/^(' . preg_quote($namespace) . ')/i', $itemtype);
-
-        $expected_lc_path = str_ireplace(
-            [$namespace, '\\'],
-            [''        , DIRECTORY_SEPARATOR],
-            strtolower($itemtype) . '.php'
-        );
-
-        if (array_key_exists($expected_lc_path, $files[$context])) {
-            $itemtype = ($uses_namespace ? $namespace : '') . $files[$context][$expected_lc_path];
-        }
-
-        return $itemtype;
     }
 
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -261,7 +261,7 @@ class Plugin extends CommonDBTM
                 include_once("$plugin_directory/setup.php");
                 if (!in_array($plugin_key, self::$loaded_plugins)) {
                     // Register PSR-4 autoloader
-                    $psr4_dir = GLPI_ROOT . $plugin_directory . '/src';
+                    $psr4_dir = $plugin_directory . '/src';
                     if (is_dir($psr4_dir)) {
                         $psr4_autoloader = new \Composer\Autoload\ClassLoader();
                         $psr4_autoloader->addPsr4(NS_PLUG . ucfirst($plugin_key) . '\\', $psr4_dir);

--- a/src/Toolbox/ClassHandler.php
+++ b/src/Toolbox/ClassHandler.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Toolbox;
+
+use Plugin;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use SplFileInfo;
+
+class ClassHandler
+{
+    /**
+     * Get proper class name, i.e. with the correct case and in the correct namespace.
+     *
+     * @param string $classname
+     *
+     * @return string|null
+     */
+    public static function getProperClassname(string $classname): ?string
+    {
+        // Both potential classname (with or without namespace) are pointing to the same file, so it will trigger a
+        // "Cannot declare class XXX, because the name is already in use" error if the "wrong" version is
+        // required by the autoloader when the good version is already loaded.
+        // i.e. `class_exists('Glpi\Computer')` will load `src/Computer.php` which may redeclare the `Computer class`
+        //
+        // To prevent this, we check existence of both without allowing the autoloader to be used.
+        // If none exists yet, we try to trigger the autoloader to load the class file.
+        //
+        // Then we check again existence of both without allowing the autoloader to be used,
+        // in order to find the good class to use.
+
+        $classname = preg_replace('/\\\+/', '\\', $classname); // Unescape slashes (may trigger errors)
+
+        if (($class_specs = isPluginItemType($classname)) !== false) {
+            $plugin               = $class_specs['plugin'];
+            $base_classname       = 'Plugin' . $plugin . str_replace('\\', '_', $class_specs['class']);
+            $namespaced_classname = NS_PLUG . $plugin . '\\' . str_replace('_', '\\', $class_specs['class']);
+        } else {
+            $plugin = null;
+            if (str_starts_with($classname, NS_GLPI)) {
+                $base_classname       = str_replace('\\', '_', str_replace(NS_GLPI, '', $classname));
+                $namespaced_classname = $classname;
+            } else {
+                $base_classname       = $classname;
+                $namespaced_classname = NS_GLPI . str_replace('_', '\\', $classname);
+            }
+        }
+
+        $base_classname = self::fixClassnameCase($base_classname, $plugin);
+        $namespaced_classname = self::fixClassnameCase($namespaced_classname, $plugin);
+
+        if (!class_exists($base_classname, false) && !class_exists($namespaced_classname, false)) {
+            // Try to trigger loading using classname without namespace.
+            if (class_exists($base_classname)) {
+                // Class has been loaded without a namespace.
+                // Check if classname was loaded from a GLPI source file.
+                // If it is not the case, then the proper classname is probably the namespaced one.
+                $reflection = new ReflectionClass($base_classname);
+                $try_namespaced = $reflection->getFileName() === false
+                    || !str_starts_with(realpath($reflection->getFileName()), realpath(GLPI_ROOT));
+            } else {
+                // Retry with namespaced classname if neither form has been loaded yet.
+                $try_namespaced = !class_exists($namespaced_classname, false);
+            }
+            if ($try_namespaced) {
+                class_exists($namespaced_classname); // Try to trigger loading using namespaced classname
+            }
+        }
+
+        if (class_exists($namespaced_classname, false)) {
+            return $namespaced_classname;
+        }
+
+        if (class_exists($base_classname, false)) {
+            return $base_classname;
+        }
+
+        return null;
+    }
+
+    /**
+     * Try to fix classname case.
+     * PSR-4 loading requires classnames to be used with their correct case.
+     *
+     * @param string      $classname
+     * @param string|null $plugin
+     *
+     * @return string
+     */
+    private static function fixClassnameCase(string $classname, ?string $plugin = null)
+    {
+        // If a class exists for this itemtype, just return the declared class name.
+        $matches = preg_grep('/^' . preg_quote($classname) . '$/i', get_declared_classes());
+        if (count($matches) === 1) {
+            return current($matches);
+        }
+
+        static $files = [];
+
+        $context = $plugin === null ? 'glpi-core' : strtolower($plugin);
+
+        $namespace      = $plugin === null ? NS_GLPI : NS_PLUG . $plugin . '\\';
+        $uses_namespace = preg_match('/^(' . preg_quote($namespace) . ')/i', $classname) === 1;
+
+        if (!array_key_exists($context, $files)) {
+            // Fetch filenames from "src" directory of context (GLPI core or given plugin).
+            $files[$context] = [];
+
+            $srcdir = ($context === 'glpi-core' ? GLPI_ROOT : Plugin::getPhpDir($context)) . '/src';
+            if (!is_dir($srcdir)) {
+                // Cannot search in files if dir not exists (can correspond to a deleted plugin)
+                return $classname;
+            }
+            $files_iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($srcdir),
+                RecursiveIteratorIterator::SELF_FIRST
+            );
+            /** @var SplFileInfo $file */
+            foreach ($files_iterator as $file) {
+                if (!$file->isReadable() || !$file->isFile() || '.php' === !$file->getExtension()) {
+                    continue;
+                }
+                $relative_path = str_replace($srcdir . DIRECTORY_SEPARATOR, '', $file->getPathname());
+
+                // Store into files list:
+                // - key is the lowercased filename;
+                // - value is the classname with correct case.
+                $files[$context][strtolower($relative_path)] = str_replace(
+                    [DIRECTORY_SEPARATOR, '.php'],
+                    ['\\',                ''],
+                    $relative_path
+                );
+            }
+        }
+
+        $expected_lc_path = strtolower($classname) . '.php';
+        if ($uses_namespace) {
+            // File path does not contains PSR4 namespace prefix
+            $expected_lc_path = str_ireplace($namespace, '', $expected_lc_path);
+        }
+        $expected_lc_path = str_replace('\\', DIRECTORY_SEPARATOR, $expected_lc_path); // Use platform directory separator
+
+        if (array_key_exists($expected_lc_path, $files[$context])) {
+            $classname = ($uses_namespace ? $namespace : '') . $files[$context][$expected_lc_path];
+        }
+
+        return $classname;
+    }
+}

--- a/src/Toolbox/Sanitizer.php
+++ b/src/Toolbox/Sanitizer.php
@@ -71,8 +71,8 @@ class Sanitizer
             return $value;
         }
 
-        if (preg_match('/^[a-zA-Z0-9_\\\]+$/', $value) && class_exists($value)) {
-           // Do not sanitize values that corresponds to an existing class, as classnames are considered safe
+        if (preg_match('/^[a-zA-Z0-9_\\\]+$/', $value) && $value === ClassHandler::getProperClassname($value)) {
+            // Do not sanitize values that corresponds to an existing class, as classnames are considered safe
             return $value;
         }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -774,3 +774,6 @@ function getItemByTypeName($type, $name, $onlyid = false)
 }
 
 loadDataset();
+
+// Ensure the tester plugin is loaded
+Plugin::load('tester');

--- a/tests/fixtures/plugins/tester/src/PluginTesterBaseClass.php
+++ b/tests/fixtures/plugins/tester/src/PluginTesterBaseClass.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+class PluginTesterBaseClass
+{
+
+}

--- a/tests/fixtures/plugins/tester/src/PluginTesterItemWithoutNamespace.php
+++ b/tests/fixtures/plugins/tester/src/PluginTesterItemWithoutNamespace.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+class PluginTesterItemWithoutNamespace
+{
+
+}

--- a/tests/fixtures/plugins/tester/src/PluginTesterTestItem.php
+++ b/tests/fixtures/plugins/tester/src/PluginTesterTestItem.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+class PluginTesterTestItem
+{
+
+}

--- a/tests/fixtures/plugins/tester/src/RootNamespacedItem.php
+++ b/tests/fixtures/plugins/tester/src/RootNamespacedItem.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Tester;
+
+class RootNamespacedItem
+{
+
+}

--- a/tests/fixtures/plugins/tester/src/Service/CacheService.php
+++ b/tests/fixtures/plugins/tester/src/Service/CacheService.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Tester\Service;
+
+class CacheService
+{
+
+}

--- a/tests/fixtures/plugins/tester/src/Service/DbService.php
+++ b/tests/fixtures/plugins/tester/src/Service/DbService.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Tester\Service;
+
+class DbService
+{
+
+}

--- a/tests/fixtures/plugins/tester/src/SomeNamespacedItem.php
+++ b/tests/fixtures/plugins/tester/src/SomeNamespacedItem.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Tester;
+
+class SomeNamespacedItem
+{
+
+}

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -34,7 +34,6 @@
 namespace tests\units;
 
 use DbTestCase;
-use org\bovigo\vfs\vfsStream;
 
 /* Test for inc/dbutils.class.php */
 
@@ -1251,90 +1250,5 @@ class DbUtils extends DbTestCase
                ->exists();
         }
         $this->string($autoname)->isIdenticalTo($expected);
-    }
-
-
-    /**
-     * Data provider for self::testGetItemtypeWithFixedCase().
-     */
-    protected function fixItemtypeCaseProvider()
-    {
-        return [
-         // Bad case classnames matching and existing class file
-            [
-                'itemtype' => 'myclass',
-                'expected' => 'MyClass',
-            ],
-            [
-                'itemtype' => 'glpi\\appliCation\\CoNsOlE\\MyCommand',
-                'expected' => 'Glpi\\Application\\Console\\MyCommand',
-            ],
-            [
-                'itemtype' => 'PluginFooBaritem',
-                'expected' => 'PluginFooBarItem',
-            ],
-            [
-                'itemtype' => 'GlpiPluGin\\Foo\\Namespacedbar',
-                'expected' => 'GlpiPlugin\\Foo\\NamespacedBar',
-            ],
-         // Good case (should not be altered)
-            [
-                'itemtype' => 'MyClass',
-                'expected' => 'MyClass',
-            ],
-            [
-                'itemtype' => 'Glpi\\Application\\Console\\MyCommand',
-                'expected' => 'Glpi\\Application\\Console\\MyCommand',
-            ],
-            [
-                'itemtype' => 'GlpiPlugin\\Foo\\NamespacedBar',
-                'expected' => 'GlpiPlugin\\Foo\\NamespacedBar',
-            ],
-         // Not matching any class file (should not be altered)
-            [
-                'itemtype' => 'notanitemtype',
-                'expected' => 'notanitemtype',
-            ],
-            [
-                'itemtype' => 'GlpiPlugin\\Invalid\\itemtype',
-                'expected' => 'GlpiPlugin\\Invalid\\itemtype',
-            ],
-        ];
-    }
-
-    /**
-     * @dataProvider fixItemtypeCaseProvider
-     */
-    public function testGetItemtypeWithFixedCase($itemtype, $expected)
-    {
-
-        $this->newTestedInstance();
-
-        vfsStream::setup(
-            'glpi',
-            null,
-            [
-                'src' => [
-                    'Application' => [
-                        'Console' => [
-                            'MyCommand.php' => '',
-                        ],
-                    ],
-                    'MyClass.php' => '',
-                    'NamespacedClass.php' => '',
-                ],
-                'plugins' => [
-                    'foo' => [
-                        'src' => [
-                            'NamespacedBar.php' => '',
-                            'PluginFooBarItem.php' => '',
-                        ],
-                    ],
-                ],
-            ]
-        );
-
-        $result = $this->testedInstance->fixItemtypeCase($itemtype, vfsStream::url('glpi'));
-        $this->variable($result)->isEqualTo($expected);
     }
 }

--- a/tests/units/Glpi/Toolbox/ClassHandler.php
+++ b/tests/units/Glpi/Toolbox/ClassHandler.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Toolbox;
+
+use GLPITestCase;
+
+class ClassHandler extends GLPITestCase
+{
+    protected function getProperClassnameProvider(): iterable
+    {
+        // Good case and namespace (should not be altered)
+        yield [
+            'classname' => 'Database',
+            'expected'  => 'Database',
+        ];
+        yield [
+            'classname' => 'Glpi\\Console\\Database\\UpdateCommand',
+            'expected'  => 'Glpi\\Console\\Database\\UpdateCommand',
+        ];
+        yield [
+            'classname' => 'PluginTesterTestItem',
+            'expected'  => 'PluginTesterTestItem',
+        ];
+        yield [
+            'classname' => 'GlpiPlugin\\Tester\\Service\\CacheService',
+            'expected'  => 'GlpiPlugin\\Tester\\Service\\CacheService',
+        ];
+
+        // Bad case classnames matching an existing class file
+        yield [
+            'classname' => 'computer',
+            'expected'  => 'Computer',
+        ];
+        yield [
+            'classname' => 'glPI\\sockeT',
+            'expected'  => 'Glpi\\Socket',
+        ];
+        yield [
+            'classname' => 'glpi\\CoNsOlE\\database\\Installcommand',
+            'expected'  => 'Glpi\\Console\\Database\\InstallCommand',
+        ];
+        yield [
+            'classname' => 'PluginTesterBaSeClaSs',
+            'expected'  => 'PluginTesterBaseClass',
+        ];
+        yield [
+            'classname' => 'GlpiPlugin\\Tester\\RootNamESpACedItem',
+            'expected'  => 'GlpiPlugin\\Tester\\RootNamespacedItem',
+        ];
+        yield [
+            'classname' => 'GlpiPlugin\\Tester\\SeRviCe\\DBservice',
+            'expected'  => 'GlpiPlugin\\Tester\\Service\\DbService',
+        ];
+
+        // Classname that does not use the good namespace
+        yield [
+            'classname' => 'Event',
+            'expected'  => 'Glpi\\Event',
+        ];
+        yield [
+            'classname' => 'Glpi\\Monitor',
+            'expected'  => 'Monitor',
+        ];
+        yield [
+            'classname' => 'GlpiPlugin\\Tester\\ItemWithoutNamespace',
+            'expected'  => 'PluginTesterItemWithoutNamespace',
+        ];
+        yield [
+            'classname' => 'PluginTesterSomeNamespacedItem',
+            'expected'  => 'GlpiPlugin\\Tester\\SomeNamespacedItem',
+        ];
+
+        // Edge case using escaped slashes as namespace separator
+        yield [
+            'classname' => 'Glpi\\\\Supplier',
+            'expected'  => 'Supplier',
+        ];
+
+        // Not matching any class file
+        yield [
+            'classname' => 'notaclassname',
+            'expected'  => null,
+        ];
+        yield [
+            'classname' => 'Glpi\\Not\\Valid',
+            'expected'  => null,
+        ];
+        yield [
+            'classname' => 'PluginTesterInvalidItem',
+            'expected'  => null,
+        ];
+        yield [
+            'classname' => 'GlpiPlugin\\Tester\\InvalidClassname',
+            'expected'  => null,
+        ];
+    }
+
+    /**
+     * @dataProvider getProperClassnameProvider
+     */
+    public function testGetProperClassname(string $classname, ?string $expected): void
+    {
+        $this->newTestedInstance();
+        $result = $this->testedInstance->getProperClassname($classname);
+        $this->variable($result)->isEqualTo($expected);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10528 

Logic that handle the normalization of classnames in PSR-4 context has been moved in a dedicated class to be reused in sanitize process.
Also, some tests have been added, and some PSR-4 loading in plugin context has been fixed.
