### PR TITLE
Use calculated options for tokenizer

### DIFF
--- a/js/modules/SearchTokenizer/SearchInput.js
+++ b/js/modules/SearchTokenizer/SearchInput.js
@@ -65,7 +65,7 @@ export default class SearchInput {
                 data: {}
             }
         }, options || {});
-        this.tokenizer = new SearchTokenizer(options.allowed_tags || {}, options.drop_unallowed_tags || false, options.tokenizer_options);
+        this.tokenizer = new SearchTokenizer(this.options.allowed_tags || {}, this.options.drop_unallowed_tags || false, this.options.tokenizer_options);
 
         this.displayed_input = $(`
          <div class="form-control search-input d-flex" tabindex="0"></div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Search tokenizer was always given the user-specified options passed into the SearchInput JS class instead of the computed options (default + user-specified). This bug currently doesn't affect anything in the core as all required options are specified.