### PR TITLE
Add new right for assigning service levels

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -5994,7 +5994,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'slm',
-                'rights' => READ | UPDATE | CREATE | PURGE,
+                'rights' => READ | UPDATE | CREATE | PURGE | SLM::RIGHT_ASSIGN,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'rule_dictionnary_printer',
@@ -6562,7 +6562,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'slm',
-                'rights' => READ,
+                'rights' => READ | SLM::RIGHT_ASSIGN,
             ], [
                 'profiles_id' => self::PROFILE_TECHNICIAN,
                 'name' => 'rule_dictionnary_printer',

--- a/install/migrations/update_10.0.x_to_10.1.0/slm.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/slm.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+$migration->addRight(SLM::$rightname, SLM::RIGHT_ASSIGN, ['ticket' => UPDATE]);

--- a/src/SLM.php
+++ b/src/SLM.php
@@ -51,6 +51,8 @@ class SLM extends CommonDBTM
     const TTR = 0; // Time to resolve
     const TTO = 1; // Time to own
 
+    const RIGHT_ASSIGN = 256;
+
     public static function getTypeName($nb = 0)
     {
         return _n('Service level', 'Service levels', $nb);
@@ -292,5 +294,16 @@ class SLM extends CommonDBTM
     public static function getIcon()
     {
         return "ti ti-checkup-list";
+    }
+
+    public function getRights($interface = 'central')
+    {
+        $values = parent::getRights();
+        $values[self::RIGHT_ASSIGN]  = [
+            'short' => __('Assign'),
+            'long'  => __('Search result user display'),
+        ];
+
+        return $values;
     }
 }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1065,6 +1065,16 @@ class Ticket extends CommonITILObject
             }
         }
 
+        $can_assign_slm = Session::haveRight(SLM::$rightname, SLM::RIGHT_ASSIGN);
+        if (!$can_assign_slm) {
+            foreach ([SLM::TTR, SLM::TTO] as $slmType) {
+                [$dateField, $slaField] = SLA::getFieldNames($slmType);
+                unset($input[$dateField], $input[$slaField]);
+                [$dateField, $olaField] = OLA::getFieldNames($slmType);
+                unset($input[$dateField], $input[$olaField]);
+            }
+        }
+
        //must be handled here for tickets. @see CommonITILObject::prepareInputForUpdate()
         $input = $this->handleTemplateFields($input);
         if ($input === false) {
@@ -1800,6 +1810,16 @@ class Ticket extends CommonITILObject
                         break(2);
                     }
                 }
+            }
+        }
+
+        $can_assign_slm = Session::haveRight(SLM::$rightname, SLM::RIGHT_ASSIGN);
+        if (!$can_assign_slm) {
+            foreach ([SLM::TTR, SLM::TTO] as $slmType) {
+                [$dateField, $slaField] = SLA::getFieldNames($slmType);
+                unset($input[$dateField], $input[$slaField]);
+                [$dateField, $olaField] = OLA::getFieldNames($slmType);
+                unset($input[$dateField], $input[$olaField]);
             }
         }
 

--- a/templates/components/itilobject/service_levels.html.twig
+++ b/templates/components/itilobject/service_levels.html.twig
@@ -74,7 +74,7 @@
    }
 ]) %}
 
-
+{% set can_assign_sla_ola = canupdate and has_profile_right('slm', constant('SLM::RIGHT_ASSIGN')) %}
 {% for la_field in la_fields %}
    {% set rand = random() %}
    {% set date_displayed = field_options.fields_template is not defined or not field_options.fields_template.isHiddenField(la_field.datefieldname) %}
@@ -99,7 +99,7 @@
                         {{ get_item_name(la_field.la.getType(), item.fields[la_field.lafieldname]) }}
                      </span>
 
-                     {% if canupdate %}
+                     {% if can_assign_sla_ola %}
                         <i class="ti ti-x ms-1" role="button"
                            onclick="delete_date_{{ rand }}(event)"
                            title="{{ _x('button', 'Delete permanently') }}"
@@ -154,7 +154,7 @@
                         {
                            'include_field': false,
                            'id': 'date_' ~ assign_la_id,
-                           'disabled': (not canupdate),
+                           'disabled': (not can_assign_sla_ola),
                         }
                      ) }}
                   </div>
@@ -171,13 +171,13 @@
                            'include_field': false,
                            'entity': item.fields['entities_id'],
                            'condition': {'type': la_field.type},
-                           'disabled': (not canupdate),
+                           'disabled': (not can_assign_sla_ola),
                            'add_field_class': (is_expanded ? 'col-sm-6' : ''),
                         }
                      ) }}
                   </div>
 
