### PR TITLE
add some hidden features to network ports display

### DIFF
--- a/css/includes/_includes.scss
+++ b/css/includes/_includes.scss
@@ -48,6 +48,7 @@ $is-dark: false !default;
 @import "components/kanban";
 @import "components/browser_tree";
 @import "components/mini-tabs";
+@import "components/networkport";
 @import "components/pictures";
 @import "components/racks";
 @import "components/richtext";

--- a/css/includes/components/_networkport.scss
+++ b/css/includes/components/_networkport.scss
@@ -1,0 +1,68 @@
+.netport {
+    &:target {
+        animation: shakeX; // from animate css dependencies
+        animation-duration: 2s;
+        scroll-margin-top: 5em;
+    }
+
+    td {
+       &.green {
+       background-color: green;
+          color: white;
+       }
+
+       &.red {
+          background-color: red;
+          color: white;
+       }
+
+       &.orange {
+          background-color: orange;
+          color: white;
+       }
+    }
+
+    &.trunk {
+       background-color: MediumAquamarine;
+    }
+
+    &.hub {
+       background-color: LightSalmon;
+    }
+
+    &.cotrunk {
+       background-color: silver;
+    }
+
+    &.aggregated,
+    .aggregated {
+       background-color: teal;
+       color: white;
+       padding-left: 2em;
+
+       a {
+          color: white;
+       }
+    }
+
+    .hub {
+       border: 1px grey solid;
+       margin: 0 .5em 0 .5em;
+
+       div {
+          padding: .2em .5em;
+          border-bottom: 1px grey solid;
+          &:last-of-type {
+             border-bottom: none;
+          }
+       }
+    }
+ }
+
+ .netport-legend {
+    width: 100%;
+    td.netport {
+       text-align: center;
+       width: 25%;
+    }
+}

