### PR TITLE
Fix satisfaction survey notification; fixes #9931

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -583,7 +583,7 @@ class CommonDBTM extends CommonGLPI {
 
       if (count($oldvalues)) {
          Log::constructHistory($this, $oldvalues, $this->fields);
-         $this->getFromDB($this->fields['id']);
+         $this->getFromDB($this->fields[$this->getIndexName()]);
       }
 
       return true;
@@ -617,7 +617,7 @@ class CommonDBTM extends CommonGLPI {
                $this->fields['id'] = $DB->insertId();
             }
 
-            $this->getFromDB($this->fields['id']);
+            $this->getFromDB($this->fields[$this->getIndexName()]);
 
             return $this->fields['id'];
          }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #9931

`CommonDBTM::getFromDB()` is loading the object based on the value of its index field (i.e. the field having the name returned by `CommonDBTM::getIndexName()`).