### PR TITLE
Fix issues with raw namespaced itemtypes

### DIFF
--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1249,8 +1249,9 @@ class DBmysql
             if (Sanitizer::isClassOfCallableIdentifier($value)) {
                 // Values that corresponds to an existing class are not sanitized (see `Glpi\Toolbox\Sanitizer::sanitize()`).
                 // However, if they contains backslashes, they have to be escaped.
+                // Note: method is called statically, so `$DB` may be not defined yet in edge cases (install process).
                 global $DB;
-                $value = $DB->escape($value);
+                $value = $DB instanceof DBmysql && $DB->connected ? $DB->escape($value) : $value;
             }
 
            // phone numbers may start with '+' and will be considered as numeric

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -33,6 +33,7 @@
 
 use Glpi\Application\ErrorHandler;
 use Glpi\System\Requirement\DbTimezones;
+use Glpi\Toolbox\Sanitizer;
 
 /**
  *  Database class for Mysql
@@ -1237,15 +1238,22 @@ class DBmysql
     public static function quoteValue($value)
     {
         if ($value instanceof QueryParam || $value instanceof QueryExpression) {
-           //no quote for query parameters nor expressions
+            //no quote for query parameters nor expressions
             $value = $value->getValue();
         } else if ($value === null || $value === 'NULL' || $value === 'null') {
             $value = 'NULL';
         } else if (is_bool($value)) {
-           // transform boolean as int (prevent `false` to be transformed to empty string)
+            // transform boolean as int (prevent `false` to be transformed to empty string)
             $value = "'" . (int)$value . "'";
         } else {
-           //phone numbers may start with '+' and will be considered as numeric
+            if (Sanitizer::isClassOfCallableIdentifier($value)) {
+                // Values that corresponds to an existing class are not sanitized (see `Glpi\Toolbox\Sanitizer::sanitize()`).
+                // However, if they contains backslashes, they have to be escaped.
+                global $DB;
+                $value = $DB->escape($value);
+            }
+
+           // phone numbers may start with '+' and will be considered as numeric
             $value = "'$value'";
         }
         return $value;

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1246,9 +1246,9 @@ class DBmysql
             // transform boolean as int (prevent `false` to be transformed to empty string)
             $value = "'" . (int)$value . "'";
         } else {
-            if (Sanitizer::isClassOfCallableIdentifier($value)) {
-                // Values that corresponds to an existing class are not sanitized (see `Glpi\Toolbox\Sanitizer::sanitize()`).
-                // However, if they contains backslashes, they have to be escaped.
+            if (Sanitizer::isNsClassOrCallableIdentifier($value)) {
+                // Values that corresponds to an existing namespaced class are not sanitized (see `Glpi\Toolbox\Sanitizer::sanitize()`).
+                // However, they have to be escaped in SQL queries.
                 // Note: method is called statically, so `$DB` may be not defined yet in edge cases (install process).
                 global $DB;
                 $value = $DB instanceof DBmysql && $DB->connected ? $DB->escape($value) : $value;

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -390,6 +390,7 @@ final class DbUtils
          . preg_quote('\\', '/') // followed by an additionnal \
          . '/';
         if (preg_match($sanitized_namespaced_pattern, $itemtype)) {
+            trigger_error(sprintf('Unexpected sanitized itemtype "%s" encountered.', $itemtype), E_USER_WARNING);
             $itemtype = stripslashes($itemtype);
         }
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -4528,17 +4528,17 @@ JAVASCRIPT;
 
             case "equals":
                 if ($nott) {
-                    $SEARCH = " <> '$val'";
+                    $SEARCH = " <> " . DBmysql::quoteValue($val);
                 } else {
-                    $SEARCH = " = '$val'";
+                    $SEARCH = " = " . DBmysql::quoteValue($val);
                 }
                 break;
 
             case "notequals":
                 if ($nott) {
-                    $SEARCH = " = '$val'";
+                    $SEARCH = " = " . DBmysql::quoteValue($val);
                 } else {
-                    $SEARCH = " <> '$val'";
+                    $SEARCH = " <> " . DBmysql::quoteValue($val);
                 }
                 break;
 
@@ -8755,7 +8755,7 @@ HTML;
         if ($val == null) {
             $SEARCH = " IS $NOT NULL ";
         } else {
-            $SEARCH = " $NOT LIKE '$val' ";
+            $SEARCH = " $NOT LIKE " . DBmysql::quoteValue($val) . " ";
         }
         return $SEARCH;
     }

--- a/src/Toolbox/Sanitizer.php
+++ b/src/Toolbox/Sanitizer.php
@@ -71,12 +71,9 @@ class Sanitizer
             return $value;
         }
 
-        $class_match = [];
-        if (
-            preg_match('/^(?<class>[a-zA-Z0-9_\\\]+)(:?:[a-zA-Z0-9_]+)?$/', $value, $class_match)
-            && class_exists($class_match['class'])
-        ) {
-            // Do not sanitize values that corresponds to an existing class, as classnames are considered safe
+        if (self::isClassOfCallableIdentifier($value)) {
+            // Do not sanitize values that corresponds to an existing class, to prevent prevent having to unsanitize
+            // every usage of `itemtype` to correctly handle namespaces.
             return $value;
         }
 
@@ -222,6 +219,20 @@ class Sanitizer
         }
 
         return $has_special_chars;
+    }
+
+    /**
+     * Check wether the value correspond to a valid class (or a callable itentifier related to a valid class).
+     *
+     * @param string $value
+     *
+     * @return bool
+     */
+    public static function isClassOfCallableIdentifier(string $value): bool
+    {
+        $class_match = [];
+        return preg_match('/^(?<class>[a-zA-Z0-9_\\\]+)(:?:[a-zA-Z0-9_]+)?$/', $value, $class_match)
+            && class_exists($class_match['class']);
     }
 
     /**

--- a/src/Toolbox/Sanitizer.php
+++ b/src/Toolbox/Sanitizer.php
@@ -71,8 +71,8 @@ class Sanitizer
             return $value;
         }
 
-        if (self::isClassOfCallableIdentifier($value)) {
-            // Do not sanitize values that corresponds to an existing class, to prevent prevent having to unsanitize
+        if (self::isNsClassOrCallableIdentifier($value)) {
+            // Do not sanitize values that corresponds to an existing namespaced class, to prevent prevent having to unsanitize
             // every usage of `itemtype` to correctly handle namespaces.
             return $value;
         }
@@ -222,16 +222,16 @@ class Sanitizer
     }
 
     /**
-     * Check wether the value correspond to a valid class (or a callable itentifier related to a valid class).
+     * Check wether the value correspond to a valid namespaced class (or a callable identifier related to a valid class).
      *
      * @param string $value
      *
      * @return bool
      */
