### PR TITLE
Expose getFiltersCriteria function on dashboard/provider.class.php

### DIFF
--- a/inc/dashboard/provider.class.php
+++ b/inc/dashboard/provider.class.php
@@ -1425,7 +1425,7 @@ class Provider extends CommonGLPI {
       return $s_criteria;
    }
 
-   private static function getFiltersCriteria(string $table = "", array $apply_filters = []) {
+   public static function getFiltersCriteria(string $table = "", array $apply_filters = []) {
       $DB = DBConnection::getReadConnection();
 
       $where = [];


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->

I stumbled across this minor change I needed to do for my custom cards to work properly. I've separated my customs cards on a plug-in and just needed to create a new query to get data. Thing is, as I just wanted to change the information, I didn't need to create new filter criterias... I just can use the native getFiltersCriteria and make my cards work! Thing is, this function is private in dashboard/provider.class.php. I exposed the function on my instance and now everything works fine. I would like to know if it's possible to expose this function and maybe some others, because new dashboards widgets on most cases can reuse existing functions from dashboard directory. Best regards :-)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | pending
