### PR TITLE
Allow custom options for SearchInput JS

### DIFF
--- a/js/modules/SearchTokenizer/SearchInput.js
+++ b/js/modules/SearchTokenizer/SearchInput.js
@@ -86,22 +86,34 @@ export default class SearchInput {
         if (typeof this.options.input_options.attributes === 'object') {
             new_attrs = this.options.input_options.attributes;
         } else if (this.options.input_options.attributes === 'copy') {
-            const original_attr = this.original_input.attr();
-            // Get only non-data attributes
-            new_attrs = Object.keys(original_attr).filter(key => !key.startsWith('data-')).reduce((obj, key) => {
-                obj[key] = original_attr[key];
-                return obj;
-            }, {});
+            const original_attr = this.original_input.get(0).attributes;
+            for (let i = 0; i < original_attr.length; i++) {
+                // Get only non-data attributes
+                if (!original_attr[i].name.startsWith('data-')) {
+                    new_attrs[original_attr[i].name] = original_attr[i].value;
+                }
+            }
         }
 
         let new_data = {};
+        let old_data_attrs = {};
         if (typeof this.options.input_options.data === 'object') {
             new_data = this.options.input_options.data;
         } else if (this.options.input_options.data === 'copy') {
             new_data = this.original_input.data();
+            const original_attr = this.original_input.get(0).attributes;
+            // Get data attributes in case they aren't in jQuery data
+            for (let i = 0; i < original_attr.length; i++) {
+                // Get only data attributes
+                if (original_attr[i].name.startsWith('data-')) {
+                    old_data_attrs[original_attr[i].name] = original_attr[i].value;
+                }
+            }
         }
+
         // Add data attributes. We don't use $.data() because having the DOM attribute may be needed and using $.data doesn't add them.
-        Object.assign(Object.keys(new_data).reduce((obj, key) => {
+        // Information from $.data will override any data attributes of the same name
+        new_attrs = Object.assign(old_data_attrs, Object.keys(new_data).reduce((obj, key) => {
             obj['data-' + key] = new_data[key];
             return obj;
         }, new_attrs));

--- a/js/modules/SearchTokenizer/SearchInput.js
+++ b/js/modules/SearchTokenizer/SearchInput.js
@@ -89,7 +89,7 @@ export default class SearchInput {
             const original_attr = this.original_input.get(0).attributes;
             for (let i = 0; i < original_attr.length; i++) {
                 // Get only non-data attributes
-                if (!original_attr[i].name.startsWith('data-')) {
+                if (!original_attr[i].name.startsWith('data-') && original_attr[i].name !== 'class') {
                     new_attrs[original_attr[i].name] = original_attr[i].value;
                 }
             }

--- a/js/modules/SearchTokenizer/SearchInput.js
+++ b/js/modules/SearchTokenizer/SearchInput.js
@@ -113,7 +113,7 @@ export default class SearchInput {
         if (Array.isArray(this.options.input_options.classes)) {
             this.displayed_input.addClass(this.options.input_options.classes.join(' '));
         } else if (this.options.input_options.classes === 'copy') {
-            this.displayed_input.addClass(this.original_input.attr('class').join(' '));
+            this.displayed_input.addClass(this.original_input.attr('class'));
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
                 "@babel/plugin-transform-modules-commonjs": "^7.15.0",
                 "@babel/plugin-transform-runtime": "^7.15.0",
                 "@babel/preset-env": "^7.15.0",
+                "@testing-library/jest-dom": "^5.16.2",
                 "babel-jest": "^27.3.0",
                 "clean-webpack-plugin": "^4.0.0",
                 "copy-webpack-plugin": "^10.0.0",
@@ -2722,6 +2723,95 @@
                 "react-dom": "^16.x || 17.x"
             }
         },
+        "node_modules/@testing-library/jest-dom": {
+            "version": "5.16.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.2.tgz",
+            "integrity": "sha512-6ewxs1MXWwsBFZXIk4nKKskWANelkdUehchEOokHsN8X7c2eKXGw+77aRV63UU8f/DTSVUPLaGxdrj4lN7D/ug==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.9.2",
+                "@types/testing-library__jest-dom": "^5.9.1",
+                "aria-query": "^5.0.0",
+                "chalk": "^3.0.0",
+                "css": "^3.0.0",
+                "css.escape": "^1.5.1",
+                "dom-accessibility-api": "^0.5.6",
+                "lodash": "^4.17.15",
+                "redent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8",
+                "npm": ">=6",
+                "yarn": ">=1"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/@tootallnate/once": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -2841,6 +2931,16 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
+        "node_modules/@types/jest": {
+            "version": "27.4.1",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
+            "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
+            "dev": true,
+            "dependencies": {
+                "jest-matcher-utils": "^27.0.0",
+                "pretty-format": "^27.0.0"
+            }
+        },
         "node_modules/@types/json-schema": {
             "version": "7.0.9",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -2888,6 +2988,15 @@
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
             "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
             "dev": true
+        },
+        "node_modules/@types/testing-library__jest-dom": {
+            "version": "5.14.3",
+            "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.3.tgz",
+            "integrity": "sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==",
+            "dev": true,
+            "dependencies": {
+                "@types/jest": "*"
+            }
         },
         "node_modules/@types/yargs": {
             "version": "16.0.4",
@@ -3304,6 +3413,15 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "node_modules/aria-query": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+            "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.0"
+            }
+        },
         "node_modules/array-union": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
@@ -3348,6 +3466,18 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
+        },
+        "node_modules/atob": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "dev": true,
+            "bin": {
+                "atob": "bin/atob.js"
+            },
+            "engines": {
+                "node": ">= 4.5.0"
+            }
         },
         "node_modules/babel-jest": {
             "version": "27.5.1",
@@ -4109,6 +4239,17 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+            "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+            "dev": true,
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "source-map": "^0.6.1",
+                "source-map-resolve": "^0.6.0"
+            }
+        },
         "node_modules/css-functions-list": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.1.tgz",
@@ -4173,6 +4314,21 @@
             }
         },
         "node_modules/css-tree/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+            "dev": true
+        },
+        "node_modules/css/node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
@@ -4383,6 +4539,15 @@
             "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
             "dev": true
         },
