### PR TITLE
Fix domains entity filtering on domains alerts

### DIFF
--- a/inc/domain.class.php
+++ b/inc/domain.class.php
@@ -579,6 +579,7 @@ class Domain extends CommonDropdown {
          'FROM'   => self::getTable(),
          'WHERE'  => [
             'NOT' => ['date_expiration' => null],
+            'entities_id'  => $entities_id,
             'is_deleted'   => 0,
             new QueryExpression("DATEDIFF(CURDATE(), " . $DB->quoteName('date_expiration') . ") > $delay"),
             new QueryExpression("DATEDIFF(CURDATE(), " . $DB->quoteName('date_expiration') . ") > 0")
@@ -601,6 +602,7 @@ class Domain extends CommonDropdown {
          'FROM'   => self::getTable(),
          'WHERE'  => [
             'NOT' => ['date_expiration' => null],
+            'entities_id'  => $entities_id,
             'is_deleted'   => 0,
             new QueryExpression("DATEDIFF(CURDATE(), " . $DB->quoteName('date_expiration') . ") > -$delay"),
             new QueryExpression("DATEDIFF(CURDATE(), " . $DB->quoteName('date_expiration') . ") < 0")

--- a/tests/functionnal/Domain.php
+++ b/tests/functionnal/Domain.php
@@ -115,14 +115,14 @@ class Domain extends DbTestCase {
       $iterator = $DB->request(\Domain::expiredDomainsCriteria($entity->fields['id']));
       $this->string($iterator->getSql())->isIdenticalTo(
          "SELECT * FROM `glpi_domains` WHERE " .
-         "NOT (`date_expiration` IS NULL) AND `is_deleted` = '0' ".
+         "NOT (`date_expiration` IS NULL) AND `entities_id` = '{$entity->fields['id']}' AND `is_deleted` = '0' ".
          "AND DATEDIFF(CURDATE(), `date_expiration`) > 1 AND DATEDIFF(CURDATE(), `date_expiration`) > 0"
       );
 
       $iterator = $DB->request(\Domain::closeExpiriesDomainsCriteria($entity->fields['id']));
       $this->string($iterator->getSql())->isIdenticalTo(
          "SELECT * FROM `glpi_domains` WHERE " .
-         "NOT (`date_expiration` IS NULL) AND `is_deleted` = '0' ".
+         "NOT (`date_expiration` IS NULL) AND `entities_id` = '{$entity->fields['id']}' AND `is_deleted` = '0' ".
          "AND DATEDIFF(CURDATE(), `date_expiration`) > -7 AND DATEDIFF(CURDATE(), `date_expiration`) < 0"
       );
    }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Currently, domain alerts, which are sent for each entity that has alerts activated, contains expired domains from all entities.