### PR TITLE
Improve timeline item form layouts for non-xxl screens

### DIFF
--- a/templates/components/itilobject/answer.html.twig
+++ b/templates/components/itilobject/answer.html.twig
@@ -29,7 +29,7 @@
  # ---------------------------------------------------------------------
  #}
 
-<div id="new-itilobject-form" class="ms-2">
+<div id="new-itilobject-form" class="ms-auto ps-3">
    {% for timeline_itemtype in timeline_itemtypes %}
       {% set show_kb_sol = load_kb_sol > 0 and timeline_itemtype.type == 'ITILSolution' %}
       <div class="timeline-item mb-3  {{ timeline_itemtype.type }} collapse {{ show_kb_sol ? 'show' : '' }}"

--- a/templates/components/itilobject/answer.html.twig
+++ b/templates/components/itilobject/answer.html.twig
@@ -29,7 +29,7 @@
  # ---------------------------------------------------------------------
  #}
 
-<div id="new-itilobject-form" class="ms-auto">
+<div id="new-itilobject-form" class="ms-2">
    {% for timeline_itemtype in timeline_itemtypes %}
       {% set show_kb_sol = load_kb_sol > 0 and timeline_itemtype.type == 'ITILSolution' %}
       <div class="timeline-item mb-3  {{ timeline_itemtype.type }} collapse {{ show_kb_sol ? 'show' : '' }}"

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -29,12 +29,12 @@
  # ---------------------------------------------------------------------
  #}
 
-{% set timeline_btns_cls = "col-md-8" %}
-{% set form_btns_cls     = "col-md" %}
+{% set timeline_btns_cls = left_regular_cls %}
+{% set form_btns_cls     = is_expanded ? right_expanded_cls : "col-md" %}
 {% set switch_btn_cls    = "fa-caret-left" %}
 {% if is_expanded %}
-    {% set timeline_btns_cls = "col-md-4" %}
-    {% set form_btns_cls     = "col-md-8" %}
+    {% set timeline_btns_cls = left_expanded_cls %}
+    {% set form_btns_cls     = right_expanded_cls %}
     {% set switch_btn_cls    = "fa-caret-right" %}
 {% endif %}
 
@@ -85,10 +85,10 @@
       <div class="form-buttons {{ form_btns_cls }} d-flex justify-content-end ms-auto ms-md-0 my-n2 py-2 pe-3 card-footer border-top-0 position-relative">
          <span class="d-none d-md-block position-absolute top-0 start-0"
                data-bs-toggle="tooltip" data-bs-placement="top" title="{{ __('Toggle panels width') }}">
-            <button type="button" class="switch-panel-width btn btn-sm btn-square btn-icon btn-ghost-secondary">
+            <button type="button" class="switch-panel-width btn btn-sm btn-square btn-icon btn-ghost-secondary px-0">
                <i class="fas {{ switch_btn_cls }}"></i>
             </button>
-            <button type="button" class="collapse-panel btn btn-sm btn-square btn-icon btn-ghost-secondary">
+            <button type="button" class="collapse-panel btn btn-sm btn-square btn-icon btn-ghost-secondary px-0 mr-1">
                <i class="fas fa-caret-right"></i>
             </button>
          </span>

--- a/templates/components/itilobject/layout.html.twig
+++ b/templates/components/itilobject/layout.html.twig
@@ -38,11 +38,11 @@
 {% set collapsed_cls = (is_collapsed ? "right-collapsed" : "") %}
 {% set expanded_cls  = (is_expanded == "true" ? "right-expanded" : "") %}
 
-{% set left_side_cls = "col-md-8" %}
-{% set right_side_cls = "col-md-4" %}
+{% set left_side_cls = "col-xxl-9 col-md-10" %}
+{% set right_side_cls = "col-xxl-3 col-md-2" %}
 {% if is_expanded %}
-    {% set left_side_cls = "col-md-4" %}
-    {% set right_side_cls = "col-md-8" %}
+    {% set left_side_cls = "col-xxl-4" %}
+    {% set right_side_cls = "col-xxl-8" %}
 {% endif %}
 
 

--- a/templates/components/itilobject/layout.html.twig
+++ b/templates/components/itilobject/layout.html.twig
@@ -38,11 +38,17 @@
 {% set collapsed_cls = (is_collapsed ? "right-collapsed" : "") %}
 {% set expanded_cls  = (is_expanded == "true" ? "right-expanded" : "") %}
 
-{% set left_side_cls = "col-xl-8 col-md-10" %}
-{% set right_side_cls = "col-xl-4 col-md-2" %}
+{% set left_regular_cls = "col-xl-8 col-md-10" %}
+{% set right_regular_cls = "col-xl-4 col-md-2" %}
+
+{% set left_expanded_cls = "col-xxl-4 col-md-4" %}
+{% set right_expanded_cls = "col-xxl-8 col-md-8" %}
+
+{% set left_side_cls = left_regular_cls %}
+{% set right_side_cls = right_regular_cls %}
 {% if is_expanded %}
