### PR TITLE
fix a warning when displaying refused equipment

### DIFF
--- a/src/Features/Inventoriable.php
+++ b/src/Features/Inventoriable.php
@@ -70,14 +70,16 @@ trait Inventoriable
      */
     public function getInventoryFileName(bool $prepend_dir_path = true): ?string
     {
-        $source = new \AutoUpdateSystem();
-        $source->getFromDBByCrit(['name' => 'GLPI Native Inventory']);
 
-        if ($this->isField('autoupdatesystems_id')
-            && (!$this->isDynamic()
+        if ($this->isField('autoupdatesystems_id')) {
+            $source = new \AutoUpdateSystem();
+            $source->getFromDBByCrit(['name' => 'GLPI Native Inventory']);
+
+            if (!$this->isDynamic()
                 || !isset($source->fields['id'])
                 || $this->fields['autoupdatesystems_id'] != $source->fields['id'])) {
-            return null;
+                return null;
+            }
         }
 
         $inventory_dir_path = GLPI_INVENTORY_DIR . '/';

--- a/src/Features/Inventoriable.php
+++ b/src/Features/Inventoriable.php
@@ -73,7 +73,12 @@ trait Inventoriable
         $source = new \AutoUpdateSystem();
         $source->getFromDBByCrit(['name' => 'GLPI Native Inventory']);
 
-        if (!$this->isDynamic() || !isset($source->fields['id']) || $this->fields['autoupdatesystems_id'] != $source->fields['id']) {
+        if (!($this instanceof RefusedEquipment)
+            && (
+                !$this->isDynamic()
+                || !isset($source->fields['id'])
+                || $this->fields['autoupdatesystems_id'] != $source->fields['id']
+            )) {
             return null;
         }
 

--- a/src/Features/Inventoriable.php
+++ b/src/Features/Inventoriable.php
@@ -73,7 +73,7 @@ trait Inventoriable
         $source = new \AutoUpdateSystem();
         $source->getFromDBByCrit(['name' => 'GLPI Native Inventory']);
 
-        if (!($this instanceof RefusedEquipment)
+        if ($this->isField('autoupdatesystems_id')
             && (!$this->isDynamic()
                 || !isset($source->fields['id'])
                 || $this->fields['autoupdatesystems_id'] != $source->fields['id'])) {

--- a/src/Features/Inventoriable.php
+++ b/src/Features/Inventoriable.php
@@ -75,9 +75,11 @@ trait Inventoriable
             $source = new \AutoUpdateSystem();
             $source->getFromDBByCrit(['name' => 'GLPI Native Inventory']);
 
-            if (!$this->isDynamic()
+            if (
+                !$this->isDynamic()
                 || !isset($source->fields['id'])
-                || $this->fields['autoupdatesystems_id'] != $source->fields['id']) {
+                || $this->fields['autoupdatesystems_id'] != $source->fields['id']
+            ) {
                 return null;
             }
         }

--- a/src/Features/Inventoriable.php
+++ b/src/Features/Inventoriable.php
@@ -77,7 +77,7 @@ trait Inventoriable
 
             if (!$this->isDynamic()
                 || !isset($source->fields['id'])
-                || $this->fields['autoupdatesystems_id'] != $source->fields['id'])) {
+                || $this->fields['autoupdatesystems_id'] != $source->fields['id']) {
                 return null;
             }
         }

--- a/src/Features/Inventoriable.php
+++ b/src/Features/Inventoriable.php
@@ -74,11 +74,9 @@ trait Inventoriable
         $source->getFromDBByCrit(['name' => 'GLPI Native Inventory']);
 
         if (!($this instanceof RefusedEquipment)
-            && (
-                !$this->isDynamic()
+            && (!$this->isDynamic()
                 || !isset($source->fields['id'])
-                || $this->fields['autoupdatesystems_id'] != $source->fields['id']
-            )) {
+                || $this->fields['autoupdatesystems_id'] != $source->fields['id'])) {
             return null;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Fix:
```
PHP Warning (2): Undefined array key "autoupdatesystems_id" in /var/www/html/glpi/10.0.git/src/Features/Inventoriable.php at line 76
```

I guessed as `RefusedEquipment` doesn't have `autoupdatesystems_id` field, it still should have the xml link displayed
