### PR TITLE
Fix SLA/OLA replay infinite loop

### DIFF
--- a/src/OlaLevel_Ticket.php
+++ b/src/OlaLevel_Ticket.php
@@ -346,12 +346,18 @@ class OlaLevel_Ticket extends CommonDBTM
         ];
 
         $number = 0;
+        $last_escalation = -1;
         do {
             $iterator = $DB->request($criteria);
             $number = count($iterator);
             if ($number == 1) {
                 $data = $iterator->current();
+                if ($data['id'] === $last_escalation) {
+                    // Possible infinite loop. Trying to apply exact same SLA assignment.
+                    break;
+                }
                 self::doLevelForTicket($data, $olaType);
+                $last_escalation = $data['id'];
             }
         } while ($number == 1);
     }

--- a/src/SlaLevel_Ticket.php
+++ b/src/SlaLevel_Ticket.php
@@ -339,12 +339,18 @@ class SlaLevel_Ticket extends CommonDBTM
         ];
 
         $number = 0;
+        $last_escalation = -1;
         do {
             $iterator = $DB->request($criteria);
             $number = count($iterator);
             if ($number == 1) {
                 $data = $iterator->current();
+                if ($data['id'] === $last_escalation) {
+                    // Possible infinite loop. Trying to apply exact same SLA assignment.
+                    break;
+                }
                 self::doLevelForTicket($data, $slaType);
+                $last_escalation = $data['id'];
             }
         } while ($number == 1);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6010

When trying to apply a SLA/OLA on a solved ticket, no new escalation level is assigned and none is removed. This causes the `replayForTicket` function to loop indefinitely and call `doLevelForTicket` for the same level.
This is an alternative to #9740 where here we only check if it tries applying the same level twice in a row.

I'm not sure how this could be regression tested since the previous behavior was an infinite loop.