### PR TITLE
Fix dashboard dropdown being smaller than the text

### DIFF
--- a/css/standalone/dashboard.scss
+++ b/css/standalone/dashboard.scss
@@ -286,7 +286,7 @@ $break_tablet: 1400px;
             padding: 5px;
             border: 2px solid var(--input-border);
             border-radius: 3px;
-            min-width: 100px;
+            min-width: 140px;
             cursor: pointer;
 
             option {


### PR DESCRIPTION
In French for example the arrow was overlapping the text in the word "Assistance".

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
