### PR TITLE
Improve scrolling with vertical menu on small screens

### DIFF
--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -38,7 +38,7 @@
    <div class="page">
 
       {% if is_vertical %}
-      <aside class="navbar navbar-vertical navbar-expand-lg sticky-top sidebar">
+      <aside class="navbar navbar-vertical navbar-expand-lg sticky-lg-top sidebar">
          <div class="container-fluid">
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu">
                <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | (Related to #10580)

When the menu is expanded enough to cover the screen, the vertical menu wouldn't allow you to scroll past the menu to see the page content while the horizontal menu would.