### PR TITLE
fix(search): do not compute link (and / or) if statement is having

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -1205,7 +1205,7 @@ class Search
                     $tmplink = " AND ";
                 }
                // Manage Link if not first item
-                if (!empty($sql)) {
+               if (!empty($sql) && !$is_having) {
                     $sql .= $globallink;
                 }
                 $first2 = true;

--- a/src/Search.php
+++ b/src/Search.php
@@ -1204,8 +1204,8 @@ class Search
                 } else {
                     $tmplink = " AND ";
                 }
-               // Manage Link if not first item
-               if (!empty($sql) && !$is_having) {
+                // Manage Link if not first item
+                if (!empty($sql) && !$is_having) {
                     $sql .= $globallink;
                 }
                 $first2 = true;


### PR DESCRIPTION
Error occurs when ```Search``` use ```having``` (from memory size for example)  and  ```contain``` clauses

![image](https://user-images.githubusercontent.com/7335054/161565196-b5fa5835-cd8a-4a63-861a-e3736dd1a126.png)

```Order By``` statement is preceded by ```AND```

see !23616


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23616
