### PR TITLE
Make database plugin migration non destructive

### DIFF
--- a/src/Change_Item.php
+++ b/src/Change_Item.php
@@ -46,7 +46,10 @@ class Change_Item extends CommonItilObject_Item
     public static $items_id_2          = 'items_id';
     public static $checkItem_2_Rights  = self::DONT_CHECK_ITEM_RIGHTS;
 
-
+    public static function getTypeName($nb = 0)
+    {
+        return _n('Change item', 'Change items', $nb);
+    }
 
     public function getForbiddenStandardMassiveAction()
     {

--- a/src/Console/Migration/AbstractPluginToCoreCommand.php
+++ b/src/Console/Migration/AbstractPluginToCoreCommand.php
@@ -33,12 +33,15 @@
 
 namespace Glpi\Console\Migration;
 
+use CommonDBTM;
+use Infocom;
 use Plugin;
 use Glpi\Console\AbstractCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Toolbox;
 
 abstract class AbstractPluginToCoreCommand extends AbstractCommand
 {
@@ -55,6 +58,21 @@ abstract class AbstractPluginToCoreCommand extends AbstractCommand
      * @var integer
      */
     const ERROR_PLUGIN_IMPORT_FAILED = 2;
+
+    /**
+     * Target items mapping.
+     *
+     * @var array
+     */
+    private $target_items_mapping = [];
+
+    /**
+     * Matching items mapping.
+     * Acts as a local cache to prevent DB queries when matching was found earlier for same criteria.
+     *
+     * @var array
+     */
+    private $matching_items_mapping = [];
 
     protected function configure()
     {
@@ -73,6 +91,28 @@ abstract class AbstractPluginToCoreCommand extends AbstractCommand
         parent::initialize($input, $output);
 
         $this->checkPlugin();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $no_interaction = $input->getOption('no-interaction');
+        if (!$no_interaction) {
+            // Ask for confirmation (unless --no-interaction)
+            $output->writeln(
+                [
+                    sprintf(__('You are about to launch migration of "%s" plugin data into GLPI core tables.'), $this->getPluginKey()),
+                    __('It is better to make a backup of your existing data before continuing.')
+                ],
+                OutputInterface::VERBOSITY_QUIET
+            );
+
+            $this->askForConfirmation();
+        }
+
+        $this->migratePlugin();
+
+        $output->writeln('<info>' . __('Migration done.') . '</info>');
+        return 0; // Success
     }
 
     /**
@@ -144,12 +184,13 @@ abstract class AbstractPluginToCoreCommand extends AbstractCommand
      * Handle import error message.
      * Throws a `\Glpi\Console\Exception\EarlyExitException` unless `skip-errors` option is used.
      *
-     * @param string           $message
-     * @param ProgressBar|null $progress_bar
+     * @param string            $message
+     * @param ProgressBar|null  $progress_bar
+     * @param bool              $prevent_exit
      *
      * @return void
      */
-    protected function handleImportError($message, ProgressBar $progress_bar = null): void
+    protected function handleImportError($message, ProgressBar $progress_bar = null, bool $prevent_exit = false): void
     {
         $skip_errors = $this->input->getOption('skip-errors');
 
@@ -159,23 +200,211 @@ abstract class AbstractPluginToCoreCommand extends AbstractCommand
 
         $message = '<error>' . $message . '</error>';
 
-        if ($skip_errors && $progress_bar instanceof ProgressBar) {
+        if ($progress_bar instanceof ProgressBar) {
+            if (!$skip_errors && !$prevent_exit) {
+                $this->output->write(PHP_EOL); // Keep progress bar last state and go to next line
+            }
+
             $this->writelnOutputWithProgressBar(
                 $message,
                 $progress_bar,
                 $verbosity
             );
         } else {
-            if (!$skip_errors && $progress_bar instanceof ProgressBar) {
-                $this->output->write(PHP_EOL); // Keep progress bar last state and go to next line
-            }
             $this->output->writeln(
                 $message,
                 $verbosity
             );
+        }
+
+        if (!$skip_errors && !$prevent_exit) {
             throw new \Glpi\Console\Exception\EarlyExitException(
                 '<error>' . __('Plugin data import failed.') . '</error>',
                 self::ERROR_PLUGIN_IMPORT_FAILED
+            );
+        }
+    }
+
+    /**
+     * Get ID of existing item that matches given fields, if any.
+     *
+     * @param string $itemtype
+     * @param array $criteria
+     *
+     * @return int|null
+     */
+    protected function getMatchingElementId(string $itemtype, array $criteria): ?int
+    {
+        if (!array_key_exists($itemtype, $this->matching_items_mapping)) {
+            $this->matching_items_mapping[$itemtype] = [];
+        }
+
+        $criteria_sha = sha1(serialize($criteria));
+        if (array_key_exists($criteria_sha, $this->matching_items_mapping[$itemtype])) {
+            return $this->matching_items_mapping[$itemtype][$criteria_sha];
+        }
+
+        $item = getItemForItemtype($itemtype);
+        if ($item === false) {
+            return null;
+        }
+
+        if ($item->getFromDBByCrit(Toolbox::addslashes_deep($criteria))) {
+            $id = $item->getID();
+            $this->matching_items_mapping[$itemtype][$criteria_sha] = $id;
+            return $id;
+        }
+
+        return null;
+    }
+
+    /**
+     * Define target item for given source item.
+     *
+     * @param string  $source_itemtype
+     * @param integer $source_id
+     * @param string  $target_itemtype
+     * @param integer $target_id
+     *
+     * @return void
+     */
+    protected function defineTargetItem(string $source_itemtype, int $source_id, string $target_itemtype, int $target_id): void
+    {
+        if (!array_key_exists($source_itemtype, $this->target_items_mapping)) {
+            $this->target_items_mapping[$source_itemtype] = [];
+        }
+        $this->target_items_mapping[$source_itemtype][$source_id] = [
+            'itemtype' => $target_itemtype,
+            'id'       => $target_id,
+        ];
+    }
+
+    /**
+     * Returns target item corresponding to given itemtype and id.
+     *
+     * @param string  $source_itemtype
+     * @param integer $source_id
+     *
+     * @return null|CommonDBTM
+     */
+    protected function getTargetItem(string $source_itemtype, int $source_id): ?CommonDBTM
+    {
+        if (
+            !array_key_exists($source_itemtype, $this->target_items_mapping)
+            || !array_key_exists($source_id, $this->target_items_mapping[$source_itemtype])
+        ) {
+            return null;
+        }
+
+        $mapping  = $this->target_items_mapping[$source_itemtype][$source_id];
+        $id       = $mapping['id'];
+        $itemtype = $mapping['itemtype'];
+
+        if (!is_a($itemtype, CommonDBTM::class, true)) {
+            return null;
+        }
+
+        $item = new $itemtype();
+        if (!$item->getFromDB($id)) {
+            return null;
+        }
+
+        return $item;
+    }
+
+    /**
+     * Store an item. Will update existing item if `$existing_item_id` is passed,
+     * otherwise will create a new item.
+     *
+     * @param string $itemtype
+     * @param int|null $existing_item_id
+     * @param array $input
+     * @param ProgressBar|null $progress_bar
+     *
+     * @return null|CommonDBTM Stored item.
+     */
+    protected function storeItem(string $itemtype, ?int $existing_item_id, array $input, ProgressBar $progress_bar = null): ?CommonDBTM
+    {
+        if (!is_a($itemtype, CommonDBTM::class, true)) {
+            throw new \LogicException(sprintf('Invalid itemtype "%s".', $itemtype));
+        }
+
+        $item = new $itemtype();
+        if ($existing_item_id !== null) {
+            $input[$itemtype::getIndexName()] = $existing_item_id;
+            if ($item->update($input) === false) {
+                $this->handleImportError(
+                    sprintf(
+                        __('Unable to update %s "%s" (%d).'),
+                        $itemtype::getTypeName(),
+                        $input['name'] ?? NOT_AVAILABLE,
+                        (int) $existing_item_id
+                    ),
+                    $progress_bar
+                );
+                return null;
+            }
+        } else {
+            if ($item->add($input) === false) {
+                $this->handleImportError(
+                    sprintf(
+                        __('Unable to create %s "%s" (%d).'),
+                        $itemtype::getTypeName(),
+                        $input['name'] ?? NOT_AVAILABLE,
+                        (int) $input[$itemtype::getIndexName()]
+                    ),
+                    $progress_bar
+                );
+                return null;
+            }
+        }
+
+        return $item;
+    }
+
+    /**
+     * Store infocom data related to given item.
+     *
+     * @param CommonDBTM $item
+     * @param array $infocom_input
+     * @param ProgressBar|null $progress_bar
+     *
+     * @return void
+     */
+    protected function storeInfocomForItem(CommonDBTM $item, array $infocom_input, ProgressBar $progress_bar = null): void
+    {
+        $infocom = new Infocom();
+
+        $exists = $infocom->getFromDBByCrit(
+            [
+                'itemtype'  => $item->getType(),
+                'items_id'  => $item->getID(),
+            ]
+        );
+        if ($exists) {
+            $infocom_input += [
+                'id' => $infocom->fields['id']
+            ];
+            $success = $infocom->update($infocom_input);
+        } else {
+            $infocom_input += [
+                'itemtype'     => $item->getType(),
+                'items_id'     => $item->getID(),
+                'entities_id'  => $item->fields['entities_id'] ?? 0,
+                'is_recursive' => $item->fields['is_recursive'] ?? 0,
+            ];
+            $success = $infocom->add($infocom_input);
+        }
+
+        if (!$success) {
+            $this->handleImportError(
+                sprintf(
+                    __('Unable to financial and administrative information for %s "%s" (%d).'),
+                    $item->getType(),
+                    $item->getName(),
+                    $item->getID()
+                ),
+                $progress_bar
             );
         }
     }
@@ -201,4 +430,11 @@ abstract class AbstractPluginToCoreCommand extends AbstractCommand
      * @return array
      */
     abstract protected function getRequiredDatabasePluginFields(): array;
+
+    /**
+     * Migrate plugin data.
+     *
+     * @return void
+     */
+    abstract protected function migratePlugin(): void;
 }

--- a/src/Console/Migration/DatabasesPluginToCoreCommand.php
+++ b/src/Console/Migration/DatabasesPluginToCoreCommand.php
@@ -39,65 +39,25 @@ use DatabaseInstanceCategory;
 use DatabaseInstanceType;
 use Change_Item;
 use Contract_Item;
-use DB;
 use Document_Item;
-use Glpi\Toolbox\Sanitizer;
-use Infocom;
 use Item_Problem;
 use Item_Project;
 use Item_Ticket;
 use KnowbaseItem_Item;
-use Log;
 use Profile;
+use Session;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Toolbox;
 
 class DatabasesPluginToCoreCommand extends AbstractPluginToCoreCommand
 {
-    /**
-     * Error code returned when cleaning code tables failed.
-     *
-     * @var integer
-     */
-    const ERROR_CORE_DATA_CLEAN_FAILED = 3;
-
-    /**
-     * Itemtype corresponding to database in plugin.
-     *
-     * @var string
-     */
-    const PLUGIN_DATABASES_ITEMTYPE = "PluginDatabasesDatabase";
-
     protected function configure()
     {
         parent::configure();
 
         $this->setName('glpi:migration:databases_plugin_to_core');
         $this->setDescription(__('Migrate Databases plugin data into GLPI core tables'));
-    }
-
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {
-        $no_interaction = $input->getOption('no-interaction');
-        if (!$no_interaction) {
-            // Ask for confirmation (unless --no-interaction)
-            $output->writeln(
-                [
-                    __('You are about to launch migration of Databases plugin data into GLPI core tables.'),
-                    __('Any previous database created in core will be lost.'),
-                    __('It is better to make a backup of your existing data before continuing.')
-                ],
-                OutputInterface::VERBOSITY_QUIET
-            );
-
-            $this->askForConfirmation();
-        }
-
-        $this->migratePlugin();
-
-        $output->writeln('<info>' . __('Migration done.') . '</info>');
-        return 0; // Success
     }
 
     protected function getPluginKey(): string
@@ -123,6 +83,7 @@ class DatabasesPluginToCoreCommand extends AbstractPluginToCoreCommand
             'glpi_plugin_databases_databases.comment',
             'glpi_plugin_databases_databases.locations_id',
             'glpi_plugin_databases_databases.manufacturers_id',
+            'glpi_plugin_databases_databases.suppliers_id',
             'glpi_plugin_databases_databases.users_id',
             'glpi_plugin_databases_databases.groups_id',
             'glpi_plugin_databases_databases.date_mod',
@@ -144,48 +105,7 @@ class DatabasesPluginToCoreCommand extends AbstractPluginToCoreCommand
         ];
     }
 
-    /**
-     * Clean data from core tables.
-     *
-     * @return void
-     */
-    private function cleanCoreTables(): void
-    {
-        $core_tables = [
-            Database::getTable(),
-            DatabaseInstance::getTable(),
-            DatabaseInstanceType::getTable(),
-            DatabaseInstanceCategory::getTable(),
-        ];
-        foreach ($core_tables as $table) {
-            $result = $this->db->query('TRUNCATE ' . DB::quoteName($table));
-
-            if (!$result) {
-                throw new \Glpi\Console\Exception\EarlyExitException(
-                    '<error>' . sprintf(__('Cleaning table "%s" failed.'), $table) . '</error>',
-                    self::ERROR_PLUGIN_VERSION_OR_DATA_INVALID
-                );
-            }
-        }
-
-        $table  = Infocom::getTable();
-        $result = $this->db->delete($table, [
-            'itemtype' => DatabaseInstance::class
-        ]);
-        if (!$result) {
-            throw new \Glpi\Console\Exception\EarlyExitException(
-                '<error>' . sprintf(__('Cleaning table "%s" failed.'), $table) . '</error>',
-                self::ERROR_PLUGIN_VERSION_OR_DATA_INVALID
-            );
-        }
-    }
-
-    /**
-     * Copy plugin tables to backup tables from plugin to core keeping same ID.
-     *
-     * @return void
-     */
-    private function migratePlugin(): void
+    protected function migratePlugin(): void
     {
         //prevent infocom creation from general setup
         global $CFG_GLPI;
@@ -193,14 +113,12 @@ class DatabasesPluginToCoreCommand extends AbstractPluginToCoreCommand
             $CFG_GLPI['auto_create_infocoms'] = false;
         }
 
-        $this->cleanCoreTables();
-
-        $this->createDatabaseInstanceTypes();
-        $this->createDatabaseInstanceCategories();
-        $this->createDatabaseInstances();
-        $this->createDatabases();
-        $this->updateItemtypes();
-        $this->updateProfilesDatabaseRights();
+        $this->importDatabaseInstanceTypes();
+        $this->importDatabaseInstanceCategories();
+        $this->importDatabaseInstances();
+        $this->importDatabases();
+        $this->importItemsRelations();
+        $this->updateProfiles();
     }
 
     /**
@@ -208,90 +126,17 @@ class DatabasesPluginToCoreCommand extends AbstractPluginToCoreCommand
      *
      * @return void
      */
