### PR TITLE
Handle empty values in Toolbox::isFloat()

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -3608,6 +3608,10 @@ HTML;
     * @return bool
     */
    public static function isFloat($value): bool {
+      if ($value === null || $value === '') {
+         return false;
+      }
+
       if (!is_numeric($value)) {
          $type = gettype($value);
 

--- a/tests/units/Toolbox.php
+++ b/tests/units/Toolbox.php
@@ -1101,6 +1101,16 @@ class Toolbox extends \GLPITestCase {
     */
    protected function testIsFloatProvider(): Generator {
       yield [
+         'value'    => null,
+         'expected' => false,
+      ];
+
+      yield [
+         'value'    => "",
+         'expected' => false,
+      ];
+
+      yield [
          'value'    => "1",
          'expected' => false,
       ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Following code is generated a warning. It should not.

```php
Dropdown::showNumber(
    'fieldname',
    [
        'value'   => null,
        'min'     => 0,
        'max'     => 100,
        'step'    => 1,
    ]
);
```