### PR TITLE
Preserve form events during Kanban refresh

### DIFF
--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -575,7 +575,9 @@ class GLPIKanbanRights {
                 if (forms.length > 0) {
                     self.temp_forms[column.id] = [];
                     $.each(forms, function(i2, form) {
-                        self.temp_forms[column.id].push($(form).clone());
+                        // Copy event handlers for element and child elements
+                        // Otherwise, the Add button will act like a normal submit button (not wanted)
+                        self.temp_forms[column.id].push($(form).clone(true, true));
                     });
                 }
             });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10900

During a background refresh of the Kanban, any open Add or Bulk Add form is copied outside the DOM and then added back in. During the preservation, the jQuery `clone` method is used but the option to clone events wasn't enabled so after the restore, the Add button in the form acted like a regular submit button instead of using the custom handler.