### PR TITLE
Hide promote to ticket when cannot create Tickets

### DIFF
--- a/templates/components/itilobject/timeline/timeline_item_header.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header.html.twig
@@ -71,7 +71,7 @@
             </li>
          {% endset %}
          {% set actions = actions|merge({promoted_btn}) %}
-      {% elseif item.getType() is same as 'Ticket' and (entry['type'] is same as 'ITILFollowup' or entry['type'] is same as 'TicketTask')  %}
+      {% elseif item.getType() is same as 'Ticket' and item.canCreate() and (entry['type'] is same as 'ITILFollowup' or entry['type'] is same as 'TicketTask')  %}
          {% set promote_url = '?_promoted_fup_id=' ~ entry_i['id'] %}
          {% if entry['type'] is same as 'TicketTask' %}
             {% set promote_url = '?_promoted_task_id=' ~ entry_i['id'] %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Hide "Promote to Ticket" option for tasks and followups in the timeline if the user doesn't have permission to create Tickets.