### PR TITLE
Fix mini dashboard loading

### DIFF
--- a/ajax/dashboard.php
+++ b/ajax/dashboard.php
@@ -144,7 +144,11 @@ switch ($_REQUEST['action']) {
         }
         echo json_encode($result);
         break;
-
+    case 'get_all_cards':
+        session_write_close();
+        header("Content-Type: application/json; charset=UTF-8");
+        echo json_encode($grid->getAllDasboardCards($_REQUEST['force'] ?? false));
+        break;
     case 'display_add_filter':
         $grid->displayFilterForm($_REQUEST);
         break;

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -109,7 +109,7 @@ var Dashboard = {
                 draggable: { // override jquery ui draggable options
                     'cancel': 'textarea' // avoid draggable on some child elements
                 },
-                'minWidth': 768 -  width_offset
+                'minWidth': 768 -  width_offset, // breakpoint of one column mode (based on the dashboard container width), trying to reduce to match the `-md` breakpoint of bootstrap (this last is based on viewport width)
             });
 
             // set grid in static to prevent edition (unless user click on edit button)

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -424,7 +424,6 @@ HTML;
             rand:        '{$rand}',
             embed:       {$embed_str},
             ajax_cards:  {$ajax_cards},
-            all_cards:   {$cards_json},
             all_widgets: {$all_widgets_json},
             context:     "{$this->context}",
             cache_key:   "{$cache_key}",

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -276,10 +276,6 @@ HTML;
             }
         }
 
-       // prepare all available cards
-        $cards = $this->getAllDasboardCards();
-        $cards_json = json_encode($cards);
-
        // prepare all available widgets
         $all_widgets = Widget::getAllTypes();
         $all_widgets_json = json_encode($all_widgets);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fix dashboard loading. For some reason, regular dashboards load OK but loading the mini dashboard (after fix from #10771) shows a blank dashboard. Looking at the page sources, the script block content is truncated. The `all_cards` JS property is incomplete and none of the other properties show.

Rather than dump every card definition into the main page content, I changed this so that the cards would be loaded over AJAX first during the display method and then afterwards, the dashboard content would load. This at least fixes the dashboard to the point of displaying it's items but now I am working on fixing an issue where all of the cards in the mini dashboard are displayed over top each other and take the full size of the dashboard when the data in the database seems correct for position and size.

This requires #10771