### PR TITLE
Fix missing users_id value for KB item

### DIFF
--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -817,7 +817,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         echo "<tr class='tab_bg_1'>";
         echo "<td colspan=2></td>";
         echo "<td>";
-        echo "<input type='hidden' name='users_id' value=\"".Session::getLoginUserID()."\">";
+        echo "<input type='hidden' name='users_id' value=\"" . Session::getLoginUserID() . "\">";
         if ($this->fields["date_creation"]) {
            //TRANS: %s is the datetime of insertion
             printf(__('Created on %s'), Html::convDateTime($this->fields["date_creation"]));

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -817,6 +817,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         echo "<tr class='tab_bg_1'>";
         echo "<td colspan=2></td>";
         echo "<td>";
+        echo "<input type='hidden' name='users_id' value=\"".Session::getLoginUserID()."\">";
         if ($this->fields["date_creation"]) {
            //TRANS: %s is the datetime of insertion
             printf(__('Created on %s'), Html::convDateTime($this->fields["date_creation"]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The hidden field used for the `users_id` value was missing. It looks like it was accidentally removed when KB categories were reworked because the hidden field was placed between the Category header and the Category field.