### PR TITLE
Update @tabler/core to 1.0.0-beta9

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -304,12 +304,3 @@ table {
     background-color: $color-contrast-light;
     color: $dark;
 }
-
-.list-group .list-group-item {
-    color: inherit;
-    border-color: $table-border-color;
-
-    &:hover {
-        background-color: $hover-bg;
-    }
-}

--- a/css/includes/_fonts.scss
+++ b/css/includes/_fonts.scss
@@ -29,7 +29,22 @@
  * ---------------------------------------------------------------------
  */
 
-$assets-base: "../css/lib/tabler/core/dist"; // Tabler assets base url
+@import "~@fontsource/inter/scss/mixins";
+
+$fontDir: "../css/lib/fontsource/inter/files";
+
+@include fontFace($weight: 100);
+@include fontFace($weight: 200);
+@include fontFace($weight: 300);
+@include fontFace($weight: 400);
+@include fontFace($weight: 500);
+@include fontFace($weight: 600);
+@include fontFace($weight: 700);
+@include fontFace($weight: 800);
+@include fontFace($weight: 900);
+
+$google-font: false;
+$font-family-sans-serif: inter, -apple-system, blinkmacsystemfont, san francisco, segoe ui, roboto, helvetica neue, sans-serif !default;
 $ti-font-path: "../css/lib/tabler/icons/iconfont/fonts";
 
 @import "~@tabler/icons/iconfont/tabler-icons";

--- a/css/includes/_fonts.scss
+++ b/css/includes/_fonts.scss
@@ -43,7 +43,6 @@ $fontDir: "../css/lib/fontsource/inter/files";
 @include fontFace($weight: 800);
 @include fontFace($weight: 900);
 
-$google-font: false;
 $font-family-sans-serif: inter, -apple-system, blinkmacsystemfont, san francisco, segoe ui, roboto, helvetica neue, sans-serif !default;
 $ti-font-path: "../css/lib/tabler/icons/iconfont/fonts";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "license": "GPL-2.0",
             "dependencies": {
                 "@eastdesire/jscolor": "^2.4.6",
+                "@fontsource/inter": "^4.5.4",
                 "@fortawesome/fontawesome-free": "^6.0.0",
                 "@fullcalendar/bootstrap": "^4.4.0",
                 "@fullcalendar/core": "^4.4.0",
@@ -1811,6 +1812,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/@fontsource/inter": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-4.5.4.tgz",
+            "integrity": "sha512-D0icTFpt9bWvB/OEXMztYf0bhUQZoDIYpsco5C7GVfxgKDRl8Jdn3N2aHHQqwjgRUUvRuyMv8HrRM8Hrt4U52w=="
         },
         "node_modules/@fortawesome/fontawesome-free": {
             "version": "6.0.0",
@@ -12203,6 +12209,11 @@
                     "dev": true
                 }
             }
+        },
+        "@fontsource/inter": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-4.5.4.tgz",
+            "integrity": "sha512-D0icTFpt9bWvB/OEXMztYf0bhUQZoDIYpsco5C7GVfxgKDRl8Jdn3N2aHHQqwjgRUUvRuyMv8HrRM8Hrt4U52w=="
         },
         "@fortawesome/fontawesome-free": {
             "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@fullcalendar/list": "^4.4.0",
                 "@fullcalendar/rrule": "^4.4.0",
                 "@fullcalendar/timegrid": "^4.4.0",
-                "@tabler/core": "^v1.0.0-beta8",
+                "@tabler/core": "^1.0.0-beta9",
                 "@tabler/icons": "^1.53.0",
                 "animate.css": "^4.1.1",
                 "bootstrap": "^5.1.1",
@@ -2643,9 +2643,9 @@
             }
         },
         "node_modules/@tabler/core": {
-            "version": "1.0.0-beta8",
-            "resolved": "https://registry.npmjs.org/@tabler/core/-/core-1.0.0-beta8.tgz",
-            "integrity": "sha512-iKdV2JbsmboFq5eMwgLyQDScSTnZ2SR5o/SL9FwDMLcdCDsMO0VHkAxFJso5scYECfWEPzL8/Y6P17UIgNDXkQ==",
+            "version": "1.0.0-beta9",
+            "resolved": "https://registry.npmjs.org/@tabler/core/-/core-1.0.0-beta9.tgz",
+            "integrity": "sha512-4+QYkL+s0IXZUlJc6oNpugVIFgwXOW5HfcxSO08SKCIaa8uGBZ9OqFq5duX+IpG/PWKroEnIQO8XAGELigvK7A==",
             "dependencies": {
                 "@popperjs/core": "^2.11.2",
                 "@tabler/icons": "^1.53.0",
@@ -2659,12 +2659,12 @@
                 "url": "https://github.com/sponsors/codecalm"
             },
             "peerDependencies": {
-                "apexcharts": "^3.33.0",
+                "apexcharts": "^3.33.1",
                 "autosize": "^5.0.1",
-                "choices.js": "^10.0.0",
+                "choices.js": "^10.1.0",
                 "countup.js": "^2.0.8",
                 "flatpickr": "^4.6.9",
-                "imask": "^6.4.0",
+                "imask": "^6.4.2",
                 "jsvectormap": "^1.4.4",
                 "litepicker": "^2.0.12",
                 "nouislider": "^15.5.1",
@@ -12835,9 +12835,9 @@
             }
         },
         "@tabler/core": {
-            "version": "1.0.0-beta8",
-            "resolved": "https://registry.npmjs.org/@tabler/core/-/core-1.0.0-beta8.tgz",
-            "integrity": "sha512-iKdV2JbsmboFq5eMwgLyQDScSTnZ2SR5o/SL9FwDMLcdCDsMO0VHkAxFJso5scYECfWEPzL8/Y6P17UIgNDXkQ==",
+            "version": "1.0.0-beta9",
+            "resolved": "https://registry.npmjs.org/@tabler/core/-/core-1.0.0-beta9.tgz",
+            "integrity": "sha512-4+QYkL+s0IXZUlJc6oNpugVIFgwXOW5HfcxSO08SKCIaa8uGBZ9OqFq5duX+IpG/PWKroEnIQO8XAGELigvK7A==",
             "requires": {
                 "@popperjs/core": "^2.11.2",
                 "@tabler/icons": "^1.53.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     },
     "dependencies": {
         "@eastdesire/jscolor": "^2.4.6",
+        "@fontsource/inter": "^4.5.4",
         "@fortawesome/fontawesome-free": "^6.0.0",
         "@fullcalendar/bootstrap": "^4.4.0",
         "@fullcalendar/core": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "@fullcalendar/list": "^4.4.0",
         "@fullcalendar/rrule": "^4.4.0",
         "@fullcalendar/timegrid": "^4.4.0",
-        "@tabler/core": "^v1.0.0-beta8",
+        "@tabler/core": "^1.0.0-beta9",
         "@tabler/icons": "^1.53.0",
         "animate.css": "^4.1.1",
         "bootstrap": "^5.1.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -178,8 +178,13 @@ var filesToCopy = [
     },
     // SCSS files
     {
+        package: '@fontsource/inter',
+        from: '{scss/mixins.scss,files/*[0-9]00*.woff2}',
+        to: scssOutputPath,
+    },
+    {
         package: '@tabler/core',
-        from: '{dist/fonts/*.woff2,src/scss/**/*.scss}',
+        from: 'src/scss/**/*.scss',
         to: scssOutputPath,
     },
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Inter font has finally been removed from tabler bundle (see https://github.com/tabler/tabler/pull/1048). I had to revert d4a75ab6b046053ea34544820a50f08c3dd06c5e .