### PR TITLE
Update update1NTableData and load1NTableData visiblity

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5963,7 +5963,7 @@ class CommonDBTM extends CommonGLPI
      *
      * @return void
      */
-    protected function update1NTableData(
+    public function update1NTableData(
         string $commondb_relation,
         string $field,
         array $extra_input = []
@@ -6076,7 +6076,7 @@ class CommonDBTM extends CommonGLPI
      *
      * @return void
      */
-    protected function load1NTableData(
+    public function load1NTableData(
         string $commondb_relation,
         string $field,
         array $extra_input = []

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -3990,20 +3990,11 @@ HTML
         $linked = $item->input[$field];
         $this->array($linked);
 
-        // Allow protected calls on update1NTableData and load1NTableData
-        // Needed as these methods are not used in GLPI core yet, there is
-        // no itemtype calling them in their post_update and post_load process
-        // -> we need to be able to call them directly in this test
-        $update1NTableData = new \ReflectionMethod($item, "update1NTableData");
-        $update1NTableData->setAccessible(true);
-        $load1NTableData = new \ReflectionMethod($item, "load1NTableData");
-        $load1NTableData->setAccessible(true);
-
         // Update DB
-        $update1NTableData->invoke($item, $commondb_relation, $field, $extra_input);
+        $item->update1NTableData($commondb_relation, $field, $extra_input);
 
         // Load values
-        $load1NTableData->invoke($item, $commondb_relation, $field, $extra_input);
+        $item->load1NTableData($commondb_relation, $field, $extra_input);
 
         // Compare values
         $this->array($item->fields[$field])->isEqualTo($linked);


### PR DESCRIPTION
I found a use case where I need to use these methods from a `/front` file, thus they should be `public` not `protected`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
