### PR TITLE
Use direct query for createLinkTable

### DIFF
--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1608,7 +1608,7 @@ class Migration
         $default_collation = DBConnection::getDefaultCollation();
         $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
-        $this->addPreQuery("
+        $DB->queryOrDie("
             CREATE TABLE `$table` (
                 `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
                 `$fk_1` int {$default_key_sign} NOT NULL DEFAULT '0',


### PR DESCRIPTION
I'm trying to run this very simple migration:
```php
$this->migration->createLinkTable($table, PluginFormcreatorForm::class, $class);
$this->migration->addField($table, 'uuid', 'string');
```

It fails because `migration->addField()` execute its queries directly, thus bypassing the pre/post query system offered by its own class.
It is unexpected as any `addPreQuery` should be ran before any other migrations.

For now I've only changed `migration->createLinkTable()` to avoid this issue but maybe in the future any methods from `migration` should respect pre/post query orders.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
