### PR TITLE
Enhance cancel-workflow action configuration

### DIFF
--- a/.github/workflows/cancel_workflow_runs.yml
+++ b/.github/workflows/cancel_workflow_runs.yml
@@ -1,0 +1,19 @@
+name: "Cancel workflow runs"
+
+on:
+  workflow_run:
+    workflows:
+      - "GLPI CI"
+      - "GLPI test code coverage"
+    types:
+      - requested
+
+jobs:
+  cancel:
+    runs-on: "${{ github.repository == 'glpi-network/glpi' && 'self-hosted' || 'ubuntu-latest' }}"
+    steps:
+      - name: "Cancel outdated workflow runs"
+        uses: "styfle/cancel-workflow-action@0.9.1"
+        with:
+          all_but_latest: true
+          workflow_id: ${{ github.event.workflow.id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,6 @@ jobs:
       PHP_IMAGE: "githubactions-php:${{ matrix.php-version }}"
       UPDATE_FILES_ACL: true
     steps:
-      - name: "Cancel previous runs"
-        uses: "styfle/cancel-workflow-action@0.9.1"
-        with:
-          access_token: "${{ github.token }}"
       - name: "Clean workspace"
         run: |
           echo "APP_CONTAINER_HOME=${{ runner.temp }}/app_home" >> $GITHUB_ENV
@@ -127,11 +123,6 @@ jobs:
       PHP_IMAGE: "githubactions-php:${{ matrix.php-version }}"
       UPDATE_FILES_ACL: true
     steps:
-      - name: "Cancel previous runs"
-        if: env.skip != 'true'
-        uses: "styfle/cancel-workflow-action@0.9.1"
-        with:
-          access_token: "${{ github.token }}"
       - name: "Clean workspace"
         if: env.skip != 'true'
         run: |


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

1. Cancel all but latest
Currently, only previous workflow runs are canceled. It means that if a new workflow is scheduled multiple times without an available worker to trigger it, previous runs will not be cancelled and will all be run. Using the `all_but_latest` option fix this.

2. Handle workflows triggered by PR from fork
As far as I understand, moving the cancel step in a dedicated workflow will permit it to be executed from the fork context, and so it will be able to cancel workflow runs triggered from this fork.

3. Handle coverage workflow

For more information, see https://github.com/marketplace/actions/cancel-workflow-action 