### PR TITLE
AbstractRightDropdown value parsing in front files

### DIFF
--- a/src/AbstractRightsDropdown.php
+++ b/src/AbstractRightsDropdown.php
@@ -290,7 +290,7 @@ abstract class AbstractRightsDropdown
      *
      * @return array List of ids
      */
-    public static function inflateValues(array $values, string $class): array
+    public static function getPostedIds(array $values, string $class): array
     {
         $inflated_values = [];
 

--- a/src/AbstractRightsDropdown.php
+++ b/src/AbstractRightsDropdown.php
@@ -268,4 +268,43 @@ abstract class AbstractRightsDropdown
 
         return $groups_items;
     }
+
+    /**
+     * To be used in front files dealing with dropdown input created by
+     * static::show()
+     * Read values from a "flattened" select 2 multi itemtype dropdown like this:
+     * [
+     *    0 => 'users_id-3',
+     *    1 => 'users_id-14',
+     *    2 => 'groups_id-2',
+     *    3 => 'groups_id-78',
+     *    4 => 'profiles_id-1',
+     * ]
+     * into an array containings the ids of the specified $class parameter:
+     * $class = User -> [3, 14]
+     * $class = Group -> [2, 78]
+     * $class = Profile -> [1]
+     *
+     * @param array  $values Flattened array containing multiple itemtypes and ids
+     * @param string $class  Class to filter results on
+     *
+     * @return array List of ids
+     */
+    public static function inflateValues(array $values, string $class): array
+    {
+        $inflated_values = [];
+
+        foreach ($values as $value) {
+            // Split fkey and ids
+            $parsed_values = explode("-", $value);
+            $fkey  = $parsed_values[0];
+            $value = $parsed_values[1];
+
+            if ($fkey == $class::getForeignKeyField()) {
+                $inflated_values[] = $value;
+            }
+        }
+
+        return $inflated_values;
+    }
 }

--- a/tests/units/AbstractRightsDropdown.php
+++ b/tests/units/AbstractRightsDropdown.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Change;
+use Generator;
+use Group;
+use Profile;
+use Ticket;
+use User;
+
+class AbstractRightsDropdown extends \GLPITestCase
+{
+    protected function testInflateValuesProvider(): Generator
+    {
+        $flat_values_set = [
+            'users_id-3',
+            'users_id-14',
+            'groups_id-2',
+            'groups_id-78',
+            'profiles_id-1',
+        ];
+
+        // Test 1: looking for users_id
+        yield [
+            'values'       => $flat_values_set,
+            'class'        => User::class,
+            'expected_ids' => [3, 14],
+        ];
+
+        // Test 2: looking for groups_id
+        yield [
+            'values'       => $flat_values_set,
+            'class'        => Group::class,
+            'expected_ids' => [2, 78],
+        ];
+
+        // Test 3: looking for profiles_id
+        yield [
+            'values'       => $flat_values_set,
+            'class'        => Profile::class,
+            'expected_ids' => [1],
+        ];
+
+        // Test 4: looking for tickets_id (no values)
+        yield [
+            'values'       => $flat_values_set,
+            'class'        => Ticket::class,
+            'expected_ids' => [],
+        ];
+
+        // Test 5: empty input
+        yield [
+            'values'       => [],
+            'class'        => Change::class,
+            'expected_ids' => [],
+        ];
+    }
+
+    /**
+     * @dataprovider testInflateValuesProvider
+     */
+    public function testInflateValues(
+        array $values,
+        string $class,
+        array $expected_ids
+    ): void {
+        $ids = \AbstractRightsDropdown::inflateValues($values, $class);
+        $this->array($ids)->isEqualTo($expected_ids);
+    }
+}

--- a/tests/units/AbstractRightsDropdown.php
+++ b/tests/units/AbstractRightsDropdown.php
@@ -42,7 +42,7 @@ use User;
 
 class AbstractRightsDropdown extends \GLPITestCase
 {
-    protected function testInflateValuesProvider(): Generator
+    protected function testGetPostedIdsProvider(): Generator
     {
         $flat_values_set = [
             'users_id-3',
@@ -89,14 +89,14 @@ class AbstractRightsDropdown extends \GLPITestCase
     }
 
     /**
-     * @dataprovider testInflateValuesProvider
+     * @dataprovider testGetPostedIdsProvider
      */
-    public function testInflateValues(
+    public function testGetPostedIds(
         array $values,
         string $class,
         array $expected_ids
     ): void {
-        $ids = \AbstractRightsDropdown::inflateValues($values, $class);
+        $ids = \AbstractRightsDropdown::getPostedIds($values, $class);
         $this->array($ids)->isEqualTo($expected_ids);
     }
 }


### PR DESCRIPTION
Suggested by @btry in https://github.com/pluginsGLPI/formcreator/pull/2615#discussion_r811924588.

The `AbstractRightDropdown` dropdown will post "flattened" values in the `$_POST` data, like this:
```php
[
     'users_id-3'
     'users_id-14
     'groups_id-2'
     'groups_id-78'
     'profiles_id-1'
]
```

Each front files handling these values must parse this array to get the matching ids for each expected itemtype.
```php
foreach ($_POST['restrictions'] ?? [] as $restriction_values) {
   // Split fkey and ids
   $restriction_values = explode("-", $restriction);
   $fkey = $restriction_values[0];
   $value = $restriction_values[1];

   // Parse values
   if ($fkey == User::getForeignKeyField()) {
      $input['users'][] = $value;
   } elseif ($fkey == Group::getForeignKeyField()) {
      $input['groups'][] = $value;
   } elseif ($fkey == Profile::getForeignKeyField()) {
      $input['profiles'][] = $value;
   }
}
```

With this changes, we only need to call the new `AbstractRightsDropdown::getPostedIds` method, which is centralized and unit tested:
```php
$restrictions = $_POST['restrictions'] ?? [];
$input['users']    = AbstractRightsDropdown::getPostedIds($restrictions, User::class);
$input['groups']   = AbstractRightsDropdown::getPostedIds($restrictions, Group::class);
$input['profiles'] = AbstractRightsDropdown::getPostedIds($restrictions, Profile::class);
```

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
