### PR TITLE
AbstractRightDropdown front URL

### DIFF
--- a/ajax/getAbstractRightDropdownValue.php
+++ b/ajax/getAbstractRightDropdownValue.php
@@ -37,6 +37,8 @@ header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 Session::checkLoginUser();
 
-$search = $_POST['searchText'] ?? "";
-
-echo json_encode(ShareDashboardDropdown::fetchValues($search));
+function show_rights_dropdown(string $class)
+{
+    $search = $_POST['searchText'] ?? "";
+    echo json_encode($class::fetchValues($search));
+}

--- a/ajax/getAbstractRightDropdownValue.php
+++ b/ajax/getAbstractRightDropdownValue.php
@@ -31,7 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
-include('../inc/includes.php');
+include(__DIR__ . '/../inc/includes.php');
 
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();

--- a/ajax/getShareDashboardDropdownValue.php
+++ b/ajax/getShareDashboardDropdownValue.php
@@ -31,22 +31,10 @@
  * ---------------------------------------------------------------------
  */
 
-class ShareDashboardDropdown extends AbstractRightsDropdown
-{
-    protected function getAjaxUrl(): string
-    {
-        global $CFG_GLPI;
+include('getAbstractRightDropdownValue.php');
 
-        return $CFG_GLPI['root_doc'] . "/ajax/getShareDashboardDropdownValue.php";
-    }
+// Only users who can update dashboard are allowed to share dashboard
+// Users without this right shouldn't be allowed to read this dropdown values
+Session::checkRight('dashboard', UPDATE);
 
-    protected static function getTypes(): array
-    {
-        return [
-            User::getType(),
-            Entity::getType(),
-            Profile::getType(),
-            Group::getType(),
-        ];
-    }
-}
+show_rights_dropdown(ShareDashboardDropdown::class);

--- a/ajax/getShareDashboardDropdownValue.php
+++ b/ajax/getShareDashboardDropdownValue.php
@@ -31,7 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
-include('getAbstractRightDropdownValue.php');
+include(__DIR__ . '/getAbstractRightDropdownValue.php');
 
 // Only users who can update dashboards are allowed to use the "share dashboard" feature
 // Users without this right shouldn't be allowed to read this dropdown values

--- a/ajax/getShareDashboardDropdownValue.php
+++ b/ajax/getShareDashboardDropdownValue.php
@@ -33,7 +33,7 @@
 
 include('getAbstractRightDropdownValue.php');
 
-// Only users who can update dashboard are allowed to share dashboard
+// Only users who can update dashboards are allowed to use the "share dashboard" feature
 // Users without this right shouldn't be allowed to read this dropdown values
 Session::checkRight('dashboard', UPDATE);
 

--- a/src/AbstractRightsDropdown.php
+++ b/src/AbstractRightsDropdown.php
@@ -45,7 +45,7 @@ abstract class AbstractRightsDropdown
      *
      * @return string
      */
-    abstract protected function getAjaxUrl(): string;
+    abstract protected static function getAjaxUrl(): string;
 
     /**
      * To be redefined by subclasses, specify enabled types

--- a/src/AbstractRightsDropdown.php
+++ b/src/AbstractRightsDropdown.php
@@ -38,17 +38,21 @@ abstract class AbstractRightsDropdown
     /**
      * Max limit per itemtype
      */
-    const LIMIT = 50;
+    public const LIMIT = 50;
+
+    /**
+     * To be redefined by subclasses, URL to front file
+     *
+     * @return string
+     */
+    abstract protected function getAjaxUrl(): string;
 
     /**
      * To be redefined by subclasses, specify enabled types
      *
      * @return array
      */
-    protected static function getTypes(): array
-    {
-        return [];
-    }
+    abstract protected static function getTypes(): array;
 
     /**
      * Check if a given type is enabled
@@ -73,8 +77,6 @@ abstract class AbstractRightsDropdown
      */
     public static function show(string $name, array $values): string
     {
-        global $CFG_GLPI;
-
         // Flatten values
         $dropdown_values = [];
         foreach ($values as $fkey => $ids) {
@@ -87,7 +89,7 @@ abstract class AbstractRightsDropdown
         $field_id = $name . "_" . mt_rand();
 
         // Build url
-        $url = $CFG_GLPI['root_doc'] . "/ajax/getRightDropdownValue.php";
+        $url = static::getAjaxUrl();
 
         // Build params
         $params = [

--- a/src/ShareDashboardDropdown.php
+++ b/src/ShareDashboardDropdown.php
@@ -33,7 +33,7 @@
 
 class ShareDashboardDropdown extends AbstractRightsDropdown
 {
-    protected function getAjaxUrl(): string
+    protected static function getAjaxUrl(): string
     {
         global $CFG_GLPI;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -85,6 +85,7 @@ include_once __DIR__ . '/APIBaseClass.php';
 include_once __DIR__ . '/InventoryTestCase.php';
 include_once __DIR__ . '/functionnal/CommonITILRecurrent.php';
 include_once __DIR__ . '/functionnal/Glpi/ContentTemplates/Parameters/AbstractParameters.php';
+include_once __DIR__ . '/units/AbstractRightsDropdown.php';
 
 // check folder exists instead of class_exists('\GuzzleHttp\Client'), to prevent global includes
 if (file_exists(__DIR__ . '/../vendor/autoload.php') && !file_exists(__DIR__ . '/../vendor/guzzlehttp/guzzle')) {

--- a/tests/units/AbstractRightsDropdown.php
+++ b/tests/units/AbstractRightsDropdown.php
@@ -40,7 +40,7 @@ use Profile;
 use Ticket;
 use User;
 
-class AbstractRightsDropdown extends \GLPITestCase
+abstract class AbstractRightsDropdown extends \GLPITestCase
 {
     protected function testGetPostedIdsProvider(): Generator
     {

--- a/tests/units/ShareDashboardDropdown.php
+++ b/tests/units/ShareDashboardDropdown.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+class ShareDashboardDropdown extends AbstractRightsDropdown
+{
+}


### PR DESCRIPTION
The ajax front file used to load the values of `AbstractRightDropdown` was directly referencing `ShareDashboardDropdown`.
This was not a problem when `ShareDashboardDropdown` was the only implementation of `AbstractRightDropdown` but this is no longer the case since https://github.com/pluginsGLPI/formcreator/pull/2615.

With these changes, each implementation of `AbstractRightDropdown` must have their own ajax front file where they:
* Include the parent ajax file `getAbstractRightDropdownValue.php` which contains the shared logic
* Do their own additional right checks (user who can't access the dropdown shouldn't ajax the ajax endpoint)
* Call `show_rights_dropdown` with the correct class for their specific implementation

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
