### PR TITLE
Fix default visibility value in group creation form; see #10582

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -83,6 +83,7 @@ class Group extends CommonTreeDropdown
         $this->fields['is_requester'] = 1;
         $this->fields['is_watcher']   = 1;
         $this->fields['is_assign']    = 1;
+        $this->fields['is_task']      = 1;
         $this->fields['is_notify']    = 1;
         $this->fields['is_itemgroup'] = 1;
         $this->fields['is_usergroup'] = 1;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a new group is created, all visibility flags are set to "yes" except the `is_task` flag (see image below).
![image](https://user-images.githubusercontent.com/33253653/154092244-8aa0cb30-2f04-45b4-a039-57eb737ca46f.png)

With proposed change, this flag will act as all other flags in group creation form.