### PR TITLE
Fix SearchInput overflow

### DIFF
--- a/js/modules/SearchTokenizer/SearchInput.js
+++ b/js/modules/SearchTokenizer/SearchInput.js
@@ -68,7 +68,7 @@ export default class SearchInput {
         this.tokenizer = new SearchTokenizer(options.allowed_tags || {}, options.drop_unallowed_tags || false, options.tokenizer_options);
 
         this.displayed_input = $(`
-         <div class="form-control search-input d-flex" tabindex="0"></div>
+         <div class="form-control search-input d-flex overflow-auto" tabindex="0"></div>
       `).insertBefore(input);
         this.displayed_input.append(`<span class="search-input-tag-input flex-grow-1" contenteditable="true"></span>`);
         this.applyInputOptions();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If there are a lot of filters used in the Kanban, they can overflow the input box since it isn't a real text box. The scroll behavior for the overflow has to be added.