### PR TITLE
Add ability to define plugin options

### DIFF
--- a/src/Marketplace/Controller.php
+++ b/src/Marketplace/Controller.php
@@ -80,11 +80,11 @@ class Controller extends CommonGLPI {
    /**
     * Download and uncompress plugin archive
     *
-    * @return int plugin status, @see properties of \Plugin class
+    * @return bool
     */
-   public function downloadPlugin():int {
+   public function downloadPlugin():bool {
       if (!self::hasWriteAccess()) {
-         return Plugin::UNKNOWN;
+         return false;
       }
 
       $api      = self::getAPI();
@@ -100,7 +100,7 @@ class Controller extends CommonGLPI {
             false,
             ERROR
          );
-         return Plugin::UNKNOWN;
+         return false;
       }
 
       // extract the archive
@@ -111,7 +111,7 @@ class Controller extends CommonGLPI {
             false,
             ERROR
          );
-         return Plugin::UNKNOWN;
+         return false;
       }
       $archive = UnifiedArchive::open($dest);
       $error = $archive === null;
@@ -133,7 +133,7 @@ class Controller extends CommonGLPI {
             false,
             ERROR
          );
-         return Plugin::UNKNOWN;
+         return false;
       }
 
       $plugin_inst = new Plugin();
@@ -153,6 +153,10 @@ class Controller extends CommonGLPI {
 
       // inform api the plugin has been downloaded
       $api->incrementPluginDownload($this->plugin_key, $plugin_inst->fields['version']);
+
+      if ($plugin_inst->getPluginOption($this->plugin_key, Plugin::OPTION_AUTOINSTALL_DISABLED, false)) {
+          return true;
+      }
 
       // try to install (or update) directly the plugin
       return $this->installPlugin();

--- a/tests/functionnal/Plugin.php
+++ b/tests/functionnal/Plugin.php
@@ -841,4 +841,145 @@ PHP
             )->isNotEqualTo(false);
         }
     }
+
+    public function testGetPluginOptionsWithExpectedResult()
+    {
+        $key = $this->test_plugin_directory;
+        $plugin_path = $this->getTestPluginPath($key);
+
+        $this->boolean(
+            mkdir($plugin_path, 0700, true)
+        )->isTrue();
+        $this->variable(
+            file_put_contents(
+                implode(DIRECTORY_SEPARATOR, [$plugin_path, 'setup.php']),
+                <<<PHP
+<?php
+function plugin_version_{$key}() {
+    return [
+        'name'    => 'Test plugin',
+        'version' => '1.0',
+    ];
+}
+function plugin_{$key}_options() {
+    return [
+        'marketplace_autoinstal_disabled' => true,
+        'another_option'                  => 'abc',
+    ];
+}
+PHP
+            )
+        )->isNotEqualTo(false);
+
+        $plugin = new \Plugin();
+        $plugin_id = $plugin->add(
+            [
+                'directory' => $key,
+                'name'      => 'Test plugin',
+                'version'   => '1.0',
+                'state'     => \Plugin::ACTIVATED,
+            ]
+        );
+        $this->integer((int)$plugin_id)->isGreaterThan(0);
+
+        $this->array($plugin->getPluginOptions($key))->isEqualTo(
+            [
+                'marketplace_autoinstal_disabled' => true,
+                'another_option'                  => 'abc',
+            ]
+        );
+    }
+
+    public function testGetPluginOptionsWithoutDeclaredFunction()
+    {
+        $key = $this->test_plugin_directory;
+        $plugin_path = $this->getTestPluginPath($key);
+
+        $this->boolean(
+            mkdir($plugin_path, 0700, true)
+        )->isTrue();
+        $this->variable(
+            file_put_contents(
+                implode(DIRECTORY_SEPARATOR, [$plugin_path, 'setup.php']),
+                <<<PHP
+<?php
+function plugin_version_{$key}() {
+    return [
+        'name'    => 'Test plugin',
+        'version' => '1.0',
+    ];
+}
+PHP
+            )
+        )->isNotEqualTo(false);
+
+        $plugin = new \Plugin();
+        $plugin_id = $plugin->add(
+            [
+                'directory' => $key,
+                'name'      => 'Test plugin',
+                'version'   => '1.0',
+                'state'     => \Plugin::ACTIVATED,
+            ]
+        );
+        $this->integer((int)$plugin_id)->isGreaterThan(0);
+
+        $this->array($plugin->getPluginOptions($key))->isEqualTo([]);
+    }
+
+    public function testGetPluginOptionsWithUnexpectedResult()
+    {
+        $key = $this->test_plugin_directory;
+        $plugin_path = $this->getTestPluginPath($key);
+
+        $this->boolean(
+            mkdir($plugin_path, 0700, true)
+        )->isTrue();
+        $this->variable(
+            file_put_contents(
+                implode(DIRECTORY_SEPARATOR, [$plugin_path, 'setup.php']),
+                <<<PHP
+<?php
+function plugin_version_{$key}() {
+    return [
+        'name'    => 'Test plugin',
+        'version' => '1.0',
+    ];
+}
+function plugin_{$key}_options() {
+    return 'malformed result';
+}
+PHP
+            )
+        )->isNotEqualTo(false);
+
+        $plugin = new \Plugin();
+        $plugin_id = $plugin->add(
+            [
+                'directory' => $key,
+                'name'      => 'Test plugin',
+                'version'   => '1.0',
+                'state'     => \Plugin::ACTIVATED,
+            ]
+        );
+        $this->integer((int)$plugin_id)->isGreaterThan(0);
+
+        $result = null;
+        $this->when(
+            function () use ($plugin, $key, &$result) {
+                $result = $plugin->getPluginOptions($key);
+            }
+        )->error()
+         ->withType(E_USER_WARNING)
+         ->withMessage(sprintf('Invalid "options" key provided by plugin `plugin_%s_options()` method.', $key))
+            ->exists();
+
+        $this->array($result)->isEqualTo([]);
+    }
+
+    public function testGetPluginOptionsOnUnexistingPlugin()
+    {
+        $plugin = new \Plugin();
+        $this->array($plugin->getPluginOptions('thisplugindoesnotexists'))->isEqualTo([]);
+    }
 }

--- a/tests/functionnal/Plugin.php
+++ b/tests/functionnal/Plugin.php
@@ -863,8 +863,8 @@ function plugin_version_{$key}() {
 }
 function plugin_{$key}_options() {
     return [
-        'marketplace_autoinstal_disabled' => true,
-        'another_option'                  => 'abc',
+        'autoinstall_disabled' => true,
+        'another_option'       => 'abc',
     ];
 }
 PHP
@@ -884,8 +884,8 @@ PHP
 
         $this->array($plugin->getPluginOptions($key))->isEqualTo(
             [
-                'marketplace_autoinstal_disabled' => true,
-                'another_option'                  => 'abc',
+                'autoinstall_disabled' => true,
+                'another_option'       => 'abc',
             ]
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Not used yet, but will be used soon to give ability to plugins to prevent automaticall executuion of their install function when downloaded from marketplace.