### PR TITLE
Use Inter font bundled in @tabler/core

### DIFF
--- a/css/includes/_fonts.scss
+++ b/css/includes/_fonts.scss
@@ -29,22 +29,7 @@
  * ---------------------------------------------------------------------
  */
 
-@import "~@fontsource/inter/scss/mixins";
-
-$fontDir: "../css/lib/fontsource/inter/files";
-
-@include fontFace($weight: 100);
-@include fontFace($weight: 200);
-@include fontFace($weight: 300);
-@include fontFace($weight: 400);
-@include fontFace($weight: 500);
-@include fontFace($weight: 600);
-@include fontFace($weight: 700);
-@include fontFace($weight: 800);
-@include fontFace($weight: 900);
-
-$google-font: false;
-$font-family-sans-serif: inter, -apple-system, blinkmacsystemfont, san francisco, segoe ui, roboto, helvetica neue, sans-serif !default;
+$assets-base: "../css/lib/tabler/core/dist"; // Tabler assets base url
 $ti-font-path: "../css/lib/tabler/icons/iconfont/fonts";
 
 @import "~@tabler/icons/iconfont/tabler-icons";

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
             "license": "GPL-2.0",
             "dependencies": {
                 "@eastdesire/jscolor": "^2.4.6",
-                "@fontsource/inter": "^4.5.4",
                 "@fortawesome/fontawesome-free": "^5.12.1",
                 "@fullcalendar/bootstrap": "^4.4.0",
                 "@fullcalendar/core": "^4.4.0",
@@ -1811,11 +1810,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/@fontsource/inter": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-4.5.4.tgz",
-            "integrity": "sha512-D0icTFpt9bWvB/OEXMztYf0bhUQZoDIYpsco5C7GVfxgKDRl8Jdn3N2aHHQqwjgRUUvRuyMv8HrRM8Hrt4U52w=="
         },
         "node_modules/@fortawesome/fontawesome-free": {
             "version": "5.15.4",
@@ -12191,11 +12185,6 @@
                     "dev": true
                 }
             }
-        },
-        "@fontsource/inter": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-4.5.4.tgz",
-            "integrity": "sha512-D0icTFpt9bWvB/OEXMztYf0bhUQZoDIYpsco5C7GVfxgKDRl8Jdn3N2aHHQqwjgRUUvRuyMv8HrRM8Hrt4U52w=="
         },
         "@fortawesome/fontawesome-free": {
             "version": "5.15.4",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     },
     "dependencies": {
         "@eastdesire/jscolor": "^2.4.6",
-        "@fontsource/inter": "^4.5.4",
         "@fortawesome/fontawesome-free": "^5.12.1",
         "@fullcalendar/bootstrap": "^4.4.0",
         "@fullcalendar/core": "^4.4.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -178,13 +178,8 @@ var filesToCopy = [
     },
     // SCSS files
     {
-        package: '@fontsource/inter',
-        from: '{scss/mixins.scss,files/*[0-9]00*.woff2}',
-        to: scssOutputPath,
-    },
-    {
         package: '@tabler/core',
-        from: 'src/scss/**/*.scss',
+        from: '{dist/fonts/*.woff2,src/scss/**/*.scss}',
         to: scssOutputPath,
     },
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fetching Inter font from `@fontsource/inter` #10698 was finally not usefull, as is is now bundled in `@tabler/core` since #10646.