### PR TITLE
Minor CSS Fixes

### DIFF
--- a/css/includes/_highcontrast.scss
+++ b/css/includes/_highcontrast.scss
@@ -183,7 +183,6 @@
     }
 
     .btn.btn-ghost-secondary {
-        border-color: $hc-border-color-contrast;
         border: 1px solid $hc-border-color-contrast;
     }
 

--- a/css/includes/components/_fileupload.scss
+++ b/css/includes/components/_fileupload.scss
@@ -35,9 +35,8 @@
     background: #cccccc1c;
     min-height: 65px;
     border-radius: 5px;
-    margin: 0.5em auto;
     padding: 0.5em;
-    margin-top: 5px;
+    margin: 5px auto 0.5em;
     width: 100%;
 
     input[type="file"] {

--- a/css/includes/components/_gantt.scss
+++ b/css/includes/components/_gantt.scss
@@ -149,7 +149,6 @@
 }
 
 .gantt_tooltip {
-    left: 350 !important;
     box-sizing: border-box;
     white-space: pre-line;
     overflow-wrap: break-word;

--- a/css/includes/components/_global-menu.scss
+++ b/css/includes/components/_global-menu.scss
@@ -49,7 +49,7 @@
         &:hover {
             background-color: rgba($color: $mainmenu-fg, $alpha: 80%);
             color: rgba($color: $mainmenu-bg, $alpha: 80%);
-            border-color: transparend;
+            border-color: transparent;
         }
     }
 }

--- a/css/includes/components/_racks.scss
+++ b/css/includes/components/_racks.scss
@@ -51,15 +51,11 @@
 
         /* fallback */
         cursor: grab;
-        cursor: grab;
-        cursor: grab;
 
         &:active {
             cursor: move;
 
             /* fallback */
-            cursor: grabbing;
-            cursor: grabbing;
             cursor: grabbing;
         }
     }

--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -111,8 +111,7 @@
                 right: auto;
                 top: -1px;
                 bottom: auto;
-                border: 7px solid;
-                border-color: transparent;
+                border: 7px solid transparent;
             }
 
             &::after {
@@ -124,8 +123,7 @@
                 right: auto;
                 top: 0;
                 bottom: auto;
-                border: 6px solid;
-                border-color: transparent;
+                border: 6px solid transparent;
             }
 
             &.t-right {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Gantt tooltip `left` style removed completely as it wasn't working with its invalid value and no units make it display correctly. Without the property, the tooltips show OK.