### PR TITLE
Do not allow iframes in rich text only by default

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3793,6 +3793,9 @@ JS;
         if (!$enable_images) {
             $invalid_elements .= ',img';
         }
+        if (!GLPI_ALLOW_IFRAME_IN_RICH_TEXT) {
+            $invalid_elements .= ',iframe';
+        }
 
         $plugins = [
             'autoresize',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Iframes should be allowed only when `GLPI_ALLOW_IFRAME_IN_RICH_TEXT` is set to true.

In GLPI 9.5, they were not allowed at all, see #10747