### PR TITLE
Add ITILFollowup::ADD_AS_OBSERVER right as default on some profiles

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -5588,7 +5588,7 @@ $tables['glpi_profilerights'] = [
     ], [
         'profiles_id' => '3',
         'name'        => 'followup',
-        'rights'      => '15383',
+        'rights'      => '31767',
     ], [
         'profiles_id' => '3',
         'name'        => 'task',
@@ -5876,7 +5876,7 @@ $tables['glpi_profilerights'] = [
     ], [
         'profiles_id' => '4',
         'name'        => 'followup',
-        'rights'      => '15383',
+        'rights'      => '31767',
     ], [
         'profiles_id' => '4',
         'name'        => 'task',
@@ -6732,7 +6732,7 @@ $tables['glpi_profilerights'] = [
     ], [
         'profiles_id' => '7',
         'name'        => 'followup',
-        'rights'      => '15383',
+        'rights'      => '31767',
     ], [
         'profiles_id' => '7',
         'name'        => 'task',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Related to #8992.