### PR TITLE
Allow assigning without UPDATE right

### DIFF
--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -76,9 +76,7 @@ if (isset($_POST["add"])) {
     }
     Html::back();
 } else if (isset($_POST['update'])) {
-    if (!$track->canAssign()) {
-        $track->check($_POST['id'], UPDATE);
-    }
+    $track->check($_POST['id'], UPDATE);
     $track->update($_POST);
 
     if (isset($_POST['kb_linked_id'])) {

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -76,7 +76,9 @@ if (isset($_POST["add"])) {
     }
     Html::back();
 } else if (isset($_POST['update'])) {
-    $track->check($_POST['id'], UPDATE);
+    if (!$track::canUpdate()) {
+        Html::displayRightError();
+    }
     $track->update($_POST);
 
     if (isset($_POST['kb_linked_id'])) {

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -76,7 +76,9 @@ if (isset($_POST["add"])) {
     }
     Html::back();
 } else if (isset($_POST['update'])) {
-    $track->check($_POST['id'], UPDATE);
+    if (!$track->canAssign()) {
+        $track->check($_POST['id'], UPDATE);
+    }
     $track->update($_POST);
 
     if (isset($_POST['kb_linked_id'])) {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1032,6 +1032,7 @@ abstract class CommonITILObject extends CommonDBTM
                // Manage assign and steal right
                 if (static::getType() === Ticket::getType() && Session::haveRightsOr(static::$rightname, [Ticket::ASSIGN, Ticket::STEAL])) {
                     $allowed_fields[] = '_itil_assign';
+                    $allowed_fields[] = '_actors'; // This will be filtered in CommonITILObject::updateActors()
                 }
 
                // Can only update initial fields if no followup or task already added
@@ -7741,6 +7742,9 @@ abstract class CommonITILObject extends CommonDBTM
        // parse posted actors
         foreach ($this->input['_actors'] as $actortype_str => $actors) {
             $actortype = constant("CommonITILActor::" . strtoupper($actortype_str));
+            if (!$this->canAssign() && $actortype == CommonITILActor::ASSIGN) {
+                continue;
+            }
             $existings = $this->getActorsForType($actortype);
 
             $added   = [];

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7742,7 +7742,11 @@ abstract class CommonITILObject extends CommonDBTM
        // parse posted actors
         foreach ($this->input['_actors'] as $actortype_str => $actors) {
             $actortype = constant("CommonITILActor::" . strtoupper($actortype_str));
-            if (!$this->canAssign() && $actortype == CommonITILActor::ASSIGN) {
+            if ($actortype === CommonITILActor::ASSIGN && !$this->canAssign()) {
+                continue;
+            }
+
+            if ($actortype !== CommonITILActor::ASSIGN && !$this->canUpdateItem()) {
                 continue;
             }
             $existings = $this->getActorsForType($actortype);

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -537,6 +537,7 @@ class Ticket extends CommonITILObject
         if (
             !Session::haveRight(self::$rightname, UPDATE)
             && !$this->ownItem()
+            && !$this->canAssign()
         ) {
            //we always return false, as ownItem() = true is managed by below self::canUpdate
             return false;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -536,8 +536,7 @@ class Ticket extends CommonITILObject
        // if we don't have global UPDATE right, maybe we can own the current ticket
         if (
             !Session::haveRight(self::$rightname, UPDATE)
-            && !$this->ownItem()
-            && !$this->canAssign()
+            && (!$this->ownItem() || !$this->canAssign())
         ) {
            //we always return false, as ownItem() = true is managed by below self::canUpdate
             return false;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -536,7 +536,7 @@ class Ticket extends CommonITILObject
        // if we don't have global UPDATE right, maybe we can own the current ticket
         if (
             !Session::haveRight(self::$rightname, UPDATE)
-            && (!$this->ownItem() && !$this->canAssign())
+            && (!$this->ownItem())
         ) {
            //we always return false, as ownItem() = true is managed by below self::canUpdate
             return false;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -536,7 +536,7 @@ class Ticket extends CommonITILObject
        // if we don't have global UPDATE right, maybe we can own the current ticket
         if (
             !Session::haveRight(self::$rightname, UPDATE)
-            && (!$this->ownItem())
+            && !$this->ownItem()
         ) {
            //we always return false, as ownItem() = true is managed by below self::canUpdate
             return false;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -536,7 +536,7 @@ class Ticket extends CommonITILObject
        // if we don't have global UPDATE right, maybe we can own the current ticket
         if (
             !Session::haveRight(self::$rightname, UPDATE)
-            && (!$this->ownItem() || !$this->canAssign())
+            && (!$this->ownItem() && !$this->canAssign())
         ) {
            //we always return false, as ownItem() = true is managed by below self::canUpdate
             return false;

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -772,8 +772,8 @@ class Ticket extends DbTestCase
         ob_end_clean();
         $crawler = new Crawler($output);
 
-       $backtrace = debug_backtrace(0, 1);
-       $caller = "File: {$backtrace[0]['file']} Function: {$backtrace[0]['function']}:{$backtrace[0]['line']}";
+        $backtrace = debug_backtrace(0, 1);
+        $caller = "File: {$backtrace[0]['file']} Function: {$backtrace[0]['function']}:{$backtrace[0]['line']}";
        // Opening date, editable
         $matches = iterator_to_array($crawler->filter("#itil-data input[name=date]:not([disabled])"));
         $this->array($matches)->hasSize(($openDate === true ? 1 : 0), "RW Opening date $caller");

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -772,61 +772,63 @@ class Ticket extends DbTestCase
         ob_end_clean();
         $crawler = new Crawler($output);
 
+       $backtrace = debug_backtrace(0, 1);
+       $caller = "File: {$backtrace[0]['file']} Function: {$backtrace[0]['function']}:{$backtrace[0]['line']}";
        // Opening date, editable
         $matches = iterator_to_array($crawler->filter("#itil-data input[name=date]:not([disabled])"));
-        $this->array($matches)->hasSize(($openDate === true ? 1 : 0), 'RW Opening date');
+        $this->array($matches)->hasSize(($openDate === true ? 1 : 0), "RW Opening date $caller");
 
        // Time to own, editable
         $matches = iterator_to_array($crawler->filter("#itil-data input[name=time_to_own]:not([disabled])"));
-        $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0), 'Time to own editable');
+        $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0), "Time to own editable $caller");
 
        // Internal time to own, editable
         $matches = iterator_to_array($crawler->filter("#itil-data input[name=internal_time_to_own]:not([disabled])"));
-        $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0), 'Internal time to own editable');
+        $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0), "Internal time to own editable $caller");
 
        // Time to resolve, editable
         $matches = iterator_to_array($crawler->filter("#itil-data input[name=time_to_resolve]:not([disabled])"));
-        $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0), 'Time to resolve');
+        $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0), "Time to resolve $caller");
 
        // Internal time to resolve, editable
         $matches = iterator_to_array($crawler->filter("#itil-data input[name=internal_time_to_resolve]:not([disabled])"));
