### PR TITLE
Handle 'any' step in number fields

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -142,7 +142,7 @@
 
 
 {% macro numberField(name, value, label = '', options = {}) %}
-   {% if options.step|round(0, 'floor') != options.step %}
+   {% if options.step != 'any' and options.step|round(0, 'floor') != options.step %}
       {# Only format number if not a whole number #}
       {% set value = call('Html::formatNumber', [value, true]) %}
    {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In `fields` plugin, we need to be able to propose a `number` field that may contains an unpredictable count of decimals. To do so, we have to use the `any` keyword in `step` attribute. In this case, value should not be formatted, as it may be contains more decimals than `$CFG_GLPI["decimal_number"]`.

For instance when a user creates an object with a number field defined to `12.002`, the value will be rendered as `12.00` in object edition form.