### PR TITLE
Fix update MA on namespaced classes

### DIFF
--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1128,6 +1128,8 @@ class MassiveAction
                 foreach ($search_options as $search_option) {
                     $search_option = explode(':', $search_option);
                     $itemtype      = $search_option[0];
+                    // id_field value was previously sanitized because it was not a standalone class name
+                    $itemtype = Sanitizer::unsanitize($itemtype);
                     $index         = $search_option[1];
 
                     if (!$item = getItemForItemtype($itemtype)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Encountered autoloading bug with Sockets when trying to select a field in the dropdown for the update massive action. The search option (the dropdown value) is a combination of the class name and the search option ID separated by `:`. Since the full value isn't a valid class, the sanitizer doesn't skip the sanitization process and the class name's `\` gets escaped. This class name gets split out and is used in an `instanceof` check which tries to autoload the class `Glpi\\Socket` but will fail because it was already loaded under the correct name `Glpi\Socket`.

The solution here isn't great but I cannot think of anything better at the moment. When the class name is split out, it will get unsanitized.