### PR TITLE
Fix removal of saved NetworkPort input

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1194,16 +1194,16 @@ class CommonDBTM extends CommonGLPI
             $this->saveInput();
         }
 
+       if (isset($this->input['add'])) {
+          $this->input['_add'] = $this->input['add'];
+          unset($this->input['add']);
+       }
+
        // Call the plugin hook - $this->input can be altered
        // This hook get the data from the form, not yet altered
         Plugin::doHook(Hooks::PRE_ITEM_ADD, $this);
 
         if ($this->input && is_array($this->input)) {
-            if (isset($this->input['add'])) {
-                $this->input['_add'] = $this->input['add'];
-                unset($this->input['add']);
-            }
-
             $this->input = $this->prepareInputForAdd($this->input);
         }
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1194,10 +1194,10 @@ class CommonDBTM extends CommonGLPI
             $this->saveInput();
         }
 
-       if (isset($this->input['add'])) {
-          $this->input['_add'] = $this->input['add'];
-          unset($this->input['add']);
-       }
+        if (isset($this->input['add'])) {
+            $this->input['_add'] = $this->input['add'];
+            unset($this->input['add']);
+        }
 
        // Call the plugin hook - $this->input can be altered
        // This hook get the data from the form, not yet altered
@@ -1506,10 +1506,10 @@ class CommonDBTM extends CommonGLPI
             $this->saveInput();
         }
 
-       if (isset($this->input['update'])) {
-          $this->input['_update'] = $this->input['update'];
-          unset($this->input['update']);
-       }
+        if (isset($this->input['update'])) {
+            $this->input['_update'] = $this->input['update'];
+            unset($this->input['update']);
+        }
 
        // Plugin hook - $this->input can be altered
         Plugin::doHook(Hooks::PRE_ITEM_UPDATE, $this);

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1506,15 +1506,15 @@ class CommonDBTM extends CommonGLPI
             $this->saveInput();
         }
 
+       if (isset($this->input['update'])) {
+          $this->input['_update'] = $this->input['update'];
+          unset($this->input['update']);
+       }
+
        // Plugin hook - $this->input can be altered
         Plugin::doHook(Hooks::PRE_ITEM_UPDATE, $this);
         if ($this->input && is_array($this->input)) {
             $this->input = $this->prepareInputForUpdate($this->input);
-
-            if (isset($this->input['update'])) {
-                $this->input['_update'] = $this->input['update'];
-                unset($this->input['update']);
-            }
             $this->filterValues(!isCommandLine());
         }
 

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -279,7 +279,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
        // update last editor if content change
         if (
-            isset($input['update'])
+            isset($input['_update'])
             && ($uid = Session::getLoginUserID())
         ) { // Change from task form
             $input["users_id_editor"] = $uid;

--- a/src/Config.php
+++ b/src/Config.php
@@ -133,7 +133,7 @@ class Config extends CommonDBTM
             $config_context = $input['config_context'];
             unset($input['id']);
             unset($input['_glpi_csrf_token']);
-            unset($input['update']);
+            unset($input['_update']);
             unset($input['config_context']);
             if (
                 (!empty($input['config_class']))
@@ -261,7 +261,7 @@ class Config extends CommonDBTM
        // Beware : with new management system, we must update each value
         unset($input['id']);
         unset($input['_glpi_csrf_token']);
-        unset($input['update']);
+        unset($input['_update']);
 
        // Add skipMaintenance if maintenance mode update
         if (isset($input['maintenance_mode']) && $input['maintenance_mode']) {

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -506,7 +506,6 @@ class ITILFollowup extends CommonDBChild
         }
         unset($input["add_reopen"]);
        // }
-        unset($input["add"]);
 
         $itemtype = $input['itemtype'];
 

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -336,7 +336,7 @@ class ITILSolution extends CommonDBChild
             return false;
         }
 
-        if (isset($input['update']) && ($uid = Session::getLoginUserID())) {
+        if (isset($input['_update']) && ($uid = Session::getLoginUserID())) {
             $input["users_id_editor"] = $uid;
         }
 

--- a/tests/functionnal/Computer.php
+++ b/tests/functionnal/Computer.php
@@ -623,4 +623,27 @@ class Computer extends DbTestCase
         ]);
         $this->integer(count($softwares))->isidenticalTo(1);
     }
