### PR TITLE
Enhance Sanitizer API

### DIFF
--- a/ajax/inputtext.php
+++ b/ajax/inputtext.php
@@ -46,6 +46,6 @@ if (isset($_POST['name'])) {
     echo "<input type='text' " . (isset($_POST["size"]) ? " size='" . $_POST["size"] . "' " : "") . " " .
          (isset($_POST["maxlength"]) ? "maxlength='" . $_POST["maxlength"] . "' " : "") . " name='" .
          $_POST['name'] . "' value=\"" .
-         Html::cleanInputText(Sanitizer::sanitize(rawurldecode(stripslashes($_POST["data"])), false)) .
+         Html::cleanInputText(Sanitizer::encodeHtmlSpecialChars(rawurldecode(stripslashes($_POST["data"])))) .
         "\">";
 }

--- a/ajax/textarea.php
+++ b/ajax/textarea.php
@@ -44,6 +44,6 @@ Session::checkLoginUser();
 if (isset($_POST['name'])) {
     echo "<textarea " . (isset($_POST['rows']) ? " rows='" . $_POST['rows'] . "' " : "") . " " .
          (isset($_POST['cols']) ? " cols='" . $_POST['cols'] . "' " : "") . "  name='" . $_POST['name'] . "'>";
-    echo Html::cleanPostForTextArea(Sanitizer::sanitize(rawurldecode(($_POST["data"])), false));
+    echo Html::cleanPostForTextArea(Sanitizer::encodeHtmlSpecialChars(rawurldecode(($_POST["data"]))));
     echo "</textarea>";
 }

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -8441,7 +8441,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
 
         $tables[DomainRecordType::getTable()] = DomainRecordType::getDefaults();
         $tables[DomainRelation::getTable()] = DomainRelation::getDefaults();
