### PR TITLE
Fix search engine namespaces issues

### DIFF
--- a/ajax/search.php
+++ b/ajax/search.php
@@ -63,7 +63,7 @@ switch ($_REQUEST['action']) {
         }
 
         /** @var CommonDBTM $itemtype */
-        $itemtype = $_REQUEST['itemtype'];
+        $itemtype = $_UREQUEST['itemtype'];
         if (!$itemtype::canView()) {
             http_response_code(403);
             die;


### PR DESCRIPTION
Class with namespaces can't be used with the new ajax searchengine: 

```
[2022-03-18 17:16:52] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Class 'GlpiPlugin\\Advancedforms\\Workflow\\Workflow' not found in /home/adrie/localhost/gmaster/ajax/search.php at line 67  
```

Fixed by using the unescaped `$_UREQUEST`, I don't suppose the itemtype is used in SQL queries so it should be safe. 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
