### PR TITLE
Fix restore of saved input

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1124,6 +1124,7 @@ JAVASCRIPT;
     {
         // Item might already be loaded, skip load and rights checks
         $item_loaded = $options['loaded'] ?? false;
+        unset($options['loaded']);
         if (!$item_loaded) {
             if (
                 isset($options['id'])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Related to #10292.
Since #10114, a new form option `loaded` was added during the loading of a tab and this caused the saved input of a form to be overridden with this one value before it could be restored.