### PR TITLE
Fix upload handler

### DIFF
--- a/src/GLPIUploadHandler.php
+++ b/src/GLPIUploadHandler.php
@@ -134,9 +134,7 @@ class GLPIUploadHandler extends UploadHandler
         $upload_handler = new self(
             [
                 'accept_file_types'         => DocumentType::getUploadableFilePattern(),
-                'image_versions'            => [
-                    'auto_orient' => false,
-                ],
+                'image_versions'            => [],
                 'param_name'                => $pname,
                 'replace_dots_in_filenames' => false,
                 'upload_dir'                => $upload_dir,

--- a/src/GLPIUploadHandler.php
+++ b/src/GLPIUploadHandler.php
@@ -171,23 +171,48 @@ class GLPIUploadHandler extends UploadHandler
         return $upload_handler->generate_response($response, $params['print_response']);
     }
 
+    /**
+     * Overrided method to prevent deprecation when variable does not exist.
+     * @see UploadHandler::get_upload_data()
+     */
     protected function get_upload_data($id)
     {
-        return array_key_exists($id, $_FILES) ? $_FILES[$id] : null;
+        return array_key_exists($id, $_FILES) ? $_FILES[$id] : '';
     }
 
+    /**
+     * Overrided method to prevent deprecation when variable does not exist.
+     * @see UploadHandler::get_post_param()
+     */
     protected function get_post_param($id)
     {
-        return array_key_exists($id, $_POST) ? $_POST[$id] : null;
+        return array_key_exists($id, $_POST) ? $_POST[$id] : '';
     }
 
+    /**
+     * Overrided method to prevent deprecation when variable does not exist.
+     * @see UploadHandler::get_query_param()
+     */
     protected function get_query_param($id)
     {
-        return array_key_exists($id, $_GET) ? $_GET[$id] : null;
+        return array_key_exists($id, $_GET) ? $_GET[$id] : '';
     }
 
+    /**
+     * Overrided method to prevent deprecation when variable does not exist.
+     * @see UploadHandler::get_server_var()
+     */
     protected function get_server_var($id)
     {
-        return array_key_exists($id, $_SERVER) ? $_SERVER[$id] : null;
+        return array_key_exists($id, $_SERVER) ? $_SERVER[$id] : '';
+    }
+
+    /**
+     * Overrided method to prevent deprecation when using default `$suffix` value.
+     * @see UploadHandler::basename()
+     */
+    protected function basename($filepath, $suffix = '')
+    {
+        return parent::basename($filepath, $suffix);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11120

1. Fix deprecations on PHP 8.1.

2. Fix image processing configuration, to disable any image processing. Configuration was not set at correct place, so every image was loaded by gd library, which may cause memory issues when uploading large images.