### PR TITLE
Fix FA6 compatibility

### DIFF
--- a/css/includes/components/_global-menu.scss
+++ b/css/includes/components/_global-menu.scss
@@ -131,12 +131,11 @@
     }
 
     .reduce-menu::before {
-        font-family: "Font Awesome 5 Free";
+        font: var(--fa-font-solid);
         content: "\f100";
         display: inline-block;
         padding-right: 3px;
         vertical-align: middle;
-        font-weight: 900;
         font-size: 1.3333em;
         line-height: 0.75em;
     }

--- a/css/includes/components/_kanban.scss
+++ b/css/includes/components/_kanban.scss
@@ -144,8 +144,7 @@
             li.dropdown-trigger {
                 a::after {
                     content: "\f054";
-                    font-family: "Font Awesome 5 Free";
-                    font-weight: 900;
+                    font: var(--fa-font-solid);
                     padding-left: 10px;
                 }
             }

--- a/css/includes/components/_mini-tabs.scss
+++ b/css/includes/components/_mini-tabs.scss
@@ -82,9 +82,8 @@
             left: 0;
             top: 0;
             font-size: 15px;
-            font-family: "Font Awesome 5 Free";
+            font: var(--fa-font-solid);
             position: absolute;
-            font-weight: 900;
         }
 
         &.active::before {

--- a/css/includes/components/_mini-tabs.scss
+++ b/css/includes/components/_mini-tabs.scss
@@ -81,8 +81,7 @@
             content: "\f204";
             left: 0;
             top: 0;
-            font-size: 15px;
-            font: var(--fa-font-solid);
+            font: 15px var(--fa-font-solid);
             position: absolute;
         }
 

--- a/css/includes/components/_racks.scss
+++ b/css/includes/components/_racks.scss
@@ -149,9 +149,8 @@ ul.indexes {
         font-size: 1em;
         color: grey;
         top: 1px;
-        font-family: "Font Awesome 5 Free";
+        font: var(--fa-font-solid);
         position: absolute;
-        font-weight: 900;
     }
 
     &:hover {

--- a/css/includes/components/_racks.scss
+++ b/css/includes/components/_racks.scss
@@ -146,10 +146,9 @@ ul.indexes {
     &::after {
         content: "\2b";
         left: 45%;
-        font-size: 1em;
         color: grey;
         top: 1px;
-        font: var(--fa-font-solid);
+        font: 1em var(--fa-font-solid);
         position: absolute;
     }
 

--- a/css/includes/components/itilobject/_dates_timelines.scss
+++ b/css/includes/components/itilobject/_dates_timelines.scss
@@ -76,7 +76,7 @@
 
         &::before {
             color: #929292;
-            font-family: "Font Awesome 5 Free";
+            font: var(--fa-font-solid);
             padding-left: 3px;
         }
     }
@@ -103,8 +103,7 @@
         left: 161px;
 
         &::before {
-            content: "\f069";
-            font-weight: 900;
+            content: "\2a";
         }
     }
 
@@ -120,17 +119,15 @@
             color: #ff0014;
 
             &::before {
-                content: "\f12a";
-                padding-left: 8px;
+                content: "\21";
+                padding-left: 4px;
                 color: #e54e5a;
-                font-weight: 900;
             }
         }
     }
 
     .checked .dot::before {
         content: "\f00c";
-        font-weight: 900;
     }
 
     .end .dot {
@@ -140,7 +137,6 @@
 
         &::before {
             content: "\f024";
-            font-weight: 900;
         }
     }
 

--- a/css/legacy/includes/_planning.scss
+++ b/css/legacy/includes/_planning.scss
@@ -51,8 +51,7 @@
          display: block;
 
          &::before {
-            font-family: "Font Awesome 5 Free";
-            font-weight: 900;
+            font: var(--fa-font-solid);
             content: "\f191";
          }
       }
@@ -61,8 +60,7 @@
          .toggle {
             float: none;
             &::before {
-               font-family: "Font Awesome 5 Free";
-               font-weight: 900;
+               font: var(--fa-font-solid);
                content: "\f152";
             }
          }
