### PR TITLE
Fix dashboard card link for URLs with existing params

### DIFF
--- a/src/Dashboard/Provider.php
+++ b/src/Dashboard/Provider.php
@@ -117,7 +117,8 @@ class Provider
             ]
         ];
 
-        $url = $item::getSearchURL() . "?" . Toolbox::append_params([
+        $search_url = $item::getSearchURL();
+        $url = $search_url . (str_contains($search_url, '?') ? '&' : '?') . Toolbox::append_params([
             $search_criteria,
             'reset' => 'reset',
         ]);

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -790,6 +790,8 @@ class Toolbox
                 $params[] = (!empty($parent) ? $parent . '%5B' . rawurlencode($k) . '%5D' : rawurlencode($k)) . '=' . rawurlencode($v);
             }
         }
+        //Remove empty values
+        $params = array_filter($params);
         return implode($separator, $params);
     }
 

--- a/tests/functionnal/Glpi/Dashboard/Provider.php
+++ b/tests/functionnal/Glpi/Dashboard/Provider.php
@@ -44,6 +44,7 @@ class Provider extends DbTestCase
         return [
             ['item' => new \Computer()],
             ['item' => new \Ticket()],
+            ['item' => new \Item_DeviceSimcard()],
         ];
     }
 
@@ -68,8 +69,16 @@ class Provider extends DbTestCase
                 'label',
                 'icon',
             ]);
-            $this->integer($result['number'])->isGreaterThan(0);
+            if ($item::getType() !== 'Item_DeviceSimcard') {
+                // Ignore count for simcards. None are added in Bootstrap process and is here for regression testing only.
+                $this->integer($result['number'])->isGreaterThan(0);
+            }
             $this->string($result['url'])->contains($item::getSearchURL());
+            //Verify URL doesn't have two query param joiners next to each other
+            $this->string($result['url'])->notContains('&&');
+            $this->string($result['url'])->notContains('?&');
+            //Verify URL only has one ? joiner
+            $this->integer(substr_count($result['url'], '?'))->isLessThanOrEqualTo(1);
             $this->string($result['label'])->isNotEmpty();
             $this->string($result['icon'])->isEqualTo($item::getIcon());
         }

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -1071,7 +1071,14 @@ class Toolbox extends DbTestCase
                     ],
                     'b'   => 'test3'
                 ], '_', 'a%5B0%5D=test1_a%5B1%5D=test2_b=test3' // '[' converted to %5B, ']' converted to %5D
-            ]
+            ],
+            [
+                [
+                    'a'   => 'test1',
+                    [], // Empty array Should be ignored
+                    'b'   => 'test2'
+                ], '&', 'a=test1&b=test2'
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10863

Also added logic to avoid adding empty parameters to the query string. If there were no filters in the dashboard, I noticed that there would be an empty parameter leading to "&&" and breaking the url.