### PR TITLE
fix(certificate): date_expiration format

### DIFF
--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -283,10 +283,17 @@
                      {% endif %}
 
                      {% if item.isField('date_expiration') %}
-                        {{ fields.datetimeField('date_expiration', item.fields['date_expiration'], __('Expiration date'), {
-                           'helper': __('Empty for infinite'),
-                           'checkIsExpired': true
-                        }) }}
+                        {% if item_type == 'Certificate' %}
+                           {{ fields.dateField('date_expiration', item.fields['date_expiration'], __('Expiration date'), {
+                              'helper': __('Empty for infinite'),
+                              'checkIsExpired': true
+                           }) }}
+                        {% else %}
+                           {{ fields.datetimeField('date_expiration', item.fields['date_expiration'], __('Expiration date'), {
+                              'helper': __('Empty for infinite'),
+                              'checkIsExpired': true
+                           }) }}
+                        {% endif %}
                      {% endif %}
 
                      {% if item.isField('ref') %}

--- a/templates/pages/management/certificate.html.twig
+++ b/templates/pages/management/certificate.html.twig
@@ -50,10 +50,6 @@
       withtemplate
    ) }}
 
-   {{ fields.datetimeField('expire', item.fields['expire'], __('Expiration'), {
-      'helper': __('On search engine, use "Expiration contains NULL" to search licenses with no expiration date')
-   }) }}
-
    {{ fields.textareaField('command', item.fields['command'], __('Command used')) }}
 
    {{ fields.textareaField('certificate_request', item.fields['certificate_request'], __('Certificate request (CSR)')) }}


### PR DESCRIPTION
- In the form, the field was a 'datetime' but in the database, a 'date' is recorded.
- There was an additional field 'expire' which does not exist in the database.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10932