-                  {% if canupdate %}
+                  {% if can_assign_sla_ola %}
                      <button class="btn btn-sm btn-ghost-secondary ms-1" type="button"
                            id="button_{{ assign_la_id }}"
                            data-bs-toggle="modal" data-bs-target="#{{ assign_la_id }}"

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -778,59 +778,59 @@ class Ticket extends DbTestCase
 
         $backtrace = debug_backtrace(0, 1);
         $caller = "File: {$backtrace[0]['file']} Function: {$backtrace[0]['function']}:{$backtrace[0]['line']}";
-       // Opening date, editable
+        // Opening date, editable
         $matches = iterator_to_array($crawler->filter("#itil-data input[name=date]:not([disabled])"));
         $this->array($matches)->hasSize(($openDate === true ? 1 : 0), "RW Opening date $caller");
 
-       // Time to own, editable
+        // Time to own, editable
         $matches = iterator_to_array($crawler->filter("#itil-data input[name=time_to_own]:not([disabled])"));
         $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0), "Time to own editable $caller");
 
-       // Internal time to own, editable
+        // Internal time to own, editable
         $matches = iterator_to_array($crawler->filter("#itil-data input[name=internal_time_to_own]:not([disabled])"));
         $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0), "Internal time to own editable $caller");
 
-       // Time to resolve, editable
+        // Time to resolve, editable
         $matches = iterator_to_array($crawler->filter("#itil-data input[name=time_to_resolve]:not([disabled])"));
         $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0), "Time to resolve $caller");
 
        // Internal time to resolve, editable
-        $matches = iterator_to_array($crawler->filter("#itil-data input[name=internal_time_to_resolve]:not([disabled])"));
+         $matches = iterator_to_array($crawler->filter("#itil-data input[name=internal_time_to_resolve]:not([disabled])"));
         $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0), "Internal time to resolve $caller");
 
-       //Type
+        //Type
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=type]:not([disabled])"));
         $this->array($matches)->hasSize(($type === true ? 1 : 0), "Type $caller");
 
-       //Status
+        //Status
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=status]:not([disabled])"));
         $this->array($matches)->hasSize(($status === true ? 1 : 0), "Status $caller");
 
-       //Urgency
+        //Urgency
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=urgency]:not([disabled])"));
         $this->array($matches)->hasSize(($urgency === true ? 1 : 0), "Urgency $caller");
 
-       //Impact
+        //Impact
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=impact]:not([disabled])"));
         $this->array($matches)->hasSize(($impact === true ? 1 : 0), "Impact $caller");
 
-       //Category
+        //Category
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=itilcategories_id]:not([disabled])"));
         $this->array($matches)->hasSize(($category === true ? 1 : 0), "Category $caller");
 
-       //Request source file_put_contents('/tmp/out.html', $output)
+        //Request source file_put_contents('/tmp/out.html', $output)
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=requesttypes_id]:not([disabled])"));
         $this->array($matches)->hasSize($requestSource === true ? 1 : 0, "Request source $caller");
 
-       //Location
+        //Location
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=locations_id]:not([disabled])"));
         $this->array($matches)->hasSize(($location === true ? 1 : 0), "Location $caller");
 
-       //Priority, editable
+        //Priority, editable
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=priority]:not([disabled])"));
         $this->array($matches)->hasSize(($priority === true ? 1 : 0), "RW priority $caller");
 
-       //Save button
+        //Save button
         $matches = iterator_to_array($crawler->filter("#itil-footer button[type=submit][name=update]:not([disabled])"));
         $this->array($matches)->hasSize(($save === true ? 1 : 0), ($save === true ? 'Save button missing' : 'Save button present') . ' ' . $caller);
 
@@ -933,7 +933,7 @@ class Ticket extends DbTestCase
         $this->boolean($ticket->getFromDB($ticket->getId()))->isTrue();
 
        //check output with default ACLs
-        $this->changeTechRight();
+        $this->changeTechRights(['ticket' => null]);
         $this->checkFormOutput(
             $ticket,
             $name = false,
@@ -952,8 +952,8 @@ class Ticket extends DbTestCase
             $location = true
         );
 
-       //drop UPDATE ticket right from tech profile (still with OWN)
-        $this->changeTechRight(168965);
+//       //drop UPDATE ticket right from tech profile (still with OWN)
+        $this->changeTechRights(['ticket' => 168965]);
         $this->checkFormOutput(
             $ticket,
             $name = false,
@@ -973,7 +973,7 @@ class Ticket extends DbTestCase
         );
 
        //drop UPDATE ticket right from tech profile (without OWN)
