### PR TITLE
Ticket[s] waiting typo

### DIFF
--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -1174,7 +1174,7 @@ HTML;
 
             $tickets_cases = [
                 'late'               => __("Late tickets"),
-                'waiting_validation' => __("Ticket waiting for your approval"),
+                'waiting_validation' => __("Tickets waiting for your approval"),
                 'notold'             => __('Not solved tickets'),
                 'incoming'           => __("New tickets"),
                 'waiting'            => __('Pending tickets'),

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -166,9 +166,9 @@ class Ticket extends CommonITILObject
             $opt['criteria'][4]['link']       = 'AND NOT';
 
             $pic_validate = '
-            <i class="ti ti-eye-check" title="' . __s('Ticket waiting for your approval') . '"></i>
+            <i class="ti ti-eye-check" title="' . __s('Tickets waiting for your approval') . '"></i>
             <span class="d-none d-xxl-block">
-               ' . __s('Ticket waiting for your approval') . '
+               ' . __s('Tickets waiting for your approval') . '
             </span>
          ';
 
@@ -5507,7 +5507,7 @@ JAVASCRIPT;
 
             $twig_params['items'][] = [
                 'link'    => self::getSearchURL() . "?" . Toolbox::append_params($opt),
-                'text'    => __('Ticket waiting for your approval'),
+                'text'    => __('Tickets waiting for your approval'),
                 'icon'    => 'fas fa-check',
                 'count'   => $number_waitapproval
             ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

"Ticket waiting for your approval", "Ticket" should be plural in this case in English/default translation.