### PR TITLE
Hide empty optgroups in MA fields dropdown

### DIFF
--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -851,6 +851,10 @@ class MassiveAction
                     }
 
                     echo "</tr><tr>";
+                    // Remove empty option groups
+                    $options = array_filter($options, static function($v) {
+                        return !is_array($v) || count($v) > 0;
+                    });
                     if ($choose_field) {
                         echo "<td>";
                         $field_rand = Dropdown::showFromArray(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When selecting a field to update in the Massive Action UI, all search option groups are shown even if they don't contain any options. For example with Tickets, there are no fields in the SLA group that can be updated but there is still an optgroup in the dropdown for it. The result is a very cluttered dropdown where half or more of the elements in some cases are just labels with no items.
This PR removes all empty optgroups from the dropdown.