### PR TITLE
Fix undefined key in Ticket MA

### DIFF
--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -634,6 +634,7 @@ class MassiveAction
 
        // Manage forbidden actions : try complete action name or MassiveAction:action_name
         $forbidden_actions = $item->getForbiddenStandardMassiveAction();
+        $whitedlisted_actions = [];
         if (
             !isAPI() // Do no filter single actions for API
             && $items_id !== null && $item->getFromDB($items_id)
@@ -642,8 +643,8 @@ class MassiveAction
                 $forbidden_actions,
                 $item->getForbiddenSingleMassiveActions()
             );
+            $whitedlisted_actions = $item->getWhitelistedSingleMassiveActions();
         }
-        $whitedlisted_actions = $item->getWhitelistedSingleMassiveActions();
 
         if (is_array($forbidden_actions) && count($forbidden_actions)) {
             foreach ($forbidden_actions as $actiontodel) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10939

Fix undefined `status` key error when trying to get whitelisted massive actions for single items when there isn't an item (Not in single item context).

Also, I didn't see any way to use these single Massive Action options in the ITILObject UI anymore.