### PR TITLE
Add missing links between ITIL Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ The present file will list all changes made to the project; according to the
 ## [10.1.0] unreleased
 
 ### Added
+- `Link ITIL Object` and `Unlink ITIL Object` massive actions for Tickets, Changes, and Problems.
 
 ### Changed
+- ITIL Objects can now be linked to any other ITIL Objects similar to the previous Ticket/Ticket links.
 
 ### Deprecated
 
 ### Removed
+- `Link tickets` massive action for Tickets (Use `Link ITIL Object` instead).
+- `Link to a problem` massive action for Tickets (Use `Link ITIL Object` instead).
 
 ### API changes
 
@@ -20,8 +24,19 @@ The present file will list all changes made to the project; according to the
 #### Changes
 
 #### Deprecated
+- `front/change_problem.form.php` script usage.
+- `front/change_ticket.form.php` script usage.
+- `front/problem_ticket.form.php` script usage.
+- `front/ticket_ticket.form.php` script usage.
+- `Ticket` `link_to_problem` massive action is deprecated. Use `CommonITILObject_CommonITILObject` `add` massive action instead.
+- `Ticket_Ticket` `add` massive action is deprecated. Use `CommonITILObject_CommonITILObject` `add` massive action instead.
+- `Ticket_Ticket::checkParentSon()`
+- `Ticket_Ticket::countOpenChildren()`
+- `Ticket_Ticket::getLinkedTicketsTo()`
+- `Ticket_Ticket::manageLinkedTicketsOnSolved()`
 
 #### Removed
+
 
 ## [10.0.0] unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@ The present file will list all changes made to the project; according to the
 
 #### Removed
 
-
 ## [10.0.0] unreleased
 
 ### Added

