### PR TITLE
Fix edge case on dashboard filters migration; fixes #10577

### DIFF
--- a/install/migrations/update_9.5.x_to_10.0.0/dashboard_filters.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/dashboard_filters.php
@@ -40,10 +40,10 @@ $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
 $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
-if (!$DB->tableExists('glpi_dashboards_filters')) {
-    $migration->addField('glpi_dashboards_dashboards', 'users_id', "int {$default_key_sign} NOT NULL DEFAULT '0'", ['after' => 'context']);
-    $migration->addKey('glpi_dashboards_dashboards', 'users_id');
+$migration->addField('glpi_dashboards_dashboards', 'users_id', "int {$default_key_sign} NOT NULL DEFAULT '0'", ['after' => 'context']);
+$migration->addKey('glpi_dashboards_dashboards', 'users_id');
 
+if (!$DB->tableExists('glpi_dashboards_filters')) {
     $query = "CREATE TABLE `glpi_dashboards_filters` (
          `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
          `dashboards_dashboards_id` int {$default_key_sign} NOT NULL DEFAULT '0',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10577

As the `glpi_dashboards_filters` table creation query is synchronous and `glpi_dashboards_dashboards.users_id` field creation is asynchronous, if migration fails at some point, the `glpi_dashboards_dashboards.users_id` field may not be created, even if migration is replayed. Its creation should not be conditionned to the `glpi_dashboards_filters` table existence.