### PR TITLE
Search engine: restore "is"/"is not" for mio searches

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -7957,6 +7957,7 @@ HTML;
 
             if (isset($searchopt[$field_num]['datatype'])) {
                 switch ($searchopt[$field_num]['datatype']) {
+                    case 'mio':
                     case 'count':
                     case 'number':
                         $opt = [


### PR DESCRIPTION
Followup of #11113, keep same search option as numbers search (= is / is not) for new "mio" search types.
See last comment of !23616.

![image](https://user-images.githubusercontent.com/42734840/161284277-b47750df-2926-4b51-bd6d-45b819f03da2.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23616
