### PR TITLE
Do not always trigger errors when inventory file is missing; fixes #10849

### DIFF
--- a/front/inventory.php
+++ b/front/inventory.php
@@ -43,8 +43,15 @@ $inventory_request->handleHeaders();
 $handle = true;
 if (isset($_GET['refused'])) {
     $refused = new RefusedEquipment();
-    $refused->getFromDB($_GET['refused']);
-    $contents = file_get_contents($refused->getInventoryFileName());
+    if ($refused->getFromDB($_GET['refused']) && ($inventory_file = $refused->getInventoryFileName()) !== null) {
+        $contents = file_get_contents($inventory_file);
+    } else {
+        trigger_error(
+            sprintf('Invalid RefusedEquipment "%s" or inventory file missing', $_GET['refused']),
+            E_USER_WARNING
+        );
+        $contents = '';
+    }
 } else if ($_SERVER['REQUEST_METHOD'] != 'POST') {
     if (isset($_GET['action']) && $_GET['action'] == 'getConfig') {
         /**

--- a/src/Features/Inventoriable.php
+++ b/src/Features/Inventoriable.php
@@ -87,7 +87,6 @@ trait Inventoriable
         if (!file_exists($inventory_dir_path . $filename)) {
             $filename = $conf->buildInventoryFileName($itemtype, $items_id, 'json');
             if (!file_exists($inventory_dir_path . $filename)) {
-                trigger_error('Inventory file missing: ' . $filename, E_USER_WARNING);
                 return null;
             }
         }

--- a/src/RuleImportAssetCollection.php
+++ b/src/RuleImportAssetCollection.php
@@ -120,15 +120,17 @@ class RuleImportAssetCollection extends RuleCollection
     public function prepareInputDataForProcess($input, $params)
     {
         $refused_id = $params['refusedequipments_id'] ?? null;
-        if ($refused_id !== null) {
-            $refused = new RefusedEquipment();
-            $refused->getFromDB($refused_id);
-
+        $refused = new RefusedEquipment();
+        if (
+            $refused_id !== null
+            && $refused->getFromDB($refused_id)
+            && ($inventory_file = $refused->getInventoryFileName()) !== null
+        ) {
             $inventory_request = new \Glpi\Inventory\Request();
-            $contents = file_get_contents($refused->getInventoryFileName());
+            $contents = file_get_contents($inventory_file);
             $inventory_request
-            ->testRules()
-            ->handleRequest($contents);
+                ->testRules()
+                ->handleRequest($contents);
 
             $inventory = $inventory_request->getInventory();
             $item = $inventory->getItem();
@@ -149,6 +151,12 @@ class RuleImportAssetCollection extends RuleCollection
 
           //keep user values if any
             $input += $rules_input;
+        } else {
+            trigger_error(
+                sprintf('Invalid RefusedEquipment "%s" or inventory file missing', $refused_id),
+                E_USER_WARNING
+            );
+            $contents = '';
         }
 
         return $input;

--- a/src/RuleImportAssetCollection.php
+++ b/src/RuleImportAssetCollection.php
@@ -120,12 +120,12 @@ class RuleImportAssetCollection extends RuleCollection
     public function prepareInputDataForProcess($input, $params)
     {
         $refused_id = $params['refusedequipments_id'] ?? null;
+        if ($refused_id === null) {
+            return $input;
+        }
+
         $refused = new RefusedEquipment();
-        if (
-            $refused_id !== null
-            && $refused->getFromDB($refused_id)
-            && ($inventory_file = $refused->getInventoryFileName()) !== null
-        ) {
+        if ($refused->getFromDB($refused_id) && ($inventory_file = $refused->getInventoryFileName()) !== null) {
             $inventory_request = new \Glpi\Inventory\Request();
             $contents = file_get_contents($inventory_file);
             $inventory_request


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10849

Inventory file may be missing from filesystem. There is no need to trigger an error unless an new inventory based on this file is requested.