### PR TITLE
Fix migration file sorting

### DIFF
--- a/src/Update.php
+++ b/src/Update.php
@@ -372,7 +372,7 @@ class Update
             }
         }
 
-        ksort($migrations);
+        ksort($migrations, SORT_NATURAL);
 
         return $migrations;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Default sorting algorithm makes GLPI try applying version 10.0.X - 10.1.0 migration before any 9.XX migrations because of the first digit.
Using natural sorting seems to fix this issue.