### PR TITLE
Fix date field name

### DIFF
--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -247,8 +247,7 @@ class KnowbaseItem_Item extends CommonDBRelation
 
             $link = $linked_item::getFormURLWithID($linked_item->getID());
 
-            $createdate = $item::getType() == KnowbaseItem::getType() ? 'date_creation' : 'date';
-           // show line
+            // show line
             echo "<tr class='tab_bg_2'>";
 
             if ($canedit) {
@@ -264,7 +263,7 @@ class KnowbaseItem_Item extends CommonDBRelation
 
             echo "<td>" . $type . "</td>" .
                  "<td><a href=\"" . $link . "\">" . $name . "</a></td>" .
-                 "<td class='tab_date'>" . Html::convDateTime($linked_item->fields[$createdate]) . "</td>" .
+                 "<td class='tab_date'>" . Html::convDateTime($linked_item->fields['date_creation']) . "</td>" .
                  "<td class='tab_date'>" . Html::convDateTime($linked_item->fields['date_mod']) . "</td>";
             echo "</tr>";
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10794

Since 8fc5d4f67700de642e63b8845066306c4abca2e3 the date field for KnowbaseItem is now standardized with the others to be `date_creation`.
