### PR TITLE
Fix "Undefined array key" when attribute does not exist in LDAP

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -4321,10 +4321,12 @@ class AuthLDAP extends CommonDBTM
     public static function getFieldValue($infos, $field)
     {
         $value = null;
-        if (is_array($infos[$field])) {
-            $value = $infos[$field][0];
-        } else {
-            $value = $infos[$field];
+        if (array_key_exists($field, $infos)) {
+            if (is_array($infos[$field])) {
+                $value = $infos[$field][0];
+            } else {
+                $value = $infos[$field];
+            }
         }
         if ($field != 'objectguid') {
             return $value;


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->

It should fixes warning such as:

`[2022-02-16 09:18:02] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "mail" in E:\GLPI\src\AuthLDAP.php at line 4327
  Backtrace :
  src\AuthLDAP.php:2774                              AuthLDAP::getFieldValue()
  src\User.php:4965                                  AuthLDAP::ldapImportUserByServerId()
  src\MailCollector.php:1026                         User::getOrImportByEmail()
  src\MailCollector.php:759                          MailCollector->buildTicket()
  src\MailCollector.php:1821                         MailCollector->collect()
  src\CronTask.php:1016                              MailCollector::cronMailgate()
  front\cron.php:82                                  CronTask::launch()`

When a configured attribute does not exists on an LDAP object.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
