### PR TITLE
Add getWebDir to twig "Plugin" extension

### DIFF
--- a/src/Application/View/Extension/PluginExtension.php
+++ b/src/Application/View/Extension/PluginExtension.php
@@ -47,6 +47,7 @@ class PluginExtension extends AbstractExtension
         return [
             new TwigFunction('call_plugin_hook', [$this, 'callPluginHook']),
             new TwigFunction('call_plugin_hook_func', [$this, 'callPluginHookFunction']),
+            new TwigFunction('get_plugin_web_dir', [$this, 'getPluginWebDir']),
         ];
     }
 
@@ -84,5 +85,22 @@ class PluginExtension extends AbstractExtension
         if ($return_result) {
             return $result;
         }
+    }
+
+    /**
+     * Call Plugin::getWebDir() with given params.
+     *
+     * @param string  $plugin
+     * @param bool    $full
+     * @param bool    $use_url_base
+     *
+     * @return mixed|void
+     */
+    public function getPluginWebDir(
+        string $plugin,
+        bool $full = true,
+        bool $use_url_base = false
+    ) {
+        return Plugin::getWebDir($plugin, $full, $use_url_base);
     }
 }

--- a/src/Application/View/Extension/PluginExtension.php
+++ b/src/Application/View/Extension/PluginExtension.php
@@ -100,7 +100,12 @@ class PluginExtension extends AbstractExtension
         string $plugin,
         bool $full = true,
         bool $use_url_base = false
-    ) ?string {
-        return Plugin::getWebDir($plugin, $full, $use_url_base);
+    ): ?string {
+        $directory = Plugin::getWebDir($plugin, $full, $use_url_base);
+        if (empty($directory)) {
+            return null;
+        }
+
+        return $directory;
     }
 }

--- a/src/Application/View/Extension/PluginExtension.php
+++ b/src/Application/View/Extension/PluginExtension.php
@@ -101,11 +101,6 @@ class PluginExtension extends AbstractExtension
         bool $full = true,
         bool $use_url_base = false
     ): ?string {
-        $directory = Plugin::getWebDir($plugin, $full, $use_url_base);
-        if (empty($directory)) {
-            return null;
-        }
-
-        return $directory;
+        return Plugin::getWebDir($plugin, $full, $use_url_base) ?: null;
     }
 }

--- a/src/Application/View/Extension/PluginExtension.php
+++ b/src/Application/View/Extension/PluginExtension.php
@@ -94,13 +94,13 @@ class PluginExtension extends AbstractExtension
      * @param bool    $full
      * @param bool    $use_url_base
      *
-     * @return mixed|void
+     * @return string|null
      */
     public function getPluginWebDir(
         string $plugin,
         bool $full = true,
         bool $use_url_base = false
-    ) {
+    ) ?string {
         return Plugin::getWebDir($plugin, $full, $use_url_base);
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2591,6 +2591,10 @@ class Plugin extends CommonDBTM
             }
         }
 
+        if ($directory === false) {
+            return false;
+        }
+
         if (!$full) {
             $directory = str_replace(GLPI_ROOT, "", $directory);
         }
@@ -2615,6 +2619,11 @@ class Plugin extends CommonDBTM
         global $CFG_GLPI;
 
         $directory = self::getPhpDir($plugin_key, false);
+
+        if ($directory === false) {
+            return false;
+        }
+
         $directory = ltrim($directory, '/\\');
 
         if ($full) {


### PR DESCRIPTION
Add a useful `get_plugin_web_dir` function to the `PluginExtension`.

Usage:
```twig
{% set ajax_url = get_plugin_web_dir('my_plugin') ~ '/ajax/my_url.php' %}
```

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
