### PR TITLE
Fix displayHeader misuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The present file will list all changes made to the project; according to the
 - Usage of XML-RPC API is deprecated.
 - The database "slaves" property in the status checker (/status.php and glpi:system:status) is deprecated. Use "replicas" instead,
 - The database "master" property in the status checker (/status.php and glpi:system:status) is deprecated. Use "main" instead,
+- `CommonDropdown::displayHeader()` has been deprecated, call `CommonDropdown::displayCentralHeader()` instead and make sure to override properly `first_level_menu`, `second_level_menu` and `third_level_menu`.
 
 ### Removed
 - Autocomplete feature on text fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ The present file will list all changes made to the project; according to the
 - Usage of XML-RPC API is deprecated.
 - The database "slaves" property in the status checker (/status.php and glpi:system:status) is deprecated. Use "replicas" instead,
 - The database "master" property in the status checker (/status.php and glpi:system:status) is deprecated. Use "main" instead,
-- `CommonDropdown::displayHeader()` has been deprecated, call `CommonDropdown::displayCentralHeader()` instead and make sure to override properly `first_level_menu`, `second_level_menu` and `third_level_menu`.
 
 ### Removed
 - Autocomplete feature on text fields.
@@ -86,6 +85,7 @@ The present file will list all changes made to the project; according to the
 - `Toolbox::sodiumEncrypt()`
 - `Toolbox::startsWith()`
 - `Toolbox::unclean_cross_side_scripting_deep()`
+- `CommonDropdown::displayHeader()`, use `CommonDropdown::displayCentralHeader()` instead and make sure to override properly `first_level_menu`, `second_level_menu` and `third_level_menu`.
 
 #### Removed
 - `jQueryUI` has been removed in favor of `twbs/bootstrap`. This implies removal of following widgets: `$.accordion`, `$.autocomplete`,

