### PR TITLE
Fix date conversion for colored expiration date

### DIFF
--- a/src/Contract.php
+++ b/src/Contract.php
@@ -1764,7 +1764,7 @@ class Contract extends CommonDBTM
             $start_date = Html::convDate($item->fields['begin_date']);
             echo Search::showItem($p['output_type'], $start_date, $item_num, $p['row_num'], $align);
 
-            $end_date = Html::convDate(Infocom::getWarrantyExpir($item->fields['begin_date'], $item->fields['duration'], 0, true));
+            $end_date = Infocom::getWarrantyExpir($item->fields['begin_date'], $item->fields['duration'], 0, true);
             echo Search::showItem($p['output_type'], $end_date, $item_num, $p['row_num'], $align);
 
             $comment = $item->fields['comment'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature? |  no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The date returned from `Infocom::getWarrantyExpire` may be wrapped in a span element if the test is colored. Whether it is or not, the date is always converted so there is no need to try and convert it again. Doing so when the text is inside a span was causing a PHP error to thrown.