### PR TITLE
Fix Rule/Search/Transfer tests

### DIFF
--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -153,38 +153,32 @@ class DbTestCase extends \GLPITestCase
         );
 
         $classes = [];
-        foreach (new \DirectoryIterator('inc/') as $fileInfo) {
-            if (!$fileInfo->isFile()) {
+        foreach (new \DirectoryIterator('src/') as $fileInfo) {
+            if ($fileInfo->getExtension() !== 'php') {
                 continue;
             }
 
-            $php_file = file_get_contents("inc/" . $fileInfo->getFilename());
-            $tokens = token_get_all($php_file);
-            $class_token = false;
-            foreach ($tokens as $token) {
-                if (is_array($token)) {
-                    if ($token[0] == T_CLASS) {
-                        $class_token = true;
-                    } else if ($class_token && $token[0] == T_STRING) {
-                        $classname = $token[1];
-
-                        foreach ($excludes as $exclude) {
-                            if ($classname === $exclude || @preg_match($exclude, $classname) === 1) {
-                                 break 2; // Class is excluded from results, go to next file
-                            }
-                        }
-
-                        if ($function) {
-                            if (method_exists($classname, $function)) {
-                                $classes[] = $classname;
-                            }
-                        } else {
-                            $classes[] = $classname;
-                        }
-
-                        break; // Assume there is only one class by file
-                    }
+            $classname = $fileInfo->getBasename('.php');
+            foreach ($excludes as $exclude) {
+                if ($classname === $exclude || @preg_match($exclude, $classname) === 1) {
+                     break 2; // Class is excluded from results, go to next file
                 }
+            }
+
+            if (!class_exists($classname)) {
+                continue;
+            }
+            $reflectionClass = new ReflectionClass($classname);
+            if ($reflectionClass->isAbstract()) {
+                continue;
+            }
+
+            if ($function) {
+                if (method_exists($classname, $function)) {
+                    $classes[] = $classname;
+                }
+            } else {
+                $classes[] = $classname;
             }
         }
         return array_unique($classes);

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -694,7 +694,7 @@ class Search extends DbTestCase
             default:
                 if (array_key_exists('table', $so_data) && array_key_exists('field', $so_data)) {
                     $field = $DB->tableExists($so_data['table']) ? $DB->getField($so_data['table'], $so_data['field']) : null;
-                    if (preg_match('/int(\(\d+\))?$/', $field['Type'] ?? '')) {
+                    if (preg_match('/int(\(\d+\))?( unsigned)?$/', $field['Type'] ?? '')) {
                         $val = 1;
                         break;
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The method used to fetch all existing lasses was still searching in `inc` directory, so many tests were not done anymore.