### PR TITLE
fix dcroom grid offset

### DIFF
--- a/css/includes/components/_racks.scss
+++ b/css/includes/components/_racks.scss
@@ -180,7 +180,7 @@ ul.indexes {
     .racks_add {
         border: 1px solid $table-border-color;
         border-width: 0 1px 1px 0;
-        background-size: var(--grid-room-cell-w) var(--grid-room-cell-h);
+        background-size: var(--dcroom-grid-cellw) var(--dcroom-grid-cellh);
         background-image:
             linear-gradient(
                 to right,
@@ -195,8 +195,8 @@ ul.indexes {
         margin-left: 15px;
 
         .cell_add {
-            height: var(--grid-room-cell-h);
-            width: var(--grid-room-cell-w);
+            height: var(--dcroom-grid-cellh);
+            width: var(--dcroom-grid-cellw);
             float: left;
 
             &::after {
@@ -278,7 +278,7 @@ ul.indexes {
 
             li {
                 float: left;
-                width: var(--grid-room-cell-w);
+                width: var(--dcroom-grid-cellw);
             }
         }
 
@@ -286,8 +286,8 @@ ul.indexes {
             width: 15px;
 
             li {
-                height: var(--grid-room-cell-h);
-                line-height: calc(var(--grid-room-cell-h) + 1px);
+                height: var(--dcroom-grid-cellh);
+                line-height: calc(var(--dcroom-grid-cellh) + 1px);
             }
         }
     }

--- a/css/includes/components/_racks.scss
+++ b/css/includes/components/_racks.scss
@@ -180,7 +180,7 @@ ul.indexes {
     .racks_add {
         border: 1px solid $table-border-color;
         border-width: 0 1px 1px 0;
-        background-size: 40px 39px;
+        background-size: var(--grid-room-cell-w) var(--grid-room-cell-h);
         background-image:
             linear-gradient(
                 to right,
@@ -195,8 +195,8 @@ ul.indexes {
         margin-left: 15px;
 
         .cell_add {
-            height: 39px;
-            width: 40px;
+            height: var(--grid-room-cell-h);
+            width: var(--grid-room-cell-w);
             float: left;
 
             &::after {
@@ -278,7 +278,7 @@ ul.indexes {
 
             li {
                 float: left;
-                width: 40px;
+                width: var(--grid-room-cell-w);
             }
         }
 
@@ -286,8 +286,8 @@ ul.indexes {
             width: 15px;
 
             li {
-                height: 39px;
-                line-height: 40px;
+                height: var(--grid-room-cell-h);
+                line-height: calc(var(--grid-room-cell-h) + 1px);
             }
         }
     }

--- a/src/DCRoom.php
+++ b/src/DCRoom.php
@@ -38,9 +38,6 @@ class DCRoom extends CommonDBTM
 {
     use Glpi\Features\DCBreadcrumb;
 
-    const CELL_HEIGHT = 39;
-    const CELL_WIDTH  = 40;
-
    // From CommonDBTM
     public $dohistory                   = true;
     protected $usenotepad               = true;

--- a/src/DCRoom.php
+++ b/src/DCRoom.php
@@ -38,6 +38,9 @@ class DCRoom extends CommonDBTM
 {
     use Glpi\Features\DCBreadcrumb;
 
+    const CELL_HEIGHT = 39;
+    const CELL_WIDTH  = 40;
+
    // From CommonDBTM
     public $dohistory                   = true;
     protected $usenotepad               = true;

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -430,8 +430,8 @@ class Rack extends CommonDBTM
         $rows     = (int) $room->fields['vis_rows'];
         $cols     = (int) $room->fields['vis_cols'];
         $w_prct   = 100 / $cols;
-        $cell_w   = DCRoom::CELL_WIDTH;
-        $cell_h   = DCRoom::CELL_HEIGHT;
+        $cell_w   = 40;
+        $cell_h   = 39;
         $grid_w   = $cell_w * $cols;
         $grid_h   = $cell_h * $rows;
         $ajax_url = $CFG_GLPI['root_doc'] . "/ajax/rack.php";

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -435,7 +435,7 @@ class Rack extends CommonDBTM
         $cell_w   = DCRoom::CELL_WIDTH;
         $cell_h   = DCRoom::CELL_HEIGHT;
         $grid_w   = DCRoom::CELL_WIDTH * $cols;
-        $grid_h   = ($cell_h * $rows) + 16;
+        $grid_h   = $cell_h * $rows;
         $ajax_url = $CFG_GLPI['root_doc'] . "/ajax/rack.php";
 
        //fill rows
@@ -501,13 +501,13 @@ class Rack extends CommonDBTM
             $blueprint = "
             <div class='blueprint'
                  style='background: url({$blueprint_url}) no-repeat top left/100% 100%;
-                        height: " . ($grid_h - 16) . "px;'></div>";
+                        height: " . $grid_h . "px;'></div>";
             $blueprint_ctrl = "<span class='mini_toggle active'
                                   id='toggle_blueprint'>" . __('Blueprint') . "</span>";
         }
 
         echo "
-      <div class='grid-room' style='width: " . ($grid_w + 16) . "px; min-height: " . $grid_h . "px'>
+      <div class='grid-room' style='width: " . ($grid_w + 16) . "px; min-height: " . ($grid_h + 16) . "px'>
          <span class='racks_view_controls'>
             $blueprint_ctrl
             <span class='mini_toggle active'

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -432,8 +432,10 @@ class Rack extends CommonDBTM
         $rows     = (int) $room->fields['vis_rows'];
         $cols     = (int) $room->fields['vis_cols'];
         $w_prct   = 100 / $cols;
-        $grid_w   = 40 * $cols;
-        $grid_h   = (39 * $rows) + 16;
+        $cell_w   = DCRoom::CELL_WIDTH;
+        $cell_h   = DCRoom::CELL_HEIGHT;
+        $grid_w   = DCRoom::CELL_WIDTH * $cols;
+        $grid_h   = ($cell_h * $rows) + 16;
         $ajax_url = $CFG_GLPI['root_doc'] . "/ajax/rack.php";
 
        //fill rows
@@ -475,7 +477,11 @@ class Rack extends CommonDBTM
             echo "</tbody></table>";
         }
 
-        echo "<style>";
+        echo "<style>
+            :root {
+                --grid-room-cell-w: {$cell_w}px;
+                --grid-room-cell-h: {$cell_h}px;
+            }";
         for ($i = 0; $i < $cols; $i++) {
             $left  = $i * $w_prct;
             $width = ($i + 1) * $w_prct;
@@ -495,7 +501,7 @@ class Rack extends CommonDBTM
             $blueprint = "
             <div class='blueprint'
                  style='background: url({$blueprint_url}) no-repeat top left/100% 100%;
-                        height: " . $grid_h . "px;'></div>";
+                        height: " . ($grid_h - 16) . "px;'></div>";
             $blueprint_ctrl = "<span class='mini_toggle active'
                                   id='toggle_blueprint'>" . __('Blueprint') . "</span>";
         }
@@ -566,7 +572,7 @@ class Rack extends CommonDBTM
          GridStack.init({
             column: $cols,
             maxRow: ($rows + 1),
-            cellHeight: 39,
+            cellHeight: {$cell_h},
             margin: 0,
             float: true,
             disableOneColumnMode: true,

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -427,18 +427,16 @@ class Rack extends CommonDBTM
 
         echo "<div id='viewgraph'>";
 
-        $data = [];
-
         $rows     = (int) $room->fields['vis_rows'];
         $cols     = (int) $room->fields['vis_cols'];
         $w_prct   = 100 / $cols;
         $cell_w   = DCRoom::CELL_WIDTH;
         $cell_h   = DCRoom::CELL_HEIGHT;
-        $grid_w   = DCRoom::CELL_WIDTH * $cols;
+        $grid_w   = $cell_w * $cols;
         $grid_h   = $cell_h * $rows;
         $ajax_url = $CFG_GLPI['root_doc'] . "/ajax/rack.php";
 
-       //fill rows
+        //fill rows
         $cells    = [];
         $outbound = [];
         foreach ($racks as &$item) {
@@ -530,7 +528,7 @@ class Rack extends CommonDBTM
             }
         }
 
-       // add a locked element to bottom to display a full grid
+        // add a locked element to bottom to display a full grid
         echo "<div class='grid-stack-item lock-bottom'
                  gs-no-resize='true'
                  gs-no-move='true'

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -479,8 +479,8 @@ class Rack extends CommonDBTM
 
         echo "<style>
             :root {
-                --grid-room-cell-w: {$cell_w}px;
-                --grid-room-cell-h: {$cell_h}px;
+                --dcroom-grid-cellw: {$cell_w}px;
+                --dcroom-grid-cellh: {$cell_h}px;
             }";
         for ($i = 0; $i < $cols; $i++) {
             $left  = $i * $w_prct;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10529

1st step to have the cell size definition at only one place.
May permits override when finish (i'm not sure yet how to do this properly)

the -16 is strange but seems to corresponds to an offset in the height of the grid definition
i'm not 100% sure but we may want to remove both (i don't see any issue when doing it).

@kabassanov this is mostly your suggestions but more generic (usage of variables for width and height instead of raw values). Note the pr targets version 10.

