### PR TITLE
Do not support legacy data (ZERO_DATE) on future GLPI instances

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -310,6 +310,7 @@ $default_prefs = [
     'document_max_size'                       => max(1, floor(Toolbox::return_bytes_from_ini_vars(ini_get('upload_max_filesize')) / 1024 / 1024)),
     'planning_work_days'                      => exportArrayToDB([0, 1, 2, 3, 4, 5, 6]),
     'system_user'                             => 6,
+    'support_legacy_data'                     => 0, // New installation should not support legacy data
 ];
 
 $tables['glpi_configs'] = [];

--- a/install/migrations/update_9.5.x_to_10.0.0/configs.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/configs.php
@@ -52,6 +52,7 @@ $migration->addConfig([
     'noreply_email_name'    => '',
     'replyto_email'         => '',
     'replyto_email_name'    => '',
+    'support_legacy_data'   => 1, // GLPI instances updated from GLPI < 10.0 should support legacy data
 ]);
 $migration->addField("glpi_users", "default_central_tab", "tinyint DEFAULT 0");
 $migration->addField('glpi_users', 'page_layout', 'char(20) DEFAULT NULL', ['after' => 'palette']);

--- a/src/Config.php
+++ b/src/Config.php
@@ -2925,6 +2925,22 @@ HTML;
         return $result;
     }
 
+
+    /**
+     * Get config value
+     *
+     * @param $context  string   context to get values (default for glpi is core)
+     * @param $name     string   config name
+     *
+     * @return mixed
+     *
+     * @since 10.0.0
+     */
+    public static function getConfigurationValue(string $context, string $name)
+    {
+        return self::getConfigurationValues($context, [$name])[$name] ?? null;
+    }
+
     /**
      * Load legacy configuration into $CFG_GLPI global variable.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Follows #10783.

With this logic, updates GLPI that has been initiated on GLPI 10.0+ will not use the empty `sql_mode`.

It would also permit, in the future, to propose a command that fixes legacy data, and to set this flag to 0 on GLPI that has been initiated in older versions.