### PR TITLE
Improve searches on Mio

### DIFF
--- a/src/DeviceMemory.php
+++ b/src/DeviceMemory.php
@@ -250,7 +250,7 @@ class DeviceMemory extends CommonDevice
             'name'               => _n('Memory', 'Memories', 1),
             'forcegroupby'       => true,
             'usehaving'          => true,
-            'datatype'           => 'number',
+            'datatype'           => 'mio',
             'width'              => 100,
             'massiveaction'      => false,
             'joinparams'         => $main_joinparams,

--- a/src/Search.php
+++ b/src/Search.php
@@ -3394,6 +3394,11 @@ JAVASCRIPT;
 
        // Preformat items
         if (isset($searchopt[$ID]["datatype"])) {
+            if ($searchopt[$ID]["datatype"] == "mio") {
+                // Parse value as it may contain a few different formats
+                $val = Toolbox::getMioSizeFromString($val);
+            }
+
             switch ($searchopt[$ID]["datatype"]) {
                 case "datetime":
                     if (in_array($searchtype, ['contains', 'notcontains'])) {
@@ -3426,6 +3431,7 @@ JAVASCRIPT;
                     return " {$LINK} ({$DB->quoteName($NAME)} $operator {$DB->quoteValue($val)}) ";
                 break;
                 case "count":
+                case "mio":
                 case "number":
                 case "decimal":
                 case "timestamp":
@@ -4900,6 +4906,11 @@ JAVASCRIPT;
 
        // Preformat items
         if (isset($searchopt[$ID]["datatype"])) {
+            if ($searchopt[$ID]["datatype"] == "mio") {
+                // Parse value as it may contain a few different formats
+                $val = Toolbox::getMioSizeFromString($val);
+            }
+
             switch ($searchopt[$ID]["datatype"]) {
                 case "itemtypename":
                     if (in_array($searchtype, ['equals', 'notequals'])) {
@@ -5013,6 +5024,7 @@ JAVASCRIPT;
                    // No break here : use number comparaison case
 
                 case "count":
+                case "mio":
                 case "number":
                 case "decimal":
                 case "timestamp":
@@ -7147,6 +7159,7 @@ JAVASCRIPT;
 
                 case "count":
                 case "number":
+                case "mio":
                     $out           = "";
                     $count_display = 0;
                     for ($k = 0; $k < $data[$ID]['count']; $k++) {

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -3465,4 +3465,39 @@ HTML;
 
         return strlen(preg_replace('/\d*\./', '', floatval($value)));
     }
+
+    /**
+     * Try to convert to Mio the given input
+     *
+     * @param string $size Input string
+     *
+     * @return mixed The Mio value as an integer if we were able to parse the
+     * input, else the unchanged input string
+     */
+    public static function getMioSizeFromString(string $size)
+    {
+        if (is_numeric($size)) {
+            // Already a numeric value, no work to be done
+            return $size;
+        }
+
+        if (!preg_match('/(\d+).*?(\w+)/', $size, $matches)) {
+            // Unkown format, keep the string as it is
+            return $size;
+        }
+        $supported_sizes = [
+            'mo'  => 0,
+            'mio' => 0,
+            'go'  => 1,
+            'gio' => 1,
+            'to'  => 2,
+            'tio' => 2,
+        ];
+        $exp = $supported_sizes[strtolower($matches[2]) ?? null];
+        if ($exp === null) {
+            // Unkown format, keep the string as it is
+            return $size;
+        }
+        return $matches[1] * pow(1024, $exp);
+    }
 }

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -1266,4 +1266,68 @@ class Toolbox extends DbTestCase
 
         $this->integer($result)->isEqualTo($decimals);
     }
+
+    /**
+     * Data provider for testGetMioSizeFromString
+     *
+     * @return Generator
+     */
+    protected function testGetMioSizeFromStringProvider(): Generator
+    {
+        yield [
+            'size'     => "1024",
+            'expected' => 1024,
+        ];
+
+        yield [
+            'size'     => "1024 mo",
+            'expected' => 1024,
+        ];
+
+        yield [
+            'size'     => "1024 mio",
+            'expected' => 1024,
+        ];
+
+        yield [
+            'size'     => "1024MO",
+            'expected' => 1024,
+        ];
+
+        yield [
+            'size'     => "2 gio",
+            'expected' => 2048,
+        ];
+
+        yield [
+            'size'     => "2gO",
+            'expected' => 2048,
+        ];
+
+        yield [
+            'size'     => "2 tio",
+            'expected' => 2097152,
+        ];
+
+        yield [
+            'size'     => "2TO",
+            'expected' => 2097152,
+        ];
+    }
+
+    /**
+     * Tests for Toolbox::getMioSizeFromString()
+     *
+     * @dataprovider testGetMioSizeFromStringProvider
+     *
+     * @param string $value
+     * @param mixed $expected
+     *
+     * @return void
+     */
+    public function testGetMioSizeFromString(string $size, $expected): void
+    {
+        $result = \Toolbox::getMioSizeFromString($size);
+        $this->variable($result)->isEqualTo($expected);
+    }
 }


### PR DESCRIPTION
Memory sizes are displayed in multiple formats in the search engine:

![image](https://user-images.githubusercontent.com/42734840/160146812-45de79e7-855e-4ee7-805b-cd059bbe6f0e.png)

However, the users are only allowed to search for memory sizes using one format, the raw "mio" value.

It is a bad design for two reasons:
* Formats displayed in the search results should be valid search values, as the user will be tempted to use them.
* It shouldn't be expected for users to know the format conversion, e.g. that they need to write "2048" to search for 2 Gio.

After these changes, the search allow a few different formats :
- Raw Mio values (1024, 2028, 1024 Mio, 1024Mo, ...)
- Gio values (1 Gio, 1GO, 1Gio, ...)
- Tio values (1 Tio, 1to, 1tio, ...)

Note that "Tio" shouldn't be very likely for memory size but I suppose these changes could be applied to other similar fields (hdd size ?).

Search examples:

![image](https://user-images.githubusercontent.com/42734840/160147958-356a09e6-e5df-45e3-980e-b3440d688f0a.png)
![image](https://user-images.githubusercontent.com/42734840/160147990-7427b71c-55ab-486b-847b-380641baecb8.png)
![image](https://user-images.githubusercontent.com/42734840/160148038-72bb694b-a5dc-4bfb-977a-0751ef5e0f1d.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23616