+
+   public function testClearSavedInputAfterUpdate()
+   {
+      $this->login();
+
+      // Check that there is no saveInput already
+      if (isset($_SESSION['saveInput']) && is_array($_SESSION['saveInput'])) {
+         $this->array($_SESSION['saveInput'])->notHasKey('Computer');
+      }
+      $computer = $this->getNewComputer();
+      $cid = $computer->fields['id'];
+
+      $result = $computer->update([
+         'id'    => $cid,
+         'comment'  => 'test'
+      ]);
+      $this->boolean($result)->isTrue();
+
+      // Check that there is no savedInput after update
+      if (isset($_SESSION['saveInput']) && is_array($_SESSION['saveInput'])) {
+         $this->array($_SESSION['saveInput'])->notHasKey('Computer');
+      }
+   }
 }

--- a/tests/functionnal/Computer.php
+++ b/tests/functionnal/Computer.php
@@ -624,26 +624,26 @@ class Computer extends DbTestCase
         $this->integer(count($softwares))->isidenticalTo(1);
     }
 
-   public function testClearSavedInputAfterUpdate()
-   {
-      $this->login();
+    public function testClearSavedInputAfterUpdate()
+    {
+        $this->login();
 
-      // Check that there is no saveInput already
-      if (isset($_SESSION['saveInput']) && is_array($_SESSION['saveInput'])) {
-         $this->array($_SESSION['saveInput'])->notHasKey('Computer');
-      }
-      $computer = $this->getNewComputer();
-      $cid = $computer->fields['id'];
+        // Check that there is no saveInput already
+        if (isset($_SESSION['saveInput']) && is_array($_SESSION['saveInput'])) {
+            $this->array($_SESSION['saveInput'])->notHasKey('Computer');
+        }
+        $computer = $this->getNewComputer();
+        $cid = $computer->fields['id'];
 
-      $result = $computer->update([
-         'id'    => $cid,
-         'comment'  => 'test'
-      ]);
-      $this->boolean($result)->isTrue();
+        $result = $computer->update([
+            'id'    => $cid,
+            'comment'  => 'test'
+        ]);
+        $this->boolean($result)->isTrue();
 
-      // Check that there is no savedInput after update
-      if (isset($_SESSION['saveInput']) && is_array($_SESSION['saveInput'])) {
-         $this->array($_SESSION['saveInput'])->notHasKey('Computer');
-      }
-   }
+        // Check that there is no savedInput after update
+        if (isset($_SESSION['saveInput']) && is_array($_SESSION['saveInput'])) {
+            $this->array($_SESSION['saveInput'])->notHasKey('Computer');
+        }
+    }
 }

--- a/tests/functionnal/NetworkPort.php
+++ b/tests/functionnal/NetworkPort.php
@@ -324,4 +324,40 @@ class NetworkPort extends DbTestCase
             }
         }
     }
+
+    public function testClearSavedInputAfterUpdate()
+    {
+       $this->login();
+
+       // Check that there is no saveInput already
+       if (isset($_SESSION['saveInput']) && is_array($_SESSION['saveInput'])) {
+          $this->array($_SESSION['saveInput'])->notHasKey('NetworkPort');
+       }
+       $computer1 = getItemByTypeName('Computer', '_test_pc01');
+       $networkport = new \NetworkPort();
+
+       // Be sure added
+       $np_id = $networkport->add([
+          'items_id'           => $computer1->getID(),
+          'itemtype'           => 'Computer',
+          'entities_id'        => $computer1->fields['entities_id'],
+          'is_recursive'       => 0,
+          'logical_number'     => 5,
+          'mac'                => '00:24:81:eb:c6:d5',
+          'instantiation_type' => 'NetworkPortEthernet',
+          'name'               => 'eth1',
+       ]);
+       $this->integer((int)$np_id)->isGreaterThan(0);
+
+       $result = $networkport->update([
+          'id'                 => $np_id,
+          'comment'            => 'test',
+       ]);
+       $this->boolean($result)->isTrue();
+
+       // Check that there is no savedInput after update
+       if (isset($_SESSION['saveInput']) && is_array($_SESSION['saveInput'])) {
+          $this->array($_SESSION['saveInput'])->notHasKey('NetworkPort');
+       }
+    }
 }

