### PR TITLE
Namespaced class fixes

### DIFF
--- a/front/displaypreference.form.php
+++ b/front/displaypreference.form.php
@@ -66,7 +66,7 @@ if (isset($_POST["activate"])) {
 
 // Datas may come from GET or POST : use REQUEST
 if (isset($_REQUEST["itemtype"])) {
-    $setupdisplay->display(['displaytype' => $_REQUEST['itemtype']]);
+    $setupdisplay->display(['displaytype' => addslashes($_REQUEST['itemtype'])]);
 }
 
 Html::popFooter();

--- a/front/displaypreference.form.php
+++ b/front/displaypreference.form.php
@@ -66,7 +66,7 @@ if (isset($_POST["activate"])) {
 
 // Datas may come from GET or POST : use REQUEST
 if (isset($_REQUEST["itemtype"])) {
-    $setupdisplay->display(['displaytype' => addslashes($_REQUEST['itemtype'])]);
+    $setupdisplay->display(['displaytype' => $_REQUEST['itemtype']]);
 }
 
 Html::popFooter();

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -874,7 +874,7 @@ JAVASCRIPT;
             }
 
            // prevent double sanitize, because the includes.php sanitize all data
-            $cleaned_options = Toolbox::stripslashes_deep($cleaned_options);
+            $cleaned_options = Sanitizer::unsanitize($cleaned_options);
 
             $extraparamhtml = "&amp;" . Toolbox::append_params($cleaned_options, '&amp;');
         }

--- a/src/Search.php
+++ b/src/Search.php
@@ -2536,12 +2536,13 @@ class Search
         $idor_display_meta_criteria  = Session::getNewIDORToken($itemtype);
         $idor_display_criteria_group = Session::getNewIDORToken($itemtype);
 
+        $itemtype_escaped = addslashes($itemtype);
         $JS = <<<JAVASCRIPT
          $('#addsearchcriteria$rand_criteria').on('click', function(event) {
             event.preventDefault();
             $.post('{$CFG_GLPI['root_doc']}/ajax/search.php', {
                'action': 'display_criteria',
-               'itemtype': '$itemtype',
+               'itemtype': '$itemtype_escaped',
                'num': $nbsearchcountvar,
                'p': $json_p,
                '_idor_token': '$idor_display_criteria'
@@ -2556,7 +2557,7 @@ class Search
             event.preventDefault();
             $.post('{$CFG_GLPI['root_doc']}/ajax/search.php', {
                'action': 'display_meta_criteria',
-               'itemtype': '$itemtype',
+               'itemtype': '$itemtype_escaped',
                'meta': true,
                'num': $nbsearchcountvar,
                'p': $json_p,
@@ -2572,7 +2573,7 @@ class Search
             event.preventDefault();
             $.post('{$CFG_GLPI['root_doc']}/ajax/search.php', {
                'action': 'display_criteria_group',
-               'itemtype': '$itemtype',
+               'itemtype': '$itemtype_escaped',
                'meta': true,
                'num': $nbsearchcountvar,
                'p': $json_p,

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -158,7 +158,7 @@ $(document).ready(function() {
       modal += '</div>';
       modal += '<div class="modal-body">';
       modal += '<div class="ratio ratio-4x3">';
-      modal += '<iframe src="{{ path('front/displaypreference.form.php?itemtype=' ~ itemtype) }}"></iframe>'
+      modal += '<iframe src="{{ path('front/displaypreference.form.php?itemtype=' ~ itemtype|escape('url')) }}"></iframe>'
       modal += '</div>';
       modal += '</div>';
       modal += '</div>';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixes issue displaying display preferences modal.
Fixes issue adding search criteria.

The first issue was caused by a properly formatted namespaced class name like `Glpi\Socket` having its only `\` stripped out in the `CommonGLPI::showTabsContent` method. Also, the itemtype didn't seem to be properly escaped for the iframe src.

The second issue wasn't clear with the cause. In the JS code generated for the button event listeners, it looks like a properly formatted namespaced class name like `Glp\Socket` would have been in the POST payload but Chrome's dev tools showed that the slash was removed before it was actually sent to the server.