### PR TITLE
Fix commonitil form display

### DIFF
--- a/templates/components/itilobject/layout.html.twig
+++ b/templates/components/itilobject/layout.html.twig
@@ -53,7 +53,7 @@
    {% endif %}
 
    <div class="row d-flex flex-column alin-items-stretch itil-object">
-      {% set fl_direction = (item.isNewItemg ? 'flex-column' : 'flex-column-reverse') %}
+      {% set fl_direction = (item.isNewItem ? 'flex-column' : 'flex-column-reverse') %}
       <div class="itil-left-side col-12 {{ left_side_cls }} order-last order-md-first pt-2 pe-2 pe-md-4 d-flex {{ fl_direction }} border-top border-4">
          {% if item.isNewItem() %}
             {{ include('components/itilobject/timeline/new_form.html.twig') }}


### PR DESCRIPTION
I was annoyed at the display changes that put the ticket description input at the bottom:

![image](https://user-images.githubusercontent.com/42734840/156774628-49dcbe52-e1dc-48b7-b74a-2cc5ebb6e04b.png)

I looked into it and it seems unintentional, a variable is misspelled so the condition that apply the correct flex direction is never true.

After fix:

![image](https://user-images.githubusercontent.com/42734840/156774922-2bafa9e9-74b1-4462-84b9-7b808416e599.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
