### PR TITLE
Decrease Kanban team member padding

### DIFF
--- a/templates/components/kanban/item_panels/default_panel.html.twig
+++ b/templates/components/kanban/item_panels/default_panel.html.twig
@@ -78,7 +78,7 @@
                      <h5>{{ item.getTeamRoleName(team_role, get_plural_number()) }}</h5>
                      <ul class="list-group team-list" data-role="{{ team_role }}">
                         {% for team_member in role_members %}
-                           <li class="list-group-item d-flex justify-content-between" data-itemtype="{{ team_member.itemtype }}"
+                           <li class="list-group-item d-flex justify-content-between p-2" data-itemtype="{{ team_member.itemtype }}"
                                data-items_id="{{ team_member.items_id }}"
                                data-name="{{ team_member.display_name|default(team_member.name)|verbatim_value }}"
                                data-firstname="{{ team_member.firstname|verbatim_value }}"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The default padding for list-group-item is a bit too high for the team member list for Kanban. Adding `p-2` to those elements, reclaims some wasted space while still having enough to separate items.