### PR TITLE
Marketplace CLI commands

### DIFF
--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -50,16 +50,13 @@ class DownloadCommand extends AbstractCommand
         $this->setAliases(['marketplace:download']);
         $this->setDescription('Download plugin from the GLPI marketplace');
 
-        $this->addArgument('plugins', InputArgument::REQUIRED, 'The internal plugin name(s)');
+        $this->addArgument('plugins', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'The internal plugin name(s)');
         $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Force download even if the plugin is already downloaded');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $plugins = $input->getArgument('plugins');
-        if (!empty($plugins)) {
-            $plugins = explode(' ', $plugins);
-        }
 
         foreach ($plugins as $plugin) {
             if (!empty(trim($plugin))) {

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -57,7 +57,7 @@ class DownloadCommand extends AbstractCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if (!GLPINetwork::isRegistered()) {
-            $output->writeln("<error>" . __("The GLPI Network registration key io missing or invalid") . "</error>");
+            $output->writeln("<error>" . __("The GLPI Network registration key is missing or invalid") . "</error>");
         }
 
         $plugins = $input->getArgument('plugins');

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Marketplace;
+
+use Glpi\Console\AbstractCommand;
+use Glpi\Marketplace\Controller;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DownloadCommand extends AbstractCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->setName('glpi:marketplace:download');
+        $this->setAliases(['marketplace:download']);
+        $this->setDescription('Download plugin from the GLPI marketplace');
+
+        $this->addArgument('plugins', InputArgument::REQUIRED, 'The internal plugin name(s)');
+        $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Force download even if the plugin is already downloaded');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $plugins = $input->getArgument('plugins');
+        if (!empty($plugins)) {
+            $plugins = explode(' ', $plugins);
+        }
+
+        foreach ($plugins as $plugin) {
+            if (!empty(trim($plugin))) {
+                // If the plugin is already downloaded, refuse to download it again
+                if (!$input->getOption('force') && is_dir(GLPI_MARKETPLACE_DIR . '/' . $plugin)) {
+                    $error_msg = sprintf('Plugin "%s" is already downloaded. Use --force to force it to re-download.', $plugin);
+                    $output->writeln("<error>$error_msg</error>");
+                    continue;
+                }
+                $controller = new Controller($plugin);
+                if ($controller->canBeDownloaded()) {
+                    $result = $controller->downloadPlugin(true);
+                    $success_msg = sprintf(__("Plugin %s downloaded successfully"), $plugin);
+                    $error_msg = sprintf(__("Plugin %s could not be downloaded"), $plugin);
+                    if ($result) {
+                        $output->writeln("<info>$success_msg</info>");
+                    } else {
+                        $output->writeln("<error>$error_msg</error>");
+                    }
+                } else {
+                    throw new \RuntimeException(sprintf(__('Plugin "%s" cannot be downloaded'), $plugin));
+                }
+            }
+        }
+
+        return 0; // Success
+    }
+}

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -59,27 +59,28 @@ class DownloadCommand extends AbstractCommand
         $plugins = $input->getArgument('plugins');
 
         foreach ($plugins as $plugin) {
-            if (!empty(trim($plugin))) {
-                // If the plugin is already downloaded, refuse to download it again
-                if (!$input->getOption('force') && is_dir(GLPI_MARKETPLACE_DIR . '/' . $plugin)) {
-                    $error_msg = sprintf(__('Plugin "%s" is already downloaded. Use --force to force it to re-download.'), $plugin);
-                    $output->writeln("<error>$error_msg</error>");
-                    continue;
-                }
-                $controller = new Controller($plugin);
-                if ($controller->canBeDownloaded()) {
-                    $result = $controller->downloadPlugin(true);
-                    $success_msg = sprintf(__("Plugin %s downloaded successfully"), $plugin);
-                    $error_msg = sprintf(__("Plugin %s could not be downloaded"), $plugin);
-                    if ($result) {
-                        $output->writeln("<info>$success_msg</info>");
-                    } else {
-                        $output->writeln("<error>$error_msg</error>");
-                    }
+            if (empty(trim($plugin))) {
+                continue;
+            }
+            // If the plugin is already downloaded, refuse to download it again
+            if (!$input->getOption('force') && is_dir(GLPI_MARKETPLACE_DIR . '/' . $plugin)) {
+                $error_msg = sprintf(__('Plugin "%s" is already downloaded. Use --force to force it to re-download.'), $plugin);
+                $output->writeln("<error>$error_msg</error>");
+                continue;
+            }
+            $controller = new Controller($plugin);
+            if ($controller->canBeDownloaded()) {
+                $result = $controller->downloadPlugin(false);
+                $success_msg = sprintf(__("Plugin %s downloaded successfully"), $plugin);
+                $error_msg = sprintf(__("Plugin %s could not be downloaded"), $plugin);
+                if ($result) {
+                    $output->writeln("<info>$success_msg</info>");
                 } else {
-                    $output->writeln('<error>' . sprintf(__('Plugin "%s" cannot be downloaded'), $plugin) . '</error>');
-                    return 1;
+                    $output->writeln("<error>$error_msg</error>");
                 }
+            } else {
+                $output->writeln('<error>' . sprintf(__('Plugin "%s" cannot be downloaded'), $plugin) . '</error>');
+                return 1;
             }
         }
 

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -48,10 +48,10 @@ class DownloadCommand extends AbstractCommand
 
         $this->setName('glpi:marketplace:download');
         $this->setAliases(['marketplace:download']);
-        $this->setDescription('Download plugin from the GLPI marketplace');
+        $this->setDescription(__('Download plugin from the GLPI marketplace'));
 
-        $this->addArgument('plugins', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'The internal plugin name(s)');
-        $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Force download even if the plugin is already downloaded');
+        $this->addArgument('plugins', InputArgument::REQUIRED | InputArgument::IS_ARRAY, __('The plugin key'));
+        $this->addOption('force', 'f', InputOption::VALUE_NONE, __('Force download even if the plugin is already downloaded'));
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -62,7 +62,7 @@ class DownloadCommand extends AbstractCommand
             if (!empty(trim($plugin))) {
                 // If the plugin is already downloaded, refuse to download it again
                 if (!$input->getOption('force') && is_dir(GLPI_MARKETPLACE_DIR . '/' . $plugin)) {
-                    $error_msg = sprintf('Plugin "%s" is already downloaded. Use --force to force it to re-download.', $plugin);
+                    $error_msg = sprintf(__('Plugin "%s" is already downloaded. Use --force to force it to re-download.'), $plugin);
                     $output->writeln("<error>$error_msg</error>");
                     continue;
                 }
@@ -77,7 +77,8 @@ class DownloadCommand extends AbstractCommand
                         $output->writeln("<error>$error_msg</error>");
                     }
                 } else {
-                    throw new \RuntimeException(sprintf(__('Plugin "%s" cannot be downloaded'), $plugin));
+                    $output->writeln('<error>' . sprintf(__('Plugin "%s" cannot be downloaded'), $plugin) . '</error>');
+                    return 1;
                 }
             }
         }

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -56,6 +56,10 @@ class DownloadCommand extends AbstractCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (!GLPINetwork::isRegistered()) {
+            $output->writeln("<error>" . __("The GLPI Network registration key io missing or invalid") . "</error>");
+        }
+
         $plugins = $input->getArgument('plugins');
 
         foreach ($plugins as $plugin) {

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -33,6 +33,7 @@
 
 namespace Glpi\Console\Marketplace;
 
+use GLPINetwork;
 use Glpi\Console\AbstractCommand;
 use Glpi\Marketplace\Controller;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/Console/Marketplace/InfoCommand.php
+++ b/src/Console/Marketplace/InfoCommand.php
@@ -33,6 +33,7 @@
 
 namespace Glpi\Console\Marketplace;
 
+use GLPINetwork;
 use Glpi\Console\AbstractCommand;
 use Glpi\Marketplace\Api\Plugins;
 use Glpi\Marketplace\Controller;
@@ -57,8 +58,6 @@ class InfoCommand extends AbstractCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        global $CFG_GLPI;
-
         if (!GLPINetwork::isRegistered()) {
             $output->writeln("<error>" . __("The GLPI Network registration key is missing or invalid") . "</error>");
         }

--- a/src/Console/Marketplace/InfoCommand.php
+++ b/src/Console/Marketplace/InfoCommand.php
@@ -59,6 +59,10 @@ class InfoCommand extends AbstractCommand
     {
         global $CFG_GLPI;
 
+        if (!GLPINetwork::isRegistered()) {
+            $output->writeln("<error>" . __("The GLPI Network registration key io missing or invalid") . "</error>");
+        }
+
         $plugin = $input->getArgument('plugin');
 
         $controller = new Controller();

--- a/src/Console/Marketplace/InfoCommand.php
+++ b/src/Console/Marketplace/InfoCommand.php
@@ -60,7 +60,7 @@ class InfoCommand extends AbstractCommand
         global $CFG_GLPI;
 
         if (!GLPINetwork::isRegistered()) {
-            $output->writeln("<error>" . __("The GLPI Network registration key io missing or invalid") . "</error>");
+            $output->writeln("<error>" . __("The GLPI Network registration key is missing or invalid") . "</error>");
         }
 
         $plugin = $input->getArgument('plugin');

--- a/src/Console/Marketplace/InfoCommand.php
+++ b/src/Console/Marketplace/InfoCommand.php
@@ -50,9 +50,9 @@ class InfoCommand extends AbstractCommand
 
         $this->setName('glpi:marketplace:info');
         $this->setAliases(['marketplace:info']);
-        $this->setDescription('Get information about a plugin');
+        $this->setDescription(__('Get information about a plugin'));
 
-        $this->addArgument('plugin', InputArgument::REQUIRED, 'The plugin key');
+        $this->addArgument('plugin', InputArgument::REQUIRED, __('The plugin key'));
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -69,7 +69,7 @@ class InfoCommand extends AbstractCommand
         });
 
         if (count($result) === 0) {
-            $output->writeln('<error>Plugin not found</error>');
+            $output->writeln('<error>' . __('Plugin not found') . '</error>');
             return 1;
         }
 

