### PR TITLE
Fix adding Socket from Location

### DIFF
--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1770,6 +1770,10 @@ class NetworkPort extends CommonDBChild
     {
         $port_link = parent::getLink($options);
 
+        if (!isset($this->fields['itemtype']) || !class_exists($this->fields['itemtype'])) {
+            return $port_link;
+        }
+
         $itemtype = $this->fields['itemtype'];
         /** @var CommonDBTM */
         $equipment = new $itemtype();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Few issues fixed here:

- The form showed an Itemtype dropdown but didn't let you select an item afterwards.
- Selecting an itemtype was required, but I'm not sure that is intended. The DB allows a NULL value for the itemtype.
- If no itemtype was selected, a "0" was entered for the itemtype

I also added some checks to prevent errors during the display when there is no item connected.