### PR TITLE
render single twig blocks

### DIFF
--- a/src/Application/View/TemplateRenderer.php
+++ b/src/Application/View/TemplateRenderer.php
@@ -179,4 +179,23 @@ class TemplateRenderer
             ErrorHandler::getInstance()->handleTwigError($e);
         }
     }
+
+    /**
+     * Renders a block in a template.
+     *
+     * @param string $template  Path to the template name
+     * @param string $block     Name of the block to render
+     * @param array  $variables Variables needed to render the template
+     *
+     * @return string
+     */
+    public function renderBlock(string $template, string $block, array $variables = []): string
+    {
+        try {
+            return $this->environment->load($template)->renderBlock($block, $variables);
+        } catch (\Twig\Error\Error $e) {
+            ErrorHandler::getInstance()->handleTwigError($e);
+        }
+        return '';
+    }
 }


### PR DESCRIPTION
To convert more parts of Formcreator to twig, I need to render template blocks alone then send them via AJAX to the browser.

Still WIP in the plugin side.

Each question type has a method getDesignSpecializationField to send via AJAX specific HTML inputs when designing a question. To do this properly  I chosed to define twig blocks to render individually then send to the  browser.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
