### PR TITLE
Prevent requiring --allow-unstable when DB current version is not stable

### DIFF
--- a/src/Console/Database/UpdateCommand.php
+++ b/src/Console/Database/UpdateCommand.php
@@ -142,7 +142,7 @@ class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionComma
             return 0;
         }
 
-        if (!VersionParser::isStableRelease(GLPI_VERSION) && !$allow_unstable) {
+        if (VersionParser::isStableRelease($current_version) && !VersionParser::isStableRelease(GLPI_VERSION) && !$allow_unstable) {
            // Prevent unstable update unless explicitly asked
             $output->writeln(
                 sprintf(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

It does not seems relevant to force usage of `--allow-unstable` option on update command when current version is not a stable version.