### PR TITLE
Prevent memory issues on archives handling in marketplace

### DIFF
--- a/src/Marketplace/Controller.php
+++ b/src/Marketplace/Controller.php
@@ -118,6 +118,13 @@ class Controller extends CommonGLPI
             );
             return false;
         }
+
+        if (Toolbox::getMemoryLimit() < (512 * 1024 * 1024)) {
+            // Some plugins archives may be huge, as they may embed some binaries.
+            // Upgrade memory limit to 512M, which should be enough.
+            ini_set('memory_limit', '512M');
+        }
+
         $archive = UnifiedArchive::open($dest);
         $error = $archive === null;
         if (!$error) {

--- a/src/Marketplace/Controller.php
+++ b/src/Marketplace/Controller.php
@@ -119,9 +119,10 @@ class Controller extends CommonGLPI
             return false;
         }
 
-        if (Toolbox::getMemoryLimit() < (512 * 1024 * 1024)) {
-            // Some plugins archives may be huge, as they may embed some binaries.
-            // Upgrade memory limit to 512M, which should be enough.
+        // Some plugins archives may be huge, as they may embed some binaries.
+        // Upgrade memory limit to 512M, which should be enough.
+        $memory_limit = (int)Toolbox::getMemoryLimit();
+        if ($memory_limit > 0 && $memory_limit < (512 * 1024 * 1024)) {
             ini_set('memory_limit', '512M');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

I encountered the case where 128M of memory was not enough to extract a plugin archive.