### PR TITLE
Fix/project template dates

### DIFF
--- a/src/Project.php
+++ b/src/Project.php
@@ -1544,7 +1544,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             echo "<td>";
 
             $date = $this->fields["date"];
-            if (!$ID) {
+            if (!$ID || $from_template) {
                 $date = $_SESSION['glpi_currenttime'];
             }
             Html::showDateTimeField("date", ['value' => $date,

--- a/src/Project.php
+++ b/src/Project.php
@@ -1386,6 +1386,10 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
         if (isset($input["id"]) && ($input["id"] > 0)) {
             $input["_oldID"] = $input["id"];
         }
+        if (isset($input['withtemplate']) && (int) $input['withtemplate'] == 2) {
+            // Remove dates for template from input. Keep date_creation because it can be overridden
+            unset($input['date'], $input['date_mod']);
+        }
         unset($input['id']);
         unset($input['withtemplate']);
 
@@ -1531,25 +1535,27 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
         $this->initForm($ID, $options);
         $this->showFormHeader($options);
 
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Creation date') . "</td>";
-        echo "<td>";
+        if (!isset($options['withtemplate']) || (int) $options['withtemplate'] !== 1) {
+            echo "<tr class='tab_bg_1'>";
+            echo "<td>" . __('Creation date') . "</td>";
+            echo "<td>";
 
-        $date = $this->fields["date"];
-        if (!$ID) {
-            $date = $_SESSION['glpi_currenttime'];
+            $date = $this->fields["date"];
+            if (!$ID) {
+                $date = $_SESSION['glpi_currenttime'];
+            }
+            Html::showDateTimeField("date", ['value' => $date,
+                'maybeempty' => false
+            ]);
+            echo "</td>";
+            if ($ID) {
+                echo "<td>" . __('Last update') . "</td>";
+                echo "<td >" . Html::convDateTime($this->fields["date_mod"]) . "</td>";
+            } else {
+                echo "<td colspan='2'>&nbsp;</td>";
+            }
+            echo "</tr>";
         }
-        Html::showDateTimeField("date", ['value'      => $date,
-            'maybeempty' => false
-        ]);
-        echo "</td>";
-        if ($ID) {
-            echo "<td>" . __('Last update') . "</td>";
-            echo "<td >" . Html::convDateTime($this->fields["date_mod"]) . "</td>";
-        } else {
-            echo "<td colspan='2'>&nbsp;</td>";
-        }
-        echo "</tr>";
 
         echo "<tr class='tab_bg_1'>";
         echo "<td>" . __('Name') . "</td>";

--- a/src/Project.php
+++ b/src/Project.php
@@ -1535,7 +1535,10 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
         $this->initForm($ID, $options);
         $this->showFormHeader($options);
 
-        if (!isset($options['withtemplate']) || (int) $options['withtemplate'] !== 1) {
+        $is_template = isset($options['withtemplate']) && (int) $options['withtemplate'] === 1;
+        $from_template = isset($options['withtemplate']) && (int) $options['withtemplate'] === 2;
+
+        if (!$is_template) {
             echo "<tr class='tab_bg_1'>";
             echo "<td>" . __('Creation date') . "</td>";
             echo "<td>";
@@ -1548,7 +1551,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
                 'maybeempty' => false
             ]);
             echo "</td>";
-            if ($ID) {
+            if ($ID && !$from_template) {
                 echo "<td>" . __('Last update') . "</td>";
                 echo "<td >" . Html::convDateTime($this->fields["date_mod"]) . "</td>";
             } else {

--- a/tests/functionnal/Project.php
+++ b/tests/functionnal/Project.php
@@ -168,6 +168,10 @@ class Project extends DbTestCase
         );
         $this->integer($task2_id)->isGreaterThan(0);
 
+        // Add 1 second to GLPI current time
+        $date2 = date('Y-m-d H:i:s', strtotime($date) + 1);
+        $_SESSION['glpi_currenttime'] = $date2;
+
        // Create from template
         $entity_id = getItemByTypeName('Entity', '_test_child_2', true);
         $project_id = $project->add(
@@ -184,6 +188,11 @@ class Project extends DbTestCase
        // Check created project
         $this->integer($project->fields['entities_id'])->isEqualTo($entity_id);
         $this->integer($project->fields['is_recursive'])->isEqualTo(0);
+
+        // Verify that the creation date was not copied from the template
+        $this->variable($project->fields['date'])->isNotEqualTo($date);
+        $this->variable($project->fields['date_creation'])->isNotEqualTo($date);
+        $this->variable($project->fields['date_mod'])->isNotEqualTo($date);
 
        // Check created tasks
         $tasks_data = getAllDataFromTable($project_task->getTable(), ['projects_id' => $project_id]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes?
| New feature?  | no?
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10969

1. Hide date fields for Project templates
2. Hide modification date when adding Projects from a template but allow changing the Creation date
3. Creation date is auto-set to the current datetime when adding from a template which it wasn't before