### PR TITLE
Prevent empty followups generated by mail collector; fixes #10792

### DIFF
--- a/tests/emails-tests/29.1-ticket-followup-above-header-and-under-footer-lines.eml
+++ b/tests/emails-tests/29.1-ticket-followup-above-header-and-under-footer-lines.eml
@@ -1,0 +1,24 @@
+Return-Path: tech@glpi-project.org
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+	by mail.glpi-project.org (Postfix) with ESMTP id B74527E805E8
+	for <unittests@glpi-project.org>; Wed,  3 Apr 2019 11:48:35 +0200 (CEST)
+Subject: Re: [GLPI #0000101] New database issue
+From: Tech Ni Cian <tech@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <961c2885-94e6-2343-b000-280c809fcdb1@glpi-project.org>
+Date: Wed, 3 Apr 2019 11:48:25 +0200
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Language: fr-FR
+Content-Transfer-Encoding: 7bit
+
+My followup starts above header line...
+
+=-=-=-= To answer by email, write above this line =-=-=-=
+
+HERE IS THE INITIAL NOTIFICATION CONTENT
+
+=_=_=_= To answer by email, write under this line =_=_=_=
+
+...and finishes under footer line.
+

--- a/tests/emails-tests/29.2-ticket-followup-above-header-line.eml
+++ b/tests/emails-tests/29.2-ticket-followup-above-header-line.eml
@@ -1,0 +1,21 @@
+Return-Path: tech@glpi-project.org
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+	by mail.glpi-project.org (Postfix) with ESMTP id B74527E805E8
+	for <unittests@glpi-project.org>; Wed,  3 Apr 2019 11:48:35 +0200 (CEST)
+Subject: Re: [GLPI #0000101] New database issue
+From: Tech Ni Cian <tech@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <961c2885-94e6-2343-b000-280c809fcdb1@glpi-project.org>
+Date: Wed, 3 Apr 2019 11:48:25 +0200
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Language: fr-FR
+Content-Transfer-Encoding: 7bit
+
+My followup is located above header line.
+
+=-=-=-= To answer by email, write above this line =-=-=-=
+
+HERE IS THE INITIAL NOTIFICATION CONTENT
+
+=_=_=_= To answer by email, write under this line =_=_=_=

--- a/tests/emails-tests/29.3-ticket-followup-under-footer-line.eml
+++ b/tests/emails-tests/29.3-ticket-followup-under-footer-line.eml
@@ -1,0 +1,21 @@
+Return-Path: tech@glpi-project.org
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+    by mail.glpi-project.org (Postfix) with ESMTP id B74527E805E8
+    for <unittests@glpi-project.org>; Wed,  3 Apr 2019 11:48:35 +0200 (CEST)
+Subject: Re: [GLPI #0000101] New database issue
+From: Tech Ni Cian <tech@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <961c2885-94e6-2343-b000-280c809fcdb1@glpi-project.org>
+Date: Wed, 3 Apr 2019 11:48:25 +0200
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Language: fr-FR
+Content-Transfer-Encoding: 7bit
+
+=-=-=-= To answer by email, write above this line =-=-=-=
+
+HERE IS THE INITIAL NOTIFICATION CONTENT
+
+=_=_=_= To answer by email, write under this line =_=_=_=
+
+My followup is located under footer line.

--- a/tests/emails-tests/29.4-ticket-followup-above-header-line-without-footer-line.eml
+++ b/tests/emails-tests/29.4-ticket-followup-above-header-line-without-footer-line.eml
@@ -1,0 +1,21 @@
+Return-Path: tech@glpi-project.org
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+	by mail.glpi-project.org (Postfix) with ESMTP id B74527E805E8
+	for <unittests@glpi-project.org>; Wed,  3 Apr 2019 11:48:35 +0200 (CEST)
+Subject: Re: [GLPI #0000101] New database issue
+From: Tech Ni Cian <tech@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <961c2885-94e6-2343-b000-280c809fcdb1@glpi-project.org>
+Date: Wed, 3 Apr 2019 11:48:25 +0200
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Language: fr-FR
+Content-Transfer-Encoding: 7bit
+
+My followup is located above header line, and there is no footer line.
+
+=-=-=-= To answer by email, write above this line =-=-=-=
+
+HERE IS THE INITIAL NOTIFICATION CONTENT
+
+What is written here will not be preserved.

--- a/tests/emails-tests/29.5-ticket-followup-under-footer-line-without-header-line.eml
+++ b/tests/emails-tests/29.5-ticket-followup-under-footer-line-without-header-line.eml
@@ -1,0 +1,21 @@
+Return-Path: tech@glpi-project.org
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+    by mail.glpi-project.org (Postfix) with ESMTP id B74527E805E8
+    for <unittests@glpi-project.org>; Wed,  3 Apr 2019 11:48:35 +0200 (CEST)
+Subject: Re: [GLPI #0000101] New database issue
+From: Tech Ni Cian <tech@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <961c2885-94e6-2343-b000-280c809fcdb1@glpi-project.org>
+Date: Wed, 3 Apr 2019 11:48:25 +0200
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Language: fr-FR
+Content-Transfer-Encoding: 7bit
+
+What is written here will not be preserved.
+
+HERE IS THE INITIAL NOTIFICATION CONTENT
+
+=_=_=_= To answer by email, write under this line =_=_=_=
+
+My followup is located under footer line, and there is no header line.

--- a/tests/emails-tests/29.6-ticket-followup-under-header-line-without-footer-line.eml
+++ b/tests/emails-tests/29.6-ticket-followup-under-header-line-without-footer-line.eml
@@ -1,0 +1,21 @@
+Return-Path: tech@glpi-project.org
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+    by mail.glpi-project.org (Postfix) with ESMTP id B74527E805E8
+    for <unittests@glpi-project.org>; Wed,  3 Apr 2019 11:48:35 +0200 (CEST)
+Subject: Re: [GLPI #0000101] New database issue
+From: Tech Ni Cian <tech@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <961c2885-94e6-2343-b000-280c809fcdb1@glpi-project.org>
+Date: Wed, 3 Apr 2019 11:48:25 +0200
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Language: fr-FR
+Content-Transfer-Encoding: 7bit
+
+=-=-=-= To answer by email, write above this line =-=-=-=
+
+My followup starts under header line...
+
+HERE IS THE INITIAL NOTIFICATION CONTENT
+
+...and there is no footer line.

--- a/tests/emails-tests/29.7-ticket-followup-above-footer-line-without-header-line.eml
+++ b/tests/emails-tests/29.7-ticket-followup-above-footer-line-without-header-line.eml
@@ -1,0 +1,21 @@
+Return-Path: tech@glpi-project.org
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+    by mail.glpi-project.org (Postfix) with ESMTP id B74527E805E8
+    for <unittests@glpi-project.org>; Wed,  3 Apr 2019 11:48:35 +0200 (CEST)
+Subject: Re: [GLPI #0000101] New database issue
+From: Tech Ni Cian <tech@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <961c2885-94e6-2343-b000-280c809fcdb1@glpi-project.org>
+Date: Wed, 3 Apr 2019 11:48:25 +0200
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Language: fr-FR
+Content-Transfer-Encoding: 7bit
+
+My followup starts above footer line...
+
+HERE IS THE INITIAL NOTIFICATION CONTENT
+
+...and there is no header line.
+
+=_=_=_= To answer by email, write under this line =_=_=_=

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -855,10 +855,57 @@ HTML,
                 'users_id' => $tuid,
                 'content'  => 'This is a reply that references Ticket 100 in References header (new format).' . "\r\n" . 'It should be added as followup.',
             ],
+            [
+                // 29.1-ticket-followup-above-header-and-under-footer-lines.eml
+                'items_id' => 101,
+                'users_id' => $tuid,
+                'content'  => 'My followup starts above header line...' . "\r\n" . '...and finishes under footer line.',
+            ],
+            [
+                // 29.2-ticket-followup-above-header-line.eml
+                'items_id' => 101,
+                'users_id' => $tuid,
+                'content'  => 'My followup is located above header line.',
+            ],
+            [
+                // 29.3-ticket-followup-under-footer-line.eml
+                'items_id' => 101,
+                'users_id' => $tuid,
+                'content'  => 'My followup is located under footer line.',
+            ],
+            [
+                // 29.4-ticket-followup-above-header-line-without-footer-line.eml
+                'items_id' => 101,
+                'users_id' => $tuid,
+                'content'  => 'My followup is located above header line, and there is no footer line.',
+            ],
+            [
+                // 29.5-ticket-followup-under-footer-line-without-header-line.eml
+                'items_id' => 101,
+                'users_id' => $tuid,
+                'content'  => 'My followup is located under footer line, and there is no header line.',
+            ],
+            [
+                // 29.6-ticket-followup-under-header-line-without-footer-line.eml
+                'items_id' => 101,
+                'users_id' => $tuid,
+                'content'  => 'My followup starts under header line...' . "\r\n\r\n"
+                    . 'HERE IS THE INITIAL NOTIFICATION CONTENT' . "\r\n\r\n"
+                    . '...and there is no footer line.',
+            ],
+            [
+                // 29.7-ticket-followup-under-header-line-without-footer-line.eml
+                'items_id' => 101,
+                'users_id' => $tuid,
+                'content'  => 'My followup starts above footer line...' . "\r\n\r\n"
+                    . 'HERE IS THE INITIAL NOTIFICATION CONTENT' . "\r\n\r\n"
+                    . '...and there is no header line.',
+            ],
         ];
 
         foreach ($expected_followups as $expected_followup) {
-            $this->integer(countElementsInTable(ITILFollowup::getTable(), Sanitizer::sanitize($expected_followup)))->isEqualTo(1);
+            $this->integer(countElementsInTable(ITILFollowup::getTable(), Sanitizer::sanitize($expected_followup)))
+                ->isEqualTo(1, sprintf("Followup not found:\n> %s", $expected_followup['content']));
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10792 

With this proposal, when initial notification stripping logic leads to an empty followup, then the "non stripped" mail content will be used.

I opened this PR on master branch as it is changing the mail collector behaviour.