### PR TITLE
Fix error when backspacing in empty token

### DIFF
--- a/js/modules/SearchTokenizer/SearchInput.js
+++ b/js/modules/SearchTokenizer/SearchInput.js
@@ -554,7 +554,7 @@ export default class SearchInput {
         const selection = document.getSelection();
         const range = document.createRange();
 
-        if (node.lastChild.nodeType === Node.TEXT_NODE) {
+        if (node.lastChild && node.lastChild.nodeType === Node.TEXT_NODE) {
             range.setStart(node.lastChild, node.lastChild.length);
         } else {
             range.setStart(node, node.childNodes.length);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

This had no noticeable effect to functionality but would show an error in the console indicating `node.lastChild` was null if you backspaced inside an empty tag/token.