### PR TITLE
Fix summary menu option

### DIFF
--- a/src/Project.php
+++ b/src/Project.php
@@ -269,7 +269,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
 
             $links[$pic_validate] = ProjectTask::getSearchURL(false);
 
-            $links['summary'] = Project::getFormURL(false) . '?showglobalgantt=1';
+            $links['summary_gantt'] = Project::getFormURL(false) . '?showglobalgantt=1';
             $links['summary_kanban'] = Project::getFormURL(false) . '?showglobalkanban=1';
         }
         if (count($links)) {

--- a/templates/layout/parts/context_links.html.twig
+++ b/templates/layout/parts/context_links.html.twig
@@ -80,6 +80,13 @@
       </li>
    {% elseif type == 'summary' %}
       <li class="nav-item">
+         <a href="{{ path(link) }}" class="btn btn-icon btn-sm btn-outline-secondary me-1 pe-2" title="{{ __('Summary') }}">
+            <i class="ti ti-notes"></i>
+            <span class="d-none d-xxl-block">{{ __('Summary') }}</span>
+         </a>
+      </li>
+   {% elseif type == 'summary_gantt' %}
+      <li class="nav-item">
          <a href="{{ path(link) }}" class="btn btn-icon btn-sm btn-outline-secondary me-1 pe-2" title="{{ __('Global GANTT') }}">
             <i class="fas fa-stream"></i>
             <span class="d-none d-xxl-block">{{ __('Global GANTT') }}</span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The additional menu option `summary` was used by Consumables (and maybe others) as a summary view of their usage which Projects used it to represent the global Gantt.

![Selection_062](https://user-images.githubusercontent.com/17678637/160112493-3eeb3f0f-5d3b-4a97-8e72-271116a71a73.png)

Project was changed to use `summary_gantt` instead since it is the only itemtype to use it. The context link template was updated to handle both cases properly.

![Selection_063](https://user-images.githubusercontent.com/17678637/160112506-4801ebe3-118c-4d74-86ee-37c54743031b.png)