--- a/src/Console/Marketplace/InfoCommand.php
+++ b/src/Console/Marketplace/InfoCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Marketplace;
+
+use Glpi\Console\AbstractCommand;
+use Glpi\Marketplace\Api\Plugins;
+use Glpi\Marketplace\Controller;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class InfoCommand extends AbstractCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->setName('glpi:marketplace:info');
+        $this->setAliases(['marketplace:info']);
+        $this->setDescription('Get information about a plugin');
+
+        $this->addArgument('plugin', InputArgument::REQUIRED, 'The plugin key');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        global $CFG_GLPI;
+
+        $plugin = $input->getArgument('plugin');
+
+        $controller = new Controller();
+        $plugins = $controller::getAPI()->getAllPlugins();
+
+        $result = array_filter($plugins, static function ($p) use ($plugin) {
+            return strtolower($p['key']) === strtolower($plugin);
+        });
+
+        if (count($result) === 0) {
+            $output->writeln('<error>Plugin not found</error>');
+            return 1;
+        }
+
+        $result = reset($result);
+        $output->write(var_export($result, true));
+
+        return 0; // Success
+    }
+}

--- a/src/Console/Marketplace/SearchCommand.php
+++ b/src/Console/Marketplace/SearchCommand.php
@@ -59,6 +59,10 @@ class SearchCommand extends AbstractCommand
     {
         global $CFG_GLPI;
 
+        if (!GLPINetwork::isRegistered()) {
+            $output->writeln("<error>" . __("The GLPI Network registration key io missing or invalid") . "</error>");
+        }
+
         $term = $input->getArgument('term');
         $term = strtolower($term);
 

--- a/src/Console/Marketplace/SearchCommand.php
+++ b/src/Console/Marketplace/SearchCommand.php
@@ -33,9 +33,11 @@
 
 namespace Glpi\Console\Marketplace;
 
+use GLPINetwork;
 use Glpi\Console\AbstractCommand;
 use Glpi\Marketplace\Api\Plugins;
 use Glpi\Marketplace\Controller;
+use Glpi\RichText\RichText;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -109,6 +111,10 @@ class SearchCommand extends AbstractCommand
                     break;
                 }
             }
