### PR TITLE
match gridstack breakpoint of one colum mode with medium breakpoint o…

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -88,6 +88,10 @@ var Dashboard = {
         this.cols         = options.cols;
         this.cache_key    = options.cache_key || "";
 
+        // compute the width offset of gridstack container relatively to viewport
+        var elem_domRect = this.elem_dom.getBoundingClientRect();
+        var width_offset = elem_domRect.left + (window.innerWidth - elem_domRect.right) + 0.02;
+
         Dashboard.grid = GridStack.init({
             column: options.cols,
             maxRow: (options.rows + 1), // +1 for a hidden item at bottom (to fix height)
@@ -96,7 +100,8 @@ var Dashboard = {
             animate: false, // as we don't move widget automatically, we don't need animation
             draggable: { // override jquery ui draggable options
                 'cancel': 'textarea' // avoid draggable on some child elements
-            }
+            },
+            'minWidth': 768 -  width_offset, // breakpoint of one column mode (based on the dashboard container width), trying to reduce to match the `-md` breakpoint of bootstrap (this last is based on viewport width)
         });
 
         // set grid in static to prevent edition (unless user click on edit button)

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -405,7 +405,7 @@ HTML;
 
         if ($mini) {
             $html = "<div class='card mb-4 d-none d-md-block dashboard-card'>
-            <div class='card-body'>
+            <div class='card-body p-2'>
                $html
             </div>
          </div>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/glpi-project/glpi/pull/10772#issuecomment-1049344518

Ttry to align breakpoints of bootstrap and gridstack.
The gridstack one triggers on container width, the boostrap one on viewport width.

https://github.com/glpi-project/glpi/blob/10.0.0-rc2/src%2FDashboard%2FGrid.php#L394
The mini dashboard is displayed only starting from medium screen size.
There was a small gap of size between the display  of the mini dashboard (vw = 768px) and the dashboard switching to grid mode instead of one colum mode (vw=835px)

To note, we may expect a change in option name with future versions of gridstack:
https://github.com/gridstack/gridstack.js/pull/1938
