### PR TITLE
Harmonize ITIL Object link notification behavior

### DIFF
--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -345,4 +345,22 @@ class Change_Problem extends CommonDBRelation
         }
         echo "</div>";
     }
+
+    public function post_addItem()
+    {
+        global $CFG_GLPI;
+
+        $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
+
+        if ($donotif) {
+            $problem = new Problem();
+            $change  = new Change();
+            if ($problem->getFromDB($this->input["problems_id"]) && $change->getFromDB($this->input["changes_id"])) {
+                NotificationEvent::raiseEvent("update", $problem);
+                NotificationEvent::raiseEvent('update', $change);
+            }
+        }
+
+        parent::post_addItem();
+    }
 }

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -471,4 +471,22 @@ class Change_Ticket extends CommonDBRelation
         }
         echo "</div>";
     }
+
+    public function post_addItem()
+    {
+        global $CFG_GLPI;
+
+        $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
+
+        if ($donotif) {
+            $change = new Change();
+            $ticket  = new Ticket();
+            if ($change->getFromDB($this->input["changes_id"]) && $ticket->getFromDB($this->input["tickets_id"])) {
+                NotificationEvent::raiseEvent("update", $change);
+                NotificationEvent::raiseEvent('update', $ticket);
+            }
+        }
+
+        parent::post_addItem();
+    }
 }

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -114,9 +114,10 @@ class Problem_Ticket extends CommonDBRelation
 
         if ($donotif) {
             $problem = new Problem();
-            if ($problem->getFromDB($this->input["problems_id"])) {
-                $options = [];
-                NotificationEvent::raiseEvent("new", $problem, $options);
+            $ticket  = new Ticket();
+            if ($problem->getFromDB($this->input["problems_id"]) && $ticket->getFromDB($this->input["tickets_id"])) {
+                NotificationEvent::raiseEvent("update", $problem);
+                NotificationEvent::raiseEvent('update', $ticket);
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10990

All ITIL Object linking now generates update notifications for both items in the link to match the behavior of Ticket/Ticket links.
This also fixes the bad behavior of the Ticket/Problem links which generated a "new" notification for the Problem instead of an update notification for both.