### PR TITLE
Make Update::getMigrationsToDo() private

### DIFF
--- a/src/Update.php
+++ b/src/Update.php
@@ -342,7 +342,7 @@ class Update
      *
      * @return array
      */
-    public function getMigrationsToDo(string $current_version, bool $force_latest = false): array
+    private function getMigrationsToDo(string $current_version, bool $force_latest = false): array
     {
         $migrations = [];
 

--- a/tests/functionnal/Update.php
+++ b/tests/functionnal/Update.php
@@ -258,8 +258,12 @@ class Update extends \GLPITestCase
      */
     public function testGetMigrationsToDo(string $current_version, bool $force_latest, array $expected_migrations)
     {
+        $class = new \ReflectionClass(\Update::class);
+        $method = $class->getMethod('getMigrationsToDo');
+        $method->setAccessible(true);
+
         global $DB;
         $update = new \Update($DB);
-        $this->array($update->getMigrationsToDo($current_version, $force_latest))->isIdenticalTo($expected_migrations);
+        $this->array($method->invokeArgs($update, [$current_version, $force_latest]))->isIdenticalTo($expected_migrations);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Related to #10780 .

This method has been introduced in GLPI 10.0 and is not used in plugins yet. It was public for tests purposes, but should not. Making it private will permit to change its signature in the future without introducing BC breaks.