### PR TITLE
Fix old survey clean

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1702,10 +1702,7 @@ class Ticket extends CommonITILObject
             && (mt_rand(1, 100) <= $rate)
         ) {
             // For reopened ticket
-            if ($inquest->getFromDB($this->fields['id'])) {
-                $resp = $inquest->fields;
-                $inquest->delete($resp);
-            }
+            $inquest->delete(['tickets_id' => $this->fields['id']]);
 
             $inquest->add(
                 [

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -4079,14 +4079,8 @@ HTML
         $entities_id = $ticket->fields['entities_id'];
         // Update Entity to enable survey
         $entity = new \Entity();
-        $entity->getFromDB($entities_id);
-        $original_inquest_values = [
-            'inquest_config'    => $entity->fields['inquest_config'],
-            'inquest_rate'      => $entity->fields['inquest_rate'],
-            'inquest_delay'     => $entity->fields['inquest_delay'],
-        ];
         $result = $entity->update([
-            'id' => $entities_id,
+            'id'                => $entities_id,
             'inquest_config'    => 1,
             'inquest_rate'      => 100,
             'inquest_delay'     => 0,
@@ -4106,21 +4100,10 @@ HTML
         $this->integer($it->count())->isEqualTo(0);
 
         // Close ticket
-        $result_ticket = $ticket->update([
+        $this->boolean($ticket->update([
             'id' => $tickets_id,
             'status' => \CommonITILObject::CLOSED
-        ]);
-
-        // Reset entity
-        $result = $entity->update([
-            'id' => $entities_id,
-            'inquest_config'    => $original_inquest_values['inquest_config'],
-            'inquest_rate'      => $original_inquest_values['inquest_rate'],
-            'inquest_delay'     => $original_inquest_values['inquest_delay'],
-        ]);
-        $this->boolean($result)->isTrue();
-
-        $this->boolean($result_ticket)->isTrue();
+        ]))->isTrue();
 
         // Verify survey created
         $it = $DB->request([
@@ -4149,14 +4132,8 @@ HTML
         $entities_id = $ticket->fields['entities_id'];
         // Update Entity to enable survey
         $entity = new \Entity();
-        $entity->getFromDB($entities_id);
-        $original_inquest_values = [
-            'inquest_config'    => $entity->fields['inquest_config'],
-            'inquest_rate'      => $entity->fields['inquest_rate'],
-            'inquest_delay'     => $entity->fields['inquest_delay'],
-        ];
         $result = $entity->update([
-            'id' => $entities_id,
+            'id'                => $entities_id,
             'inquest_config'    => 1,
             'inquest_rate'      => 100,
             'inquest_delay'     => 0,
@@ -4176,21 +4153,10 @@ HTML
         $this->integer($it->count())->isEqualTo(0);
 
         // Close ticket
-        $result_ticket = $ticket->update([
+        $this->boolean($ticket->update([
             'id' => $tickets_id,
             'status' => \CommonITILObject::CLOSED
-        ]);
-
-        // Reset entity
-        $result = $entity->update([
-            'id' => $entities_id,
-            'inquest_config'    => $original_inquest_values['inquest_config'],
-            'inquest_rate'      => $original_inquest_values['inquest_rate'],
-            'inquest_delay'     => $original_inquest_values['inquest_delay'],
-        ]);
-        $this->boolean($result)->isTrue();
-
-        $this->boolean($result_ticket)->isTrue();
+        ]))->isTrue();
 
         // Reopen ticket
         $this->boolean($ticket->update([
@@ -4207,21 +4173,10 @@ HTML
         $this->boolean($result)->isTrue();
 
         // Re-close ticket
-        $result_ticket = $ticket->update([
+        $this->boolean($ticket->update([
             'id' => $tickets_id,
             'status' => \CommonITILObject::CLOSED
-        ]);
-
-        // Reset entity
-        $result = $entity->update([
-            'id' => $entities_id,
-            'inquest_config'    => $original_inquest_values['inquest_config'],
-            'inquest_rate'      => $original_inquest_values['inquest_rate'],
-            'inquest_delay'     => $original_inquest_values['inquest_delay'],
-        ]);
-        $this->boolean($result)->isTrue();
-
-        $this->boolean($result_ticket)->isTrue();
+        ]))->isTrue();
 
         // Verify survey created and only one exists
         $it = $DB->request([

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -4062,4 +4062,175 @@ HTML
         $this->boolean($ticket->getFromDB($tickets_id))->isTrue();
         $this->integer($ticket->fields['status'])->isEqualTo(\CommonITILObject::CLOSED);
     }
+
+    public function testSurveyCreation()
+    {
+        global $DB;
+
+        $this->login();
+        // Create ticket
+        $ticket = new \Ticket();
+        $tickets_id = $ticket->add([
+            'name' => 'testSurveyCreation',
+            'content' => 'testSurveyCreation',
+        ]);
+        $this->integer($tickets_id)->isGreaterThan(0);
+
+        $entities_id = $ticket->fields['entities_id'];
+        // Update Entity to enable survey
+        $entity = new \Entity();
+        $entity->getFromDB($entities_id);
+        $original_inquest_values = [
+            'inquest_config'    => $entity->fields['inquest_config'],
+            'inquest_rate'      => $entity->fields['inquest_rate'],
+            'inquest_delay'     => $entity->fields['inquest_delay'],
+        ];
+        $result = $entity->update([
+            'id' => $entities_id,
+            'inquest_config'    => 1,
+            'inquest_rate'      => 100,
+            'inquest_delay'     => 0,
+        ]);
+        $this->boolean($result)->isTrue();
+
+        $inquest = new \TicketSatisfaction();
+
+        // Verify no existing survey for ticket
+        $it = $DB->request([
+            'SELECT' => ['id'],
+            'FROM' => \TicketSatisfaction::getTable(),
+            'WHERE' => [
+                'tickets_id' => $tickets_id,
+            ],
+        ]);
+        $this->integer($it->count())->isEqualTo(0);
+
+        // Close ticket
+        $result_ticket = $ticket->update([
+            'id' => $tickets_id,
+            'status' => \CommonITILObject::CLOSED
+        ]);
+
+        // Reset entity
+        $result = $entity->update([
+            'id' => $entities_id,
+            'inquest_config'    => $original_inquest_values['inquest_config'],
+            'inquest_rate'      => $original_inquest_values['inquest_rate'],
+            'inquest_delay'     => $original_inquest_values['inquest_delay'],
+        ]);
+        $this->boolean($result)->isTrue();
+
+        $this->boolean($result_ticket)->isTrue();
+
+        // Verify survey created
+        $it = $DB->request([
+            'SELECT' => ['id'],
+            'FROM' => \TicketSatisfaction::getTable(),
+            'WHERE' => [
+                'tickets_id' => $tickets_id,
+            ],
+        ]);
+        $this->integer($it->count())->isEqualTo(1);
+    }
+
+    public function testSurveyCreationOnReopened()
+    {
+        global $DB;
+
+        $this->login();
+        // Create ticket
+        $ticket = new \Ticket();
+        $tickets_id = $ticket->add([
+            'name' => 'testSurveyCreation',
+            'content' => 'testSurveyCreation',
+        ]);
+        $this->integer($tickets_id)->isGreaterThan(0);
+
+        $entities_id = $ticket->fields['entities_id'];
+        // Update Entity to enable survey
+        $entity = new \Entity();
+        $entity->getFromDB($entities_id);
+        $original_inquest_values = [
+            'inquest_config'    => $entity->fields['inquest_config'],
+            'inquest_rate'      => $entity->fields['inquest_rate'],
+            'inquest_delay'     => $entity->fields['inquest_delay'],
+        ];
+        $result = $entity->update([
+            'id' => $entities_id,
+            'inquest_config'    => 1,
+            'inquest_rate'      => 100,
+            'inquest_delay'     => 0,
+        ]);
+        $this->boolean($result)->isTrue();
+
+        $inquest = new \TicketSatisfaction();
+
+        // Verify no existing survey for ticket
+        $it = $DB->request([
+            'SELECT' => ['id'],
+            'FROM' => \TicketSatisfaction::getTable(),
+            'WHERE' => [
+                'tickets_id' => $tickets_id,
+            ],
+        ]);
+        $this->integer($it->count())->isEqualTo(0);
+
+        // Close ticket
+        $result_ticket = $ticket->update([
+            'id' => $tickets_id,
+            'status' => \CommonITILObject::CLOSED
+        ]);
+
+        // Reset entity
+        $result = $entity->update([
+            'id' => $entities_id,
+            'inquest_config'    => $original_inquest_values['inquest_config'],
+            'inquest_rate'      => $original_inquest_values['inquest_rate'],
+            'inquest_delay'     => $original_inquest_values['inquest_delay'],
+        ]);
+        $this->boolean($result)->isTrue();
+
+        $this->boolean($result_ticket)->isTrue();
+
+        // Reopen ticket
+        $this->boolean($ticket->update([
+            'id' => $tickets_id,
+            'status' => \CommonITILObject::INCOMING
+        ]))->isTrue();
+
+        $result = $entity->update([
+            'id' => $entities_id,
+            'inquest_config'    => 1,
+            'inquest_rate'      => 100,
+            'inquest_delay'     => 0,
+        ]);
+        $this->boolean($result)->isTrue();
+
+        // Re-close ticket
+        $result_ticket = $ticket->update([
+            'id' => $tickets_id,
+            'status' => \CommonITILObject::CLOSED
+        ]);
+
+        // Reset entity
+        $result = $entity->update([
+            'id' => $entities_id,
+            'inquest_config'    => $original_inquest_values['inquest_config'],
+            'inquest_rate'      => $original_inquest_values['inquest_rate'],
+            'inquest_delay'     => $original_inquest_values['inquest_delay'],
+        ]);
+        $this->boolean($result)->isTrue();
+
+        $this->boolean($result_ticket)->isTrue();
+
+        // Verify survey created and only one exists
+        $it = $DB->request([
+            'SELECT' => ['id'],
+            'FROM' => \TicketSatisfaction::getTable(),
+            'WHERE' => [
+                'tickets_id' => $tickets_id,
+            ],
+        ]);
+        $this->integer($it->count())->isEqualTo(1);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Found while looking into #9931 but may not be related.
The code looks like it is removing any survey that has the same ID as the current ticket rather than deleting old surveys for this ticket.