### PR TITLE
Fix showing documents in timeline not added by subitem

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6790,7 +6790,6 @@ abstract class CommonITILObject extends CommonDBTM
 
                 $timeline_key = $document_item['itemtype'] . "_" . $document_item['items_id'];
                 if ($document_item['itemtype'] == static::getType()) {
-
                   // document associated directly to itilobject
                     $timeline["Document_" . $document_item['documents_id']] = [
                         'type' => 'Document_Item',

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6785,11 +6785,12 @@ abstract class CommonITILObject extends CommonDBTM
                 $item['documents_item_id'] = $document_item['id'];
 
                 $item['timeline_position'] = $document_item['timeline_position'];
+                $item['_can_edit'] = $can_view_documents && $document_obj->canUpdateItem();
+                $item['_can_delete'] = $can_view_documents && $document_obj->canDeleteItem();
 
                 $timeline_key = $document_item['itemtype'] . "_" . $document_item['items_id'];
                 if ($document_item['itemtype'] == static::getType()) {
-                    $item['_can_edit'] = $can_view_documents && $document_obj->canUpdateItem();
-                    $item['_can_delete'] = $can_view_documents && $document_obj->canDeleteItem();
+
                   // document associated directly to itilobject
                     $timeline["Document_" . $document_item['documents_id']] = [
                         'type' => 'Document_Item',
@@ -6806,8 +6807,6 @@ abstract class CommonITILObject extends CommonDBTM
                     $sub_document = [
                         'type' => 'Document_Item',
                         'item' => $item,
-                        '_can_edit' => $can_view_documents && $document_obj->canUpdateItem(),
-                        '_can_delete' => $can_view_documents && $document_obj->canDeleteItem(),
                     ];
                     if ($is_image) {
                         $sub_document['_is_image'] = true;

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6526,7 +6526,7 @@ abstract class CommonITILObject extends CommonDBTM
                 'label'         => _x('button', 'Add a document'),
                 'template'      => 'components/itilobject/timeline/form_document_item.html.twig',
                 'item'          => new Document_Item(),
-                'show_in_menu'  => false
+                'hide_in_menu'  => true
             ];
         }
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6526,7 +6526,7 @@ abstract class CommonITILObject extends CommonDBTM
                 'label'         => _x('button', 'Add a document'),
                 'template'      => 'components/itilobject/timeline/form_document_item.html.twig',
                 'item'          => new Document_Item(),
-                'hide_in_menu'  => true
+                'show_in_menu'  => false
             ];
         }
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6518,6 +6518,17 @@ abstract class CommonITILObject extends CommonDBTM
                 'item'      => $validation
             ];
         }
+        if ($canadd_document) {
+            $itemtypes['document'] = [
+                'type'          => 'Document_Item',
+                'class'         => Document_Item::class,
+                'icon'          => Document_Item::getIcon(),
+                'label'         => _x('button', 'Add a document'),
+                'template'      => 'components/itilobject/timeline/form_document_item.html.twig',
+                'item'          => new Document_Item(),
+                'show_in_menu'  => false
+            ];
+        }
 
         if (isset($PLUGIN_HOOKS[Hooks::TIMELINE_ANSWER_ACTIONS])) {
             foreach ($PLUGIN_HOOKS[Hooks::TIMELINE_ANSWER_ACTIONS] as $plugin => $hook_itemtypes) {

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -60,7 +60,7 @@
                      </button>
                   {% endif %}
                   <ul class="dropdown-menu">
-                     {% for action, timeline_itemtype in timeline_itemtypes|filter((v, k) => v.show_in_menu is not defined or v.show_in_menu == true) %}
+                     {% for action, timeline_itemtype in timeline_itemtypes|filter((v, k) => v.hide_in_menu is not defined or v.hide_in_menu != true) %}
                         {% if loop.index0 > 0 %}
                            <li><a class="dropdown-item action-{{ action }} answer-action" href="#"
                               data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -60,7 +60,7 @@
                      </button>
                   {% endif %}
                   <ul class="dropdown-menu">
-                     {% for action, timeline_itemtype in timeline_itemtypes %}
+                     {% for action, timeline_itemtype in timeline_itemtypes|filter((v, k) => v.show_in_menu is not defined or v.show_in_menu == true) %}
                         {% if loop.index0 > 0 %}
                            <li><a class="dropdown-item action-{{ action }} answer-action" href="#"
                               data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">

--- a/templates/components/itilobject/timeline/sub_documents.html.twig
+++ b/templates/components/itilobject/timeline/sub_documents.html.twig
@@ -44,7 +44,7 @@
          {% set post_figure_content %}
             <div class="col-auto">
                <div class="list-group-item-actions d-flex flex-column">
-                  {% if document['_can_edit'] %}
+                  {% if document['item']['_can_edit'] %}
                      <a href="{{ 'Document'|itemtype_form_path(document['item']['id']) }}"
                         class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Edit') }}"
                         data-bs-toggle="tooltip" data-bs-placement="top">
@@ -52,7 +52,7 @@
                      </a>
                   {% endif %}
 
-                  {% if document['_can_delete'] %}
+                  {% if document['item']['_can_delete'] %}
                      <a href="{{ delete_link }}"
                         class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Delete permanently') }}"
                         data-bs-toggle="tooltip" data-bs-placement="top">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10839

Since #10647, the timeline relies on the defined timeline itemtypes for rendering. "Document_Item" was not in this list presumably so it wouldn't be in the menu to add it. However, it is required for files added during the ticket creation and for the Screenshot plugin. I added it to the list of timeline itemtypes but also added a flag that lets you hide certain types from the menu.