### PR TITLE
Remove obsolete hacky encoding fallback in collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The present file will list all changes made to the project; according to the
 #### Changes
 
 #### Deprecated
+- `Toolbox::seems_utf8()`
 
 #### Removed
 

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1089,17 +1089,10 @@ class MailCollector extends CommonDBTM
             $subject = '';
         }
         $tkt['name'] = $this->cleanSubject($subject);
-        if (!Toolbox::seems_utf8($tkt['name'])) {
-            $tkt['name'] = Toolbox::encodeInUtf8($tkt['name']);
-        }
 
         $tkt['_message']  = $message;
 
-        if (!Toolbox::seems_utf8($body)) {
-            $tkt['content'] = Toolbox::encodeInUtf8($body);
-        } else {
-            $tkt['content'] = $body;
-        }
+        $tkt['content'] = $body;
 
        // Search for referenced item in headers
         $found_item = $this->getItemFromHeaders($message);

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -203,9 +203,12 @@ class Toolbox
      * @param $str string   string to analyse
      *
      * @return boolean
+     *
+     * @deprecated 10.1.0
      **/
     public static function seems_utf8($str)
     {
+        Toolbox::deprecated();
         return mb_check_encoding($str, "UTF-8");
     }
 

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -417,7 +417,7 @@ class Toolbox extends DbTestCase
      */
     public function testSeems_utf8($string, $utf)
     {
-        $this->boolean(\Toolbox::seems_utf8($string))->isIdenticalTo($utf);
+        $this->boolean(@\Toolbox::seems_utf8($string))->isIdenticalTo($utf);
     }
 
     public function testSaveAndDeletePicture()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

MailCollector is now handling email encoding using a clean logic that is based on email headers. This hacky code is no longer needed.