### PR TITLE
when instanciation_type is empty, the old port was deleted depsite be…

### DIFF
--- a/src/Inventory/Asset/InventoryNetworkPort.php
+++ b/src/Inventory/Asset/InventoryNetworkPort.php
@@ -377,6 +377,8 @@ trait InventoryNetworkPort
                 foreach (['name', 'mac', 'instantiation_type'] as $field) {
                     if (property_exists($data, $field)) {
                         $comp_data[$field] = strtolower($data->$field);
+                    } else {
+                        $comp_data[$field] = "";
                     }
                 }
 

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -1754,8 +1754,8 @@ class Inventory extends InventoryTestCase
             \Log::HISTORY_DEL_RELATION => 2,//monitor-computer relation
             \Log::HISTORY_ADD_SUBITEM => 1211,//network port/name, ip address, VMs, Software
             \Log::HISTORY_UPDATE_SUBITEM => 828,//disks usage, softwares updates
-            \Log::HISTORY_DELETE_SUBITEM => 36,//networkport and networkname, Software?
-            \Log::HISTORY_CREATE_ITEM => 198, //virtual machines, os, manufacturer, net ports, net names, ...
+            \Log::HISTORY_DELETE_SUBITEM => 35,//networkport and networkname, Software?
+            \Log::HISTORY_CREATE_ITEM => 197, //virtual machines, os, manufacturer, net ports, net names, ...
             \Log::HISTORY_UPDATE_RELATION => 2,//kernel version
         ];
 

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -1749,7 +1749,7 @@ class Inventory extends InventoryTestCase
         $this->integer(count($logs))->isIdenticalTo(2279);
 
         $expected_types_count = [
-            0 => 2, //Agent version, disks usage
+            0 => 3, //Agent version, disks usage
             \Log::HISTORY_ADD_RELATION => 1, //new IPNetwork/IPAddress
             \Log::HISTORY_DEL_RELATION => 2,//monitor-computer relation
             \Log::HISTORY_ADD_SUBITEM => 1211,//network port/name, ip address, VMs, Software

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -1569,7 +1569,7 @@ class Inventory extends InventoryTestCase
             'LIMIT' => $nblogsnow,
             'OFFSET' => $this->nblogs,
         ]);
-        $this->integer(count($logs))->isIdenticalTo(3); //FIXME: should be 0
+        $this->integer(count($logs))->isIdenticalTo(1); //FIXME: should be 0
 
         //real computer update
         $json = file_get_contents(self::INV_FIXTURES . 'computer_3_updated.json');

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -1746,7 +1746,7 @@ class Inventory extends InventoryTestCase
             'OFFSET' => $nblogsnow,
         ]);
 
-        $this->integer(count($logs))->isIdenticalTo(2280);
+        $this->integer(count($logs))->isIdenticalTo(2279);
 
         $expected_types_count = [
             0 => 2, //Agent version, disks usage


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

issue:
![image](https://user-images.githubusercontent.com/418844/160625697-89ac2c17-b220-4c0d-b4fa-40d4f951863b.png)

Seen also in https://github.com/glpi-project/glpi-inventory-plugin/issues/85

ports without instanciation_type, are removed and re-added (without logs)
example of ports from xml data : 
```
Array
  (
      [131715] => Array
          (
              [name] => lo
              [mac] => xxxxx
              [instantiation_type] => networkportethernet
          )
  
      [131716] => Array
          (
              [name] => bond0
              [mac] => xxxxx
              [instantiation_type] => networkportethernet
          )
  
      [131720] => Array
          (
              [name] => eth0
              [mac] => xxxxxx
              [instantiation_type] => networkportethernet
          )
  
      [131787] => Array
          (
              [name] => dummy0
              [mac] => xxxxxx
          )
  
      [131788] => Array
          (
              [name] => tunl0@none
              [mac] => 
          )
  
      [131789] => Array
          (
              [name] => sit0@none
              [mac] => 
          )
  )
```

The 3 last ports doesn't have instanciation_type key (and maybe shouldn't have it)
but the comparison with db checks for full equality of the array (and a missing key fails the test).
Also on DB data, we have the key but with empty string.

So i though just filling the key with empty string on xml data side when missing should do the trick
