### PR TITLE
Fix user import when manager not in GLPI

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -1838,7 +1838,10 @@ class User extends CommonDBTM
                             break;
 
                         case 'users_id_supervisor':
-                            $this->fields[$k] = self::getIdByField('user_dn', $val, false);
+                            $supervisor_id = self::getIdByField('user_dn', $val, false);
+                            if ($supervisor_id) {
+                                $this->fields[$k] = $supervisor_id;
+                            }
                             break;
 
                         default:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10532

If an LDAP user's manager is not in GLPI, the import would fail if this field is mapped.
New behavior skips trying to set the user's supervisor if they don't exist in GLPI. This should get mapped whenever they log in or the user syncs again if the manager is added by that point.