### PR TITLE
Force migration of -1 foreign keys values in GLPI core tables

### DIFF
--- a/src/Console/Migration/UnsignedKeysCommand.php
+++ b/src/Console/Migration/UnsignedKeysCommand.php
@@ -37,6 +37,7 @@ namespace Glpi\Console\Migration;
 
 use DBConnection;
 use Glpi\Console\AbstractCommand;
+use Plugin;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -70,6 +71,7 @@ class UnsignedKeysCommand extends AbstractCommand
         );
 
         $errors = false;
+        $errored_plugins = [];
 
         if ($columns->count() === 0) {
             $output->writeln('<info>' . __('No migration needed.') . '</info>');
@@ -88,24 +90,9 @@ class UnsignedKeysCommand extends AbstractCommand
                 $default     = $column['COLUMN_DEFAULT'];
                 $extra       = $column['EXTRA'];
 
-                $min = $this->db
-                    ->request(['SELECT' => ['MIN' => sprintf('%s AS min', $column_name)], 'FROM' => $table_name])
-                    ->current()['min'];
-
-                if (($min !== null && $min < 0) || ($default !== null && $default < 0)) {
-                    $message = sprintf(
-                        __('Migration of column "%s.%s" cannot be done as it contains negative values.'),
-                        $table_name,
-                        $column_name
-                    );
-                    $this->writelnOutputWithProgressBar(
-                        '<error>' . $message . '</error>',
-                        $progress_bar,
-                        OutputInterface::VERBOSITY_QUIET
-                    );
-                    $errors = true;
-                    continue; // Do not migrate this column
-                }
+                $plugin_matches  = [];
+                $is_plugin_table = preg_match('/^glpi_plugin_(?<plugin_key>[^_]+)_/', $table_name, $plugin_matches) === 1;
+                $plugin_key      = $is_plugin_table ? $plugin_matches['plugin_key'] : null;
 
                 // Ensure that column is not referenced in a CONSTRAINT key.
                 foreach ($foreign_keys as $foreign_key) {
@@ -127,7 +114,87 @@ class UnsignedKeysCommand extends AbstractCommand
                             OutputInterface::VERBOSITY_QUIET
                         );
                         $errors = true;
+                        if ($is_plugin_table) {
+                            $errored_plugins[] = $plugin_key;
+                        }
                         continue 2; // Non blocking error, it should not prevent migration of other fields
+                    }
+                }
+
+                // Ensure that column has not a negative default value
+                if ($default !== null && $default < 0) {
+                    $message = sprintf(
+                        __('Migration of column "%s.%s" cannot be done as its default value is negative.'),
+                        $table_name,
+                        $column_name
+                    );
+                    $this->writelnOutputWithProgressBar(
+                        '<error>' . $message . '</error>',
+                        $progress_bar,
+                        OutputInterface::VERBOSITY_QUIET
+                    );
+                    $errors = true;
+                    if ($is_plugin_table) {
+                        $errored_plugins[] = $plugin_key;
+                    }
+                    continue; // Do not migrate this column
+                }
+
+                // Check for negative values in table data
+                $min = $this->db
+                    ->request(['SELECT' => ['MIN' => sprintf('%s AS min', $column_name)], 'FROM' => $table_name])
+                    ->current()['min'];
+                if ($min !== null && $min < 0) {
+                    if (!$is_plugin_table) {
+                        // Force migration of unconsistent -1 values in core tables
+                        $forced_value = $default !== null || $nullable ? $default : 0;
+                        $message = sprintf(
+                            __('Column "%s.%s" contains negative values. Updating them to "%s"...'),
+                            $table_name,
+                            $column_name,
+                            $forced_value === null ? 'NULL' : $forced_value
+                        );
+                        $this->writelnOutputWithProgressBar(
+                            '<comment>' . $message . '</comment>',
+                            $progress_bar
+                        );
+                        $result = $this->db->update(
+                            $table_name,
+                            [$column_name => $forced_value],
+                            [$column_name => ['<', 0]]
+                        );
+                        if ($result === false) {
+                            $message = sprintf(
+                                __('Updating column "%s.%s" values failed with message "(%s) %s".'),
+                                $table_name,
+                                $column_name,
+                                $this->db->errno(),
+                                $this->db->error()
+                            );
+                            $this->writelnOutputWithProgressBar(
+                                '<error>' . $message . '</error>',
+                                $progress_bar,
+                                OutputInterface::VERBOSITY_QUIET
+                            );
+                            $errors = true;
+                            continue; // Go to next column
+                        }
+                    } else {
+                        // Cannot determine whether -1 values in plugin tables are legitimate (bad foreign key design)
+                        // or inconsistent (wrong value inserted in DB)
+                        $message = sprintf(
+                            __('Migration of column "%s.%s" cannot be done as it contains negative values.'),
+                            $table_name,
+                            $column_name
+                        );
+                        $this->writelnOutputWithProgressBar(
+                            '<error>' . $message . '</error>',
+                            $progress_bar,
+                            OutputInterface::VERBOSITY_QUIET
+                        );
+                        $errors = true;
+                        $errored_plugins[] = $plugin_key;
+                        continue; // Do not migrate this column
                     }
                 }
 
@@ -163,6 +230,9 @@ class UnsignedKeysCommand extends AbstractCommand
                         OutputInterface::VERBOSITY_QUIET
                     );
                     $errors = true;
+                    if ($is_plugin_table) {
+                        $errored_plugins[] = $plugin_key;
+                    }
                     continue; // Go to next column
                 }
             }
@@ -178,8 +248,22 @@ class UnsignedKeysCommand extends AbstractCommand
         }
 
         if ($errors) {
+            $message = '<error>' . __('Errors occurred during migration.') . '</error>';
+            if (count($errored_plugins) > 0) {
+                $errored_plugins = array_unique($errored_plugins);
+                $plugin = new Plugin();
+                $plugins_names = [];
+                foreach ($errored_plugins as $errored_plugin) {
+                    $plugins_names[] = $plugin->getInformationsFromDirectory($errored_plugin)['name'] ?? $errored_plugin;
+                }
+                $message .= "\n";
+                $message .= sprintf(
+                    '<comment>' . __('You should try to update following plugins to their latest version and run the command again: %s.') . '</comment>',
+                    implode(', ', $plugins_names)
+                );
+            }
             throw new \Glpi\Console\Exception\EarlyExitException(
-                '<error>' . __('Errors occurred during migration.') . '</error>',
+                $message,
                 self::ERROR_COLUMN_MIGRATION_FAILED
             );
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see #10534, #10556, #10566, #11345

We had some feedback related to unsigned int migration where users had error related to presence of negative values in foreign keys in GLPI core tables. For #10534, #10556, and #10566, these values were not inconsistent, and probably produced by a buggy code. For instance, using the `getId()` method after a failure of `getFromDB()` returns `-1`.

I propose, for GLPI core tables, to force replacement of negative values by the default one (or 0 if there is no default).

I keep this PR as a draft, as I want to make some more tests.