-    public static function isClassOfCallableIdentifier(string $value): bool
+    public static function isNsClassOrCallableIdentifier(string $value): bool
     {
         $class_match = [];
-        return preg_match('/^(?<class>[a-zA-Z0-9_\\\]+)(:?:[a-zA-Z0-9_]+)?$/', $value, $class_match)
+        return preg_match('/^(?<class>(([a-zA-Z0-9_]+\\\)+[a-zA-Z0-9_]+))(:?:[a-zA-Z0-9_]+)?$/', $value, $class_match)
             && class_exists($class_match['class']);
     }
 

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -247,9 +247,18 @@ class DbUtils extends DbTestCase
 
         $this
          ->if($this->newTestedInstance)
-         ->then
-            ->object($this->testedInstance->getItemForItemtype(addslashes('Glpi\Event')))->isInstanceOf('Glpi\Event')
-            ->object($this->testedInstance->getItemForItemtype(addslashes('GlpiPlugin\Bar\Foo')))->isInstanceOf('GlpiPlugin\Bar\Foo');
+         ->when(function () {
+               $this->object($this->testedInstance->getItemForItemtype(addslashes('Glpi\Event')))->isInstanceOf('Glpi\Event');
+         })->error
+            ->withType(E_USER_WARNING)
+            ->withMessage('Unexpected sanitized itemtype "Glpi\\\\Event" encountered.')
+            ->exists()
+         ->when(function () {
+               $this->object($this->testedInstance->getItemForItemtype(addslashes('GlpiPlugin\Bar\Foo')))->isInstanceOf('GlpiPlugin\Bar\Foo');
+         })->error
+            ->withType(E_USER_WARNING)
+            ->withMessage('Unexpected sanitized itemtype "GlpiPlugin\\\\Bar\\\\Foo" encountered.')
+            ->exists();
     }
 
     public function testGetItemForItemtypeAbstract()

