### PR TITLE
Fix default confirmation values on commands

### DIFF
--- a/src/Console/Migration/AppliancesPluginToCoreCommand.php
+++ b/src/Console/Migration/AppliancesPluginToCoreCommand.php
@@ -160,7 +160,7 @@ class AppliancesPluginToCoreCommand extends AbstractCommand
                 __('It is better to make a backup of your existing data before continuing.')
             ]);
 
-            $this->askForConfirmation();
+            $this->askForConfirmation(false);
         }
 
         if (!$this->checkPlugin()) {

--- a/src/Console/Migration/RacksPluginToCoreCommand.php
+++ b/src/Console/Migration/RacksPluginToCoreCommand.php
@@ -216,7 +216,7 @@ class RacksPluginToCoreCommand extends AbstractCommand
                 ]
             );
 
-            $this->askForConfirmation();
+            $this->askForConfirmation(false);
         }
 
         if (!$this->checkPlugin()) {

--- a/tools/deleteorphanlogscommand.class.php
+++ b/tools/deleteorphanlogscommand.class.php
@@ -66,7 +66,7 @@ class DeleteOrphanLogsCommand extends AbstractCommand
            // Ask for confirmation (unless --no-interaction)
             $output->writeln(__('You are about to delete orphan logs of GLPI log table (glpi_logs).'));
 
-            $this->askForConfirmation();
+            $this->askForConfirmation(false);
         }
 
         $globalCount = 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Prior to #10368, these 3 command had a default value to `false` in launch confirmation interaction process. This PR just put back behaviour that was existing in GLPI 9.5.