### PR TITLE
Fix adding tasks from ITIL templates

### DIFF
--- a/templates/components/itilobject/mainform_open.html.twig
+++ b/templates/components/itilobject/mainform_open.html.twig
@@ -85,3 +85,8 @@
    {% if params['_skip_promoted_fields'] is defined and params['_skip_promoted_fields'] > 0 %}
       <input type="hidden" name="_skip_promoted_fields" value="{{ params['_skip_promoted_fields'] }}" />
    {% endif %}
+   {% if params['_tasktemplates_id'] is defined and params['_tasktemplates_id']|length > 0 %}
+      {% for tasktemplate_id in params['_tasktemplates_id'] %}
+         <input type="hidden" name="_tasktemplates_id[]" value="{{ tasktemplate_id }}" />
+      {% endfor %}
+   {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While testing #9828 to see if there was a bug that would need fixed for GLPI 10, I noticed that I couldn't add tasks from an ITIL template even without missing a mandatory field at first. After re-adding the missing hidden field (was present in 9.5), it worked as expected and I couldn't recreate the issue reported in #9828 at all on v10.