@@ -139,16 +137,14 @@
                   vertical-align: middle;
 
                   &::before {
-                     font-family: "Font Awesome 5 Free";
-                     font-weight: 900;
+                     font: var(--fa-font-solid);
                      content: "\f0fe";
                   }
                }
 
                &.expanded .toggle {
                   &::before {
-                     font-family: "Font Awesome 5 Free";
-                     font-weight: 900;
+                     font: var(--fa-font-solid);
                      content: "\f146";
                   }
                }

--- a/css/standalone/dashboard.scss
+++ b/css/standalone/dashboard.scss
@@ -453,9 +453,8 @@ $break_tablet: 1400px;
 
                         &::after {
                             position: absolute;
-                            font-family: "Font Awesome 5 Free";
                             color: #509ee3;
-                            font-weight: 900;
+                            font: var(--fa-font-solid);
                             content: "\f057";
                             opacity: 0.7;
                             font-size: 11px;
@@ -482,7 +481,7 @@ $break_tablet: 1400px;
                     }
 
                     &::after {
-                        font-family: "Font Awesome 5 Free";
+                        font: var(--fa-font-solid);
                         color: #74838f;
                         opacity: 0.7;
                         font-size: 14px;
@@ -575,14 +574,13 @@ $break_tablet: 1400px;
             }
 
             &::after {
-                content: "\f067";
+                content: "\2b";
                 left: 40%;
                 top: 40%;
                 font-size: 1em;
                 color: grey;
-                font-family: "Font Awesome 5 Free";
+                font: var(--fa-font-solid);
                 position: absolute;
-                font-weight: 900;
             }
         }
     }
@@ -695,8 +693,7 @@ $break_tablet: 1400px;
 
                 &::before {
                     content: "\f338";
-                    font-family: "Font Awesome 5 Free";
-                    font-weight: 900;
+                    font: var(--fa-font-solid);
                     font-size: 13px;
                     position: absolute;
                     bottom: -5px;
@@ -1318,9 +1315,8 @@ $break_tablet: 1400px;
                 bottom: 3px;
                 font-size: 1em;
                 color: rgb(39, 39, 39);
-                font-family: "Font Awesome 5 Free";
+                font: var(--fa-font-solid);
                 position: absolute;
-                font-weight: 900;
             }
         }
     }

--- a/css/standalone/dashboard.scss
+++ b/css/standalone/dashboard.scss
@@ -454,10 +454,9 @@ $break_tablet: 1400px;
                         &::after {
                             position: absolute;
                             color: #509ee3;
-                            font: var(--fa-font-solid);
+                            font: 11px var(--fa-font-solid);
                             content: "\f057";
                             opacity: 0.7;
-                            font-size: 11px;
                             left: 7px;
                         }
 
@@ -481,10 +480,9 @@ $break_tablet: 1400px;
                     }
 
                     &::after {
-                        font: var(--fa-font-solid);
+                        font: 14px var(--fa-font-solid);
                         color: #74838f;
                         opacity: 0.7;
-                        font-size: 14px;
                         pointer-events: none;
                         position: absolute;
                         right: 0;
@@ -577,9 +575,8 @@ $break_tablet: 1400px;
                 content: "\2b";
                 left: 40%;
                 top: 40%;
-                font-size: 1em;
                 color: grey;
-                font: var(--fa-font-solid);
+                font: 1em var(--fa-font-solid);
                 position: absolute;
             }
         }
@@ -693,8 +690,7 @@ $break_tablet: 1400px;
 
                 &::before {
                     content: "\f338";
-                    font: var(--fa-font-solid);
-                    font-size: 13px;
+                    font: 13px var(--fa-font-solid);
                     position: absolute;
                     bottom: -5px;
                     right: 1px;
@@ -1313,9 +1309,8 @@ $break_tablet: 1400px;
                 content: "\f00c";
                 right: 5px;
                 bottom: 3px;
-                font-size: 1em;
                 color: rgb(39, 39, 39);
-                font: var(--fa-font-solid);
+                font: 1em var(--fa-font-solid);
                 position: absolute;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11123

Readdressing what I started in #11098 since the issue wasn't fully fixed.
This PR fixes all character codes changed between Font Awesome 5 and 6. It also removes the use of `font-family` and `font-weight` and replaces them with the new `font: var(--fa-font-solid);` syntax.
Finally, this PR fixes a small alignment issue with the icons in the timeline statistics view where the icon was not centered in the circle.