### PR TITLE
Replace usage of -1 entities_id rules; fixes #10903

### DIFF
--- a/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
@@ -770,7 +770,6 @@ $DB->updateOrDie(
     ['entities_id' => 0],
     ['entities_id' => -1]
 );
-$migration->changeField('glpi_rules', 'entities_id', 'entities_id', "int {$default_key_sign} DEFAULT NULL");
 
 // Replace unused -1 default values on entities_id foreign keys
 $tables = [

--- a/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
@@ -764,6 +764,14 @@ foreach ($tables as $table) {
     );
 }
 
+// Replace -1 default values on glpi_rules.entities_id
+$DB->updateOrDie(
+    'glpi_rules',
+    ['entities_id' => 0],
+    ['entities_id' => -1]
+);
+$migration->changeField('glpi_rules', 'entities_id', 'entities_id', "int {$default_key_sign} DEFAULT NULL");
+
 // Replace unused -1 default values on entities_id foreign keys
 $tables = [
     'glpi_fieldunicities',

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -3000,7 +3000,7 @@ class Rule extends CommonDBTM
         $this->dropdownRulesMatch();
         echo "</td><td class='tab_bg_2 center'>";
         echo "<input type=hidden name='sub_type' value='" . get_class($this) . "'>";
-        echo "<input type=hidden name='entities_id' value='-1'>";
+        echo "<input type=hidden name='entities_id' value='0'>";
         echo "<input type=hidden name='affectentity' value='$ID'>";
         echo "<input type=hidden name='_method' value='AddRule'>";
         echo "<input type='submit' name='execute' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";

--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -64,7 +64,7 @@ class RuleRight extends Rule
         $this->dropdownRulesMatch();
         echo "</td><td rowspan='2' class='tab_bg_2 center middle'>";
         echo "<input type=hidden name='sub_type' value='" . get_class($this) . "'>";
-        echo "<input type=hidden name='entities_id' value='-1'>";
+        echo "<input type=hidden name='entities_id' value='0'>";
         echo "<input type=hidden name='affectentity' value='$ID'>";
         echo "<input type=hidden name='_method' value='AddRule'>";
         echo "<input type='submit' name='execute' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10903

`showNewRuleForm()` is used only on rules that cannot be assigned to entities. These rules are not using the `entities_id` field.