### PR TITLE
Do not hide timeline actions in mobile

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -83,13 +83,15 @@
         }
     }
 
-    .timeline-more-actions {
-        visibility: hidden;
-    }
-
-    &:hover {
+    @media (hover: hover) {
         .timeline-more-actions {
-            visibility: visible;
+            visibility: hidden;
+        }
+
+        &:hover {
+            .timeline-more-actions {
+                visibility: visible;
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

On mobile, there isn't a proper hover action. It gets triggered on touch.
Currently the the 3 dot menu in timeline items is hidden until the user hovers over the item. On mobile, you have to touch inside the item first or just know instinctively where the menu is. By using the hover media query, we can make the menu button always show on mobile or other devices without hover capabilities while leaving the current behavior for other devices.