-    private function updateProfilesDatabaseRights(): void
+    private function updateProfiles(): void
     {
         $this->output->writeln(
             '<comment>' . __('Updating profiles...') . '</comment>',
             OutputInterface::VERBOSITY_NORMAL
         );
 
-        $table  = Profile::getTable();
-        $result = $this->db->query(
-            sprintf(
-                "UPDATE %s SET helpdesk_item_type = REPLACE(helpdesk_item_type, '%s', '%s')",
-                DB::quoteName($table),
-                self::PLUGIN_DATABASES_ITEMTYPE,
-                DatabaseInstance::class
-            )
-        );
-        if (false === $result) {
-            $this->handleImportError(
-                sprintf(__('Unable to update "%s" in profiles.'), __('Associable items to a ticket'))
-            );
-        }
-    }
-
-    /**
-     * Rename itemtype in core tables.
-     *
-     * @return void
-     */
-    private function updateItemtypes(): void
-    {
-        $this->output->writeln(
-            '<comment>' . __('Updating GLPI itemtypes...') . '</comment>',
-            OutputInterface::VERBOSITY_NORMAL
-        );
-        $itemtypes_tables = [
-            Item_Ticket::getTable(),
-            Item_Problem::getTable(),
-            Change_Item::getTable(),
-            Item_Project::getTable(),
-            Log::getTable(),
-            Infocom::getTable(),
-            Document_Item::getTable(),
-            Contract_Item::getTable(),
-            KnowbaseItem_Item::getTable(),
-        ];
-
-        foreach ($itemtypes_tables as $itemtype_table) {
-            $result = $this->db->update(
-                $itemtype_table,
-                [
-                    'itemtype' => DatabaseInstance::class,
-                ],
-                [
-                    'itemtype' => self::PLUGIN_DATABASES_ITEMTYPE,
-                ]
-            );
-
-            if (false === $result) {
-                $this->handleImportError(
-                    sprintf(
-                        __('Migration of table "%s" failed with message "(%s) %s".'),
-                        $itemtype_table,
-                        $this->db->errno(),
-                        $this->db->error()
-                    )
-                );
-            }
-        }
-    }
-
-    /**
-     * Create database instance categories.
-     *
-     * @return void
-     */
-    private function createDatabaseInstanceCategories(): void
-    {
-        $this->output->writeln(
-            '<comment>' . sprintf(__('Creating %s...'), DatabaseInstanceCategory::getTypeName()) . '</comment>',
-            OutputInterface::VERBOSITY_NORMAL
-        );
-
         $iterator = $this->db->request([
-            'FROM' => 'glpi_plugin_databases_databasecategories'
+            'SELECT' => ['id', 'name', 'helpdesk_item_type'],
+            'FROM'   => Profile::getTable(),
+            'ORDER'  => 'id ASC',
         ]);
 
         if ($iterator->count() === 0) {
@@ -300,24 +145,186 @@ class DatabasesPluginToCoreCommand extends AbstractPluginToCoreCommand
 
         $progress_bar = new ProgressBar($this->output);
 
+        foreach ($progress_bar->iterate($iterator) as $profile_data) {
+            $helpdesk_item_types = importArrayFromDB($profile_data['helpdesk_item_type']);
+            if (
+                in_array('PluginDatabasesDatabase', $helpdesk_item_types)
+                && !in_array(DatabaseInstance::class, $helpdesk_item_types)
+            ) {
+                $profile = new Profile();
+                if (!$profile->update(['id' => $profile_data['id'], 'helpdesk_item_type' => $helpdesk_item_types])) {
+                    $this->handleImportError(
+                        sprintf(
+                            __('Unable to update "%s" in profile "%s" (%s).'),
+                            __('Associable items to a ticket'),
+                            $profile_data['name'],
+                            $profile_data['id']
+                        )
+                    );
+                }
+            }
+        }
+
+        $this->output->write(PHP_EOL);
+    }
+
+    /**
+     * Import items relations.
+     *
+     * @return void
+     */
+    private function importItemsRelations(): void
+    {
+        $this->output->writeln(
+            '<comment>' . __('Importing relations with other itemtypes...') . '</comment>',
+            OutputInterface::VERBOSITY_NORMAL
+        );
+
+        $relations_itemtypes = [
+            Item_Ticket::class,
+            Item_Problem::class,
+            Change_Item::class,
+            Item_Project::class,
+            Document_Item::class,
+            Contract_Item::class,
+            KnowbaseItem_Item::class,
+        ];
+
+        foreach ($relations_itemtypes as $relation_itemtype) {
+            $this->output->writeln(
+                '<comment>' . sprintf(__('Importing %s...'), $relation_itemtype::getTypeName(Session::getPluralNumber())) . '</comment>',
+                OutputInterface::VERBOSITY_NORMAL
+            );
+
+            $iterator = $this->db->request([
+                'FROM'  => $relation_itemtype::getTable(),
+                'WHERE' => ['itemtype' => 'PluginDatabasesDatabase'],
+                'ORDER' => 'id ASC'
+            ]);
+
+            if ($iterator->count() === 0) {
+                $this->output->writeln('<comment>' . __('No elements found.') . '</comment>');
+                return;
+            }
+
+            $opposite_fkey = $relation_itemtype::$items_id_1;
+
+            $progress_bar = new ProgressBar($this->output);
+
+            foreach ($progress_bar->iterate($iterator) as $relation_data) {
+                $mapped_database = $this->getTargetItem('PluginDatabasesDatabase', $relation_data['items_id']);
+                if ($mapped_database === null) {
+                    $this->handleImportError(
+                        sprintf(
+                            __('Unable to find target item for %s #%s.'),
+                            'PluginDatabasesDatabase',
+                            $relation_data['items_id']
+                        ),
+                        $progress_bar,
+                        true // Do not block migration as this error is probably resulting in presence of obsolete data in DB
+                    );
+                    continue;
+                }
+
+                $database_id = $mapped_database->fields['id'];
+
+                $core_relation_id = $this->getMatchingElementId(
+                    $relation_itemtype,
+                    [
+                        $opposite_fkey => $relation_data[$opposite_fkey],
+                        'itemtype'     => DatabaseInstance::class,
+                        'items_id'     => $database_id,
+                    ]
+                );
+
+                $this->writelnOutputWithProgressBar(
+                    sprintf(
+                        $core_relation_id !== null ? __('Skip existing %s "%s".') : __('Importing %s "%s"...'),
+                        $relation_itemtype::getTypeName(),
+                        $relation_data[$opposite_fkey] . ' ' . DatabaseInstance::class . ' ' . $database_id
+                    ),
+                    $progress_bar,
+                    OutputInterface::VERBOSITY_VERY_VERBOSE
+                );
+
+                if ($core_relation_id !== null) {
+                     // If relation already exist in DB, there is nothing to change
+                     continue;
+                }
+
+                $relation_input = $relation_data;
+                unset($relation_input['id']);
+                $relation_input['itemtype'] = DatabaseInstance::class;
+                $relation_input['items_id'] = $database_id;
+                $relation_input = Toolbox::addslashes_deep($relation_input);
+
+                $item = new $relation_itemtype();
+                if ($item->add($relation_input) === false) {
+                    $message = sprintf(
+                        __('Unable to create %s "%s" (%d).'),
+                        $relation_itemtype::getTypeName(),
+                        $relation_data[$opposite_fkey] . ' ' . DatabaseInstance::class . ' ' . $database_id
+                    );
+                    $this->handleImportError($message, $progress_bar);
+                }
+            }
+        }
+    }
+
+    /**
+     * Import database instance categories.
+     *
+     * @return void
+     */
+    private function importDatabaseInstanceCategories(): void
+    {
+        $this->output->writeln(
+            '<comment>' . sprintf(__('Importing %s...'), DatabaseInstanceCategory::getTypeName(Session::getPluralNumber())) . '</comment>',
+            OutputInterface::VERBOSITY_NORMAL
+        );
+
+        $iterator = $this->db->request([
+            'FROM'  => 'glpi_plugin_databases_databasecategories',
+            'ORDER' => 'id ASC'
+        ]);
+
+        if ($iterator->count() === 0) {
+            $this->output->writeln('<comment>' . __('No elements found.') . '</comment>');
+            return;
+        }
+
+        $progress_bar = new ProgressBar($this->output);
+
         foreach ($progress_bar->iterate($iterator) as $category_data) {
+            $core_category_id = $this->getMatchingElementId(DatabaseInstanceCategory::class, ['name' => $category_data['name']]);
+
             $this->writelnOutputWithProgressBar(
-                sprintf(__('Importing %s "%s"...'), DatabaseInstanceCategory::getTypeName(), $category_data['name']),
+                sprintf(
+                    $core_category_id !== null ? __('Updating existing %s "%s"...') : __('Importing %s "%s"...'),
+                    DatabaseInstanceCategory::getTypeName(),
+                    $category_data['name']
+                ),
                 $progress_bar,
                 OutputInterface::VERBOSITY_VERY_VERBOSE
             );
 
-            $category_fields = Sanitizer::sanitize([
-                'id'        => $category_data['id'],
-                'name'      => $category_data['name'],
-                'comment'   => $category_data['comment']
-            ]);
+            $category = $this->storeItem(
+                DatabaseInstanceCategory::class,
+                $core_category_id,
+                Toolbox::addslashes_deep(
+                    [
+                        'name'      => $category_data['name'],
+                        'comment'   => $category_data['comment']
+                    ]
+                )
+            );
 
-            $category = new DatabaseInstanceCategory();
-            if ($category->getFromDBByCrit($category_fields) === false && $category->add($category_fields) === false) {
-                $this->handleImportError(
-                    sprintf(__('Unable to create %s "%s" (%d).'), DatabaseInstanceCategory::getTypeName(), $category_data['name'], (int) $category_data['id']),
-                    $progress_bar
+            if ($category !== null) {
+                $this->defineTargetItem(
+                    'PluginDatabasesDatabaseCategory',
+                    $category_data['id'],
+                    DatabaseInstanceCategory::class,
+                    $category->getID()
                 );
             }
         }
@@ -330,44 +337,90 @@ class DatabasesPluginToCoreCommand extends AbstractPluginToCoreCommand
      *
      * @return void
      */
-    private function createDatabases(): void
+    private function importDatabases(): void
     {
         $this->output->writeln(
-            '<comment>' . sprintf(__('Creating %s...'), Database::getTypeName()) . '</comment>',
+            '<comment>' . sprintf(__('Importing %s...'), Database::getTypeName(Session::getPluralNumber())) . '</comment>',
             OutputInterface::VERBOSITY_NORMAL
         );
         $iterator = $this->db->request([
-            'FROM' => 'glpi_plugin_databases_instances' // Database in GLPI core corresponds to PluginDatabasesInstance
+            'FROM'  => 'glpi_plugin_databases_instances', // Database in GLPI core corresponds to PluginDatabasesInstance
+            'ORDER' => 'id ASC'
         ]);
 
         if ($iterator->count() === 0) {
+            $this->output->writeln('<comment>' . __('No elements found.') . '</comment>');
             return;
         }
 
         $progress_bar = new ProgressBar($this->output);
 
         foreach ($progress_bar->iterate($iterator) as $database_data) {
+            $mapped_instance = $this->getTargetItem('PluginDatabasesDatabase', $database_data['plugin_databases_databases_id']);
+            if ($database_data['plugin_databases_databases_id'] != 0 && $mapped_instance === null) {
+                $this->handleImportError(
+                    sprintf(
+                        __('Unable to find target item for %s #%s.'),
+                        'PluginDatabasesDatabase',
+                        $database_data['plugin_domains_domains_id']
+                    ),
+                    $progress_bar,
+                    true // Do not block migration as this error is probably resulting in presence of obsolete data in DB
+                );
+            }
+
+            $core_database_id = $this->getMatchingElementId(
+                Database::class,
+                [
+                    'name'                  => $database_data['name'],
+                    'databaseinstances_id'  => $mapped_instance !== null ? $mapped_instance->getID() : 0,
+                ]
+            );
+
             $this->writelnOutputWithProgressBar(
-                sprintf(__('Importing %s "%s"...'), Database::getTypeName(), $database_data['name']),
+                sprintf(
+                    $core_database_id !== null ? __('Updating existing %s "%s"...') : __('Importing %s "%s"...'),
+                    Database::getTypeName(),
+                    $database_data['name']
+                ),
                 $progress_bar,
                 OutputInterface::VERBOSITY_VERY_VERBOSE
             );
 
-            $database_fields = Sanitizer::sanitize([
-                'id'                    => $database_data['id'],
-                'entities_id'           => $database_data['entities_id'],
-                'is_recursive'          => $database_data['is_recursive'],
-                'name'                  => $database_data['name'],
-                'is_deleted'            => 0,
-                'is_active'             => 1,
-                'databaseinstances_id'  => $database_data['plugin_databases_databases_id'],
-            ]);
-
-            $database = new Database();
-            if ($database->getFromDBByCrit($database_fields) === false && $database->add($database_fields) === false) {
+            $mapped_instance = $this->getTargetItem('PluginDatabasesDatabase', $database_data['plugin_databases_databases_id']);
+            if ($database_data['plugin_databases_databases_id'] != 0 && $mapped_instance === null) {
                 $this->handleImportError(
-                    sprintf(__('Unable to create %s "%s" (%d).'), Database::getTypeName(), $database_data['name'], (int) $database_data['id']),
-                    $progress_bar
+                    sprintf(
+                        __('Unable to find target item for %s #%s.'),
+                        'PluginDatabasesDatabase',
+                        $database_data['plugin_domains_domains_id']
+                    ),
+                    $progress_bar,
+                    true // Do not block migration as this error is probably resulting in presence of obsolete data in DB
+                );
+            }
+
+            $database = $this->storeItem(
+                Database::class,
+                $core_database_id,
+                Toolbox::addslashes_deep(
+                    [
+                        'entities_id'           => $database_data['entities_id'],
+                        'is_recursive'          => $database_data['is_recursive'],
+                        'name'                  => $database_data['name'],
+                        'is_deleted'            => 0,
+                        'is_active'             => 1,
+                        'databaseinstances_id'  => $mapped_instance !== null ? $mapped_instance->getID() : 0,
+                    ]
+                )
+            );
+
+            if ($database !== null) {
+                $this->defineTargetItem(
+                    'PluginDatabasesInstance',
+                    $database_data['id'],
+                    Database::class,
+                    $database->getID()
                 );
             }
         }
@@ -376,59 +429,102 @@ class DatabasesPluginToCoreCommand extends AbstractPluginToCoreCommand
     }
 
    /**
-    * Create databases instances.
+    * Import databases instances.
     *
     * @return void
     */
-    private function createDatabaseInstances(): void
+    private function importDatabaseInstances(): void
     {
         $this->output->writeln(
-            '<comment>' . sprintf(__('Creating %s...'), DatabaseInstance::getTypeName()) . '</comment>',
+            '<comment>' . sprintf(__('Importing %s...'), DatabaseInstance::getTypeName(Session::getPluralNumber())) . '</comment>',
             OutputInterface::VERBOSITY_NORMAL
         );
         $iterator = $this->db->request([
-            'FROM' => 'glpi_plugin_databases_databases' // Database in GLPI core corresponds to PluginDatabasesDatabase
+            'FROM'  => 'glpi_plugin_databases_databases', // Database in GLPI core corresponds to PluginDatabasesDatabase
+            'ORDER' => 'id ASC'
         ]);
 
         if ($iterator->count() === 0) {
+            $this->output->writeln('<comment>' . __('No elements found.') . '</comment>');
             return;
         }
 
         $progress_bar = new ProgressBar($this->output);
 
         foreach ($progress_bar->iterate($iterator) as $instance_data) {
+            $core_instance_id = $this->getMatchingElementId(DatabaseInstance::class, ['name' => $instance_data['name']]);
+
             $this->writelnOutputWithProgressBar(
-                sprintf(__('Importing %s "%s"...'), DatabaseInstance::getTypeName(), $instance_data['name']),
+                sprintf(
+                    $core_instance_id !== null ? __('Updating existing %s "%s"...') : __('Importing %s "%s"...'),
+                    DatabaseInstance::getTypeName(),
+                    $instance_data['name']
+                ),
                 $progress_bar,
                 OutputInterface::VERBOSITY_VERY_VERBOSE
             );
 
-            $database_fields = Sanitizer::sanitize([
-                'id'                            => $instance_data['id'],
-                'entities_id'                   => $instance_data['entities_id'],
-                'is_recursive'                  => $instance_data['is_recursive'],
-                'name'                          => $instance_data['name'],
-                'is_deleted'                    => $instance_data['is_deleted'],
-                'is_active'                     => 1,
-                'databaseinstancetypes_id'      => $instance_data['plugin_databases_databasetypes_id'],
-                'databaseinstancecategories_id' => $instance_data['plugin_databases_databasecategories_id'],
-                'comment'                       => $instance_data['comment'],
-                'locations_id'                  => $instance_data['locations_id'],
-                'manufacturers_id'              => $instance_data['manufacturers_id'],
-                'users_id_tech'                 => $instance_data['users_id'],
-                'groups_id_tech'                => $instance_data['groups_id'],
-                'date_mod'                      => $instance_data['date_mod'],
-                'is_helpdesk_visible'           => $instance_data['is_helpdesk_visible'],
-                'states_id'                     => 0,
-                'is_dynamic'                    => 0,
-            ]);
-
-            $instance = new DatabaseInstance();
-            if ($instance->getFromDBByCrit($database_fields) === false && $instance->add($database_fields) === false) {
+            $mapped_type = $this->getTargetItem('PluginDatabasesDatabaseType', $instance_data['plugin_databases_databasetypes_id']);
+            if ($instance_data['plugin_databases_databasetypes_id'] != 0 && $mapped_type === null) {
                 $this->handleImportError(
-                    sprintf(__('Unable to create %s "%s" (%d).'), DatabaseInstance::getTypeName(), $instance_data['name'], (int) $instance_data['id']),
-                    $progress_bar
+                    sprintf(
+                        __('Unable to find target item for %s #%s.'),
+                        'PluginDatabasesDatabaseType',
+                        $instance_data['plugin_domains_domains_id']
+                    ),
+                    $progress_bar,
+                    true // Do not block migration as this error is probably resulting in presence of obsolete data in DB
                 );
+            }
+
+            $mapped_category = $this->getTargetItem('PluginDatabasesDatabaseCategory', $instance_data['plugin_databases_databasecategories_id']);
+            if ($instance_data['plugin_databases_databasecategories_id'] != 0 && $mapped_category === null) {
+                $this->handleImportError(
+                    sprintf(
+                        __('Unable to find target item for %s #%s.'),
+                        'PluginDatabasesDatabaseCategory',
+                        $instance_data['plugin_databases_databasecategories_id']
+                    ),
+                    $progress_bar,
+                    true // Do not block migration as this error is probably resulting in presence of obsolete data in DB
+                );
+            }
+
+            $instance = $this->storeItem(
+                DatabaseInstance::class,
+                $core_instance_id,
+                Toolbox::addslashes_deep(
+                    [
+                        'entities_id'                   => $instance_data['entities_id'],
+                        'is_recursive'                  => $instance_data['is_recursive'],
+                        'name'                          => $instance_data['name'],
+                        'is_deleted'                    => $instance_data['is_deleted'],
+                        'is_active'                     => 1,
+                        'databaseinstancetypes_id'      => $mapped_type !== null ? $mapped_type->getID() : 0,
+                        'databaseinstancecategories_id' => $mapped_category !== null ? $mapped_category->getID() : 0,
+                        'comment'                       => $instance_data['comment'],
+                        'locations_id'                  => $instance_data['locations_id'],
+                        'manufacturers_id'              => $instance_data['manufacturers_id'],
+                        'users_id_tech'                 => $instance_data['users_id'],
+                        'groups_id_tech'                => $instance_data['groups_id'],
+                        'date_mod'                      => $instance_data['date_mod'],
+                        'is_helpdesk_visible'           => $instance_data['is_helpdesk_visible'],
+                        'states_id'                     => 0,
+                        'is_dynamic'                    => 0,
+                    ]
+                )
+            );
+
+            if ($instance !== null) {
+                $this->defineTargetItem(
+                    'PluginDatabasesDatabase',
+                    $instance_data['id'],
+                    DatabaseInstance::class,
+                    $instance->getID()
+                );
+                if (!empty($instance_data['suppliers_id'])) {
+                    $this->storeInfocomForItem($instance, ['suppliers_id' => $instance_data['suppliers_id']], $progress_bar);
+                }
             }
         }
 
@@ -436,45 +532,55 @@ class DatabasesPluginToCoreCommand extends AbstractPluginToCoreCommand
     }
 
     /**
-     * Create database instance types.
+     * Import database instance types.
      *
      * @return void
      */
-    private function createDatabaseInstanceTypes(): void
+    private function importDatabaseInstanceTypes(): void
     {
         $this->output->writeln(
-            '<comment>' . sprintf(__('Creating %s...'), DatabaseInstanceType::getTypeName()) . '</comment>',
+            '<comment>' . sprintf(__('Importing %s...'), DatabaseInstanceType::getTypeName(Session::getPluralNumber())) . '</comment>',
             OutputInterface::VERBOSITY_NORMAL
         );
 
         $iterator = $this->db->request([
-            'FROM' => 'glpi_plugin_databases_databasetypes'
+            'FROM'  => 'glpi_plugin_databases_databasetypes',
+            'ORDER' => 'id ASC'
         ]);
 
         if ($iterator->count() === 0) {
+            $this->output->writeln('<comment>' . __('No elements found.') . '</comment>');
             return;
         }
 
         $progress_bar = new ProgressBar($this->output);
 
         foreach ($progress_bar->iterate($iterator) as $type_data) {
+            $core_type_id = $this->getMatchingElementId(DatabaseInstanceType::class, ['name' => $type_data['name']]);
+
             $this->writelnOutputWithProgressBar(
-                sprintf(__('Importing %s "%s"...'), DatabaseInstanceType::getTypeName(), $type_data['name']),
+                sprintf(
+                    $core_type_id !== null ? __('Updating existing %s "%s"...') : __('Importing %s "%s"...'),
+                    DatabaseInstanceType::getTypeName(),
+                    $type_data['name']
+                ),
                 $progress_bar,
                 OutputInterface::VERBOSITY_VERY_VERBOSE
             );
 
-            $type_fields = Sanitizer::sanitize([
-                'id'        => $type_data['id'],
+            $type_input = Toolbox::addslashes_deep([
                 'name'      => $type_data['name'],
                 'comment'   => $type_data['comment'],
             ]);
 
-            $type = new DatabaseInstanceType();
-            if ($type->getFromDBByCrit($type_fields) === false && $type->add($type_fields) === false) {
-                $this->handleImportError(
-                    sprintf(__('Unable to create %s "%s" (%d).'), DatabaseInstanceType::getTypeName(), $type_data['name'], (int) $type_data['id']),
-                    $progress_bar
+            $type = $this->storeItem(DatabaseInstanceType::class, $core_type_id, $type_input);
+
+            if ($type !== null) {
+                $this->defineTargetItem(
+                    'PluginDatabasesDatabaseType',
+                    $type_data['id'],
+                    DatabaseInstanceType::class,
+                    $type->getID()
                 );
             }
         }

--- a/src/Console/Migration/DomainsPluginToCoreCommand.php
+++ b/src/Console/Migration/DomainsPluginToCoreCommand.php
@@ -224,7 +224,7 @@ class DomainsPluginToCoreCommand extends AbstractPluginToCoreCommand
                         'entities_id'           => $domain_data['entities_id'],
                         'is_recursive'          => $domain_data['is_recursive'],
                         'domaintypes_id'        => $mapped_type !== null ? $mapped_type->getID() : 0,
-                        'date_creation'         => $domain_data['date_creation'],
+                        'date_domaincreation'   => $domain_data['date_creation'],
                         'date_expiration'       => $domain_data['date_expiration'],
                         'users_id_tech'         => $domain_data['users_id_tech'],
                         'groups_id_tech'        => $domain_data['groups_id_tech'],

--- a/src/Console/Migration/DomainsPluginToCoreCommand.php
+++ b/src/Console/Migration/DomainsPluginToCoreCommand.php
@@ -33,270 +33,84 @@
 
 namespace Glpi\Console\Migration;
 
-use CommonDBTM;
 use Domain;
 use Domain_Item;
 use DomainType;
-use Glpi\Console\AbstractCommand;
-use Plugin;
-use Symfony\Component\Console\Exception\LogicException;
+use Session;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Toolbox;
 
-class DomainsPluginToCoreCommand extends AbstractCommand
+class DomainsPluginToCoreCommand extends AbstractPluginToCoreCommand
 {
-    /**
-     * Error code returned if plugin version or plugin data is invalid.
-     *
-     * @var integer
-     */
-    const ERROR_PLUGIN_VERSION_OR_DATA_INVALID = 1;
-
-    /**
-     * Error code returned if import failed.
-     *
-     * @var integer
-     */
-    const ERROR_PLUGIN_IMPORT_FAILED = 1;
-
-    /**
-     * Version of Domains plugin required for this migration.
-     * @var string
-     */
-    const DOMAINS_REQUIRED_VERSION = '2.1.0';
-
-    /**
-     * Imported elements mapping.
-     *
-     * @var array
-     */
-    private $elements_mapping;
-
     protected function configure()
     {
         parent::configure();
 
         $this->setName('glpi:migration:domains_plugin_to_core');
         $this->setDescription(__('Migrate Domains plugin data into GLPI core tables'));
-
-        $this->addOption(
-            'update-plugin',
-            'u',
-            InputOption::VALUE_NONE,
-            sprintf(
-                __('Run Domains plugin update (you need version %s files to do this)'),
-                self::DOMAINS_REQUIRED_VERSION
-            )
-        );
-
-        $this->addOption(
-            'without-plugin',
-            'w',
-            InputOption::VALUE_NONE,
-            sprintf(
-                __('Enable migration without plugin files (we cannot validate that plugin data are compatible with supported %s version)'),
-                self::DOMAINS_REQUIRED_VERSION
-            )
-        );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function getPluginKey(): string
     {
-
-        $this->elements_mapping = []; // Clear elements mapping
-
-        $no_interaction = $input->getOption('no-interaction');
-
-        if (!$no_interaction) {
-           // Ask for confirmation (unless --no-interaction)
-            $output->writeln(
-                [
-                    __('You are about to launch migration of Domains plugin data into GLPI core tables.'),
-                    __('It is better to make a backup of your existing data before continuing.')
-                ]
-            );
-
-            $this->askForConfirmation();
-        }
-
-        if (!$this->checkPlugin()) {
-            return self::ERROR_PLUGIN_VERSION_OR_DATA_INVALID;
-        }
-
-        if (!$this->migratePlugin()) {
-            return self::ERROR_PLUGIN_IMPORT_FAILED;
-        }
-
-        $output->writeln('<info>' . __('Migration done.') . '</info>');
-
-        return 0; // Success
+        return 'domains';
     }
 
-    /**
-     * Check that plugin state and existing data are OK for migration.
-     *
-     * @throws LogicException
-     *
-     * @return boolean
-     */
-    private function checkPlugin()
+    protected function getRequiredMinimalPluginVersion(): ?string
     {
+        return '2.1.0';
+    }
 
-        $check_version = !$this->input->getOption('without-plugin');
+    protected function getRequiredDatabasePluginFields(): array
+    {
+        return [
+            'glpi_plugin_domains_domains.id',
+            'glpi_plugin_domains_domains.name',
+            'glpi_plugin_domains_domains.comment',
+            'glpi_plugin_domains_domains.entities_id',
+            'glpi_plugin_domains_domains.is_recursive',
+            'glpi_plugin_domains_domains.is_deleted',
+            'glpi_plugin_domains_domains.date_creation',
+            'glpi_plugin_domains_domains.date_mod',
+            'glpi_plugin_domains_domains.date_expiration',
+            'glpi_plugin_domains_domains.plugin_domains_domaintypes_id',
+            'glpi_plugin_domains_domains.users_id_tech',
+            'glpi_plugin_domains_domains.groups_id_tech',
+            'glpi_plugin_domains_domains.suppliers_id',
 
-        if ($check_version) {
-            $this->output->writeln(
-                '<comment>' . __('Checking plugin version...') . '</comment>',
-                OutputInterface::VERBOSITY_VERBOSE
-            );
+            'glpi_plugin_domains_domaintypes.id',
+            'glpi_plugin_domains_domaintypes.name',
+            'glpi_plugin_domains_domaintypes.entities_id',
+            'glpi_plugin_domains_domaintypes.comment',
 
-            $plugin = new Plugin();
-            $plugin->checkPluginState('domains');
-
-            if (!$plugin->getFromDBbyDir('domains')) {
-                 $message  = __('Domains plugin is not part of GLPI plugin list. It has never been installed or has been cleaned.')
-                  . ' '
-                  . sprintf(
-                      __('You have to install Domains plugin files in version %s to be able to continue.'),
-                      self::DOMAINS_REQUIRED_VERSION
-                  );
-                 $this->output->writeln(
-                     [
-                         '<error>' . $message . '</error>',
-                     ],
-                     OutputInterface::VERBOSITY_QUIET
-                 );
-                 return false;
-            }
-
-            $is_version_ok = self::DOMAINS_REQUIRED_VERSION === $plugin->fields['version'];
-            if (!$is_version_ok) {
-                $message  = sprintf(
-                    __('You have to install Domains plugin files in version %s to be able to continue.'),
-                    self::DOMAINS_REQUIRED_VERSION
-                );
-                $this->output->writeln(
-                    '<error>' . $message . '</error>',
-                    OutputInterface::VERBOSITY_QUIET
-                );
-                return false;
-            }
-
-            $is_installable = in_array(
-                $plugin->fields['state'],
-                [
-                    Plugin::TOBECLEANED, // Can be in this state if check was done without the plugin dir
-                    Plugin::NOTINSTALLED, // Can be not installed if plugin has been cleaned in plugin list
-                    Plugin::NOTUPDATED, // Plugin 1.8.0 version has never been installed
-                ]
-            );
-            if ($is_installable) {
-                if ($this->input->getOption('update-plugin')) {
-                    $message  = sprintf(
-                        __('Migrating plugin to %s version...'),
-                        self::DOMAINS_REQUIRED_VERSION
-                    );
-                    $this->output->writeln(
-                        '<info>' . $message . '</info>',
-                        OutputInterface::VERBOSITY_NORMAL
-                    );
-
-                    ob_start();
-                    $plugin->install($plugin->fields['id']);
-                    ob_end_clean();
-
-                   // Reload and check migration result
-                    $plugin->getFromDB($plugin->fields['id']);
-                    if (!in_array($plugin->fields['state'], [Plugin::TOBECONFIGURED, Plugin::NOTACTIVATED])) {
-                            $message  = sprintf(
-                                __('Plugin migration to %s version failed.'),
-                                self::DOMAINS_REQUIRED_VERSION
-                            );
-                            $this->output->writeln(
-                                '<error>' . $message . '</error>',
-                                OutputInterface::VERBOSITY_QUIET
-                            );
-                            return false;
-                    }
-                } else {
-                    $message = sprintf(
-                        __('Domains plugin data has to be updated to %s version. It can be done using the --update-plugin option.'),
-                        self::DOMAINS_REQUIRED_VERSION
-                    );
-                    $this->output->writeln(
-                        '<comment>' . $message . '</comment>',
-                        OutputInterface::VERBOSITY_QUIET
-                    );
-                    return false;
-                }
-            }
-
-            $is_state_ok   = in_array(
-                $plugin->fields['state'],
-                [
-                    Plugin::ACTIVATED, // Should not be possible as 1.8.0 is not compatible with 9.3
-                    Plugin::TOBECONFIGURED, // Should not be possible as check_config of plugin returns always true
-                    Plugin::NOTACTIVATED,
-                ]
-            );
-            if (!$is_state_ok) {
-                 // Should not happens as installation should put plugin in awaited state
-                 throw new \Symfony\Component\Console\Exception\LogicException('Unexpected plugin state.');
-            }
-        }
-
-        $domains_tables = [
-            'glpi_plugin_domains_configs',
-            'glpi_plugin_domains_domains',
-            'glpi_plugin_domains_domains_items',
-            'glpi_plugin_domains_domaintypes',
+            'glpi_plugin_domains_domains_items.plugin_domains_domains_id',
+            'glpi_plugin_domains_domains_items.itemtype',
+            'glpi_plugin_domains_domains_items.items_id',
         ];
-        $missing_tables = false;
-        foreach ($domains_tables as $table) {
-            if (!$this->db->tableExists($table)) {
-                $this->output->writeln(
-                    '<error>' . sprintf(__('Domains plugin table "%s" is missing.'), $table) . '</error>',
-                    OutputInterface::VERBOSITY_QUIET
-                );
-                $missing_tables = true;
-            }
-        }
-        if ($missing_tables) {
-            $this->output->writeln(
-                '<error>' . __('Migration cannot be done.') . '</error>',
-                OutputInterface::VERBOSITY_QUIET
-            );
-            return false;
-        }
-
-        return true;
     }
 
-
-    private function migratePlugin()
+    protected function migratePlugin(): void
     {
+        //prevent infocom creation from general setup
+        global $CFG_GLPI;
+        if (isset($CFG_GLPI["auto_create_infocoms"]) && $CFG_GLPI["auto_create_infocoms"]) {
+            $CFG_GLPI['auto_create_infocoms'] = false;
+        }
 
-        $failure = !$this->importDomainTypes()
-         || !$this->importDomains()
-         || !$this->importDomainItems();
-
-        return !$failure;
+        $this->importDomainTypes();
+        $this->importDomains();
+        $this->importDomainItems();
     }
 
     /**
      * Migrate domain types
      *
-     * @return boolean
+     * @return void
      */
-    protected function importDomainTypes()
+    protected function importDomainTypes(): void
     {
-        $has_errors = false;
-
         $this->output->writeln(
-            '<comment>' . __('Importing domains types...') . '</comment>',
+            '<comment>' . sprintf(__('Importing %s...'), DomainType::getTypeName(Session::getPluralNumber())) . '</comment>',
             OutputInterface::VERBOSITY_NORMAL
         );
 
@@ -305,105 +119,61 @@ class DomainsPluginToCoreCommand extends AbstractCommand
             'ORDER'  => 'id ASC'
         ]);
 
-        $core_types = [];
-        $coret_iterator = $this->db->request([
-            'SELECT' => ['id', 'name'],
-            'FROM'   => DomainType::getTable()
-        ]);
-        foreach ($coret_iterator as $row) {
-            $core_types[$row['name']] = $row['id'];
+        if ($types_iterator->count() === 0) {
+            $this->output->writeln('<comment>' . __('No elements found.') . '</comment>');
+            return;
         }
 
-        if ($types_iterator->count()) {
-            $progress_bar = new ProgressBar($this->output, $types_iterator->count());
-            $progress_bar->start();
+        $progress_bar = new ProgressBar($this->output);
 
-            foreach ($types_iterator as $typ) {
-                $progress_bar->advance(1);
-                $core_type = null;
+        foreach ($progress_bar->iterate($types_iterator) as $type_data) {
+            $core_type_id = $this->getMatchingElementId(DomainType::class, ['name' => $type_data['name']]);
 
-                if (isset($core_types[$typ['name']])) {
-                    $core_type = $core_types[$typ['name']];
-                    $message = sprintf(
-                        __('Updating existing domain type %s...'),
-                        $typ['name']
-                    );
-                } else {
-                    $message = sprintf(
-                        __('Importing domain type %s...'),
-                        $typ['name']
-                    );
-                }
-                $this->writelnOutputWithProgressBar(
-                    $message,
-                    $progress_bar,
-                    OutputInterface::VERBOSITY_VERY_VERBOSE
-                );
+            $this->writelnOutputWithProgressBar(
+                sprintf(
+                    $core_type_id !== null ? __('Updating existing %s "%s"...') : __('Importing %s "%s"...'),
+                    DomainType::getTypeName(),
+                    $type_data['name']
+                ),
+                $progress_bar,
+                OutputInterface::VERBOSITY_VERY_VERBOSE
+            );
 
-                $type_input = [
-                    'name'         => $typ['name'],
-                    'entities_id'  => $typ['entities_id'],
-                    'comment'      => $typ['comment'],
-                ];
-                $type_input = Toolbox::addslashes_deep($type_input);
+            $domaintype = $this->storeItem(
+                Domain::class,
+                $core_type_id,
+                Toolbox::addslashes_deep(
+                    [
+                        'name'         => $type_data['name'],
+                        'entities_id'  => $type_data['entities_id'],
+                        'comment'      => $type_data['comment'],
+                    ]
+                ),
+                $progress_bar
+            );
 
-                $domaintype = new DomainType();
-                if ($core_type !== null) {
-                    $res = (bool)$domaintype->update($type_input + ['id' => $core_type]);
-                } else {
-                    $new_tid = (int)$domaintype->add($type_input);
-                    $res = $new_tid > 0;
-                    if ($res) {
-                        $core_types[$typ['name']] = $new_tid;
-                    }
-                }
-
-                if (!$res) {
-                    $has_errors = true;
-
-                    $message = sprintf(
-                        $core_type === null ?
-                        __('Unable to add domain type %s.') :
-                        __('Unable to update domain type %s.'),
-                        $typ['name']
-                    );
-                    $this->outputImportError($message, $progress_bar);
-                    return false;
-                }
-
-                $this->addElementToMapping(
+            if ($domaintype !== null) {
+                $this->defineTargetItem(
                     'PluginDomainsDomaintype',
-                    $typ['id'],
-                    'DomainType',
-                    $new_tid ?? $core_type
+                    $type_data['id'],
+                    DomainType::class,
+                    $domaintype->getID()
                 );
             }
-
-            $progress_bar->finish();
-            $this->output->write(PHP_EOL);
-        } else {
-            $this->output->writeln(
-                '<comment>' . __('No domains types found.') . '</comment>',
-                OutputInterface::VERBOSITY_NORMAL
-            );
         }
 
-        return !$has_errors;
+        $this->output->write(PHP_EOL);
     }
 
     /**
-     * Migrate domains
+     * Migrate domains.
      *
-     * @throws LogicException
-     *
-     * @return boolean
+     * @return void
      */
-    protected function importDomains()
+    protected function importDomains(): void
     {
-        $has_errors = false;
-
         $this->output->writeln(
-            '<comment>' . __('Importing domains...') . '</comment>',
+            '<comment>' . sprintf(__('Importing %s...'), Domain::getTypeName(Session::getPluralNumber())) . '</comment>',
             OutputInterface::VERBOSITY_NORMAL
         );
 
@@ -412,148 +182,86 @@ class DomainsPluginToCoreCommand extends AbstractCommand
             'ORDER'  => 'id ASC'
         ]);
 
-        $core_domains = [];
-        $cored_iterator = $this->db->request([
-            'SELECT' => ['id', 'name'],
-            'FROM'   => Domain::getTable()
-        ]);
-        foreach ($cored_iterator as $row) {
-            $core_domains[$row['name']] = $row['id'];
+        if ($domains_iterator->count() === 0) {
+            $this->output->writeln('<comment>' . __('No elements found.') . '</comment>');
+            return;
         }
 
-        if ($domains_iterator->count()) {
-            $progress_bar = new ProgressBar($this->output, $domains_iterator->count());
-            $progress_bar->start();
+        $progress_bar = new ProgressBar($this->output);
 
-            foreach ($domains_iterator as $dom) {
-                $progress_bar->advance(1);
-                $core_dom = null;
+        foreach ($progress_bar->iterate($domains_iterator) as $domain_data) {
+            $core_domain_id = $this->getMatchingElementId(DomainType::class, ['name' => $domain_data['name']]);
 
-                if (isset($core_domains[$dom['name']])) {
-                    $core_dom = $core_domains[$dom['name']];
-                    $message = sprintf(
-                        __('Updating existing domain %s...'),
-                        $dom['name']
-                    );
-                } else {
-                    $message = sprintf(
-                        __('Importing domain %s...'),
-                        $dom['name']
-                    );
-                }
-                $this->writelnOutputWithProgressBar(
-                    $message,
+            $this->writelnOutputWithProgressBar(
+                sprintf(
+                    $core_domain_id !== null ? __('Updating existing %s "%s"...') : __('Importing %s "%s"...'),
+                    Domain::getTypeName(),
+                    $domain_data['name']
+                ),
+                $progress_bar,
+                OutputInterface::VERBOSITY_VERY_VERBOSE
+            );
+
+            $mapped_type = $this->getTargetItem('PluginDomainsDomaintype', $domain_data['plugin_domains_domaintypes_id']);
+            if ($domain_data['plugin_domains_domaintypes_id'] != 0 && $mapped_type === null) {
+                $this->handleImportError(
+                    sprintf(
+                        __('Unable to find target item for %s #%s.'),
+                        'PluginDomainsDomaintype',
+                        $domain_data['plugin_domains_domaintypes_id']
+                    ),
                     $progress_bar,
-                    OutputInterface::VERBOSITY_VERY_VERBOSE
+                    true // Do not block migration as this error is probably resulting in presence of obsolete data in DB
                 );
-
-                $mapped_type = $this->getCorrespondingItem('PluginDomainsDomaintype', $dom['plugin_domains_domaintypes_id']);
-                if ($dom['plugin_domains_domaintypes_id'] != 0 && $mapped_type === null) {
-                     $message = sprintf(
-                         __('Unable to find mapping for type %s.'),
-                         $dom['plugin_domains_domaintypes_id']
-                     );
-                       $this->outputImportError($message, $progress_bar);
-                       return false;
-                }
-                $types_id = $mapped_type !== null ? $mapped_type->fields['id'] : 0;
-                $domain_input = [
-                    'name'                  => $dom['name'],
-                    'entities_id'           => $dom['entities_id'],
-                    'is_recursive'          => $dom['is_recursive'],
-                    'domaintypes_id'        => $types_id,
-                    'date_creation'         => $dom['date_creation'],
-                    'date_expiration'       => $dom['date_expiration'],
-                    'users_id_tech'         => $dom['users_id_tech'],
-                    'groups_id_tech'        => $dom['groups_id_tech'],
-                //suppliers_id not present in core
-                    'comment'               => $dom['comment'],
-                    'others'                => $dom['others'],
-                    'is_helpdesk_visible'   => $dom['is_helpdesk_visible'],
-                    'date_mod'              => $dom['date_mod'],
-                    'is_deleted'            => $dom['is_deleted']
-                ];
-                $domain_input = Toolbox::addslashes_deep($domain_input);
-
-                $domain = new Domain();
-                if ($core_dom !== null) {
-                    $res = (bool)$domain->update($domain_input + ['id' => $core_dom]);
-                } else {
-                    $new_did = (int)$domain->add($domain_input);
-                    $res = $new_did > 0;
-                    if ($res) {
-                        $core_domains[$dom['name']] = $new_did;
-                    }
-                }
-
-                if (!$res) {
-                    $has_errors = true;
-
-                    $message = sprintf(
-                        $core_dom === null ?
-                        __('Unable to add domain %s.') :
-                        __('Unable to update domain %s.'),
-                        $dom['name']
-                    );
-                    $this->outputImportError($message, $progress_bar);
-                    return false;
-                }
-
-                $this->addElementToMapping(
-                    'PluginDomainsDomains',
-                    $dom['id'],
-                    'Domain',
-                    $new_did ?? $core_dom
-                );
-
-               //handle infocoms
-                $infocom = new \Infocom();
-                $infocom_input = [
-                    'itemtype'     => 'Domain',
-                    'items_id'     => $new_did ?? $core_dom,
-                    'suppliers_id' => $dom['suppliers_id'],
-                    'entities_id'  => $dom['entities_id'],
-                    'is_recursive' => $dom['is_recursive']
-                ];
-                if ($core_dom === null) {
-                    $infocom->add($infocom_input);
-                } else {
-                    $found = $infocom->getFromDBByCrit([
-                        'itemtype'  => 'Domain',
-                        'items_id'  => $core_dom
-                    ]);
-                    if ($found) {
-                        $infocom_input['id'] = $infocom->fields['id'];
-                        $infocom->update($infocom_input);
-                    } else {
-                        $infocom->add($infocom_input);
-                    }
-                }
             }
 
-            $progress_bar->finish();
-            $this->output->write(PHP_EOL);
-        } else {
-            $this->output->writeln(
-                '<comment>' . __('No domains found.') . '</comment>',
-                OutputInterface::VERBOSITY_NORMAL
+            $domain = $this->storeItem(
+                Domain::class,
+                $core_domain_id,
+                Toolbox::addslashes_deep(
+                    [
+                        'name'                  => $domain_data['name'],
+                        'entities_id'           => $domain_data['entities_id'],
+                        'is_recursive'          => $domain_data['is_recursive'],
+                        'domaintypes_id'        => $mapped_type !== null ? $mapped_type->getID() : 0,
+                        'date_creation'         => $domain_data['date_creation'],
+                        'date_expiration'       => $domain_data['date_expiration'],
+                        'users_id_tech'         => $domain_data['users_id_tech'],
+                        'groups_id_tech'        => $domain_data['groups_id_tech'],
+                        //suppliers_id handled in infocom
+                        'comment'               => $domain_data['comment'],
+                        'date_mod'              => $domain_data['date_mod'],
+                        'is_deleted'            => $domain_data['is_deleted']
+                    ]
+                ),
+                $progress_bar
             );
+
+            if ($domain !== null) {
+                $this->defineTargetItem(
+                    'PluginDomainsDomains',
+                    $domain_data['id'],
+                    Domain::class,
+                    $domain->getID()
+                );
+                if (!empty($domain_data['suppliers_id'])) {
+                    $this->storeInfocomForItem($domain, ['suppliers_id' => $domain_data['suppliers_id']], $progress_bar);
+                }
+            }
         }
 
-        return !$has_errors;
+        $this->output->write(PHP_EOL);
     }
 
     /**
      * Migrate domain items
      *
-     * @return boolean
+     * @return void
      */
-    protected function importDomainItems()
+    protected function importDomainItems(): void
     {
-        $has_errors = false;
-
         $this->output->writeln(
-            '<comment>' . __('Importing domains items...') . '</comment>',
+            '<comment>' . sprintf(__('Importing %s...'), Domain_Item::getTypeName(Session::getPluralNumber())) . '</comment>',
             OutputInterface::VERBOSITY_NORMAL
         );
 
@@ -562,184 +270,71 @@ class DomainsPluginToCoreCommand extends AbstractCommand
             'ORDER'  => 'id ASC'
         ]);
 
-        $core_items = [];
-        $coreitems_iterator = $this->db->request([
-            'FROM'   => Domain_Item::getTable()
-        ]);
-        foreach ($coreitems_iterator as $row) {
-            $core_items[$row['domains_id'] . $row['itemtype'] . $row['items_id']] = $row['id'];
+        if ($items_iterator->count() === 0) {
+            $this->output->writeln('<comment>' . __('No elements found.') . '</comment>');
+            return;
         }
 
-        if ($items_iterator->count()) {
-            $progress_bar = new ProgressBar($this->output, $items_iterator->count());
-            $progress_bar->start();
+        $progress_bar = new ProgressBar($this->output);
 
-            foreach ($items_iterator as $itm) {
-                $progress_bar->advance(1);
-                $core_item = null;
-                $mapped_domain = $this->getCorrespondingItem('PluginDomainsDomains', $itm['plugin_domains_domains_id']);
-                if ($mapped_domain === null) {
-                    $message = sprintf(
-                        __('Unable to find corresponding domain for item %s (%s).'),
-                        $itm['itemtype'],
-                        $itm['items_id']
-                    );
-                     $this->outputImportError($message, $progress_bar);
-                     // Do not block migration as this error is probably resulting in presence of obsolete data in DB
-                     continue;
-                }
-                $domains_id = $mapped_domain->fields['id'];
-
-                if (isset($core_items[$domains_id . $itm['itemtype'] . $itm['items_id']])) {
-                    $core_item = $core_items[$domains_id . $itm['itemtype'] . $itm['items_id']];
-                    $message = sprintf(
-                        __('Skip existing domain item %s...'),
-                        $domains_id . ' ' . $itm['itemtype'] . ' ' . $itm['items_id']
-                    );
-                } else {
-                    $message = sprintf(
-                        __('Importing domain item %s...'),
-                        $domains_id . ' ' . $itm['itemtype'] . ' ' . $itm['items_id']
-                    );
-                }
-                $this->writelnOutputWithProgressBar(
-                    $message,
+        foreach ($progress_bar->iterate($items_iterator) as $relation_data) {
+            $mapped_domain = $this->getTargetItem('PluginDomainsDomains', $relation_data['plugin_domains_domains_id']);
+            if ($mapped_domain === null) {
+                $this->handleImportError(
+                    sprintf(
+                        __('Unable to find target item for %s #%s.'),
+                        'PluginDomainsDomains',
+                        $relation_data['plugin_domains_domains_id']
+                    ),
                     $progress_bar,
-                    OutputInterface::VERBOSITY_VERY_VERBOSE
+                    true // Do not block migration as this error is probably resulting in presence of obsolete data in DB
                 );
-
-                if ($core_item !== null) {
-                     //if it already exist in DB, there is nothing to change
-                     continue;
-                }
-
-                $item_input = [
-                    'domains_id'            => $domains_id,
-                    'itemtype'              => $itm['itemtype'],
-                    'items_id'              => $itm['items_id'],
-                    'domainrelations_id'    => 0
-                ];
-                $item_input = Toolbox::addslashes_deep($item_input);
-
-                $item = new Domain_Item();
-                $new_iid = (int)$item->add($item_input);
-                $res = $new_iid > 0;
-                if ($res) {
-                    $core_items[$domains_id . $itm['itemtype'] . $itm['items_id']] = $new_iid;
-                }
-
-                if (!$res) {
-                    $has_errors = true;
-
-                    $message = sprintf(
-                        $core_item === null ?
-                        __('Unable to add domain item %s.') :
-                        __('Unable to update domain item %s.'),
-                        $domains_id . ' ' . $itm['itemtype'] . ' ' . $itm['items_id']
-                    );
-                    $this->outputImportError($message, $progress_bar);
-                    return false;
-                }
+                continue;
             }
+            $domains_id = $mapped_domain->fields['id'];
 
-            $progress_bar->finish();
-            $this->output->write(PHP_EOL);
-        } else {
-            $this->output->writeln(
-                '<comment>' . __('No domains items found.') . '</comment>',
-                OutputInterface::VERBOSITY_NORMAL
+            $core_relation_id = $this->getMatchingElementId(
+                Domain_Item::class,
+                [
+                    'domains_id' => $domains_id,
+                    'itemtype'   => $relation_data['itemtype'],
+                    'items_id'   => $relation_data['items_id'],
+                ]
             );
-        }
 
-        return !$has_errors;
-    }
-
-
-    /**
-     * Add an element to mapping.
-     *
-     * @param string  $old_itemtype
-     * @param integer $old_id
-     * @param string  $new_itemtype
-     * @param integer $new_id
-     *
-     * @return void
-     */
-    private function addElementToMapping($old_itemtype, $old_id, $new_itemtype, $new_id)
-    {
-
-        if (!array_key_exists($old_itemtype, $this->elements_mapping)) {
-            $this->elements_mapping[$old_itemtype] = [];
-        }
-        $this->elements_mapping[$old_itemtype][$old_id] = [
-            'itemtype' => $new_itemtype,
-            'id'       => $new_id,
-        ];
-    }
-
-    /**
-     * Returns item corresponding to itemtype and id.
-     * If item has been migrated to another itemtype, il will return the new item.
-     *
-     * @param string  $itemtype
-     * @param integer $id
-     *
-     * @return null|CommonDBTM
-     */
-    private function getCorrespondingItem($itemtype, $id)
-    {
-
-        if (
-            array_key_exists($itemtype, $this->elements_mapping)
-            && array_key_exists($id, $this->elements_mapping[$itemtype])
-        ) {
-           // Element exists in mapping, get new element
-            $mapping  = $this->elements_mapping[$itemtype][$id];
-            $id       = $mapping['id'];
-            $itemtype = $mapping['itemtype'];
-        }
-
-        if (!class_exists($itemtype)) {
-            return null;
-        }
-
-        $item = new $itemtype();
-        if ($id !== 0 && !$item->getFromDB($id)) {
-            return null;
-        }
-
-        return $item;
-    }
-
-    /**
-     * Output import error message.
-     *
-     * @param string           $message
-     * @param ProgressBar|null $progress_bar
-     *
-     * @return void
-     */
-    private function outputImportError($message, ProgressBar $progress_bar = null)
-    {
-
-        $verbosity = OutputInterface::VERBOSITY_QUIET;
-
-        $message = '<error>' . $message . '</error>';
-
-        if ($progress_bar instanceof ProgressBar) {
             $this->writelnOutputWithProgressBar(
-                $message,
+                sprintf(
+                    $core_relation_id !== null ? __('Skip existing %s "%s".') : __('Importing %s "%s"...'),
+                    Domain_Item::getTypeName(),
+                    $domains_id . ' ' . $relation_data['itemtype'] . ' ' . $relation_data['items_id']
+                ),
                 $progress_bar,
-                $verbosity
+                OutputInterface::VERBOSITY_VERY_VERBOSE
             );
-        } else {
-            if ($progress_bar instanceof ProgressBar) {
-                $this->output->write(PHP_EOL); // Keep progress bar last state and go to next line
+
+            if ($core_relation_id !== null) {
+                 //if it already exist in DB, there is nothing to change
+                 continue;
             }
-            $this->output->writeln(
-                $message,
-                $verbosity
-            );
+
+            $item_input = Toolbox::addslashes_deep([
+                'domains_id'            => $domains_id,
+                'itemtype'              => $relation_data['itemtype'],
+                'items_id'              => $relation_data['items_id'],
+                'domainrelations_id'    => 0
+            ]);
+
+            $item = new Domain_Item();
+            if ($item->add($item_input) === false) {
+                $message = sprintf(
+                    __('Unable to create %s "%s" (%d).'),
+                    Domain_Item::getTypeName(),
+                    $domains_id . ' ' . $relation_data['itemtype'] . ' ' . $relation_data['items_id']
+                );
+                $this->handleImportError($message, $progress_bar);
+            }
         }
+
+        $this->output->write(PHP_EOL);
     }
 }

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -47,6 +47,10 @@ class Document_Item extends CommonDBRelation
     public static $items_id_2    = 'items_id';
     public static $take_entity_2 = false;
 
+    public static function getTypeName($nb = 0)
+    {
+        return _n('Document item', 'Document items', $nb);
+    }
 
     public function getForbiddenStandardMassiveAction()
     {

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -42,6 +42,11 @@ class Domain_Item extends CommonDBRelation
 
     public static $rightname = 'domain';
 
+    public static function getTypeName($nb = 0)
+    {
+        return _n('Domain item', 'Domain items', $nb);
+    }
+
     public static function cleanForItem(CommonDBTM $item)
     {
         $temp = new self();

--- a/src/Item_Problem.php
+++ b/src/Item_Problem.php
@@ -46,7 +46,10 @@ class Item_Problem extends CommonItilObject_Item
     public static $items_id_2          = 'items_id';
     public static $checkItem_2_Rights  = self::HAVE_VIEW_RIGHT_ON_ITEM;
 
-
+    public static function getTypeName($nb = 0)
+    {
+        return _n('Problem item', 'Problem items', $nb);
+    }
 
     public function getForbiddenStandardMassiveAction()
     {

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -48,7 +48,10 @@ class Item_Project extends CommonDBRelation
     public static $items_id_2          = 'items_id';
     public static $checkItem_2_Rights  = self::HAVE_VIEW_RIGHT_ON_ITEM;
 
-
+    public static function getTypeName($nb = 0)
+    {
+        return _n('Project item', 'Project items', $nb);
+    }
 
     public function getForbiddenStandardMassiveAction()
     {

--- a/src/Item_Ticket.php
+++ b/src/Item_Ticket.php
@@ -48,7 +48,10 @@ class Item_Ticket extends CommonItilObject_Item
     public static $items_id_2          = 'items_id';
     public static $checkItem_2_Rights  = self::HAVE_VIEW_RIGHT_ON_ITEM;
 
-
+    public static function getTypeName($nb = 0)
+    {
+        return _n('Ticket item', 'Ticket items', $nb);
+    }
 
     /**
      * @since 0.84


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I transformed the database plugin migration to make it non destructive. It means that it will not erase existing core databases, and that it can be replayed if it fails in the middle of the migration.

I also refactored the domains plugin migration, as lot of code can be shared.

Now, it will be easier to produce plugins migration commands.