### PR TITLE
Fix dropdown search

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3549,9 +3549,11 @@ class Dropdown
         if (isset($_POST['searchText']) && (strlen($post['searchText']) > 0)) {
             $search = ['LIKE', Search::makeTextSearchValue($post['searchText'])];
             $orwhere = [
-                'name'   => $search,
-                'id'     => $post['searchText']
+                'name'   => $search
             ];
+            if (is_int($post['searchText']) || (is_string($post['searchText'] && ctype_digit($post['searchText'])))) {
+                $orwhere[] = ['id' => $post['searchText']];
+            }
 
             if ($DB->fieldExists($post['table'], "contact")) {
                 $orwhere['contact'] = $search;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Since enabling SQL warnings, the dropdown search breaks because it always tries to match the search text with the ID column without any type checking. MySQL throws a "'Truncated incorrect DOUBLE value" warning. I added type checking and if the search text is not an integer or integer string, no attempt will be made to use the ID column in the search.

This may fix #10769