--- a/ajax/dropdownAllItems.php
+++ b/ajax/dropdownAllItems.php
@@ -65,6 +65,9 @@ if ($_POST["idtable"] && class_exists($_POST["idtable"])) {
     if (isset($_POST['value'])) {
         $p['value'] = $_POST['value'];
     }
+    if (isset($_POST['valuename'])) {
+        $p['valuename'] = $_POST['valuename'];
+    }
     if (isset($_POST['entity_restrict'])) {
         $p['entity_restrict'] = $_POST['entity_restrict'];
     }

--- a/front/change_ticket.form.php
+++ b/front/change_ticket.form.php
@@ -37,6 +37,8 @@ include('../inc/includes.php');
 
 Session::checkLoginUser();
 
+Toolbox::deprecated();
+
 $item = new Change_Ticket();
 if (isset($_POST["add"])) {
     if (!empty($_POST['tickets_id']) && empty($_POST['changes_id'])) {

--- a/front/commonitilobject_commonitilobject.form.php
+++ b/front/commonitilobject_commonitilobject.form.php
@@ -31,29 +31,64 @@
  * ---------------------------------------------------------------------
  */
 
+/**
+ * @since 10.1.0
+ */
+
 use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkLoginUser();
+Session ::checkCentralAccess();
 
-Toolbox::deprecated();
+if (isset($_POST['add'])) {
+    $link_class = isset($_POST['itemtype_1'], $_POST['itemtype_2'])
+        ? CommonITILObject_CommonITILObject::getLinkClass($_POST['itemtype_1'], $_POST['itemtype_2'])
+        : null;
 
-$item = new Change_Problem();
-if (isset($_POST["add"])) {
-    $item->check(-1, CREATE, $_POST);
+    if ($link_class === null || !isset($_POST['items_id_1'], $_POST['items_id_2'])) {
+        Session::addMessageAfterRedirect(
+            __('Cannot create link.'),
+            false,
+            ERROR
+        );
+    }
 
-    if ($item->add($_POST)) {
+    $itil_itil = new $link_class();
+
+    $input = $itil_itil->normalizeInput($_POST);
+
+    $itil_itil->check(-1, CREATE, $input);
+
+    if ($itil_itil->add($input)) {
         Event::log(
-            $_POST["changes_id"],
-            "change",
+            $_POST['items_id_1'],
+            $_POST['itemtype_1'],
             4,
-            "maintain",
+            "tracking",
             //TRANS: %s is the user login
             sprintf(__('%s adds a link with an item'), $_SESSION["glpiname"])
         );
     }
     Html::back();
 }
+if (isset($_POST['purge'], $_POST['id'])) {
+    [$link_class_1, $link_class_2, $link_id] = explode('_', $_POST['id'], 3);
+    $link_class = $link_class_1 . '_' . $link_class_2;
+    $itil_itil = new $link_class();
+    $_POST['id'] = $link_id;
+    $itil_itil->check($_POST['id'], PURGE);
 
+    $itil_itil->delete($_POST, 1);
+
+    Event::log(
+        $_POST['items_id'],
+        strtolower($_POST['itemtype']),
+        4,
+        "tracking",
+        //TRANS: %s is the user login
+        sprintf(__('%s purges link between ITIL Objects'), $_SESSION["glpiname"])
+    );
+    Html::redirect($_POST['itemtype']::getFormURLWithID($_POST['items_id']));
+}
 Html::displayErrorAndDie("lost");

--- a/front/problem_ticket.form.php
+++ b/front/problem_ticket.form.php
@@ -37,6 +37,8 @@ include('../inc/includes.php');
 
 Session ::checkLoginUser();
 
+Toolbox::deprecated();
+
 $item = new Problem_Ticket();
 
 if (isset($_POST["add"])) {

--- a/install/migrations/update_10.0.x_to_10.1.0/commonitilobject_commonitilobject.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/commonitilobject_commonitilobject.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+$to_add_link = ['glpi_changes_problems', 'glpi_changes_tickets', 'glpi_problems_tickets'];
+
+foreach ($to_add_link as $table) {
+    if (!$DB->fieldExists($table, 'link')) {
+        $migration->addField($table, 'link', 'int', [
+            'value' => 1,
+        ]);
+    }
+}
+
+$default_charset = DBConnection::getDefaultCharset();
+$default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
+
+// Create new tables
+
+if (!$DB->tableExists('glpi_changes_changes')) {
+    $query = "CREATE TABLE `glpi_changes_changes` (
+        `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+        `changes_id_1` int {$default_key_sign} NOT NULL DEFAULT '0',
+        `changes_id_2` int {$default_key_sign} NOT NULL DEFAULT '0',
+        `link` int NOT NULL DEFAULT '1',
+        PRIMARY KEY (`id`),
+        UNIQUE KEY `unicity` (`changes_id_1`,`changes_id_2`),
+        KEY `changes_id_2` (`changes_id_2`)
+        ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
+    $DB->queryOrDie($query, "10.1.0 add table glpi_changes_changes");
+}
+
+if (!$DB->tableExists('glpi_problems_problems')) {
+    $query = "CREATE TABLE `glpi_problems_problems` (
+        `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+        `problems_id_1` int {$default_key_sign} NOT NULL DEFAULT '0',
+        `problems_id_2` int {$default_key_sign} NOT NULL DEFAULT '0',
+        `link` int NOT NULL DEFAULT '1',
+        PRIMARY KEY (`id`),
+        UNIQUE KEY `unicity` (`problems_id_1`,`problems_id_2`),
+        KEY `problems_id_2` (`problems_id_2`)
+        ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
+    $DB->queryOrDie($query, "10.1.0 add table glpi_problems_problems");
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -729,6 +729,7 @@ CREATE TABLE `glpi_changes_problems` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `changes_id` int unsigned NOT NULL DEFAULT '0',
   `problems_id` int unsigned NOT NULL DEFAULT '0',
+  `link` int NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`changes_id`,`problems_id`),
   KEY `problems_id` (`problems_id`)
@@ -758,6 +759,7 @@ CREATE TABLE `glpi_changes_tickets` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `changes_id` int unsigned NOT NULL DEFAULT '0',
   `tickets_id` int unsigned NOT NULL DEFAULT '0',
+  `link` int NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`changes_id`,`tickets_id`),
   KEY `tickets_id` (`tickets_id`)
@@ -5568,6 +5570,7 @@ CREATE TABLE `glpi_problems_tickets` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `problems_id` int unsigned NOT NULL DEFAULT '0',
   `tickets_id` int unsigned NOT NULL DEFAULT '0',
+  `link` int NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`problems_id`,`tickets_id`),
   KEY `tickets_id` (`tickets_id`)
@@ -9193,3 +9196,25 @@ CREATE TABLE `glpi_snmpcredentials` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 SET FOREIGN_KEY_CHECKS=1;
+
+DROP TABLE IF EXISTS `glpi_changes_changes`;
+CREATE TABLE `glpi_changes_changes` (
+   `id` int unsigned NOT NULL AUTO_INCREMENT,
+   `changes_id_1` int unsigned NOT NULL DEFAULT '0',
+   `changes_id_2` int unsigned NOT NULL DEFAULT '0',
+   `link` int NOT NULL DEFAULT '1',
+   PRIMARY KEY (`id`),
+   UNIQUE KEY `unicity` (`changes_id_1`,`changes_id_2`),
+   KEY `changes_id_2` (`changes_id_2`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
+DROP TABLE IF EXISTS `glpi_problems_problems`;
+CREATE TABLE `glpi_problems_problems` (
+   `id` int unsigned NOT NULL AUTO_INCREMENT,
+   `problems_id_1` int unsigned NOT NULL DEFAULT '0',
+   `problems_id_2` int unsigned NOT NULL DEFAULT '0',
+   `link` int NOT NULL DEFAULT '1',
+   PRIMARY KEY (`id`),
+   UNIQUE KEY `unicity` (`problems_id_1`,`problems_id_2`),
+   KEY `problems_id_2` (`problems_id_2`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -2597,6 +2597,7 @@ abstract class API
                 $hclasses[] = "TicketCost";
                 $hclasses[] = "Problem_Ticket";
                 $hclasses[] = "Change_Ticket";
+                $hclasses[] = 'Ticket_Ticket';
                 $hclasses[] = "Item_Ticket";
                 $hclasses[] = "ITILSolution";
                 $hclasses[] = "ITILFollowup";
@@ -2610,6 +2611,7 @@ abstract class API
                 $hclasses[] = "ProblemCost";
                 $hclasses[] = "Change_Problem";
                 $hclasses[] = "Problem_Ticket";
+                $hclasses[] = 'Problem_Problem';
                 $hclasses[] = "Item_Problem";
                 $hclasses[] = "ITILSolution";
                 $hclasses[] = "ITILFollowup";
@@ -2624,6 +2626,7 @@ abstract class API
                 $hclasses[] = "Itil_Project";
                 $hclasses[] = "Change_Problem";
                 $hclasses[] = "Change_Ticket";
+                $hclasses[] = 'Change_Change';
                 $hclasses[] = "Change_Item";
                 $hclasses[] = "ITILSolution";
                 $hclasses[] = "ITILFollowup";

--- a/src/Change.php
+++ b/src/Change.php
@@ -274,15 +274,16 @@ class Change extends CommonITILObject
 
         $this->deleteChildrenAndRelationsFromDb(
             [
-            // Done by parent: Change_Group::class,
+                // Done by parent: Change_Group::class,
                 Change_Item::class,
                 Change_Problem::class,
-            // Done by parent: Change_Supplier::class,
+                // Done by parent: Change_Supplier::class,
                 Change_Ticket::class,
-            // Done by parent: Change_User::class,
+                // Done by parent: Change_User::class,
                 ChangeCost::class,
                 ChangeValidation::class,
-            // Done by parent: ITILSolution::class,
+                // Done by parent: ITILSolution::class,
+                Change_Change::class,
             ]
         );
 

--- a/src/Change_Change.php
+++ b/src/Change_Change.php
@@ -32,32 +32,23 @@
  */
 
 /**
- * @since 0.84
- */
+ * @since 10.1.0
+ *
+ * Change_Change Class
+ *
+ * Relation between Changes and other Changes
+ **/
+class Change_Change extends CommonITILObject_CommonITILObject
+{
+    // From CommonDBRelation
+    public static $itemtype_1   = 'Change';
+    public static $items_id_1   = 'changes_id_1';
 
-use Glpi\Event;
+    public static $itemtype_2   = 'Change';
+    public static $items_id_2   = 'changes_id_2';
 
-include('../inc/includes.php');
-
-$ticket_ticket = new Ticket_Ticket();
-
-Session ::checkCentralAccess();
-
-Toolbox::deprecated();
-
-if (isset($_POST['purge'])) {
-    $ticket_ticket->check($_POST['id'], PURGE);
-
-    $ticket_ticket->delete($_POST, 1);
-
-    Event::log(
-        $_POST['tickets_id'],
-        "ticket",
-        4,
-        "tracking",
-        //TRANS: %s is the user login
-        sprintf(__('%s purges link between tickets'), $_SESSION["glpiname"])
-    );
-    Html::redirect(Ticket::getFormURLWithID($_POST['tickets_id']));
+    public static function getTypeName($nb = 0)
+    {
+        return _n('Link Change/Change', 'Links Change/Change', $nb);
+    }
 }
-Html::displayErrorAndDie("lost");

--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -38,7 +38,7 @@
  *
  * Relation between Changes and Problems
  **/
-class Change_Problem extends CommonDBRelation
+class Change_Problem extends CommonITILObject_CommonITILObject
 {
    // From CommonDBRelation
     public static $itemtype_1   = 'Change';
@@ -46,16 +46,6 @@ class Change_Problem extends CommonDBRelation
 
     public static $itemtype_2   = 'Problem';
     public static $items_id_2   = 'problems_id';
-
-
-
-    public function getForbiddenStandardMassiveAction()
-    {
-
-        $forbidden   = parent::getForbiddenStandardMassiveAction();
-        $forbidden[] = 'update';
-        return $forbidden;
-    }
 
 
     public static function getTypeName($nb = 0)
@@ -159,19 +149,24 @@ class Change_Problem extends CommonDBRelation
             echo "<div class='firstbloc'>";
 
             echo "<form name='changeproblem_form$rand' id='changeproblem_form$rand' method='post'
-                action='" . Toolbox::getItemTypeFormURL(__CLASS__) . "'>";
+                action='" . CommonITILObject_CommonITILObject::getFormURL() . "'>";
 
             echo "<table class='tab_cadre_fixe'>";
-            echo "<tr class='tab_bg_2'><th colspan='3'>" . __('Add a change') . "</th></tr>";
+            echo "<tr class='tab_bg_2'><th colspan='2'>" . __('Add a change') . "</th></tr>";
 
             echo "<tr class='tab_bg_2'><td>";
-            echo "<input type='hidden' name='problems_id' value='$ID'>";
+            echo "<input type='hidden' name='itemtype_1' value='Problem'>";
+            echo "<input type='hidden' name='items_id_1' value='$ID'>";
+            echo "<input type='hidden' name='itemtype_2' value='Change'>";
+            echo self::dropdownLinks('link');
+            echo "&nbsp;";
             Change::dropdown([
+                'name'        => 'items_id_2',
                 'used'        => $used,
                 'entity'      => $problem->getEntityID(),
                 'entity_sons' => $problem->isRecursive(),
             ]);
-            echo "</td><td class='center'>";
+            echo "&nbsp;";
             echo "<input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";
             echo "</td><td>";
             if (Session::haveRight('change', CREATE)) {
@@ -281,19 +276,24 @@ class Change_Problem extends CommonDBRelation
             echo "<div class='firstbloc'>";
 
             echo "<form name='changeproblem_form$rand' id='changeproblem_form$rand' method='post'
-                action='" . Toolbox::getItemTypeFormURL(__CLASS__) . "'>";
+                action='" . CommonITILObject_CommonITILObject::getFormURL() . "'>";
 
             echo "<table class='tab_cadre_fixe'>";
-            echo "<tr class='tab_bg_2'><th colspan='2'>" . __('Add a problem') . "</th></tr>";
+            echo "<tr class='tab_bg_2'><th>" . __('Add a problem') . "</th></tr>";
 
             echo "<tr class='tab_bg_2'><td>";
-            echo "<input type='hidden' name='changes_id' value='$ID'>";
+            echo "<input type='hidden' name='itemtype_1' value='Change'>";
+            echo "<input type='hidden' name='items_id_1' value='$ID'>";
+            echo "<input type='hidden' name='itemtype_2' value='Problem'>";
+            echo self::dropdownLinks('link');
+            echo "&nbsp;";
             Problem::dropdown([
-                'used'   => $used,
-                'entity' => $change->getEntityID(),
+                'name'      => 'items_id_2',
+                'used'      => $used,
+                'entity'    => $change->getEntityID(),
                 'condition' => Problem::getOpenCriteria()
             ]);
-            echo "</td><td class='center'>";
+            echo "&nbsp;";
             echo "<input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";
             echo "</td></tr></table>";
             Html::closeForm();
@@ -344,23 +344,5 @@ class Change_Problem extends CommonDBRelation
             Html::closeForm();
         }
         echo "</div>";
-    }
-
-    public function post_addItem()
-    {
-        global $CFG_GLPI;
-
-        $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
-
-        if ($donotif) {
-            $problem = new Problem();
-            $change  = new Change();
-            if ($problem->getFromDB($this->input["problems_id"]) && $change->getFromDB($this->input["changes_id"])) {
-                NotificationEvent::raiseEvent("update", $problem);
-                NotificationEvent::raiseEvent('update', $change);
-            }
-        }
-
-        parent::post_addItem();
     }
 }

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -36,7 +36,7 @@
  *
  * Relation between Changes and Tickets
  **/
-class Change_Ticket extends CommonDBRelation
+class Change_Ticket extends CommonITILObject_CommonITILObject
 {
    // From CommonDBRelation
     public static $itemtype_1   = 'Change';
@@ -44,16 +44,6 @@ class Change_Ticket extends CommonDBRelation
 
     public static $itemtype_2   = 'Ticket';
     public static $items_id_2   = 'tickets_id';
-
-
-
-    public function getForbiddenStandardMassiveAction()
-    {
-
-        $forbidden   = parent::getForbiddenStandardMassiveAction();
-        $forbidden[] = 'update';
-        return $forbidden;
-    }
 
 
     public static function getTypeName($nb = 0)
@@ -267,21 +257,26 @@ class Change_Ticket extends CommonDBRelation
         if ($canedit) {
             echo "<div class='firstbloc'>";
             echo "<form name='changeticket_form$rand' id='changeticket_form$rand' method='post'
-                action='" . Toolbox::getItemTypeFormURL(__CLASS__) . "'>";
+                action='" . CommonITILObject_CommonITILObject::getFormURL() . "'>";
 
             echo "<table class='tab_cadre_fixe'>";
-            echo "<tr class='tab_bg_2'><th colspan='2'>" . __('Add a ticket') . "</th></tr>";
+            echo "<tr class='tab_bg_2'><th>" . __('Add a ticket') . "</th></tr>";
 
-            echo "<tr class='tab_bg_2'><td>";
-            echo "<input type='hidden' name='changes_id' value='$ID'>";
+            echo "<tr class='tab_bg_2'><td class='left'>";
+            echo "<input type='hidden' name='itemtype_1' value='Change'>";
+            echo "<input type='hidden' name='items_id_1' value='$ID'>";
+            echo "<input type='hidden' name='itemtype_2' value='Ticket'>";
+            echo self::dropdownLinks('link');
+            echo "&nbsp;";
             Ticket::dropdown([
+                'name'        => 'items_id_2',
                 'used'        => $used,
                 'entity'      => $change->getEntityID(),
                 'entity_sons' => $change->isRecursive(),
                 'displaywith' => ['id'],
                 'condition'   => Ticket::getOpenCriteria()
             ]);
-            echo "</td><td class='center'>";
+            echo "&nbsp;";
             echo "<input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";
             echo "</td></tr>";
 
@@ -402,18 +397,23 @@ class Change_Ticket extends CommonDBRelation
         if ($canedit) {
             echo "<div class='firstbloc'>";
             echo "<form name='changeticket_form$rand' id='changeticket_form$rand' method='post'
-               action='" . Toolbox::getItemTypeFormURL(__CLASS__) . "'>";
+                action='" . CommonITILObject_CommonITILObject::getFormURL() . "'>";
 
             echo "<table class='tab_cadre_fixe'>";
             echo "<tr class='tab_bg_2'><th colspan='3'>" . __('Add a change') . "</th></tr>";
             echo "<tr class='tab_bg_2'><td>";
-            echo "<input type='hidden' name='tickets_id' value='$ID'>";
+            echo "<input type='hidden' name='itemtype_1' value='Ticket'>";
+            echo "<input type='hidden' name='items_id_1' value='$ID'>";
+            echo "<input type='hidden' name='itemtype_2' value='Change'>";
+            echo self::dropdownLinks('link');
+            echo "&nbsp;";
             Change::dropdown([
+                'name'      => 'items_id_2',
                 'used'      => $used,
                 'entity'    => $ticket->getEntityID(),
                 'condition' => Change::getOpenCriteria(),
             ]);
-            echo "</td><td class='center'>";
+            echo "&nbsp;";
             echo "<input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";
             echo "</td><td>";
             if (Session::haveRight('change', CREATE)) {
@@ -470,23 +470,5 @@ class Change_Ticket extends CommonDBRelation
             Html::closeForm();
         }
         echo "</div>";
-    }
-
-    public function post_addItem()
-    {
-        global $CFG_GLPI;
-
-        $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
-
-        if ($donotif) {
-            $change = new Change();
-            $ticket  = new Ticket();
-            if ($change->getFromDB($this->input["changes_id"]) && $ticket->getFromDB($this->input["tickets_id"])) {
-                NotificationEvent::raiseEvent("update", $change);
-                NotificationEvent::raiseEvent('update', $ticket);
-            }
-        }
-
-        parent::post_addItem();
     }
 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1359,6 +1359,56 @@ abstract class CommonITILObject extends CommonDBTM
         return $input;
     }
 
+    protected function manageITILObjectLinkInput($input)
+    {
+        if (isset($input['_link'])) {
+            $link = $input['_link'];
+
+            if (isset($link['tickets_id_2'])) {
+                Toolbox::deprecated();
+                $link = [
+                    'itemtype_1' => Ticket::class,
+                    'items_id_1' => $link['tickets_id_1'] ?? 0,
+                    'itemtype_2' => Ticket::class,
+                    'items_id_2' => $link['tickets_id_2'],
+                    'link'       => $link['link'] ?? CommonITILObject_CommonITILObject::LINK_TO,
+                ];
+            }
+
+            if (!isset($link['itemtype_1'], $link['items_id_1'], $link['itemtype_2'], $link['items_id_2'], $link['link'])) {
+                // Not enough data, ignore link silently
+                return;
+            }
+
+            if ($link['itemtype_1'] == $this->getType() && $link['items_id_1'] == 0) {
+                // Link was added in creation form, ID was not available yet
+                $link['items_id_1'] = $this->getID();
+            }
+
+            $link_class = !empty($link['itemtype_1']) && !empty($link['itemtype_2'])
+                ? CommonITILObject_CommonITILObject::getLinkClass($link['itemtype_1'], $link['itemtype_2'])
+                : null;
+
+            if ($link_class === null) {
+                trigger_error(
+                    sprintf('Invalid itemtypes "%s"/"%s" on ITIL objects link.', $link['itemtype_1'], $link['itemtype_2']),
+                    E_USER_WARNING
+                );
+                return;
+            }
+
+            $itil_itil = new $link_class();
+
+            $link = $itil_itil->normalizeInput($link);
+
+            if ($itil_itil->can(-1, CREATE, $link) && $itil_itil->add($link)) {
+                $input['_forcenotif'] = true;
+            } else {
+                Session::addMessageAfterRedirect(__('Unknown ITIL Object'), false, ERROR);
+            }
+        }
+    }
+
     public function prepareInputForUpdate($input)
     {
 
@@ -1741,6 +1791,8 @@ abstract class CommonITILObject extends CommonDBTM
 
        // handle actors changes
         $this->updateActors();
+
+        $this->manageITILObjectLinkInput($this->input);
 
         parent::post_updateItem();
     }
@@ -2751,6 +2803,8 @@ abstract class CommonITILObject extends CommonDBTM
 
        // Additional actors
         $this->addAdditionalActors($this->input);
+
+        $this->manageITILObjectLinkInput($this->input);
 
         parent::post_addItem();
     }
@@ -3843,6 +3897,29 @@ abstract class CommonITILObject extends CommonDBTM
         return parent::getSpecificValueToSelect($field, $name, $values, $options);
     }
 
+    public function getSpecificMassiveActions($checkitem = null)
+    {
+
+        $actions = [];
+
+        if (Session::getCurrentInterface() == 'central') {
+            $can_update_itilobject = Session::haveRight(Ticket::$rightname, UPDATE)
+                || Session::haveRight(Change::$rightname, UPDATE)
+                || Session::haveRight(Problem::$rightname, UPDATE);
+            if ($can_update_itilobject) {
+                $actions['CommonITILObject_CommonITILObject' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add']
+                    = "<i class='fa-fw fas fa-link'></i>" .
+                    _x('button', 'Link ITIL Object');
+                $actions['CommonITILObject_CommonITILObject' . MassiveAction::CLASS_ACTION_SEPARATOR . 'delete']
+                    = "<i class='fa-fw fas fa-link'></i>" .
+                    _x('button', 'Unlink ITIL Object');
+            }
+        }
+
+        $actions += parent::getSpecificMassiveActions($checkitem);
+
+        return $actions;
+    }
 
     /**
      * @since 0.85
@@ -7765,6 +7842,8 @@ abstract class CommonITILObject extends CommonDBTM
         $excluded[] = '*:add_actor';
         $excluded[] = '*:add_task';
         $excluded[] = '*:add_followup';
+        $excluded[] = 'CommonITILObject_CommonITILObject:add';
+        $excluded[] = 'CommonITILObject_CommonITILObject:delete';
 
         return $excluded;
     }
@@ -8376,53 +8455,10 @@ abstract class CommonITILObject extends CommonDBTM
             $data['_itemtype'] = static::class;
             $data['_team'] = $team;
             if (static::class === Ticket::class) {
-                $ticket_table = Ticket::getTable();
-                $tt_table = Ticket_Ticket::getTable();
                 $links = [];
-                $link_iterator = $DB->request([
-                    'FROM'   => new \QueryUnion([
-                        [
-                            'SELECT' => [
-                                new QueryExpression($DB->quoteName('tickets_id_1') . ' AS ' . $DB->quoteName('tickets_id')),
-                                'status'
-                            ],
-                            'FROM'   => $tt_table,
-                            'LEFT JOIN' => [
-                                $ticket_table => [
-                                    'ON'  => [
-                                        $ticket_table  => 'id',
-                                        $tt_table      => 'tickets_id_1'
-                                    ]
-                                ]
-                            ],
-                            'WHERE'  => [
-                                'tickets_id_1' => $data['id'],
-                                'link' => Ticket_Ticket::PARENT_OF
-                            ]
-                        ],
-                        [
-                            'SELECT' => [
-                                new QueryExpression($DB->quoteName('tickets_id_2') . ' AS ' . $DB->quoteName('tickets_id')),
-                                'status'
-                            ],
-                            'FROM'   => $tt_table,
-                            'LEFT JOIN' => [
-                                $ticket_table => [
-                                    'ON'  => [
-                                        $ticket_table  => 'id',
-                                        $tt_table      => 'tickets_id_1'
-                                    ]
-                                ]
-                            ],
-                            'WHERE'  => [
-                                'tickets_id_2' => $data['id'],
-                                'link' => Ticket_Ticket::SON_OF
-                            ]
-                        ]
-                    ])
-                ]);
-                foreach ($link_iterator as $link_data) {
-                     $links[$link_data['tickets_id']] = $link_data;
+                $links_temp = Ticket_Ticket::getLinkedTo('Ticket', $data['id']);
+                foreach ($links_temp as $link_data) {
+                    $links[$link_data['items_id']] = $link_data;
                 }
                 if ($links) {
                     if (count($links)) {
@@ -8901,6 +8937,38 @@ abstract class CommonITILObject extends CommonDBTM
             static::getTypeName(1),
             $this->getID(),
             $this->getHeaderName()
+        );
+    }
+
+
+    /**
+     * Count number of open children having same type as current item.
+     *
+     * @return integer
+     */
+    public function countOpenChildrenOfSameType()
+    {
+        $itemtype = $this->getType();
+        $link_class = CommonITILObject_CommonITILObject::getLinkClass($itemtype, $itemtype);
+
+        if ($link_class === null || $this->isNewItem()) {
+            return 0;
+        }
+
+        $not_open_statuses = array_merge(
+            static::getSolvedStatusArray(),
+            static::getClosedStatusArray()
+        );
+        $open_statuses = array_diff(
+            array_keys(static::getAllStatusArray()),
+            $not_open_statuses
+        );
+
+        return $link_class::countLinksByStatus(
+            $this->getType(),
+            $this->getID(),
+            $open_statuses,
+            [CommonITILObject_CommonITILObject::SON_OF]
         );
     }
 }

--- a/src/CommonITILObject_CommonITILObject.php
+++ b/src/CommonITILObject_CommonITILObject.php
@@ -1,0 +1,704 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+use Glpi\Toolbox\Sanitizer;
+
+/**
+ * Links CommonITILObjects to other CommonITILObjects
+ * @since 10.1.0
+ */
+abstract class CommonITILObject_CommonITILObject extends CommonDBRelation
+{
+    const LINK_TO        = 1;
+    const DUPLICATE_WITH = 2;
+    const SON_OF         = 3;
+    const PARENT_OF      = 4;
+
+    public static function getTypeName($nb = 0)
+    {
+        return _n('Linked ITIL Object', 'Linked ITIL Objects', $nb);
+    }
+
+    public function prepareInputForAdd($input)
+    {
+        if (!isset($input[static::$items_id_1], $input[static::$items_id_2])) {
+            return false;
+        }
+
+        // Clean values
+        $input[static::$items_id_1] = (int) $input[static::$items_id_1];
+        $input[static::$items_id_2] = (int) $input[static::$items_id_2];
+
+        // Prevent self-link
+        if (static::$itemtype_1 === static::$itemtype_2 && $input[static::$items_id_1] === $input[static::$items_id_2]) {
+            return false;
+        }
+
+        if (!isset($input['link'])) {
+            $input['link'] = self::LINK_TO;
+        }
+
+        $input = $this->normalizeParentSonRelation($input);
+
+        // No multiple links
+        $links = static::getLinkedTo(static::$itemtype_1, $input[static::$items_id_1]);
+        if (count($links)) {
+            foreach ($links as $link) {
+                // Allow reclassifying LINK_TO as DUPLICATE_WITH, but otherwise, no duplicates allowed
+                if ($link['items_id'] === $input[static::$items_id_1] || $link['items_id'] === $input[static::$items_id_2]) {
+                    if ((int) $link['link'] === self::LINK_TO && (int) $input['link'] === self::DUPLICATE_WITH) {
+                        $link_item = new $link['link_class']();
+                        $link_item->delete(['id' => $link['id']]);
+                        return $input;
+                    }
+                    // Even if link is updated, cancel the addition of the duplicate link
+                    return false;
+                }
+            }
+        }
+
+        return parent::prepareInputForAdd($input);
+    }
+
+    public function prepareInputForUpdate($input)
+    {
+        $input = $this->normalizeParentSonRelation($input);
+
+        return parent::prepareInputForAdd($input);
+    }
+
+    public function getForbiddenStandardMassiveAction()
+    {
+        $forbidden   = parent::getForbiddenStandardMassiveAction();
+        $forbidden[] = 'update';
+        return $forbidden;
+    }
+
+    public static function showMassiveActionsSubForm(MassiveAction $ma)
+    {
+        switch ($ma->getAction()) {
+            case 'add':
+                Dropdown::showSelectItemFromItemtypes([
+                    'items_id_name'   => 'items_id_2',
+                    'itemtype_name'   => 'itemtype_2',
+                    'itemtypes'       => [Ticket::class, Change::class, Problem::class],
+                    'checkright'      => true,
+                    'entity_restrict' => $_SESSION['glpiactive_entity']
+                ]);
+                self::dropdownLinks('link');
+                echo "<br><input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";
+                return true;
+            case 'delete':
+                Dropdown::showSelectItemFromItemtypes([
+                    'items_id_name'   => 'items_id_2',
+                    'itemtype_name'   => 'itemtype_2',
+                    'itemtypes'       => [Ticket::class, Change::class, Problem::class],
+                    'checkright'      => true,
+                    'entity_restrict' => $_SESSION['glpiactive_entity']
+                ]);
+                echo "<br><input type='submit' name='delete' value=\"" . __('Delete permanently') . "\" class='btn btn-primary'>";
+                return true;
+        }
+        return false;
+    }
+
+    public static function processMassiveActionsForOneItemtype(MassiveAction $ma, CommonDBTM $item, array $ids)
+    {
+        switch ($ma->getAction()) {
+            case 'add':
+                $input = $ma->getInput();
+
+                foreach ($ids as $id) {
+                    if (empty($input['itemtype_2']) || empty($input['items_id_2']) || $item->getFromDB($id) === false) {
+                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
+                        return;
+                    }
+                    // Use ITIL object update method to use `CommonITILObject::manageITILObjectLinkInput()` logic.
+                    $update_input = [
+                        'id' => $id,
+                        '_link' => [
+                            'itemtype_1' => $item->getType(),
+                            'items_id_1' => $id,
+                            'itemtype_2' => $input['itemtype_2'],
+                            'items_id_2' => $input['items_id_2'],
+                            'link'       => $input['link'],
+                        ]
+                    ];
+                    if ($item->can($id, UPDATE)) {
+                        if ($item->update($update_input)) {
+                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        } else {
+                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
+                        }
+                    } else {
+                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
+                    }
+                }
+                return;
+
+            case 'delete':
+                $input = $ma->getInput();
+                foreach ($ids as $id) {
+                    if (empty($input['itemtype_2']) || empty($input['items_id_2']) || $item->getFromDB($id) === false) {
+                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
+                        return;
+                    }
+                    $input['itemtype_1'] = $item->getType();
+                    $input['items_id_1'] = $id;
+
+                    $link_class = self::getLinkClass($input['itemtype_1'], $input['itemtype_2']);
+
+                    if ($link_class !== null) {
+                        /* @var CommonDBRelation $link_class */
+                        /* @var CommonDBRelation $link */
+                        $condition = [];
+                        $link = new $link_class();
+                        if ($link_class::$itemtype_1 == $link_class::$itemtype_2) {
+                            // Handle Change_Change, Problem_Problem, Ticket_Ticket
+                            $condition = [
+                                'OR' => [
+                                    [
+                                        $link_class::$items_id_1 => $input['items_id_1'],
+                                        $link_class::$items_id_2 => $input['items_id_2'],
+                                    ],
+                                    [
+                                        $link_class::$items_id_1 => $input['items_id_2'],
+                                        $link_class::$items_id_2 => $input['items_id_1'],
+                                    ]
+                                ],
+                            ];
+                        } else {
+                            $condition = [
+                                $input['itemtype_1']::getForeignKeyField() => $input['items_id_1'],
+                                $input['itemtype_2']::getForeignKeyField() => $input['items_id_2'],
+                            ];
+                        }
+
+                        $link_found = $link->find($condition);
+
+                        if (!empty($link_found)) {
+                            $link_id = array_key_first($link_found);
+                            if ($link->can($link_id, DELETE)) {
+                                if ($link->delete(['id' => $link_id])) {
+                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                } else {
+                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                    $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
+                                }
+                            } else {
+                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                                $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
+                            }
+                        } else {
+                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
+                        }
+                    } else {
+                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
+                    }
+                }
+                return;
+        }
+        parent::processMassiveActionsForOneItemtype($ma, $item, $ids);
+    }
+
+    public function post_addItem()
+    {
+        $this->updateParentItems();
+
+        parent::post_addItem();
+    }
+
+    public function post_deleteFromDB()
+    {
+        $this->updateParentItems();
+
+        parent::post_deleteFromDB();
+    }
+
+    /**
+     * Update parent items when relation is added/deleted.
+     *
+     * @return void
+     */
+    private function updateParentItems(): void
+    {
+
+        $item_1 = new static::$itemtype_1();
+        $item_2 = new static::$itemtype_2();
+
+        if (
+            $item_1->getFromDB($this->fields[static::$items_id_1])
+            && $item_2->getFromDB($this->fields[static::$items_id_2])
+        ) {
+            $item_1->updateDateMod($this->fields[static::$items_id_1]);
+            $item_2->updateDateMod($this->fields[static::$items_id_2]);
+
+            if (!isset($this->input['_disablenotif'])) {
+                NotificationEvent::raiseEvent('update', $item_1);
+                NotificationEvent::raiseEvent('update', $item_2);
+            }
+        }
+    }
+
+    /**
+     * Get links to given item.
+     *
+     * @param string $itemtype Itemtype of the ITIL Object (Ticket, Change, or Problem)
+     * @param int $items_id ID of the ITIL Object
+     *
+     * @return array Array of linked ITIL Objects  array(id=>linktype)
+     **/
+    public static function getLinkedTo(string $itemtype, int $items_id): array
+    {
+        if (static::class == self::class) {
+            throw new \LogicException(sprintf('%s should be called only from sub classes.', __METHOD__));
+        }
+        global $DB;
+
+        $links = [];
+
+        // Check if link is between 2 items of the same type
+        $is_same_itemtype = static::$itemtype_1 === $itemtype && static::$itemtype_2 === $itemtype;
+
+        if ($is_same_itemtype) {
+            // Fetch items from Change_Change, Problem_Problem, or Ticket_Ticket
+            $iterator = $DB->request([
+                'FROM' => static::getTable(),
+                'WHERE' => [
+                    'OR' => [
+                        static::$items_id_1 => $items_id,
+                        static::$items_id_2 => $items_id
+                    ]
+                ]
+            ]);
+        } else {
+            // Fetch items from Change_Problem, Change_Ticket, or Problem_Ticket
+            $item_fk = static::$itemtype_1 === $itemtype ? static::$items_id_1 : static::$items_id_2;
+            $iterator = $DB->request([
+                'FROM' => static::getTable(),
+                'WHERE' => [
+                    $item_fk => $items_id
+                ]
+            ]);
+        }
+
+        foreach ($iterator as $data) {
+            // Map data to array with itemtype_1, itemtype_2, items_id_1, items_id_2
+            $link = [
+                'id'            => $data['id'],
+                'link_class'    => static::getType(),
+                'itemtype_1'    => static::$itemtype_1,
+                'itemtype_2'    => static::$itemtype_2,
+                'items_id_1'    => $data[static::$items_id_1],
+                'items_id_2'    => $data[static::$items_id_2],
+                'link'          => $data['link'],
+            ];
+            if ($is_same_itemtype) {
+                $link['itemtype'] = $link['itemtype_1'];
+                if ($link['items_id_1'] === $items_id) {
+                    $link['items_id'] = $link['items_id_2'];
+                } else {
+                    $link['items_id'] = $link['items_id_1'];
+                }
+            } else {
+                if (static::$itemtype_1 === $itemtype) {
+                    $link['itemtype'] = $link['itemtype_2'];
+                    $link['items_id'] = $link['items_id_2'];
+                } else {
+                    $link['itemtype'] = $link['itemtype_1'];
+                    $link['items_id'] = $link['items_id_1'];
+                }
+            }
+
+            $links[static::getType() . '_' . $link['id']] = $link;
+        }
+
+        ksort($links);
+        return $links;
+    }
+
+    /**
+     * Get all links between given item and any CommonITILObject item.
+     * Get linked CommonITILObjects to a specific CommonITILObject
+     *
+     * @param string $itemtype Itemtype of the ITIL Object (Ticket, Change, or Problem)
+     * @param int $items_id ID of the ITIL Object
+     *
+     * @return array Array of linked ITIL Objects  array(id=>linktype)
+     **/
+    public static function getAllLinkedTo(string $itemtype, int $items_id): array
+    {
+        /** @var CommonDBRelation[] $link_classes */
+        $link_classes = self::getAllLinkClasses();
+        $links = [];
+
+        foreach ($link_classes as $link_class) {
+            // If the link class is for the given itemtype
+            if ($link_class::$itemtype_1 === $itemtype || $link_class::$itemtype_2 === $itemtype) {
+                $links = array_merge($links, $link_class::getLinkedTo($itemtype, $items_id));
+            }
+        }
+
+        ksort($links);
+        return $links;
+    }
+
+    /**
+     * Dropdown for link types
+     *
+     * @param string  $myname select name
+     * @param integer $value  default value (default self::LINK_TO)
+     *
+     * @return void
+     **/
+    public static function dropdownLinks($myname, $value = self::LINK_TO)
+    {
+
+        $tmp[self::LINK_TO]        = __('Linked to');
+        $tmp[self::DUPLICATE_WITH] = __('Duplicates');
+        $tmp[self::SON_OF]         = __('Son of');
+        $tmp[self::PARENT_OF]      = __('Parent of');
+        Dropdown::showFromArray($myname, $tmp, ['value' => $value]);
+    }
+
+    /**
+     * Get Link Name
+     *
+     * @param integer $value     Current value
+     * @param boolean $inverted  Whether to invert label
+     * @param boolean $with_icon prefix label with an icon
+     *
+     * @return string
+     **/
+    public static function getLinkName($value, bool $inverted = false, bool $with_icon = false): string
+    {
+        $tmp = [];
+
+        if (!$inverted) {
+            $tmp[self::LINK_TO]        = __('Linked to');
+            $tmp[self::DUPLICATE_WITH] = __('Duplicates');
+            $tmp[self::SON_OF]         = __('Son of');
+            $tmp[self::PARENT_OF]      = __('Parent of');
+        } else {
+            $tmp[self::LINK_TO]        = __('Linked to');
+            $tmp[self::DUPLICATE_WITH] = __('Duplicated by');
+            $tmp[self::SON_OF]         = __('Parent of');
+            $tmp[self::PARENT_OF]      = __('Son of');
+        }
+
+        if ($with_icon) {
+            $icon_tag = '<i class="fas %1$s me-1" title="%2$s" data-bs-toggle="tooltip"></i>%2$s';
+            $tmp[self::LINK_TO]        = sprintf($icon_tag, "fa-link", $tmp[self::LINK_TO]);
+            $tmp[self::DUPLICATE_WITH] = sprintf($icon_tag, "fa-clone", $tmp[self::DUPLICATE_WITH]);
+            $icon_son                  = $inverted ? "fa-level-down-alt" : "fa-level-up-alt fa-flip-horizontal";
+            $tmp[self::SON_OF]         = sprintf($icon_tag, $icon_son, $tmp[self::SON_OF]);
+            $icon_parent               = $inverted ? "fa-level-down-alt" : "fa-level-up-alt";
+            $tmp[self::PARENT_OF]      = sprintf($icon_tag, $icon_parent, $tmp[self::PARENT_OF]);
+        }
+
+        if (isset($tmp[$value])) {
+            return $tmp[$value];
+        }
+        return NOT_AVAILABLE;
+    }
+
+    /**
+     * Get the name of the class that represents a link of the specified ITIL Object itemtypes.
+     *
+     * @param string $itemtype_1 The first itemtype
+     * @param string $itemtype_2 The second itemtype
+     * @return string|null The name of the class representing the link or null if the provided itemtypes are not valid
+     */
+    public static function getLinkClass(string $itemtype_1, string $itemtype_2): ?string
+    {
+        $itemtypes = [$itemtype_1, $itemtype_2];
+        if (in_array('Change', $itemtypes, true) && in_array('Problem', $itemtypes, true)) {
+            return Change_Problem::class;
+        } else if (in_array('Change', $itemtypes, true) && in_array('Ticket', $itemtypes, true)) {
+            return Change_Ticket::class;
+        } else if (in_array('Problem', $itemtypes, true) && in_array('Ticket', $itemtypes, true)) {
+            return Problem_Ticket::class;
+        } else if ($itemtype_1 === $itemtype_2) {
+            if ($itemtype_1 === 'Change') {
+                return Change_Change::class;
+            } else if ($itemtype_1 === 'Problem') {
+                return Problem_Problem::class;
+            } else if ($itemtype_1 === 'Ticket') {
+                return Ticket_Ticket::class;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get array of all ITIL Object link classes
+     * @return string[]
+     */
+    public static function getAllLinkClasses(): array
+    {
+        return [
+            Change_Change::class,
+            Change_Problem::class,
+            Change_Ticket::class,
+            Problem_Problem::class,
+            Problem_Ticket::class,
+            Ticket_Ticket::class,
+        ];
+    }
+
+    /**
+     * Count all links between given item and any CommonITILObject item.
+     *
+     * @param string $itemtype
+     * @param int $items_id
+     *
+     * @return int
+     */
+    public static function countAllLinks(string $itemtype, int $items_id): int
+    {
+        $links = static::getAllLinkedTo($itemtype, $items_id);
+        return count($links);
+    }
+
+    /**
+     * Count linked ITIL Objects.
+     *
+     * @param string $itemtype The given item's type
+     * @param int $items_id The given item's ID
+     * @param string $itemtype_2 The desired linked item's type (Subclass of CommonITILObject)
+     * @param array $status Optional array of statuses that the linked item must have to be included.
+     *  If no statuses are specified, then linked items of all statuses will be included.
+     * @param array $link_types Optional array of link types that the linked item must have to be included.
+     *  If no link types are specified, then linked items of all link types will be included.
+     * @return int The number of linked ITIL Objects
+     */
+    public static function countLinksByStatus(string $itemtype, int $items_id, array $status = [], array $link_types = []): int
+    {
+        if (static::class == self::class) {
+            throw new \LogicException(sprintf('%s should be called only from sub classes.', __METHOD__));
+        }
+
+        global $DB;
+
+        $count = 0;
+
+        if (static::$itemtype_1 === static::$itemtype_2) {
+            $linked_table = $itemtype::getTable();
+            $linked_fk    = static::$items_id_1;
+
+            $where = [
+                'links.' . static::$items_id_2 => $items_id,
+            ];
+
+            if (in_array(self::PARENT_OF, $link_types)) {
+                if (($key = array_search(self::PARENT_OF, $link_types, true)) !== false) {
+                    unset($link_types[$key]);
+                }
+                $other_link_types = $link_types;
+                if (($key = array_search(self::SON_OF, $other_link_types, true)) !== false) {
+                    unset($other_link_types[$key]);
+                }
+                // Count everything except SON_OF links using original parameters
+                if (!empty($other_link_types)) {
+                    $count = static::countLinksByStatus($itemtype, $items_id, $status, $other_link_types);
+                }
+
+                // Count only SON_OF links here using swapped parameters
+                $where = [
+                    'links.' . static::$items_id_1 => $items_id,
+                ];
+                $link_types = [self::SON_OF];
+                $linked_fk  = static::$items_id_2;
+            }
+        } else {
+            $linked_table = static::$itemtype_1 === $itemtype ? static::$itemtype_2::getTable() : static::$itemtype_1::getTable();
+            $linked_fk    = static::$itemtype_1 === $itemtype ? static::$items_id_2 : static::$items_id_1;
+
+            $where_fk = static::$itemtype_1 === $itemtype ? static::$items_id_1 : static::$items_id_2;
+            $where = [
+                'links.' . $where_fk => $items_id
+            ];
+        }
+
+        if (!empty($link_types)) {
+            $where['links.link'] = $link_types;
+        }
+
+        if (!empty($status)) {
+            $where['items.status'] = $status;
+        }
+
+        $result = $DB->request([
+            'COUNT'        => 'cpt',
+            'FROM'         => static::getTable() . ' AS links',
+            'INNER JOIN'   => [
+                $linked_table . ' AS items' => [
+                    'ON' => [
+                        'links' => $linked_fk,
+                        'items' => 'id'
+                    ]
+                ],
+            ],
+            'WHERE'        => $where
+        ])->current();
+        return ((int)$result['cpt']) + $count;
+    }
+
+    public static function manageLinksOnChange($itemtype, $items_id, $changes): void
+    {
+        if ($itemtype === Ticket::class) {
+            $ticket = new Ticket();
+            if ($ticket->getfromDB($items_id)) {
+                $linked_tickets = Ticket_Ticket::getLinkedTo($itemtype, $items_id);
+                if (count($linked_tickets)) {
+                    $tickets = array_filter($linked_tickets, static function ($data) {
+                        $linked_ticket = new Ticket();
+                        $linked_ticket->getFromDB($data['items_id']);
+                        return $linked_ticket->can($data['items_id'], UPDATE)
+                            && ($data['link'] === self::DUPLICATE_WITH)
+                            && ($linked_ticket->fields['status'] !== CommonITILObject::SOLVED)
+                            && ($linked_ticket->fields['status'] !== CommonITILObject::CLOSED);
+                    });
+
+                    if (isset($changes['_solution']) && $changes['_solution'] instanceof ITILSolution) {
+                        // Add same solution to duplicates
+                        $solution = $changes['_solution'];
+                        $solution_data = $solution->fields;
+                        unset($solution_data['id']);
+                        unset($solution_data['date_creation']);
+                        unset($solution_data['date_mod']);
+
+                        foreach ($tickets as $data) {
+                            $solution_data['items_id'] = $data['items_id'];
+                            $solution_data['_linked_ticket'] = true;
+                            $new_solution = new ITILSolution();
+                            $new_solution->add(Sanitizer::dbEscapeRecursive($solution_data));
+                        }
+                    } else if (isset($changes['status']) && in_array($changes['status'], Ticket::getSolvedStatusArray())) {
+                        $linked_ticket = new Ticket();
+                        foreach ($tickets as $data) {
+                            $linked_ticket->update([
+                                'id'     => $data['items_id'],
+                                'status' => $changes['status']
+                            ]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Normalize input from generic format to expected format.
+     * e.g. [`itemtype_1`, `items_id_1`, `itemtype_2`, `items_id_2`, `link`] -> [`changes_id`, `problems_id`, `link`]
+     *
+     * @param array $input
+     *
+     * @return array
+     */
+    final public function normalizeInput(array $input): array
+    {
+        if (!isset($input['itemtype_1'], $input['items_id_1'], $input['itemtype_2'], $input['items_id_2'])) {
+            // Not enough data, cannot normalize
+            return $input;
+        }
+
+        if (!array_key_exists('link', $input)) {
+            $input['link'] = self::LINK_TO;
+        }
+
+        if (
+            $input['itemtype_1'] !== $input['itemtype_2']
+            && $input['itemtype_1'] === static::$itemtype_2 && $input['itemtype_2'] === static::$itemtype_1
+        ) {
+            // Ensure that link always qualifies relation FROM `$items_id_1` TO `$items_id_2`.
+            $input = [
+                'itemtype_1' => $input['itemtype_2'],
+                'items_id_1' => $input['items_id_2'],
+                'itemtype_2' => $input['itemtype_1'],
+                'items_id_2' => $input['items_id_1'],
+                'link'       => in_array($input['link'], [self::SON_OF, self::PARENT_OF])
+                    ? ($input['link'] == self::SON_OF ? self::PARENT_OF : self::SON_OF)
+                    : $input['link'],
+            ];
+        }
+
+        // Transform itemtype/items_id to foreign keys
+        $input = [
+            static::$items_id_1 => $input['items_id_1'],
+            static::$items_id_2 => $input['items_id_2'],
+            'link'              => $input['link'],
+        ];
+
+        $input = $this->normalizeParentSonRelation($input);
+
+        return $input;
+    }
+
+
+    /**
+     * Normalize PARENT_OF/SON_OF relation.
+     *
+     * This method ensure to always use SON_OF relations for relation between 2 identical itemtypes, as it is
+     * a prerequisite for "Parent/Child" search options that cannot use conditionnal `linkfield`.
+     *
+     * @param array $input
+     *
+     * @return array
+     */
+    final protected static function normalizeParentSonRelation(array $input): array
+    {
+        if (static::$itemtype_1 !== static::$itemtype_2) {
+            return $input; // Normalization only affects relation between same itemtypes
+        }
+
+        if (array_key_exists('link', $input) && $input['link'] == self::PARENT_OF) {
+            $input = array_merge(
+                $input,
+                [
+                    static::$items_id_1 => $input[static::$items_id_2],
+                    static::$items_id_2 => $input[static::$items_id_1],
+                    'link' => self::SON_OF,
+                ]
+            );
+        }
+
+        return $input;
+    }
+}

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1523,20 +1523,22 @@ class Dropdown
     {
         global $CFG_GLPI;
 
-        $params = [];
-        $params['itemtype_name']       = 'itemtype';
-        $params['items_id_name']       = 'items_id';
-        $params['itemtypes']           = '';
-        $params['default_itemtype']    = 0;
-        $params['entity_restrict']     = -1;
-        $params['onlyglobal']          = false;
-        $params['checkright']          = false;
-        $params['showItemSpecificity'] = '';
-        $params['emptylabel']          = self::EMPTY_VALUE;
-        $params['used']                = [];
-        $params['ajax_page']           = $CFG_GLPI["root_doc"] . "/ajax/dropdownAllItems.php";
-        $params['display']             = true;
-        $params['rand']                = mt_rand();
+        $params = [
+            'itemtype_name'         => 'itemtype',
+            'items_id_name'         => 'items_id',
+            'itemtypes'             => '',
+            'default_itemtype'      => 0,
+            'default_items_id'      => -1,
+            'entity_restrict'       => -1,
+            'onlyglobal'            => false,
+            'checkright'            => false,
+            'showItemSpecificity'   => '',
+            'emptylabel'            => self::EMPTY_VALUE,
+            'used'                  => [],
+            'ajax_page'             => $CFG_GLPI["root_doc"] . "/ajax/dropdownAllItems.php",
+            'display'               => true,
+            'rand'                  => mt_rand(),
+        ];
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -1549,7 +1551,7 @@ class Dropdown
             'name'       => $params['itemtype_name'],
             'emptylabel' => $params['emptylabel'],
             'display'    => $params['display'],
-            'rand'       => $params['rand'],
+            'rand'       => $params['rand']
         ]);
 
         $p_ajax = [
@@ -1566,6 +1568,15 @@ class Dropdown
         }
         if ($params['used']) {
             $p_ajax['used'] = $params['used'];
+        }
+        if (!empty($params['default_itemtype']) && $params['default_items_id'] > 0) {
+            $p_ajax["value"] = $params['default_items_id'];
+            // If default itemtype is a CommonDBTM
+            if (is_subclass_of($params['default_itemtype'], 'CommonDBTM', true)) {
+                $item = new $params['default_itemtype']();
+                $item->getFromDB($params['default_items_id']);
+                $p_ajax["valuename"] = $item->getName();
+            }
         }
 
         $field_id = Html::cleanId("dropdown_" . $params['itemtype_name'] . $params['rand']);

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -295,9 +295,11 @@ class ITILSolution extends CommonDBChild
             ]
         );
 
-       // Add solution to duplicates
+       // Add solution to duplicates (only for tickets)
         if ($this->item->getType() == 'Ticket' && !isset($this->input['_linked_ticket'])) {
-            Ticket_Ticket::manageLinkedTicketsOnSolved($this->item->getID(), $this);
+            CommonITILObject_CommonITILObject::manageLinksOnChange('Ticket', $this->item->getID(), [
+                '_solution' => $this,
+            ]);
         }
 
         if (!isset($this->input['_linked_ticket'])) {

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1378,6 +1378,44 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
 
        // Complex mode
         if (!$simple) {
+            $linked = CommonITILObject_CommonITILObject::getAllLinkedTo($item->getType(), $item->getField('id'));
+            $data['linkedtickets'] = [];
+            $data['linkedchanges'] = [];
+            $data['linkedproblems'] = [];
+
+            foreach ($linked as $link) {
+                $itemtype = $link['itemtype'];
+                $link_item = new $link['itemtype']();
+                if ($link_item->getFromDB($link['items_id'])) {
+                    $tmp = [];
+                    $tmp['##linked' . strtolower($itemtype) . '.id##'] = $link['items_id'];
+                    $tmp['##linked' . strtolower($itemtype) . '.link##'] = CommonITILObject_CommonITILObject::getLinkName($link['link']);
+                    $tmp['##linked' . strtolower($itemtype) . '.url##'] = $this->formatURL(
+                        $options['additionnaloption']['usertype'],
+                        strtolower($itemtype) . "_" . $link['items_id']
+                    );
+
+                    $tmp['##linked' . strtolower($itemtype) . '.title##'] = $link_item->getField('name');
+                    $tmp['##linked' . strtolower($itemtype) . '.content##'] = $link_item->getField('content');
+
+                    switch ($itemtype) {
+                        case 'Ticket':
+                            $data['linkedtickets'][] = $tmp;
+                            break;
+                        case 'Change':
+                            $data['linkedchanges'][] = $tmp;
+                            break;
+                        case 'Problem':
+                            $data['linkedproblems'][] = $tmp;
+                            break;
+                    }
+                }
+            }
+
+            $data['##ticket.numberoflinkedtickets##'] = count($data['linkedtickets']);
+            $data['##ticket.numberoflinkedchanges##'] = count($data['linkedchanges']);
+            $data['##ticket.numberoflinkedproblems##'] = count($data['linkedproblems']);
+
             $show_private = $options['additionnaloption']['show_private'] ?? false;
             $followup_restrict = [];
             $followup_restrict['items_id'] = $item->getField('id');
@@ -1869,6 +1907,9 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             'timelineitems.typename'            => _n('Type', 'Types', 1),
             'timelineitems.description'         => __('Description'),
             'timelineitems.position'            => __('Position'),
+            $objettype . '.numberoflinkedtickets' => _x('quantity', 'Number of linked tickets'),
+            $objettype . '.numberoflinkedchanges' => _x('quantity', 'Number of linked changes'),
+            $objettype . '.numberoflinkedproblems' => _x('quantity', 'Number of linked problems'),
 
         ];
 
@@ -1887,7 +1928,10 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             'costs'     => _n('Cost', 'Costs', Session::getPluralNumber()),
             'authors'   => _n('Requester', 'Requesters', Session::getPluralNumber()),
             'suppliers' => _n('Supplier', 'Suppliers', Session::getPluralNumber()),
-            'timelineitems' => sprintf(__('Processing %1$s'), strtolower($objettype))
+            'timelineitems' => sprintf(__('Processing %1$s'), strtolower($objettype)),
+            'linkedtickets' => _n('Linked ticket', 'Linked tickets', Session::getPluralNumber()),
+            'linkedchanges' => _n('Linked change', 'Linked changes', Session::getPluralNumber()),
+            'linkedproblems' => _n('Linked problem', 'Linked problems', Session::getPluralNumber()),
         ];
 
         foreach ($tags as $tag => $label) {
@@ -1899,14 +1943,18 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
         }
 
        //Tags with just lang
-        $tags = [$objettype . '.days'               => _n('Day', 'Days', Session::getPluralNumber()),
-            $objettype . '.attribution'        => __('Assigned to'),
-            $objettype . '.entity'             => Entity::getTypeName(1),
-            $objettype . '.nocategoryassigned' => __('No defined category'),
-            $objettype . '.log'                => __('Historical'),
-            $objettype . '.tasks'              => _n('Task', 'Tasks', Session::getPluralNumber()),
-            $objettype . '.costs'              => _n('Cost', 'Costs', Session::getPluralNumber()),
-            $objettype . '.timelineitems'       => sprintf(__('Processing %1$s'), strtolower($objettype))
+        $tags = [
+            $objettype . '.days'                => _n('Day', 'Days', Session::getPluralNumber()),
+            $objettype . '.attribution'         => __('Assigned to'),
+            $objettype . '.entity'              => Entity::getTypeName(1),
+            $objettype . '.nocategoryassigned'  => __('No defined category'),
+            $objettype . '.log'                 => __('Historical'),
+            $objettype . '.tasks'               => _n('Task', 'Tasks', Session::getPluralNumber()),
+            $objettype . '.costs'               => _n('Cost', 'Costs', Session::getPluralNumber()),
+            $objettype . '.timelineitems'       => sprintf(__('Processing %1$s'), strtolower($objettype)),
+            $objettype . '.linkedtickets'       => _n('Linked ticket', 'Linked tickets', Session::getPluralNumber()),
+            $objettype . '.linkedchanges'       => _n('Linked change', 'Linked changes', Session::getPluralNumber()),
+            $objettype . '.linkedproblems'      => _n('Linked problem', 'Linked problems', Session::getPluralNumber()),
         ];
 
         foreach ($tags as $tag => $label) {
@@ -1993,7 +2041,82 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 __('%1$s: %2$s'),
                 Document::getTypeName(Session::getPluralNumber()),
                 __('URL')
-            )
+            ),
+            'linkedticket.id'         => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked ticket', 'Linked tickets', 1),
+                __('ID')
+            ),
+            'linkedticket.link'       => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked ticket', 'Linked tickets', 1),
+                Link::getTypeName(1)
+            ),
+            'linkedticket.url'        => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked ticket', 'Linked tickets', 1),
+                __('URL')
+            ),
+            'linkedticket.title'      => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked ticket', 'Linked tickets', 1),
+                __('Title')
+            ),
+            'linkedticket.content'    => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked ticket', 'Linked tickets', 1),
+                __('Description')
+            ),
+            'linkedchange.id'         => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked change', 'Linked changes', 1),
+                __('ID')
+            ),
+            'linkedchange.link'       => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked change', 'Linked changes', 1),
+                Link::getTypeName(1)
+            ),
+            'linkedchange.url'        => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked change', 'Linked changes', 1),
+                __('URL')
+            ),
+            'linkedchange.title'      => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked change', 'Linked changes', 1),
+                __('Title')
+            ),
+            'linkedchange.content'    => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked change', 'Linked changes', 1),
+                __('Description')
+            ),
+            'linkedproblem.id'         => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked problem', 'Linked problems', 1),
+                __('ID')
+            ),
+            'linkedproblem.link'       => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked problem', 'Linked problems', 1),
+                Link::getTypeName(1)
+            ),
+            'linkedproblem.url'        => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked problem', 'Linked problems', 1),
+                __('URL')
+            ),
+            'linkedproblem.title'      => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked problem', 'Linked problems', 1),
+                __('Title')
+            ),
+            'linkedproblem.content'    => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked problem', 'Linked problems', 1),
+                __('Description')
+            ),
         ];
 
         foreach ($tags as $tag => $label) {

--- a/src/NotificationTargetTicket.php
+++ b/src/NotificationTargetTicket.php
@@ -386,39 +386,8 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
 
         $data['##ticket.numberofitems##'] = count($data['items']);
 
-       // Get followups, log, validation, satisfaction, linked tickets
+       // Get followups, log, validation, satisfaction
         if (!$simple) {
-           // Linked tickets
-            $linked_tickets         = Ticket_Ticket::getLinkedTicketsTo($item->getField('id'));
-            $data['linkedtickets'] = [];
-            if (count($linked_tickets)) {
-                $linkedticket = new Ticket();
-                foreach ($linked_tickets as $row) {
-                    if ($linkedticket->getFromDB($row['tickets_id'])) {
-                        $tmp = [];
-
-                        $tmp['##linkedticket.id##']
-                                    = $row['tickets_id'];
-                        $tmp['##linkedticket.link##']
-                                    = Ticket_Ticket::getLinkName($row['link']);
-                        $tmp['##linkedticket.url##']
-                                    = $this->formatURL(
-                                        $options['additionnaloption']['usertype'],
-                                        "ticket_" . $row['tickets_id']
-                                    );
-
-                        $tmp['##linkedticket.title##']
-                                    = $linkedticket->getField('name');
-                        $tmp['##linkedticket.content##']
-                                    = $linkedticket->getField('content');
-
-                        $data['linkedtickets'][] = $tmp;
-                    }
-                }
-            }
-
-            $data['##ticket.numberoflinkedtickets##'] = count($data['linkedtickets']);
-
             $restrict          = ['tickets_id' => $item->getField('id')];
             $problems          = getAllDataFromTable('glpi_problems_tickets', $restrict);
             $data['problems'] = [];
@@ -656,7 +625,6 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
             'ticket.item.user'             => User::getTypeName(1),
             'ticket.item.group'            => Group::getTypeName(1),
             'ticket.isdeleted'             => __('Deleted'),
-            'ticket.numberoflinkedtickets' => _x('quantity', 'Number of linked tickets'),
             'ticket.numberofproblems'      => _x('quantity', 'Number of problems'),
             'ticket.numberofchanges'       => _x('quantity', 'Number of changes'),
             'ticket.numberofitems'         => _x('quantity', 'Number of items'),
@@ -769,7 +737,6 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
 
        //Foreach global tags
         $tags = ['validations'   => _n('Validation', 'Validations', Session::getPluralNumber()),
-            'linkedtickets' => _n('Linked ticket', 'Linked tickets', Session::getPluralNumber()),
             'problems'      => Problem::getTypeName(Session::getPluralNumber()),
             'changes'       => _n('Change', 'Changes', Session::getPluralNumber()),
             'items'         => _n('Associated item', 'Associated items', Session::getPluralNumber()),
@@ -785,7 +752,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
         }
 
        //Tags with just lang
-        $tags = ['ticket.linkedtickets'    => _n('Linked ticket', 'Linked tickets', Session::getPluralNumber()),
+        $tags = [
             'ticket.problems'         => Problem::getTypeName(Session::getPluralNumber()),
             'ticket.changes'          => _n('Change', 'Changes', Session::getPluralNumber()),
             'ticket.autoclosewarning'
@@ -825,31 +792,6 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                 __('%1$s: %2$s'),
                 __('Satisfaction'),
                 __('URL')
-            ),
-            'linkedticket.id'         => sprintf(
-                __('%1$s: %2$s'),
-                _n('Linked ticket', 'Linked tickets', 1),
-                __('ID')
-            ),
-            'linkedticket.link'       => sprintf(
-                __('%1$s: %2$s'),
-                _n('Linked ticket', 'Linked tickets', 1),
-                Link::getTypeName(1)
-            ),
-            'linkedticket.url'        => sprintf(
-                __('%1$s: %2$s'),
-                _n('Linked ticket', 'Linked tickets', 1),
-                __('URL')
-            ),
-            'linkedticket.title'      => sprintf(
-                __('%1$s: %2$s'),
-                _n('Linked ticket', 'Linked tickets', 1),
-                __('Title')
-            ),
-            'linkedticket.content'    => sprintf(
-                __('%1$s: %2$s'),
-                _n('Linked ticket', 'Linked tickets', 1),
-                __('Description')
             ),
             'problem.id'              => sprintf(__('%1$s: %2$s'), Problem::getTypeName(1), __('ID')),
             'problem.date'            => sprintf(__('%1$s: %2$s'), Problem::getTypeName(1), _n('Date', 'Dates', 1)),

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -213,8 +213,6 @@ class Problem extends CommonITILObject
         if ($this->hasImpactTab()) {
             $this->addStandardTab('Impact', $ong, $options);
         }
-        $this->addStandardTab('Change_Problem', $ong, $options);
-        $this->addStandardTab('Problem_Ticket', $ong, $options);
         $this->addStandardTab('Notepad', $ong, $options);
         $this->addStandardTab('KnowbaseItem_Item', $ong, $options);
         $this->addStandardTab('Log', $ong, $options);
@@ -232,13 +230,14 @@ class Problem extends CommonITILObject
         $this->deleteChildrenAndRelationsFromDb(
             [
                 Change_Problem::class,
-            // Done by parent: Group_Problem::class,
+                // Done by parent: Group_Problem::class,
                 Item_Problem::class,
-            // Done by parent: ITILSolution::class,
-            // Done by parent: Problem_Supplier::class,
+                // Done by parent: ITILSolution::class,
+                // Done by parent: Problem_Supplier::class,
                 Problem_Ticket::class,
-            // Done by parent: Problem_User::class,
+                // Done by parent: Problem_User::class,
                 ProblemCost::class,
+                Problem_Problem::class,
             ]
         );
 
@@ -558,6 +557,7 @@ class Problem extends CommonITILObject
             'name'               => __('Problems')
         ];
 
+        //FIXME: Fix the search options for linked ITIL objects
         $tab[] = [
             'id'                 => '200',
             'table'              => 'glpi_problems_tickets',

--- a/src/Problem_Problem.php
+++ b/src/Problem_Problem.php
@@ -32,32 +32,23 @@
  */
 
 /**
- * @since 0.84
- */
+ * @since 10.1.0
+ *
+ * Problem_Problem Class
+ *
+ * Relation between Problems and other Problems
+ **/
+class Problem_Problem extends CommonITILObject_CommonITILObject
+{
+    // From CommonDBRelation
+    public static $itemtype_1   = 'Problem';
+    public static $items_id_1   = 'problems_id_1';
 
-use Glpi\Event;
+    public static $itemtype_2   = 'Problem';
+    public static $items_id_2   = 'problems_id_2';
 
-include('../inc/includes.php');
-
-$ticket_ticket = new Ticket_Ticket();
-
-Session ::checkCentralAccess();
-
-Toolbox::deprecated();
-
-if (isset($_POST['purge'])) {
-    $ticket_ticket->check($_POST['id'], PURGE);
-
-    $ticket_ticket->delete($_POST, 1);
-
-    Event::log(
-        $_POST['tickets_id'],
-        "ticket",
-        4,
-        "tracking",
-        //TRANS: %s is the user login
-        sprintf(__('%s purges link between tickets'), $_SESSION["glpiname"])
-    );
-    Html::redirect(Ticket::getFormURLWithID($_POST['tickets_id']));
+    public static function getTypeName($nb = 0)
+    {
+        return _n('Link Problem/Problem', 'Links Problem/Problem', $nb);
+    }
 }
-Html::displayErrorAndDie("lost");

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -31,7 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
-class Problem_Ticket extends CommonDBRelation
+class Problem_Ticket extends CommonITILObject_CommonITILObject
 {
    // From CommonDBRelation
     public static $itemtype_1   = 'Problem';
@@ -39,19 +39,6 @@ class Problem_Ticket extends CommonDBRelation
 
     public static $itemtype_2   = 'Ticket';
     public static $items_id_2   = 'tickets_id';
-
-
-    /**
-     * @since 0.84
-     **/
-    public function getForbiddenStandardMassiveAction()
-    {
-
-        $forbidden   = parent::getForbiddenStandardMassiveAction();
-        $forbidden[] = 'update';
-        return $forbidden;
-    }
-
 
     public static function getTypeName($nb = 0)
     {
@@ -100,49 +87,6 @@ class Problem_Ticket extends CommonDBRelation
                 break;
         }
         return true;
-    }
-
-
-    /**
-     * @since 0.84
-     **/
-    public function post_addItem()
-    {
-        global $CFG_GLPI;
-
-        $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
-
-        if ($donotif) {
-            $problem = new Problem();
-            $ticket  = new Ticket();
-            if ($problem->getFromDB($this->input["problems_id"]) && $ticket->getFromDB($this->input["tickets_id"])) {
-                NotificationEvent::raiseEvent("update", $problem);
-                NotificationEvent::raiseEvent('update', $ticket);
-            }
-        }
-
-        parent::post_addItem();
-    }
-
-
-    /**
-     * @since 0.84
-     **/
-    public function post_deleteFromDB()
-    {
-        global $CFG_GLPI;
-
-        $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
-
-        if ($donotif) {
-            $problem = new Problem();
-            if ($problem->getFromDB($this->fields["problems_id"])) {
-                $options = [];
-                NotificationEvent::raiseEvent("delete", $problem, $options);
-            }
-        }
-
-        parent::post_deleteFromDB();
     }
 
 
@@ -295,20 +239,25 @@ class Problem_Ticket extends CommonDBRelation
         if ($canedit) {
             echo "<div class='firstbloc'>";
             echo "<form name='changeticket_form$rand' id='changeticket_form$rand' method='post'
-               action='" . Toolbox::getItemTypeFormURL(__CLASS__) . "'>";
+                action='" . CommonITILObject_CommonITILObject::getFormURL() . "'>";
 
             echo "<table class='tab_cadre_fixe'>";
-            echo "<tr class='tab_bg_2'><th colspan='2'>" . __('Add a ticket') . "</th></tr>";
+            echo "<tr class='tab_bg_2'><th>" . __('Add a ticket') . "</th></tr>";
 
-            echo "<tr class='tab_bg_2'><td class='right'>";
-            echo "<input type='hidden' name='problems_id' value='$ID'>";
+            echo "<tr class='tab_bg_2'><td>";
+            echo "<input type='hidden' name='itemtype_1' value='Problem'>";
+            echo "<input type='hidden' name='items_id_1' value='$ID'>";
+            echo "<input type='hidden' name='itemtype_2' value='Ticket'>";
+            echo self::dropdownLinks('link');
+            echo "&nbsp;";
             Ticket::dropdown([
+                'name'        => 'items_id_2',
                 'used'        => $used,
                 'entity'      => $problem->getEntityID(),
                 'entity_sons' => $problem->isRecursive(),
                 'displaywith' => ['id'],
             ]);
-            echo "</td><td class='center'>";
+            echo "&nbsp;";
             echo "<input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";
             echo "</td></tr>";
 
@@ -406,19 +355,23 @@ class Problem_Ticket extends CommonDBRelation
         if ($canedit) {
             echo "<div class='firstbloc'>";
             echo "<form name='problemticket_form$rand' id='problemticket_form$rand' method='post'
-                action='" . Toolbox::getItemTypeFormURL(__CLASS__) . "'>";
+                action='" . CommonITILObject_CommonITILObject::getFormURL() . "'>";
 
             echo "<table class='tab_cadre_fixe'>";
-            echo "<tr class='tab_bg_2'><th colspan='3'>" . __('Add a problem') . "</th></tr>";
+            echo "<tr class='tab_bg_2'><th colspan='2'>" . __('Add a problem') . "</th></tr>";
             echo "<tr class='tab_bg_2'><td>";
-            echo "<input type='hidden' name='tickets_id' value='$ID'>";
-
+            echo "<input type='hidden' name='itemtype_1' value='Ticket'>";
+            echo "<input type='hidden' name='items_id_1' value='$ID'>";
+            echo "<input type='hidden' name='itemtype_2' value='Problem'>";
+            echo self::dropdownLinks('link');
+            echo "&nbsp;";
             Problem::dropdown([
+                'name'      => 'items_id_2',
                 'used'      => $used,
                 'entity'    => $ticket->getEntityID(),
                 'condition' => Problem::getOpenCriteria()
             ]);
-            echo "</td><td class='center'>";
+            echo "&nbsp;";
             echo "<input type='submit' name='add' value=\"" . _sx('button', 'Add') . "\" class='btn btn-primary'>";
             echo "</td><td>";
             if (Session::haveRight('problem', CREATE)) {

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1269,19 +1269,6 @@ class Ticket extends CommonITILObject
             }
         }
 
-        if (isset($input['_link'])) {
-            $ticket_ticket = new Ticket_Ticket();
-            if (!empty($input['_link']['tickets_id_2'])) {
-                if ($ticket_ticket->can(-1, CREATE, $input['_link'])) {
-                    if ($ticket_ticket->add($input['_link'])) {
-                        $input['_forcenotif'] = true;
-                    }
-                } else {
-                    Session::addMessageAfterRedirect(__('Unknown ticket'), false, ERROR);
-                }
-            }
-        }
-
        // SLA / OLA affect by rules : reset time_to_resolve / internal_time_to_resolve
        // Manual SLA / OLA defined : reset time_to_resolve / internal_time_to_resolve
        // No manual SLA / OLA and due date defined : reset auto SLA / OLA
@@ -1604,7 +1591,9 @@ class Ticket extends CommonITILObject
             && (in_array($this->input['status'], $this->getSolvedStatusArray())
               || in_array($this->input['status'], $this->getClosedStatusArray()))
         ) {
-            Ticket_Ticket::manageLinkedTicketsOnSolved($this->getID());
+            CommonITILObject_CommonITILObject::manageLinksOnChange('Ticket', $this->getID(), [
+                'status'       => $this->input['status'],
+            ]);
         }
 
         $donotif = count($this->updates);
@@ -2041,26 +2030,12 @@ class Ticket extends CommonITILObject
         }
 
         $ticket_ticket = new Ticket_Ticket();
-
-       // From interface
-        if (isset($this->input['_link'])) {
-            $this->input['_link']['tickets_id_1'] = $this->fields['id'];
-           // message if ticket's ID doesn't exist
-            if (!empty($this->input['_link']['tickets_id_2'])) {
-                if ($ticket_ticket->can(-1, CREATE, $this->input['_link'])) {
-                    $ticket_ticket->add($this->input['_link']);
-                } else {
-                    Session::addMessageAfterRedirect(__('Unknown ticket'), false, ERROR);
-                }
-            }
-        }
-
        // From mailcollector : do not check rights
         if (isset($this->input["_linkedto"])) {
             $input2 = [
                 'tickets_id_1' => $this->fields['id'],
                 'tickets_id_2' => $this->input["_linkedto"],
-                'link'         => Ticket_Ticket::LINK_TO,
+                'link'         => CommonITILObject_CommonITILObject::LINK_TO,
             ];
             $ticket_ticket->add($input2);
         }
@@ -2729,7 +2704,7 @@ class Ticket extends CommonITILObject
     public function getSpecificMassiveActions($checkitem = null)
     {
 
-        $actions = [];
+        $actions = parent::getSpecificMassiveActions($checkitem);
 
         if (Session::getCurrentInterface() == 'central') {
             if (Ticket::canUpdate() && Ticket::canDelete()) {
@@ -2773,9 +2748,6 @@ class Ticket extends CommonITILObject
                  __('Add an actor');
                 $actions[__CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'update_notif']
                 = __('Set notifications for all actors');
-                $actions['Ticket_Ticket' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add']
-                = "<i class='fa-fw fas fa-link'></i>" .
-                 _x('button', 'Link tickets');
                 $actions['ProjectTask_Ticket' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add']
                 = "<i class='fa-fw fas fa-link'></i>" .
                 _x('button', 'Link project task');
@@ -2784,12 +2756,6 @@ class Ticket extends CommonITILObject
                  _x('button', 'Add contract');
 
                 KnowbaseItem_Item::getMassiveActionsForItemtype($actions, __CLASS__, 0, $checkitem);
-            }
-
-            if (Problem::canUpdate()) {
-                $actions[self::getType() . MassiveAction::CLASS_ACTION_SEPARATOR . 'link_to_problem']
-                = "<i class='fa-fw " . Problem::getIcon() . "' ></i>" .
-                __("Link to a problem");
             }
 
             if (self::canUpdate()) {
@@ -2847,12 +2813,12 @@ class Ticket extends CommonITILObject
                 ]);
                 echo "</td></tr><tr><td><label for='dropdown_link_type$rand'>" . __('Link type') . "</label></td><td colspan='3'>";
                 Dropdown::showFromArray('link_type', [
-                    0                             => __('None'),
-                    Ticket_Ticket::LINK_TO        => __('Linked to'),
-                    Ticket_Ticket::DUPLICATE_WITH => __('Duplicates'),
-                    Ticket_Ticket::SON_OF         => __('Son of'),
-                    Ticket_Ticket::PARENT_OF      => __('Parent of')
-                ], ['value' => Ticket_Ticket::SON_OF, 'rand' => $rand]);
+                    0                                                   => __('None'),
+                    CommonITILObject_CommonITILObject::LINK_TO          => __('Linked to'),
+                    CommonITILObject_CommonITILObject::DUPLICATE_WITH   => __('Duplicates'),
+                    CommonITILObject_CommonITILObject::SON_OF           => __('Son of'),
+                    CommonITILObject_CommonITILObject::PARENT_OF        => __('Parent of')
+                ], ['value' => CommonITILObject_CommonITILObject::SON_OF, 'rand' => $rand]);
                 echo "</td></tr><tr><tr><td colspan='4'>";
                 echo Html::submit(_x('button', 'Merge'), [
                     'name'      => 'merge',
@@ -2862,6 +2828,7 @@ class Ticket extends CommonITILObject
                 return true;
 
             case 'link_to_problem':
+                Toolbox::deprecated('Ticket "link_to_problem" massive action is deprecated. Use CommonITILObject_CommonITILObject "add" massive action.');
                 Problem::dropdown([
                     'name'      => 'problems_id',
                     'condition' => Problem::getOpenCriteria()
@@ -3015,6 +2982,7 @@ JAVASCRIPT;
                 return;
 
             case 'link_to_problem':
+                Toolbox::deprecated('Ticket "link_to_problem" massive action is deprecated. Use CommonITILObject_CommonITILObject "add" massive action.');
                // Skip if not tickets
                 if ($item::getType() !== Ticket::getType()) {
                     $ma->addMessage($item->getErrorMessage(ERROR_COMPAT));
@@ -3616,7 +3584,7 @@ JAVASCRIPT;
                 'searchtype'         => 'equals',
                 'joinparams'         => [
                     'jointype'           => 'item_item',
-                    'condition'          => ['NEWTABLE.link' => Ticket_Ticket::DUPLICATE_WITH]
+                    'condition'          => ['NEWTABLE.link' => CommonITILObject_CommonITILObject::DUPLICATE_WITH]
                 ],
                 'additionalfields'   => ['tickets_id_2'],
                 'forcegroupby'       => true
@@ -3645,7 +3613,7 @@ JAVASCRIPT;
                 'usehaving'          => true,
                 'joinparams'         => [
                     'jointype'           => 'item_item',
-                    'condition'          => ['NEWTABLE.link' => Ticket_Ticket::DUPLICATE_WITH]
+                    'condition'          => ['NEWTABLE.link' => CommonITILObject_CommonITILObject::DUPLICATE_WITH]
                 ]
             ];
 
@@ -3665,7 +3633,7 @@ JAVASCRIPT;
                         'joinparams'         => [
                             'jointype'           => 'child',
                             'linkfield'          => 'tickets_id_1',
-                            'condition'          => ['NEWTABLE.link' => Ticket_Ticket::SON_OF]
+                            'condition'          => ['NEWTABLE.link' => CommonITILObject_CommonITILObject::SON_OF]
                         ]
                     ]
                 ],
@@ -3688,7 +3656,7 @@ JAVASCRIPT;
                         'joinparams'         => [
                             'jointype'           => 'child',
                             'linkfield'          => 'tickets_id_2',
-                            'condition'          => ['NEWTABLE.link' => Ticket_Ticket::SON_OF]
+                            'condition'          => ['NEWTABLE.link' => CommonITILObject_CommonITILObject::SON_OF]
                         ]
                     ]
                 ],
@@ -3706,7 +3674,7 @@ JAVASCRIPT;
                 'joinparams'         => [
                     'linkfield'          => 'tickets_id_2',
                     'jointype'           => 'child',
-                    'condition'          => ['NEWTABLE.link' => Ticket_Ticket::SON_OF]
+                    'condition'          => ['NEWTABLE.link' => CommonITILObject_CommonITILObject::SON_OF]
                 ],
                 'forcegroupby'       => true
             ];
@@ -3722,7 +3690,7 @@ JAVASCRIPT;
                 'joinparams'         => [
                     'linkfield'          => 'tickets_id_1',
                     'jointype'           => 'child',
-                    'condition'          => ['NEWTABLE.link' => Ticket_Ticket::SON_OF]
+                    'condition'          => ['NEWTABLE.link' => CommonITILObject_CommonITILObject::SON_OF]
                 ],
                 'additionalfields'   => ['tickets_id_2']
             ];
@@ -4333,7 +4301,9 @@ JAVASCRIPT;
                 'alternative_email' => ['']
             ],
             '_groups_id_observer'       => 0,
-            '_link'                     => ['tickets_id_2' => '',
+            // FIXME Use new format
+            '_link'                     => [
+                'tickets_id_2' => '',
                 'link'         => ''
             ],
             '_suppliers_id_assign'      => 0,
@@ -4440,8 +4410,9 @@ JAVASCRIPT;
                 if ($fup->getFromDB($options['_promoted_fup_id'])) {
                     $options['content'] = $fup->getField('content');
                     $options['_users_id_requester'] = $fup->fields['users_id'];
+                    // FIXME Use new format
                     $options['_link'] = [
-                        'link'         => Ticket_Ticket::SON_OF,
+                        'link'         => CommonITILObject_CommonITILObject::SON_OF,
                         'tickets_id_2' => $fup->fields['items_id']
                     ];
 
@@ -4463,8 +4434,9 @@ JAVASCRIPT;
                     $options['_users_id_requester'] = $tickettask->fields['users_id'];
                     $options['_users_id_assign'] = $tickettask->fields['users_id_tech'];
                     $options['_groups_id_assign'] = $tickettask->fields['groups_id_tech'];
+                    // FIXME Use new format
                     $options['_link'] = [
-                        'link'         => Ticket_Ticket::SON_OF,
+                        'link'         => CommonITILObject_CommonITILObject::SON_OF,
                         'tickets_id_2' => $tickettask->fields['tickets_id']
                     ];
 
@@ -4578,6 +4550,14 @@ JAVASCRIPT;
             $item_ticket = new Item_Ticket();
         }
 
+        // If a link is specified in the old format, convert it to the new one
+        if (isset($options['_link']) && isset($options['_link']['tickets_id_2'])) {
+            $options['_link'] = [
+                'itemtype_1' => 'Ticket',
+                'itemtype_2' => 'Ticket',
+                'items_id_2' => $options['_link']['tickets_id_2'],
+            ];
+        }
         TemplateRenderer::getInstance()->display('components/itilobject/layout.html.twig', [
             'item'               => $this,
             'timeline_itemtypes' => $this->getTimelineItemtypes(),
@@ -4587,7 +4567,6 @@ JAVASCRIPT;
             'itiltemplate_key'   => self::getTemplateFormFieldName(),
             'itiltemplate'       => $tt,
             'predefined_fields'  => Toolbox::prepareArrayForInput($predefined_fields),
-            'ticket_ticket'      => new Ticket_Ticket(),
             'item_ticket'        => $item_ticket,
             'sla'                => $sla,
             'ola'                => $ola,
@@ -6753,7 +6732,7 @@ JAVASCRIPT;
      *       full_transaction - Boolean value indicating if the entire merge must complete successfully, or if partial merges are allowed.
      *                By default, the full merge must complete. On failure, all database operations performed are rolled back.
      *       link_type - Integer indicating the link type of the merged tickets (See types in Ticket_Ticket).
-     *                By default, this is Ticket_Ticket::SON_OF. To disable linking, use 0 or a negative value.
+     *                By default, this is CommonITILObject_CommonITILObject::SON_OF. To disable linking, use 0 or a negative value.
      *       append_actors - Array of actor types to migrate into the ticket $merge_ticket. See types in CommonITILActor.
      *                By default, all actors are added to the ticket.
      * @param array $status Reference array that this function uses to store the status of each ticket attempted to be merged.
@@ -6768,7 +6747,7 @@ JAVASCRIPT;
         $p = [
             'linktypes'          => [],
             'full_transaction'   => true,
-            'link_type'          => Ticket_Ticket::SON_OF,
+            'link_type'          => CommonITILObject_CommonITILObject::SON_OF,
             'append_actors'      => [CommonITILActor::REQUESTER, CommonITILActor::OBSERVER, CommonITILActor::ASSIGN]
         ];
         $p = array_replace($p, $params);

--- a/src/Ticket_Ticket.php
+++ b/src/Ticket_Ticket.php
@@ -32,7 +32,7 @@
  */
 
 /// Class Ticket links
-class Ticket_Ticket extends CommonDBRelation
+class Ticket_Ticket extends CommonITILObject_CommonITILObject
 {
    // From CommonDBRelation
     public static $itemtype_1     = 'Ticket';
@@ -41,13 +41,6 @@ class Ticket_Ticket extends CommonDBRelation
     public static $items_id_2     = 'tickets_id_2';
 
     public static $check_entity_coherency = false;
-
-   // Ticket links
-    const LINK_TO        = 1;
-    const DUPLICATE_WITH = 2;
-    const SON_OF         = 3;
-    const PARENT_OF      = 4;
-
 
     public static function getTypeName($nb = 0)
     {
@@ -65,6 +58,7 @@ class Ticket_Ticket extends CommonDBRelation
 
         switch ($ma->getAction()) {
             case 'add':
+                Toolbox::deprecated('Ticket_Ticket "add" massive action is deprecated. Use CommonITILObject_CommonITILObject "add" massive action.');
                 Ticket_Ticket::dropdownLinks('link');
                 printf(__('%1$s: %2$s'), Ticket::getTypeName(1), __('ID'));
                 echo "&nbsp;<input type='text' name='tickets_id_1' value='' size='10'>\n";
@@ -90,6 +84,7 @@ class Ticket_Ticket extends CommonDBRelation
 
         switch ($ma->getAction()) {
             case 'add':
+                Toolbox::deprecated('Ticket_Ticket "add" massive action is deprecated. Use CommonITILObject_CommonITILObject "add" massive action.');
                 $input = $ma->getInput();
                 $ticket = new Ticket();
                 if (
@@ -129,9 +124,12 @@ class Ticket_Ticket extends CommonDBRelation
      * @param $ID ID of the ticket id
      *
      * @return array of linked tickets  array(id=>linktype)
+     * @deprecated 10.1.0 Use CommonITILObject_CommonITILObject::getLinkedTo()
      **/
     public static function getLinkedTicketsTo($ID)
     {
+        Toolbox::deprecated('Use "Ticket_Ticket::getLinkedTo()"');
+
         global $DB;
 
        // Make new database object and fill variables
@@ -169,124 +167,19 @@ class Ticket_Ticket extends CommonDBRelation
         return $tickets;
     }
 
-
-    /**
-     * Dropdown for links between tickets
-     *
-     * @param string  $myname select name
-     * @param integer $value  default value (default self::LINK_TO)
-     *
-     * @return void
-     **/
-    public static function dropdownLinks($myname, $value = self::LINK_TO)
-    {
-
-        $tmp[self::LINK_TO]        = __('Linked to');
-        $tmp[self::DUPLICATE_WITH] = __('Duplicates');
-        $tmp[self::SON_OF]         = __('Son of');
-        $tmp[self::PARENT_OF]      = __('Parent of');
-        Dropdown::showFromArray($myname, $tmp, ['value' => $value]);
-    }
-
-
-    /**
-     * Get Link Name
-     *
-     * @param integer $value     Current value
-     * @param boolean $inverted  Whether to invert label
-     * @param boolean $with_icon prefix label with an icon
-     *
-     * @return string
-     **/
-    public static function getLinkName($value, bool $inverted = false, bool $with_icon = false): string
-    {
-        $tmp = [];
-
-        if (!$inverted) {
-            $tmp[self::LINK_TO]        = __('Linked to');
-            $tmp[self::DUPLICATE_WITH] = __('Duplicates');
-            $tmp[self::SON_OF]         = __('Son of');
-            $tmp[self::PARENT_OF]      = __('Parent of');
-        } else {
-            $tmp[self::LINK_TO]        = __('Linked to');
-            $tmp[self::DUPLICATE_WITH] = __('Duplicated by');
-            $tmp[self::SON_OF]         = __('Parent of');
-            $tmp[self::PARENT_OF]      = __('Son of');
-        }
-
-        if ($with_icon) {
-            $icon_tag = '<i class="fas %1$s me-1" title="%2$s" data-bs-toggle="tooltip"></i>%2$s';
-            $tmp[self::LINK_TO]        = sprintf($icon_tag, "fa-link", $tmp[self::LINK_TO]);
-            $tmp[self::DUPLICATE_WITH] = sprintf($icon_tag, "fa-clone", $tmp[self::DUPLICATE_WITH]);
-            $icon_son                  = $inverted ? "fa-level-down-alt" : "fa-level-up-alt fa-flip-horizontal";
-            $tmp[self::SON_OF]         = sprintf($icon_tag, $icon_son, $tmp[self::SON_OF]);
-            $icon_parent               = $inverted ? "fa-level-down-alt" : "fa-level-up-alt";
-            $tmp[self::PARENT_OF]      = sprintf($icon_tag, $icon_parent, $tmp[self::PARENT_OF]);
-        }
-
-        if (isset($tmp[$value])) {
-            return $tmp[$value];
-        }
-        return NOT_AVAILABLE;
-    }
-
-
-    public function prepareInputForAdd($input)
-    {
-       // Clean values
-        $input['tickets_id_1'] = Toolbox::cleanInteger($input['tickets_id_1']);
-        $input['tickets_id_2'] = Toolbox::cleanInteger($input['tickets_id_2']);
-
-       // Check of existance of rights on both Ticket(s) is done by the parent
-        if ($input['tickets_id_2'] == $input['tickets_id_1']) {
-            return false;
-        }
-
-        if (!isset($input['link'])) {
-            $input['link'] = self::LINK_TO;
-        }
-
-        $this->checkParentSon($input);
-
-       // No multiple links
-        $tickets = self::getLinkedTicketsTo($input['tickets_id_1']);
-        if (count($tickets)) {
-            foreach ($tickets as $key => $t) {
-                if ($t['tickets_id'] == $input['tickets_id_2']) {
-                    // Delete old simple link
-                    if (
-                        ($input['link'] == self::DUPLICATE_WITH)
-                        && ($t['link'] == self::LINK_TO)
-                    ) {
-                        $tt = new Ticket_Ticket();
-                        $tt->delete(["id" => $key]);
-                    } else { // No duplicate link
-                        return false;
-                    }
-                }
-            }
-        }
-
-        return parent::prepareInputForAdd($input);
-    }
-
-
-    public function prepareInputForUpdate($input)
-    {
-        $this->checkParentSon($input);
-        return parent::prepareInputForAdd($input);
-    }
-
-
     /**
      * Check for parent relation (inverse of son)
      *
      * @param array $input Input
      *
      * @return void
+     *
+     * @deprecated 10.1
      */
     public function checkParentSon(&$input)
     {
+        Toolbox::deprecated();
+
         if (isset($input['link']) && $input['link'] == Ticket_Ticket::PARENT_OF) {
            //a PARENT_OF relation is an inverted SON_OF one :)
             $id1 = $input['tickets_id_2'];
@@ -298,75 +191,20 @@ class Ticket_Ticket extends CommonDBRelation
     }
 
 
-    public function post_deleteFromDB()
-    {
-        global $CFG_GLPI;
-
-        $t = new Ticket();
-        $t->updateDateMod($this->fields['tickets_id_1']);
-        $t->updateDateMod($this->fields['tickets_id_2']);
-        parent::post_deleteFromDB();
-
-        $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
-        if ($donotif) {
-            $t->getFromDB($this->fields['tickets_id_1']);
-            NotificationEvent::raiseEvent("update", $t);
-            $t->getFromDB($this->fields['tickets_id_2']);
-            NotificationEvent::raiseEvent("update", $t);
-        }
-    }
-
-
-    public function post_addItem()
-    {
-        global $CFG_GLPI;
-
-        $t = new Ticket();
-        $t->updateDateMod($this->fields['tickets_id_1']);
-        $t->updateDateMod($this->fields['tickets_id_2']);
-        parent::post_addItem();
-
-        $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
-        if ($donotif) {
-            $t->getFromDB($this->fields['tickets_id_1']);
-            NotificationEvent::raiseEvent("update", $t);
-            $t->getFromDB($this->fields['tickets_id_2']);
-            NotificationEvent::raiseEvent("update", $t);
-        }
-    }
-
-
     /**
      * Count number of open children for a parent
      *
      * @param integer $pid Parent ID
      *
      * @return integer
+     * @deprecated 10.1.0 Use CommonITILObject_CommonITILObject::countLinksByStatus()
      */
     public static function countOpenChildren($pid)
     {
-        global $DB;
-
-        $result = $DB->request([
-            'COUNT'        => 'cpt',
-            'FROM'         => self::getTable() . ' AS links',
-            'INNER JOIN'   => [
-                Ticket::getTable() . ' AS tickets' => [
-                    'ON' => [
-                        'links'     => 'tickets_id_1',
-                        'tickets'   => 'id'
-                    ]
-                ]
-            ],
-            'WHERE'        => [
-                'links.link'         => self::SON_OF,
-                'links.tickets_id_2' => $pid,
-                'NOT'                => [
-                    'tickets.status'  => Ticket::getClosedStatusArray() + Ticket::getSolvedStatusArray()
-                ]
-            ]
-        ])->current();
-        return (int)$result['cpt'];
+        Toolbox::deprecated('Use "CommonITILObject::countOpenChildrenOfSameType()"');
+        $ticket = new Ticket();
+        $ticket->getFromDB($pid);
+        return $ticket->countOpenChildrenOfSameType();
     }
 
 
@@ -377,57 +215,15 @@ class Ticket_Ticket extends CommonDBRelation
      * @param ITILSolution|null $solution  Ticket's solution
      *
      * @return void
+     * @deprecated 10.1.0 Use {@link CommonITILObject_CommonITILObject::manageLinksOnChange()} instead using '_solution' and/or '_status' properties in $changes parameter
      **/
     public static function manageLinkedTicketsOnSolved($ID, $solution = null)
     {
-
-        $ticket = new Ticket();
-        if (!$ticket->getfromDB($ID)) {
-            return;
-        }
-        $tickets = self::getLinkedTicketsTo($ID);
-
-        if (false === $tickets) {
-            return;
-        }
-
-        $tickets = array_filter(
-            $tickets,
-            function ($data) {
-                $linked_ticket = new Ticket();
-                $linked_ticket->getFromDB($data['tickets_id']);
-                return $linked_ticket->can($data['tickets_id'], UPDATE)
-                && ($data['link'] == self::DUPLICATE_WITH)
-                && ($linked_ticket->fields['status'] != CommonITILObject::SOLVED)
-                && ($linked_ticket->fields['status'] != CommonITILObject::CLOSED);
-            }
-        );
-
-        if (null === $solution) {
-           // Change status without adding a solution
-           // This will be done if a ticket is solved/closed without a solution
-            foreach ($tickets as $data) {
-                $linked_ticket = new Ticket();
-                $linked_ticket->update(
-                    [
-                        'id'     => $data['tickets_id'],
-                        'status' => $ticket->fields['status']
-                    ]
-                );
-            }
+        Toolbox::deprecated('Use "CommonITILObject_CommonITILObject::manageLinksOnChange()"');
+        if ($solution !== null) {
+            self::manageLinksOnChange('Ticket', $ID, ['_solution' => $solution]);
         } else {
-           // Add same solution to duplicates
-            $solution_data = $solution->fields;
-            unset($solution_data['id']);
-            unset($solution_data['date_creation']);
-            unset($solution_data['date_mod']);
-
-            foreach ($tickets as $data) {
-                $solution_data['items_id'] = $data['tickets_id'];
-                $solution_data['_linked_ticket'] = true;
-                $new_solution = new ITILSolution();
-                $new_solution->add(Toolbox::addslashes_deep($solution_data));
-            }
+            self::manageLinksOnChange('Ticket', $ID, ['_status' => CommonITILObject::SOLVED]);
         }
     }
 }

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -400,32 +400,29 @@
       </div>
    {% endif %}
 
-   {% if ticket_ticket %}
-      {% set linked_tickets_show = headers_states['linked_tickets'] is defined and headers_states['linked_tickets'] == "true" ? true : false %}
-      <div class="accordion-item">
-         <h2 class="accordion-header" id="linked_tickets-heading" title="{{ 'Ticket_Ticket'|itemtype_name(nb_linked_tickets) }}" data-bs-toggle="tooltip">
-            <button class="accordion-button {{ linked_tickets_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#linked_tickets" aria-expanded="true" aria-controls="linked_tickets">
-               <i class="ti ti-link me-1"></i>
-               {% set linked_tickets = ticket_ticket.getLinkedTicketsTo(item.fields['id']) %}
-               {% set nb_linked_tickets = linked_tickets|length %}
-               {% if item.isNewItem() and params['_link']['tickets_id_2']|length > 0 %}
-                  {% set nb_linked_tickets = 1 %}
-               {% endif %}
-               <span class="item-title">
-                    {{ 'Ticket_Ticket'|itemtype_name(nb_linked_tickets) }}
-               </span>
-               {% if nb_linked_tickets > 0 %}
-                  <span class="badge bg-secondary ms-2">{{ nb_linked_tickets }}</span>
-               {% endif %}
-            </button>
-         </h2>
-         <div id="linked_tickets" class="accordion-collapse collapse {{ linked_tickets_show ? "show" : "" }}" aria-labelledby="linked_tickets-heading">
-            <div class="accordion-body">
-               {{ include('components/itilobject/linked_tickets.html.twig') }}
-            </div>
+   {% set linked_itilobjects_show = headers_states['linked_itilobjects'] is defined and headers_states['linked_itilobjects'] == "true" ? true : false %}
+   {% set nb_linked_itilobjects = call('CommonITILObject_CommonITILObject::countAllLinks', [item.getType(), item.fields['id']]) %}
+   <div class="accordion-item">
+      <h2 class="accordion-header" id="linked_itilobjects-heading" title="{{ 'CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects) }}" data-bs-toggle="tooltip">
+         <button class="accordion-button {{ linked_itilobjects_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#linked_itilobjects" aria-expanded="true" aria-controls="linked_itilobjects">
+            <i class="ti ti-link me-1"></i>
+            {% if item.isNewItem() and params['_link']['items_id_2']|length > 0 %}
+               {% set nb_linked_itilobjects = 1 %}
+            {% endif %}
+            <span class="item-title">
+                 {{ 'CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects) }}
+            </span>
+            {% if nb_linked_itilobjects > 0 %}
+               <span class="badge bg-secondary ms-2">{{ nb_linked_itilobjects }}</span>
+            {% endif %}
+         </button>
+      </h2>
+      <div id="linked_itilobjects" class="accordion-collapse collapse {{ linked_itilobjects_show ? "show" : "" }}" aria-labelledby="linked_itilobjects-heading">
+         <div class="accordion-body">
+            {{ include('components/itilobject/linked_itilobjects.html.twig') }}
          </div>
       </div>
-   {% endif %}
+   </div>
 
     <button type="button" class="switch-panel-width btn btn-sm btn-square btn-icon btn-ghost-secondary position-absolute bottom-0 start-0 mb-2">
         <i class="fas fa-caret-left"></i>

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -401,7 +401,7 @@
    {% endif %}
 
    {% set linked_itilobjects_show = headers_states['linked_itilobjects'] is defined and headers_states['linked_itilobjects'] == "true" ? true : false %}
-   {% set nb_linked_itilobjects = call('CommonITILObject_CommonITILObject::countAllLinks', [item.getType(), item.fields['id']]) %}
+   {% set nb_linked_itilobjects = item.isNewItem() ? 0 : call('CommonITILObject_CommonITILObject::countAllLinks', [item.getType(), item.getId()]) %}
    <div class="accordion-item">
       <h2 class="accordion-header" id="linked_itilobjects-heading" title="{{ 'CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects) }}" data-bs-toggle="tooltip">
          <button class="accordion-button {{ linked_itilobjects_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#linked_itilobjects" aria-expanded="true" aria-controls="linked_itilobjects">

--- a/templates/components/itilobject/layout.html.twig
+++ b/templates/components/itilobject/layout.html.twig
@@ -88,14 +88,13 @@
 
 </div>
 
-{% if ticket_ticket %}
-   {# Common form fields for ticket_ticket purge action #}
-   <form method="POST" action="{{ ticket_ticket.getFormURL() }}" class="d-none" id="linked_tickets_{{ main_rand }}" data-submit-once>
-      <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
-      <input type="hidden" name="purge" value="1" />
-      <input type="hidden" name="tickets_id" value="{{ item.fields['id'] }}" />
-   </form>
-{% endif %}
+{# Common form fields for CommonITILObject_CommonITILObject purge action #}
+<form method="POST" action="{{ call('CommonITILObject_CommonITILObject::getFormURL') }}" class="d-none" id="linked_itilobjects_{{ main_rand }}" data-submit-once>
+   <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+   <input type="hidden" name="purge" value="1" />
+   <input type="hidden" name="itemtype" value="{{ item.getType() }}" />
+   <input type="hidden" name="items_id" value="{{ item.fields['id'] }}" />
+</form>
 
 {# Common form fields for "addme_as_actor" action #}
 {% for actortype in ['requester', 'observer', 'assign'] %}

--- a/templates/components/itilobject/linked_itilobjects.html.twig
+++ b/templates/components/itilobject/linked_itilobjects.html.twig
@@ -32,7 +32,7 @@
 <input type="hidden" name="_link[itemtype_1]" value="{{ item.getType() }}" />
 <input type="hidden" name="_link[items_id_1]" value="{{ item.fields['id'] }}" />
 
-{% set linked_itilobjects = call('CommonITILObject_CommonITILObject::getAllLinkedTo', [item.getType(), item.fields['id']]) %}
+{% set linked_itilobjects = item.isNewItem() ? 0 : call('CommonITILObject_CommonITILObject::getAllLinkedTo', [item.getType(), item.getId()]) %}
 {% if linked_itilobjects|length %}
    <div class="card">
       <div class="list-group list-group-flush list-group-hoverable">

--- a/templates/components/itilobject/linked_itilobjects.html.twig
+++ b/templates/components/itilobject/linked_itilobjects.html.twig
@@ -1,0 +1,106 @@
+{#
+ # ---------------------------------------------------------------------
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ # Copyright (C) 2015-2022 Teclib' and contributors.
+ #
+ # http://glpi-project.org
+ #
+ # based on GLPI - Gestionnaire Libre de Parc Informatique
+ # Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # GLPI is free software; you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation; either version 2 of the License, or
+ # (at your option) any later version.
+ #
+ # GLPI is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ # ---------------------------------------------------------------------
+ #}
+
+<input type="hidden" name="_link[itemtype_1]" value="{{ item.getType() }}" />
+<input type="hidden" name="_link[items_id_1]" value="{{ item.fields['id'] }}" />
+
+{% set linked_itilobjects = call('CommonITILObject_CommonITILObject::getAllLinkedTo', [item.getType(), item.fields['id']]) %}
+{% if linked_itilobjects|length %}
+   <div class="card">
+      <div class="list-group list-group-flush list-group-hoverable">
+         {% for id, linked in linked_itilobjects %}
+            {% set new_itilobject = get_item(linked['itemtype'], linked['items_id']) %}
+            <div class="list-group-item">
+               <div class="row">
+                  <div class="col-auto">
+                     {{ call('CommonITILObject_CommonITILObject::getLinkName', [
+                        linked['link'],
+                        linked['itemtype_2'] == item.getType() and linked['items_id_2'] == item.fields['id'],
+                        true
+                     ])|raw }}
+                  </div>
+                  <div class="col text-truncate">
+                     <a href="{{ linked['itemtype']|itemtype_form_path(linked['items_id']) }}" class="col-9 overflow-hidden text-nowrap">
+                        {{ new_itilobject.getStatusIcon(new_itilobject.fields['status'])|raw }}
+                        <span title="{{ new_itilobject.fields['name']|verbatim_value }}" data-bs-toggle="tooltip">
+                     {{ new_itilobject.fields['name']|verbatim_value }}
+                  </span>
+                        ({{ new_itilobject.fields['id'] }})
+                     </a>
+                  </div>
+
+                  {% if canupdate %}
+                     <div class="col-auto">
+                        <button type="submit"
+                                form="linked_itilobjects_{{ main_rand }}"
+                                name="id"
+                                value="{{ id }}"
+                                class="btn btn-sm btn-ghost-danger"
+                                title="{{ _x('button', 'Delete permanently') }}"
+                                data-bs-toggle="tooltip">
+                           <i class="fas fa-unlink"></i>
+                        </button>
+                     </div>
+                  {% endif %}
+               </div>
+            </div>
+         {% endfor %}
+      </div>
+   </div>
+{% endif %}
+
+{% if canupdate and not params['template_preview'] %}
+   {% set has_pending_link = params['_link']['items_id_2']|length > 0 %}
+   <div class="mt-2">
+      <button class="btn btn-sm btn-ghost-secondary {{ has_pending_link ? 'd-none' : '' }}" type="button"
+              data-bs-toggle="collapse" data-bs-target="#link_itilobject_dropdowns"
+              aria-expanded="false" aria-controls="link_itilobject_dropdowns" onclick="$(this).hide();">
+         <i class="fas fa-plus"></i>
+         <span>{{ __('Add') }}</span>
+      </button>
+
+      <span class="collapse {{ has_pending_link ? "show" : "" }}" id="link_itilobject_dropdowns">
+         {% do call('CommonITILObject_CommonITILObject::dropdownLinks', [
+            '_link[link]',
+            params['_link']['link'] ?? ''
+         ]) %}
+         {% do call('Dropdown::showSelectItemFromItemtypes', [{
+            'items_id_name': '_link[items_id_2]',
+            'itemtype_name': '_link[itemtype_2]',
+            'itemtypes': ['Ticket', 'Change', 'Problem'],
+            'checkright': true,
+            'entity_restrict': session('glpiactive_entity'),
+            'default_itemtype': params['_link']['itemtype_2'] ?? '',
+            'default_items_id': params['_link']['items_id_2'] ?? ''
+         }]) %}
+      </span>
+   </div>
+{% endif %}

--- a/templates/components/itilobject/linked_tickets.html.twig
+++ b/templates/components/itilobject/linked_tickets.html.twig
@@ -29,6 +29,9 @@
  # ---------------------------------------------------------------------
  #}
 
+{% do call('Toolbox::deprecated', ['Use "components/itilobject/linked_itilobjects.html.twig" instead.']) %}
+
+
 <input type="hidden" name="_link[tickets_id_1]" value="{{ item.fields['id'] }}" />
 
 {% set linked_tickets = ticket_ticket.getLinkedTicketsTo(item.fields['id']) %}

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -86,7 +86,7 @@
             <input type="hidden" name="_no_message_link" value="1" />
             {{ call_plugin_hook('pre_item_form', {"item": subitem, 'options': params}) }}
 
-            {% if call('Ticket_Ticket::countOpenChildren', [item.fields['id']]) > 0 %}
+            {% if item.getType() == 'Ticket' and item.countOpenChildrenOfSameType() > 0 %}
                <div class="alert alert-important alert-warning">
                   <i class="fas fa-2x fa-info me-2"></i>
                   <span>{{ __('Warning: non closed children tickets depends on current ticket. Are you sure you want to close it?') }}</span>

--- a/tests/functionnal/CommonITILObject_CommonITILObject.php
+++ b/tests/functionnal/CommonITILObject_CommonITILObject.php
@@ -1,0 +1,517 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+
+/*
+ * Test for src/CommonITILObject_CommonITILObject.php
+ * */
+class CommonITILObject_CommonITILObject extends DbTestCase
+{
+    public function testCountAllLinks()
+    {
+        // Create a Ticket
+        $ticket = new \Ticket();
+        $tickets_id = $ticket->add([
+            'name' => 'test',
+            'content' => 'test',
+            'status' => \Ticket::INCOMING
+        ]);
+        $this->integer($tickets_id)->isGreaterThan(0);
+
+        // Create a Change
+        $change = new \Change();
+        $changes_id = $change->add([
+            'name' => 'test',
+            'content' => 'test',
+            'status' => \Change::INCOMING
+        ]);
+        $this->integer($changes_id)->isGreaterThan(0);
+
+        // Link the Ticket to the Change
+        $itil_itil = new \Change_Ticket();
+        $itil_itil_id = $itil_itil->add([
+            'tickets_id' => $tickets_id,
+            'changes_id' => $changes_id,
+            'link' => \CommonITILObject_CommonITILObject::LINK_TO
+        ]);
+        $this->integer($itil_itil_id)->isGreaterThan(0);
+
+        // Check the number of links
+        $this->integer(\CommonITILObject_CommonITILObject::countAllLinks('Ticket', $tickets_id))->isEqualTo(1);
+
+        // Create a Problem
+        $problem = new \Problem();
+        $problems_id = $problem->add([
+            'name' => 'test',
+            'content' => 'test',
+            'status' => \Problem::INCOMING
+        ]);
+        $this->integer($problems_id)->isGreaterThan(0);
+
+        // Link the Ticket to the Problem
+        $itil_itil = new \Problem_Ticket();
+        $itil_itil_id = $itil_itil->add([
+            'tickets_id' => $tickets_id,
+            'problems_id' => $problems_id,
+            'link' => \CommonITILObject_CommonITILObject::DUPLICATE_WITH
+        ]);
+        $this->integer($itil_itil_id)->isGreaterThan(0);
+
+        $this->integer(\CommonITILObject_CommonITILObject::countAllLinks('Ticket', $tickets_id))->isEqualTo(2);
+
+        // Add another ticket
+        $tickets_id2 = $ticket->add([
+            'name' => 'test2',
+            'content' => 'test2',
+            'status' => \Ticket::INCOMING
+        ]);
+        $this->integer($tickets_id2)->isGreaterThan(0);
+
+        // Link the second Ticket to the original ticket
+        $ticket_ticket = new \Ticket_Ticket();
+        $ticket_ticket_id = $ticket_ticket->add([
+            'tickets_id_1' => $tickets_id2,
+            'tickets_id_2' => $tickets_id,
+            'link' => \CommonITILObject_CommonITILObject::LINK_TO
+        ]);
+        $this->integer($ticket_ticket_id)->isGreaterThan(0);
+
+        // Count links for both tickets
+        $this->integer(\CommonITILObject_CommonITILObject::countAllLinks('Ticket', $tickets_id))->isEqualTo(3);
+        $this->integer(\CommonITILObject_CommonITILObject::countAllLinks('Ticket', $tickets_id2))->isEqualTo(1);
+    }
+
+    public function testCountLinksByStatus()
+    {
+        $this->login(); // Required to be able to update a Change
+
+        // Create a Ticket
+        $ticket = new \Ticket();
+        $tickets_id = $ticket->add([
+            'name' => 'test',
+            'content' => 'test',
+            'status' => \Ticket::INCOMING
+        ]);
+        $this->integer($tickets_id)->isGreaterThan(0);
+
+        // Create a Change
+        $change = new \Change();
+        $changes_id = $change->add([
+            'name' => 'test',
+            'content' => 'test',
+            'status' => \Change::INCOMING
+        ]);
+        $this->integer($changes_id)->isGreaterThan(0);
+
+        // Link the Ticket to the Change
+        $itil_itil = new \Change_Ticket();
+        $itil_itil_id = $itil_itil->add([
+            'tickets_id' => $tickets_id,
+            'changes_id' => $changes_id,
+            'link' => \CommonITILObject_CommonITILObject::LINK_TO
+        ]);
+        $this->integer($itil_itil_id)->isGreaterThan(0);
+
+        // Check the number of links by status
+        $this->integer(\Change_Ticket::countLinksByStatus('Ticket', $tickets_id, [\Change::INCOMING]))->isEqualTo(1);
+        $this->integer(\Change_Ticket::countLinksByStatus('Change', $changes_id, [\Ticket::INCOMING]))->isEqualTo(1);
+
+        // Create a Problem
+        $problem = new \Problem();
+        $problems_id = $problem->add([
+            'name' => 'test',
+            'content' => 'test',
+            'status' => \Problem::INCOMING
+        ]);
+        $this->integer($problems_id)->isGreaterThan(0);
+
+        // Link the Ticket to the Problem
+        $itil_itil = new \Problem_Ticket();
+        $itil_itil_id = $itil_itil->add([
+            'tickets_id' => $tickets_id,
+            'problems_id' => $problems_id,
+            'link' => \CommonITILObject_CommonITILObject::DUPLICATE_WITH
+        ]);
+        $this->integer($itil_itil_id)->isGreaterThan(0);
+
+        $this->integer(\Problem_Ticket::countLinksByStatus('Ticket', $tickets_id, [\Problem::INCOMING]))->isEqualTo(1);
+        $this->integer(\Change_Ticket::countLinksByStatus('Change', $changes_id, [\Ticket::INCOMING]))->isEqualTo(1);
+        $this->integer(\Problem_Ticket::countLinksByStatus('Problem', $problems_id, [\Ticket::INCOMING]))->isEqualTo(1);
+        $this->integer(\Problem_Ticket::countLinksByStatus('Problem', $problems_id, [\Ticket::INCOMING], [\CommonITILObject_CommonITILObject::LINK_TO]))->isEqualTo(0);
+        $this->integer(\Problem_Ticket::countLinksByStatus('Problem', $problems_id, [\Ticket::INCOMING], [\CommonITILObject_CommonITILObject::DUPLICATE_WITH]))->isEqualTo(1);
+
+        // Update Change status
+        $this->boolean($change->update([
+            'id' => $changes_id,
+            'status' => \Change::PLANNED
+        ]))->isTrue();
+
+        $this->integer(\Problem_Ticket::countLinksByStatus('Ticket', $tickets_id, [\Problem::INCOMING]))->isEqualTo(1);
+        $this->integer(\Change_Ticket::countLinksByStatus('Ticket', $tickets_id, [\Change::INCOMING]))->isEqualTo(0);
+        $this->integer(\Change_Ticket::countLinksByStatus('Ticket', $tickets_id, [\Change::PLANNED]))->isEqualTo(1);
+        $this->integer(\Problem_Ticket::countLinksByStatus('Ticket', $tickets_id, [\Problem::INCOMING]))->isEqualTo(1);
+    }
+
+    public function testGetLinkedTo()
+    {
+        // Create a Ticket
+        $ticket = new \Ticket();
+        $tickets_id = $ticket->add([
+            'name' => 'test',
+            'content' => 'test',
+            'status' => \Ticket::INCOMING
+        ]);
+        $this->integer($tickets_id)->isGreaterThan(0);
+
+        // Create a Change
+        $change = new \Change();
+        $changes_id = $change->add([
+            'name' => 'test',
+            'content' => 'test',
+            'status' => \Change::INCOMING
+        ]);
+        $this->integer($changes_id)->isGreaterThan(0);
+
+        // Link the Ticket to the Change
+        $itil_itil = new \Change_Ticket();
+        $itil_itil_id = $itil_itil->add([
+            'tickets_id' => $tickets_id,
+            'changes_id' => $changes_id,
+            'link' => \CommonITILObject_CommonITILObject::LINK_TO
+        ]);
+        $this->integer($itil_itil_id)->isGreaterThan(0);
+
+        // Create a Problem
+        $problem = new \Problem();
+        $problems_id = $problem->add([
+            'name' => 'test',
+            'content' => 'test',
+            'status' => \Problem::INCOMING
+        ]);
+        $this->integer($changes_id)->isGreaterThan(0);
+
+        // Link the Ticket to the Problem
+        $itil_itil = new \Problem_Ticket();
+        $itil_itil_id = $itil_itil->add([
+            'tickets_id' => $tickets_id,
+            'problems_id' => $problems_id,
+            'link' => \CommonITILObject_CommonITILObject::LINK_TO
+        ]);
+        $this->integer($itil_itil_id)->isGreaterThan(0);
+
+        $this->integer(count(\Ticket_Ticket::getLinkedTo('Ticket', $tickets_id)))->isEqualTo(0);
+        $this->integer(count(\Change_Ticket::getLinkedTo('Ticket', $tickets_id)))->isEqualTo(1);
+        $this->integer(count(\Problem_Ticket::getLinkedTo('Ticket', $tickets_id)))->isEqualTo(1);
+    }
+
+    public function testGetAllLinkedTo()
+    {
+// Create a Ticket
+        $ticket = new \Ticket();
+        $tickets_id = $ticket->add([
+            'name' => 'test',
+            'content' => 'test',
+            'status' => \Ticket::INCOMING
+        ]);
+        $this->integer($tickets_id)->isGreaterThan(0);
+
+        // Create a Change
+        $change = new \Change();
+        $changes_id = $change->add([
+            'name' => 'test',
+            'content' => 'test',
+            'status' => \Change::INCOMING
+        ]);
+        $this->integer($changes_id)->isGreaterThan(0);
+
+        // Link the Ticket to the Change
+        $itil_itil = new \Change_Ticket();
+        $itil_itil_id = $itil_itil->add([
+            'tickets_id' => $tickets_id,
+            'changes_id' => $changes_id,
+            'link' => \CommonITILObject_CommonITILObject::LINK_TO
+        ]);
+        $this->integer($itil_itil_id)->isGreaterThan(0);
+
+        // Create a Problem
+        $problem = new \Problem();
+        $problems_id = $problem->add([
+            'name' => 'test',
+            'content' => 'test',
+            'status' => \Problem::INCOMING
+        ]);
+        $this->integer($changes_id)->isGreaterThan(0);
+
+        // Link the Ticket to the Problem
+        $itil_itil = new \Problem_Ticket();
+        $itil_itil_id = $itil_itil->add([
+            'tickets_id' => $tickets_id,
+            'problems_id' => $problems_id,
+            'link' => \CommonITILObject_CommonITILObject::LINK_TO
+        ]);
+        $this->integer($itil_itil_id)->isGreaterThan(0);
+
+        $this->integer(count(\CommonITILObject_CommonITILObject::getAllLinkedTo('Ticket', $tickets_id)))->isEqualTo(2);
+        $this->integer(count(\CommonITILObject_CommonITILObject::getAllLinkedTo('Change', $changes_id)))->isEqualTo(1);
+        $this->integer(count(\CommonITILObject_CommonITILObject::getAllLinkedTo('Problem', $problems_id)))->isEqualTo(1);
+    }
+
+    public function testGetLinkName()
+    {
+        $link_types = [
+            \CommonITILObject_CommonITILObject::LINK_TO,
+            \CommonITILObject_CommonITILObject::DUPLICATE_WITH,
+            \CommonITILObject_CommonITILObject::SON_OF,
+            \CommonITILObject_CommonITILObject::PARENT_OF
+        ];
+        foreach ($link_types as $link_type) {
+            $normal = \CommonITILObject_CommonITILObject::getLinkName($link_type, false, false);
+            $inverted = \CommonITILObject_CommonITILObject::getLinkName($link_type, true, false);
+            $with_icon = \CommonITILObject_CommonITILObject::getLinkName($link_type, false, true);
+
+            $this->boolean(is_string($normal))->isTrue();
+            $this->boolean(is_string($inverted))->isTrue();
+            $this->boolean(is_string($with_icon))->isTrue();
+
+            if ($link_type !== \CommonITILObject_CommonITILObject::LINK_TO) {
+                $this->string($normal)->isNotEqualTo($inverted);
+            }
+            $this->string($with_icon)->contains('<i class');
+        }
+
+        // Test invalid link type
+        $invalid_link_type = -1;
+        $normal = \CommonITILObject_CommonITILObject::getLinkName($invalid_link_type, false, false);
+        $inverted = \CommonITILObject_CommonITILObject::getLinkName($invalid_link_type, true, false);
+        $with_icon = \CommonITILObject_CommonITILObject::getLinkName($invalid_link_type, false, true);
+        $this->string($normal)->isEqualTo(NOT_AVAILABLE);
+        $this->string($inverted)->isEqualTo(NOT_AVAILABLE);
+        $this->string($with_icon)->isEqualTo(NOT_AVAILABLE);
+    }
+
+    protected function getLinkClassProvider()
+    {
+        return [
+            ['Ticket', 'Ticket', \Ticket_Ticket::class],
+            ['Ticket', 'Change', \Change_Ticket::class],
+            ['Ticket', 'Problem', \Problem_Ticket::class],
+            ['Change', 'Ticket', \Change_Ticket::class],
+            ['Change', 'Change', \Change_Change::class],
+            ['Change', 'Problem', \Change_Problem::class],
+            ['Problem', 'Ticket', \Problem_Ticket::class],
+            ['Problem', 'Change', \Change_Problem::class],
+            ['Problem', 'Problem', \Problem_Problem::class],
+        ];
+    }
+
+    /**
+     * @dataProvider getLinkClassProvider
+     */
+    public function testGetLinkClass(string $itemtype_1, string $itemtype_2, string $expected)
+    {
+        $this->string(\CommonITILObject_CommonITILObject::getLinkClass($itemtype_1, $itemtype_2))->isEqualTo($expected);
+    }
+
+    public function testGetAllLinkClasses()
+    {
+        $link_classes = \CommonITILObject_CommonITILObject::getAllLinkClasses();
+        $this->integer(count($link_classes))->isGreaterThanOrEqualTo(6);
+
+        foreach ($link_classes as $link_class) {
+            $this->boolean(is_subclass_of($link_class, \CommonITILObject_CommonITILObject::class, true))->isTrue();
+        }
+    }
+
+    protected function normalizeInputProvider()
+    {
+        return [
+            [
+                'class' => \Ticket_Ticket::class,
+                'input' => [
+                    'itemtype_1'    => 'Ticket',
+                    'items_id_1'    => 1,
+                    'itemtype_2'    => 'Ticket',
+                    'items_id_2'    => 2,
+                ],
+                'expected' => [
+                    'tickets_id_1'  => 1,
+                    'tickets_id_2'  => 2,
+                    'link'          => \CommonITILObject_CommonITILObject::LINK_TO,
+                ]
+            ],
+            [
+                'class' => \Ticket_Ticket::class,
+                'input' => [
+                    'itemtype_1'    => 'Ticket',
+                    'items_id_1'    => 1,
+                    'itemtype_2'    => 'Ticket',
+                    'items_id_2'    => 2,
+                    'link'          => \CommonITILObject_CommonITILObject::PARENT_OF,
+                ],
+                'expected' => [
+                    'tickets_id_1'  => 2,
+                    'tickets_id_2'  => 1,
+                    'link'          => \CommonITILObject_CommonITILObject::SON_OF,
+                ]
+            ],
+            [
+                'class' => \Change_Change::class,
+                'input' => [
+                    'itemtype_1'    => 'Change',
+                    'items_id_1'    => 1,
+                    'itemtype_2'    => 'Change',
+                    'items_id_2'    => 2,
+                ],
+                'expected' => [
+                    'changes_id_1'  => 1,
+                    'changes_id_2'  => 2,
+                    'link'          => \CommonITILObject_CommonITILObject::LINK_TO,
+                ]
+            ],
+            [
+                'class' => \Change_Ticket::class,
+                'input' => [
+                    'itemtype_1'    => 'Change',
+                    'items_id_1'    => 1,
+                    'itemtype_2'    => 'Ticket',
+                    'items_id_2'    => 2,
+                ],
+                'expected' => [
+                    'changes_id'    => 1,
+                    'tickets_id'    => 2,
+                    'link'          => \CommonITILObject_CommonITILObject::LINK_TO,
+                ]
+            ],
+            [
+                'class' => \Change_Ticket::class,
+                'input' => [
+                    'itemtype_1'    => 'Ticket',
+                    'items_id_1'    => 2,
+                    'itemtype_2'    => 'Change',
+                    'items_id_2'    => 1,
+                ],
+                'expected' => [
+                    'changes_id'    => 1,
+                    'tickets_id'    => 2,
+                    'link'          => \CommonITILObject_CommonITILObject::LINK_TO,
+                ]
+            ],
+            [
+                'class' => \Change_Ticket::class,
+                'input' => [
+                    'itemtype_1'    => 'Change',
+                    'items_id_1'    => 1,
+                    'itemtype_2'    => 'Ticket',
+                    'items_id_2'    => 2,
+                    'link'          => \CommonITILObject_CommonITILObject::PARENT_OF,
+                ],
+                'expected' => [
+                    'changes_id'    => 1,
+                    'tickets_id'    => 2,
+                    'link'          => \CommonITILObject_CommonITILObject::PARENT_OF,
+                ]
+            ],
+            [
+                'class' => \Change_Ticket::class,
+                'input' => [
+                    'itemtype_1'    => 'Ticket',
+                    'items_id_1'    => 2,
+                    'itemtype_2'    => 'Change',
+                    'items_id_2'    => 1,
+                    'link'          => \CommonITILObject_CommonITILObject::PARENT_OF,
+                ],
+                'expected' => [
+                    'changes_id'    => 1,
+                    'tickets_id'    => 2,
+                    'link'          => \CommonITILObject_CommonITILObject::SON_OF,
+                ]
+            ],
+            [
+                'class' => \Problem_Ticket::class,
+                'input' => [
+                    'itemtype_1'    => 'Ticket',
+                    'items_id_1'    => 2,
+                    'itemtype_2'    => 'Problem',
+                    'items_id_2'    => 1,
+                ],
+                'expected' => [
+                    'problems_id'   => 1,
+                    'tickets_id'    => 2,
+                    'link'          => \CommonITILObject_CommonITILObject::LINK_TO,
+                ]
+            ],
+            [
+                'class' => \Problem_Ticket::class,
+                'input' => [
+                    'itemtype_1'    => 'Problem',
+                    'items_id_1'    => 1,
+                    'itemtype_2'    => 'Ticket',
+                    'items_id_2'    => 2,
+                    'link'          => \CommonITILObject_CommonITILObject::PARENT_OF,
+                ],
+                'expected' => [
+                    'problems_id'   => 1,
+                    'tickets_id'    => 2,
+                    'link'          => \CommonITILObject_CommonITILObject::PARENT_OF,
+                ]
+            ],
+            [
+                'class' => \Problem_Ticket::class,
+                'input' => [
+                    'itemtype_1'    => 'Ticket',
+                    'items_id_1'    => 2,
+                    'itemtype_2'    => 'Problem',
+                    'items_id_2'    => 1,
+                    'link'          => \CommonITILObject_CommonITILObject::PARENT_OF,
+                ],
+                'expected' => [
+                    'problems_id'   => 1,
+                    'tickets_id'    => 2,
+                    'link'          => \CommonITILObject_CommonITILObject::SON_OF,
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider normalizeInputProvider
+     */
+    public function testNormalizeInput(string $class, array $input, array $expected)
+    {
+        $instance = new $class();
+        $this->array($instance->normalizeInput($input))->isIdenticalTo($expected);
+    }
+}

--- a/tests/functionnal/ITILSolution.php
+++ b/tests/functionnal/ITILSolution.php
@@ -264,7 +264,7 @@ class ITILSolution extends DbTestCase
             (int)$link->add([
                 'tickets_id_1' => $duplicated,
                 'tickets_id_2' => $duplicate,
-                'link'         => \Ticket_Ticket::DUPLICATE_WITH
+                'link'         => \CommonITILObject_CommonITILObject::DUPLICATE_WITH
             ])
         )->isGreaterThan(0);
 

--- a/tests/functionnal/MassiveAction.php
+++ b/tests/functionnal/MassiveAction.php
@@ -87,7 +87,7 @@ class MassiveAction extends DbTestCase
                 'itemtype'     => 'Ticket',
                 'items_id'     => '_ticket01',
                 'allcount'     => 20,
-                'singlecount'  => 10
+                'singlecount'  => 9
             ], [
                 'itemtype'     => 'Profile',
                 'items_id'     => 'Super-Admin',
@@ -419,7 +419,7 @@ class MassiveAction extends DbTestCase
         }
 
        // Execute action
-        $this->processMassiveActionsForOneItemtype(
+        @$this->processMassiveActionsForOneItemtype(
             "link_to_problem",
             $item,
             [$item->fields['id']],

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -2872,7 +2872,7 @@ class Ticket extends DbTestCase
                 'TicketTask',
                 'Document'
             ],
-            'link_type'  => \Ticket_Ticket::SON_OF
+            'link_type'  => \CommonITILObject_CommonITILObject::SON_OF
         ];
 
         \Ticket::merge($ticket1, [$ticket2, $ticket3], $status, $mergeparams);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -

Original plan was to refactor existing link classes for ITIL Object <-> ITIL Object relations into a single `CommonITILObject_CommonITILObject` class. This would allow any combination of links including Change <-> Change and Problem <-> Problem which were not possible before. This also allows specifying the type of link between all ITIL Objects and not just Ticket <-> Ticket.

However, to avoid adding breaking changes in a minor version, this PR was reworked to add new tables and classes for Change/Change and Problem/Problem relations. The `CommonITILObject_CommonITILObject` remains even though it has no table, as a way to get links of any type for a CommonITILObject.

The plan is to drop all separate tables and classes for v11.0 and merge them into the new one.
Only Ticket <-> Ticket links have the special logic implemented for how duplicates are handled when one is solved.