### PR TITLE
fix(massiveation): disabled categories was available

### DIFF
--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1189,6 +1189,24 @@ class MassiveAction
                     if (isset($ma->POST['options'])) {
                         $options = $ma->POST['options'];
                     }
+                    if (isset($ma->POST['container'])) {
+                        switch ($ma->POST['container']) {
+                            case 'massformChange':
+                                $search['condition'][] = 'is_change';
+                                break;
+                            case 'massformProblem':
+                                $search['condition'][] = 'is_problem';
+                                break;
+                            case 'massformTicket':
+                                $search['condition'][] = [
+                                    'OR' => [
+                                        'is_incident',
+                                        'is_request'
+                                    ]
+                                ];
+                                break;
+                        }
+                    }
                     if (isset($ma->POST['additionalvalues'])) {
                         $values = $ma->POST['additionalvalues'];
                     }

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1189,23 +1189,21 @@ class MassiveAction
                     if (isset($ma->POST['options'])) {
                         $options = $ma->POST['options'];
                     }
-                    if (isset($ma->POST['container'])) {
-                        switch ($ma->POST['container']) {
-                            case 'massformChange':
-                                $search['condition'][] = 'is_change';
-                                break;
-                            case 'massformProblem':
-                                $search['condition'][] = 'is_problem';
-                                break;
-                            case 'massformTicket':
-                                $search['condition'][] = [
-                                    'OR' => [
-                                        'is_incident',
-                                        'is_request'
-                                    ]
-                                ];
-                                break;
-                        }
+                    switch ($item->getType()) {
+                        case 'Change':
+                            $search['condition'][] = 'is_change';
+                            break;
+                        case 'Problem':
+                            $search['condition'][] = 'is_problem';
+                            break;
+                        case 'Ticket':
+                            $search['condition'][] = [
+                                'OR' => [
+                                    'is_incident',
+                                    'is_request'
+                                ]
+                            ];
+                            break;
                     }
                     if (isset($ma->POST['additionalvalues'])) {
                         $values = $ma->POST['additionalvalues'];

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -298,6 +298,25 @@ class Ticket extends CommonITILObject
                             return false;
                         }
                         break;
+                    case 'itilcategories_id':
+                        $cat = new ITILCategory();
+                        if ($cat->getFromDB($value)) {
+                            switch ($this->fields['type']) {
+                                case self::INCIDENT_TYPE:
+                                    if (!$cat->getField('is_incident')) {
+                                        return false;
+                                    }
+                                    break;
+                                case self::DEMAND_TYPE:
+                                    if (!$cat->getField('is_request')) {
+                                        return false;
+                                    }
+                                    break;
+                                default:
+                                    break;
+                            }
+                        }
+                        break;
                 }
                 break;
         }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -303,12 +303,12 @@ class Ticket extends CommonITILObject
                         if ($cat->getFromDB($value)) {
                             switch ($this->fields['type']) {
                                 case self::INCIDENT_TYPE:
-                                    if (!$cat->getField('is_incident')) {
+                                    if (!$cat->fields['is_incident']) {
                                         return false;
                                     }
                                     break;
                                 case self::DEMAND_TYPE:
-                                    if (!$cat->getField('is_request')) {
+                                    if (!$cat->fields['is_request']) {
                                         return false;
                                     }
                                     break;


### PR DESCRIPTION
When a category is deactivated, it still appeared in the update values of the massive actions, which made it possible to assign unavailable values.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23703
