### PR TITLE
fix overflow between avatar and content of timeline-item

### DIFF
--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -135,7 +135,7 @@
                {% endif %}
             </div>
             <div class="col-12 col-sm d-flex flex-column content-part">
-               <span class="row mt-2 timeline-content {{ solution_class }} flex-grow-1 {{ item_position }} card">
+               <span class="mt-2 timeline-content {{ solution_class }} flex-grow-1 {{ item_position }} card">
                   <div class="card-body">
                      {{ include('components/itilobject/timeline/timeline_item_header.html.twig') }}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Fix : 
![image](https://user-images.githubusercontent.com/418844/155535568-bd014ad3-bb64-4ab1-919a-f13893202701.png)

I don't remember why we had `.row` class here
