### PR TITLE
Handle missing of ifstatus information

### DIFF
--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1119,9 +1119,6 @@ class NetworkPort extends CommonDBChild
                             break;
                         case 40:
                             $co_class = '';
-                            if (empty($port['ifstatus'])) {
-                                break;
-                            }
                             switch ($port['ifstatus']) {
                                 case 1: //up
                                     $co_class = 'fa-link netport green';
@@ -1135,13 +1132,14 @@ class NetworkPort extends CommonDBChild
                                     $co_class = 'fa-link netport orange';
                                     $title = __('Testing');
                                     break;
-                                case 4: //unknown
-                                    $co_class = 'fa-question-circle';
-                                    $title = __('Unknown');
-                                    break;
                                 case 5: //dormant
                                     $co_class = 'fa-link netport grey';
                                     $title = __('Dormant');
+                                    break;
+                                case 4: //unknown
+                                default:
+                                    $co_class = 'fa-question-circle';
+                                    $title = __('Unknown');
                                     break;
                             }
                             $output .= "<i class='fas $co_class' title='$title'></i> <span class='sr-only'>$title</span>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23271

When network ports are created manually, they have no `ifstatus` value. In this case, I propose to display an "unknown" status, instead of having an empty cell.

![image](https://user-images.githubusercontent.com/33253653/158802437-c781a303-3e8d-4855-8724-785ab11bb8df.png)
