### PR TITLE
Use $_SESSION['glpi_currenttime'] as default alert date

### DIFF
--- a/src/Alert.php
+++ b/src/Alert.php
@@ -48,7 +48,7 @@ class Alert extends CommonDBTM
     {
 
         if (!isset($input['date']) || empty($input['date'])) {
-            $input['date'] = date("Y-m-d H:i:s");
+            $input['date'] = $_SESSION['glpi_currenttime'];
         }
         return $input;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Will fix following test error:
```
=> tests\units\Domain::testCronDomainsAlert():
In file /var/glpi/tests/functionnal/Domain.php on line 261, array() failed: array(4) is not equal to array(4)
-Expected
+Actual
@@ -2,2 +2 @@
-  ["date"]=>
-  string(19) "2022-03-24 09:56:43"
@@ -9 +9,2 @@
+  ["date"]=>
+  string(19) "2022-03-24 09:56:44"
```