### PR TITLE
Fix missing validator type localization

### DIFF
--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -165,8 +165,8 @@
 
                 {% if subitem.isNewItem() %}
                     {{ fields.dropdownArrayField('validatortype', subitem.fields['validatortype'], {
-                    'User': 'User',
-                    'Group': 'Group'
+                    'User': 'User'|itemtype_name,
+                    'Group': 'Group'|itemtype_name
                     }, __('Approver'), {
                     'display_emptychoice': true,
                     'rand': rand,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

User and Group options for approval dropdown weren't using localization functions.