### PR TITLE
Fix visible for problem dropdown visibility

### DIFF
--- a/inc/itilcategory.class.php
+++ b/inc/itilcategory.class.php
@@ -47,73 +47,103 @@ class ITILCategory extends CommonTreeDropdown {
 
    function getAdditionalFields() {
 
-      $tab = [['name'      => $this->getForeignKeyField(),
-                         'label'     => __('As child of'),
-                         'type'      => 'parent',
-                         'list'      => false],
-                   ['name'      => 'users_id',
-                         'label'     => __('Technician in charge of the hardware'),
-                         'type'      => 'UserDropdown',
-                         'right'     => 'own_ticket',
-                         'list'      => true],
-                   ['name'      => 'groups_id',
-                         'label'     => __('Group in charge of the hardware'),
-                         'type'      => 'dropdownValue',
-                         'condition' => ['is_assign' => 1],
-                         'list'      => true],
-                   ['name'      => 'knowbaseitemcategories_id',
-                         'label'     => __('Knowledge base'),
-                         'type'      => 'dropdownValue',
-                         'list'      => true],
-                   ['name'      => 'code',
-                         'label'     => __('Code representing the ticket category'),
-                         'type'      => 'text',
-                         'list'      => false],
-                   ['name'      => 'is_helpdeskvisible',
-                         'label'     => __('Visible in the simplified interface'),
-                         'type'      => 'bool',
-                         'list'      => true],
-                   ['name'      => 'is_incident',
-                         'label'     => __('Visible for an incident'),
-                         'type'      => 'bool',
-                         'list'      => true],
-                   ['name'      => 'is_request',
-                         'label'     => __('Visible for a request'),
-                         'type'      => 'bool',
-                         'list'      => true],
-                   ['name'      => 'is_problem',
-                         'label'     => __('Visible for a problem'),
-                         'type'      => 'bool',
-                         'list'      => true],
-                   ['name'      => 'is_change',
-                         'label'     => __('Visible for a change'),
-                         'type'      => 'bool',
-                         'list'      => true],
-                   ['name'      => 'tickettemplates_id_demand',
-                         'label'     => __('Template for a request'),
-                         'type'      => 'dropdownValue',
-                         'list'      => true],
-                   ['name'      => 'tickettemplates_id_incident',
-                         'label'     => __('Template for an incident'),
-                         'type'      => 'dropdownValue',
-                         'list'      => true],
-                   ['name'      => 'changetemplates_id',
-                         'label'     => __('Template for a change'),
-                         'type'      => 'dropdownValue',
-                         'list'      => true],
-                   ['name'      => 'problemtemplates_id',
-                         'label'     => __('Template for a problem'),
-                         'type'      => 'dropdownValue',
-                         'list'      => true],
-                  ];
+      $tab = [
+         [
+            'name' => $this->getForeignKeyField(),
+            'label' => __('As child of'),
+            'type' => 'parent',
+            'list' => false
+         ],
+         [
+            'name' => 'users_id',
+            'label' => __('Technician in charge of the hardware'),
+            'type' => 'UserDropdown',
+            'right' => 'own_ticket',
+            'list' => true
+         ],
+         [
+            'name' => 'groups_id',
+            'label' => __('Group in charge of the hardware'),
+            'type' => 'dropdownValue',
+            'condition' => ['is_assign' => 1],
+            'list' => true
+         ],
+         [
+            'name' => 'knowbaseitemcategories_id',
+            'label' => __('Knowledge base'),
+            'type' => 'dropdownValue',
+            'list' => true
+         ],
+         [
+            'name' => 'code',
+            'label' => __('Code representing the ticket category'),
+            'type' => 'text',
+            'list' => false
+         ],
+         [
+            'name' => 'is_helpdeskvisible',
+            'label' => __('Visible in the simplified interface'),
+            'type' => 'bool',
+            'list' => true
+         ],
+         [
+            'name' => 'is_incident',
+            'label' => __('Visible for an incident'),
+            'type' => 'bool',
+            'list' => true
+         ],
+         [
+            'name' => 'is_request',
+            'label' => __('Visible for a request'),
+            'type' => 'bool',
+            'list' => true
+         ],
+      ];
 
-      if (!Session::haveRightsOr('problem', [CREATE, UPDATE, DELETE,
-                                                  Problem::READALL, Problem::READMY])) {
+      $show_for_problem = Session::haveRightsOr('problem', [CREATE, UPDATE, DELETE, Problem::READALL, Problem::READMY]);
 
-         unset($tab[7]);
+      if ($show_for_problem) {
+         $tab[] = [
+            'name' => 'is_problem',
+            'label' => __('Visible for a problem'),
+            'type' => 'bool',
+            'list' => true
+         ];
       }
-      return $tab;
 
+      $tab = array_merge($tab, [
+         [
+            'name' => 'is_change',
+            'label' => __('Visible for a change'),
+            'type' => 'bool',
+            'list' => true
+         ],
+         [
+            'name' => 'tickettemplates_id_demand',
+            'label' => __('Template for a request'),
+            'type' => 'dropdownValue',
+            'list' => true
+         ],
+         [
+            'name' => 'tickettemplates_id_incident',
+            'label' => __('Template for an incident'),
+            'type' => 'dropdownValue',
+            'list' => true
+         ],
+         [
+            'name' => 'changetemplates_id',
+            'label' => __('Template for a change'),
+            'type' => 'dropdownValue',
+            'list' => true
+         ],
+         [
+            'name' => 'problemtemplates_id',
+            'label' => __('Template for a problem'),
+            'type' => 'dropdownValue',
+            'list' => true
+         ],
+      ]);
+      return $tab;
    }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10484

When you don't have any rights for Problems, the wrong dropdown option was being removed from the ITILCategory itemtype. I fixed that and refactored the logic to make it less likely this could be broken again. Previously it was unset from the array by a static index.

This does not include any additional visibility restrictions as that would be a new behavior. I don't know the reason only the visible for problems dropdown is handled like this but I can add other visibility restrictions in a new PR for GLPI 10.