### PR TITLE
fix(contract): display of recorded hours

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -598,10 +598,8 @@
       {% set options = options|merge({specific_tags: {'disabled': 'disabled'}}) %}
    {% endif %}
 
-   {% set types = options['types']|default([]) %}
-
    {% set field %}
-      {% do call('Dropdown::showHours', [name, types, {
+      {% do call('Dropdown::showHours', [name, {
          'rand': rand,
          'width': '100%',
          'value': value


### PR DESCRIPTION
In the contracts, the hours (in Support hours) were recorded in the base but not displayed.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23559
