### PR TITLE
Fix line operator form

### DIFF
--- a/src/LineOperator.php
+++ b/src/LineOperator.php
@@ -51,12 +51,12 @@ class LineOperator extends CommonDropdown
     {
         return [['name'  => 'mcc',
             'label' => __('Mobile Country Code'),
-            'type'  => 'text',
+            'type'  => 'integer',
             'list'  => true
         ],
             ['name'  => 'mnc',
                 'label' => __('Mobile Network Code'),
-                'type'  => 'text',
+                'type'  => 'integer',
                 'list'  => true
             ],
         ];
@@ -71,7 +71,7 @@ class LineOperator extends CommonDropdown
             'table'              => $this->getTable(),
             'field'              => 'mcc',
             'name'               => __('Mobile Country Code'),
-            'datatype'           => 'text',
+            'datatype'           => 'integer',
         ];
 
         $tab[] = [
@@ -79,7 +79,7 @@ class LineOperator extends CommonDropdown
             'table'              => $this->getTable(),
             'field'              => 'mnc',
             'name'               => __('Mobile Network Code'),
-            'datatype'           => 'text',
+            'datatype'           => 'integer',
         ];
 
         return $tab;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes issue where the MCC and MNC fields showed as text but the DB schema has them are integers. Without filling these fields, it tried inserting an empty string and failed. Field types and search option data types have been updated to match the actual schema.