### PR TITLE
Fix clone name uniqueness

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -168,18 +168,18 @@ class CommonDBTM extends CommonGLPI {
    static $undisclosedFields = [];
 
    /**
-    * Constructor
-   **/
-   function __construct () {
-   }
-
-   /**
     * Cache used to keep track of the last clone index
     * Usefull when cloning an item multiple time to avoid iterating on the sql
     * results multiple time while looking for an available unique name
     * @var null|int
     */
-   public static ?int $last_clone_index = null;
+   public static $last_clone_index = null;
+
+   /**
+    * Constructor
+   **/
+   function __construct () {
+   }
 
    /**
     * Return the table used to store this object
@@ -1238,7 +1238,7 @@ class CommonDBTM extends CommonGLPI {
     *
     * @return int|bool the new ID of the clone (or false if fail)
     */
-   public function cloneNTimes(
+   public function cloneMultiple(
       int $n,
       array $override_input = [],
       bool $history = true
@@ -1489,7 +1489,6 @@ class CommonDBTM extends CommonGLPI {
          // Try to find an available name
          do {
             $copy_name = $this->computeCloneName($current_name, ++$copy_index);
-            Toolbox::logError($copy_name);
          } while (countElementsInTable($table, [$name_field => $copy_name]) > 0);
 
          // Update index cache

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -1482,8 +1482,8 @@ class CommonDBTM extends CommonGLPI {
          $copy_index = 0;
 
          // Use index cache if defined
-         if (!is_null(self::$last_clone_index)) {
-            $copy_index = self::$last_clone_index;
+         if (!is_null($this->last_clone_index)) {
+            $copy_index = $this->last_clone_index;
          }
 
          // Try to find an available name

--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -173,7 +173,7 @@ class CommonDBTM extends CommonGLPI {
     * results multiple time while looking for an available unique name
     * @var null|int
     */
-   public static $last_clone_index = null;
+   public $last_clone_index = null;
 
    /**
     * Constructor
@@ -1247,7 +1247,7 @@ class CommonDBTM extends CommonGLPI {
 
       try {
          // Init index cache
-         self::$last_clone_index = 0;
+         $this->last_clone_index = 0;
          for ($i = 0; $i < $n && !$failure; $i++) {
             if ($this->clone($override_input, $history) === false) {
                // Increment clone index cache to use less SQL
@@ -1257,7 +1257,7 @@ class CommonDBTM extends CommonGLPI {
          }
       } finally {
          // Make sure cache is cleaned even on exception
-         self::$last_clone_index = null;
+         $this->last_clone_index = null;
       }
 
       return !$failure;
@@ -1492,7 +1492,7 @@ class CommonDBTM extends CommonGLPI {
          } while (countElementsInTable($table, [$name_field => $copy_name]) > 0);
 
          // Update index cache
-         self::$last_clone_index = $copy_index;
+         $this->last_clone_index = $copy_index;
 
          // Override input with the first found valid name
          $input[$name_field] = $copy_name;

--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -1314,12 +1314,6 @@ class MassiveAction {
                   // recovers the item from DB
                   if ($item->getFromDB($id)) {
                      $succeed = $item->cloneMultiple($input["nb_copy"]);
-                     // clone in a loop
-                     // for ($i = 0; $i < $input["nb_copy"] && $succeed; $i++) {
-                     //    if ($item->clone() === false) {
-                     //       $succeed = false;
-                     //    }
-                     // }
                      if ($succeed) {
                         $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
                      } else {

--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -1313,7 +1313,7 @@ class MassiveAction {
                if ($item->can($id, CREATE)) {
                   // recovers the item from DB
                   if ($item->getFromDB($id)) {
-                     $succeed = $item->cloneNTimes($input["nb_copy"]);
+                     $succeed = $item->cloneMultiple($input["nb_copy"]);
                      // clone in a loop
                      // for ($i = 0; $i < $input["nb_copy"] && $succeed; $i++) {
                      //    if ($item->clone() === false) {

--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -1313,13 +1313,13 @@ class MassiveAction {
                if ($item->can($id, CREATE)) {
                   // recovers the item from DB
                   if ($item->getFromDB($id)) {
-                     $succeed = true;
+                     $succeed = $item->cloneNTimes($input["nb_copy"]);
                      // clone in a loop
-                     for ($i = 0; $i < $input["nb_copy"] && $succeed; $i++) {
-                        if ($item->clone() === false) {
-                           $succeed = false;
-                        }
-                     }
+                     // for ($i = 0; $i < $input["nb_copy"] && $succeed; $i++) {
+                     //    if ($item->clone() === false) {
+                     //       $succeed = false;
+                     //    }
+                     // }
                      if ($succeed) {
                         $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
                      } else {

--- a/inc/rule.class.php
+++ b/inc/rule.class.php
@@ -3179,7 +3179,6 @@ class Rule extends CommonDBTM {
       $nextRanking = $this->getNextRanking();
 
       //Update fields of the new collection
-      $input['name']        = sprintf(__('Copy of %s'), $input['name']);
       $input['is_active']   = 0;
       $input['ranking']     = $nextRanking;
       $input['uuid']        = static::getUuid();

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -656,19 +656,14 @@ class User extends CommonDBTM {
       return $input;
    }
 
-   public function prepareInputForClone($input) {
-      if (isset($input['name'])) {
-         $suffix = 1;
-         $possibleName = $input['name'].$suffix;
-         while ($this->getFromDBbyName($possibleName)) {
-            $suffix++;
-            $possibleName = $input['name'].$suffix;
-         }
-         $input['name'] = $possibleName;
-      }
-      return $input;
+   public function computeCloneName(
+      string $current_name,
+      ?int $copy_index = null
+   ): string {
+      return Toolbox::slugify(
+         parent::computeCloneName($current_name, $copy_index)
+      );
    }
-
 
    function post_addItem() {
 

--- a/tests/functionnal/Appliance.php
+++ b/tests/functionnal/Appliance.php
@@ -155,7 +155,7 @@ class Appliance extends DbTestCase {
                $this->dateTime($dateClone)->isEqualTo($expectedDate);
                break;
             case 'name':
-               $this->variable($clonedApp->getField($k))->isEqualTo("Copy of {$app->getField($k)} (1)");
+               $this->variable($clonedApp->getField($k))->isEqualTo("{$app->getField($k)} (copy)");
                break;
             default:
                $this->variable($clonedApp->getField($k))->isEqualTo($app->getField($k));

--- a/tests/functionnal/Appliance.php
+++ b/tests/functionnal/Appliance.php
@@ -154,6 +154,9 @@ class Appliance extends DbTestCase {
                $expectedDate = new \DateTime($date);
                $this->dateTime($dateClone)->isEqualTo($expectedDate);
                break;
+            case 'name':
+               $this->variable($clonedApp->getField($k))->isEqualTo("Copy of {$app->getField($k)} (1)");
+               break;
             default:
                $this->variable($clonedApp->getField($k))->isEqualTo($app->getField($k));
          }

--- a/tests/functionnal/Certificate.php
+++ b/tests/functionnal/Certificate.php
@@ -148,6 +148,9 @@ class Certificate extends DbTestCase {
                $expectedDate = new \DateTime($date);
                $this->dateTime($dateClone)->isEqualTo($expectedDate);
                break;
+            case 'name':
+               $this->variable($clonedCertificate->getField($k))->isEqualTo("Copy of {$certificate->getField($k)} (1)");
+               break;
             default:
                $this->variable($clonedCertificate->getField($k))->isEqualTo($certificate->getField($k));
          }

--- a/tests/functionnal/Certificate.php
+++ b/tests/functionnal/Certificate.php
@@ -149,7 +149,7 @@ class Certificate extends DbTestCase {
                $this->dateTime($dateClone)->isEqualTo($expectedDate);
                break;
             case 'name':
-               $this->variable($clonedCertificate->getField($k))->isEqualTo("Copy of {$certificate->getField($k)} (1)");
+               $this->variable($clonedCertificate->getField($k))->isEqualTo("{$certificate->getField($k)} (copy)");
                break;
             default:
                $this->variable($clonedCertificate->getField($k))->isEqualTo($certificate->getField($k));

--- a/tests/functionnal/Computer.php
+++ b/tests/functionnal/Computer.php
@@ -464,6 +464,9 @@ class Computer extends DbTestCase {
                $expectedDate = new \DateTime($date);
                $this->dateTime($dateClone)->isEqualTo($expectedDate);
                break;
+            case 'name':
+               $this->variable($clonedComputer->getField($k))->isEqualTo("Copy of {$computer->getField($k)} (1)");
+               break;
             default:
                $this->variable($clonedComputer->getField($k))->isEqualTo($computer->getField($k));
          }

--- a/tests/functionnal/Computer.php
+++ b/tests/functionnal/Computer.php
@@ -465,7 +465,7 @@ class Computer extends DbTestCase {
                $this->dateTime($dateClone)->isEqualTo($expectedDate);
                break;
             case 'name':
-               $this->variable($clonedComputer->getField($k))->isEqualTo("Copy of {$computer->getField($k)} (1)");
+               $this->variable($clonedComputer->getField($k))->isEqualTo("{$computer->getField($k)} (copy)");
                break;
             default:
                $this->variable($clonedComputer->getField($k))->isEqualTo($computer->getField($k));

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -489,18 +489,18 @@ class Entity extends DbTestCase {
 
       $this->createItems('Entity', [
          [
-            'name'        => 'test_clone entity',
+            'name'        => 'test clone entity',
             'entities_id' => 0,
          ]
       ]);
 
       // Check that no clones exists
       $entity = new \Entity;
-      $res = $entity->find(['name' => ['LIKE', 'Copy of test_clone%']]);
+      $res = $entity->find(['name' => ['LIKE', 'test clone entity %']]);
       $this->array($res)->hasSize(0);
 
       // Clone multiple times
-      $entity = getItemByTypeName('Entity', 'test_clone entity', false);
+      $entity = getItemByTypeName('Entity', 'test clone entity', false);
       $this->integer($entity->clone())->isGreaterThan(0);
       $this->integer($entity->clone())->isGreaterThan(0);
       $this->integer($entity->clone())->isGreaterThan(0);
@@ -508,13 +508,13 @@ class Entity extends DbTestCase {
 
       // Check that 4 clones were created
       $entity = new \Entity;
-      $res = $entity->find(['name' => ['LIKE', 'Copy of test_clone%']]);
+      $res = $entity->find(['name' => ['LIKE', 'test clone entity %']]);
       $this->array($res)->hasSize(4);
 
       // Try to read each clones
-      $this->integer(getItemByTypeName('Entity', 'Copy of test_clone entity (1)', true))->isGreaterThan(0);
-      $this->integer(getItemByTypeName('Entity', 'Copy of test_clone entity (2)', true))->isGreaterThan(0);
-      $this->integer(getItemByTypeName('Entity', 'Copy of test_clone entity (3)', true))->isGreaterThan(0);
-      $this->integer(getItemByTypeName('Entity', 'Copy of test_clone entity (4)', true))->isGreaterThan(0);
+      $this->integer(getItemByTypeName('Entity', 'test clone entity (copy)', true))->isGreaterThan(0);
+      $this->integer(getItemByTypeName('Entity', 'test clone entity (copy 2)', true))->isGreaterThan(0);
+      $this->integer(getItemByTypeName('Entity', 'test clone entity (copy 3)', true))->isGreaterThan(0);
+      $this->integer(getItemByTypeName('Entity', 'test clone entity (copy 4)', true))->isGreaterThan(0);
    }
 }

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -501,10 +501,7 @@ class Entity extends DbTestCase {
 
       // Clone multiple times
       $entity = getItemByTypeName('Entity', 'test clone entity', false);
-      $this->integer($entity->clone())->isGreaterThan(0);
-      $this->integer($entity->clone())->isGreaterThan(0);
-      $this->integer($entity->clone())->isGreaterThan(0);
-      $this->integer($entity->clone())->isGreaterThan(0);
+      $this->boolean($entity->cloneMultiple(4))->isTrue();
 
       // Check that 4 clones were created
       $entity = new \Entity;

--- a/tests/functionnal/Entity.php
+++ b/tests/functionnal/Entity.php
@@ -483,4 +483,38 @@ class Entity extends DbTestCase {
       $this->boolean($entity->getFromDB($entity_id))->isTrue();
       $this->string($entity->getCustomCssTag())->isEqualTo($expected);
    }
+
+   public function testMultipleClones() {
+      $this->login();
+
+      $this->createItems('Entity', [
+         [
+            'name'        => 'test_clone entity',
+            'entities_id' => 0,
+         ]
+      ]);
+
+      // Check that no clones exists
+      $entity = new \Entity;
+      $res = $entity->find(['name' => ['LIKE', 'Copy of test_clone%']]);
+      $this->array($res)->hasSize(0);
+
+      // Clone multiple times
+      $entity = getItemByTypeName('Entity', 'test_clone entity', false);
+      $this->integer($entity->clone())->isGreaterThan(0);
+      $this->integer($entity->clone())->isGreaterThan(0);
+      $this->integer($entity->clone())->isGreaterThan(0);
+      $this->integer($entity->clone())->isGreaterThan(0);
+
+      // Check that 4 clones were created
+      $entity = new \Entity;
+      $res = $entity->find(['name' => ['LIKE', 'Copy of test_clone%']]);
+      $this->array($res)->hasSize(4);
+
+      // Try to read each clones
+      $this->integer(getItemByTypeName('Entity', 'Copy of test_clone entity (1)', true))->isGreaterThan(0);
+      $this->integer(getItemByTypeName('Entity', 'Copy of test_clone entity (2)', true))->isGreaterThan(0);
+      $this->integer(getItemByTypeName('Entity', 'Copy of test_clone entity (3)', true))->isGreaterThan(0);
+      $this->integer(getItemByTypeName('Entity', 'Copy of test_clone entity (4)', true))->isGreaterThan(0);
+   }
 }

--- a/tests/functionnal/Monitor.php
+++ b/tests/functionnal/Monitor.php
@@ -119,6 +119,9 @@ class Monitor extends DbTestCase {
 
       $expected = Monitor::getMonitorFields($added, $date);
 
+      $this->string($clonedMonitor->fields['name'])->isEqualTo("Copy of $expected[name] (1)");
+      unset($clonedMonitor->fields['name'], $expected['name']);
+
       $this->array($clonedMonitor->fields)->isIdenticalTo($expected);
    }
 }

--- a/tests/functionnal/Monitor.php
+++ b/tests/functionnal/Monitor.php
@@ -119,7 +119,7 @@ class Monitor extends DbTestCase {
 
       $expected = Monitor::getMonitorFields($added, $date);
 
-      $this->string($clonedMonitor->fields['name'])->isEqualTo("Copy of $expected[name] (1)");
+      $this->string($clonedMonitor->fields['name'])->isEqualTo("$expected[name] (copy)");
       unset($clonedMonitor->fields['name'], $expected['name']);
 
       $this->array($clonedMonitor->fields)->isIdenticalTo($expected);

--- a/tests/functionnal/NetworkPort.php
+++ b/tests/functionnal/NetworkPort.php
@@ -273,6 +273,9 @@ class NetworkPort extends DbTestCase {
                $expectedDate = new \DateTime($date);
                $this->dateTime($dateClone)->isEqualTo($expectedDate);
                break;
+            case 'name':
+               $this->variable($clonedNetworkport->getField($k))->isEqualTo("Copy of {$networkport->getField($k)} (1)");
+               break;
             default:
                $this->variable($clonedNetworkport->getField($k))->isEqualTo($networkport->getField($k));
          }

--- a/tests/functionnal/NetworkPort.php
+++ b/tests/functionnal/NetworkPort.php
@@ -274,7 +274,7 @@ class NetworkPort extends DbTestCase {
                $this->dateTime($dateClone)->isEqualTo($expectedDate);
                break;
             case 'name':
-               $this->variable($clonedNetworkport->getField($k))->isEqualTo("Copy of {$networkport->getField($k)} (1)");
+               $this->variable($clonedNetworkport->getField($k))->isEqualTo("{$networkport->getField($k)} (copy)");
                break;
             default:
                $this->variable($clonedNetworkport->getField($k))->isEqualTo($networkport->getField($k));

--- a/tests/functionnal/Project.php
+++ b/tests/functionnal/Project.php
@@ -235,6 +235,10 @@ class Project extends DbTestCase {
       $project_clone = new \Project();
       $this->boolean($project_clone->getFromDB($projects_id_clone))->isTrue();
 
+      // Check name
+      $this->string($project_clone->fields['name'])->isEqualTo("Copy of $project_input[name] (1)");
+      unset($project_clone->fields['name'], $project_input['name']);
+
       // Check basics fields
       foreach (array_keys($project_input) as $field) {
          $this->variable($project_clone->fields[$field])->isEqualTo($project->fields[$field]);

--- a/tests/functionnal/Project.php
+++ b/tests/functionnal/Project.php
@@ -236,7 +236,7 @@ class Project extends DbTestCase {
       $this->boolean($project_clone->getFromDB($projects_id_clone))->isTrue();
 
       // Check name
-      $this->string($project_clone->fields['name'])->isEqualTo("Copy of $project_input[name] (1)");
+      $this->string($project_clone->fields['name'])->isEqualTo("$project_input[name] (copy)");
       unset($project_clone->fields['name'], $project_input['name']);
 
       // Check basics fields

--- a/tests/functionnal/Rule.php
+++ b/tests/functionnal/Rule.php
@@ -551,7 +551,7 @@ class Rule extends DbTestCase {
       $this->boolean($rule->getFromDB($cloned))->isTrue();
 
       $this->integer($rule->fields['is_active'])->isIdenticalTo(0);
-      $this->string($rule->fields['name'])->isIdenticalTo('Copy of One user assignation');
+      $this->string($rule->fields['name'])->isIdenticalTo('Copy of One user assignation (1)');
 
       foreach ($relations as $relation => $expected) {
          $this->integer(

--- a/tests/functionnal/Rule.php
+++ b/tests/functionnal/Rule.php
@@ -551,7 +551,7 @@ class Rule extends DbTestCase {
       $this->boolean($rule->getFromDB($cloned))->isTrue();
 
       $this->integer($rule->fields['is_active'])->isIdenticalTo(0);
-      $this->string($rule->fields['name'])->isIdenticalTo('Copy of One user assignation (1)');
+      $this->string($rule->fields['name'])->isIdenticalTo('One user assignation (copy)');
 
       foreach ($relations as $relation => $expected) {
          $this->integer(

--- a/tests/functionnal/RuleSoftwareCategory.php
+++ b/tests/functionnal/RuleSoftwareCategory.php
@@ -101,7 +101,7 @@ class RuleSoftwareCategory extends DbTestCase {
       $this->boolean($rule->getFromDB($cloned))->isTrue();
 
       $this->integer($rule->fields['is_active'])->isIdenticalTo(0);
-      $this->string($rule->fields['name'])->isIdenticalTo('Copy of Import category from inventory tool (1)');
+      $this->string($rule->fields['name'])->isIdenticalTo('Import category from inventory tool (copy)');
 
       foreach ($relations as $relation => $expected) {
          $this->integer(

--- a/tests/functionnal/RuleSoftwareCategory.php
+++ b/tests/functionnal/RuleSoftwareCategory.php
@@ -101,7 +101,7 @@ class RuleSoftwareCategory extends DbTestCase {
       $this->boolean($rule->getFromDB($cloned))->isTrue();
 
       $this->integer($rule->fields['is_active'])->isIdenticalTo(0);
-      $this->string($rule->fields['name'])->isIdenticalTo('Copy of Import category from inventory tool');
+      $this->string($rule->fields['name'])->isIdenticalTo('Copy of Import category from inventory tool (1)');
 
       foreach ($relations as $relation => $expected) {
          $this->integer(

--- a/tests/functionnal/Software.php
+++ b/tests/functionnal/Software.php
@@ -256,7 +256,7 @@ class Software extends DbTestCase {
 
       $this->boolean($software->getFromDB($softwares_id_2))->isTrue();
       $this->variable($software->fields['is_template'])->isEqualTo(0);
-      $this->string($software->fields['name'])->isIdenticalTo('Copy of MySoft (1)');
+      $this->string($software->fields['name'])->isIdenticalTo('MySoft (copy)');
 
       $query = ['itemtype' => 'Software', 'items_id' => $softwares_id_2];
       $this->integer((int)countElementsInTable('glpi_infocoms', $query))->isIdenticalTo(1);

--- a/tests/functionnal/Software.php
+++ b/tests/functionnal/Software.php
@@ -256,7 +256,7 @@ class Software extends DbTestCase {
 
       $this->boolean($software->getFromDB($softwares_id_2))->isTrue();
       $this->variable($software->fields['is_template'])->isEqualTo(0);
-      $this->string($software->fields['name'])->isIdenticalTo('MySoft');
+      $this->string($software->fields['name'])->isIdenticalTo('Copy of MySoft (1)');
 
       $query = ['itemtype' => 'Software', 'items_id' => $softwares_id_2];
       $this->integer((int)countElementsInTable('glpi_infocoms', $query))->isIdenticalTo(1);

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -1420,12 +1420,15 @@ class Ticket extends DbTestCase {
                $expectedDate = new \DateTime($date);
                $this->dateTime($dateClone)->isEqualTo($expectedDate);
                break;
+            case 'name':
+               $this->variable($clonedTicket->getField($k))->isEqualTo("Copy of {$ticket->getField($k)} (1)");
+               break;
             default:
                $this->executeOnFailure(
                   function() use ($k) {
-                      dump($k);
+                     var_dump($k);
                   }
-               )->variable($clonedTicket->getField($k))->isEqualTo($ticket->getField($k))->dump($k);
+               )->variable($clonedTicket->getField($k))->isEqualTo($ticket->getField($k));
          }
       }
    }

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -1421,7 +1421,7 @@ class Ticket extends DbTestCase {
                $this->dateTime($dateClone)->isEqualTo($expectedDate);
                break;
             case 'name':
-               $this->variable($clonedTicket->getField($k))->isEqualTo("Copy of {$ticket->getField($k)} (1)");
+               $this->variable($clonedTicket->getField($k))->isEqualTo("{$ticket->getField($k)} (copy)");
                break;
             default:
                $this->executeOnFailure(

--- a/tests/functionnal/User.php
+++ b/tests/functionnal/User.php
@@ -510,8 +510,10 @@ class User extends \DbTestCase {
       foreach ($fields as $k => $v) {
          switch ($k) {
             case 'id':
-            case 'name':
                $this->variable($clonedUser->getField($k))->isNotEqualTo($user->getField($k));
+               break;
+            case 'name':
+               $this->variable($clonedUser->getField($k))->isEqualTo("copy-of-_test_user-1");
                break;
             case 'date_mod':
             case 'date_creation':

--- a/tests/functionnal/User.php
+++ b/tests/functionnal/User.php
@@ -513,7 +513,7 @@ class User extends \DbTestCase {
                $this->variable($clonedUser->getField($k))->isNotEqualTo($user->getField($k));
                break;
             case 'name':
-               $this->variable($clonedUser->getField($k))->isEqualTo("copy-of-_test_user-1");
+               $this->variable($clonedUser->getField($k))->isEqualTo("_test_user-copy");
                break;
             case 'date_mod':
             case 'date_creation':


### PR DESCRIPTION
Cloning an entity fail silently because entity names must be unique.

To fix this, I've improved the cloning system to make sure it always set unique name to new items.
For example, if you clone an item named "Test", the clone will be named "Copy of Test (1)".
If "Copy of Test (1)" already exist then we move on to "Copy of Test (2)" and so on.

This also makes it easier to spot cloned items (and renamed them manually as needed):

![image](https://user-images.githubusercontent.com/42734840/154709656-dbc6df27-29d1-42e2-b588-f32ed28b61ea.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23470
