### PR TITLE
fix(hbar): display negative value

### DIFF
--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -1261,11 +1261,22 @@ HTML;
 
                if (is_horizontal) {
                   var word_width = value.length * 5 + 5;
-                  labelX = data.x2 - word_width;
+
+                  if (value > 0) {
+                     labelX = data.x2 - word_width;
+                  } else{
+                     labelX = data.x2 + word_width;
+                  }
                   labelY = data.y2;
 
+                  if (value > 0) {
+                     width = data.x2 - data.x1;
+                  } else{
+                     width = data.x1 - data.x2;
+                  }
+
                   // don't display label if width too short
-                  if (data.x2 - data.x1 < word_width) {
+                  if (width < word_width) {
                      display_labels = false;
                   }
                }


### PR DESCRIPTION
Display negative value from HorizontalBar (widget)

Before
![image](https://user-images.githubusercontent.com/7335054/154273154-e5a0ceda-f149-4ce8-8eb0-dfeb769a683b.png)


After
![image](https://user-images.githubusercontent.com/7335054/154273166-5d442b91-3f2e-4b73-9c12-6576b57b135c.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23427
