### PR TITLE
Set memory/execution time limits on inventory

### DIFF
--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -148,9 +148,6 @@ class Conf extends CommonGLPI
      */
     public function importFile($files): Request
     {
-        ini_set("memory_limit", "-1");
-        ini_set("max_execution_time", "0");
-
         $path = $files['importfile']['tmp_name'];
         $name = $files['importfile']['name'];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Having no limits may be dangerous.
2. Limits were applied only to manually imported files.

I did not trie to optimize memory usage, but I guess limit could be lowered with some work on it.