### PR TITLE
Fix spacing between text and user link in timeline badge

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -315,10 +315,12 @@
     }
 
     .timeline-badges {
-        margin-bottom: -0.5rem;
+        margin-bottom: -0.75rem;
 
         .badge {
             @include tabler-badge-fix;
+
+            display: inline-block;
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | UX issue of #10558

Text content inside a flexbox doesn't treat trailing spaces properly. Solution is to use `inline-block` display, but keep the other "tabler badge fixes". I also increased the negative margin as the gap between the badge and the bottom of the form grew when I changed the display.