### PR TITLE
Fix helpdesk form

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4167,7 +4167,7 @@ JAVASCRIPT;
         );
 
         // override current fields in options with template fields and return the array of these predefined fields
-        $predefined_fields = $this->getPredefinedTemplateFields($tt, $options, $default_values);
+        $predefined_fields = $this->setPredefinedFields($tt, $options, $default_values);
 
         $delegating = User::getDelegateGroupsForUser($options['entities_id']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`getPredefinedTemplateFields()` method has been removed in #11014.