### PR TITLE
Fix PSR-4 autoloading logic for classes without namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,8 +100,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Glpi\\": "src/",
-            "": "src/"
+            "Glpi\\": "src/"
         }
     },
     "autoload-dev": {

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -263,34 +263,15 @@ final class DbUtils
             }
 
             $base_itemtype = $this->fixItemtypeCase($prefix . $table);
-            $namespaced_itemtype = $this->fixItemtypeCase($pref2 . str_replace('_', '\\', $table));
-
-           // Both potential itemtype (with or without namespace) are pointing to the same file, so it will trigger a
-           // "Cannot declare class XXX, because the name is already in use" error if the "wrong" version is
-           // required by the autoloader when the good version is already loaded.
-           // i.e. `class_exists('Glpi\Computer')` will load `src/Computer.php` which may redeclare the `Computer class`
-           //
-           // To prevent this, we check existence of both without allowing the autoloader to be used.
-           // If none exists yet, we trigger the autoloader to ensure the class file is loaded and the class is defined.
-           //
-           // Then we check again existence of both without allowing the autoloader to be used,
-           // in order to find the good class to use.
-            if (!class_exists($base_itemtype, false) && !class_exists($namespaced_itemtype, false)) {
-                // Try to trigger loading of base itemtype
-                class_exists($base_itemtype);
-                if (!class_exists($namespaced_itemtype, false) && !class_exists($base_itemtype, false)) {
-                    // Namespace itemtype file will not be loaded by call to `class_exists($base_itemtype)`:
-                    // - if namespace has more than one level (i.e. "Glpi\Dashboard\Dashboard")
-                    // - if clanname without namespace already exists (i.e. `Socket` from `sockets` extension, `Event` from `event` extension, ...)
-                    class_exists($namespaced_itemtype); // Try to trigger loading of namespaced itemtype
-                }
-            }
 
             $itemtype = null;
-            if (class_exists($base_itemtype, false)) {
+            if (class_exists($base_itemtype)) {
                 $itemtype = $base_itemtype;
-            } else if (class_exists($namespaced_itemtype, false)) {
-                $itemtype = $namespaced_itemtype;
+            } else {
+                $namespaced_itemtype = $this->fixItemtypeCase($pref2 . str_replace('_', '\\', $table));
+                if (class_exists($namespaced_itemtype)) {
+                    $itemtype = $namespaced_itemtype;
+                }
             }
 
             if ($itemtype !== null && $item = $this->getItemForItemtype($itemtype)) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -265,7 +265,6 @@ class Plugin extends CommonDBTM
                     if (is_dir($psr4_dir)) {
                         $psr4_autoloader = new \Composer\Autoload\ClassLoader();
                         $psr4_autoloader->addPsr4(NS_PLUG . ucfirst($plugin_key) . '\\', $psr4_dir);
-                        $psr4_autoloader->addPsr4('', $psr4_dir);
                         $psr4_autoloader->register();
                     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10528

Replaces #10711 and #10649.

Using the composer PSR-4 loader for classes without namespace is generating too many issues. This is due to the fact that composer uses a `include` directive and not a `include_once`. So if you call something like `class_exists('Socket')` or `new Socket()` while `Glpi\Socket` class is already loaded, the `src/Socket.php` file will still be included and it will fail with a fatal error `Cannot redeclare Glpi\Socket class...`.

Moving back loading of classes without namespace in our own autoloader and uses a `include_once` directive fixes this issue. Also, we can remove hacky logic from `getItemTypeForTable()`.