### PR TITLE
Re-add missing reminders on Central page

### DIFF
--- a/ajax/central.php
+++ b/ajax/central.php
@@ -81,6 +81,9 @@ switch ($_REQUEST['widget']) {
             $itemtype::showListForCentral($personal);
         } else if ($itemtype === Planning::class) {
             $itemtype::showCentral($params['who']);
+        } else if ($itemtype === Reminder::class) {
+            $personal = ($params['personal'] ?? true) !== 'false';
+            $itemtype::showListForCentral($personal);
         }
         break;
     default:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This was noticed while checking #10654 (Issued reported for 9.5.X but I was testing with GLPI 10). I noticed reminders were not showing at all in GLPI 10 on the central page. This only applies to master. The issue with public reminder visibility would still need checked and presumably fixed for 9.5.X and 10 both as I don't think the back-end code that gets the data for the lists changed.