### PR TITLE
Fix/Improve AbstractRightsDropdown

### DIFF
--- a/src/AbstractRightsDropdown.php
+++ b/src/AbstractRightsDropdown.php
@@ -75,20 +75,28 @@ abstract class AbstractRightsDropdown
     {
         global $CFG_GLPI;
 
-       // Build DOM id
+        // Flatten values
+        $dropdown_values = [];
+        foreach ($values as $fkey => $ids) {
+            foreach ($ids as $id) {
+                $dropdown_values[] = $fkey . "-" . $id;
+            }
+        }
+
+        // Build DOM id
         $field_id = $name . "_" . mt_rand();
 
-       // Build url
+        // Build url
         $url = $CFG_GLPI['root_doc'] . "/ajax/getRightDropdownValue.php";
 
-       // Build params
+        // Build params
         $params = [
-            'values' => $values,
-            'valuesnames' => self::getValueNames($values),
+            'name'        => $name . "[]",
+            'values'      => $dropdown_values,
+            'valuesnames' => self::getValueNames($dropdown_values),
             'multiple'    => true,
         ];
-
-        return Html::jsAjaxDropdown($name, $field_id, $url, $params);
+        return Html::jsAjaxDropdown($params['name'], $field_id, $url, $params);
     }
 
     /**

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -821,19 +821,13 @@ HTML;
            __("Or share the dashboard to these target objects:") .
            "</label><br>";
 
-        $values = [];
-        $raw_values = [
+        $values = [
             'profiles_id' => self::$all_dashboards[$this->current]['rights']['profiles_id'] ?? [],
             'entities_id' => self::$all_dashboards[$this->current]['rights']['entities_id'] ?? [],
             'users_id'    => self::$all_dashboards[$this->current]['rights']['users_id'] ?? [],
             'groups_id'   => self::$all_dashboards[$this->current]['rights']['groups_id'] ?? [],
         ];
 
-        foreach ($raw_values as $fkey => $ids) {
-            foreach ($ids as $id) {
-                $values[] = $fkey . "-" . $id;
-            }
-        }
         echo ShareDashboardDropdown::show($rand, $values);
         echo "<br>";
 


### PR DESCRIPTION
The `AbstractRightsDropdown` class was added in #9348 to makes it easier to create "rights restriction" dropdown containing entities, users, groups, ...

![image](https://user-images.githubusercontent.com/42734840/154947561-dcd45ac6-4196-46fa-bba1-2627f53dca6e.png)

It was only used for the "Share dashboard" feature at the time.

I've now been using it for another development and I needed the two following improvements/fixes to make it works properly:
- The input need to be an array ("input_name[]') or no values will be retrieved in the HTML form (this issue wasn't detected when using the "Share dropdown" feature because it does not submit the form but use instead some custom js/ajax). 
- Move the code responsible for flattening the values into the abstraction layer, no need to have it in multiple places.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
