### PR TITLE
Use MySQL delete operation to truncate tables

### DIFF
--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1574,8 +1574,9 @@ class DBmysql
      */
     public function truncate($table)
     {
-        $table_name = $this::quoteName($table);
-        return $this->query("TRUNCATE $table_name");
+        // Use delete to prevent table corruption on some MySQL operations
+        // (i.e. when using mysqldump without `--single-transaction` option)
+        return $this->delete($table, [1]);
     }
 
     /**


### PR DESCRIPTION
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`$DB->truncate()` was introduced in GLPI 10.0 and is used only once. Another solution could be to drop this method (or to deprecate it and to remove it from the changelog).