### PR TITLE
Fix entity config display

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -1863,7 +1863,11 @@ class Entity extends CommonTreeDropdown
         echo "<tr><th colspan='4'>" . __('Automatic inventory') . "</th></tr>";
         echo "<tr class='tab_bg_2'>";
         echo "<td><label for='agent_base_url'>" . __('Agent base URL') . "</label></td>";
-        echo "<td>" . Html::input('agent_base_url') . "</td>";
+        echo "<td>";
+        echo Html::input('agent_base_url', ['value' => $entity->fields['agent_base_url']]);
+        if (empty($entity->fields['agent_base_url']) && $ID > 0) {
+            self::inheritedValue(self::getUsedConfig('agent_base_url', $ID, '', ''));
+        }
         echo "</td><td colspan='2'></td></tr>";
 
         Plugin::doHook(Hooks::POST_ITEM_FORM, ['item' => $entity, 'options' => &$options]);
@@ -1917,7 +1921,7 @@ class Entity extends CommonTreeDropdown
         echo "<td>" . __('Administrator email address') . "</td>";
         echo "<td>";
         echo Html::input('admin_email', ['value' => $entity->fields['admin_email']]);
-        if (empty($entity->fields['admin_email'])) {
+        if (empty($entity->fields['admin_email']) && $ID > 0) {
             self::inheritedValue(self::getUsedConfig('admin_email', $ID, '', ''));
         }
         echo "</td>";
@@ -1925,7 +1929,7 @@ class Entity extends CommonTreeDropdown
        // we inherit only if email inherit also
         echo Html::input('admin_email_name', ['value' => $entity->fields['admin_email_name']]);
        // warning, we rely on email field to inherit name field
-        if (empty($entity->fields['admin_email']) == 0) {
+        if (empty($entity->fields['admin_email']) && $ID > 0) {
             self::inheritedValue(self::getUsedConfig('admin_email_name', $ID, '', ''));
         }
         echo "</td></tr>";
@@ -1934,7 +1938,7 @@ class Entity extends CommonTreeDropdown
         echo "<td>" . __('Email sender address') . "</td>";
         echo "<td>";
         echo Html::input('from_email', ['value' => $entity->fields['from_email']]);
-        if (empty($entity->fields['from_email']) == 0) {
+        if (empty($entity->fields['from_email']) && $ID > 0) {
             self::inheritedValue(self::getUsedConfig('from_email', $ID, '', ''));
         }
         echo "</td>";
@@ -1942,7 +1946,7 @@ class Entity extends CommonTreeDropdown
         // we inherit only if email inherit also
         echo Html::input('from_email_name', ['value' => $entity->fields['from_email_name']]);
         // warning, we rely on email field to inherit name field
-        if (empty($entity->fields['from_email']) == 0) {
+        if (empty($entity->fields['from_email']) && $ID > 0) {
             self::inheritedValue(self::getUsedConfig('from_email_name', $ID, '', ''));
         }
         echo "</td></tr>";
@@ -1951,7 +1955,7 @@ class Entity extends CommonTreeDropdown
         echo "<td>" . __('No-Reply address') . "</td>";
         echo "<td>";
         echo Html::input('noreply_email', ['value' => $entity->fields['noreply_email']]);
-        if (empty($entity->fields['noreply_email']) == 0) {
+        if (empty($entity->fields['noreply_email']) && $ID > 0) {
             self::inheritedValue(self::getUsedConfig('noreply_email', $ID, '', ''));
         }
         echo "</td>";
@@ -1959,7 +1963,7 @@ class Entity extends CommonTreeDropdown
         // we inherit only if email inherit also
         echo Html::input('noreply_email_name', ['value' => $entity->fields['noreply_email_name']]);
         // warning, we rely on email field to inherit name field
-        if (empty($entity->fields['noreply_email']) == 0) {
+        if (empty($entity->fields['noreply_email']) && $ID > 0) {
             self::inheritedValue(self::getUsedConfig('noreply_email_name', $ID, '', ''));
         }
         echo "</td></tr>";
@@ -1968,7 +1972,7 @@ class Entity extends CommonTreeDropdown
         echo "<td><label for='replyto_email'>" . __('Reply-To address') . "</label></td>";
         echo "<td>";
         echo Html::input('replyto_email', ['value' => $entity->fields['replyto_email']]);
-        if (empty($entity->fields['replyto_email']) == 0) {
+        if (empty($entity->fields['replyto_email']) && $ID > 0) {
             self::inheritedValue(self::getUsedConfig('replyto_email', $ID, '', ''));
         }
         echo "</td>";
@@ -1976,7 +1980,7 @@ class Entity extends CommonTreeDropdown
         echo "<td>";
         echo Html::input('replyto_email_name', ['value' => $entity->fields['replyto_email_name']]);
        // warning, we rely on email field to inherit name field
-        if (empty($entity->fields['replyto_email']) == 0) {
+        if (empty($entity->fields['replyto_email']) && $ID > 0) {
             self::inheritedValue(self::getUsedConfig('replyto_email_name', $ID, '', ''));
         }
         echo "</td></tr>";
@@ -1985,7 +1989,7 @@ class Entity extends CommonTreeDropdown
         echo "<td>" . __('Prefix for notifications') . "</td>";
         echo "<td>";
         echo Html::input('notification_subject_tag', ['value' => $entity->fields['notification_subject_tag']]);
-        if (empty($entity->fields['notification_subject_tag']) == 0) {
+        if (empty($entity->fields['notification_subject_tag']) && $ID > 0) {
             self::inheritedValue(self::getUsedConfig('notification_subject_tag', $ID, '', ''));
         }
         echo "</td>";
@@ -2031,7 +2035,7 @@ class Entity extends CommonTreeDropdown
         echo "<td colspan='3'>";
         echo "<textarea rows='5' name='mailing_signature' class='form-control'>" .
              $entity->fields["mailing_signature"] . "</textarea>";
-        if (empty($entity->fields['mailing_signature']) == 0) {
+        if (empty($entity->fields['mailing_signature']) && $ID > 0) {
             self::inheritedValue(self::getUsedConfig('mailing_signature', $ID, '', ''));
         }
         echo "</td></tr>";
@@ -2662,10 +2666,7 @@ class Entity extends CommonTreeDropdown
 
         TicketTemplate::dropdown($options);
 
-        if (
-            ($entity->fields["tickettemplates_id"] == self::CONFIG_PARENT)
-            && ($ID != 0)
-        ) {
+        if ($entity->fields["tickettemplates_id"] == self::CONFIG_PARENT) {
             $tt  = new TicketTemplate();
             $tid = self::getUsedConfig('tickettemplates_strategy', $ID, 'tickettemplates_id', 0);
             if (!$tid) {
@@ -2691,10 +2692,7 @@ class Entity extends CommonTreeDropdown
 
         ChangeTemplate::dropdown($options);
 
-        if (
-            ($entity->fields["changetemplates_id"] == self::CONFIG_PARENT)
-            && ($ID != 0)
-        ) {
+        if ($entity->fields["changetemplates_id"] == self::CONFIG_PARENT) {
             $tt  = new ChangeTemplate();
             $tid = self::getUsedConfig('changetemplates_strategy', $ID, 'changetemplates_id', 0);
             if (!$tid) {
@@ -2720,10 +2718,7 @@ class Entity extends CommonTreeDropdown
 
         ProblemTemplate::dropdown($options);
 
-        if (
-            ($entity->fields["problemtemplates_id"] == self::CONFIG_PARENT)
-            && ($ID != 0)
-        ) {
+        if ($entity->fields["problemtemplates_id"] == self::CONFIG_PARENT) {
             $tt  = new ProblemTemplate();
             $tid = self::getUsedConfig('problemtemplates_strategy', $ID, 'problemtemplates_id', 0);
             if (!$tid) {
@@ -2747,10 +2742,7 @@ class Entity extends CommonTreeDropdown
         }
         Calendar::dropdown($options);
 
-        if (
-            ($entity->fields["calendars_id"] == self::CONFIG_PARENT)
-            && ($ID != 0)
-        ) {
+        if ($entity->fields["calendars_id"] == self::CONFIG_PARENT) {
             $calendar = new Calendar();
             $cid = self::getUsedConfig('calendars_strategy', $ID, 'calendars_id', 0);
             if (!$cid) {
@@ -2771,10 +2763,7 @@ class Entity extends CommonTreeDropdown
             'toadd' => $toadd
         ]);
 
-        if (
-            ($entity->fields['tickettype'] == self::CONFIG_PARENT)
-            && ($ID != 0)
-        ) {
+        if ($entity->fields['tickettype'] == self::CONFIG_PARENT) {
             self::inheritedValue(Ticket::getTicketTypeName(self::getUsedConfig(
                 'tickettype',
                 $ID,
@@ -2799,10 +2788,7 @@ class Entity extends CommonTreeDropdown
             ['value' => $entity->fields["auto_assign_mode"]]
         );
 
-        if (
-            ($entity->fields['auto_assign_mode'] == self::CONFIG_PARENT)
-            && ($ID != 0)
-        ) {
+        if ($entity->fields['auto_assign_mode'] == self::CONFIG_PARENT) {
             $auto_assign_mode = self::getUsedConfig('auto_assign_mode', $entity->fields['entities_id']);
             self::inheritedValue($autoassign[$auto_assign_mode], true);
         }
@@ -2824,7 +2810,7 @@ class Entity extends CommonTreeDropdown
         );
 
        // If the entity is using it's parent value, print it
-        if ($currentSupplierValue == self::CONFIG_PARENT && $ID != 0) {
+        if ($currentSupplierValue == self::CONFIG_PARENT) {
             $parentSupplierValue = self::getUsedConfig(
                 'suppliers_as_private',
                 $entity->fields['entities_id']
@@ -2849,7 +2835,7 @@ class Entity extends CommonTreeDropdown
         );
 
        // If the entity is using it's parent value, print it
-        if ($current_anonymize_value == self::CONFIG_PARENT && $ID != 0) {
+        if ($current_anonymize_value == self::CONFIG_PARENT) {
             $parent_helpdesk_value = self::getUsedConfig(
                 'anonymize_support_agents',
                 $entity->fields['entities_id']
@@ -2874,7 +2860,7 @@ class Entity extends CommonTreeDropdown
         );
 
        // If the entity is using it's parent value, print it
-        if ($currentInitialsValue == self::CONFIG_PARENT && $ID != 0) {
+        if ($currentInitialsValue == self::CONFIG_PARENT) {
             $parentSupplierValue = self::getUsedConfig(
                 'display_users_initials',
                 $entity->fields['entities_id']
@@ -2905,7 +2891,7 @@ class Entity extends CommonTreeDropdown
         ]);
 
         // If the entity is using it's parent value, print it
-        if ($current_default_contract_value == self::CONFIG_PARENT && $ID != 0) {
+        if ($current_default_contract_value == self::CONFIG_PARENT) {
             $inherited_default_contract_strategy = self::getUsedConfig(
                 'contracts_strategy_default',
                 $entity->fields['entities_id']
@@ -2966,10 +2952,7 @@ class Entity extends CommonTreeDropdown
             ]
         );
 
-        if (
-            ($entity->fields['autoclose_delay'] == self::CONFIG_PARENT)
-            && ($ID != 0)
-        ) {
+        if ($entity->fields['autoclose_delay'] == self::CONFIG_PARENT) {
             $autoclose_mode = self::getUsedConfig(
                 'autoclose_delay',
                 $entity->fields['entities_id'],
@@ -3017,10 +3000,7 @@ class Entity extends CommonTreeDropdown
             ]
         );
 
-        if (
-            ($entity->fields['autopurge_delay'] == self::CONFIG_PARENT)
-            && ($ID != 0)
-        ) {
+        if ($entity->fields['autopurge_delay'] == self::CONFIG_PARENT) {
             $autopurge_mode = self::getUsedConfig(
                 'autopurge_delay',
                 $entity->fields['entities_id'],
@@ -3062,11 +3042,7 @@ class Entity extends CommonTreeDropdown
         );
         echo "</td></tr>\n";
 
-       // Do not display for root entity in inherit case
-        if (
-            ($entity->fields['inquest_config'] == self::CONFIG_PARENT)
-            && ($ID != 0)
-        ) {
+        if ($entity->fields['inquest_config'] == self::CONFIG_PARENT) {
             $inquestconfig = self::getUsedConfig('inquest_config', $entity->fields['entities_id']);
             $inquestrate   = self::getUsedConfig(
                 'inquest_config',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Display existing/inherited value of `agent_base_url` field (field was blank even if a value was stored in DB).
2. Fix empty checks (`empty($var) == 0` was not a correct check).
3. Display inherited value even on root entity when configuration is `Entity::CONFIG_PARENT`. It should not happens, but could permit to detect data inconsistency.