### PR TITLE
Improve error message when network property missing

### DIFF
--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -249,7 +249,8 @@ class IPNetwork extends CommonImplicitTreeDropdown
         $netmask = new IPNetmask();
        // Don't validate an empty network
         if (empty($input["network"])) {
-            return ['error' => __('Invalid network address'),
+            return [
+                'error' => __('Missing network property (In CIDR notation. Ex: 192.168.1.1/24)'),
                 'input' => false
             ];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Related to #2573. IPNetworks have a "virtual" field `network` used during add and update and it sets the different address and netmask fields from it. When you retrieve an IPNetwork over the API, you see all the address and netmask fields and it may cause confusion when you try using that schema to update one or create a new one.
Currently, you would get "Invalid network address" error if you don't use `network` but that could make you think one of the address fields you set is wrong.
New message should help indicate that there should be a `network` property in CIDR notation.