### PR TITLE
Sanitizing value property for hidden fields

### DIFF
--- a/inc/itiltemplate.class.php
+++ b/inc/itiltemplate.class.php
@@ -436,7 +436,7 @@ abstract class ITILTemplate extends CommonDropdown {
       if ($this->isHiddenField($field)) {
          $output .= "</span>";
          if ($ticket && isset($ticket->fields[$field])) {
-            $output .= "<input type='hidden' name='$field' value=\"".$ticket->fields[$field]."\">";
+            $output .= "<input type='hidden' name='$field' value=\"".htmlspecialchars($ticket->fields[$field], ENT_COMPAT)."\">";
          }
          if ($this->isPredefinedField($field)
              && !is_null($ticket)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

When we hide the description field of the ticket template, any change in the ticket causes the value to be truncated if it has special html characters. This PR applies the htmlspecialchars function in the value property to the hidden fields to avoid this problem.