### PR TITLE
Fix DB service status check output

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -321,7 +321,7 @@ class Application extends BaseApplication
         }
 
         global $DB;
-        $DB = new DB();
+        $DB = @new DB();
         $this->db = $DB;
 
         if (!$this->db->connected) {

--- a/src/Console/System/CheckStatusCommand.php
+++ b/src/Console/System/CheckStatusCommand.php
@@ -42,6 +42,8 @@ use Toolbox;
 
 class CheckStatusCommand extends AbstractCommand
 {
+    protected $requires_db = false;
+
     protected function configure()
     {
         parent::configure();

--- a/src/System/Status/StatusChecker.php
+++ b/src/System/Status/StatusChecker.php
@@ -212,7 +212,7 @@ final class StatusChecker
             }
 
            // Check main server connection
-            if (!DBConnection::establishDBConnection(false, true, false)) {
+            if (!@DBConnection::establishDBConnection(false, true, false)) {
                 $status['master'] = [
                     'status' => self::STATUS_PROBLEM
                 ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If DB is not available, the status check shows a PHP warning before the status check output. For JSON output, this results in an invalid JSON string. It makes sense to suppress these warnings in the console and status check contexts.