### PR TITLE
don't check right when updating CommonDBRelation on inventory process

### DIFF
--- a/src/CommonDBConnexity.php
+++ b/src/CommonDBConnexity.php
@@ -299,7 +299,7 @@ abstract class CommonDBConnexity extends CommonDBTM
             }
         }
 
-        if ($have_to_check) {
+        if ($have_to_check && !Session::isInventory()) {
             $new_item = clone $this;
 
            // Solution 1 : If we cannot create the new item or delete the old item,

--- a/src/CommonDBConnexity.php
+++ b/src/CommonDBConnexity.php
@@ -299,7 +299,7 @@ abstract class CommonDBConnexity extends CommonDBTM
             }
         }
 
-        if ($have_to_check && !Session::isInventory()) {
+        if ($have_to_check) {
             $new_item = clone $this;
 
            // Solution 1 : If we cannot create the new item or delete the old item,

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2761,6 +2761,10 @@ class CommonDBTM extends CommonGLPI
      **/
     public function can($ID, $right, array &$input = null)
     {
+        if (Session::isInventory()) {
+            return true;
+        }
+
        // Clean ID :
         $ID = Toolbox::cleanInteger($ID);
 

--- a/src/Inventory/Inventory.php
+++ b/src/Inventory/Inventory.php
@@ -752,7 +752,7 @@ class Inventory
             }
         }
 
-        if (isCommandLine()) {
+        if (isCommandLine() && !defined('TU_USER')) {
             echo $output . "\n";
         } else {
             Toolbox::logInFile(

--- a/src/Session.php
+++ b/src/Session.php
@@ -1122,7 +1122,11 @@ class Session
     {
         global $DB;
 
-       //If GLPI is using the slave DB -> read only mode
+        if (Session::isInventory()) {
+            return true;
+        }
+
+        //If GLPI is using the slave DB -> read only mode
         if (
             $DB->isSlave()
             && ($right & (CREATE | UPDATE | DELETE | PURGE))

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -78,6 +78,18 @@ class DbTestCase extends \GLPITestCase
     }
 
     /**
+     * Log out current user
+     *
+     * @return void
+     */
+    protected function logOut()
+    {
+        $ctime = $_SESSION['glpi_currenttime'];
+        \Session::destroy();
+        $_SESSION['glpi_currenttime'] = $ctime;
+    }
+
+    /**
      * change current entity
      *
      * @param int|string $entityname Name of the entity (or its id)

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkCard.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkCard.php
@@ -248,7 +248,6 @@ class NetworkCard extends AbstractInventoryAsset
      */
     public function testNoVirtuals($xml, $expected, $virtual)
     {
-        $this->login();
         $converter = new \Glpi\Inventory\Converter();
         $data = $converter->convert($xml);
         $json = json_decode($data);
@@ -256,11 +255,15 @@ class NetworkCard extends AbstractInventoryAsset
         $computer = getItemByTypeName('Computer', '_test_pc01');
         $asset = new \Glpi\Inventory\Asset\NetworkCard($computer, $json->content->networks);
         $asset->setExtraData((array)$json->content);
+        $this->login();
         $conf = new \Glpi\Inventory\Conf();
         $this->boolean($conf->saveConf(['component_networkcardvirtual' => 0]))->isTrue();
+        $this->logOut();
         $asset->checkConf($conf);
         $result = $asset->prepare();
+        $this->login();
         $this->boolean($conf->saveConf(['component_networkcardvirtual' => 1]))->isTrue();
+        $this->logOut();
         if ($virtual) {
             $this->array($result)->isEmpty();
         } else {

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkPort.php
@@ -324,7 +324,6 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
      */
     public function testPrepare($xml, $ports, $connections, $vlans, $aggregates)
     {
-        $this->login();
         $converter = new \Glpi\Inventory\Converter();
         $data = $converter->convert($xml);
         $json = json_decode($data);

--- a/tests/functionnal/Glpi/Inventory/Assets/OperatingSystem.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/OperatingSystem.php
@@ -767,7 +767,6 @@ class OperatingSystem extends AbstractInventoryAsset
 
     public function testInventoryUpdate()
     {
-        $this->login();
         $computer = new \Computer();
         $os = new \OperatingSystem();
         $cos = new \Item_OperatingSystem();

--- a/tests/functionnal/Glpi/Inventory/Assets/Volume.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/Volume.php
@@ -431,10 +431,12 @@ class Volume extends AbstractInventoryAsset
                 'component_removablemedia' => 0
             ])
         )->isTrue();
+        $this->logout();
 
        //first inventory should import no disk.
         $inventory = $this->doInventory($xml_source, true);
 
+        $this->login();
         $this->boolean(
             $conf->saveConf([
                 'import_volume' => 1,
@@ -442,6 +444,7 @@ class Volume extends AbstractInventoryAsset
                 'component_removablemedia' => 1
             ])
         )->isTrue();
+        $this->logOut();
 
         $computer = $inventory->getItem();
         $computers_id = $computer->fields['id'];
@@ -451,6 +454,7 @@ class Volume extends AbstractInventoryAsset
         $this->integer(count($disks))->isIdenticalTo(0);
 
        //set config to inventory disks, but no network nor removable
+        $this->login();
         $this->boolean(
             $conf->saveConf([
                 'import_volume' => 1,
@@ -458,10 +462,12 @@ class Volume extends AbstractInventoryAsset
                 'component_removablemedia' => 0
             ])
         )->isTrue();
+        $this->logOut();
 
        //first inventory should import 2 disks (C: and Z:).
         $inventory = $this->doInventory($xml_source, true);
 
+        $this->login();
         $this->boolean(
             $conf->saveConf([
                 'import_volume' => 1,
@@ -469,6 +475,7 @@ class Volume extends AbstractInventoryAsset
                 'component_removablemedia' => 1
             ])
         )->isTrue();
+        $this->logOut();
 
         $computer = $inventory->getItem();
         $computers_id = $computer->fields['id'];
@@ -478,6 +485,7 @@ class Volume extends AbstractInventoryAsset
         $this->integer(count($disks))->isIdenticalTo(2);
 
        //set config to inventory disks, network and removable (the default)
+        $this->login();
         $this->boolean(
             $conf->saveConf([
                 'import_volume' => 1,
@@ -485,6 +493,7 @@ class Volume extends AbstractInventoryAsset
                 'component_removablemedia' => 1
             ])
         )->isTrue();
+        $this->logout();
 
        //inventory should import all 4 disks.
         $inventory = $this->doInventory($xml_source, true);
@@ -506,6 +515,7 @@ class Volume extends AbstractInventoryAsset
         $this->boolean($item_disk->getFromDB($removables_id))->isTrue();
 
        //set config to inventory disks and network, but no removable
+        $this->login();
         $this->boolean(
             $conf->saveConf([
                 'import_volume' => 1,
@@ -513,9 +523,11 @@ class Volume extends AbstractInventoryAsset
                 'component_removablemedia' => 0
             ])
         )->isTrue();
+        $this->logout();
 
-        $inventory = $this->doInventory($xml_source, true);
+        $this->doInventory($xml_source, true);
 
+        $this->login();
         $this->boolean(
             $conf->saveConf([
                 'import_volume' => 1,
@@ -523,6 +535,7 @@ class Volume extends AbstractInventoryAsset
                 'component_removablemedia' => 1
             ])
         )->isTrue();
+        $this->logout();
 
        //3 disks are now been linked to the computer
         $disks = $item_disk->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -4366,6 +4366,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->login();
         $conf = new \Glpi\Inventory\Conf();
         $this->boolean($conf->saveConf(['vm_as_computer' => 1]))->isTrue();
+        $this->logout();
 
         $inventory = $this->doInventory($json);
 


### PR DESCRIPTION
ex update of OS

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://forum.glpi-project.org/viewtopic.php?pid=490556

- update of OS done here https://github.com/glpi-project/glpi/blob/ab8b4df675c0d1b188e5669de484e32f611f1318/src/Inventory/Asset/OperatingSystem.php#L136
- `CommonRelation::prepareInputForUpdate` called with a check on rights : https://github.com/glpi-project/glpi/blob/ab8b4df675c0d1b188e5669de484e32f611f1318/src/CommonDBRelation.php#L766-L770
- as we don't have any rights when doing inventories, false is returned, OS is not updated

Maybe we can up more, by adding return true to `CommonDBTM::can` and `Session::haveRight` when `Session::isIventory` return true also, but it seems too much
