### PR TITLE
Use correct Dashboard auto-refresh value

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -209,7 +209,7 @@ var Dashboard = {
             var active = $(this).hasClass('active');
 
             if (active) {
-                var seconds = parseInt(CFG_GLPI.refresh_ticket_list) * 60 || 30;
+                const seconds = parseInt(CFG_GLPI.refresh_views || 30) * 60;
                 Dashboard.interval = setInterval(function() {
                     Dashboard.refreshDashboard();
                 }, seconds * 1000);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`refresh_ticket_list` setting has been named `refresh_views` for a while now so the auto-refresh of the dashboard was always going to be 30 seconds. It isn't possible to set the auto-refresh lower than a minute so it also seemed like a bug that the fallback was 30 seconds and it seemed like it could have been intended to be 30 minutes, so I've made that change too.

There is another bug where user preferences are not available in JS (just system defaults) but that affects much more than Dashboards so it wasn't fixed here.