-        $this->changeTechRight(136197);
+        $this->changeTechRights(['ticket' => 136197]);
         $this->checkFormOutput(
             $ticket,
             $name = false,
@@ -993,7 +993,7 @@ class Ticket extends DbTestCase
         );
 
        // only assign and priority right for tech (without UPDATE and OWN rights)
-        $this->changeTechRight(94209);
+        $this->changeTechRights(['ticket' => 94209]);
         $this->checkFormOutput(
             $ticket,
             $name = false,
@@ -1012,8 +1012,52 @@ class Ticket extends DbTestCase
             $location = false
         );
 
-       // no update rights, only display for tech
-        $this->changeTechRight(3077);
+        $this->changeTechRights([
+            'ticket'    => 168967,
+            'slm'       => 256,
+        ]);
+        $this->checkFormOutput(
+            $ticket,
+            $name = true,
+            $textarea = true,
+            $priority = false,
+            $save = true,
+            $assign = true,
+            $openDate = true,
+            $timeOwnResolve = true,
+            $type = true,
+            $status = true,
+            $urgency = true,
+            $impact = true,
+            $category = true,
+            $requestSource = true,
+            $location = true
+        );
+
+        $this->changeTechRights([
+            'ticket'    => 168967,
+            'slm'       => 255,
+        ]);
+        $this->checkFormOutput(
+            $ticket,
+            $name = true,
+            $textarea = true,
+            $priority = false,
+            $save = true,
+            $assign = true,
+            $openDate = true,
+            $timeOwnResolve = false,
+            $type = true,
+            $status = true,
+            $urgency = true,
+            $impact = true,
+            $category = true,
+            $requestSource = true,
+            $location = true
+        );
+
+        // no update rights, only display for tech
+        $this->changeTechRights(['ticket' => 3077]);
         $this->checkFormOutput(
             $ticket,
             $name = false,
@@ -1064,35 +1108,64 @@ class Ticket extends DbTestCase
         );
     }
 
-    public function changeTechRight($rights = 168967)
+    public function changeTechRights(array $rights)
     {
         global $DB;
 
-       // set new rights
-        $DB->update(
-            'glpi_profilerights',
-            ['rights' => $rights],
-            [
-                'profiles_id'  => 6,
-                'name'         => 'ticket'
-            ]
-        );
+        $default_rights = [
+            'ticket'    => 168967,
+            'slm'       => 255,
+        ];
 
-       //ACLs have changed: login again.
-        $auth = new \Auth();
-        $this->boolean((bool) $auth->Login('tech', 'tech', true))->isTrue();
+        foreach ($rights as $name => $value) {
+            if (is_array($value) && isset($value['default'])) {
+                $default_rights[$name] = $value;
+            }
+            $default_value = $default_rights[$name] ?? null;
+            if ($default_value === null) {
+                throw new \Exception("Unknown right $name with no default value specified");
+            }
+            if ($value === null) {
+                $value = $default_value;
+            }
+            $this->dump("changeTechRight $name: $value");
 
-        if ($rights != 168967) {
-           //reset rights. Done here so ACLs are reset even if tests fails.
+            // set new rights
             $DB->update(
                 'glpi_profilerights',
-                ['rights' => 168967],
+                ['rights' => $value],
                 [
                     'profiles_id'  => 6,
-                    'name'         => 'ticket'
+                    'name'         => $name
                 ]
             );
+
+            //ACLs have changed: login again.
+            $auth = new \Auth();
+            $this->boolean((bool) $auth->Login('tech', 'tech', true))->isTrue();
+
+            if ($rights != $default_value) {
+                //reset rights. Done here so ACLs are reset even if tests fails.
+                $DB->update(
+                    'glpi_profilerights',
+                    ['rights' => $default_value],
+                    [
+                        'profiles_id'  => 6,
+                        'name'         => $name
+                    ]
+                );
+            }
         }
+    }
+
+    /**
+     * @param $rights
+     * @return void
+     * @deprecated 10.1.0 - Use changeTechRights() instead
+     */
+    public function changeTechRight($rights = 168967)
+    {
+        $this->changeTechRights(['ticket' => $rights]);
     }
 
     public function testPriorityAcl()
@@ -1195,6 +1268,7 @@ class Ticket extends DbTestCase
 
         $this->boolean((bool)$ticket->canAssign())->isFalse();
         $this->boolean((bool)$ticket->canAssignToMe())->isFalse();
+        $this->changeTechRights(['ticket' => 168967]);
        //check output with default ACLs
         $this->checkFormOutput(
             $ticket,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3595 

Adds a new SLM right for assigning/changing SLA and OLA fields on ITILObjects. This doesn't take priority over the standard UPDATE right for those items.