--- a/tests/functionnal/NetworkPort.php
+++ b/tests/functionnal/NetworkPort.php
@@ -327,37 +327,37 @@ class NetworkPort extends DbTestCase
 
     public function testClearSavedInputAfterUpdate()
     {
-       $this->login();
+        $this->login();
 
-       // Check that there is no saveInput already
-       if (isset($_SESSION['saveInput']) && is_array($_SESSION['saveInput'])) {
-          $this->array($_SESSION['saveInput'])->notHasKey('NetworkPort');
-       }
-       $computer1 = getItemByTypeName('Computer', '_test_pc01');
-       $networkport = new \NetworkPort();
+        // Check that there is no saveInput already
+        if (isset($_SESSION['saveInput']) && is_array($_SESSION['saveInput'])) {
+            $this->array($_SESSION['saveInput'])->notHasKey('NetworkPort');
+        }
+        $computer1 = getItemByTypeName('Computer', '_test_pc01');
+        $networkport = new \NetworkPort();
 
-       // Be sure added
-       $np_id = $networkport->add([
-          'items_id'           => $computer1->getID(),
-          'itemtype'           => 'Computer',
-          'entities_id'        => $computer1->fields['entities_id'],
-          'is_recursive'       => 0,
-          'logical_number'     => 5,
-          'mac'                => '00:24:81:eb:c6:d5',
-          'instantiation_type' => 'NetworkPortEthernet',
-          'name'               => 'eth1',
-       ]);
-       $this->integer((int)$np_id)->isGreaterThan(0);
+        // Be sure added
+        $np_id = $networkport->add([
+            'items_id'           => $computer1->getID(),
+            'itemtype'           => 'Computer',
+            'entities_id'        => $computer1->fields['entities_id'],
+            'is_recursive'       => 0,
+            'logical_number'     => 5,
+            'mac'                => '00:24:81:eb:c6:d5',
+            'instantiation_type' => 'NetworkPortEthernet',
+            'name'               => 'eth1',
+        ]);
+        $this->integer((int)$np_id)->isGreaterThan(0);
 
-       $result = $networkport->update([
-          'id'                 => $np_id,
-          'comment'            => 'test',
-       ]);
-       $this->boolean($result)->isTrue();
+        $result = $networkport->update([
+            'id'                 => $np_id,
+            'comment'            => 'test',
+        ]);
+        $this->boolean($result)->isTrue();
 
-       // Check that there is no savedInput after update
-       if (isset($_SESSION['saveInput']) && is_array($_SESSION['saveInput'])) {
-          $this->array($_SESSION['saveInput'])->notHasKey('NetworkPort');
-       }
+        // Check that there is no savedInput after update
+        if (isset($_SESSION['saveInput']) && is_array($_SESSION['saveInput'])) {
+            $this->array($_SESSION['saveInput'])->notHasKey('NetworkPort');
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8980

NetworkPort's prepareInputForUpdate was calling `NetworkPort::splitInputForElements` which was removing all non-fields that didn't start with an underscore. This meant that the `update` input was being removed and later in the update method, it was failing that check which would have cleared the saved input.

This fix I propose sets the `_update` property in `CommonDBTM::update` just before `prepareInputForUpdate` is called while leaving the original `update` property. Then afterwards, the `update` property is removed. This should fix the reported issue without too much risk in causing a break in compatibility.