### PR TITLE
Replace usage of `CommonDBTM::$search` dynamic property in MassiveAction

### DIFF
--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1154,6 +1154,10 @@ class MassiveAction
                     break; // No need to process all items a corresponding item/searchoption has been found
                 }
 
+                if ($item === null) {
+                    exit();
+                }
+
                 $plugdisplay = false;
                 if (
                     ($plug = isPluginItemType($item->getType()))

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1146,7 +1146,7 @@ class MassiveAction
 
                     $itemtype_search_options = Search::getOptions($so_itemtype);
                     if (!isset($itemtype_search_options[$so_index])) {
-                       exit();
+                        exit();
                     }
 
                     $item   = $so_item;

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1124,52 +1124,47 @@ class MassiveAction
                     $search_options = [];
                 }
 
-                $items         = [];
+                // TODO: ensure that all items are equivalent ...
+                $item   = null;
+                $search = null;
                 foreach ($search_options as $search_option) {
                     $search_option = explode(':', $search_option);
-                    $itemtype      = $search_option[0];
-                    $index         = $search_option[1];
+                    $so_itemtype   = $search_option[0];
+                    $so_index      = $search_option[1];
 
-                    if (!$item = getItemForItemtype($itemtype)) {
+                    if (!$so_item = getItemForItemtype($so_itemtype)) {
                         continue;
                     }
 
-                    if (Infocom::canApplyOn($itemtype)) {
-                        Session::checkSeveralRightsOr([$itemtype  => UPDATE,
+                    if (Infocom::canApplyOn($so_itemtype)) {
+                        Session::checkSeveralRightsOr([$so_itemtype  => UPDATE,
                             "infocom"  => UPDATE
                         ]);
                     } else {
-                        $item->checkGlobal(UPDATE);
+                        $so_item->checkGlobal(UPDATE);
                     }
 
-                    $search = Search::getOptions($itemtype);
-                    if (!isset($search[$index])) {
-                         exit();
+                    $itemtype_search_options = Search::getOptions($so_itemtype);
+                    if (!isset($itemtype_search_options[$so_index])) {
+                       exit();
                     }
-                    $item->search = $search[$index];
 
-                    $items[] = $item;
+                    $item   = $so_item;
+                    $search = $itemtype_search_options[$so_index];
+                    break; // No need to process all items a corresponding item/searchoption has been found
                 }
-
-                if (count($items) == 0) {
-                    exit();
-                }
-
-                // TODO: ensure that all items are equivalent ...
-                $item   = $items[0];
-                $search = $item->search;
 
                 $plugdisplay = false;
                 if (
                     ($plug = isPluginItemType($item->getType()))
                     // Specific for plugin which add link to core object
-                    || ($plug = isPluginItemType(getItemTypeForTable($item->search['table'])))
+                    || ($plug = isPluginItemType(getItemTypeForTable($search['table'])))
                 ) {
                     $plugdisplay = Plugin::doOneHook(
                         $plug['plugin'],
                         'MassiveActionsFieldsDisplay',
                         ['itemtype' => $item->getType(),
-                            'options'  => $item->search
+                            'options'  => $search
                         ]
                     );
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Will prevent a deprecation error on PHP 8.2 when using `update` massive action.