### PR TITLE
Prevent changing approver for existing request

### DIFF
--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -203,7 +203,8 @@
                     subitem.fields['users_id_validate'],
                     __('Approver'),
                     {
-                        'full_width': true,
+                       'disabled': true,
+                       'full_width': true,
                     }
                     ) }}
                 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Approver dropdown in the validation edit form currently shows options for the current approver and then an empty option. I think this is different than previous versions, but I'm not sure it makes sense to change the approver at all without deleting the existing request and creating a new one. It may make sense to disable this field to discourage the behavior in the UI but not necessarily prevent changing the approver in other ways.