### PR TITLE
Enhance performances on Entity::getUsedConfig() usage

### DIFF
--- a/src/CartridgeItem.php
+++ b/src/CartridgeItem.php
@@ -111,12 +111,14 @@ class CartridgeItem extends CommonDBTM
     public function post_getEmpty()
     {
 
-        $this->fields["alarm_threshold"] = Entity::getUsedConfig(
-            "cartridges_alert_repeat",
-            $this->fields["entities_id"],
-            "default_cartridges_alarm_threshold",
-            10
-        );
+        if (isset($_SESSION['glpiactive_entity'])) {
+            $this->fields["alarm_threshold"] = Entity::getUsedConfig(
+                "cartridges_alert_repeat",
+                $_SESSION['glpiactive_entity'],
+                "default_cartridges_alarm_threshold",
+                10
+            );
+        }
     }
 
 

--- a/src/CartridgeItem.php
+++ b/src/CartridgeItem.php
@@ -112,7 +112,7 @@ class CartridgeItem extends CommonDBTM
     {
 
         $this->fields["alarm_threshold"] = Entity::getUsedConfig(
-            "cartriges_alert_repeat",
+            "cartridges_alert_repeat",
             $this->fields["entities_id"],
             "default_cartridges_alarm_threshold",
             10

--- a/src/ConsumableItem.php
+++ b/src/ConsumableItem.php
@@ -113,12 +113,14 @@ class ConsumableItem extends CommonDBTM
     public function post_getEmpty()
     {
 
-        $this->fields["alarm_threshold"] = Entity::getUsedConfig(
-            "consumables_alert_repeat",
-            $this->fields["entities_id"],
-            "default_consumables_alarm_threshold",
-            10
-        );
+        if (isset($_SESSION['glpiactive_entity'])) {
+            $this->fields["alarm_threshold"] = Entity::getUsedConfig(
+                "consumables_alert_repeat",
+                $_SESSION['glpiactive_entity'],
+                "default_consumables_alarm_threshold",
+                10
+            );
+        }
     }
 
 

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -71,12 +71,14 @@ class Contract extends CommonDBTM
     public function post_getEmpty()
     {
 
-        $this->fields["alert"] = Entity::getUsedConfig(
-            "use_contracts_alert",
-            $this->fields["entities_id"],
-            "default_contract_alert",
-            0
-        );
+        if (isset($_SESSION['glpiactive_entity'])) {
+            $this->fields["alert"] = Entity::getUsedConfig(
+                "use_contracts_alert",
+                $_SESSION['glpiactive_entity'],
+                "default_contract_alert",
+                0
+            );
+        }
         $this->fields["notice"] = 0;
     }
 

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -584,7 +584,7 @@ class Entity extends CommonTreeDropdown
         $this->cleanEntitySelectorCache();
 
         // Delete any cache entry corresponding to an updated entity config
-        // for current entities and all its childs
+        // for current entities and all its children
         $entities_ids = array_merge([$this->fields['id']], getSonsOf(self::getTable(), $this->fields['id']));
         $ignored_fields = [
             'name',

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -115,12 +115,14 @@ class Infocom extends CommonDBChild
     public function post_getEmpty()
     {
 
-        $this->fields["alert"] = Entity::getUsedConfig(
-            "use_infocoms_alert",
-            $this->fields["entities_id"],
-            "default_infocom_alert",
-            0
-        );
+        if (isset($_SESSION['glpiactive_entity'])) {
+            $this->fields["alert"] = Entity::getUsedConfig(
+                "use_infocoms_alert",
+                $_SESSION['glpiactive_entity'],
+                "default_infocom_alert",
+                0
+            );
+        }
     }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When used in a tree having many levels, `Entity::getUsedConfig()` mays require many DB requests to be able to give a result. Thus, it can be either call many times for a same entity on a page (e.g the `anonymize_support_agents` is fetched for each user name display in Ticket page) or call for many entities on a cron task (see #9137).

First commit fetch the whole values required to compute the inherited value for an entity in a unique request. It may increase the fetched data from the DB, but, unless someone has thousands levels in its entity tree, it should not be an issue.

Second commit add a caching logic, in order to not have to use any DB query when value is already in cache. The counterpart to this is that we have to invalidate cache on all childs when an entity config field is updated. On a GLPI instance that have thousand entities, if the root entity config is updated, it may lead to thousands cache entries invalidation. Entity config is not update often, and I guess people that have thousand entities will use memcached or redis cache system, which should support massive invalidation.

Third commit fixes a typo.