### PR TITLE
fix(knowbase): export

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2426,6 +2426,9 @@ class Dropdown
 
         $rand = mt_rand();
         Dropdown::showFromArray('display_type', $values, ['rand' => $rand]);
+        echo "<button type='submit' name='export' class='btn' ".
+             " title=\"" . _sx('button', 'Export') . "\">" .
+             "<i class='far fa-save'></i><span class='sr-only'>"._sx('button', 'Export')."<span>";
     }
 
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -8124,7 +8124,7 @@ HTML;
             case self::PDF_OUTPUT_LANDSCAPE: //pdf
             case self::PDF_OUTPUT_PORTRAIT:
                 global $PDF_TABLE;
-                $value = DataExport::normalizeValueForTextExport($value);
+                $value = DataExport::normalizeValueForTextExport($value ?? '');
                 $value = htmlspecialchars($value);
                 $value = preg_replace('/' . self::LBBR . '/', '<br>', $value);
                 $value = preg_replace('/' . self::LBHR . '/', '<hr>', $value);


### PR DESCRIPTION
- The export button was missing
![image](https://user-images.githubusercontent.com/8530352/158779350-e4c44518-3dcc-40f9-b230-b4f44bcd6f0b.png)

- Error message when data is `null`:
   ```
   Uncaught Exception TypeError : Argument 1 passé à Glpi\Toolbox\DataExport::normalizeValueForTextExport() must be of the type string, null given, appelé dans /home/teclib/Dev/GLPI/master/src/Search.php on line 8127 in /home/teclib/Dev/GLPI/master/src/Toolbox/DataExport.php at line 48
   ```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NO