--- a/front/dropdown.common.form.php
+++ b/front/dropdown.common.form.php
@@ -168,12 +168,7 @@ if (isset($_POST["add"])) {
     if (!isset($options)) {
         $options = [];
     }
-    $menus = [
-        $dropdown->first_level_menu,
-        $dropdown->second_level_menu,
-        empty($dropdown->third_level_menu) ? $dropdown->getType() : $dropdown->third_level_menu,
-    ];
-    $dropdown::displayFullPageForItem($_GET['id'], $menus, [
+    $dropdown::displayFullPageForItem($_GET['id'], null, [
         'formoptions' => ($options['formoptions'] ?? '') . ' data-track-changes=true',
         'id'          => $_GET["id"],
     ]);

--- a/front/dropdown.common.php
+++ b/front/dropdown.common.php
@@ -45,7 +45,7 @@ if (!$dropdown->canView()) {
     Html::displayRightError();
 }
 
-$dropdown->displayHeader();
+$dropdown::displayCentralHeader();
 
 Search::show(get_class($dropdown));
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6198,7 +6198,7 @@ class CommonDBTM extends CommonGLPI
      * @param int|string  $id      Id of the item to be displayed, may be a
      *                             string due to some weird default values.
      *                             Will be cast to int straight away.
-     * @param anull|array $menus   Menu path used to load specific JS file and
+     * @param null|array  $menus   Menu path used to load specific JS file and
      *                             show breadcumbs, see $CFG_GLPI['javascript']
      *                             and Html::includeHeader()
      *                             Three possible formats:
@@ -6295,11 +6295,6 @@ class CommonDBTM extends CommonGLPI
             $title = static::getTypeName(1);
         }
 
-        // Default menu if not specified: default values of Html::header
-        if (is_null($menus)) {
-            $menus = ['none', 'none', ''];
-        }
-
         Html::header(
             $title,
             $_SERVER['PHP_SELF'],
@@ -6325,11 +6320,6 @@ class CommonDBTM extends CommonGLPI
         // Default title if not specified: itemtype
         if (is_null($title)) {
             $title = static::getTypeName(1);
-        }
-
-        // Default menu if not specified: default values of Html::helpHeader
-        if (is_null($menus)) {
-            $menus = ['self-service', 'none', ''];
         }
 
         Html::helpHeader(

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6127,24 +6127,12 @@ class CommonDBTM extends CommonGLPI
     public static function displayItemNotFoundPage(array $menus): void
     {
         $helpdesk = Session::getCurrentInterface() == "helpdesk";
+        $title = __('Item not found');
 
         if (!$helpdesk) {
-            Html::header(
-                __('Item not found'),
-                $_SERVER['PHP_SELF'],
-                $menus[0] ?? 'none',
-                $menus[1] ?? 'none',
-                $menus[2] ?? '',
-                false
-            );
+            static::displayCentralHeader($title, $menus);
         } else {
-            Html::helpHeader(
-                __('Item not found'),
-                $menus[0] ?? 'self-service',
-                $menus[1] ?? 'none',
-                $menus[2] ?? '',
-                false
-            );
+            static::displayHelpdeskHeader($title, $menus);
         }
 
         Html::displayNotFoundError();
@@ -6161,25 +6149,13 @@ class CommonDBTM extends CommonGLPI
     public static function displayAccessDeniedPage(array $menus): void
     {
         $helpdesk = Session::getCurrentInterface() == "helpdesk";
+        $title = __('Access denied');
 
         if (!$helpdesk) {
             Toolbox::handleProfileChangeRedirect();
-            Html::header(
-                __('Access denied'),
-                $_SERVER['PHP_SELF'],
-                $menus[0] ?? 'none',
-                $menus[1] ?? 'none',
-                $menus[2] ?? '',
-                false
-            );
+            static::displayCentralHeader($title, $menus);
         } else {
-            Html::helpHeader(
-                __('Access denied'),
-                $menus[0] ?? 'self-service',
-                $menus[1] ?? 'none',
-                $menus[2] ?? '',
-                false
-            );
+            static::displayHelpdeskHeader($title, $menus);
         }
 
         Html::displayRightError();
@@ -6219,25 +6195,28 @@ class CommonDBTM extends CommonGLPI
     /**
      * Display a full helpdesk page (header + content + footer) for a given item
      *
-     * @param int|string $id       Id of the item to be displayed, may be a
+     * @param int|string  $id      Id of the item to be displayed, may be a
      *                             string due to some weird default values.
      *                             Will be cast to int straight away.
-     * @param array      $menus    Menu path used to load specific JS file and
+     * @param anull|array $menus   Menu path used to load specific JS file and
      *                             show breadcumbs, see $CFG_GLPI['javascript']
      *                             and Html::includeHeader()
-     *                             Two possible formats:
+     *                             Three possible formats:
      *                             - [menu 1, menu 2, menu 3]
      *                             - [
      *                                'central'  => [menu 1, menu 2, menu 3],
      *                                'helpdesk' => [menu 1, menu 2, menu 3],
      *                               ]
+     *                             - null (use auto computed values, mainly
+     *                             used for childs of commondropdown that can
+     *                             define their menus as object properties)
      * @param array      $options  Display options
      *
      * @return void
      */
     public static function displayFullPageForItem(
         $id,
-        array $menus,
+        ?array $menus = null,
         array $options = []
     ): void {
         $id = (int) $id;
@@ -6277,22 +6256,9 @@ class CommonDBTM extends CommonGLPI
 
         // Show header
         if ($interface == 'central') {
-            Html::header(
-                $title,
-                $_SERVER['PHP_SELF'],
-                $menus[0] ?? 'none',
-                $menus[1] ?? 'none',
-                $menus[2] ?? '',
-                false
-            );
+            static::displayCentralHeader($title, $menus);
         } else {
-            Html::helpHeader(
-                $title,
-                $menus[0] ?? 'self-service',
-                $menus[1] ?? 'none',
-                $menus[2] ?? '',
-                false
-            );
+            static::displayHelpdeskHeader($title, $menus);
         }
 
         // Show item
@@ -6310,5 +6276,68 @@ class CommonDBTM extends CommonGLPI
         } else {
             Html::helpFooter();
         }
+    }
+
+    /**
+     * Display a header for the "central" interface
+     *
+     * @param null|string  $title
+     * @param array|string $menus
+     *
+     * @return void
+     */
+    public static function displayCentralHeader(
+        ?string $title = null,
+        ?array $menus = null
+    ): void {
+        // Default title if not specified: current itemtype
+        if (is_null($title)) {
+            $title = static::getTypeName(1);
+        }
+
+        // Default menu if not specified: default values of Html::header
+        if (is_null($menus)) {
+            $menus = ['none', 'none', ''];
+        }
+
+        Html::header(
+            $title,
+            $_SERVER['PHP_SELF'],
+            $menus[0] ?? 'none',
+            $menus[1] ?? 'none',
+            $menus[2] ?? '',
+            false
+        );
+    }
+
+    /**
+     * Display a header for the "helpdesk" interface
+     *
+     * @param null|string  $title
+     * @param array|string $menus
+     *
+     * @return void
+     */
+    public static function displayHelpdeskHeader(
+        ?string $title = null,
+        ?array $menus = null
+    ): void {
+        // Default title if not specified: itemtype
+        if (is_null($title)) {
+            $title = static::getTypeName(1);
+        }
+
+        // Default menu if not specified: default values of Html::helpHeader
+        if (is_null($menus)) {
+            $menus = ['self-service', 'none', ''];
+        }
+
+        Html::helpHeader(
+            $title,
+            $menus[0] ?? 'self-service',
+            $menus[1] ?? 'none',
+            $menus[2] ?? '',
+            false
+        );
     }
 }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6208,7 +6208,7 @@ class CommonDBTM extends CommonGLPI
      *                                'helpdesk' => [menu 1, menu 2, menu 3],
      *                               ]
      *                             - null (use auto computed values, mainly
-     *                             used for childs of commondropdown that can
+     *                             used for children of commondropdown that can
      *                             define their menus as object properties)
      * @param array      $options  Display options
      *

--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -44,6 +44,9 @@ abstract class CommonDevice extends CommonDropdown
    // From CommonDBTM
     public $dohistory           = true;
 
+    public $first_level_menu  = "config";
+    public $second_level_menu = "commondevice";
+    public $third_level_menu  = "";
 
     public static function getTypeName($nb = 0)
     {
@@ -304,13 +307,6 @@ abstract class CommonDevice extends CommonDropdown
             $this->getSearchURL()
         );
     }
-
-
-    public function displayHeader()
-    {
-        Html::header($this->getTypeName(1), '', "config", "commondevice", get_class($this));
-    }
-
 
     /**
      * @since 0.84

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -203,7 +203,7 @@ abstract class CommonDropdown extends CommonDBTM
     }
 
 
-    public function displayHeader()
+    final public function displayHeader()
     {
 
         if (empty($this->third_level_menu)) {

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -202,22 +202,31 @@ abstract class CommonDropdown extends CommonDBTM
         return $ong;
     }
 
-
-    final public function displayHeader()
+    public function displayHeader()
     {
-
-        if (empty($this->third_level_menu)) {
-            $this->third_level_menu = $this->getType();
-        }
-        Html::header(
-            $this->getTypeName(Session::getPluralNumber()),
-            '',
-            $this->first_level_menu,
-            $this->second_level_menu,
-            $this->third_level_menu
+        Toolbox::deprecated(
+            "This method is deprecated. Use displayCentralHeader() instead"
         );
     }
 
+    public static function displayCentralHeader(
+        ?string $title = null,
+        ?array $menus = null
+    ): void {
+        if (is_null($menus)) {
+            $dropdown = new static();
+
+            $menus = [
+                $dropdown->first_level_menu,
+                $dropdown->second_level_menu,
+                empty($dropdown->third_level_menu) ?
+                    $dropdown->getType() :
+                    $dropdown->third_level_menu
+            ];
+        }
+
+        parent::displayCentralHeader($title, $menus);
+    }
 
     /**
      * @since 0.83.3

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -220,9 +220,7 @@ abstract class CommonDropdown extends CommonDBTM
             $menus = [
                 $dropdown->first_level_menu,
                 $dropdown->second_level_menu,
-                empty($dropdown->third_level_menu) ?
-                    $dropdown->getType() :
-                    $dropdown->third_level_menu
+                $dropdown->third_level_menu ?: $dropdown->getType()
             ];
         }
 

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -207,6 +207,7 @@ abstract class CommonDropdown extends CommonDBTM
         Toolbox::deprecated(
             "This method is deprecated. Use displayCentralHeader() instead"
         );
+        static::displayCentralHeader();
     }
 
     public static function displayCentralHeader(

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -484,13 +484,6 @@ class Entity extends CommonTreeDropdown
        // Empty title for entities
     }
 
-
-    public function displayHeader()
-    {
-        Html::header($this->getTypeName(1), '', "admin", "entity");
-    }
-
-
     /**
      * Get the ID of entity assigned to the object
      *

--- a/src/FieldUnicity.php
+++ b/src/FieldUnicity.php
@@ -39,7 +39,8 @@ class FieldUnicity extends CommonDropdown
    // From CommonDBTM
     public $dohistory          = true;
 
-    public $second_level_menu  = "control";
+    public $first_level_menu   = "config";
+    public $second_level_menu  = "fieldunicity";
     public $can_be_translated  = false;
 
     public static $rightname          = 'config';
@@ -63,12 +64,6 @@ class FieldUnicity extends CommonDropdown
     public static function canPurge()
     {
         return static::canUpdate();
-    }
-
-
-    public function displayHeader()
-    {
-        Html::header(FieldUnicity::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "config", "fieldunicity");
     }
 
     public function getAdditionalFields()


### PR DESCRIPTION
Fix #10593

`CommonDropdown::displayHeader()` handle breadcrumbs using the item properties: 

![image](https://user-images.githubusercontent.com/42734840/154280070-64934ed8-8807-44f9-8034-dbfe3ff0f895.png)

Instead of overriding these properties, some item override the `displayHeader` method, for example:

![image](https://user-images.githubusercontent.com/42734840/154280238-8e2f18ae-d1bb-40f0-aa75-8c81a43f81ed.png)

These items should redefine `$first_level_menu`, `second_level_menu` and `$third_level_menu` properly instead of changing this function.  
I've set the function to final to avoid this but it may trigger some fatal error if some plugins are doing the same thing.  
Maybe a depreciation warning instead ? Or is it OK since we are doing a major update from 9 to 10 ?  


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10593
