### PR TITLE
Handle PSR4 classes case sensitivity in getItemForItemtype

### DIFF
--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -396,11 +396,6 @@ final class DbUtils
             return false;
         }
 
-        if ($itemtype === 'Event') {
-           //to avoid issues when pecl-event is installed...
-            $itemtype = 'Glpi\\Event';
-        }
-
        // If itemtype starts with "Glpi\" or "GlpiPlugin\" followed by a "\",
        // then it is a namespaced itemtype that has been "sanitized".
        // Strip slashes to get its actual value.
@@ -410,6 +405,13 @@ final class DbUtils
          . '/';
         if (preg_match($sanitized_namespaced_pattern, $itemtype)) {
             $itemtype = stripslashes($itemtype);
+        }
+
+        $itemtype = $this->fixItemtypeCase($itemtype);
+
+        if ($itemtype === 'Event') {
+           //to avoid issues when pecl-event is installed...
+            $itemtype = 'Glpi\\Event';
         }
 
         if (!is_subclass_of($itemtype, CommonGLPI::class, true)) {

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -198,16 +198,34 @@ class DbUtils extends DbTestCase
         }
     }
 
-    /**
-     * @dataProvider dataTableType
-     **/
-    public function testGetItemForItemtype($table, $itemtype, $is_valid_type)
+    protected function getItemForItemtypeProvider(): iterable
     {
-        if ($is_valid_type) {
+        foreach ($this->dataTableType() as $test_case) {
+            yield [
+                'itemtype'       => $test_case['1'],
+                'is_valid'       => $test_case['2'],
+                'expected_class' => $test_case['1'],
+            ];
+
+            // Should find itemtype even if wrong case is used
+            yield [
+                'itemtype'       => strtolower($test_case['1']),
+                'is_valid'       => $test_case['2'],
+                'expected_class' => $test_case['1'],
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider getItemForItemtypeProvider
+     **/
+    public function testGetItemForItemtype($itemtype, $is_valid, $expected_class)
+    {
+        if ($is_valid) {
             $this
             ->if($this->newTestedInstance)
             ->then
-               ->object($this->testedInstance->getItemForItemtype($itemtype))->isInstanceOf($itemtype);
+               ->object($this->testedInstance->getItemForItemtype($itemtype))->isInstanceOf($expected_class);
         } else {
             $this
             ->if($this->newTestedInstance)
@@ -216,9 +234,8 @@ class DbUtils extends DbTestCase
         }
 
        //keep testing old method from db.function
-        if ($is_valid_type) {
-            $this->object(getItemForItemtype($itemtype))
-            ->isInstanceOf($itemtype);
+        if ($is_valid) {
+            $this->object(getItemForItemtype($itemtype))->isInstanceOf($expected_class);
         } else {
             $this->boolean(getItemForItemtype($itemtype))->isFalse();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In some case, in plugins, an itemtype may be retieved from URL (i.e. `ticket.form.php` -> `ticket`). Since introduction of PSR-4 class files naming convention, `getItemForItemtype('ticket')` will return false.

I propose to make this method case insensitive, which corresponds to the GLPI 9.5 behaviour, as there I did not find any other way to get the item class that corresponds to the current URL.