### PR TITLE
PHP 8.2 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The present file will list all changes made to the project; according to the
 - `CommonDropdown::displayHeader()`, use `CommonDropdown::displayCentralHeader()` instead and make sure to override properly `first_level_menu`, `second_level_menu` and `third_level_menu`.
 - `GLPI::getLogLevel()`
 - `Html::clean()`
+- `MailCollector::listEncodings()`
 - `RuleImportComputer` class
 - `RuleImportComputerCollection` class
 - `Toolbox::clean_cross_side_scripting_deep()`

--- a/src/Agent/Communication/Headers/Common.php
+++ b/src/Agent/Communication/Headers/Common.php
@@ -179,8 +179,7 @@ class Common
     {
         $propname = strtolower(str_replace('-', '_', $name));
 
-        //TODO: check header does exists, and has expected value
-        return $this->$propname;
+        return property_exists($this, $propname) ? $this->$propname : null;
     }
 
     /**
@@ -241,7 +240,9 @@ class Common
     public function setHeader($name, $value): self
     {
         $propname = strtolower(str_replace('-', '_', $name));
-        $this->$propname = $value;
+        if (property_exists($this, $propname)) {
+            $this->$propname = $value;
+        }
         return $this;
     }
 
@@ -255,6 +256,6 @@ class Common
     public function hasHeader($name): bool
     {
         $propname = strtolower(str_replace('-', '_', $name));
-        return (isset($this->$propname) && !empty($this->$propname));
+        return property_exists($this, $propname) && !empty($this->$propname);
     }
 }

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -45,6 +45,13 @@ class Blacklist extends CommonDropdown
 
     public $can_be_translated = false;
 
+    /**
+     * Loaded blacklists.
+     * Used for caching purposes.
+     * @var array
+     */
+    private $blacklists;
+
     const IP             = 1;
     const MAC            = 2;
     const SERIAL         = 3;

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -41,10 +41,6 @@ use Glpi\Toolbox\Sanitizer;
 
 /**
  * Common DataBase Table Manager Class - Persistent Object
- *
- * @property array $input     Add/Update fields input. Only defined during add/update process.
- * @property array $updates   Updated fields keys. Only defined during update process.
- * @property array $oldvalues Previous values of updated fields. Only defined during update process.
  */
 class CommonDBTM extends CommonGLPI
 {
@@ -54,6 +50,28 @@ class CommonDBTM extends CommonGLPI
      * @var mixed[]
      */
     public $fields = [];
+
+    /**
+     * Add/Update fields input. Filled during add/update process.
+     *
+     * @var mixed[]
+     */
+    public $input = [];
+
+    /**
+     * Updated fields keys. Filled during update process.
+     *
+     * @var mixed[]
+     */
+    public $updates = [];
+
+    /**
+     * Previous values of updated fields. Filled during update process.
+     *
+     * @var mixed[]
+     */
+    public $oldvalues = [];
+
 
     /**
      * Flag to determine whether or not changes must be logged into history.

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2806,7 +2806,7 @@ class CommonDBTM extends CommonGLPI
         if ($this->right !== $right) {
             return false;
         }
-        unset($this->right);
+        $this->right = null;
 
         switch ($right) {
             case READ:
@@ -4050,7 +4050,7 @@ class CommonDBTM extends CommonGLPI
        // }
        //Type mismatched fields
         $fails = [];
-        if (isset($this->input) && is_array($this->input) && count($this->input)) {
+        if (is_array($this->input) && count($this->input)) {
             foreach ($this->input as $key => $value) {
                 $unset        = false;
                 $regs         = [];

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -193,6 +193,13 @@ class CommonDBTM extends CommonGLPI
      */
     public static $undisclosedFields = [];
 
+    /**
+     * Current right that can be evaluated in "item_can" hook.
+     * Variable is set prior to hook call then unset.
+     * @var int
+     */
+    public $right;
+
 
     /**
      * Return the table used to store this object

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -124,7 +124,6 @@ class DBmysqlIterator implements SeekableIterator, Countable
     {
         $this->sql = null;
         $this->res = false;
-        $this->parameters = [];
 
         $is_legacy = false;
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -296,7 +296,7 @@ class Html
     {
 
         if (is_array($value)) {
-            return array_map([__CLASS__, __METHOD__], $value);
+            return array_map(__METHOD__, $value);
         }
         $order   = ['\r\n',
             '\n',

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -186,7 +186,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
     public function getAddress()
     {
 
-        if (!isset($this->address)) {
+        if ($this->address === null) {
             $this->address = new IPAddress();
             if (!$this->address->setAddressFromArray($this->fields, "version", "address", "address")) {
                 return false;
@@ -199,7 +199,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
     public function getNetmask()
     {
 
-        if (!isset($this->netmask)) {
+        if ($this->netmask === null) {
             $this->netmask = new IPNetmask();
             if (!$this->netmask->setAddressFromArray($this->fields, "version", "netmask", "netmask")) {
                 return false;
@@ -212,7 +212,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
     public function getGateway()
     {
 
-        if (!isset($this->gateway)) {
+        if ($this->gateway === null) {
             $this->gateway = new IPAddress();
             if (!$this->gateway->setAddressFromArray($this->fields, "version", "gateway", "gateway")) {
                 return false;
@@ -229,9 +229,9 @@ class IPNetwork extends CommonImplicitTreeDropdown
     {
 
        // Be sure to remove addresses, otherwise reusing will provide old objects for getAddress, ...
-        unset($this->address);
-        unset($this->netmask);
-        unset($this->gateway);
+        $this->address = null;
+        $this->netmask = null;
+        $this->gateway = null;
 
         if (
             isset($this->fields["address"])
@@ -280,7 +280,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
     public function getNewAncestor()
     {
 
-        if (isset($this->data_for_implicit_update)) {
+        if ($this->data_for_implicit_update !== null) {
             $params = ["address" => $this->data_for_implicit_update['address'],
                 "netmask" => $this->data_for_implicit_update['netmask']
             ];
@@ -497,8 +497,10 @@ class IPNetwork extends CommonImplicitTreeDropdown
             IPAddress_IPNetwork::linkIPAddressFromIPNetwork($this);
         }
 
-        unset($this->networkUpdate);
         parent::post_addItem();
+
+        $this->networkUpdate = null;
+        $this->data_for_implicit_update = null;
     }
 
 
@@ -529,7 +531,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
     public function getPotentialSons()
     {
 
-        if (isset($this->data_for_implicit_update)) {
+        if ($this->data_for_implicit_update !== null) {
             $params = ["address"     => $this->data_for_implicit_update['address'],
                 "netmask"     => $this->data_for_implicit_update['netmask'],
                 "exclude IDs" => $this->getID()

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -109,7 +109,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
             case 'data_for_implicit_update':
             case 'gateway':
             case 'netmask':
-                Toolbox::deprecated();
+                Toolbox::deprecated(sprintf('Writing private property %s::%s is deprecated', __CLASS__, $property));
                 // no break is intentionnal
             case 'networkUpdate':
                 // TODO Deprecate write access to variable in GLPI 10.1.

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -77,7 +77,53 @@ class IPNetwork extends CommonImplicitTreeDropdown
      * Variable will be set during add/update process and unset after it.
      * @var bool
      */
-    public $networkUpdate;
+    private $networkUpdate;
+
+    public function __get(string $property)
+    {
+        // TODO Deprecate read access to all variables in GLPI 10.1.
+        $value = null;
+        switch ($property) {
+            case 'address':
+            case 'data_for_implicit_update':
+            case 'gateway':
+            case 'netmask':
+            case 'networkUpdate':
+                $value = $this->$property;
+                break;
+            default:
+                $trace = debug_backtrace();
+                trigger_error(
+                    sprintf('Undefined property: %s::%s in %s on line %d', __CLASS__, $property, $trace[0]['file'], $trace[0]['line']),
+                    E_USER_WARNING
+                );
+                break;
+        }
+        return $value;
+    }
+
+    public function __set(string $property, $value)
+    {
+        switch ($property) {
+            case 'address':
+            case 'data_for_implicit_update':
+            case 'gateway':
+            case 'netmask':
+                Toolbox::deprecated();
+                // no break is intentionnal
+            case 'networkUpdate':
+                // TODO Deprecate write access to variable in GLPI 10.1.
+                $this->$property = $value;
+                break;
+            default:
+                $trace = debug_backtrace();
+                trigger_error(
+                    sprintf('Undefined property: %s::%s in %s on line %d', __CLASS__, $property, $trace[0]['file'], $trace[0]['line']),
+                    E_USER_WARNING
+                );
+                break;
+        }
+    }
 
     public static function getTypeName($nb = 0)
     {

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -46,7 +46,38 @@ class IPNetwork extends CommonImplicitTreeDropdown
 
     public static $rightname = 'internet';
 
+    /**
+     * Data used during add/update process to handle CommonImplicitTreeDropdown ancestors/sons.
+     * @var array
+     */
+    private $data_for_implicit_update;
 
+    /**
+     * Computed address.
+     * Used for caching purpose.
+     * @var IPAddress
+     */
+    private $address;
+
+    /**
+     * Computed netmask.
+     * Used for caching purpose.
+     * @var IPNetmask
+     */
+    private $netmask;
+    /**
+     * Computed gateway.
+     * Used for caching purpose.
+     * @var IPAddress
+     */
+    private $gateway;
+
+    /**
+     * Indicates whether the IPAddress or the IPNetmask has been updated during add/update process.
+     * Variable will be set during add/update process and unset after it.
+     * @var bool
+     */
+    public $networkUpdate;
 
     public static function getTypeName($nb = 0)
     {

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -163,6 +163,7 @@ abstract class InventoryAsset
     public function handleLinks()
     {
         $knowns = [];
+        $foreignkey_itemtype = [];
 
         $blacklist = new Blacklist();
 
@@ -185,7 +186,7 @@ abstract class InventoryAsset
                     $manufacturer = new Manufacturer();
                     $value->$key  = $manufacturer->processName($value->$key);
                     if ($key == 'bios_manufacturers_id') {
-                        $this->foreignkey_itemtype[$key] = getItemtypeForForeignKeyField('manufacturers_id');
+                        $foreignkey_itemtype[$key] = getItemtypeForForeignKeyField('manufacturers_id');
                     }
                 }
                 if (!is_numeric($val)) {
@@ -207,11 +208,11 @@ abstract class InventoryAsset
                             $entities_id,
                             ['manufacturer' => $manufacturer_name]
                         );
-                    } else if (isset($this->foreignkey_itemtype[$key])) {
-                        $value->$key = Dropdown::importExternal($this->foreignkey_itemtype[$key], addslashes($value->$key), $entities_id);
+                    } else if (isset($foreignkey_itemtype[$key])) {
+                        $value->$key = Dropdown::importExternal($foreignkey_itemtype[$key], addslashes($value->$key), $entities_id);
                     } else if (isForeignKeyField($key) && $key != "users_id") {
-                        $this->foreignkey_itemtype[$key] = getItemtypeForForeignKeyField($key);
-                        $value->$key = Dropdown::importExternal($this->foreignkey_itemtype[$key], addslashes($value->$key), $entities_id);
+                        $foreignkey_itemtype[$key] = getItemtypeForForeignKeyField($key);
+                        $value->$key = Dropdown::importExternal($foreignkey_itemtype[$key], addslashes($value->$key), $entities_id);
 
                         if (
                             $key == 'operatingsystemkernelversions_id'

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -75,6 +75,8 @@ abstract class MainAsset extends InventoryAsset
     /** @var boolean */
     protected $partial = false;
 
+    protected $current_key;
+
     public function __construct(CommonDBTM $item, $data)
     {
         $namespaced = explode('\\', static::class);

--- a/src/Inventory/Asset/Monitor.php
+++ b/src/Inventory/Asset/Monitor.php
@@ -79,7 +79,6 @@ class Monitor extends InventoryAsset
             }
 
             if (!isset($serials[$val->serial])) {
-                $this->linked_items['Monitor'][] = $val;
                 $serials[$val->serial] = 1;
             }
         }

--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -223,7 +223,7 @@ class NetworkEquipment extends MainAsset
 
     public function handleLinks(array $data = null)
     {
-        if (isset($this->current_key)) {
+        if ($this->current_key !== null) {
             $data = [$this->data[$this->current_key]];
         } else {
             $data = $this->data;

--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -223,7 +223,7 @@ class NetworkEquipment extends MainAsset
 
     public function handleLinks(array $data = null)
     {
-        if (property_exists($this, 'current_key')) {
+        if (isset($this->current_key)) {
             $data = [$this->data[$this->current_key]];
         } else {
             $data = $this->data;

--- a/src/Inventory/Inventory.php
+++ b/src/Inventory/Inventory.php
@@ -263,14 +263,14 @@ class Inventory
                 }
             }
 
-            $this->unhandled_data = array_diff_key($all_props, $data);
-            if (count($this->unhandled_data)) {
+            $unhandled_data = array_diff_key($all_props, $data);
+            if (count($unhandled_data)) {
                 Session::addMessageAfterRedirect(
                     sprintf(
                         __('Following keys has been ignored during process: %1$s'),
                         implode(
                             ', ',
-                            array_keys($this->unhandled_data)
+                            array_keys($unhandled_data)
                         )
                     ),
                     true,

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -49,6 +49,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
     protected $profiles  = [];
     protected $entities  = [];
     protected $items     = [];
+    protected $knowbase_items = [];
 
     const KNOWBASEADMIN = 1024;
     const READFAQ       = 2048;
@@ -416,12 +417,6 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
 
        // Profile / entities
         $this->profiles = KnowbaseItem_Profile::getProfiles($this->fields['id']);
-
-       //Linked kb items
-        $this->knowbase_items = KnowbaseItem_Item::getItems($this);
-
-       //Linked kb categories
-        $this->knowbase_categories = KnowbaseItem_KnowbaseItemCategory::getItems($this);
     }
 
 
@@ -1038,7 +1033,8 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         $this->updateCounter();
 
         $tmp = [];
-        foreach ($this->knowbase_categories as $category) {
+        $categories = KnowbaseItem_KnowbaseItemCategory::getItems($this);
+        foreach ($categories as $category) {
             $knowbaseitemcategories_id = $category['knowbaseitemcategories_id'];
             $fullcategoryname          = getTreeValueCompleteName(
                 "glpi_knowbaseitemcategories",
@@ -1831,7 +1827,8 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
                 if ($output_type == Search::HTML_OUTPUT) {
                     $tmp = [];
                     $ki->getFromDB($data["id"]);
-                    foreach ($ki->knowbase_categories as $category) {
+                    $categories = KnowbaseItem_KnowbaseItemCategory::getItems($ki);
+                    foreach ($categories as $category) {
                         $knowbaseitemcategories_id = $category['knowbaseitemcategories_id'];
                         $fullcategoryname          = getTreeValueCompleteName(
                             "glpi_knowbaseitemcategories",

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -49,7 +49,6 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
     protected $profiles  = [];
     protected $entities  = [];
     protected $items     = [];
-    protected $knowbase_items = [];
 
     const KNOWBASEADMIN = 1024;
     const READFAQ       = 2048;

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1314,13 +1314,14 @@ class MailCollector extends CommonDBTM
    ///return supported encodings in lowercase.
     public function listEncodings()
     {
+        Toolbox::deprecated();
        // Encoding not listed
         static $enc = ['gb2312', 'gb18030'];
 
         if (count($enc) == 2) {
             foreach (mb_list_encodings() as $encoding) {
                 $enc[]   = Toolbox::strtolower($encoding);
-                $aliases = mb_encoding_aliases($encoding);
+                $aliases = @mb_encoding_aliases($encoding);
                 foreach ($aliases as $e) {
                     $enc[] = Toolbox::strtolower($e);
                 }

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -536,7 +536,7 @@ class MassiveAction
     public function __destruct()
     {
 
-        if (isset($this->identifier)) {
+        if ($this->identifier !== null) {
            // $this->identifier is unset by self::process() when the massive actions are finished
             foreach ($this->fields_to_remove_when_reload as $field) {
                 unset($this->$field);
@@ -552,20 +552,16 @@ class MassiveAction
     public function getCheckItem($POST)
     {
 
-        if (!isset($this->check_item)) {
-            if (isset($POST['check_itemtype'])) {
-                if (!($this->check_item = getItemForItemtype($POST['check_itemtype']))) {
+        if ($this->check_item === null && isset($POST['check_itemtype'])) {
+            if (!($this->check_item = getItemForItemtype($POST['check_itemtype']))) {
+                exit();
+            }
+            if (isset($POST['check_items_id'])) {
+                if (!$this->check_item->getFromDB($POST['check_items_id'])) {
                     exit();
+                } else {
+                    $this->check_item->getEmpty();
                 }
-                if (isset($POST['check_items_id'])) {
-                    if (!$this->check_item->getFromDB($POST['check_items_id'])) {
-                        exit();
-                    } else {
-                        $this->check_item->getEmpty();
-                    }
-                }
-            } else {
-                $this->check_item = null;
             }
         }
         return $this->check_item;
@@ -1334,7 +1330,7 @@ class MassiveAction
         $this->results['redirect'] = $this->redirect;
 
        // unset $this->identifier to ensure the action won't register in $_SESSION
-        unset($this->identifier);
+        $this->identifier = null;
 
         return $this->results;
     }

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -418,7 +418,7 @@ class MassiveAction
             case 'remainings':
             case 'timeout_delay':
             case 'timer':
-                Toolbox::deprecated();
+                Toolbox::deprecated(sprintf('Reading private property %s::%s is deprecated', __CLASS__, $property));
                 $value = $this->$property;
                 break;
             default:
@@ -450,7 +450,7 @@ class MassiveAction
             case 'remainings':
             case 'timeout_delay':
             case 'timer':
-                Toolbox::deprecated();
+                Toolbox::deprecated(sprintf('Writing private property %s::%s is deprecated', __CLASS__, $property));
                 $this->$property = $value;
                 break;
             default:

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -57,34 +57,34 @@ class MassiveAction
     public $POST = [];
 
     /**
+     * Results of process.
+     * @var array
+     */
+    public $results = [];
+
+    /**
      * Current action key.
      * @var string|null
      */
-    public $action;
+    private $action;
 
     /**
      * Current action name.
      * @var string|null
      */
-    public $action_name;
+    private $action_name;
 
     /**
      * Class used to process current action.
      * @var string
      */
-    public $processor;
+    private $processor;
 
     /**
      * Items to process.
      * @var array
      */
-    public $items = [];
-
-    /**
-     * Results of process.
-     * @var array
-     */
-    public $results = [];
+    private $items = [];
 
     /**
      * Current process identifier.
@@ -392,6 +392,77 @@ class MassiveAction
         }
     }
 
+    public function __get(string $property)
+    {
+        // TODO Deprecate access to variables in GLPI 10.1.
+        $value = null;
+        switch ($property) {
+            case 'action':
+                $value = $this->getAction();
+                break;
+            case 'action_name':
+                $value = $this->getActionName();
+                break;
+            case 'processor':
+                $value = $this->getProcessor();
+                break;
+            case 'items':
+                $value = $this->getItems();
+                break;
+            case 'check_item':
+            case 'done':
+            case 'fields_to_remove_when_reload':
+            case 'identifier':
+            case 'nb_done':
+            case 'nb_items':
+            case 'remainings':
+            case 'timeout_delay':
+            case 'timer':
+                Toolbox::deprecated();
+                $value = $this->$property;
+                break;
+            default:
+                $trace = debug_backtrace();
+                trigger_error(
+                    sprintf('Undefined property: %s::%s in %s on line %d', __CLASS__, $property, $trace[0]['file'], $trace[0]['line']),
+                    E_USER_WARNING
+                );
+                break;
+        }
+        return $value;
+    }
+
+    public function __set(string $property, $value)
+    {
+        // TODO Deprecate access to variables in GLPI 10.1.
+        $value = null;
+        switch ($property) {
+            case 'action':
+            case 'action_name':
+            case 'check_item':
+            case 'done':
+            case 'fields_to_remove_when_reload':
+            case 'identifier':
+            case 'items':
+            case 'nb_done':
+            case 'nb_items':
+            case 'processor':
+            case 'remainings':
+            case 'timeout_delay':
+            case 'timer':
+                Toolbox::deprecated();
+                $this->$property = $value;
+                break;
+            default:
+                $trace = debug_backtrace();
+                trigger_error(
+                    sprintf('Undefined property: %s::%s in %s on line %d', __CLASS__, $property, $trace[0]['file'], $trace[0]['line']),
+                    E_USER_WARNING
+                );
+                break;
+        }
+    }
+
 
     /**
      * Get the fields provided by previous stage through $_POST.
@@ -413,6 +484,26 @@ class MassiveAction
     public function getAction()
     {
         return $this->action;
+    }
+
+    /**
+     * Get current action name.
+     *
+     * @return
+     */
+    public function getActionName(): ?string
+    {
+        return $this->action_name;
+    }
+
+    /**
+     * Get current action processor classname.
+     *
+     * @return
+     */
+    public function getProcessor(): ?string
+    {
+        return $this->processor;
     }
 
 

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -73,6 +73,46 @@ class NetworkPort extends CommonDBChild
      */
     private $input_for_NetworkPortConnect;
 
+    public function __get(string $property)
+    {
+        $value = null;
+        switch ($property) {
+            case 'input_for_instantiation':
+            case 'input_for_NetworkName':
+            case 'input_for_NetworkPortConnect':
+                Toolbox::deprecated();
+                $value = $this->$property;
+                break;
+            default:
+                $trace = debug_backtrace();
+                trigger_error(
+                    sprintf('Undefined property: %s::%s in %s on line %d', __CLASS__, $property, $trace[0]['file'], $trace[0]['line']),
+                    E_USER_WARNING
+                );
+                break;
+        }
+        return $value;
+    }
+
+    public function __set(string $property, $value)
+    {
+        switch ($property) {
+            case 'input_for_instantiation':
+            case 'input_for_NetworkName':
+            case 'input_for_NetworkPortConnect':
+                Toolbox::deprecated();
+                $this->$property = $value;
+                break;
+            default:
+                $trace = debug_backtrace();
+                trigger_error(
+                    sprintf('Undefined property: %s::%s in %s on line %d', __CLASS__, $property, $trace[0]['file'], $trace[0]['line']),
+                    E_USER_WARNING
+                );
+                break;
+        }
+    }
+
     public function getForbiddenStandardMassiveAction()
     {
 

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -339,9 +339,9 @@ class NetworkPort extends CommonDBChild
     {
 
         if (
-            isset($this->input_for_instantiation)
-            || isset($this->input_for_NetworkName)
-            || isset($this->input_for_NetworkPortConnect)
+            $this->input_for_instantiation !== null
+            || $this->input_for_NetworkName !== null
+            || $this->input_for_NetworkPortConnect !== null
             || !isset($input)
         ) {
             return;
@@ -394,7 +394,7 @@ class NetworkPort extends CommonDBChild
         $instantiation = $this->getInstantiation();
         if (
             $instantiation !== false
-            && isset($this->input_for_instantiation)
+            && is_array($this->input_for_instantiation)
             && count($this->input_for_instantiation) > 0
         ) {
             $this->input_for_instantiation['networkports_id'] = $this->getID();
@@ -407,7 +407,7 @@ class NetworkPort extends CommonDBChild
         $this->input_for_instantiation = null;
 
         if (
-            isset($this->input_for_NetworkName)
+            is_array($this->input_for_NetworkName)
             && count($this->input_for_NetworkName) > 0
             && !isset($_POST['several'])
         ) {
@@ -445,7 +445,7 @@ class NetworkPort extends CommonDBChild
         $this->input_for_NetworkName = null;
 
         if (
-            isset($this->input_for_NetworkPortConnect)
+            is_array($this->input_for_NetworkPortConnect)
             && count($this->input_for_NetworkPortConnect) > 0
         ) {
             if (

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -57,6 +57,21 @@ class NetworkPort extends CommonDBChild
 
     public static $rightname                   = 'networking';
 
+    /**
+     * Subset of input that will be used for NetworkPortInstantiation.
+     * @var array
+     */
+    private $input_for_instantiation;
+    /**
+     * Subset of input that will be used for NetworkName.
+     * @var array
+     */
+    private $input_for_NetworkName;
+    /**
+     * Subset of input that will be used for NetworkPort_NetworkPort.
+     * @var array
+     */
+    private $input_for_NetworkPortConnect;
 
     public function getForbiddenStandardMassiveAction()
     {

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -404,7 +404,7 @@ class NetworkPort extends CommonDBChild
                 $instantiation->update($this->input_for_instantiation, $history);
             }
         }
-        unset($this->input_for_instantiation);
+        $this->input_for_instantiation = null;
 
         if (
             isset($this->input_for_NetworkName)
@@ -442,7 +442,7 @@ class NetworkPort extends CommonDBChild
                 }
             }
         }
-        unset($this->input_for_NetworkName);
+        $this->input_for_NetworkName = null;
 
         if (
             isset($this->input_for_NetworkPortConnect)
@@ -457,7 +457,7 @@ class NetworkPort extends CommonDBChild
                 $nn->add($this->input_for_NetworkPortConnect, [], $history);
             }
         }
-        unset($this->input_for_NetworkPortConnect);
+        $this->input_for_NetworkPortConnect = null;
     }
 
 

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -80,7 +80,7 @@ class NetworkPort extends CommonDBChild
             case 'input_for_instantiation':
             case 'input_for_NetworkName':
             case 'input_for_NetworkPortConnect':
-                Toolbox::deprecated();
+                Toolbox::deprecated(sprintf('Reading private property %s::%s is deprecated', __CLASS__, $property));
                 $value = $this->$property;
                 break;
             default:
@@ -100,7 +100,7 @@ class NetworkPort extends CommonDBChild
             case 'input_for_instantiation':
             case 'input_for_NetworkName':
             case 'input_for_NetworkPortConnect':
-                Toolbox::deprecated();
+                Toolbox::deprecated(sprintf('Writing private property %s::%s is deprecated', __CLASS__, $property));
                 $this->$property = $value;
                 break;
             default:

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -73,6 +73,13 @@ class NotificationTarget extends CommonDBChild
     public $options                     = [];
     public $raiseevent                  = '';
 
+    /**
+     * Recipient related to called "add_recipient_to_target" hook.
+     * Variable contains `itemtype` and `items_id` keys and is set only during hook execution.
+     * @var array
+     */
+    public $recipient_data;
+
     private $allow_response             = true;
     private $mode                       = null;
     private $event                      = null;

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -69,6 +69,11 @@ class Profile extends CommonDBTM
 
     public static $rightname             = 'profile';
 
+    /**
+     * Profile rights to update after profile update.
+     * @var array
+     */
+    private $profileRight;
 
 
     public function getForbiddenStandardMassiveAction()

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -80,7 +80,7 @@ class Profile extends CommonDBTM
         $value = null;
         switch ($property) {
             case 'profileRight':
-                Toolbox::deprecated();
+                Toolbox::deprecated(sprintf('Reading private property %s::%s is deprecated', __CLASS__, $property));
                 $value = $this->$property;
                 break;
             default:
@@ -98,7 +98,7 @@ class Profile extends CommonDBTM
     {
         switch ($property) {
             case 'profileRight':
-                Toolbox::deprecated();
+                Toolbox::deprecated(sprintf('Writing private property %s::%s is deprecated', __CLASS__, $property));
                 $this->$property = $value;
                 break;
             default:

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -229,7 +229,7 @@ class Profile extends CommonDBTM
 
         if (count($this->profileRight) > 0) {
             ProfileRight::updateProfileRights($this->getID(), $this->profileRight);
-            unset($this->profileRight);
+            $this->profileRight = null;
         }
 
         if (in_array('is_default', $this->updates) && ($this->input["is_default"] == 1)) {
@@ -268,7 +268,7 @@ class Profile extends CommonDBTM
 
         $rights = ProfileRight::getAllPossibleRights();
         ProfileRight::updateProfileRights($this->fields['id'], $rights);
-        unset($this->profileRight);
+        $this->profileRight = null;
 
         if (isset($this->fields['is_default']) && ($this->fields["is_default"] == 1)) {
             $DB->update(

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -75,6 +75,42 @@ class Profile extends CommonDBTM
      */
     private $profileRight;
 
+    public function __get(string $property)
+    {
+        $value = null;
+        switch ($property) {
+            case 'profileRight':
+                Toolbox::deprecated();
+                $value = $this->$property;
+                break;
+            default:
+                $trace = debug_backtrace();
+                trigger_error(
+                    sprintf('Undefined property: %s::%s in %s on line %d', __CLASS__, $property, $trace[0]['file'], $trace[0]['line']),
+                    E_USER_WARNING
+                );
+                break;
+        }
+        return $value;
+    }
+
+    public function __set(string $property, $value)
+    {
+        switch ($property) {
+            case 'profileRight':
+                Toolbox::deprecated();
+                $this->$property = $value;
+                break;
+            default:
+                $trace = debug_backtrace();
+                trigger_error(
+                    sprintf('Undefined property: %s::%s in %s on line %d', __CLASS__, $property, $trace[0]['file'], $trace[0]['line']),
+                    E_USER_WARNING
+                );
+                break;
+        }
+    }
+
 
     public function getForbiddenStandardMassiveAction()
     {

--- a/src/RichText/UserMention.php
+++ b/src/RichText/UserMention.php
@@ -70,10 +70,10 @@ final class UserMention
                 continue;
             }
 
-            if (property_exists($item, 'oldvalues') && array_key_exists($content_field, $item->oldvalues)) {
+            if (array_key_exists($content_field, $item->oldvalues)) {
                // Update case: content field was updated
                 $previous_value = $item->oldvalues[$content_field];
-            } else if (property_exists($item, 'updates')) {
+            } else if (count($item->updates) > 0) {
                // Update case: content field was not updated
                 $previous_value = $item->fields[$content_field];
             } else {

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -113,11 +113,17 @@ class MailCollector extends DbTestCase
 
     public function testListEncodings()
     {
-        $this
-         ->if($this->newTestedInstance)
-         ->then
-            ->array($this->testedInstance->listEncodings())
-               ->containsValues(['utf-8', 'iso-8859-1', 'iso-8859-14', 'cp1252']);
+        $this->newTestedInstance;
+
+        $this->when(
+            function () {
+                $this->array($this->testedInstance->listEncodings())
+                    ->containsValues(['utf-8', 'iso-8859-1', 'iso-8859-14', 'cp1252']);
+            }
+        )->error()
+           ->withType(E_USER_DEPRECATED)
+           ->withMessage('Called method is deprecated')
+           ->exists();
     }
 
     public function testPrepareInput()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Each commit should be reviewed individually.

See https://php.watch/versions/8.2

1. Usage of dynamic properties is deprecated. It means that using `$this->myvar = '';` when `$myvar` is not declared in class properties will trigger a deprecation error.
To fix this, I used different solutions.
 - I replaced class properties by local variables when usage of properties was not relevant.
 - I declared properties with a private visibility when they were used only locally.
 - I declared properties with a public visibility when they were used by other core or plugin classes.

2. Usage of some "pseudo" encodings are deprecated in mbstring. I used the `@` operator on `MailCollector::listEncodings()` to mute deprecation errors, adn deprecate this method as it is not used anymore (I see no occurence on GLPI or on plugins that are available in the marketplace).

3. I replaced a deprecated callable syntax in `Html::cleanPostForTextArea()`.

I was almost able to validate CI run locally, but there are some deprecation errors triggered in following dependencies:
 - `atoum/atoum` (fixed by https://github.com/atoum/atoum/pull/881, PR has to be validated);
 - `mikey179/vfsstream` (fixed by https://github.com/bovigo/vfsStream/commit/17b0f39b4a767bf950066dbad1a9a0b0ec4f7c68, have to be released);
 - `symfony/cache` (Remi is currently preparing a 3.2.0 release of the PHP extension, and we have to wait for it to be able to update `symfony/cache` to latest version, see #10810 );
 - `guzzle/psr7` (see https://github.com/guzzle/psr7/issues/482, I was not able to fix it easilly).