### PR TITLE
Rework dashboard dropdown

### DIFF
--- a/src/Central.php
+++ b/src/Central.php
@@ -70,7 +70,7 @@ class Central extends CommonGLPI
             ];
 
             $grid = new Glpi\Dashboard\Grid('central');
-            if ($grid->canViewOneDashboard()) {
+            if ($grid::canViewOneDashboard()) {
                 array_unshift($tabs, __('Dashboard'));
             }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -1590,7 +1590,8 @@ class Config extends CommonDBTM
              "</td><td>";
             Grid::dropdownDashboard("default_dashboard_mini_ticket", [
                 'value' => $data['default_dashboard_mini_ticket'],
-                'display_emptychoice' => true
+                'display_emptychoice' => true,
+                'context'   => 'mini_core',
             ]);
             echo "</td></tr>";
         }

--- a/src/Dashboard/Dashboard.php
+++ b/src/Dashboard/Dashboard.php
@@ -367,7 +367,8 @@ class Dashboard extends \CommonDBTM
      *
      * @return array dasboards
      */
-    public static function getAll(bool $force = false, bool $check_rights = true, ?string $context = 'core'): array {
+    public static function getAll(bool $force = false, bool $check_rights = true, ?string $context = 'core'): array
+    {
         global $DB;
 
         if ($force || count(self::$all_dashboards) == 0) {

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -54,22 +54,15 @@ class Grid
     protected $items           = [];
 
     public static $embed              = false;
-    public static $context            = '';
     public static $all_dashboards     = [];
 
-    public function __construct(
-        string $dashboard_key = "central",
-        int $grid_cols = 26,
-        int $grid_rows = 24,
-        string $context = "core"
-    ) {
+    public function __construct(string $dashboard_key = "central", int $grid_cols = 26, int $grid_rows = 24) {
 
         $this->current   = $dashboard_key;
         $this->grid_cols = $grid_cols;
         $this->grid_rows = $grid_rows;
 
         $this->dashboard = new Dashboard($dashboard_key);
-        self::$context   = $context;
     }
 
 
@@ -98,7 +91,7 @@ class Grid
             || count(self::$all_dashboards) === 0
             || $force
         ) {
-            self::$all_dashboards = Dashboard::getAll($force, !self::$embed, self::$context);
+            self::$all_dashboards = Dashboard::getAll($force, !self::$embed);
         }
 
         return is_array(self::$all_dashboards);
@@ -399,7 +392,7 @@ HTML;
         }
 
         $ajax_cards = GLPI_AJAX_DASHBOARD;
-        $context    = self::$context;
+        $context    = $this->dashboard->fields['context'];
         $cache_key  = sha1($_SESSION['glpiactiveentities_string '] ?? "");
 
         $js = <<<JAVASCRIPT
@@ -1478,14 +1471,13 @@ HTML;
 
     public static function dropdownDashboard(string $name = "", array $params = []): string
     {
-        self::loadAllDashboards();
+        $to_show = Dashboard::getAll(false, true, $params['context'] ?? 'core');
         $can_view_all = $params['can_view_all'] ?? false;
 
         $options_dashboards = [];
-        foreach (self::$all_dashboards as $key => $dashboard) {
+        foreach ($to_show as $key => $dashboard) {
             if (self::canViewSpecificicDashboard($key, $can_view_all)) {
                 $options_dashboards[$key] = $dashboard['name'] ?? $key;
-                ;
             }
         }
 

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -56,7 +56,8 @@ class Grid
     public static $embed              = false;
     public static $all_dashboards     = [];
 
-    public function __construct(string $dashboard_key = "central", int $grid_cols = 26, int $grid_rows = 24) {
+    public function __construct(string $dashboard_key = "central", int $grid_cols = 26, int $grid_rows = 24)
+    {
 
         $this->current   = $dashboard_key;
         $this->grid_cols = $grid_cols;

--- a/src/Search.php
+++ b/src/Search.php
@@ -87,7 +87,7 @@ class Search
             $itemtype == "Ticket"
             && $default = Glpi\Dashboard\Grid::getDefaultDashboardForMenu('mini_ticket', true)
         ) {
-            $dashboard = new Glpi\Dashboard\Grid($default, 33, 1, 'mini_core');
+            $dashboard = new Glpi\Dashboard\Grid($default, 33, 1);
             $dashboard->show(true);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10663

Core issue this tries to fix is how the Dashboard dropdowns in the user preferences work. Currently there are two contexts for dashboards (core and mini_core) where everything is thrown into the "core" context except the one default mini dashboard for Tickets. I'm not sure if there is a way to build a custom mini dashboard or not.
The dropdown asking what you want your mini Ticket dashboard to be didn't specify the context and the underlying code didn't support specifying it either.

The Grid class used a static class property to define the context but it was being set in a constructor. This didn't make sense to me. I removed the static property completely (the constructor parameter wasn't needed anywhere either).

I added a `context` parameter to `Dashboard::getAll`. Previously, this function wouldn't retrieve all dashboards. It would instead load everything in "core" context because that was what the static property was set to and never changed. The new behavior is that it will always load all dashboards into its cache, and then if a specific context is passed, it will filter those out for the result.

The only other use of the static context property is passing its value into a JS string for a context property. Since the function this is in is an instance method, we can use the context from the dashboard that it represents instead.

There remains an issue with the loading of the mini dashboard but this is a separate issue and not related to this as far as I can tell. I'll make another PR for that. I wanted to keep the scope for this one as small as possible.