### PR TITLE
Drop console log calls in inline JS

### DIFF
--- a/src/NotificationMailingSetting.php
+++ b/src/NotificationMailingSetting.php
@@ -184,7 +184,6 @@ class NotificationMailingSetting extends NotificationSetting
                 ]
             );
             $out .= Html::scriptBlock("$(function() {
-            console.log($('[name=smtp_mode]'));
             $('[name=smtp_mode]').on('change', function() {
                var _val = $(this).find('option:selected').val();
                if (_val == '" . MAIL_MAIL . "') {

--- a/templates/layout/parts/saved_searches.html.twig
+++ b/templates/layout/parts/saved_searches.html.twig
@@ -195,11 +195,9 @@ $(function() {
             .closest('.card-footer')
             .siblings('.card-tabs')
             .find('.saved-searches-panel-content .savedsearches-item');
-         console.log(_rows)
          _rows.each(function() {
             var _row = $(this);
             var rowtext = _row.text().toLowerCase();
-            console.log(_row);
 
             var show = true;
 

--- a/templates/pages/assets/cable.html.twig
+++ b/templates/pages/assets/cable.html.twig
@@ -151,7 +151,6 @@
 
                         //listener to refresh socket selector and breadcrumb
                         $(document).on('change', '#dropdown_items_id_endpoint_{{ side }}{{ rand_side }}', function(e) {
-                           console.log("test");
                            var items_id = $('#dropdown_items_id_endpoint_{{ side }}{{ rand_side }}').find(':selected').val();
                            var itemtype = $('#dropdown_itemtype_endpoint_{{ side }}{{ rand_side }}').find(':selected').val();
                            var socketmodels_id = $('#dropdown_socketmodels_id_endpoint_{{ side }}{{ rand_side }}').find(':selected').val();

--- a/templates/pages/setup/dropdowns_list.html.twig
+++ b/templates/pages/setup/dropdowns_list.html.twig
@@ -111,8 +111,6 @@ $(function () {
 
       if (input_value.length > 0) {
          timerid = setTimeout(function() {
-            console.log(input_value);
-
             $('.dropdowns-list .list-group-item:not(:icontains('+input_value+'))').hide();
             $('.dropdowns-list .list-group-item:icontains('+input_value+')')
                .closest('.accordion-collapse').addClass('show')
@@ -126,8 +124,6 @@ $(function () {
    })
 
    $('.dropdowns-list .collapse').on('shown.bs.collapse hidden.bs.collapse', function() {
-      console.log('shown.bs.collapse', $(this));
-
       $('.dropdowns-list .masonry_grid').trigger("layout:refresh");
    })
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Remove debug statements from JS code inside PHP and twig files which weren't caught by ESLint rules.