### PR TITLE
Map view fixes for new fluid search

### DIFF
--- a/front/ticket.php
+++ b/front/ticket.php
@@ -41,7 +41,17 @@ if (Session::getCurrentInterface() == "helpdesk") {
     Html::header(Ticket::getTypeName(Session::getPluralNumber()), '', "helpdesk", "ticket");
 }
 
-echo Html::manageRefreshPage(false, "$('div.ajax-container.search-display-data').data('js_class').getView().refreshResults();");
+$refresh_callback = <<<JS
+const container = $('div.ajax-container.search-display-data');
+if (container.length > 0 && container.data('js_class') !== undefined) {
+    container.data('js_class').getView().refreshResults();
+} else {
+    // Fallback when fluid search isn't initialized
+    window.location.reload();
+}
+JS;
+
+echo Html::manageRefreshPage(false, $refresh_callback);
 
 Search::show('Ticket');
 

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -31,58 +31,61 @@
 
 {% set is_ajax = data['searchform_id'] is defined and data['searchform_id'] is not null %}
 {% if not is_ajax %}
-<div class="ajax-container search-display-data">
-{% endif %}
+   <div class="ajax-container search-display-data">
+   {% endif %}
 
-{# Remove namespace separators for use in HTML attributes #}
-{% set normalized_itemtype = itemtype|replace({'\\': ''}) %}
+   {# Remove namespace separators for use in HTML attributes #}
+   {% set normalized_itemtype = itemtype|replace({'\\': ''}) %}
 
-<form id="massform{{ normalized_itemtype }}" method="get" action="{{ path('front/massiveaction.php') }}"
-      data-search-itemtype="{{ data['itemtype'] }}" data-start="{{ start }}" data-count="{{ count }}" data-limit="{{ limit }}" data-submit-once>
-   <div class="card card-sm mt-0 search-card">
-      <div class="card-header d-flex justify-content-between search-header pe-0">
-         {% if data['display_type'] == constant('Search::GLOBAL_SEARCH') %}
-            <h2>{{ itemtype|itemtype_name }}</h2>
+   <form id="massform{{ normalized_itemtype }}" method="get" action="{{ path('front/massiveaction.php') }}"
+         data-search-itemtype="{{ data['itemtype'] }}" data-start="{{ start }}" data-count="{{ count }}" data-limit="{{ limit }}" data-submit-once>
+      <div class="card card-sm mt-0 search-card">
+         <div class="card-header d-flex justify-content-between search-header pe-0">
+            {% if data['display_type'] == constant('Search::GLOBAL_SEARCH') %}
+               <h2>{{ itemtype|itemtype_name }}</h2>
 
-            {% if count > (start + constant('Search::GLOBAL_DISPLAY_COUNT')) %}
-               <a href="{{ href }}">
-                  <i class="far fa-eye"></i>
-                  {{ __('View all') }}
-               </a>
+               {% if count > (start + constant('Search::GLOBAL_DISPLAY_COUNT')) %}
+                  <a href="{{ href }}">
+                     <i class="far fa-eye"></i>
+                     {{ __('View all') }}
+                  </a>
+               {% endif %}
+            {% else %}
+               {{ include('components/search/controls.html.twig') }}
             {% endif %}
-         {% else %}
-            {{ include('components/search/controls.html.twig') }}
-         {% endif %}
-      </div>
+         </div>
 
-      {% if data['search']['as_map'] == 0 %}
-         {{ include('components/search/table.html.twig') }}
-      {% endif %}
-      {% if count > 0 %}
-         {% if data['display_type'] != constant('Search::GLOBAL_SEARCH') and data['search']['as_map'] == 0 %}
-            <div class="card-footer search-footer">
-               {{ include('components/pager.html.twig') }}
+         {% if data['search']['as_map'] == 0 %}
+            {{ include('components/search/table.html.twig') }}
+         {% endif %}
+         {% if count > 0 %}
+            {% if data['display_type'] != constant('Search::GLOBAL_SEARCH') and data['search']['as_map'] == 0 %}
+               <div class="card-footer search-footer">
+                  {{ include('components/pager.html.twig') }}
+               </div>
+            {% endif %}
+         {% elseif data['search']['as_map'] == 1 %}
+            <div class="alert alert-info mb-0 rounded-0 border-top-0 border-bottom-0 border-right-0" role="alert">
+               {{ __('No item found') }}
             </div>
          {% endif %}
-      {% elseif data['search']['as_map'] == 1 %}
-         <div class="alert alert-info mb-0 rounded-0 border-top-0 border-bottom-0 border-right-0" role="alert">
-            {{ __('No item found') }}
-         </div>
-      {% endif %}
+      </div>
+   </form>
+   {% if not is_ajax %}
    </div>
-</form>
-{% if not is_ajax %}
-</div>
-<script>
-    if (typeof initFluidSearch !== "function") {
-       window.initFluidSearch = () => {
-           new GLPI.Search.ResultsView("massform{{ normalized_itemtype }}", GLPI.Search.Table);
-       };
-    }
-    if (document.readyState === 'complete') {
-        initFluidSearch();
-    } else {
-        $(document).on('ready', initFluidSearch);
-    }
-</script>
+
+   {% if data['search']['as_map'] == 0 %}
+      <script>
+          if (typeof initFluidSearch !== "function") {
+             window.initFluidSearch = () => {
+                 new GLPI.Search.ResultsView("massform{{ normalized_itemtype }}", GLPI.Search.Table);
+             };
+          }
+          if (document.readyState === 'complete') {
+              initFluidSearch();
+          } else {
+              $(document).on('ready', initFluidSearch);
+          }
+      </script>
+   {% endif %}
 {% endif %}

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -32,46 +32,47 @@
 {% set is_ajax = data['searchform_id'] is defined and data['searchform_id'] is not null %}
 {% if not is_ajax %}
    <div class="ajax-container search-display-data">
-   {% endif %}
+{% endif %}
 
-   {# Remove namespace separators for use in HTML attributes #}
-   {% set normalized_itemtype = itemtype|replace({'\\': ''}) %}
+{# Remove namespace separators for use in HTML attributes #}
+{% set normalized_itemtype = itemtype|replace({'\\': ''}) %}
 
-   <form id="massform{{ normalized_itemtype }}" method="get" action="{{ path('front/massiveaction.php') }}"
-         data-search-itemtype="{{ data['itemtype'] }}" data-start="{{ start }}" data-count="{{ count }}" data-limit="{{ limit }}" data-submit-once>
-      <div class="card card-sm mt-0 search-card">
-         <div class="card-header d-flex justify-content-between search-header pe-0">
-            {% if data['display_type'] == constant('Search::GLOBAL_SEARCH') %}
-               <h2>{{ itemtype|itemtype_name }}</h2>
+<form id="massform{{ normalized_itemtype }}" method="get" action="{{ path('front/massiveaction.php') }}"
+      data-search-itemtype="{{ data['itemtype'] }}" data-start="{{ start }}" data-count="{{ count }}" data-limit="{{ limit }}" data-submit-once>
+   <div class="card card-sm mt-0 search-card">
+      <div class="card-header d-flex justify-content-between search-header pe-0">
+         {% if data['display_type'] == constant('Search::GLOBAL_SEARCH') %}
+            <h2>{{ itemtype|itemtype_name }}</h2>
 
-               {% if count > (start + constant('Search::GLOBAL_DISPLAY_COUNT')) %}
-                  <a href="{{ href }}">
-                     <i class="far fa-eye"></i>
-                     {{ __('View all') }}
-                  </a>
-               {% endif %}
-            {% else %}
-               {{ include('components/search/controls.html.twig') }}
+            {% if count > (start + constant('Search::GLOBAL_DISPLAY_COUNT')) %}
+               <a href="{{ href }}">
+                  <i class="far fa-eye"></i>
+                  {{ __('View all') }}
+               </a>
             {% endif %}
-         </div>
-
-         {% if data['search']['as_map'] == 0 %}
-            {{ include('components/search/table.html.twig') }}
-         {% endif %}
-         {% if count > 0 %}
-            {% if data['display_type'] != constant('Search::GLOBAL_SEARCH') and data['search']['as_map'] == 0 %}
-               <div class="card-footer search-footer">
-                  {{ include('components/pager.html.twig') }}
-               </div>
-            {% endif %}
-         {% elseif data['search']['as_map'] == 1 %}
-            <div class="alert alert-info mb-0 rounded-0 border-top-0 border-bottom-0 border-right-0" role="alert">
-               {{ __('No item found') }}
-            </div>
+         {% else %}
+            {{ include('components/search/controls.html.twig') }}
          {% endif %}
       </div>
-   </form>
-   {% if not is_ajax %}
+
+      {% if data['search']['as_map'] == 0 %}
+         {{ include('components/search/table.html.twig') }}
+      {% endif %}
+      {% if count > 0 %}
+         {% if data['display_type'] != constant('Search::GLOBAL_SEARCH') and data['search']['as_map'] == 0 %}
+            <div class="card-footer search-footer">
+               {{ include('components/pager.html.twig') }}
+            </div>
+         {% endif %}
+      {% elseif data['search']['as_map'] == 1 %}
+         <div class="alert alert-info mb-0 rounded-0 border-top-0 border-bottom-0 border-right-0" role="alert">
+            {{ __('No item found') }}
+         </div>
+      {% endif %}
+   </div>
+</form>
+
+{% if not is_ajax %}
    </div>
 
    {% if data['search']['as_map'] == 0 %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The map view currently doesn't support fluid search. A JS error is logged in the console but the view otherwise loads. The first commit removes the error by not initializing the fluid search in this view.
The second commit fixing the handling of the automatic ticket list refresh when in this map view or when the fluid search otherwise fails to initialize. In these cases, it falls back to a page reload like it did in previous versions.