--- a/css/includes/components/_networkport.scss
+++ b/css/includes/components/_networkport.scss
@@ -23,11 +23,11 @@
     }
 
     &.trunk {
-        background-color: MediumAquamarine;
+        background-color: mediumaquamarine;
     }
 
     &.hub {
-        background-color: LightSalmon;
+        background-color: lightsalmon;
     }
 
     &.cotrunk {
@@ -47,11 +47,12 @@
 
     .hub {
         border: 1px grey solid;
-        margin: 0 0.5em 0 0.5em;
+        margin: 0 0.5em;
 
         div {
             padding: 0.2em 0.5em;
             border-bottom: 1px grey solid;
+
             &:last-of-type {
                 border-bottom: none;
             }
@@ -61,6 +62,7 @@
 
 .netport-legend {
     width: 100%;
+
     td.netport {
         text-align: center;
         width: 25%;

--- a/css/includes/components/_networkport.scss
+++ b/css/includes/components/_networkport.scss
@@ -29,7 +29,7 @@
  * ---------------------------------------------------------------------
  */
 
- .netport {
+.netport {
     &:target {
         animation: shakeX; // from animate css dependencies
         animation-duration: 2s;

--- a/css/includes/components/_networkport.scss
+++ b/css/includes/components/_networkport.scss
@@ -1,4 +1,35 @@
-.netport {
+/*!
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+ .netport {
     &:target {
         animation: shakeX; // from animate css dependencies
         animation-duration: 2s;

--- a/css/includes/components/_networkport.scss
+++ b/css/includes/components/_networkport.scss
@@ -6,63 +6,63 @@
     }
 
     td {
-       &.green {
-       background-color: green;
-          color: white;
-       }
+        &.green {
+            background-color: green;
+            color: white;
+        }
 
-       &.red {
-          background-color: red;
-          color: white;
-       }
+        &.red {
+            background-color: red;
+            color: white;
+        }
 
-       &.orange {
-          background-color: orange;
-          color: white;
-       }
+        &.orange {
+            background-color: orange;
+            color: white;
+        }
     }
 
     &.trunk {
-       background-color: MediumAquamarine;
+        background-color: MediumAquamarine;
     }
 
     &.hub {
-       background-color: LightSalmon;
+        background-color: LightSalmon;
     }
 
     &.cotrunk {
-       background-color: silver;
+        background-color: silver;
     }
 
     &.aggregated,
     .aggregated {
-       background-color: teal;
-       color: white;
-       padding-left: 2em;
+        background-color: teal;
+        color: white;
+        padding-left: 2em;
 
-       a {
-          color: white;
-       }
+        a {
+            color: white;
+        }
     }
 
     .hub {
-       border: 1px grey solid;
-       margin: 0 .5em 0 .5em;
+        border: 1px grey solid;
+        margin: 0 0.5em 0 0.5em;
 
-       div {
-          padding: .2em .5em;
-          border-bottom: 1px grey solid;
-          &:last-of-type {
-             border-bottom: none;
-          }
-       }
+        div {
+            padding: 0.2em 0.5em;
+            border-bottom: 1px grey solid;
+            &:last-of-type {
+                border-bottom: none;
+            }
+        }
     }
- }
+}
 
- .netport-legend {
+.netport-legend {
     width: 100%;
     td.netport {
-       text-align: center;
-       width: 25%;
+        text-align: center;
+        width: 25%;
     }
 }

--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -1493,69 +1493,6 @@
       z-index: 11!important;
    }
 
-   .netport {
-      td {
-         &.green {
-         background-color: green;
-            color: white;
-         }
-
-         &.red {
-            background-color: red;
-            color: white;
-         }
-
-         &.orange {
-            background-color: orange;
-            color: white;
-         }
-      }
-
-      &.trunk {
-         background-color: MediumAquamarine;
-      }
-
-      &.hub {
-         background-color: LightSalmon;
-      }
-
-      &.cotrunk {
-         background-color: silver;
-      }
-
-      &.aggregated,
-      .aggregated {
-         background-color: teal;
-         color: white;
-         padding-left: 2em;
-
-         a {
-            color: white;
-         }
-      }
-
-      .hub {
-         border: 1px grey solid;
-         margin: 0 .5em 0 .5em;
-
-         div {
-            padding: .2em .5em;
-            border-bottom: 1px grey solid;
-            &:last-of-type {
-               border-bottom: none;
-            }
-         }
-      }
-   }
-
-   .netport-legend {
-      width: 100%;
-      td.netport {
-         text-align: center;
-         width: 25%;
-      }
-   }
-
    .dashboard.printer_barchart .g-chart .chart {
       flex:none;
       height: 500px;

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -31,6 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Plugin\Hooks;
 use Glpi\Socket;
 
 /**
@@ -746,6 +747,8 @@ class NetworkPort extends CommonDBChild
             Html::closeForm();
         }
 
+        Plugin::doHook(Hooks::DISPLAY_NETPORT_LIST_BEFORE);
+
         $search_config_top    = '';
         if (
             Session::haveRightsOr('search_config', [
@@ -949,7 +952,8 @@ class NetworkPort extends CommonDBChild
             }
         }
 
-        $whole_output = "<tr class='$css_class'>";
+        $port_number = $port['logical_number'] ?? "";
+        $whole_output = "<tr class='$css_class' id='port_number_{$port_number}'>";
         if ($canedit && $with_ma) {
             $whole_output .= "<td>" . Html::getMassiveActionCheckBox(__CLASS__, $port['id']) . "</td>";
         }

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -747,7 +747,7 @@ class NetworkPort extends CommonDBChild
             Html::closeForm();
         }
 
-        Plugin::doHook(Hooks::DISPLAY_NETPORT_LIST_BEFORE);
+        Plugin::doHook(Hooks::DISPLAY_NETPORT_LIST_BEFORE, ['item' => $item]);
 
         $search_config_top    = '';
         if (

--- a/src/Plugin/Hooks.php
+++ b/src/Plugin/Hooks.php
@@ -43,12 +43,13 @@ class Hooks
     const ADD_JAVASCRIPT = 'add_javascript';
 
    // Function hooks with no parameters
-    const CHANGE_ENTITY    = 'change_entity';
-    const CHANGE_PROFILE   = 'change_profile';
-    const DISPLAY_LOGIN    = 'display_login';
-    const DISPLAY_CENTRAL  = 'display_central';
-    const INIT_SESSION     = 'init_session';
-    const POST_INIT        = 'post_init';
+    const CHANGE_ENTITY               = 'change_entity';
+    const CHANGE_PROFILE              = 'change_profile';
+    const DISPLAY_LOGIN               = 'display_login';
+    const DISPLAY_CENTRAL             = 'display_central';
+    const DISPLAY_NETPORT_LIST_BEFORE = 'display_netport_list_before';
+    const INIT_SESSION                = 'init_session';
+    const POST_INIT                   = 'post_init';
 
    // Specific function hooks with parameters
     const RULE_MATCHED        = 'rule_matched';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

A special commit to add:

- anchors on ports named with logical number
- target animation (when you get scrolled to a port via an anchor)
- a hook to display something above the port list 

The idea behind this is, in the incoming month create a plugin to display above the list a switch picture with ports, their status and being clickables 

![image](https://user-images.githubusercontent.com/418844/161259529-a1061a71-61a4-40ed-afe3-49b37c8a0a0b.png)

Note, i moved the css relative to port in a dedicated file, no changes made apart the adition of the `:target `