-    {% set left_side_cls = "col-xxl-4" %}
-    {% set right_side_cls = "col-xxl-8" %}
+    {% set left_side_cls = left_expanded_cls %}
+    {% set right_side_cls = right_expanded_cls %}
 {% endif %}
 
 
@@ -111,21 +117,29 @@ $(function() {
    $(document).on("click", ".switch-panel-width", function() {
        if ($('#itil-object-container').hasClass('right-collapsed')) {
            $('#itil-object-container').removeClass('right-collapsed');
-       } else if ($('.itil-left-side').hasClass('col-md-8')) {
+       } else if ($('.itil-left-side').hasClass("{{ left_regular_cls }}")) {
+         // Expand right-side panel
          $('#itil-object-container').addClass('right-expanded');
-         $('.itil-left-side').removeClass('col-md-8').addClass('col-md-4');
-         $('.itil-footer .timeline-buttons').removeClass('col-md-8').addClass('col-md-4');
-         $('.itil-footer .form-buttons').removeClass('col-md').addClass('col-md-8');
-         $('.itil-right-side').removeClass('col-md-4').addClass('col-md-8');
+         // Left side
+         $('.itil-left-side').removeClass("{{ left_regular_cls }}").addClass("{{ left_expanded_cls }}");
+         $('.itil-footer .timeline-buttons').removeClass("{{ left_regular_cls }}").addClass("{{ left_expanded_cls }}");
+         // Right side
+         $('.itil-footer .form-buttons').removeClass('col-md').addClass("{{ right_expanded_cls }}");
+         $('.itil-right-side').removeClass("{{ right_regular_cls }}").addClass("{{ right_expanded_cls }}");
+         // Switcher buttons
          $('.switch-panel-width i.fas').removeClass('fa-caret-left').addClass('fa-caret-right');
          $('.itil-right-side .accordion-body:not(.accordion-actors).row .col-12').removeClass('col-12').addClass('col-sm-6');
          $('#actors .col-12').removeClass('col-12').addClass('col-sm-4');
       } else {
+         // Decrease right-side panel
          $('#itil-object-container').removeClass('right-expanded');
-         $('.itil-left-side').removeClass('col-md-4').addClass('col-md-8');
-         $('.itil-right-side').removeClass('col-md-8').addClass('col-md-4');
-         $('.itil-footer .timeline-buttons').removeClass('col-md-4').addClass('col-md-8');
-         $('.itil-footer .form-buttons').removeClass('col-md-8').addClass('col-md');
+         // Left side
+         $('.itil-left-side').removeClass("{{ left_expanded_cls }}").addClass("{{ left_regular_cls }}");
+         $('.itil-footer .timeline-buttons').removeClass("{{ left_expanded_cls }}").addClass("{{ left_regular_cls }}");
+         // Right side
+         $('.itil-footer .form-buttons').removeClass("{{ right_expanded_cls }}").addClass('col-md');
+         $('.itil-right-side').removeClass("{{ right_expanded_cls }}").addClass("{{ right_regular_cls }}");
+         // Switcher buttons
          $('.switch-panel-width i.fas').removeClass('fa-caret-right').addClass('fa-caret-left');
          $('.itil-right-side .accordion-body:not(.accordion-actors).row .col-sm-6').removeClass('col-sm-6').addClass('col-12');
          $('#actors .col-sm-4').removeClass('col-sm-4').addClass('col-12');

--- a/templates/components/itilobject/layout.html.twig
+++ b/templates/components/itilobject/layout.html.twig
@@ -38,8 +38,8 @@
 {% set collapsed_cls = (is_collapsed ? "right-collapsed" : "") %}
 {% set expanded_cls  = (is_expanded == "true" ? "right-expanded" : "") %}
 
-{% set left_side_cls = "col-xxl-9 col-md-10" %}
-{% set right_side_cls = "col-xxl-3 col-md-2" %}
+{% set left_side_cls = "col-xl-8 col-md-10" %}
+{% set right_side_cls = "col-xl-4 col-md-2" %}
 {% if is_expanded %}
     {% set left_side_cls = "col-xxl-4" %}
     {% set right_side_cls = "col-xxl-8" %}

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -90,7 +90,7 @@
             {% endif %}
 
             <div class="row">
-               {% set col_md = get_current_interface() == 'central' ? 'col-md-9' : 'col-md-12' %}
+               {% set col_md = get_current_interface() == 'central' ? 'col-xl-7 col-xxl-8' : 'col-xxl-12' %}
                <div class="col-12 {{ col_md }}">
                   {{ fields.textareaField(
                      'content',
@@ -107,7 +107,7 @@
                   ) }}
                </div>
                {% if get_current_interface() == 'central' %}
-                  <div class="col-12 col-md-3 order-first order-md-last">
+                  <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last">
                      <div class="row">
 
                         {% set fup_template_lbl %}

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -89,7 +89,7 @@
                <input type="hidden" name="add_reopen" value="1" />
             {% endif %}
 
-            <div class="row">
+            <div class="row mx-n3 mx-xxl-auto">
                {% set col_md = get_current_interface() == 'central' ? 'col-xl-7 col-xxl-8' : 'col-xxl-12' %}
                <div class="col-12 {{ col_md }}">
                   {{ fields.textareaField(
@@ -107,7 +107,7 @@
                   ) }}
                </div>
                {% if get_current_interface() == 'central' %}
-                  <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last">
+                  <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last pe-o pe-xxl-auto">
                      <div class="row">
 
                         {% set fup_template_lbl %}

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -93,7 +93,7 @@
                </div>
             {% endif %}
 
-            <div class="row">
+            <div class="row mx-n3 mx-xxl-auto">
                <div class="col-12 col-xl-7 col-xxl-8">
                   {% set content = subitem.fields['content'] %}
                   {% if kb_id_toload > 0 %}
@@ -115,7 +115,7 @@
                      }
                   ) }}
                </div>
-               <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last">
+               <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last pe-o pe-xxl-auto">
                   <div class="row">
                      {% if candedit %}
                         {% if can_read_kb %}

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -94,7 +94,7 @@
             {% endif %}
 
             <div class="row">
-               <div class="col-12 col-md-9">
+               <div class="col-12 col-xl-7 col-xxl-8">
                   {% set content = subitem.fields['content'] %}
                   {% if kb_id_toload > 0 %}
                      {% set content = 'TODO content' %}
@@ -115,7 +115,7 @@
                      }
                   ) }}
                </div>
