### PR TITLE
Fix handling of entity update refusal; see #10572

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -283,6 +283,9 @@ class Entity extends CommonTreeDropdown
         }
 
         $input = parent::prepareInputForAdd($input);
+        if ($input === false) {
+            return false;
+        }
 
         $input = $this->handleConfigStrategyFields($input);
 
@@ -319,8 +322,10 @@ class Entity extends CommonTreeDropdown
      **/
     public function prepareInputForUpdate($input)
     {
-
         $input = parent::prepareInputForUpdate($input);
+        if ($input === false) {
+            return false;
+        }
 
         $input = $this->handleConfigStrategyFields($input);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

A comment in #10572 mentions following error:
```
glpiphplog.CRITICAL: *** Uncaught Exception TypeError: Argument 1 passed to Entity::handleConfigStrategyFields() must be of the type array, bool given, called in /var/www/html/glpi10/src/Entity.php on line 324 in /var/www/html/glpicurrent/src/Entity.php at line 360
Backtrace :
src/Entity.php:324 Entity->handleConfigStrategyFields()
src/CommonDBTM.php:1507 Entity->prepareInputForUpdate()
front/dropdown.common.form.php:134 CommonDBTM->update()
front/entity.form.php:50 include()
```

Even if I was not able to reproduce, `parent::prepareInputFor*` may return `false`, and, in this case, child method should return `false` immediately.