### PR TITLE
Command line inventory

### DIFF
--- a/front/inventory.php
+++ b/front/inventory.php
@@ -34,7 +34,7 @@
 use Glpi\Inventory\Request;
 
 if (!defined('GLPI_ROOT')) {
-    include('../inc/includes.php');
+    include(__DIR__ . '/../inc/includes.php');
 }
 
 $inventory_request = new Request();
@@ -52,7 +52,7 @@ if (isset($_GET['refused'])) {
         );
         $contents = '';
     }
-} else if ($_SERVER['REQUEST_METHOD'] != 'POST') {
+} else if (!isCommandLine() && $_SERVER['REQUEST_METHOD'] != 'POST') {
     if (isset($_GET['action']) && $_GET['action'] == 'getConfig') {
         /**
          * Even if Fusion protocol is not supported for getConfig requests, they
@@ -66,7 +66,16 @@ if (isset($_GET['refused'])) {
     }
     $handle = false;
 } else {
-    $contents = file_get_contents("php://input");
+    if (isCommandLine()) {
+        $f = fopen( 'php://stdin', 'r' );
+        $contents = '';
+        while( $line = fgets( $f ) ) {
+            $contents .= $line;
+        }
+        fclose( $f );
+    } else {
+        $contents = file_get_contents("php://input");
+    }
 }
 
 if ($handle === true) {
@@ -81,6 +90,9 @@ if (isset($_GET['refused'])) {
     $redirect_url = $refused->handleInventoryRequest($inventory_request);
     Html::redirect($redirect_url);
 } else {
+    if (isCommandLine()) {
+        exit(0);
+    }
     $headers = $inventory_request->getHeaders(true);
     http_response_code($inventory_request->getHttpResponseCode());
     foreach ($headers as $key => $value) {

--- a/front/inventory.php
+++ b/front/inventory.php
@@ -67,12 +67,12 @@ if (isset($_GET['refused'])) {
     $handle = false;
 } else {
     if (isCommandLine()) {
-        $f = fopen( 'php://stdin', 'r' );
+        $f = fopen('php://stdin', 'r');
         $contents = '';
-        while( $line = fgets( $f ) ) {
+        while ($line = fgets($f)) {
             $contents .= $line;
         }
-        fclose( $f );
+        fclose($f);
     } else {
         $contents = file_get_contents("php://input");
     }

--- a/src/Inventory/Inventory.php
+++ b/src/Inventory/Inventory.php
@@ -752,10 +752,14 @@ class Inventory
             }
         }
 
-        Toolbox::logInFile(
-            "bench_inventory",
-            $output
-        );
+        if (isCommandLine()) {
+            echo $output . "\n";
+        } else {
+            Toolbox::logInFile(
+                "bench_inventory",
+                $output
+            );
+        }
     }
 
     public static function getIcon()


### PR DESCRIPTION
Usage:

```
php front/inventory.php < /path/to/inventory.xml
```

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes