### PR TITLE
Fix Domain inherited class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The present file will list all changes made to the project; according to the
 - `Symfony\Console` library has been upgraded to version 5.4.
 - `CommonGLPI` constructor signature has been declared in an interface (`CommonGLPIInterface`).
 - `DBmysqlIterator` class compliancy with `Iterator` has been fixed (i.e. `DBmysqlIterator::next()` does not return current row anymore).
+- `Domain` class inheritance changed from `CommonDropdown` to `CommonDBTM`.
 - `showForm()` method of all classes inheriting `CommonDBTM` have been changed to match `CommonDBTM::showForm()` signature.
 - Format of `Message-Id` header sent in Tickets notifications changed to match format used by other items.
 - Added `DB::truncate()` to replace raw SQL queries

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -32,7 +32,7 @@
  */
 
 /// Class Domain
-class Domain extends CommonDropdown
+class Domain extends CommonDBTM
 {
     use Glpi\Features\Clonable;
 

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -36,6 +36,7 @@ namespace Glpi\Inventory\Asset;
 use Agent;
 use Blacklist;
 use CommonDBTM;
+use CommonDropdown;
 use Dropdown;
 use Glpi\Inventory\Conf;
 use Glpi\Inventory\Request;
@@ -212,8 +213,8 @@ abstract class InventoryAsset
                         );
                     } else if (isset($foreignkey_itemtype[$key])) {
                         $value->$key = Dropdown::importExternal($foreignkey_itemtype[$key], addslashes($value->$key), $entities_id);
-                    } else if (isForeignKeyField($key) && $key != "users_id") {
-                        $foreignkey_itemtype[$key] = getItemtypeForForeignKeyField($key);
+                    } else if (isForeignKeyField($key) && is_a($itemtype = getItemtypeForForeignKeyField($key), CommonDropdown::class, true)) {
+                        $foreignkey_itemtype[$key] = $itemtype;
                         $value->$key = Dropdown::importExternal($foreignkey_itemtype[$key], addslashes($value->$key), $entities_id);
 
                         if (


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While working on #11068 , I noticed that Domain form was incorrectly displayed and that some fields were not saved. This is due to the fact that the class inherits from `CommonDropdown`. I guess this inheritance should have been removed in GLPI 9.5.