### PR TITLE
Fix Immobilization number infocom field

### DIFF
--- a/templates/components/infocom.html.twig
+++ b/templates/components/infocom.html.twig
@@ -146,7 +146,7 @@
 
                      {{ fields.autoNameField(
                         'immo_number',
-                        item,
+                        infocom,
                         __('Immobilization number'),
                         withtemplate,
                         {'disabled': disabled, 'value': infocom.fields['immo_number']}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Wrong item used with `autoNameField` so value wouldn't show.
Reported on Forum: https://forum.glpi-project.org/viewtopic.php?id=283122