### PR TITLE
Add separate right for impersonation

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -5869,7 +5869,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'user',
-                'rights' => ALLSTANDARDRIGHT | UNLOCK | User::IMPORTEXTAUTHUSERS | User::READAUTHENT | User::UPDATEAUTHENT,
+                'rights' => ALLSTANDARDRIGHT | UNLOCK | User::IMPORTEXTAUTHUSERS | User::READAUTHENT | User::UPDATEAUTHENT | User::IMPERSONATE,
             ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'group',

--- a/install/migrations/update_10.0.x_to_10.1.0/impersonate_right.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/impersonate_right.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+$migration->addRight('user', [User::IMPERSONATE], ['config' => UPDATE]);

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -759,8 +759,8 @@ class Profile_User extends CommonDBRelation
      *
      * @since 9.3 can pass sqlfilter as a parameter
      *
-     * @param $user_ID            user ID
-     * @param $sqlfilter  string  additional filter (default [])
+     * @param int $user_ID      User ID
+     * @param array $sqlfilter  Additional filter (default [])
      *
      * @return array of the IDs of the profiles
      **/

--- a/src/User.php
+++ b/src/User.php
@@ -59,6 +59,7 @@ class User extends CommonDBTM
     const IMPORTEXTAUTHUSERS  = 1024;
     const READAUTHENT         = 2048;
     const UPDATEAUTHENT       = 4096;
+    const IMPERSONATE         = 8192;
 
     public static $rightname = 'user';
 
@@ -5790,6 +5791,9 @@ JAVASCRIPT;
        //TRANS: short for : Update method for user authentication and synchronization
         $values[self::UPDATEAUTHENT]      = ['short' => __('Update auth and sync'),
             'long'  => __('Update method for user authentication and synchronization')
+        ];
+        $values[self::IMPERSONATE]      = ['short' => __('Impersonate'),
+            'long'  => __('Impersonate users with the same or less rights')
         ];
 
         return $values;

--- a/tests/functionnal/Session.php
+++ b/tests/functionnal/Session.php
@@ -450,4 +450,107 @@ class Session extends \DbTestCase
         ]);
         $this->boolean($result)->isTrue();
     }
