### PR TITLE
feat(planning): selection after refresh

### DIFF
--- a/css/legacy/includes/_planning.scss
+++ b/css/legacy/includes/_planning.scss
@@ -165,7 +165,7 @@
                   display: block;
 
                   > li label {
-                     width: 173px;
+                     width: 162px;
                   }
                }
             }

--- a/js/planning.js
+++ b/js/planning.js
@@ -749,7 +749,7 @@ var GLPIPlanning  = {
                 sendDisplayEvent($(this), true);
             });
 
-        $('#planning_filter li.group_users > span > input[type="checkbox"]')
+        $('#planning_filter li.group_users > input[type="checkbox"]')
             .on('change', function() {
                 var parent_checkbox    = $(this);
                 var parent_li          = parent_checkbox.parents('li');

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -934,6 +934,7 @@ class Planning extends CommonGLPI
         $actor = explode('_', $filter_key);
         $uID = 0;
         $gID = 0;
+        $expanded = '';
         if ($filter_data['type'] == 'user') {
             $uID = $actor[1];
             $user = new User();
@@ -943,6 +944,18 @@ class Planning extends CommonGLPI
             $group = new Group();
             $group->getFromDB($actor[1]);
             $title = $group->getName();
+            $enabled = $disabled = 0;
+            foreach ($filter_data['users'] as $user) {
+                if ($user['display']) {
+                    $enabled++;
+                } else {
+                    $disabled++;
+                    $filter_data['display'] = false;
+                }
+            }
+            if ($enabled > 0 && $disabled > 0) {
+                $expanded = ' expanded';
+            }
         } else if ($filter_data['type'] == 'group') {
             $gID = $actor[1];
             $group = new Group();
@@ -967,7 +980,7 @@ class Planning extends CommonGLPI
 
         echo "<li event_type='" . $filter_data['type'] . "'
                event_name='$filter_key'
-               class='" . $filter_data['type'] . "'>";
+               class='" . $filter_data['type'] . $expanded . "'>";
         Html::showCheckbox([
             'name'          => 'filters[]',
             'value'         => $filter_key,


### PR DESCRIPTION
FEAT:
In the case of adding "All users of a group", after a refresh :
- check the group if all users are checked (uncheck the group otherwise)
- unfold the group if there is a mix of checked and unchecked users (fold if all users are the same)

FIX :
- the label was too broad
- if the group was checked, its users were not checked and vice versa.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23569
