### PR TITLE
Check required libsodium constant as version check

### DIFF
--- a/src/System/Requirement/ExtensionConstant.php
+++ b/src/System/Requirement/ExtensionConstant.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\System\Requirement;
+
+/**
+ * @since 10.0.0
+ */
+class ExtensionConstant extends AbstractRequirement
+{
+    /**
+     * Required constant name.
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @param string $name Constant name.
+     * @param bool $optional Indicated if extension is optional.
+     * @param string $description Constant description.
+     * @param string $failure_message Failure message.
+     */
+    public function __construct(string $title, string $name, bool $optional = false, string $description = '')
+    {
+        $this->title = $title;
+        $this->name = $name;
+        $this->optional = $optional;
+        $this->description = $description;
+    }
+
+    protected function check()
+    {
+        $this->validated = defined($this->name);
+        if ($this->validated) {
+            $this->validation_messages = [
+                sprintf(__('The constant %s is present.'), $this->name)
+            ];
+        } else if ($this->optional) {
+            $this->validation_messages = [
+                sprintf(__('The constant %s is not present.'), $this->name)
+            ];
+        } else {
+            $this->validation_messages = [
+                sprintf(__('The constant %s is missing.'), $this->name)
+            ];
+        }
+    }
+}

--- a/src/System/RequirementsManager.php
+++ b/src/System/RequirementsManager.php
@@ -38,6 +38,7 @@ use Glpi\System\Requirement\DbTimezones;
 use Glpi\System\Requirement\DirectoriesWriteAccess;
 use Glpi\System\Requirement\DirectoryWriteAccess;
 use Glpi\System\Requirement\Extension;
+use Glpi\System\Requirement\ExtensionConstant;
 use Glpi\System\Requirement\ExtensionGroup;
 use Glpi\System\Requirement\LogsWriteAccess;
 use Glpi\System\Requirement\MemoryLimit;
@@ -99,6 +100,12 @@ class RequirementsManager
             'zlib',
             false,
             __('Required for handling of compressed communication with inventory agents, installation of gzip packages from marketplace and PDF generation.')
+        );
+        $requirements[] = new ExtensionConstant(
+            __('Sodium ChaCha20-Poly1305 size constant'),
+            'SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES',
+            false,
+            __('Enable usage of ChaCha20-Poly1305 encryption required by GLPI. This is provided by libsodium 1.0.12 and newer.')
         );
 
         if ($db instanceof \DBmysql) {

--- a/tests/units/Glpi/System/Requirement/ExtensionConstant.php
+++ b/tests/units/Glpi/System/Requirement/ExtensionConstant.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\System\Requirement;
+
+class ExtensionConstant extends \GLPITestCase
+{
+    public function testCheckOnExistingConstant()
+    {
+        $test_constant = 'TEST_CONSTANT' . mt_rand();
+        define($test_constant, 'TEST');
+        $this->newTestedInstance('Test constant', $test_constant, false, '');
+        $this->boolean($this->testedInstance->isValidated())->isEqualTo(true);
+        $this->array($this->testedInstance->getValidationMessages())
+            ->isEqualTo(['The constant ' . $test_constant . ' is present.']);
+    }
+
+    public function testCheckOnMissingMandatoryConstant()
+    {
+        $test_constant = 'TEST_CONSTANT' . mt_rand();
+        $this->newTestedInstance('Test constant', $test_constant, false, '');
+        $this->boolean($this->testedInstance->isValidated())->isEqualTo(false);
+        $this->array($this->testedInstance->getValidationMessages())
+            ->isEqualTo(['The constant ' . $test_constant . ' is missing.']);
+    }
+
+    public function testCheckOnMissingOptionalConstant()
+    {
+        $test_constant = 'TEST_CONSTANT' . mt_rand();
+        $this->newTestedInstance('Test constant', $test_constant, true, '');
+        $this->boolean($this->testedInstance->isValidated())->isEqualTo(false);
+        $this->array($this->testedInstance->getValidationMessages())
+            ->isEqualTo(['The constant ' . $test_constant . ' is not present.']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Added new requirements check for existence of the "SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES" constant. The PHP extension only defines this is it exists from the libsodium library (exists in 1.0.12 and newer only) and just directly assigns its value from the one provided by the library.
The compatibility library used does define this constant using a hard-coded value but only for PHP 7.2 and lower it seems.

Also, given that PHP is compiled by default with the sodium extension, it is most likely that users will be running the extension and will be reliant on the libsodium library version.