### PR TITLE
Do not override Ajax element update parameters

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1199,18 +1199,23 @@ function updateItemOnEvent(dropdown_ids, target, url, params = {}, events = ['ch
                 const force_load_condition = (force_load_for.length > 0 && force_load_for.includes(zone_obj.val()));
 
                 const doLoad = () => {
+                    // Resolve params to another array to avoid overriding dynamic params like "__VALUE__"
+                    let resolved_params = {};
                     $.each(params, (k, v) => {
                         if (typeof v === "string") {
                             const reqs = v.match(/^__VALUE(\d+)__$/);
                             if (reqs !== null) {
-                                params[k] = $('#'+dropdown_ids[reqs[0]]).val();
+                                resolved_params[k] = $('#'+dropdown_ids[reqs[0]]).val();
+                            } else if (v === '__VALUE__') {
+                                resolved_params[k] = $('#'+dropdown_ids[0]).val();
+                            } else {
+                                resolved_params[k] = v;
                             }
-                            if (v === '__VALUE__') {
-                                params[k] = $('#'+dropdown_ids[0]).val();
-                            }
+                        } else {
+                            resolved_params[k] = v;
                         }
                     });
-                    $(target).load(url, params);
+                    $(target).load(url, resolved_params);
                 };
                 if (conditional && (min_size_condition || force_load_condition)) {
                     doLoad();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10726

In context of the approval form, whichever validator type you chose first (user or group) would cause the dynamic "__VALUE__" placeholder to get statically set. If you tried changing the validator type this value would be the static itemtype and not "__VALUE__" anymore. This commit puts the resolved parameters into a temporary object instead of modifying the original values.