### PR TITLE
fix(dashboard): prevent error from php 8

### DIFF
--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -930,7 +930,7 @@ HTML;
             if (isset($card_options['args']['apply_filters'])) {
                 $provider_args['params']['apply_filters'] = $card_options['args']['apply_filters'];
             }
-            $widget_args = call_user_func_array($card['provider'], $provider_args);
+            $widget_args = call_user_func_array($card['provider'], array_values($provider_args));
         }
         $widget_args = array_merge($widget_args ?? [], $card_options['args'] ?? []);
 


### PR DESCRIPTION
Error mey occurs from PHP >= 8.0

![image](https://user-images.githubusercontent.com/7335054/156325892-b5446eb9-ddfa-4665-a2da-3da061c5f06f.png)


The ```call_user_func_array()``` function will use they array keys as parameter names, and this can be a breaking-change in certain situations, where the parameter array is an associative array with non-numeric keys. 

see https://php.watch/versions/8.0/named-parameters#named-params-call_user_func_array

This PR fix this

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23519