-        $tables[NetworkPortType::getTable()] = Sanitizer::sanitize(NetworkPortType::getDefaults(), false);
+        $tables[NetworkPortType::getTable()] = Sanitizer::encodeHtmlSpecialCharsRecursive(NetworkPortType::getDefaults());
 
         $tables['glpi_agenttypes'] = [
             [

--- a/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
@@ -426,7 +426,7 @@ if (!$DB->tableExists('glpi_networkporttypes') || countElementsInTable(NetworkPo
     if (!$DB->tableExists('glpi_networkporttypes')) {
         $migration->migrationOneTable(NetworkPortType::getTable());
     }
-    $default_types = Sanitizer::sanitize(NetworkPortType::getDefaults(), false);
+    $default_types = Sanitizer::encodeHtmlSpecialCharsRecursive(NetworkPortType::getDefaults());
     $reference = array_replace(
         $default_types[0],
         array_fill_keys(

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -690,7 +690,7 @@ class Agent extends CommonDBTM
 
         switch ($request) {
             case self::ACTION_STATUS:
-                $data['answer'] = Sanitizer::sanitize(preg_replace('/status: /', '', $raw_content), false);
+                $data['answer'] = Sanitizer::encodeHtmlSpecialChars(preg_replace('/status: /', '', $raw_content));
                 break;
             case self::ACTION_INVENTORY:
                 $now = new DateTime();

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -997,7 +997,7 @@ class Auth extends CommonGLPI
         if (!$DB->isSlave()) {
            // GET THE IP OF THE CLIENT
             $ip = getenv("HTTP_X_FORWARDED_FOR") ?
-            Sanitizer::sanitize(getenv("HTTP_X_FORWARDED_FOR"), false) :
+            Sanitizer::encodeHtmlSpecialChars(getenv("HTTP_X_FORWARDED_FOR")) :
             getenv("REMOTE_ADDR");
 
             if ($this->auth_succeded) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -2019,7 +2019,7 @@ class Config extends CommonDBTM
         echo wordwrap($msg . "\n", $p['word_wrap_width'], "\n\t");
 
         if (isset($_SERVER["HTTP_USER_AGENT"])) {
-            echo "\t" . Sanitizer::sanitize($_SERVER["HTTP_USER_AGENT"], false) . "\n";
+            echo "\t" . Sanitizer::encodeHtmlSpecialChars($_SERVER["HTTP_USER_AGENT"]) . "\n";
         }
 
         foreach ($DB->getInfo() as $key => $val) {

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -1702,7 +1702,7 @@ final class DbUtils
 
         $base_name = $objectName;
 
-        $objectName = Sanitizer::unsanitize($objectName);
+        $objectName = Sanitizer::decodeHtmlSpecialChars($objectName);
         $was_sanitized = $objectName !== $base_name;
         if ($was_sanitized) {
             Toolbox::deprecated('Handling of encoded/escaped value in autoName() is deprecated.');
@@ -1846,7 +1846,7 @@ final class DbUtils
         );
 
         if ($was_sanitized) {
-            $objectName = Sanitizer::sanitize($objectName, false);
+            $objectName = Sanitizer::encodeHtmlSpecialChars($objectName);
         }
 
         return $objectName;

--- a/src/Html.php
+++ b/src/Html.php
@@ -4130,7 +4130,7 @@ JAVASCRIPT
             echo "<tr><th>KEY</th><th>=></th><th>VALUE</th></tr>";
 
             foreach ($tab as $key => $val) {
-                $key = Sanitizer::sanitize($key, false);
+                $key = Sanitizer::encodeHtmlSpecialChars($key);
                 echo "<tr><td>";
                 echo $key;
                 $is_array = is_array($val);

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -6787,7 +6787,7 @@ JAVASCRIPT;
                     $input = [
                         'itemtype'        => 'Ticket',
                         'items_id'        => $merge_target_id,
-                        'content'         => $DB->escape($ticket->fields['name'] . Sanitizer::sanitize("<br /><br />", false) . $ticket->fields['content']),
+                        'content'         => $DB->escape($ticket->fields['name'] . Sanitizer::encodeHtmlSpecialChars("<br /><br />") . $ticket->fields['content']),
                         'users_id'        => $ticket->fields['users_id_recipient'],
                         'date_creation'   => $ticket->fields['date_creation'],
                         'date_mod'        => $ticket->fields['date_mod'],

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -276,8 +276,8 @@ class Toolbox
      **/
     public static function clean_cross_side_scripting_deep($value)
     {
-        Toolbox::deprecated('Use "Glpi\Toolbox\Sanitizer::sanitize()"');
-        return Sanitizer::sanitize($value, false);
+        Toolbox::deprecated('Use "Glpi\Toolbox\Sanitizer::encodeHtmlSpecialCharsRecursive()"');
+        return Sanitizer::encodeHtmlSpecialCharsRecursive($value);
     }
 
 
@@ -294,9 +294,9 @@ class Toolbox
      **/
     public static function unclean_cross_side_scripting_deep($value)
     {
-        Toolbox::deprecated('Use "Glpi\Toolbox\Sanitizer::unsanitize()"');
+        Toolbox::deprecated('Use "Glpi\Toolbox\Sanitizer::decodeHtmlSpecialCharsRecursive()"');
         global $DB;
-        return $DB->escape(Sanitizer::unsanitize($value));
+        return $DB->escape(Sanitizer::decodeHtmlSpecialCharsRecursive($value));
     }
 
     /**
@@ -2623,7 +2623,7 @@ class Toolbox
                       // 1 - Replace direct tag (with prefix and suffix) by the image
                         $content_text = preg_replace(
                             '/' . Document::getImageTag($image['tag']) . '/',
-                            Sanitizer::sanitize($img, false),
+                            Sanitizer::encodeHtmlSpecialChars($img),
                             $content_text
                         );
 
@@ -2665,7 +2665,7 @@ class Toolbox
                                 $new_image,
                                 Sanitizer::unsanitize($content_text)
                             );
-                            $content_text = Sanitizer::sanitize($content_text, false);
+                            $content_text = Sanitizer::encodeHtmlSpecialChars($content_text);
                         }
 
                         // If the tag is from another ticket : link document to ticket

--- a/src/Toolbox/Sanitizer.php
+++ b/src/Toolbox/Sanitizer.php
@@ -60,8 +60,8 @@ class Sanitizer
     {
         if (is_array($value)) {
             return array_map(
-                function ($val) use ($db_escape) {
-                    return self::sanitize($val, $db_escape);
+                function ($val) {
+                    return self::sanitize($val);
                 },
                 $value
             );
@@ -261,6 +261,31 @@ class Sanitizer
     }
 
     /**
+     * Recursively encode HTML special chars on an array.
+     *
+     * @param array $values
+     *
+     * @return array
+     *
+     * @see self::encodeHtmlSpecialChars
+     */
+    public static function encodeHtmlSpecialCharsRecursive(array $values): array
+    {
+        return array_map(
+            function ($value) {
+                if (is_array($value)) {
+                    return self::encodeHtmlSpecialCharsRecursive($value);
+                }
+                if (is_string($value)) {
+                    return self::encodeHtmlSpecialChars($value);
+                }
+                return $value;
+            },
+            $values
+        );
+    }
+
+    /**
      * Decode HTML special chars.
      *
      * @param string $value
@@ -298,7 +323,32 @@ class Sanitizer
     }
 
     /**
-     * Escape special chars to protect DB queries.
+     * Recursively decode HTML special chars on an array.
+     *
+     * @param array $values
+     *
+     * @return array
+     *
+     * @see self::decodeHtmlSpecialChars
+     */
+    public static function decodeHtmlSpecialCharsRecursive(array $values): array
+    {
+        return array_map(
+            function ($value) {
+                if (is_array($value)) {
+                    return self::decodeHtmlSpecialCharsRecursive($value);
+                }
+                if (is_string($value)) {
+                    return self::decodeHtmlSpecialChars($value);
+                }
+                return $value;
+            },
+            $values
+        );
+    }
+
+    /**
+     * Escape DB special chars to protect DB queries.
      *
      * @param string $value
      *
@@ -314,6 +364,31 @@ class Sanitizer
 
         global $DB;
         return $DB->escape($value);
+    }
+
+    /**
+     * Recursively escape DB special chars.
+     *
+     * @param array $values
+     *
+     * @return array
+     *
+     * @see self::dbEscape
+     */
+    public static function dbEscapeRecursive(array $values): array
+    {
+        return array_map(
+            function ($value) {
+                if (is_array($value)) {
+                    return self::dbEscapeRecursive($value);
+                }
+                if (is_string($value)) {
+                    return self::dbEscape($value);
+                }
+                return $value;
+            },
+            $values
+        );
     }
 
     /**
@@ -369,5 +444,30 @@ class Sanitizer
         }
 
         return $value;
+    }
+
+    /**
+     * Recursively revert `mysqli::real_escape_string()` transformation.
+     *
+     * @param array $values
+     *
+     * @return array
+     *
+     * @see self::dbUnescape
+     */
+    public static function dbUnescapeRecursive(array $values): array
+    {
+        return array_map(
+            function ($value) {
+                if (is_array($value)) {
+                    return self::dbUnescapeRecursive($value);
+                }
+                if (is_string($value)) {
+                    return self::dbUnescape($value);
+                }
+                return $value;
+            },
+            $values
+        );
     }
 }

--- a/tests/functionnal/RuleTicket.php
+++ b/tests/functionnal/RuleTicket.php
@@ -882,7 +882,7 @@ class RuleTicket extends DbTestCase
         $this->array($ticket_tasks)->hasSize(1);
         $task_data = array_pop($ticket_tasks);
         $this->array($task_data)->hasKey('content');
-        $this->string($task_data['content'])->isEqualTo(Sanitizer::sanitize('<p>test content</p>', false));
+        $this->string($task_data['content'])->isEqualTo(Sanitizer::encodeHtmlSpecialChars('<p>test content</p>'));
 
        // Test on update
         $ticket_em = new \Ticket();
@@ -912,7 +912,7 @@ class RuleTicket extends DbTestCase
         $task_data = array_pop($ticket_tasks);
         $this->array($task_data)->hasKey('content');
         $this->string($task_data['content'])->isEqualTo(
-            Sanitizer::sanitize('<p>test content</p>', false)
+            Sanitizer::encodeHtmlSpecialChars('<p>test content</p>')
         );
 
        // Add a second action to the rule (test multiple creation)
@@ -942,13 +942,13 @@ class RuleTicket extends DbTestCase
         $task_data = array_pop($ticket_tasks);
         $this->array($task_data)->hasKey('content');
         $this->string($task_data['content'])->isEqualTo(
-            Sanitizer::sanitize('<p>test content 2</p>', false)
+            Sanitizer::encodeHtmlSpecialChars('<p>test content 2</p>')
         );
 
         $task_data = array_pop($ticket_tasks);
         $this->array($task_data)->hasKey('content');
         $this->string($task_data['content'])->isEqualTo(
-            Sanitizer::sanitize('<p>test content</p>', false)
+            Sanitizer::encodeHtmlSpecialChars('<p>test content</p>')
         );
     }
 
@@ -1014,7 +1014,7 @@ class RuleTicket extends DbTestCase
         $ticket_followups_data = array_pop($ticket_followups);
         $this->array($ticket_followups_data)->hasKey('content');
         $this->string($ticket_followups_data['content'])->isEqualTo(
-            Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule</p>', false)
+            Sanitizer::encodeHtmlSpecialChars('<p>test testFollowupTemplateAssignFromRule</p>')
         );
 
        // Test on update
@@ -1049,7 +1049,7 @@ class RuleTicket extends DbTestCase
         $ticket_followups_data = array_pop($ticket_followups);
         $this->array($ticket_followups_data)->hasKey('content');
         $this->string($ticket_followups_data['content'])->isEqualTo(
-            Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule</p>', false)
+            Sanitizer::encodeHtmlSpecialChars('<p>test testFollowupTemplateAssignFromRule</p>')
         );
 
        // Add a second action to the rule (test multiple creation)
@@ -1081,13 +1081,13 @@ class RuleTicket extends DbTestCase
         $ticket_followups_data = array_pop($ticket_followups);
         $this->array($ticket_followups_data)->hasKey('content');
         $this->string($ticket_followups_data['content'])->isEqualTo(
-            Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule 2</p>', false)
+            Sanitizer::encodeHtmlSpecialChars('<p>test testFollowupTemplateAssignFromRule 2</p>')
         );
 
         $ticket_followups_data = array_pop($ticket_followups);
         $this->array($ticket_followups_data)->hasKey('content');
         $this->string($ticket_followups_data['content'])->isEqualTo(
-            Sanitizer::sanitize('<p>test testFollowupTemplateAssignFromRule</p>', false)
+            Sanitizer::encodeHtmlSpecialChars('<p>test testFollowupTemplateAssignFromRule</p>')
         );
     }
 

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -252,7 +252,7 @@ class Ticket extends DbTestCase
 
        // 6.1 -> check first task
         $taskA = array_shift($found_tasks);
-        $this->string($taskA['content'])->isIdenticalTo(Sanitizer::sanitize('<p>my task template A</p>', false));
+        $this->string($taskA['content'])->isIdenticalTo(Sanitizer::encodeHtmlSpecialChars('<p>my task template A</p>'));
         $this->variable($taskA['taskcategories_id'])->isEqualTo($taskcat_id);
         $this->variable($taskA['actiontime'])->isEqualTo(60);
         $this->variable($taskA['is_private'])->isEqualTo(1);
@@ -262,7 +262,7 @@ class Ticket extends DbTestCase
 
        // 6.2 -> check second task
         $taskB = array_shift($found_tasks);
-        $this->string($taskB['content'])->isIdenticalTo(Sanitizer::sanitize('<p>my task template B</p>', false));
+        $this->string($taskB['content'])->isIdenticalTo(Sanitizer::encodeHtmlSpecialChars('<p>my task template B</p>'));
         $this->variable($taskB['taskcategories_id'])->isEqualTo($taskcat_id);
         $this->variable($taskB['actiontime'])->isEqualTo(120);
         $this->variable($taskB['is_private'])->isEqualTo(0);

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -547,7 +547,7 @@ class Toolbox extends DbTestCase
 
        // Processed data is expected to be escaped
         $content_text = \Toolbox::addslashes_deep($content_text);
-        $expected_result = Sanitizer::sanitize($expected_result, false);
+        $expected_result = Sanitizer::encodeHtmlSpecialChars($expected_result);
 
         $this->string(
             \Toolbox::convertTagToImage($content_text, $item, [$doc_id => ['tag' => $img_tag]])
@@ -605,7 +605,7 @@ class Toolbox extends DbTestCase
 
        // Processed data is expected to be escaped
         $content_text = \Toolbox::addslashes_deep($content_text);
-        $expected_result = Sanitizer::sanitize($expected_result, false);
+        $expected_result = Sanitizer::encodeHtmlSpecialChars($expected_result);
 
        // Save old config
         global $CFG_GLPI;
@@ -679,7 +679,7 @@ class Toolbox extends DbTestCase
 
        // Processed data is expected to be escaped
         $content_text = \Toolbox::addslashes_deep($content_text);
-        $expected_result = Sanitizer::sanitize($expected_result, false);
+        $expected_result = Sanitizer::encodeHtmlSpecialChars($expected_result);
 
         $this->string(
             \Toolbox::convertTagToImage($content_text, $item, $doc_data)
@@ -724,8 +724,8 @@ class Toolbox extends DbTestCase
 
        // Processed data is expected to be escaped
         $content_text = \Toolbox::addslashes_deep($content_text);
-        $expected_result_1 = Sanitizer::sanitize($expected_result_1, false);
-        $expected_result_2 = Sanitizer::sanitize($expected_result_2, false);
+        $expected_result_1 = Sanitizer::encodeHtmlSpecialChars($expected_result_1);
+        $expected_result_2 = Sanitizer::encodeHtmlSpecialChars($expected_result_2);
 
         $this->string(
             \Toolbox::convertTagToImage($content_text, $item, [$doc_id_1 => ['tag' => $img_tag]])
@@ -765,7 +765,7 @@ class Toolbox extends DbTestCase
 
        // Processed data is expected to be escaped
         $content_text = \Toolbox::addslashes_deep($content_text);
-        $expected_result = Sanitizer::sanitize($expected_result, false);
+        $expected_result = Sanitizer::encodeHtmlSpecialChars($expected_result);
 
         $this->string(
             \Toolbox::convertTagToImage($content_text, $item, [$doc_id => ['tag' => $img_tag]])

--- a/tests/units/Glpi/RichText/RichText.php
+++ b/tests/units/Glpi/RichText/RichText.php
@@ -78,12 +78,12 @@ class RichText extends \GLPITestCase
 XML;
         $content = '<h1>XML example</h1>' . "\n" . htmlentities($xml_sample);
         yield [
-            'content'                => Sanitizer::sanitize($content, false), // Without quotes escaping
+            'content'                => Sanitizer::encodeHtmlSpecialChars($content), // Without quotes escaping
             'encode_output_entities' => false,
             'expected_result'        => $content,
         ];
         yield [
-            'content'                => Sanitizer::sanitize($content, true), // With quotes escaping
+            'content'                => Sanitizer::sanitize($content), // With quotes escaping
             'encode_output_entities' => false,
             'expected_result'        => $content,
         ];
@@ -364,14 +364,14 @@ XML;
 XML example <?xml version="1.0" encoding="UTF-8"?> <root> <desc><![CDATA[Some CDATA content]]></desc> <url>http://www.glpi-project.org/void?test=1&amp;debug=1</url> </root>
 PLAINTEXT;
         yield [
-            'content'                => Sanitizer::sanitize($content, false), // Without quotes escaping
+            'content'                => Sanitizer::encodeHtmlSpecialChars($content), // Without quotes escaping
             'keep_presentation'      => false,
             'compact'                => false,
             'encode_output_entities' => false,
             'expected_result'        => $result,
         ];
         yield [
-            'content'                => Sanitizer::sanitize($content, true), // With quotes escaping
+            'content'                => Sanitizer::sanitize($content), // With quotes escaping
             'keep_presentation'      => false,
             'compact'                => false,
             'encode_output_entities' => false,

--- a/tests/units/Glpi/Toolbox/DataExport.php
+++ b/tests/units/Glpi/Toolbox/DataExport.php
@@ -57,7 +57,7 @@ class DataExport extends \GLPITestCase
 
         // Ticket title column
         yield [
-            'value'           => Sanitizer::sanitize(<<<HTML
+            'value'           => Sanitizer::encodeHtmlSpecialChars(<<<HTML
 <a id="Ticket1" href="/front/ticket.form.php?id=1" data-hasqtip="0">Ticket title</a>
 <div id="contentTicket1" class="invisible"><div class="content"><p>Ticket content ...</p></div></div>
 <script type="text/javascript">
@@ -69,15 +69,15 @@ $(function(){\$('#Ticket1').qtip({
 
 //]]>
 </script>
-HTML, false),
+HTML),
             'expected_result' => 'Ticket title',
         ];
 
         // Ticket status
         yield [
-            'value'           => Sanitizer::sanitize(<<<HTML
+            'value'           => Sanitizer::encodeHtmlSpecialChars(<<<HTML
 <i class="itilstatus far fa-circle assigned me-1" title="" data-bs-toggle="tooltip" data-bs-original-title="Processing (assigned)" aria-label="Processing (assigned)"></i>&nbsp;Processing (assigned)</span>
-HTML, false),
+HTML),
             'expected_result' => 'Processing (assigned)',
         ];
     }

--- a/tests/units/Glpi/Toolbox/Sanitizer.php
+++ b/tests/units/Glpi/Toolbox/Sanitizer.php
@@ -572,8 +572,7 @@ TXT;
         $sanitizer = $this->newTestedInstance();
 
         // Value should stay the same if it has been sanitized then unsanitized
-        $this->variable($sanitizer->unsanitize($sanitizer->sanitize($value, true)))->isEqualTo($value);
-        $this->variable($sanitizer->unsanitize($sanitizer->sanitize($value, false)))->isEqualTo($value);
+        $this->variable($sanitizer->unsanitize($sanitizer->sanitize($value)))->isEqualTo($value);
 
         // Re-sanitize a value provide the same result as first sanitization
         $this->variable($sanitizer->sanitize($sanitizer->unsanitize($value)))->isEqualTo($sanitized_value);

--- a/tests/units/Glpi/Toolbox/Sanitizer.php
+++ b/tests/units/Glpi/Toolbox/Sanitizer.php
@@ -40,7 +40,7 @@ class Sanitizer extends \GLPITestCase
 {
     protected function rawValueProvider(): iterable
     {
-       // Non string values should not be altered
+        // Non string values should not be altered
         yield [
             'value'           => null,
             'sanitized_value' => null,
@@ -63,36 +63,45 @@ class Sanitizer extends \GLPITestCase
             'sanitized_value' => $tempfile,
         ];
 
-       // Strings should be sanitized
+        // Strings should be sanitized
         yield [
-            'value'           => 'mystring',
-            'sanitized_value' => 'mystring',
+            'value'             => 'mystring',
+            'sanitized_value'   => 'mystring',
+            'htmlencoded_value' => 'mystring',
+            'dbescaped_value'   => 'mystring',
         ];
         yield [
-            'value'           => '5 > 1',
-            'sanitized_value' => '5 &#62; 1',
+            'value'             => '5 > 1',
+            'sanitized_value'   => '5 &#62; 1',
+            'htmlencoded_value' => '5 &#62; 1',
+            'dbescaped_value'   => '5 > 1',
         ];
         yield [
-            'value'           => '<strong>string</strong>',
-            'sanitized_value' => '&#60;strong&#62;string&#60;/strong&#62;',
+            'value'             => '<strong>string</strong>',
+            'sanitized_value'   => '&#60;strong&#62;string&#60;/strong&#62;',
+            'htmlencoded_value' => '&#60;strong&#62;string&#60;/strong&#62;',
+            'dbescaped_value'   => '<strong>string</strong>',
         ];
         yield [
-            'value'           => "<strong>text with slashable chars ' \n \"</strong>",
-            'sanitized_value' => "&#60;strong&#62;text with slashable chars \' \\n \\\"&#60;/strong&#62;",
-            'add_slashes'     => true,
+            'value'             => "<strong>text with slashable chars ' \n \"</strong>",
+            'sanitized_value'   => "&#60;strong&#62;text with slashable chars \' \\n \\\"&#60;/strong&#62;",
+            'htmlencoded_value' => "&#60;strong&#62;text with slashable chars ' \n \"&#60;/strong&#62;",
+            'dbescaped_value'   => "<strong>text with slashable chars \' \\n \\\"</strong>",
         ];
         yield [
-            'value'           => "text with ending slashable chars '\n\"",
-            'sanitized_value' => "text with ending slashable chars \'\\n\\\"",
-            'add_slashes'     => true,
+            'value'             => "text with ending slashable chars '\n\"",
+            'sanitized_value'   => "text with ending slashable chars \'\\n\\\"",
+            'htmlencoded_value' => "text with ending slashable chars '\n\"",
+            'dbescaped_value'   => "text with ending slashable chars \'\\n\\\"",
         ];
         yield [
-            'value'           => "<p>HTML containing a code snippet</p><pre>&lt;a href=&quot;/test&quot;&gt;link&lt;/a&gt;</pre>",
-            'sanitized_value' => "&#60;p&#62;HTML containing a code snippet&#60;/p&#62;&#60;pre&#62;&#38;lt;a href=&#38;quot;/test&#38;quot;&#38;gt;link&#38;lt;/a&#38;gt;&#60;/pre&#62;",
-            'add_slashes'     => true,
+            'value'             => '<p>HTML containing a code snippet</p><pre>&lt;a href=&quot;/test&quot;&gt;link&lt;/a&gt;</pre>',
+            'sanitized_value'   => '&#60;p&#62;HTML containing a code snippet&#60;/p&#62;&#60;pre&#62;&#38;lt;a href=&#38;quot;/test&#38;quot;&#38;gt;link&#38;lt;/a&#38;gt;&#60;/pre&#62;',
+            'htmlencoded_value' => '&#60;p&#62;HTML containing a code snippet&#60;/p&#62;&#60;pre&#62;&#38;lt;a href=&#38;quot;/test&#38;quot;&#38;gt;link&#38;lt;/a&#38;gt;&#60;/pre&#62;',
+            'dbescaped_value'   => '<p>HTML containing a code snippet</p><pre>&lt;a href=&quot;/test&quot;&gt;link&lt;/a&gt;</pre>',
         ];
 
-       // Strings in array should be sanitized
+        // Strings in array should be sanitized
         yield [
             'value'           => [null, '<strong>string</strong>', 3.2, 'string', true, '<p>my</p>', 9798],
             'sanitized_value' => [null, '&#60;strong&#62;string&#60;/strong&#62;', 3.2, 'string', true, '&#60;p&#62;my&#60;/p&#62;', 9798],
@@ -100,31 +109,26 @@ class Sanitizer extends \GLPITestCase
         yield [
             'value'           => [null, "<strong>text with slashable chars ' \n \"</strong>", 3.2, 'string', true, '<p>my</p>', 9798],
             'sanitized_value' => [null, "&#60;strong&#62;text with slashable chars \' \\n \\\"&#60;/strong&#62;", 3.2, 'string', true, '&#60;p&#62;my&#60;/p&#62;', 9798],
-            'add_slashes'     => true,
         ];
 
-       // Namespaced itemtypes should not be sanitized
+        // Namespaced itemtypes and MassiveAction identifier / "Class::method" callable should not be sanitized
         yield [
             'value'           => 'Glpi\Dashboard\Dashboard',
             'sanitized_value' => 'Glpi\Dashboard\Dashboard',
-            'add_slashes'     => true,
         ];
         yield [
             'value'           => ['itemtype' => 'Glpi\Dashboard\Dashboard'],
             'sanitized_value' => ['itemtype' => 'Glpi\Dashboard\Dashboard'],
-            'add_slashes'     => true,
         ];
 
-        // MassiveAction identifier / "Class::method" callable syntax should not be sanitized
+        //  syntax should not be sanitized
         yield [
             'value'           => 'Glpi\Socket:update',
             'sanitized_value' => 'Glpi\Socket:update',
-            'add_slashes'     => true,
         ];
         yield [
             'value'           => 'Glpi\Socket:update\' OR 1 = 1', // invalid syntax, should be sanitized
             'sanitized_value' => 'Glpi\\\Socket:update\\\' OR 1 = 1',
-            'add_slashes'     => true,
         ];
     }
 
@@ -134,10 +138,54 @@ class Sanitizer extends \GLPITestCase
     public function testSanitize(
         $value,
         $sanitized_value,
-        bool $add_slashes = false
+        $htmlencoded_value = null,
+        $dbescaped_value = null
     ) {
         $sanitizer = $this->newTestedInstance();
-        $this->variable($sanitizer->sanitize($value, $add_slashes))->isEqualTo($sanitized_value);
+        $this->variable($sanitizer->sanitize($value))->isEqualTo($sanitized_value);
+
+        // Calling sanitize on sanitized value should have no effect
+        $this->variable($sanitizer->sanitize($sanitized_value))->isEqualTo($sanitized_value);
+    }
+
+    /**
+     * @dataProvider rawValueProvider
+     */
+    public function testEncodeHtmlSpecialChars(
+        $value,
+        $sanitized_value,
+        $htmlencoded_value = null,
+        $dbescaped_value = null
+    ) {
+        if ($htmlencoded_value === null) {
+            return; // Unrelated entry in provider
+        }
+
+        $sanitizer = $this->newTestedInstance();
+        $this->variable($sanitizer->encodeHtmlSpecialChars($value))->isEqualTo($htmlencoded_value);
+
+        // Calling encodeHtmlSpecialChars on escaped value should have no effect
+        $this->variable($sanitizer->encodeHtmlSpecialChars($htmlencoded_value))->isEqualTo($htmlencoded_value);
+    }
+
+    /**
+     * @dataProvider rawValueProvider
+     */
+    public function testDbEscape(
+        $value,
+        $sanitized_value,
+        $htmlencoded_value = null,
+        $dbescaped_value = null
+    ) {
+        if ($dbescaped_value === null) {
+            return; // Unrelated entry in provider
+        }
+
+        $sanitizer = $this->newTestedInstance();
+        $this->variable($sanitizer->dbEscape($value))->isEqualTo($dbescaped_value);
+
+        // Calling dbEscape on escaped value should have no effect
+        $this->variable($sanitizer->dbEscape($dbescaped_value))->isEqualTo($dbescaped_value);
     }
 
     protected function sanitizedValueProvider(): iterable
@@ -146,10 +194,12 @@ class Sanitizer extends \GLPITestCase
             yield [
                 'value'             => $data['sanitized_value'],
                 'unsanitized_value' => $data['value'],
+                'htmlencoded_value' => $data['htmlencoded_value'] ?? null,
+                'dbescaped_value'   => $data['dbescaped_value'] ?? null,
             ];
         }
 
-       // Data produced by old XSS cleaning process
+        // Data produced by old XSS cleaning process
         yield [
             'value'             => '&lt;strong&gt;string&lt;/strong&gt;',
             'unsanitized_value' => '<strong>string</strong>',
@@ -171,13 +221,55 @@ class Sanitizer extends \GLPITestCase
      */
     public function testUnanitize(
         $value,
-        $unsanitized_value
+        $unsanitized_value,
+        $htmlencoded_value = null,
+        $dbescaped_value = null
     ) {
         $sanitizer = $this->newTestedInstance();
         $this->variable($sanitizer->unsanitize($value))->isEqualTo($unsanitized_value);
 
-       // Calling unsanitize multiple times should not corrupt unsanitized value
+        // Calling unsanitize multiple times should not corrupt unsanitized value
         $this->variable($sanitizer->unsanitize($unsanitized_value))->isEqualTo($unsanitized_value);
+    }
+
+    /**
+     * @dataProvider sanitizedValueProvider
+     */
+    public function testDbUnescape(
+        $value,
+        $unsanitized_value,
+        $htmlencoded_value = null,
+        $dbescaped_value = null
+    ) {
+        if ($dbescaped_value === null) {
+            return; // Unrelated entry in provider
+        }
+
+        $sanitizer = $this->newTestedInstance();
+        $this->variable($sanitizer->dbUnescape($dbescaped_value))->isEqualTo($unsanitized_value);
+
+        // Calling dbUnescape multiple times should not corrupt value
+        $this->variable($sanitizer->dbUnescape($unsanitized_value))->isEqualTo($unsanitized_value);
+    }
+
+    /**
+     * @dataProvider sanitizedValueProvider
+     */
+    public function testDecodeHtmlSpecialChars(
+        $value,
+        $unsanitized_value,
+        $htmlencoded_value = null,
+        $dbescaped_value = null
+    ) {
+        if ($htmlencoded_value === null) {
+            return; // Unrelated entry in provider
+        }
+
+        $sanitizer = $this->newTestedInstance();
+        $this->variable($sanitizer->decodeHtmlSpecialChars($htmlencoded_value))->isEqualTo($unsanitized_value);
+
+        // Calling dbUnescape multiple times should not corrupt value
+        $this->variable($sanitizer->decodeHtmlSpecialChars($unsanitized_value))->isEqualTo($unsanitized_value);
     }
 
     protected function isHtmlEncodedValueProvider(): iterable
@@ -221,11 +313,11 @@ class Sanitizer extends \GLPITestCase
         $this->boolean($sanitizer->isHtmlEncoded($value))->isEqualTo($is_encoded);
     }
 
-    protected function isEscapedValueProvider(): iterable
+    protected function isDbEscapedValueProvider(): iterable
     {
         global $DB;
 
-       // Raw char should not be considered as escaped
+        // Raw char should not be considered as escaped
         yield [
             'value'      => "\\", // raw string: `[BACKSLASH]`
             'is_escaped' => false,
@@ -243,7 +335,7 @@ class Sanitizer extends \GLPITestCase
             'is_escaped' => false,
         ];
 
-       // Values escaped by $DB should be considered as escaped
+        // Values escaped by $DB should be considered as escaped
         yield [
             'value'      => $DB->escape("\\"), // raw string: `[BACKSLASH]`
             'is_escaped' => true,
@@ -261,7 +353,7 @@ class Sanitizer extends \GLPITestCase
             'is_escaped' => true,
         ];
 
-       // Manually backslashed char should be considered as escaped
+        // Manually backslashed char should be considered as escaped
         yield [
             'value'      => "\\\\", // raw string: `\[BACKSLASH]`
             'is_escaped' => true,
@@ -279,7 +371,7 @@ class Sanitizer extends \GLPITestCase
             'is_escaped' => true,
         ];
 
-       // 2 x backslashes do not escape quotes/backslashes.
+        // 2 x backslashes do not escape quotes/backslashes.
         yield [
             'value'      => "\\\\\\", // raw string: `\[BACKSLASH][BACKSLASH]` (i.e. escaped backslash + unescaped backslash)
             'is_escaped' => false,
@@ -293,7 +385,7 @@ class Sanitizer extends \GLPITestCase
             'is_escaped' => false,
         ];
 
-       // 3 x backslashes do escape quotes/backslashes (escaped backslash followed by escaped char).
+        // 3 x backslashes do escape quotes/backslashes (escaped backslash followed by escaped char).
         yield [
             'value'      => "\\\\\\\\", // raw string: `\[BACKSLASH]\[BACKSLASH]` (i.e. escaped backslash + escaped backslash)
             'is_escaped' => true,
@@ -307,7 +399,7 @@ class Sanitizer extends \GLPITestCase
             'is_escaped' => true,
         ];
 
-       // Control chars already contains a backslash which should not be considered as an escaping backslash.
+        // Control chars already contains a backslash which should not be considered as an escaping backslash.
         yield [
             'value'      => "\\\n", // raw string: `[BACKSLASH][EOL]` (i.e. unescaped backslash + unescaped EOL)
             'is_escaped' => false,
@@ -325,7 +417,7 @@ class Sanitizer extends \GLPITestCase
             'is_escaped' => false,
         ];
 
-       // `a` is not escapable, so preceding backslash has to be considered as an unescaped backslash.
+        // `a` is not escapable, so preceding backslash has to be considered as an unescaped backslash.
         yield [
             'value'      => "\a", // raw string: `[BACKSLASH]a` (i.e. unescaped backslash + `a`)
             'is_escaped' => false,
@@ -347,7 +439,7 @@ class Sanitizer extends \GLPITestCase
             'is_escaped' => false,
         ];
 
-       // Check real values
+        // Check real values
         $txt = <<<TXT
 This string contains unexpected chars:
 - ' (a quote);
@@ -363,7 +455,7 @@ TXT;
             'is_escaped' => true,
         ];
 
-       // Values with no special chars are never considered as escaped, as escaping process cannot alter them.
+        // Values with no special chars are never considered as escaped, as escaping process cannot alter them.
         yield [
             'value'      => 'String with no escapable char',
             'is_escaped' => false,
@@ -375,7 +467,7 @@ TXT;
     }
 
     /**
-     * @dataProvider isEscapedValueProvider
+     * @dataProvider isDbEscapedValueProvider
      */
     public function testIsDbEscaped(string $value, bool $is_escaped)
     {
@@ -390,16 +482,17 @@ TXT;
     public function testSanitizationReversibility(
         $value,
         $sanitized_value,
-        bool $add_slashes = false
+        $htmlencoded_value = null,
+        $dbescaped_value = null
     ) {
         $sanitizer = $this->newTestedInstance();
 
-       // Value should stay the same if it has been sanitized then unsanitized
+        // Value should stay the same if it has been sanitized then unsanitized
         $this->variable($sanitizer->unsanitize($sanitizer->sanitize($value, true)))->isEqualTo($value);
         $this->variable($sanitizer->unsanitize($sanitizer->sanitize($value, false)))->isEqualTo($value);
 
-       // Re-sanitize a value provide the same result as first sanitization
-        $this->variable($sanitizer->sanitize($sanitizer->unsanitize($value), $add_slashes))->isEqualTo($sanitized_value);
+        // Re-sanitize a value provide the same result as first sanitization
+        $this->variable($sanitizer->sanitize($sanitizer->unsanitize($value)))->isEqualTo($sanitized_value);
     }
 
     protected function isNsClassOrCallableIdentifierProvider(): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While working on plugins, I figured out that new `Sanitizer` API, and associated deprecation messages, were misunderstood. I propose some changes to make things more clear.

Changes:
- expose `encodeHtmlSpecialChars`, `decodeHtmlSpecialChars`, `dbEscape` and `dbUnescape` and ensure they are non destructive;
- add recursive methods to handle encoding/decoding escaping/unescaping of arrays;
- replace usage of `Sanitizer::sanitize($value, false)` by `Sanitizer::encodeHtmlSpecialChars($value)`, to have a more comprehensible code.
