### PR TITLE
loose match ports to stack

### DIFF
--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -120,6 +120,7 @@ class NetworkEquipment extends MainAsset
            //keep only stack parts, not main equipment
             $this->data = [];
             $switches = $this->getStackedSwitches();
+            $switch_index = 1;
             foreach ($switches as $switch) {
                 $stack = clone $val;
                 $stack->firmware = $switch->firmware ?? $switch->version ?? '';
@@ -128,7 +129,9 @@ class NetworkEquipment extends MainAsset
                 $stack->$model_field = $switch->model;
                 $stack->description = $stack->name . ' - ' . $switch->name;
                 $stack->name = $stack->name . ' - ' . $switch->name;
+                $stack->index = $switch_index;
                 $this->data[] = $stack;
+                $switch_index++;
             }
         } else {
            //keep an entry for main equipment
@@ -394,6 +397,9 @@ class NetworkEquipment extends MainAsset
             throw new \RuntimeException('Exactly one entry in data is expected.');
         } else {
             $data = current($this->data);
+            if (property_exists($data, 'index')) {
+                return $data->index;
+            }
             return preg_replace('/.+ - (\d)/', '$1', $data->name);
         }
     }

--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -120,8 +120,7 @@ class NetworkEquipment extends MainAsset
            //keep only stack parts, not main equipment
             $this->data = [];
             $switches = $this->getStackedSwitches();
-            $switch_index = 1;
-            foreach ($switches as $switch) {
+            foreach ($switches as $switch_index => $switch) {
                 $stack = clone $val;
                 $stack->firmware = $switch->firmware ?? $switch->version ?? '';
                 $stack->serial = $switch->serial;
@@ -131,7 +130,6 @@ class NetworkEquipment extends MainAsset
                 $stack->name = $stack->name . ' - ' . $switch->name;
                 $stack->index = $switch_index;
                 $this->data[] = $stack;
-                $switch_index++;
             }
         } else {
            //keep an entry for main equipment
@@ -397,10 +395,7 @@ class NetworkEquipment extends MainAsset
             throw new \RuntimeException('Exactly one entry in data is expected.');
         } else {
             $data = current($this->data);
-            if (property_exists($data, 'index')) {
-                return $data->index;
-            }
-            return preg_replace('/.+ - (\d)/', '$1', $data->name);
+            return preg_replace('/.+ -.+(\d)/', '$1', $data->name);
         }
     }
 }

--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -309,7 +309,7 @@ class NetworkEquipment extends MainAsset
      *
      * @return array
      */
-    public function getStackedSwitches($parent_index = 0, $stack_number = 1): array
+    public function getStackedSwitches(): array
     {
         $components = $this->extra_data['network_components'] ?? [];
         if (!count($components)) {
@@ -317,17 +317,9 @@ class NetworkEquipment extends MainAsset
         }
 
         $switches = [];
-
+        $stack_number = 1;
         foreach ($components as $component) {
             switch ($component->type) {
-                // FIXME is this aims to do something more than calling twice the same code ?
-                // $parent_index is not used in recursive part
-                /* case 'stack':
-                    if ($parent_index == 0 && (!property_exists($component, 'parent_index') || !empty($component->parent_index))) {
-                        $switches += $this->getStackedSwitches($component->index, $stack_number);
-                        $stack_number += count($switches);
-                    }
-                    break; */
                 case 'chassis':
                     if (property_exists($component, 'serial')) {
                         $component->stack_number = $stack_number;

--- a/src/Inventory/Asset/NetworkPort.php
+++ b/src/Inventory/Asset/NetworkPort.php
@@ -654,7 +654,7 @@ class NetworkPort extends InventoryAsset
     {
         $mainasset = $this->extra_data['\Glpi\Inventory\Asset\\' . $this->item->getType()];
 
-       //handle ports for stacked switches
+        //handle ports for stacked switches
         if ($mainasset->isStackedSwitch()) {
             $bkp_ports = $this->ports;
             foreach ($this->ports as $k => $val) {

--- a/tests/functionnal/Glpi/Inventory/Assets/NetworkEquipment.php
+++ b/tests/functionnal/Glpi/Inventory/Assets/NetworkEquipment.php
@@ -227,6 +227,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
                 'serial' => 'FOC1243W0ED',
                 'type' => 'chassis',
                 'firmware' => '12.2(55)SE6',
+                'stack_number' => 1,
             ],
             2001 => [
                 'contained_index' => 1,
@@ -238,6 +239,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
                 'serial' => 'FOC1127Z4LH',
                 'type' => 'chassis',
                 'firmware' => '12.2(55)SE6',
+                'stack_number' => 2,
             ],
             3001 => [
                 'contained_index' => 1,
@@ -249,6 +251,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
                 'serial' => 'FOC1232W0JH',
                 'type' => 'chassis',
                 'firmware' => '12.2(55)SE6',
+                'stack_number' => 3,
             ],
             4001 => [
                 'contained_index' => 1,
@@ -260,6 +263,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
                 'serial' => 'FOC1033Y0M7',
                 'type' => 'chassis',
                 'firmware' => '12.2(55)SE6',
+                'stack_number' => 4,
             ],
             8001 => [
                 'contained_index' => 1,
@@ -271,6 +275,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
                 'serial' => 'FOC0929U1SR',
                 'type' => 'chassis',
                 'firmware' => '12.2(55)SE6',
+                'stack_number' => 8,
             ]
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/glpi-project/glpi-agent/issues/89 (3850 issue)

Currently when matching port to a stack index, the stack index is deducted from its name : https://github.com/glpi-project/glpi/blob/f4ce8bae01b691f0939cc82ddff128125289c002/src/Inventory/Asset/NetworkEquipment.php#L397

An alternative fix (tested) is to adapt the regex here to `/.+ -.+(\d)/` (in the orginal issue we had `mainname - Switch X` and so the "Switch" part didn't match the regex).
But i'm afraid we could have anything in the name of the stack, even no number at all, and so relying on this seems dangerous.

Another much more complex alternative could be to go back up all the chain of components with 
CONTAINEDININDEX keys (it aims to get the parent component) to retrieve the stack name but it seems to be difficult to achieve at the moment (and i'm not sure its a geenric key)