### PR TITLE
fix actiontime display

### DIFF
--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -227,9 +227,7 @@
                ) }}
             {% endif %}
 
-            {{ include('components/itilobject/fields/global_validation.html.twig') }}
-
-            {% if item.getType() != 'Ticket' %}
+            {% if item.getType() != 'Ticket' or item.isNewItem() %}
                {{ fields.dropdownTimestampField(
                   'actiontime',
                   item.fields['actiontime'],
@@ -237,6 +235,8 @@
                   field_options
                ) }}
             {% endif %}
+
+            {{ include('components/itilobject/fields/global_validation.html.twig') }}
 
             {{ call_plugin_hook('post_item_form', {"item": item, 'options': params}) }}
          </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

For Ticket : set actiontime create an autogenerated task with the same value.
For Change and Problem, actiontime exists in their sql tables.

Small change also, i inverted the field with global validation due to spacing issue