### PR TITLE
Fix SQL warnings during TTR/TTO late state computation

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4294,8 +4294,9 @@ abstract class CommonITILObject extends CommonDBTM
                 return 'IF(' . $DB->quoteName($table . '.' . $type) . ' IS NOT NULL
             AND ' . $DB->quoteName($table . '.status') . ' <> ' . self::WAITING . '
             AND (' . $DB->quoteName($table . '.takeintoaccount_delay_stat') . '
-                        > TIME_TO_SEC(TIMEDIFF(' . $DB->quoteName($table . '.' . $type) . ',
-                                               ' . $DB->quoteName($table . '.date') . '))
+                        > TIMESTAMPDIFF(SECOND,
+                                        ' . $DB->quoteName($table . '.date') . ',
+                                        ' . $DB->quoteName($table . '.' . $type) . ')
                  OR (' . $DB->quoteName($table . '.takeintoaccount_delay_stat') . ' = 0
                       AND ' . $DB->quoteName($table . '.' . $type) . ' < NOW())),
             1, 0)';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

During tests on #10862 , I may have produced inconsistant data, and result was that my whole dashboard was broken, due to an SQL error.

```
  *** MySQL query warnings:
  SQL: SELECT COUNT(DISTINCT(`glpi_tickets`.`id`)) AS `cpt` FROM `glpi_tickets` WHERE `glpi_tickets`.`is_deleted` = '0' AND `glpi_tickets`.`status` IN ('1', '2', '3', '4') AND (((IF(`glpi_tickets`.`time_to_resolve` IS NOT NULL
            AND `glpi_tickets`.`status` <> 4
            AND (`glpi_tickets`.`solvedate` > `glpi_tickets`.`time_to_resolve`
                  OR (`glpi_tickets`.`solvedate` IS NULL
                     AND `glpi_tickets`.`time_to_resolve` < NOW())),
            1, 0)) OR (IF(`glpi_tickets`.`internal_time_to_resolve` IS NOT NULL
            AND `glpi_tickets`.`status` <> 4
            AND (`glpi_tickets`.`solvedate` > `glpi_tickets`.`internal_time_to_resolve`
                  OR (`glpi_tickets`.`solvedate` IS NULL
                     AND `glpi_tickets`.`internal_time_to_resolve` < NOW())),
            1, 0)) OR (IF(`glpi_tickets`.`time_to_own` IS NOT NULL
            AND `glpi_tickets`.`status` <> 4
            AND (`glpi_tickets`.`takeintoaccount_delay_stat`
                        > TIME_TO_SEC(TIMEDIFF(`glpi_tickets`.`time_to_own`,
                                               `glpi_tickets`.`date`))
                 OR (`glpi_tickets`.`takeintoaccount_delay_stat` = 0
                      AND `glpi_tickets`.`time_to_own` < NOW())),
            1, 0)) OR (IF(`glpi_tickets`.`internal_time_to_own` IS NOT NULL
            AND `glpi_tickets`.`status` <> 4
            AND (`glpi_tickets`.`takeintoaccount_delay_stat`
                        > TIME_TO_SEC(TIMEDIFF(`glpi_tickets`.`internal_time_to_own`,
                                               `glpi_tickets`.`date`))
                 OR (`glpi_tickets`.`takeintoaccount_delay_stat` = 0
                      AND `glpi_tickets`.`internal_time_to_own` < NOW())),
            1, 0))))
  Warnings: 
1292: Truncated incorrect time value: '1465:52:51'
1292: Truncated incorrect time value: '3698:30:51'
```

Anyway, searching in MySQL documentation, I found that instead of using `TIMEDIFF` in TTR/TTO computation, we should use `TIMESTAMPDIFF`.
> The result returned by TIMEDIFF() is limited to the range allowed for [TIME](https://dev.mysql.com/doc/refman/5.7/en/time.html) values. Alternatively, you can use either of the functions [TIMESTAMPDIFF()](https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timestampdiff) and [UNIX_TIMESTAMP()](https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_unix-timestamp), both of which return integers.

Arguments have to be reversed:
 - TIMEDIFF() returns expr1 − expr2 expressed as a time value.
 - TIMESTAMPDIFF() returns datetime_expr2 − datetime_expr1. The unit for the result (an integer) is given by the unit argument. 