### PR TITLE
Fix return to top button overlaping with central content

### DIFF
--- a/templates/components/masonry_grid.html.twig
+++ b/templates/components/masonry_grid.html.twig
@@ -34,7 +34,7 @@
 {% endif %}
 
 {% set rand = random() %}
-<div id="grid_{{ rand }}" class="masonry_grid row row-cards">
+<div id="grid_{{ rand }}" class="masonry_grid row row-cards mb-5">
    {% for item in grid_items %}
       <div class="grid-item {{ grid_item_class }}">
          {{ item|raw }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In some cases, it there is a lot of items on the Central tabs (not including dashboard), the button to return to the top of the screen could overlap some of the content at the bottom of the grids. Adding a margin to the bottom of the grid allows you to scroll down more to prevent this issue.