### PR TITLE
Fix dropdown buttons click area and tooltips

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -318,7 +318,7 @@ class Dropdown
                 && $params['addicon']
             ) {
                   $icons .= '<div class="btn btn-outline-secondary"
-                               title="' . __s('Add') . '" data-bs-toggle="modal" data-bs-target="#add_'.$field_id.'">';
+                               title="' . __s('Add') . '" data-bs-toggle="modal" data-bs-target="#add_' . $field_id . '">';
                   $icons .= Ajax::createIframeModalWindow('add_' . $field_id, $item->getFormURL(), ['display' => false]);
                   $icons .= "<span data-bs-toggle='tooltip'>
                   <i class='fa-fw ti ti-plus'></i>

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -300,7 +300,6 @@ class Dropdown
             }
 
            // Comment icon
-            $icons .= '<div class="btn btn-outline-secondary">';
             $icons .= Ajax::updateItemOnSelectEvent(
                 $field_id,
                 $comment_id,
@@ -308,8 +307,8 @@ class Dropdown
                 $paramscomment,
                 false
             );
+            $options_tooltip['link_class'] = 'btn btn-outline-secondary';
             $icons .= Html::showToolTip($comment, $options_tooltip);
-            $icons .= '</div>';
 
            // Add icon
             if (
@@ -319,10 +318,9 @@ class Dropdown
                 && $params['addicon']
             ) {
                   $icons .= '<div class="btn btn-outline-secondary"
-                               title="' . __s('Add') . '" data-bs-toggle="tooltip">';
+                               title="' . __s('Add') . '" data-bs-toggle="modal" data-bs-target="#add_'.$field_id.'">';
                   $icons .= Ajax::createIframeModalWindow('add_' . $field_id, $item->getFormURL(), ['display' => false]);
-                  $icons .= "<span data-bs-toggle='modal' data-bs-target='#add_$field_id'
-                           >
+                  $icons .= "<span data-bs-toggle='tooltip'>
                   <i class='fa-fw ti ti-plus'></i>
                   <span class='sr-only'>" . __s('Add') . "</span>
                </span>";

--- a/src/Html.php
+++ b/src/Html.php
@@ -3629,7 +3629,7 @@ JS;
                 $out .= "</a>";
             }
 
-            $param['applyto'] = "tooltip$rand";
+            $param['applyto'] = (!empty($param['link']) && !empty($param['linkid'])) ? $param['linkid'] : "tooltip$rand";
         }
 
         if (empty($param['contentid'])) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -3569,18 +3569,21 @@ JS;
      **/
     public static function showToolTip($content, $options = [])
     {
-        $param['applyto']    = '';
-        $param['title']      = '';
-        $param['contentid']  = '';
-        $param['link']       = '';
-        $param['linkid']     = '';
-        $param['linktarget'] = '';
-        $param['awesome-class'] = 'fa-info';
-        $param['popup']      = '';
-        $param['ajax']       = '';
-        $param['display']    = true;
-        $param['autoclose']  = true;
-        $param['onclick']    = false;
+        $param = [
+            'applyto'       => '',
+            'title'         => '',
+            'contentid'     => '',
+            'link'          => '',
+            'linkid'        => '',
+            'linktarget'    => '',
+            'awesome-class' => 'fa-info',
+            'popup'         => '',
+            'ajax'          => '',
+            'display'       => true,
+            'autoclose'     => true,
+            'onclick'       => false,
+            'link_class'    => '',
+        ];
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -3603,7 +3606,7 @@ JS;
         if (empty($param['applyto'])) {
             if (!empty($param['link'])) {
                 $out .= "<a id='" . (!empty($param['linkid']) ? $param['linkid'] : "tooltiplink$rand") . "'
-                        class='dropdown_tooltip'";
+                        class='dropdown_tooltip {$param['link_class']}'";
 
                 if (!empty($param['linktarget'])) {
                     $out .= " target='" . $param['linktarget'] . "' ";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The buttons to the right of some dropdowns (info and add) were only clickable over the icon itself. I found that the area the tooltip showed for "info" was also just over the icon.