### PR TITLE
Fix Document::getDownloadLink

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -448,7 +448,7 @@ class Document extends CommonDBTM
         echo "</td>";
         if ($ID > 0) {
             echo "<td>" . __('Current file') . "</td>";
-            echo "<td>" . $this->getDownloadLink('', 45);
+            echo "<td>" . $this->getDownloadLink(null, 45);
             echo "<input type='hidden' name='current_filepath' value='" . $this->fields["filepath"] . "'>";
             echo "<input type='hidden' name='current_filename' value='" . $this->fields["filename"] . "'>";
             echo "</td>";
@@ -557,7 +557,7 @@ class Document extends CommonDBTM
             $link_params = $linked_item;
         } elseif ($linked_item !== null && !($linked_item instanceof CommonDBTM)) {
             throw new \InvalidArgumentException();
-        } else {
+        } elseif ($linked_item !== null) {
             $link_params = sprintf('&itemtype=%s&items_id=%s', $linked_item->getType(), $linked_item->getID());
         }
 
@@ -714,7 +714,7 @@ class Document extends CommonDBTM
         if (
             $itemtype !== null
             && $items_id !== null
-            && $this->canViewFileFromItem('$itemtype', $problems_id)
+            && $this->canViewFileFromItem($itemtype, $problems_id)
         ) {
             return true;
         }

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -775,11 +775,6 @@ class Document_Item extends CommonDBRelation
         if (empty($withtemplate)) {
             $withtemplate = 0;
         }
-        $linkparam = '';
-
-        if (get_class($item) == 'Ticket') {
-            $linkparam = "&amp;tickets_id=" . $item->fields['id'];
-        }
 
         $criteria = self::getDocumentForItemRequest($item, ["$sort $order"]);
 
@@ -872,7 +867,7 @@ class Document_Item extends CommonDBRelation
 
                 if ($document->getFromDB($docID)) {
                     $link         = $document->getLink();
-                    $downloadlink = $document->getDownloadLink($linkparam);
+                    $downloadlink = $document->getDownloadLink($item);
                 }
 
                 if ($item->getType() != 'Document') {

--- a/tests/functionnal/Document.php
+++ b/tests/functionnal/Document.php
@@ -570,6 +570,8 @@ class Document extends DbTestCase
         $this->boolean($inlinedDocument->canViewFile())->isFalse();
         $this->boolean($basicDocument->canViewFile([$fkey => $item->getID()]))->isFalse();
         $this->boolean($inlinedDocument->canViewFile([$fkey => $item->getID()]))->isFalse();
+        $this->boolean($basicDocument->canViewFile(['itemtype' => $item->getType(), 'items_id' => $item->getID()]))->isFalse();
+        $this->boolean($inlinedDocument->canViewFile(['itemtype' => $item->getType(), 'items_id' => $item->getID()]))->isFalse();
 
        // post-only can see documents linked to its own ITIL (ITIL content)
         $itil_user_class = $itemtype . '_User';
@@ -586,6 +588,8 @@ class Document extends DbTestCase
         $this->boolean($inlinedDocument->canViewFile())->isFalse(); // False without params
         $this->boolean($basicDocument->canViewFile([$fkey => $item->getID()]))->isTrue();
         $this->boolean($inlinedDocument->canViewFile([$fkey => $item->getID()]))->isTrue();
+        $this->boolean($basicDocument->canViewFile(['itemtype' => $item->getType(), 'items_id' => $item->getID()]))->isTrue();
+        $this->boolean($inlinedDocument->canViewFile(['itemtype' => $item->getType(), 'items_id' => $item->getID()]))->isTrue();
     }
 
     /**
@@ -686,6 +690,7 @@ class Document extends DbTestCase
         $_SESSION["glpiactiveprofile"][$itil::$rightname] = READ; // force READ write for tested ITIL type
         $this->boolean($inlinedDocument->canViewFile())->isFalse();
         $this->boolean($inlinedDocument->canViewFile([$fkey => $itil->getID()]))->isFalse();
+        $this->boolean($inlinedDocument->canViewFile(['itemtype' => $itil->getType(), 'items_id' => $itil->getID()]))->isFalse();
 
        // post-only can see documents linked to its own ITIL
         $itil_user_class = $itil_itemtype . '_User';
@@ -700,6 +705,7 @@ class Document extends DbTestCase
 
         $this->boolean($inlinedDocument->canViewFile())->isFalse(); // False without params
         $this->boolean($inlinedDocument->canViewFile([$fkey => $itil->getID()]))->isTrue();
+        $this->boolean($inlinedDocument->canViewFile(['itemtype' => $itil->getType(), 'items_id' => $itil->getID()]))->isTrue();
     }
 
     public function testCronCleanorphans()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Noticed while trying to view a Change an error stating it was trying to access `getType` on null. The cause of the issue is that the previous `$params` parameter was optional previously and this method is sometimes called without any arguments. The new behavior defaults the replacement `$linked_item` to null. The code doesn't seem to handle that case.

With this, if the argument is null or a string, the legacy behavior is used. If a string was provided, the link parameters will be the value passed. If null, it defaults to an empty string just to avoid potential issues (which would have been the default value anyways).