### PR TITLE
Add prefix to tickets number

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8554,7 +8554,7 @@ abstract class CommonITILObject extends CommonDBTM
     public function getBrowserTabName(): string
     {
         return sprintf(
-            __('%1$s (%2$s) - %3$s'),
+            __('%1$s (#%2$s) - %3$s'),
             static::getTypeName(1),
             $this->getID(),
             $this->getHeaderName()


### PR DESCRIPTION
In #10114, @cedric-anne suggested the following format for ITIL items tabs:

![image](https://user-images.githubusercontent.com/42734840/154498559-86448d02-3fcc-4362-b233-86c652aeeb4a.png)

For some reasons the `(179)` part gives me "warning, unread items" vibes like a typical mailbox tab:

![image](https://user-images.githubusercontent.com/42734840/154498767-5aceb13e-a9f9-4f36-98a7-a8a18b7a3924.png) 
![image](https://user-images.githubusercontent.com/42734840/154499289-1d006e09-66be-4416-8874-e6784b8b6aaf.png)


Maybe adding a `#` prefix makes it clearer that it's a ticket reference and avoid any confusion ?

![image](https://user-images.githubusercontent.com/42734840/154498983-4c5135a1-c7ed-44e1-aaba-56f0ca3b4a2c.png)


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
