### PR TITLE
Fix handling of max concat length and max joins in search; see #10680

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -1357,46 +1357,12 @@ class Search
         }
         $data['data'] = [];
 
-       // Use a ReadOnly connection if available and configured to be used
+        // Use a ReadOnly connection if available and configured to be used
         $DBread = DBConnection::getReadConnection();
-        $DBread->query("SET SESSION group_concat_max_len = 16384;");
-
-       // directly increase group_concat_max_len to avoid double query
-        if (count($data['search']['metacriteria'])) {
-            foreach ($data['search']['metacriteria'] as $metacriterion) {
-                if (
-                    $metacriterion['link'] == 'AND NOT'
-                    || $metacriterion['link'] == 'OR NOT'
-                ) {
-                    $DBread->query("SET SESSION group_concat_max_len = 4194304;");
-                    break;
-                }
-            }
-        }
+        $DBread->query("SET SESSION group_concat_max_len = 8194304;");
 
         $DBread->execution_time = true;
         $result = $DBread->query($data['sql']['search']);
-       /// Check group concat limit : if warning : increase limit
-        if ($result2 = $DBread->query('SHOW WARNINGS')) {
-            if ($DBread->numrows($result2) > 0) {
-                $res = $DBread->fetchAssoc($result2);
-                if ($res['Code'] == 1260) {
-                    $DBread->query("SET SESSION group_concat_max_len = 8194304;");
-                    $DBread->execution_time = true;
-                    $result = $DBread->query($data['sql']['search']);
-                }
-
-                if ($res['Code'] == 1116) { // too many tables
-                    echo self::showError(
-                        $data['search']['display_type'],
-                        __("'All' criterion is not usable with this object list, " .
-                                       "sql query fails (too many tables). " .
-                        "Please use 'Items seen' criterion instead")
-                    );
-                    return false;
-                }
-            }
-        }
 
         if ($result) {
             $data['data']['execution_time'] = $DBread->execution_time;
@@ -1654,7 +1620,17 @@ class Search
 
             $data['data']['count'] = count($data['data']['rows']);
         } else {
-            echo $DBread->error();
+            $error_no = $DBread->errno();
+            if ($error_no == 1116) { // Too many tables; MySQL can only use 61 tables in a join
+                echo self::showError(
+                    $data['search']['display_type'],
+                    __("'All' criterion is not usable with this object list, " .
+                                   "sql query fails (too many tables). " .
+                    "Please use 'Items seen' criterion instead")
+                );
+            } else {
+                echo $DBread->error();
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #10680

1. As warnings are now fetched automatically on each query, the `group_concat_max_len` was not anymore increased when first attempt failed.
However, I am not sure it is relevant to increase this value step by step, as, anyways, if this value is too small, it will be increased and the query will be done a second time. Also, unless I miss something, setting this value to its max even when it is not really necessary should not lower performances. So, IMHO, setting this value to its maximum for everyone is the simplier solution.

2. Breaking the 61 joined tables limit triggers an error. Dedicated code was based on warnings, so was never applied.