--- a/tests/functionnal/PassiveDCEquipment.php
+++ b/tests/functionnal/PassiveDCEquipment.php
@@ -39,19 +39,6 @@ use DbTestCase;
 
 class PassiveDCEquipment extends DbTestCase
 {
-    private $method;
-
-    public function beforeTestMethod($method)
-    {
-        parent::beforeTestMethod($method);
-       //to handle GLPI barbarian replacements.
-        $this->method = str_replace(
-            ['\\', 'beforeTestMethod'],
-            ['', $method],
-            __METHOD__
-        );
-    }
-
     public function testAdd()
     {
         $obj = new \PassiveDCEquipment();
@@ -66,12 +53,12 @@ class PassiveDCEquipment extends DbTestCase
 
        // getField methods
         $this->variable($obj->getField('id'))->isEqualTo($id);
-        $this->string($obj->getField('name'))->isidenticalTo($this->method);
+        $this->string($obj->getField('name'))->isidenticalTo(__METHOD__);
 
        // fields property
         $this->array($obj->fields)
          ->integer['id']->isEqualTo($id)
-         ->string['name']->isidenticalTo($this->method);
+         ->string['name']->isidenticalTo(__METHOD__);
     }
 
     public function testDelete()
@@ -125,7 +112,7 @@ class PassiveDCEquipment extends DbTestCase
         $nb_before = (int)countElementsInTable('glpi_logs', ['itemtype' => 'PassiveDCEquipment', 'items_id' => $id]);
 
        // DeleteByCriteria without history
-        $this->boolean($obj->deleteByCriteria(['name' => $this->method], 0, 0))->isTrue();
+        $this->boolean($obj->deleteByCriteria(['name' => __METHOD__], 0, 0))->isTrue();
         $this->boolean($obj->getFromDB($id))->isTrue();
         $this->variable($obj->getField('is_deleted'))->isEqualTo(1);
         $this->variable($obj->isDeleted())->isEqualTo(1);
@@ -142,7 +129,7 @@ class PassiveDCEquipment extends DbTestCase
         $nb_before = (int)countElementsInTable('glpi_logs', ['itemtype' => 'PassiveDCEquipment', 'items_id' => $id]);
 
        // DeleteByCriteria with history
-        $this->boolean($obj->deleteByCriteria(['name' => $this->method], 0, 1))->isTrue;
+        $this->boolean($obj->deleteByCriteria(['name' => __METHOD__], 0, 1))->isTrue;
         $this->boolean($obj->getFromDB($id))->isTrue();
         $this->variable($obj->getField('is_deleted'))->isEqualTo(1);
         $this->variable($obj->isDeleted())->isEqualTo(1);

--- a/tests/functionnal/Printer.php
+++ b/tests/functionnal/Printer.php
@@ -39,19 +39,6 @@ use DbTestCase;
 
 class Printer extends DbTestCase
 {
-    private $method;
-
-    public function beforeTestMethod($method)
-    {
-        parent::beforeTestMethod($method);
-       //to handle GLPI barbarian replacements.
-        $this->method = str_replace(
-            ['\\', 'beforeTestMethod'],
-            ['', $method],
-            __METHOD__
-        );
-    }
-
     public function testAdd()
     {
         $obj = new \Printer();
@@ -66,12 +53,12 @@ class Printer extends DbTestCase
 
        // getField methods
         $this->variable($obj->getField('id'))->isEqualTo($id);
-        $this->string($obj->getField('name'))->isidenticalTo($this->method);
+        $this->string($obj->getField('name'))->isidenticalTo(__METHOD__);
 
        // fields property
         $this->array($obj->fields)
          ->integer['id']->isEqualTo($id)
-         ->string['name']->isidenticalTo($this->method);
+         ->string['name']->isidenticalTo(__METHOD__);
     }
 
     public function testDelete()
@@ -153,7 +140,7 @@ class Printer extends DbTestCase
         $nb_before = (int)countElementsInTable('glpi_logs', ['itemtype' => 'Printer', 'items_id' => $id]);
 
        // DeleteByCriteria without history
-        $this->boolean($obj->deleteByCriteria(['name' => $this->method], 0, 0))->isTrue();
+        $this->boolean($obj->deleteByCriteria(['name' => __METHOD__], 0, 0))->isTrue();
         $this->boolean($obj->getFromDB($id))->isTrue();
         $this->variable($obj->getField('is_deleted'))->isEqualTo(1);
         $this->variable($obj->isDeleted())->isEqualTo(1);
@@ -170,7 +157,7 @@ class Printer extends DbTestCase
         $nb_before = (int)countElementsInTable('glpi_logs', ['itemtype' => 'Printer', 'items_id' => $id]);
 
        // DeleteByCriteria with history
-        $this->boolean($obj->deleteByCriteria(['name' => $this->method], 0, 1))->isTrue;
+        $this->boolean($obj->deleteByCriteria(['name' => __METHOD__], 0, 1))->isTrue;
         $this->boolean($obj->getFromDB($id))->isTrue();
         $this->variable($obj->getField('is_deleted'))->isEqualTo(1);
         $this->variable($obj->isDeleted())->isEqualTo(1);

--- a/tests/units/DB.php
+++ b/tests/units/DB.php
@@ -108,6 +108,7 @@ class DB extends \GLPITestCase
             ['`field', "'`field'"],
             [false, "'0'"],
             [true, "'1'"],
+            ['Glpi\Socket', "'Glpi\\\Socket'"],
         ];
     }
 

