### PR TITLE
fix(transfer): force purge for NetworkPort

### DIFF
--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -3680,7 +3680,7 @@ class Transfer extends CommonDBTM
                     // Not a copy -> delete
                     if ($ID == $newID) {
                         foreach ($iterator as $data) {
-                            $np->delete(['id' => $data['id']]);
+                            $np->delete(['id' => $data['id']], 1);
                         }
                     }
                     // Copy -> do nothing


### PR DESCRIPTION
Purge NetworkPort if needed

From ```Transfer``` NetworkPort is only ```deleted``` and not purge even if ```deleted``` option is selected.


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23547
