### PR TITLE
fix(actor): prevents deletion of actors added by rule

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7770,69 +7770,32 @@ abstract class CommonITILObject extends CommonDBTM
        // reload actors
         $this->loadActors();
 
-        if (isset($this->input['_additional_observers'])) {
-            foreach ($this->input['_additional_observers'] as $additional_observers) {
-                $this->input['_actors']['observer'][] = [
-                    'itemtype' => User::getType(),
-                    'items_id' => $additional_observers['users_id'],
-                    'use_notification' => $additional_observers['use_notification'],
-                    'alternative_email' => ''
-                ];
-            }
-        }
+        // append additional actors (from glpi rules)
+        $additionnal_actors_fields = [
+            User::class => [
+                'observer' => '_additional_observers',
+                'requester' => '_additional_requesters',
+                'assign' => '_additional_assigns',
+            ],
+            Group::class => [
+                'observer' => '_additional_groups_observers',
+                'requester' => '_additional_groups_requesters',
+                'assign' => '_additional_groups_assigns',
+            ],
+        ];
 
-        if (isset($this->input['_additional_requesters'])) {
-            foreach ($this->input['_additional_requesters'] as $additional_requesters) {
-                $this->input['_actors']['requester'][] = [
-                    'itemtype' => User::getType(),
-                    'items_id' => $additional_requesters['users_id'],
-                    'use_notification' => $additional_requesters['use_notification'],
-                    'alternative_email' => ''
-                ];
-            }
-        }
-
-        if (isset($this->input['_additional_assigns'])) {
-            foreach ($this->input['_additional_assigns'] as $additional_assigns) {
-                $this->input['_actors']['assign'][] = [
-                    'itemtype' => User::getType(),
-                    'items_id' => $additional_assigns['users_id'],
-                    'use_notification' => $additional_assigns['use_notification'],
-                    'alternative_email' => ''
-                ];
-            }
-        }
-
-        if (isset($this->input['_additional_groups_observers'])) {
-            foreach ($this->input['_additional_groups_observers'] as $additional_groups_observers) {
-                $this->input['_actors']['observer'][] = [
-                    'itemtype' => Group::getType(),
-                    'items_id' => $additional_groups_observers['groups_id'],
-                    'use_notification' => $additional_groups_observers['use_notification'],
-                    'alternative_email' => ''
-                ];
-            }
-        }
-
-        if (isset($this->input['_additional_groups_requesters'])) {
-            foreach ($this->input['_additional_groups_requesters'] as $additional_groups_requesters) {
-                $this->input['_actors']['requester'][] = [
-                    'itemtype' => Group::getType(),
-                    'items_id' => $additional_groups_requesters['groups_id'],
-                    'use_notification' => $additional_groups_requesters['use_notification'],
-                    'alternative_email' => ''
-                ];
-            }
-        }
-
-        if (isset($this->input['_additional_groups_assigns'])) {
-            foreach ($this->input['_additional_groups_assigns'] as $additional_groups_assigns) {
-                $this->input['_actors']['assign'][] = [
-                    'itemtype' => Group::getType(),
-                    'items_id' => $additional_groups_assigns['groups_id'],
-                    'use_notification' => $additional_groups_assigns['use_notification'],
-                    'alternative_email' => ''
-                ];
+        foreach ($additionnal_actors_fields as $actor_class => $fields) {
+            foreach ($fields as $actor_type => $field) {
+                if (isset($this->input[$field])) {
+                    foreach ($this->input[$field] as $additional_actor) {
+                        $this->input['_actors'][$actor_type][] = [
+                            'itemtype' => $actor_class::getType(),
+                            'items_id' => $additional_actor[$actor_class::getForeignKeyField()],
+                            'use_notification' => $additional_actor['use_notification'],
+                            'alternative_email' => ''
+                        ];
+                    }
+                }
             }
         }
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7770,6 +7770,73 @@ abstract class CommonITILObject extends CommonDBTM
        // reload actors
         $this->loadActors();
 
+        if (isset($this->input['_additional_observers'])){
+            foreach($this->input['_additional_observers'] as $additional_observers) {
+                $this->input['_actors']['observer'][] = [
+                    'itemtype' => User::getType(),
+                    'items_id' => $additional_observers['users_id'],
+                    'use_notification' => $additional_observers['use_notification'],
+                    'alternative_email' => ''
+                ];
+            }
+        }
+
+        if (isset($this->input['_additional_requesters'])){
+            foreach($this->input['_additional_requesters'] as $additional_requesters) {
+                $this->input['_actors']['requester'][] = [
+                    'itemtype' => User::getType(),
+                    'items_id' => $additional_requesters['users_id'],
+                    'use_notification' => $additional_requesters['use_notification'],
+                    'alternative_email' => ''
+                ];
+            }
+        }
+
+        if (isset($this->input['_additional_assigns'])){
+            foreach($this->input['_additional_assigns'] as $additional_assigns) {
+                $this->input['_actors']['assign'][] = [
+                    'itemtype' => User::getType(),
+                    'items_id' => $additional_assigns['users_id'],
+                    'use_notification' => $additional_assigns['use_notification'],
+                    'alternative_email' => ''
+                ];
+            }
+        }
+
+        if (isset($this->input['_additional_groups_observers'])){
+            foreach($this->input['_additional_groups_observers'] as $additional_groups_observers) {
+                $this->input['_actors']['observer'][] = [
+                    'itemtype' => Group::getType(),
+                    'items_id' => $additional_groups_observers['groups_id'],
+                    'use_notification' => $additional_groups_observers['use_notification'],
+                    'alternative_email' => ''
+                ];
+            }
+        }
+
+        if (isset($this->input['_additional_groups_requesters'])){
+            foreach($this->input['_additional_groups_requesters'] as $additional_groups_requesters) {
+                $this->input['_actors']['requester'][] = [
+                    'itemtype' => Group::getType(),
+                    'items_id' => $additional_groups_requesters['groups_id'],
+                    'use_notification' => $additional_groups_requesters['use_notification'],
+                    'alternative_email' => ''
+                ];
+            }
+        }
+
+        if (isset($this->input['_additional_groups_assigns'])){
+            foreach($this->input['_additional_groups_assigns'] as $additional_groups_assigns) {
+                $this->input['_actors']['assign'][] = [
+                    'itemtype' => Group::getType(),
+                    'items_id' => $additional_groups_assigns['groups_id'],
+                    'use_notification' => $additional_groups_assigns['use_notification'],
+                    'alternative_email' => ''
+                ];
+            }
+        }
+
+
        // parse posted actors
         foreach ($this->input['_actors'] as $actortype_str => $actors) {
             $actortype = constant("CommonITILActor::" . strtoupper($actortype_str));

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7770,8 +7770,8 @@ abstract class CommonITILObject extends CommonDBTM
        // reload actors
         $this->loadActors();
 
-        if (isset($this->input['_additional_observers'])){
-            foreach($this->input['_additional_observers'] as $additional_observers) {
+        if (isset($this->input['_additional_observers'])) {
+            foreach ($this->input['_additional_observers'] as $additional_observers) {
                 $this->input['_actors']['observer'][] = [
                     'itemtype' => User::getType(),
                     'items_id' => $additional_observers['users_id'],
@@ -7781,8 +7781,8 @@ abstract class CommonITILObject extends CommonDBTM
             }
         }
 
-        if (isset($this->input['_additional_requesters'])){
-            foreach($this->input['_additional_requesters'] as $additional_requesters) {
+        if (isset($this->input['_additional_requesters'])) {
+            foreach ($this->input['_additional_requesters'] as $additional_requesters) {
                 $this->input['_actors']['requester'][] = [
                     'itemtype' => User::getType(),
                     'items_id' => $additional_requesters['users_id'],
@@ -7792,8 +7792,8 @@ abstract class CommonITILObject extends CommonDBTM
             }
         }
 
-        if (isset($this->input['_additional_assigns'])){
-            foreach($this->input['_additional_assigns'] as $additional_assigns) {
+        if (isset($this->input['_additional_assigns'])) {
+            foreach ($this->input['_additional_assigns'] as $additional_assigns) {
                 $this->input['_actors']['assign'][] = [
                     'itemtype' => User::getType(),
                     'items_id' => $additional_assigns['users_id'],
@@ -7803,8 +7803,8 @@ abstract class CommonITILObject extends CommonDBTM
             }
         }
 
-        if (isset($this->input['_additional_groups_observers'])){
-            foreach($this->input['_additional_groups_observers'] as $additional_groups_observers) {
+        if (isset($this->input['_additional_groups_observers'])) {
+            foreach ($this->input['_additional_groups_observers'] as $additional_groups_observers) {
                 $this->input['_actors']['observer'][] = [
                     'itemtype' => Group::getType(),
                     'items_id' => $additional_groups_observers['groups_id'],
@@ -7814,8 +7814,8 @@ abstract class CommonITILObject extends CommonDBTM
             }
         }
 
-        if (isset($this->input['_additional_groups_requesters'])){
-            foreach($this->input['_additional_groups_requesters'] as $additional_groups_requesters) {
+        if (isset($this->input['_additional_groups_requesters'])) {
+            foreach ($this->input['_additional_groups_requesters'] as $additional_groups_requesters) {
                 $this->input['_actors']['requester'][] = [
                     'itemtype' => Group::getType(),
                     'items_id' => $additional_groups_requesters['groups_id'],
@@ -7825,8 +7825,8 @@ abstract class CommonITILObject extends CommonDBTM
             }
         }
 
-        if (isset($this->input['_additional_groups_assigns'])){
-            foreach($this->input['_additional_groups_assigns'] as $additional_groups_assigns) {
+        if (isset($this->input['_additional_groups_assigns'])) {
+            foreach ($this->input['_additional_groups_assigns'] as $additional_groups_assigns) {
                 $this->input['_actors']['assign'][] = [
                     'itemtype' => Group::getType(),
                     'items_id' => $additional_groups_assigns['groups_id'],


### PR DESCRIPTION
Actors added by rules are systematically drop after added.

because (I think)  actors added by rules are added in the ```_additional_******``` keys from ```input```
 and are not taken into account from ```$input['_actors']```

This PR try to prevent this

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10718 !23311