### PR TITLE
Fix error on global search view

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -1747,7 +1747,7 @@ class Search
             ]),
             'may_be_deleted'      => $item instanceof CommonDBTM && $item->maybeDeleted(),
             'may_be_located'      => $item instanceof CommonDBTM && $item->maybeLocated(),
-            'may_be_browsed'      => Toolbox::hasTrait($item, \Glpi\Features\TreeBrowse::class),
+            'may_be_browsed'      => $item !== null && Toolbox::hasTrait($item, \Glpi\Features\TreeBrowse::class),
         ]);
 
        // Add items in item list


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes following error:
```
glpiphplog.CRITICAL:   *** Uncaught Exception TypeError: class_uses(): Argument #1 ($object_or_class) must be of type object|string, null given in /var/www/glpi/src/Toolbox.php at line 3320
  Backtrace :
  src/Toolbox.php:3320                               class_uses()
  src/Search.php:1750                                Toolbox::hasTrait()
  src/Search.php:136                                 Search::displayData()
  src/Search.php:100                                 Search::showList()
  front/allassets.php:46                             Search::show()
```