### PR TITLE
Ensure 'softwarecategories_id' is always set during inventory

### DIFF
--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -611,6 +611,8 @@ class Software extends InventoryAsset
             if (!isset($this->softwares[$skey])) {
                 $stmt_columns = $this->cleanInputToPrepare((array)$val, $soft_fields);
 
+                $software->handleCategoryRules($stmt_columns);
+
                 if ($stmt === null) {
                     $stmt_types = str_repeat('s', count($stmt_columns));
                     $reference = array_fill_keys(
@@ -624,7 +626,6 @@ class Software extends InventoryAsset
                     $stmt = $DB->prepare($insert_query);
                 }
 
-                $software->handleCategoryRules($stmt_columns);
                 $stmt_values = array_values($stmt_columns);
                 $stmt->bind_param($stmt_types, ...$stmt_values);
                 $DB->executeStatement($stmt);

--- a/src/Software.php
+++ b/src/Software.php
@@ -1170,7 +1170,9 @@ class Software extends CommonDBTM
                     $input["softwarecategories_id"] = $softCat->importExternal($input["_system_category"]);
                 }
             }
-            $input["softwarecategories_id"] = 0;
+            if (!isset($input["softwarecategories_id"])) {
+                $input["softwarecategories_id"] = 0;
+            }
         }
     }
 }

--- a/src/Software.php
+++ b/src/Software.php
@@ -1169,9 +1169,8 @@ class Software extends CommonDBTM
                     $softCat = new SoftwareCategory();
                     $input["softwarecategories_id"] = $softCat->importExternal($input["_system_category"]);
                 }
-            } else {
-                $input["softwarecategories_id"] = 0;
             }
+            $input["softwarecategories_id"] = 0;
         }
     }
 }

--- a/tests/functionnal/Software.php
+++ b/tests/functionnal/Software.php
@@ -104,13 +104,13 @@ class Software extends DbTestCase
 
         $input    = ['name' => 'A name', 'is_update' => 0, 'id' => 3, 'withtemplate' => 0];
         $result   = $software->prepareInputForAdd($input);
-        $expected = ['name' => 'A name', 'is_update' => 0, 'softwares_id' => 0, '_oldID' => 3];
+        $expected = ['name' => 'A name', 'is_update' => 0, 'softwares_id' => 0, '_oldID' => 3, 'softwarecategories_id' => 0];
 
         $this->array($result)->isIdenticalTo($expected);
 
         $input    = ['name' => 'A name', 'is_update' => 0, 'withtemplate' => 0];
         $result   = $software->prepareInputForAdd($input);
-        $expected = ['name' => 'A name', 'is_update' => 0, 'softwares_id' => 0];
+        $expected = ['name' => 'A name', 'is_update' => 0, 'softwares_id' => 0, 'softwarecategories_id' => 0];
 
         $this->array($result)->isIdenticalTo($expected);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

See comments in https://github.com/glpi-project/glpi-inventory-plugin/issues/86

I may be wrong, but current logic can result in having a defined `softwarecategories_id` on some softwares after statement have been prepared, resulting in having one more value than expected.

My proposal is to ensure that `softwarecategories_id` is always defined before statement preparation.
