### PR TITLE
FIx creating item_device from form

### DIFF
--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -1423,6 +1423,7 @@ class Item_Devices extends CommonDBRelation
 
         echo "<tr class='tab_bg_1'><td>" . _n('Item', 'Items', 1) . "</td>";
         echo "<td>";
+        echo Html::hidden(self::$itemtype_1, ['value' => $this->fields[self::$itemtype_1] ?? '']);
         if ($item === false) {
             echo __('No associated item');
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10778 

When you have a component in the Assets menu and then try adding a component from that page, it opens the Item_Device form. This form doesn't allow you to set the linked item and it doesn't handle an empty itemtype. Adding an Item_Device requires this field to at least be set to an empty string.