### PR TITLE
Fix creation of glpi_printerlogs and glpi_networkportmetrics unicity keys

### DIFF
--- a/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
@@ -520,7 +520,28 @@ if (!$DB->tableExists('glpi_printerlogs')) {
     $migration->changeField('glpi_printerlogs', 'date', 'date', 'date');
 
     $migration->dropKey('glpi_printerlogs', 'printers_id');
-    $migration->addKey('glpi_printerlogs', ['printers_id', 'date'], 'unicity', 'UNIQUE');
+
+    if (!isIndex('glpi_printerlogs', 'unicity')) {
+        // Preserve only last insert for a given date.
+        $to_preserve_sql = new \QueryExpression(
+            sprintf(
+                'SELECT MAX(%s) as %s FROM %s GROUP BY %s, DATE(%s)',
+                $DB->quoteName('id'),
+                $DB->quoteName('id'),
+                $DB->quoteName('glpi_printerlogs'),
+                $DB->quoteName('printers_id'),
+                $DB->quoteName('date')
+            )
+        );
+        $to_preserve_result = $DB->query($to_preserve_sql->getValue())->fetch_all(MYSQLI_ASSOC);
+        $DB->delete(
+            'glpi_printerlogs',
+            [
+                'NOT' => ['id' => array_column($to_preserve_result, 'id')]
+            ]
+        );
+        $migration->addKey('glpi_printerlogs', ['printers_id', 'date'], 'unicity', 'UNIQUE');
+    }
 }
 
 if (!$DB->tableExists('glpi_networkportconnectionlogs')) {
@@ -577,7 +598,28 @@ if (!$DB->tableExists('glpi_networkportmetrics')) {
     $migration->changeField('glpi_networkportmetrics', 'date', 'date', 'date');
 
     $migration->dropKey('glpi_networkportmetrics', 'networkports_id');
-    $migration->addKey('glpi_networkportmetrics', ['networkports_id', 'date'], 'unicity', 'UNIQUE');
+
+    if (!isIndex('glpi_networkportmetrics', 'unicity')) {
+        // Preserve only last insert for a given date.
+        $to_preserve_sql = new \QueryExpression(
+            sprintf(
+                'SELECT MAX(%s) as %s FROM %s GROUP BY %s, DATE(%s)',
+                $DB->quoteName('id'),
+                $DB->quoteName('id'),
+                $DB->quoteName('glpi_networkportmetrics'),
+                $DB->quoteName('networkports_id'),
+                $DB->quoteName('date')
+            )
+        );
+        $to_preserve_result = $DB->query($to_preserve_sql->getValue())->fetch_all(MYSQLI_ASSOC);
+        $DB->delete(
+            'glpi_networkportmetrics',
+            [
+                'NOT' => ['id' => array_column($to_preserve_result, 'id')]
+            ]
+        );
+        $migration->addKey('glpi_networkportmetrics', ['networkports_id', 'date'], 'unicity', 'UNIQUE');
+    }
 }
 
 if (!$DB->tableExists('glpi_refusedequipments')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

One may already have data that does not respect new unicity rule.

With proposed change, only the last entry fore each item/data couple will be preserved, to prevent following error:

![image](https://user-images.githubusercontent.com/33253653/158830993-fd8c8451-6919-42fe-bc11-fa481791dc16.png)