### PR TITLE
fix(requestAgent): fix undefined variable

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -625,7 +625,7 @@ class Agent extends CommonDBTM
             }
         }
 
-        if (!$response || $response == null) {
+        if (!$response) {
             // throw last exception on no response
             throw $e;
         }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -597,6 +597,7 @@ class Agent extends CommonDBTM
             $adresses = $this->getAgentURLs();
         }
 
+        $response = null;
         foreach ($adresses as $adress) {
             $options = [
                 'base_uri'        => sprintf('%s/%s', $adress, $endpoint),
@@ -624,7 +625,7 @@ class Agent extends CommonDBTM
             }
         }
 
-        if (!$response) {
+        if (!$response || $response == null) {
             // throw last exception on no response
             throw $e;
         }


### PR DESCRIPTION
Prevent ```NOTICE``` when GLPI try to request agent (```/now```)

```
[2022-04-05 11:45:52] glpiphplog.NOTICE:   *** PHP Notice (8): Undefined variable: response in /home/stanislas/Teclib/dev/GLPI/master/src/Agent.php at line 627
  Backtrace :
  src/Agent.php:665                                  Agent->requestAgent()
  ajax/agent.php:54                                  Agent->requestInventory()
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