+        "node_modules/decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
         "node_modules/dedent": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -4536,6 +4701,12 @@
             "engines": {
                 "node": ">=6.0.0"
             }
+        },
+        "node_modules/dom-accessibility-api": {
+            "version": "0.5.13",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz",
+            "integrity": "sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==",
+            "dev": true
         },
         "node_modules/domexception": {
             "version": "2.0.1",
@@ -9732,6 +9903,17 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/source-map-resolve": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+            "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+            "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+            "dev": true,
+            "dependencies": {
+                "atob": "^2.1.2",
+                "decode-uri-component": "^0.2.0"
+            }
+        },
         "node_modules/source-map-support": {
             "version": "0.5.21",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -12854,6 +13036,74 @@
             "integrity": "sha512-X0SjUMWlu6IWsWIZP6gtMZhi9Q7pO2+BQ9vex28rOu+gtym7fZjnDXWG0okzVhtt4mlOwJ2BHQllRky29lsn7Q==",
             "requires": {}
         },
+        "@testing-library/jest-dom": {
+            "version": "5.16.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.2.tgz",
+            "integrity": "sha512-6ewxs1MXWwsBFZXIk4nKKskWANelkdUehchEOokHsN8X7c2eKXGw+77aRV63UU8f/DTSVUPLaGxdrj4lN7D/ug==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.9.2",
+                "@types/testing-library__jest-dom": "^5.9.1",
+                "aria-query": "^5.0.0",
+                "chalk": "^3.0.0",
+                "css": "^3.0.0",
+                "css.escape": "^1.5.1",
+                "dom-accessibility-api": "^0.5.6",
+                "lodash": "^4.17.15",
+                "redent": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "@tootallnate/once": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -12970,6 +13220,16 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
+        "@types/jest": {
+            "version": "27.4.1",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
+            "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
+            "dev": true,
+            "requires": {
+                "jest-matcher-utils": "^27.0.0",
+                "pretty-format": "^27.0.0"
+            }
+        },
         "@types/json-schema": {
             "version": "7.0.9",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -13017,6 +13277,15 @@
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
             "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
             "dev": true
+        },
+        "@types/testing-library__jest-dom": {
+            "version": "5.14.3",
+            "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.3.tgz",
+            "integrity": "sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==",
+            "dev": true,
+            "requires": {
+                "@types/jest": "*"
+            }
         },
         "@types/yargs": {
             "version": "16.0.4",
@@ -13369,6 +13638,12 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "aria-query": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+            "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+            "dev": true
+        },
         "array-union": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
@@ -13397,6 +13672,12 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "atob": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
         },
         "babel-jest": {
@@ -13988,6 +14269,25 @@
                 "which": "^2.0.1"
             }
         },
+        "css": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+            "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.4",
+                "source-map": "^0.6.1",
+                "source-map-resolve": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
         "css-functions-list": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.1.tgz",
@@ -14038,6 +14338,12 @@
                     "dev": true
                 }
             }
+        },
+        "css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+            "dev": true
         },
         "cssesc": {
             "version": "3.0.0",
@@ -14195,6 +14501,12 @@
             "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
             "dev": true
         },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "dev": true
+        },
         "dedent": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -14319,6 +14631,12 @@
             "requires": {
                 "esutils": "^2.0.2"
             }
