### PR TITLE
Disable mysqli exceptions during install for PHP 8.1

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -153,6 +153,7 @@ function step3($host, $user, $password, $update)
 {
 
     error_reporting(16);
+    mysqli_report(MYSQLI_REPORT_OFF);
 
    //Check if the port is in url
     $hostport = explode(":", $host);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If the connection to the DB failed under PHP 8.1, an exception is thrown instead of returning a `mysqli` object with `connect_error` set. This caused the exception to be shown during the install, but no back button or "user-friendly" error message would be shown as we expected.