### PR TITLE
Use better check for adding limit dropdown onchange

### DIFF
--- a/templates/components/pager.html.twig
+++ b/templates/components/pager.html.twig
@@ -67,7 +67,7 @@
 
 <div class="flex-grow-1 d-flex flex-wrap flex-md-nowrap  align-items-center justify-content-between mb-2 search-pager">
     {% set limitdropdown = include('components/dropdown/limit.html.twig', {
-        'no_onchange': true,
+        'no_onchange': fluid_search|default(false),
         'select_class': 'search-limit-dropdown',
     }) %}
     <span class="search-limit d-none d-md-block">

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -30,6 +30,7 @@
  #}
 
 {% set is_ajax = data['searchform_id'] is defined and data['searchform_id'] is not null %}
+{% set fluid_search = fluid_search|default(true) %}
 {% if not is_ajax %}
    <div class="ajax-container search-display-data">
 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10970

The pager controls were assumed to only be used within the main search results form so no "onchange" even is registered.
This PR adds a check for if we want to use "Fluid search" JS or not. If so, no "onchange" attribute will be added. This flag is currently only set in the "display_data" template which is only used within the main search engine.