### PR TITLE
Prevent race condition on cache operations

### DIFF
--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -329,12 +329,10 @@ abstract class CommonTreeDropdown extends CommonDropdown
         if ($cache) {
             foreach ($ancestors as $ancestor) {
                 $ckey = 'sons_cache_' . $this->getTable() . '_' . $ancestor;
-                if ($GLPI_CACHE->has($ckey)) {
-                    $sons = $GLPI_CACHE->get($ckey);
-                    if (isset($sons[$this->getID()])) {
-                        unset($sons[$this->getID()]);
-                        $GLPI_CACHE->set($ckey, $sons);
-                    }
+                $sons = $GLPI_CACHE->get($ckey, []);
+                if (isset($sons[$this->getID()])) {
+                    unset($sons[$this->getID()]);
+                    $GLPI_CACHE->set($ckey, $sons);
                 }
             }
         }
@@ -354,12 +352,10 @@ abstract class CommonTreeDropdown extends CommonDropdown
         $ancestors = getAncestorsOf($this->getTable(), $this->getID());
         foreach ($ancestors as $ancestor) {
             $ckey = 'sons_cache_' . $this->getTable() . '_' . $ancestor;
-            if ($GLPI_CACHE->has($ckey)) {
-                $sons = $GLPI_CACHE->get($ckey);
-                if (!isset($sons[$this->getID()])) {
-                    $sons[$this->getID()] = $this->getID();
-                    $GLPI_CACHE->set($ckey, $sons);
-                }
+            $sons = $GLPI_CACHE->get($ckey, []);
+            if (!isset($sons[$this->getID()])) {
+                $sons[$this->getID()] = $this->getID();
+                $GLPI_CACHE->set($ckey, $sons);
             }
         }
     }

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -329,8 +329,8 @@ abstract class CommonTreeDropdown extends CommonDropdown
         if ($cache) {
             foreach ($ancestors as $ancestor) {
                 $ckey = 'sons_cache_' . $this->getTable() . '_' . $ancestor;
-                $sons = $GLPI_CACHE->get($ckey, []);
-                if (isset($sons[$this->getID()])) {
+                $sons = $GLPI_CACHE->get($ckey);
+                if ($sons !== null && isset($sons[$this->getID()])) {
                     unset($sons[$this->getID()]);
                     $GLPI_CACHE->set($ckey, $sons);
                 }
@@ -352,8 +352,8 @@ abstract class CommonTreeDropdown extends CommonDropdown
         $ancestors = getAncestorsOf($this->getTable(), $this->getID());
         foreach ($ancestors as $ancestor) {
             $ckey = 'sons_cache_' . $this->getTable() . '_' . $ancestor;
-            $sons = $GLPI_CACHE->get($ckey, []);
-            if (!isset($sons[$this->getID()])) {
+            $sons = $GLPI_CACHE->get($ckey);
+            if ($sons !== null && !isset($sons[$this->getID()])) {
                 $sons[$this->getID()] = $this->getID();
                 $GLPI_CACHE->set($ckey, $sons);
             }

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -916,12 +916,10 @@ HTML;
                 header('Expires: ' . gmdate('D, d M Y H:i:s \G\M\T', time() + $cache_age));
             }
 
-           // server cache
-            if ($GLPI_CACHE->has($cache_key)) {
-                $dashboard_cards = $GLPI_CACHE->get($cache_key);
-                if (isset($dashboard_cards[$gridstack_id])) {
-                    return (string) $dashboard_cards[$gridstack_id];
-                }
+            // server cache
+            $dashboard_cards = $GLPI_CACHE->get($cache_key, []);
+            if (isset($dashboard_cards[$gridstack_id])) {
+                return (string) $dashboard_cards[$gridstack_id];
             }
         }
 
@@ -981,7 +979,7 @@ HTML;
 
        // store server cache
         if (strlen($dashboard)) {
-            $dashboard_cards = $GLPI_CACHE->get($cache_key) ?? [];
+            $dashboard_cards = $GLPI_CACHE->get($cache_key, []);
             $dashboard_cards[$gridstack_id] = $html;
             $GLPI_CACHE->set($cache_key, $dashboard_cards, new \DateInterval("PT" . $cache_age . "S"));
         }

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -850,13 +850,10 @@ final class DbUtils
         global $DB, $GLPI_CACHE;
 
         $ckey = 'sons_cache_' . $table . '_' . $IDf;
-        $sons = false;
 
-        if ($GLPI_CACHE->has($ckey)) {
-            $sons = $GLPI_CACHE->get($ckey);
-            if ($sons !== null) {
-                return $sons;
-            }
+        $sons = $GLPI_CACHE->get($ckey);
+        if ($sons !== null) {
+            return $sons;
         }
 
         $parentIDfield = $this->getForeignKeyFieldForTable($table);
@@ -969,14 +966,13 @@ final class DbUtils
         } else {
             $ckey .= $table . '_' . $items_id;
         }
-        $ancestors = [];
 
-        if ($GLPI_CACHE->has($ckey)) {
-            $ancestors = $GLPI_CACHE->get($ckey);
-            if ($ancestors !== null) {
-                return $ancestors;
-            }
+        $ancestors = $GLPI_CACHE->get($ckey);
+        if ($ancestors !== null) {
+            return $ancestors;
         }
+
+        $ancestors = [];
 
        // IDs to be present in the final array
         $parentIDfield = $this->getForeignKeyFieldForTable($table);

--- a/src/GLPINetwork.php
+++ b/src/GLPINetwork.php
@@ -311,8 +311,8 @@ class GLPINetwork extends CommonGLPI
         $lang = preg_replace('/^([a-z]+)_.+$/', '$1', $_SESSION["glpilanguage"]);
         $cache_key = 'glpi_network_offers_' . $lang;
 
-        if (!$force_refresh && $GLPI_CACHE->has($cache_key)) {
-            return $GLPI_CACHE->get($cache_key);
+        if (!$force_refresh && ($offers = $GLPI_CACHE->get($cache_key)) !== null) {
+            return $offers;
         }
 
         $error_message = null;

--- a/src/Html.php
+++ b/src/Html.php
@@ -6689,10 +6689,10 @@ HTML;
         $fckey = 'css_raw_file_' . $file;
         $file_hash = self::getScssFileHash($path);
 
-       //check if files has changed
+        //check if files has changed
         if (!isset($args['nocache']) && $file_hash != $GLPI_CACHE->get($fckey)) {
-           //file has changed
-           $args['reload'] = true;
+            //file has changed
+            $args['reload'] = true;
         }
 
        // Enable imports of ".scss" files from "css/lib", when path starts with "~".

--- a/src/Html.php
+++ b/src/Html.php
@@ -6690,11 +6690,9 @@ HTML;
         $file_hash = self::getScssFileHash($path);
 
        //check if files has changed
-        if (!isset($args['nocache']) && $GLPI_CACHE->has($fckey)) {
-            if ($file_hash != $GLPI_CACHE->get($fckey)) {
-               //file has changed
-                $args['reload'] = true;
-            }
+        if (!isset($args['nocache']) && $file_hash != $GLPI_CACHE->get($fckey)) {
+           //file has changed
+           $args['reload'] = true;
         }
 
        // Enable imports of ".scss" files from "css/lib", when path starts with "~".
@@ -6719,40 +6717,43 @@ HTML;
             }
         );
 
-        $css = '';
-        if (!isset($args['reload']) && !isset($args['nocache']) && $GLPI_CACHE->has($ckey)) {
+        if (!isset($args['reload']) && !isset($args['nocache'])) {
             $css = $GLPI_CACHE->get($ckey);
-        } else {
-            try {
-                Toolbox::logDebug("Compile $file");
-                $result = $scss->compileString($import, dirname($path));
-                $css = $result->getCss();
-                if (!isset($args['nocache'])) {
-                    $GLPI_CACHE->set($ckey, $css);
-                    $GLPI_CACHE->set($fckey, $file_hash);
-                }
-            } catch (\Throwable $e) {
-                ErrorHandler::getInstance()->handleException($e, true);
-                if (isset($args['debug'])) {
-                    $msg = 'An error occured during SCSS compilation: ' . $e->getMessage();
-                    $msg = str_replace(["\n", "\"", "'"], ['\00000a', '\0022', '\0027'], $msg);
-                    $css = <<<CSS
-                  html::before {
-                     background: #F33;
-                     content: '$msg';
-                     display: block;
-                     padding: 20px;
-                     position: sticky;
-                     top: 0;
-                     white-space: pre-wrap;
-                     z-index: 9999;
-                  }
+            if ($css !== null) {
+                return $css;
+            }
+        }
+
+        $css = '';
+        try {
+            Toolbox::logDebug("Compile $file");
+            $result = $scss->compileString($import, dirname($path));
+            $css = $result->getCss();
+            if (!isset($args['nocache'])) {
+                $GLPI_CACHE->set($ckey, $css);
+                $GLPI_CACHE->set($fckey, $file_hash);
+            }
+        } catch (\Throwable $e) {
+            ErrorHandler::getInstance()->handleException($e, true);
+            if (isset($args['debug'])) {
+                $msg = 'An error occured during SCSS compilation: ' . $e->getMessage();
+                $msg = str_replace(["\n", "\"", "'"], ['\00000a', '\0022', '\0027'], $msg);
+                $css = <<<CSS
+              html::before {
+                 background: #F33;
+                 content: '$msg';
+                 display: block;
+                 padding: 20px;
+                 position: sticky;
+                 top: 0;
+                 white-space: pre-wrap;
+                 z-index: 9999;
+              }
 CSS;
-                }
-                global $application;
-                if ($application instanceof Application) {
-                    throw $e;
-                }
+            }
+            global $application;
+            if ($application instanceof Application) {
+                throw $e;
             }
         }
 

--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -650,12 +650,12 @@ class NetworkPort extends InventoryAsset
         $exploded = explode(':', $mac);
 
         if (isset($exploded[2])) {
-            if (!$GLPI_CACHE->has('glpi_inventory_ouis')) {
+            $ouis = $GLPI_CACHE->get('glpi_inventory_ouis');
+            if ($ouis === null) {
                 $jsonfile = new FilesToJSON();
                 $ouis = json_decode(file_get_contents($jsonfile->getJsonFilePath('ouis')), true);
                 $GLPI_CACHE->set('glpi_inventory_ouis', $ouis);
             }
-            $ouis = $ouis ?? $GLPI_CACHE->get('glpi_inventory_ouis');
 
             $mac = sprintf('%s:%s:%s', $exploded[0], $exploded[1], $exploded[2]);
             return $ouis[strtoupper($mac)] ?? false;

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -445,10 +445,7 @@ class Item_Devices extends CommonDBRelation
     {
         global $GLPI_CACHE;
 
-        if (!$GLPI_CACHE->has('item_device_affinities')) {
-            $GLPI_CACHE->set('item_device_affinities', ['' => static::getDeviceTypes()]);
-        }
-        $items_affinities = $GLPI_CACHE->get('item_device_affinities');
+        $items_affinities = $GLPI_CACHE->get('item_device_affinities', ['' => static::getDeviceTypes()]);
 
         if (!isset($items_affinities[$itemtype])) {
             $afffinities = [];

--- a/src/Marketplace/Api/Plugins.php
+++ b/src/Marketplace/Api/Plugins.php
@@ -399,10 +399,7 @@ class Plugins {
    public function getPluginsForTag(string $tag = "", bool $force_refresh = false): array {
       global $GLPI_CACHE;
 
-      $plugins_colct = [];
-      if (!$force_refresh && $GLPI_CACHE->has("marketplace_tag_$tag")) {
-         $plugins_colct = $GLPI_CACHE->get("marketplace_tag_$tag");
-      }
+      $plugins_colct = !$force_refresh ? $GLPI_CACHE->get("marketplace_tag_$tag", []) : [];
 
       if (!count($plugins_colct)) {
          $plugins_colct = $this->getPaginatedCollection("tags/{$tag}/plugin");

--- a/src/PCIVendor.php
+++ b/src/PCIVendor.php
@@ -141,9 +141,7 @@ class PCIVendor extends CommonDropdown implements CacheableListInterface
     {
         global $GLPI_CACHE;
 
-        if ($GLPI_CACHE->has($this->cache_key)) {
-            $GLPI_CACHE->delete($this->cache_key);
-        }
+        $GLPI_CACHE->delete($this->cache_key);
     }
 
     /**

--- a/src/ProfileRight.php
+++ b/src/ProfileRight.php
@@ -53,12 +53,9 @@ class ProfileRight extends CommonDBChild
     {
         global $DB, $GLPI_CACHE;
 
-        $rights = [];
+        $rights = $GLPI_CACHE->get('all_possible_rights', []);
 
-        if (
-            !$GLPI_CACHE->has('all_possible_rights')
-            || count($GLPI_CACHE->get('all_possible_rights')) == 0
-        ) {
+        if (count($rights) == 0) {
             $iterator = $DB->request([
                 'SELECT'          => 'name',
                 'DISTINCT'        => true,
@@ -69,9 +66,8 @@ class ProfileRight extends CommonDBChild
                 $rights[$right['name']] = '';
             }
             $GLPI_CACHE->set('all_possible_rights', $rights);
-        } else {
-            $rights = $GLPI_CACHE->get('all_possible_rights');
         }
+
         return $rights;
     }
 

--- a/src/USBVendor.php
+++ b/src/USBVendor.php
@@ -142,9 +142,7 @@ class USBVendor extends CommonDropdown implements CacheableListInterface
     {
         global $GLPI_CACHE;
 
-        if ($GLPI_CACHE->has($this->cache_key)) {
-            $GLPI_CACHE->delete($this->cache_key);
-        }
+        $GLPI_CACHE->delete($this->cache_key);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While searching why some tests are randomly failing, I came to the conclusion that it may be an issue with cache read operations. Indeed following error in `DbUtils::getSonsOf()` can only happen when `$GLPI_CACHE->get($ckey)` returns a null value when `$GLPI_CACHE->has($ckey)` return true.

```
> There are 2 uncompleted methods:
=> tests\units\Glpi\Csv\LogCsvExport::testGetFileName() with exit code 255:
==> output(143) "Uncaught Exception TypeError: array_replace(): Argument #1 ($array) must be of type array, null given in /var/glpi/src/DbUtils.php at line 895"
=> tests\units\Glpi\Csv\LogCsvExport::testGetFileContent() with exit code 255:
==> output(143) "Uncaught Exception TypeError: array_replace(): Argument #1 ($array) must be of type array, null given in /var/glpi/src/DbUtils.php at line 895"
```

`Psr\SimpleCache` lib docmentation says:
```php
    /**
     * Determines whether an item is present in the cache.
     *
     * NOTE: It is recommended that has() is only to be used for cache warming type purposes
     * and not to be used within your live applications operations for get/set, as this method
     * is subject to a race condition where your has() will return true and immediately after,
     * another script can remove it making the state of your app out of date.
     *
     * @param string $key The cache item key.
     *
     * @return bool
     *
     * @throws \Psr\SimpleCache\InvalidArgumentException
     *   MUST be thrown if the $key string is not a legal value.
     */
    public function has($key);
```

So I propose to replace usage of `Psr\SimpleCache\CacheInterface::has()` method by some logic based on `Psr\SimpleCache\CacheInterface::get()` result (i.e testing `null` result).