+        },
+        "dom-accessibility-api": {
+            "version": "0.5.13",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz",
+            "integrity": "sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==",
+            "dev": true
         },
         "domexception": {
             "version": "2.0.1",
@@ -18212,6 +18530,16 @@
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
             "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
             "dev": true
+        },
+        "source-map-resolve": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+            "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+            "dev": true,
+            "requires": {
+                "atob": "^2.1.2",
+                "decode-uri-component": "^0.2.0"
+            }
         },
         "source-map-support": {
             "version": "0.5.21",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.15.0",
         "@babel/plugin-transform-runtime": "^7.15.0",
         "@babel/preset-env": "^7.15.0",
+        "@testing-library/jest-dom": "^5.16.2",
         "babel-jest": "^27.3.0",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^10.0.0",

--- a/tests/js/SearchTokenizer/SearchInput.test.js
+++ b/tests/js/SearchTokenizer/SearchInput.test.js
@@ -111,7 +111,11 @@ describe('Search Tokenizer Input', () => {
         test_input.addClass(input_options.classes);
 
         const search_input = new SearchInput(test_input, {
-            input_options: input_options
+            input_options: {
+                classes: 'copy',
+                attributes: 'copy',
+                data: 'copy',
+            }
         });
         expect(search_input.original_input).toStrictEqual(test_input);
 

--- a/tests/js/SearchTokenizer/SearchInput.test.js
+++ b/tests/js/SearchTokenizer/SearchInput.test.js
@@ -58,6 +58,73 @@ describe('Search Tokenizer Input', () => {
         expect(default_tag_input.attr('contenteditable') === 'true').toBeTrue();
     });
 
+    test('Construct with custom input options', () => {
+        const test_input = $('input[name=filter]');
+        const input_options = {
+            classes: ['custom-class-1', 'custom-class-2'],
+            attributes: {
+                'test-attr-1': 'test-attr-1-value',
+                'test-attr-2': 'test-attr-2-value'
+            },
+            data: {
+                'test-data-1': 'test-data-1-value',
+                'test-data-2': 'test-data-2-value'
+            }
+        };
+
+        const search_input = new SearchInput(test_input, {
+            input_options: input_options
+        });
+        expect(search_input.original_input).toStrictEqual(test_input);
+
+        const displayed_input = search_input.displayed_input.get(0);
+        expect(displayed_input).toHaveClass(...input_options.classes);
+        $.each(input_options.attributes, (key, value) => {
+            expect(displayed_input).toHaveAttribute(key, value);
+        });
+        $.each(input_options.data, (key, value) => {
+            expect(displayed_input).toHaveAttribute('data-' + key, value);
+        });
+    });
+
+    test('Construct with copied input options', () => {
+        const test_input = $('input[name=filter]');
+        const input_options = {
+            classes: ['custom-class-1', 'custom-class-2'],
+            attributes: {
+                'test-attr-1': 'test-attr-1-value',
+                'test-attr-2': 'test-attr-2-value'
+            },
+            data: {
+                'test-data-1': 'test-data-1-value',
+                'test-data-2': 'test-data-2-value'
+            }
+        };
+
+        //Apply input options to test_input
+        $.each(input_options.attributes, (key, value) => {
+            test_input.attr(key, value);
+        });
+        $.each(input_options.data, (key, value) => {
+            test_input.attr('data-' + key, value);
+        });
+        test_input.addClass(input_options.classes);
+
+        const search_input = new SearchInput(test_input, {
+            input_options: input_options
+        });
+        expect(search_input.original_input).toStrictEqual(test_input);
+
+        const displayed_input = search_input.displayed_input.get(0);
+        expect(displayed_input).toHaveClass(...input_options.classes);
+        $.each(input_options.attributes, (key, value) => {
+            expect(displayed_input).toHaveAttribute(key, value);
+        });
+        $.each(input_options.data, (key, value) => {
+            expect(displayed_input).toHaveAttribute('data-' + key, value);
+        });
+    });
+
     test('Tags Helper Content', () => {
         const test_input = $('input[name=filter]');
         const search_input = new SearchInput(test_input, {

--- a/tests/js/jest-setup.js
+++ b/tests/js/jest-setup.js
@@ -1,3 +1,34 @@
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
 // Load jest-dom assertion library
 import '@testing-library/jest-dom';
 

--- a/tests/js/jest-setup.js
+++ b/tests/js/jest-setup.js
@@ -1,0 +1,5 @@
+// Load jest-dom assertion library
+import '@testing-library/jest-dom';
+
+// Load extended jest assertions
+import "jest-extended/all";

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -30,7 +30,7 @@
  */
 
 module.exports = {
-    setupFilesAfterEnv: ["jest-extended/all"],
+    setupFilesAfterEnv: ["<rootDir>/jest-setup.js"],
     setupFiles: ['<rootDir>/bootstrap.js'],
     transformIgnorePatterns: [
         // Change MODULE_NAME_HERE to your module that isn't being compiled


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I'm working on something that may use the existing JS code used by the new filtering/tagging system used by the Kanban and it would require inheriting several options from the original input.
I added support for adding custom attributes, data attributes, and classes either statically or by copying them directly from the original input element.

JS tests were updates and Kanban filter was manually tested again just be be sure I didn't somehow break it.