### PR TITLE
Fix handling of invalid entity in search results; fixes #10951

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -6399,7 +6399,7 @@ JAVASCRIPT;
                             }
                         }
                         return $out;
-                    } else if (($so["datatype"] ?? "") != "itemlink") {
+                    } else if (($so["datatype"] ?? "") != "itemlink" && !empty($data[$ID][0]['name'])) {
                         return Entity::badgeCompletename($data[$ID][0]['name']);
                     }
                     break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10951

Bug can only be reproduced by either modifing the entity name to `null`, or by having a foreign key that points to an invalid entity ID.