-        $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0), 'Internal time to resolve');
+        $this->array($matches)->hasSize(($timeOwnResolve === true ? 1 : 0), "Internal time to resolve $caller");
 
        //Type
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=type]:not([disabled])"));
-        $this->array($matches)->hasSize(($type === true ? 1 : 0), 'Type');
+        $this->array($matches)->hasSize(($type === true ? 1 : 0), "Type $caller");
 
        //Status
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=status]:not([disabled])"));
-        $this->array($matches)->hasSize(($status === true ? 1 : 0), 'Status');
+        $this->array($matches)->hasSize(($status === true ? 1 : 0), "Status $caller");
 
        //Urgency
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=urgency]:not([disabled])"));
-        $this->array($matches)->hasSize(($urgency === true ? 1 : 0), 'Urgency');
+        $this->array($matches)->hasSize(($urgency === true ? 1 : 0), "Urgency $caller");
 
        //Impact
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=impact]:not([disabled])"));
-        $this->array($matches)->hasSize(($impact === true ? 1 : 0), 'Impact');
+        $this->array($matches)->hasSize(($impact === true ? 1 : 0), "Impact $caller");
 
        //Category
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=itilcategories_id]:not([disabled])"));
-        $this->array($matches)->hasSize(($category === true ? 1 : 0), 'Category');
+        $this->array($matches)->hasSize(($category === true ? 1 : 0), "Category $caller");
 
        //Request source file_put_contents('/tmp/out.html', $output)
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=requesttypes_id]:not([disabled])"));
-        $this->array($matches)->hasSize($requestSource === true ? 1 : 0, 'Request source');
+        $this->array($matches)->hasSize($requestSource === true ? 1 : 0, "Request source $caller");
 
        //Location
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=locations_id]:not([disabled])"));
-        $this->array($matches)->hasSize(($location === true ? 1 : 0), 'Location');
+        $this->array($matches)->hasSize(($location === true ? 1 : 0), "Location $caller");
 
        //Priority, editable
         $matches = iterator_to_array($crawler->filter("#itil-data select[name=priority]:not([disabled])"));
-        $this->array($matches)->hasSize(($priority === true ? 1 : 0), 'RW priority');
+        $this->array($matches)->hasSize(($priority === true ? 1 : 0), "RW priority $caller");
 
        //Save button
         $matches = iterator_to_array($crawler->filter("#itil-footer button[type=submit][name=update]:not([disabled])"));
-        $this->array($matches)->hasSize(($save === true ? 1 : 0), ($save === true ? 'Save button missing' : 'Save button present'));
+        $this->array($matches)->hasSize(($save === true ? 1 : 0), ($save === true ? 'Save button missing' : 'Save button present') . ' ' . $caller);
 
        //Assign to
        /*preg_match(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10364

Fix for #10364 done for GLPI 10. I think the only issue in 9.5 was the UPDATE right check in the front file. For GLPI 10, there were other issues due to using `_actors` instead of individual fields for each actor type (_itil_assign`).