### PR TITLE
Fix item name created from template

### DIFF
--- a/src/Features/Clonable.php
+++ b/src/Features/Clonable.php
@@ -200,8 +200,11 @@ trait Clonable
         }
         $input = $new_item->cleanCloneInput($input);
 
-        if (($copy_name = $this->getUniqueCloneName($input)) !== null) {
-            $input[static::getNameField()] = $copy_name;
+        // Do not compute a clone name if a new name is specified (Like creating from template)
+        if (!isset($override_input['name'])) {
+            if (($copy_name = $this->getUniqueCloneName($input)) !== null) {
+                $input[static::getNameField()] = $copy_name;
+            }
         }
 
         $input = $new_item->prepareInputForClone($input);

--- a/tests/functionnal/Computer.php
+++ b/tests/functionnal/Computer.php
@@ -561,6 +561,34 @@ class Computer extends DbTestCase
         ]);
     }
 
+    public function testCloneWithSpecificName()
+    {
+        /** @var \Computer $computer */
+        $computer = $this->getNewComputer();
+        $clone_id = $computer->clone([
+            'name' => 'testCloneWithSpecificName'
+        ]);
+        $this->integer($clone_id)->isGreaterThan(0);
+        $result = $computer->getFromDB($clone_id);
+        $this->boolean($result)->isTrue();
+        $this->string($computer->fields['name'])->isEqualTo('testCloneWithSpecificName');
+    }
+
+    public function testCloneWithAutoName()
+    {
+        /** @var \Computer $computer */
+        $computer = $this->getNewComputer();
+        $computer->update([
+            'id' => $computer->fields['id'],
+            'name' => 'testCloneWithAutoName'
+        ]);
+        $clone_id = $computer->clone();
+        $this->integer($clone_id)->isGreaterThan(0);
+        $result = $computer->getFromDB($clone_id);
+        $this->boolean($result)->isTrue();
+        $this->string($computer->fields['name'])->isEqualTo('testCloneWithAutoName (copy)');
+    }
+
     public function testTransfer()
     {
         $this->login();

--- a/tests/functionnal/Software.php
+++ b/tests/functionnal/Software.php
@@ -265,7 +265,7 @@ class Software extends DbTestCase
 
         $this->boolean($software->getFromDB($softwares_id_2))->isTrue();
         $this->variable($software->fields['is_template'])->isEqualTo(0);
-        $this->string($software->fields['name'])->isIdenticalTo('MySoft (copy)');
+        $this->string($software->fields['name'])->isIdenticalTo('MySoft');
 
         $query = ['itemtype' => 'Software', 'items_id' => $softwares_id_2];
         $this->integer((int)countElementsInTable('glpi_infocoms', $query))->isIdenticalTo(1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Creating an asset from a template always added "(copy)" to the name even though I was specifying the name. Automatic generation of names should probably not happen if a name is specified in `override_input`.