+
+    public function testCanImpersonate()
+    {
+        global $DB;
+
+        $user = new \User();
+        $root_entity = getItemByTypeName('Entity', '_test_root_entity', true);
+
+        $users = [];
+        for ($i = 0; $i < 6; $i++) {
+            $users_id = $user->add([
+                'name'     => 'testCanImpersonate' . $i,
+                'password' => 'test',
+                'password2' => 'test',
+                'entities_id' => $root_entity,
+            ]);
+            $this->integer($users_id)->isGreaterThan(0);
+            $users[] = $users_id;
+        }
+
+        $profiles_to_copy = ['Technician', 'Admin'];
+        // Copy the data of each profile to a new one with the same name but suffixed with '-Impersonate
+        foreach ($profiles_to_copy as $profile_name) {
+            $profile = new \Profile();
+            $profiles_id = getItemByTypeName('Profile', $profile_name, true);
+            $this->integer($profiles_id)->isGreaterThan(0);
+            $profile->getFromDB($profiles_id);
+            $new_input = $profile->fields;
+            unset($new_input['id']);
+            $new_input['name'] .= '-Impersonate';
+            $new_profiles_id = $profile->add($new_input);
+
+            // Copy all rights from original profile to the new one, adding user impersonate right
+            $rights = \ProfileRight::getProfileRights($profiles_id, ['user']);
+            $rights['user'] = (int) $rights['user'] | \User::IMPERSONATE;
+            \ProfileRight::updateProfileRights($new_profiles_id, $rights);
+        }
+
+        $assign_profile = function (int $users_id, int $profiles_id) use ($root_entity) {
+            $profile_user = new \Profile_User();
+            $result = $profile_user->add([
+                'profiles_id' => $profiles_id,
+                'users_id'    => $users_id,
+                'entities_id' => $root_entity,
+            ]);
+            $this->integer($result)->isGreaterThan(0);
+            $user = new \User();
+            $this->boolean($user->update([
+                'id' => $users_id,
+                'profiles_id' => $profiles_id,
+            ]))->isTrue();
+        };
+
+        $assign_profile($users[1], getItemByTypeName('Profile', 'Technician-Impersonate', true));
+        $assign_profile($users[2], getItemByTypeName('Profile', 'Admin-Impersonate', true));
+        $assign_profile($users[3], getItemByTypeName('Profile', 'Admin-Impersonate', true));
+        $assign_profile($users[4], getItemByTypeName('Profile', 'Super-Admin', true));
+        $assign_profile($users[5], getItemByTypeName('Profile', 'Super-Admin', true));
+
+        $this->login('testCanImpersonate1', 'test');
+        $this->boolean(\Session::canImpersonate($users[0]))->isTrue();
+        $this->boolean(\Session::canImpersonate($users[1]))->isFalse();
+        $this->boolean(\Session::canImpersonate($users[2]))->isFalse();
+        $this->boolean(\Session::canImpersonate($users[3]))->isFalse();
+        $this->boolean(\Session::canImpersonate($users[4]))->isFalse();
+
+        $this->login('testCanImpersonate2', 'test');
+        $this->boolean(\Session::canImpersonate($users[0]))->isTrue();
+        $this->boolean(\Session::canImpersonate($users[1]))->isTrue();
+        $this->boolean(\Session::canImpersonate($users[2]))->isFalse();
+        $this->boolean(\Session::canImpersonate($users[3]))->isTrue();
+        $this->boolean(\Session::canImpersonate($users[4]))->isFalse();
+
+        $this->login('testCanImpersonate3', 'test');
+        $this->boolean(\Session::canImpersonate($users[0]))->isTrue();
+        $this->boolean(\Session::canImpersonate($users[1]))->isTrue();
+        $this->boolean(\Session::canImpersonate($users[2]))->isTrue();
+        $this->boolean(\Session::canImpersonate($users[3]))->isFalse();
+        $this->boolean(\Session::canImpersonate($users[4]))->isFalse();
+
+        $this->login('testCanImpersonate4', 'test');
+        // Super-admins have config UPDATE right so they can impersonate anyone (except themselves)
+        $this->boolean(\Session::canImpersonate($users[0]))->isTrue();
+        $this->boolean(\Session::canImpersonate($users[1]))->isTrue();
+        $this->boolean(\Session::canImpersonate($users[2]))->isTrue();
+        $this->boolean(\Session::canImpersonate($users[3]))->isTrue();
+        $this->boolean(\Session::canImpersonate($users[4]))->isFalse();
+        $this->boolean(\Session::canImpersonate($users[5]))->isTrue();
+
+        $assign_profile($users[0], getItemByTypeName('Profile', 'Admin-Impersonate', true));
+        $this->login('testCanImpersonate1', 'test');
+        // User 0 now has a higher-level profile (Admin) than User 1 which is only Technician
+        $this->boolean(\Session::canImpersonate($users[0]))->isFalse();
+
+        $this->login('testCanImpersonate0', 'test');
+        // Force user 0 to use Self-Service profile initially
+        \Session::changeProfile(getItemByTypeName('Profile', 'Self-Service', true));
+        // User 0's default profile is still Self-Service, so they can't impersonate anyone
+        $this->boolean(\Session::canImpersonate($users[1]))->isFalse();
+        \Session::changeProfile(getItemByTypeName('Profile', 'Admin-Impersonate', true));
+        // User 0's default profile is now Admin-Impersonate, so they can impersonate the user with Technician-Impersonate
+        $this->boolean(\Session::canImpersonate($users[1]))->isTrue();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Adds a new User right for impersonation.
The new permission only allows users whose current profile is higher or equally privileged as every profile of the other user. For example, a technician with this right could impersonation self-service users but not admins. This is mainly to avoid privilege escalation.

If user's have the update permission for the config right, then they can impersonate anyone which is the previous behavior.