### PR TITLE
remove autoset of _user_id_request without config, see #10846

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1952,15 +1952,6 @@ abstract class CommonITILObject extends CommonDBTM
             $input['users_id_lastupdater'] = $last_updater;
         }
 
-       // No Auto set Import for external source
-        if (!isset($input['_auto_import'])) {
-            if (!isset($input["_users_id_requester"])) {
-                if ($uid = Session::getLoginUserID()) {
-                    $input["_users_id_requester"] = $uid;
-                }
-            }
-        }
-
         if (!isset($input['_skip_auto_assign']) || $input['_skip_auto_assign'] === false) {
            // No Auto set Import for external source
             if (

--- a/tests/functionnal/Glpi/ContentTemplates/Parameters/ChangeParameters.php
+++ b/tests/functionnal/Glpi/ContentTemplates/Parameters/ChangeParameters.php
@@ -85,19 +85,7 @@ class ChangeParameters extends AbstractParameters
                 'completename' => 'category_testGetValues',
             ],
             'requesters' => [
-                'users'  => [
-                    [
-                        'id'       => getItemByTypeName("User", TU_USER, true),
-                        'login'     => TU_USER,
-                        'fullname' => TU_USER,
-                        'email'    => "_test_user@glpi.com",
-                        'phone'    => null,
-                        'phone2'   => null,
-                        'mobile'   => null,
-                        'firstname'  => null,
-                        'realname'   => null,
-                        'used_items' => [],
-                    ],
+                'users'  => [],
                 ],
                 'groups' => [],
             ],

--- a/tests/functionnal/Glpi/ContentTemplates/Parameters/ChangeParameters.php
+++ b/tests/functionnal/Glpi/ContentTemplates/Parameters/ChangeParameters.php
@@ -86,7 +86,6 @@ class ChangeParameters extends AbstractParameters
             ],
             'requesters' => [
                 'users'  => [],
-                ],
                 'groups' => [],
             ],
             'observers' => [

--- a/tests/functionnal/Glpi/ContentTemplates/Parameters/ProblemParameters.php
+++ b/tests/functionnal/Glpi/ContentTemplates/Parameters/ProblemParameters.php
@@ -88,19 +88,7 @@ class ProblemParameters extends AbstractParameters
                 'completename' => 'category_testGetValues',
             ],
             'requesters' => [
-                'users'  => [
-                    [
-                        'id'       => getItemByTypeName("User", TU_USER, true),
-                        'login'    => TU_USER,
-                        'fullname' => TU_USER,
-                        'email'    => "_test_user@glpi.com",
-                        'phone'    => null,
-                        'phone2'   => null,
-                        'mobile'   => null,
-                        'firstname'  => null,
-                        'realname'   => null,
-                        'used_items' => [],
-                    ],
+                'users'  => [],
                 ],
                 'groups' => [],
             ],

--- a/tests/functionnal/Glpi/ContentTemplates/Parameters/ProblemParameters.php
+++ b/tests/functionnal/Glpi/ContentTemplates/Parameters/ProblemParameters.php
@@ -89,7 +89,6 @@ class ProblemParameters extends AbstractParameters
             ],
             'requesters' => [
                 'users'  => [],
-                ],
                 'groups' => [],
             ],
             'observers' => [

--- a/tests/functionnal/Glpi/ContentTemplates/Parameters/TicketParameters.php
+++ b/tests/functionnal/Glpi/ContentTemplates/Parameters/TicketParameters.php
@@ -141,20 +141,7 @@ class TicketParameters extends AbstractParameters
                 'completename' => 'category_testGetValues',
             ],
             'requesters' => [
-                'users'  => [
-                    [
-                        'id'         => getItemByTypeName("User", TU_USER, true),
-                        'login'      => TU_USER,
-                        'fullname'   => TU_USER,
-                        'email'      => "_test_user@glpi.com",
-                        'phone'      => null,
-                        'phone2'     => null,
-                        'mobile'     => null,
-                        'firstname'  => null,
-                        'realname'   => null,
-                        'used_items' => [],
-                    ],
-                ],
+                'users'  => [],
                 'groups' => [
                     [
                         'id'           => $requester_groups_id,

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -383,6 +383,7 @@ class Ticket extends DbTestCase
             (int)$ticket->add([
                 'name'    => '',
                 'content' => 'A ticket to check ACLS',
+                '_users_id_requester' => getItemByTypeName('User', TU_USER, true),
             ])
         )->isGreaterThan(0);
 
@@ -2888,8 +2889,8 @@ class Ticket extends DbTestCase
         $this->integer((int)$fup_count)->isEqualTo(4);
        // Target ticket should have the original document, one instance of the duplicate, and the new document from one of the source tickets
         $this->integer((int)$doc_count)->isEqualTo(3);
-       // Target ticket should have all users not marked as duplicates above + original requester (ID: 6)
-        $this->integer((int)$user_count)->isEqualTo(4);
+       // Target ticket should have all users not marked as duplicates above
+        $this->integer((int)$user_count)->isEqualTo(3);
        // Target ticket should have all groups not marked as duplicates above
         $this->integer((int)$group_count)->isEqualTo(2);
        // Target ticket should have all suppliers not marked as duplicates above

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -383,7 +383,7 @@ class Ticket extends DbTestCase
             (int)$ticket->add([
                 'name'    => '',
                 'content' => 'A ticket to check ACLS',
-                '_users_id_requester' => getItemByTypeName('User', TU_USER, true),
+                '_users_id_requester' => getItemByTypeName('User', 'post-only', true),
             ])
         )->isGreaterThan(0);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Fix the autofilling of `_users_id_requester`without regarding the user preferences