### PR TITLE
Hide navigation though items in global search context; closes #10563

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -1713,9 +1713,7 @@ class Search
         $prehref = $search['target'] . (strpos($search['target'], "?") !== false ? "&" : "?");
         $href    = $prehref . $parameters;
 
-        if ($data['display_type'] == self::HTML_OUTPUT) {
-            Session::initNavigateListItems($data['itemtype']);
-        }
+        Session::initNavigateListItems($data['itemtype']);
 
         TemplateRenderer::getInstance()->display('components/search/display_data.html.twig', [
             'data'                => $data,
@@ -1750,10 +1748,16 @@ class Search
             'may_be_browsed'      => Toolbox::hasTrait($item, \Glpi\Features\TreeBrowse::class),
         ]);
 
-       // Add items in item list
+        // Add items in item list
         foreach ($data['data']['rows'] as $row) {
-            $current_type = (isset($row['TYPE']) ? $row['TYPE'] : $data['itemtype']);
-            Session::addToNavigateListItems($current_type, $row["id"]);
+            if ($itemtype !== AllAssets::class) {
+                Session::addToNavigateListItems($itemtype, $row["id"]);
+            } else {
+                // In case of a global search, reset and empty navigation list to ensure navigation in
+                // item header context is not shown. Indeed, this list does not support navigation through
+                // multiple itemtypes, so it should not be displayed in global search context.
+                Session::initNavigateListItems($row['TYPE'] ?? $data['itemtype']);
+            }
         }
 
        // Clean previous selection


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10563 

Navigation through items is not made to be used in a global search context. Indeed, counters and available elements are partitionned by itemtypes, so previous/next/first/last items and items count are always refering to the type of the currently displayed item, whenever other item types are present in the global search results.

Fixing navigation would require lots of refactoring, so I propose to just hide navigation features when an item is shown from a global search context.