-               <div class="col-12 col-md-3 order-first order-md-last">
+               <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last">
                   <div class="row">
                      {% if candedit %}
                         {% if can_read_kb %}

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -157,7 +157,7 @@
             <input type="hidden" name="{{ item.getForeignKeyField() }}" value="{{ item.fields['id'] }}" />
             {{ call_plugin_hook('pre_item_form', {"item": subitem, 'options': params}) }}
 
-            <div class="row">
+            <div class="row mx-n3 mx-xxl-auto">
                <div class="col-12 col-xl-7 col-xxl-8">
                   {{ fields.textareaField(
                      'content',
@@ -173,7 +173,7 @@
                      }
                   ) }}
                </div>
-               <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last">
+               <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last pe-o pe-xxl-auto">
                   <div class="row">
 
                      {% set task_template_lbl %}

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -158,7 +158,7 @@
             {{ call_plugin_hook('pre_item_form', {"item": subitem, 'options': params}) }}
 
             <div class="row">
-               <div class="col-12 col-md-9">
+               <div class="col-12 col-xl-7 col-xxl-8">
                   {{ fields.textareaField(
                      'content',
                      subitem.fields['content'],
@@ -173,7 +173,7 @@
                      }
                   ) }}
                </div>
-               <div class="col-12 col-md-3 order-first order-md-last">
+               <div class="col-12 col-xl-5 col-xxl-4 order-first order-md-last">
                   <div class="row">
 
                      {% set task_template_lbl %}
@@ -339,11 +339,13 @@
                            });
                         }
                      </script>
-                     <button id="plan{{ rand }}" class="btn btn-outline-secondary d-block mb-2 text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
-                        <i class="fas fa-calendar"></i>
-                        <span>{{ __('Plan this task') }}</span>
-                     </button>
-                     <div id="viewplan{{ rand }}"></div>
+                     <div class="col-12">
+                        <button id="plan{{ rand }}" class="btn btn-outline-secondary d-block mb-2 text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
+                           <i class="fas fa-calendar"></i>
+                           <span>{{ __('Plan this task') }}</span>
+                        </button>
+                        <div id="viewplan{{ rand }}"></div>
+                     </div>
                   </div>
                </div>
             </div>

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -136,7 +136,7 @@
             </div>
             <div class="col-12 col-sm d-flex flex-column content-part">
                <span class="mt-2 timeline-content {{ solution_class }} flex-grow-1 {{ item_position }} card">
-                  <div class="card-body px-1 px-xxl-2">
+                  <div class="card-body px-1 px-xxl-3">
                      {{ include('components/itilobject/timeline/timeline_item_header.html.twig') }}
 
                      {% if itiltype in timeline_itemtypes|column('type') %}

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -136,7 +136,7 @@
             </div>
             <div class="col-12 col-sm d-flex flex-column content-part">
                <span class="mt-2 timeline-content {{ solution_class }} flex-grow-1 {{ item_position }} card">
-                  <div class="card-body">
+                  <div class="card-body px-1 px-xxl-2">
                      {{ include('components/itilobject/timeline/timeline_item_header.html.twig') }}
 
                      {% if itiltype in timeline_itemtypes|column('type') %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10931

The timeline item forms (such as tasks) can feel very cramped unless the browser window is very large. I some cases, the fields are too small to interact with. This is also an issue if, like me, you have the browser's console open often and it is docked on the left or right.

The following changes were made to alleviate these issues:
- Less padding around timeline item forms on non-xxl screens
- Adjusted timeline layout so the left side would have more space on non-xxl screens
- Adjusted col breakpoints in timeline item forms to match xxl and not md screens and added a second break point to slightly reduce the size of the `content` field before falling back on having the extra fields show under the content.

I'm still looking at the behavior of the right-side panel. The expand/collapse isn't working right and I notice some odd resize issues before my changes.