### PR TITLE
Fix tests on PHP 7.4 and 8.0

### DIFF
--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -187,14 +187,28 @@ class GLPITestCase extends atoum
     {
         $this->has_failed = true;
 
+        $records = array_map(
+            function ($record) {
+                // Keep only usefull info to display a comprehensive dump
+                return [
+                    'level'   => $record['level'],
+                    'message' => $record['message'],
+                ];
+            },
+            $handler->getRecords()
+        );
+
         $matching = null;
-        foreach ($handler->getRecords() as $record) {
+        foreach ($records as $record) {
             if ($record['level'] === Logger::toMonologLevel($level) && strpos($record['message'], $message) !== false) {
                 $matching = $record;
                 break;
             }
         }
-        $this->variable($matching)->isNotNull('No matching log found.');
+        $this->variable($matching)->isNotNull(
+            sprintf("Message not found in log records\n- %s\n+ %s", $message, print_r($records, true))
+        );
+
         $handler->dropFromRecords($matching['message'], $matching['level']);
 
         $this->has_failed = false;

--- a/tests/units/Html.php
+++ b/tests/units/Html.php
@@ -66,7 +66,7 @@ class Html extends \GLPITestCase
 
         $this->string(\Html::convDate('not a date', 2))->isIdenticalTo('not a date');
         $this->hasPhpLogRecordThatContains(
-            'Exception: Failed to parse time string (not a date) at position 0 (n): The timezone could not be found in the database',
+            'Failed to parse time string (not a date) at position 0 (n): The timezone could not be found in the database',
             LogLevel::CRITICAL
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Exception message is not exactly the same in all PHP versions. Indeed, prior to PHP 8.1, class name and method name were included in exception message, but are not anymore present in PHP 8.1.

I also enhance failure message to be able to easilly detect why logs checks are failing.

![image](https://user-images.githubusercontent.com/33253653/155278006-494b787c-2709-4ca3-b376-843e3a37da04.png)
