### PR TITLE
Fix entities encoding of RichText::getTextFromHtml() in HTML rendering context

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -4596,7 +4596,7 @@ class CommonDBTM extends CommonGLPI
 
                     case "text":
                         if (isset($searchoptions['htmltext']) && $searchoptions['htmltext']) {
-                            $value = RichText::getTextFromHtml($value, true, false);
+                            $value = RichText::getTextFromHtml($value, true, false, true);
                         }
 
                         return $options['html'] ? nl2br($value) : $value;

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1728,7 +1728,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             printf(
                 __('%1$s %2$s'),
                 $link,
-                Html::resume_text(RichText::getTextFromHtml($job->fields['content'], false, true), 50)
+                Html::resume_text(RichText::getTextFromHtml($job->fields['content'], false, true, true), 50)
             );
 
             echo "</a>";

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1794,7 +1794,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
                     echo Search::showItem(
                         $output_type,
                         "<div class='kb'>$toadd <i class='fa fa-fw $fa_class' title='$fa_title'></i> <a $href>" . Html::resume_text($name, 80) . "</a></div>
-                                       <div class='kb_resume'>" . Html::resume_text(RichText::getTextFromHtml($answer, false, false), 600) . "</div>",
+                                       <div class='kb_resume'>" . Html::resume_text(RichText::getTextFromHtml($answer, false, false, true), 600) . "</div>",
                         $item_num,
                         $row_num
                     );

--- a/src/Search.php
+++ b/src/Search.php
@@ -7033,7 +7033,8 @@ JAVASCRIPT;
                             }
                             $count_display++;
 
-                            $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], false, true);
+
+                            $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], false, true, true);
 
                             if (self::$output_type == self::HTML_OUTPUT && (Toolbox::strlen($plaintext) > $CFG_GLPI['cut'])) {
                                 $rand = mt_rand();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`RichText::getTextFromHtml()` returns by default a "plain text" that may contains html special chars, like `<` or `>`. It is important, in HTML rendering context, to indicates that expected result has its entities encoded, to prevent any display or security issue.