### PR TITLE
Add rule action to skip remaining rules

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2874,7 +2874,12 @@ class Rule extends CommonDBTM
 
     public function getActions()
     {
-        return [];
+        return [
+            '_stop_rules_processing' => [
+                'name' => __('Stop rules processing'),
+                'type' => 'yesonly',
+            ]
+        ];
     }
 
 

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2876,7 +2876,7 @@ class Rule extends CommonDBTM
     {
         return [
             '_stop_rules_processing' => [
-                'name' => __('Stop rules processing'),
+                'name' => __('Skip remaining rules'),
                 'type' => 'yesonly',
             ]
         ];

--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -153,7 +153,7 @@ class RuleAsset extends Rule
     public function getActions()
     {
 
-        $actions                                = [];
+        $actions                                = parent::getActions();
 
         $actions['states_id']['name']           = __('Status');
         $actions['states_id']['type']           = 'dropdown';

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1587,7 +1587,7 @@ JAVASCRIPT;
                     $output["_rule_process"] = false;
                     $rule->process($input, $output, $params, $p);
 
-                    if ((isset($output['_stop_rules_processing']) && $output['_stop_rules_processing'] === '1') || ($output["_rule_process"] && $this->stop_on_first_match)) {
+                    if ((isset($output['_stop_rules_processing']) && (int) $output['_stop_rules_processing'] === 1) || ($output["_rule_process"] && $this->stop_on_first_match)) {
                         unset($output["_stop_rules_processing"], $output["_rule_process"]);
                         $output["_ruleid"] = $rule->fields["id"];
                         return Toolbox::addslashes_deep($output);

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1579,6 +1579,7 @@ JAVASCRIPT;
         $params['rule_itemtype']    = $this->getRuleClassName();
 
         if (count($this->RuleList->list)) {
+            /** @var Rule $rule */
             foreach ($this->RuleList->list as $rule) {
                //If the rule is active, process it
 
@@ -1587,7 +1588,7 @@ JAVASCRIPT;
                     $rule->process($input, $output, $params, $p);
 
                     if ((isset($output['_stop_rules_processing']) && $output['_stop_rules_processing'] === '1') || ($output["_rule_process"] && $this->stop_on_first_match)) {
-                        unset($output["_rule_process"]);
+                        unset($output["_stop_rules_processing"], $output["_rule_process"]);
                         $output["_ruleid"] = $rule->fields["id"];
                         return Toolbox::addslashes_deep($output);
                     }

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1586,7 +1586,7 @@ JAVASCRIPT;
                     $output["_rule_process"] = false;
                     $rule->process($input, $output, $params, $p);
 
-                    if ($output["_rule_process"] && $this->stop_on_first_match) {
+                    if ((isset($output['_stop_rules_processing']) && $output['_stop_rules_processing'] === '1') || ($output["_rule_process"] && $this->stop_on_first_match)) {
                         unset($output["_rule_process"]);
                         $output["_ruleid"] = $rule->fields["id"];
                         return Toolbox::addslashes_deep($output);

--- a/src/RuleDictionnaryPrinter.php
+++ b/src/RuleDictionnaryPrinter.php
@@ -93,7 +93,7 @@ class RuleDictionnaryPrinter extends Rule
     public function getActions()
     {
 
-        $actions                               = [];
+        $actions                               = parent::getActions();
 
         $actions['name']['name']               = __('Name');
         $actions['name']['force_actions']      = ['assign', 'regex_result'];

--- a/src/RuleDictionnarySoftware.php
+++ b/src/RuleDictionnarySoftware.php
@@ -102,7 +102,7 @@ class RuleDictionnarySoftware extends Rule
     public function getActions()
     {
 
-        $actions                                  = [];
+        $actions                                  = parent::getActions();
 
         $actions['name']['name']                  = _n('Software', 'Software', 1);
         $actions['name']['force_actions']         = ['assign', 'regex_result'];

--- a/src/RuleImportComputer.php
+++ b/src/RuleImportComputer.php
@@ -117,7 +117,7 @@ class RuleImportComputer extends Rule
     public function getActions()
     {
 
-        $actions                           = [];
+        $actions                           = parent::getActions();
 
         $actions['_ignore_import']['name'] = __('To be unaware of import');
         $actions['_ignore_import']['type'] = 'yesonly';

--- a/src/RuleImportEntity.php
+++ b/src/RuleImportEntity.php
@@ -367,6 +367,7 @@ class RuleImportEntity extends Rule
                 'type' => 'dropdown_users'
             ]
         ];
+        $actions = array_merge(parent::getActions(), $actions);
 
         return $actions;
     }

--- a/src/RuleMailCollector.php
+++ b/src/RuleMailCollector.php
@@ -178,7 +178,7 @@ class RuleMailCollector extends Rule
     public function getActions()
     {
 
-        $actions                                              = [];
+        $actions                                              = parent::getActions();
 
         $actions['entities_id']['name']                       = Entity::getTypeName(1);
         $actions['entities_id']['type']                       = 'dropdown';

--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -314,7 +314,7 @@ class RuleRight extends Rule
     public function getActions()
     {
 
-        $actions                                              = [];
+        $actions                                              = parent::getActions();
 
         $actions['entities_id']['name']                       = Entity::getTypeName(1);
         $actions['entities_id']['type']                       = 'dropdown';

--- a/src/RuleSoftwareCategory.php
+++ b/src/RuleSoftwareCategory.php
@@ -91,7 +91,7 @@ class RuleSoftwareCategory extends Rule
     public function getActions()
     {
 
-        $actions                                   = [];
+        $actions                                   = parent::getActions();
 
         $actions['softwarecategories_id']['name']  = _n('Category', 'Categories', 1);
         $actions['softwarecategories_id']['type']  = 'dropdown';

--- a/src/RuleTicket.php
+++ b/src/RuleTicket.php
@@ -708,7 +708,7 @@ class RuleTicket extends Rule
     public function getActions()
     {
 
-        $actions                                              = [];
+        $actions                                              = parent::getActions();
 
         $actions['itilcategories_id']['name']                 = _n('Category', 'Categories', 1);
         $actions['itilcategories_id']['type']                 = 'dropdown';

--- a/tests/functionnal/Rule.php
+++ b/tests/functionnal/Rule.php
@@ -253,10 +253,10 @@ class Rule extends DbTestCase
     public function testMaxActionsCount()
     {
         $rule = new \Rule();
-        $this->integer($rule->maxActionsCount())->isIdenticalTo(0);
+        $this->integer($rule->maxActionsCount())->isIdenticalTo(1);
 
         $rule = new \RuleTicket();
-        $this->integer($rule->maxActionsCount())->isIdenticalTo(33);
+        $this->integer($rule->maxActionsCount())->isIdenticalTo(34);
 
         $rule = new \RuleDictionnarySoftware();
         $this->integer($rule->maxActionsCount())->isIdenticalTo(4);

--- a/tests/functionnal/RuleDictionnarySoftware.php
+++ b/tests/functionnal/RuleDictionnarySoftware.php
@@ -56,7 +56,7 @@ class RuleDictionnarySoftware extends DbTestCase
     {
         $rule    = new \RuleDictionnarySoftware();
         $actions = $rule->getActions();
-        $this->array($actions)->hasSize(7);
+        $this->array($actions)->hasSize(8);
     }
 
     public function testAddSpecificParamsForPreview()

--- a/tests/functionnal/RuleSoftwareCategory.php
+++ b/tests/functionnal/RuleSoftwareCategory.php
@@ -56,7 +56,7 @@ class RuleSoftwareCategory extends DbTestCase
     {
         $category = new \RuleSoftwareCategory();
         $actions  = $category->getActions();
-        $this->array($actions)->hasSize(3);
+        $this->array($actions)->hasSize(4);
     }
 
     public function testDefaultRuleExists()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add new global rule action for `Stop rules processing` which will tell the engine to skip all other rules in the collection.
Currently, some rule collections are set to stop after the first match but the default and the case for most is to run all matching rules. With this new option along with the existing ability to change the rule priority/order, this will give the user more control over which rules run and when they run.

This does not stop other collections from running for the same event.