### PR TITLE
Fix handling of admin target in notifications; fixes #10908

### DIFF
--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -86,7 +86,6 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
         $user = new User();
         if ($user->getFromDBbyEmail($CFG_GLPI['admin_email'])) {
             $admin['users_id'] = $user->getID();
-            $admin['usertype'] = $user->fields['usertype'];
         }
 
         return $admin;
@@ -115,7 +114,6 @@ class NotificationEventMailing extends NotificationEventAbstract implements Noti
                 $user = new User();
                 if ($user->getFromDBbyEmail($row['admin_email'])) {
                     $admin['users_id'] = $user->getID();
-                    $admin['usertype'] = $user->fields['usertype'];
                 }
                 $admins[] = $admin;
             }

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -655,7 +655,7 @@ class NotificationTarget extends CommonDBChild
         $admin_data = $eventclass::getAdminData();
 
         if ($admin_data) {
-            if (!isset($admin_data['usertype'])) {
+            if (!isset($admin_data['users_id']) && !isset($admin_data['usertype'])) {
                 $admin_data['usertype'] = $this->getDefaultUserType();
             }
             $this->addToRecipientsList($admin_data);
@@ -756,7 +756,7 @@ class NotificationTarget extends CommonDBChild
 
         if ($admins_data) {
             foreach ($admins_data as $admin_data) {
-                if (!isset($admin_data['usertype'])) {
+                if (!isset($admin_data['users_id']) && !isset($admin_data['usertype'])) {
                     $admin_data['usertype'] = $this->getDefaultUserType();
                 }
                 $this->addToRecipientsList($admin_data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10908

`usertype` is automatically computed by `NotificationTarget::addToRecipientsList()` as long as `users_id` is defined and is related to an active user.