### PR TITLE
OLA only for Tickets

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -1282,7 +1282,7 @@ abstract class CommonITILObject extends CommonDBTM {
 
       // check internal_time_to_resolve (OLA)
       if ((in_array("date", $this->updates) || in_array("internal_time_to_resolve", $this->updates))
-          && !is_null($this->fields["internal_time_to_resolve"])) { // Date set
+          && isset($this->fields["internal_time_to_resolve"]) && !is_null($this->fields["internal_time_to_resolve"])) { // Date set
 
          if ($this->fields["internal_time_to_resolve"] < $this->fields["date"]) {
             Session::addMessageAfterRedirect(__('Invalid dates. Update cancelled.'), false, ERROR);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10376

Check internal time field existence because OLAs are currently only for tickets.