--- a/tests/units/Glpi/Toolbox/Sanitizer.php
+++ b/tests/units/Glpi/Toolbox/Sanitizer.php
@@ -401,4 +401,29 @@ TXT;
        // Re-sanitize a value provide the same result as first sanitization
         $this->variable($sanitizer->sanitize($sanitizer->unsanitize($value), $add_slashes))->isEqualTo($sanitized_value);
     }
+
+    protected function isClassOfCallableIdentifierProvider(): iterable
+    {
+        yield [
+            'value'    => 'mystring',
+            'is_class' => false,
+        ];
+        yield [
+            'value'    => 'Computer',
+            'is_class' => true,
+        ];
+        yield [
+            'value'    => 'Glpi\Socket',
+            'is_class' => true,
+        ];
+    }
+
+    /**
+     * @dataProvider isClassOfCallableIdentifierProvider
+     */
+    public function testIsClassOfCallableIdentifier(string $value, bool $is_class)
+    {
+        $sanitizer = $this->newTestedInstance();
+        $this->boolean($sanitizer->isClassOfCallableIdentifier($value))->isEqualTo($is_class);
+    }
 }

--- a/tests/units/Glpi/Toolbox/Sanitizer.php
+++ b/tests/units/Glpi/Toolbox/Sanitizer.php
@@ -402,7 +402,7 @@ TXT;
         $this->variable($sanitizer->sanitize($sanitizer->unsanitize($value), $add_slashes))->isEqualTo($sanitized_value);
     }
 
-    protected function isClassOfCallableIdentifierProvider(): iterable
+    protected function isNsClassOrCallableIdentifierProvider(): iterable
     {
         yield [
             'value'    => 'mystring',
@@ -410,20 +410,24 @@ TXT;
         ];
         yield [
             'value'    => 'Computer',
-            'is_class' => true,
+            'is_class' => false, // not in a namespace
         ];
         yield [
             'value'    => 'Glpi\Socket',
             'is_class' => true,
         ];
+        yield [
+            'value'    => 'Glpi\\\\Socket',
+            'is_class' => false, // namespace separator are escaped, so it is not considered as a valid classname
+        ];
     }
 
     /**
-     * @dataProvider isClassOfCallableIdentifierProvider
+     * @dataProvider isNsClassOrCallableIdentifierProvider
      */
-    public function testIsClassOfCallableIdentifier(string $value, bool $is_class)
+    public function testIsNsClassOrCallableIdentifier(string $value, bool $is_class)
     {
         $sanitizer = $this->newTestedInstance();
-        $this->boolean($sanitizer->isClassOfCallableIdentifier($value))->isEqualTo($is_class);
+        $this->boolean($sanitizer->isNsClassOrCallableIdentifier($value))->isEqualTo($is_class);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23708

To handle namespaced itemtypes, we adapted the sanitization process to not sanitize classames. Main benefit is that, anywhere in the code, an `$itemtype` variable should no longer been sanitized. Previously, it was pretty hard to know if the variable value was containing a sanitized value (value passed through a http query, or manually sanitized), or a raw value.

Problem is that SQL receive a non escaped value, and it does not handle it correctly. For instance, `INSERT INTO `glpi_plugin_myplugin_test` (`name`, `class`) VALUES ('Test', 'GlpiPlugin\Myplugin\Ns\TestClass')` will insert `GlpiPluginMypluginNsTestClass'` in DB.

There are 2 solution.

1) Automatically apply escaping in `DBmysql::quoteValue()` when `Sanitizer::isDbEscaped()` returns `false`. I am pretty confident with this method result, but doiing this now seems a bit late, and I am not really able to estimate the performances impact.

2) Escaping values detected by the same test than thoose that are not sanitized. This is what I have done in this PR. I also had to fix the search class to call the `DBmysql::quoteValue()` method.
