### PR TITLE
Prevent errors on existing ZERO_DATE values

### DIFF
--- a/src/Console/Migration/TimestampsCommand.php
+++ b/src/Console/Migration/TimestampsCommand.php
@@ -115,6 +115,18 @@ class TimestampsCommand extends AbstractCommand
                         $nullable = true;
                     }
 
+                    // Fix invalid zero dates
+                    $this->db->update(
+                        $table['TABLE_NAME'],
+                        [
+                            $column['COLUMN_NAME'] => $nullable ? null : '1970-01-01 00:00:01'
+                        ],
+                        [
+                            ['NOT' => [$column['COLUMN_NAME'] => null]],
+                            [$column['COLUMN_NAME'] => ['<', '1970-01-01 00:00:01']],
+                        ]
+                    );
+
                      //guess default value
                     if (is_null($column['COLUMN_DEFAULT']) && !$nullable) { // no default
                       // Prevent MySQL/MariaDB to force "default current_timestamp on update current_timestamp"

--- a/src/Update.php
+++ b/src/Update.php
@@ -161,6 +161,12 @@ class Update
 
         $DB = $this->DB;
 
+        // Remove the `NO_ZERO_DATE` flag to prevent failure on `ALTER TABLE` operations when
+        // a row contains a `0000-00-00 00:00:00` datetime value.
+        // Unitary removal of this flag is tricky as MySQL 8.0 triggers warning if
+        // `STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO` are not used all together.
+        $DB->query("SET SESSION sql_mode = ''");
+
        // To prevent problem of execution time
         ini_set("max_execution_time", "0");
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a table structure is changed (i.e. altering any field type), existing "zero dates" (i.e. `0000-00-00 00:00:00`) are trigerring errors as we do not anymore remove the `NO_ZERO_DATE` flag from `sql_mode`:
```
SQL Error "1292": Incorrect datetime value: '0000-00-00 00:00:00' for column 'date_creation' at row 2 in query "ALTER TABLE `glpi_domains`  	 MODIFY COLUMN `date_creation` TIMESTAMP NULL DEFAULT NULL; "
```

To prevent this, I propose:
1. to fix existing "zero dates" in timestamps migration. This is anymay mandatory if we want this migration to not fail in this case;
2. to set the `sql_mode` to empty during migrations.

I would prefer something else than setting the `sql_mode` to empty in updates, but I did not find an alternative solution.