### PR TITLE
Hide item add button in tickets when no permission to add

### DIFF
--- a/src/Item_Ticket.php
+++ b/src/Item_Ticket.php
@@ -205,7 +205,8 @@ class Item_Ticket extends CommonItilObject_Item
             return false;
         }
 
-        $canedit = ($ticket->can($params['id'], UPDATE)
+        $can_add_items = $_SESSION["glpiactiveprofile"]["helpdesk_hardware"] & pow(2, Ticket::HELPDESK_MY_HARDWARE) || $_SESSION["glpiactiveprofile"]["helpdesk_hardware"] & pow(2, Ticket::HELPDESK_ALL_HARDWARE);
+        $canedit = ($can_add_items && $ticket->can($params['id'], UPDATE)
                   && $params['_canupdate']);
 
        // Ticket update case


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10686
