### PR TITLE
Fix importExternal for tree dropdowns

### DIFF
--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -776,9 +776,7 @@ abstract class CommonDropdown extends CommonDBTM
             }
         }
         // Merge extra input fields into $input
-        foreach ($external_params as $k => $v) {
-            $input[$k] = $v;
-        }
+        $input += $external_params;
 
         return ($add ? $this->import($input) : $this->findID($input));
     }

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -775,6 +775,13 @@ abstract class CommonDropdown extends CommonDBTM
                 $input["name"] = $res_rule["name"];
             }
         }
+        // Merge extra input fields back in if they were not used by rules
+        foreach ($external_params as $k => $v) {
+            if (!in_array($k, $this->additional_fields_for_dictionnary, true)) {
+                $input[$k] = $v;
+            }
+        }
+
         return ($add ? $this->import($input) : $this->findID($input));
     }
 

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -775,11 +775,9 @@ abstract class CommonDropdown extends CommonDBTM
                 $input["name"] = $res_rule["name"];
             }
         }
-        // Merge extra input fields back in if they were not used by rules
+        // Merge extra input fields into $input
         foreach ($external_params as $k => $v) {
-            if (!in_array($k, $this->additional_fields_for_dictionnary, true)) {
-                $input[$k] = $v;
-            }
+            $input[$k] = $v;
         }
 
         return ($add ? $this->import($input) : $this->findID($input));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | maybe - Some fields not imported before may be now
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

When using `Dropdown::importExternal` and/or `CommonDropdown::importExternal`, you need to provide a value for the `$value` parameter which is always mapped to the `name`. During the import of a tree dropdown value like Location, it tries searching to see if the item already exists and expects there to be an extra `locations_id` field in the input OR have a `completename` value in the input. Neither of these cases is possible since while `importExternal` does accept extra parameters as an array, they are only used for the inputs of the rules processing if that dropdown type specifically has them in an array `additional_fields_for_dictionnary` to indicate they are needed for the rules.

Location does not have a dictionary or any other rules so the only input fields assigned during import are `name`, `comment` (parameter for import function), and `entities_id` (parameter for import function).

This PR proposes merging all fields provided in the `$external_parameters` argument that have not been used by rules already after the rules have run (if needed). This will enable imports of child items and fix the issue with finding existing items during the import.

As a side-effect, anywhere that passed more fields into `$external_params` than needed for rules may find them being imported when the item is created when they had not been in the past.