+
+            // Prevent long lines to break table display, and prevent raw HTML to be displayed.
+            $short_description = wordwrap(RichText::getTextFromHtml($short_description), 70, "\n");
+
             $rows[] = [
                 'key' => $plugin['key'],
                 'name' => $plugin['name'],

--- a/src/Console/Marketplace/SearchCommand.php
+++ b/src/Console/Marketplace/SearchCommand.php
@@ -50,9 +50,9 @@ class SearchCommand extends AbstractCommand
 
         $this->setName('glpi:marketplace:search');
         $this->setAliases(['marketplace:search']);
-        $this->setDescription('Search GLPI marketplace');
+        $this->setDescription(__('Search GLPI marketplace'));
 
-        $this->addArgument('term', InputArgument::OPTIONAL, 'The search term');
+        $this->addArgument('term', InputArgument::OPTIONAL, __('The search term'));
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Console/Marketplace/SearchCommand.php
+++ b/src/Console/Marketplace/SearchCommand.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Marketplace;
+
+use Glpi\Console\AbstractCommand;
+use Glpi\Marketplace\Api\Plugins;
+use Glpi\Marketplace\Controller;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SearchCommand extends AbstractCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->setName('glpi:marketplace:search');
+        $this->setAliases(['marketplace:search']);
+        $this->setDescription('Search GLPI marketplace');
+
+        $this->addArgument('term', InputArgument::OPTIONAL, 'The search term');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        global $CFG_GLPI;
+
+        $term = $input->getArgument('term');
+        $term = strtolower($term);
+
+        $controller = new Controller();
+        $plugins = $controller::getAPI()->getAllPlugins();
+
+        if (!empty($term)) {
+            $result = array_filter($plugins, static function ($plugin) use ($term) {
+                if (stripos($plugin['key'], $term)) {
+                    return true;
+                }
+                if (stripos($plugin['name'], $term)) {
+                    return true;
+                }
+
+                foreach ($plugin['descriptions'] as $description) {
+                    if (isset($description['short_description']) && stripos($description['short_description'], $term)) {
+                        return true;
+                    }
+                    if (isset($description['long_description']) && stripos($description['long_description'], $term)) {
+                        return true;
+                    }
+                }
+                return false;
+            });
+        } else {
+            $result = $plugins;
+        }
+
+        // Output table of results with the key, name, and short description (user's language, default en, or which ever description is first
+        $rows = [];
+        $lang = strtolower($_SESSION['glpilanguage']);
+        $main_lang = explode('_', $lang)[0];
+        foreach ($result as $plugin) {
+            $short_description = $plugin['descriptions'][0]['short_description'] ?? __('No description');
+            foreach ($plugin['descriptions'] as $description) {
+                $desc_main_lang = explode('_', strtolower($description['lang']))[0];
+                if ($desc_main_lang === $main_lang) {
+                    $short_description = $description['short_description'];
+                    // Do not break here because this description doesn't match the full language
+                }
+                if (stripos($description['lang'], $lang) === 0) {
+                    $short_description = $description['short_description'];
+                    break;
+                }
+            }
+            $rows[] = [
+                'key' => $plugin['key'],
+                'name' => $plugin['name'],
+                'description' => $short_description,
+            ];
+        }
+        $table = new Table($output);
+        $table->setHeaders([__('Key'), __('Name'), __('Description')]);
+        $table->setRows($rows);
+        $table->render();
+
+        return 0; // Success
+    }
+}

--- a/src/Console/Marketplace/SearchCommand.php
+++ b/src/Console/Marketplace/SearchCommand.php
@@ -60,7 +60,7 @@ class SearchCommand extends AbstractCommand
         global $CFG_GLPI;
 
         if (!GLPINetwork::isRegistered()) {
-            $output->writeln("<error>" . __("The GLPI Network registration key io missing or invalid") . "</error>");
+            $output->writeln("<error>" . __("The GLPI Network registration key is missing or invalid") . "</error>");
         }
 
         $term = $input->getArgument('term');

--- a/src/Marketplace/Controller.php
+++ b/src/Marketplace/Controller.php
@@ -86,7 +86,7 @@ class Controller extends CommonGLPI
      *
      * @return bool
      */
-    public function downloadPlugin($skip_install = false): bool
+    public function downloadPlugin($auto_install = true): bool
     {
         if (!self::hasWriteAccess()) {
             return false;
@@ -161,7 +161,7 @@ class Controller extends CommonGLPI
         // inform api the plugin has been downloaded
         $api->incrementPluginDownload($this->plugin_key, $plugin_inst->fields['version']);
 
-        if ($skip_install || $plugin_inst->getPluginOption($this->plugin_key, Plugin::OPTION_AUTOINSTALL_DISABLED, false)) {
+        if (!$auto_install || $plugin_inst->getPluginOption($this->plugin_key, Plugin::OPTION_AUTOINSTALL_DISABLED, false)) {
             return true;
         }
 

--- a/src/Marketplace/Controller.php
+++ b/src/Marketplace/Controller.php
@@ -86,7 +86,7 @@ class Controller extends CommonGLPI
      *
      * @return bool
      */
-    public function downloadPlugin(): bool
+    public function downloadPlugin($skip_install = false): bool
     {
         if (!self::hasWriteAccess()) {
             return false;
@@ -161,7 +161,7 @@ class Controller extends CommonGLPI
         // inform api the plugin has been downloaded
         $api->incrementPluginDownload($this->plugin_key, $plugin_inst->fields['version']);
 
-        if ($plugin_inst->getPluginOption($this->plugin_key, Plugin::OPTION_AUTOINSTALL_DISABLED, false)) {
+        if ($skip_install || $plugin_inst->getPluginOption($this->plugin_key, Plugin::OPTION_AUTOINSTALL_DISABLED, false)) {
             return true;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Adds the following commands that utilize the Marketplace feature:
- `marketplace:search` - Accepts a term and returns any available plugin with that term in its key, name or description(s). If no term is specified, all available plugins are listed. The result is shown in a table with the key, name, and short description (Best match for their current language).
- `marketplace:info` - Accepts a plugin's key and returns the full information about the plugin provided by the Marketplace API.
- `marketplace:download` - Accepts one or more comma-separated plugin keys and downloads the latest compatible versions. This never installs the plugin (use the dedicated command for that) and by default, it will only download if it hasn't been downloaded already (Use --force for updates).

These commands were added with the `marketplace` prefix instead of `plugin` just so it is clear that they use the Marketplace feature.