### PR TITLE
Fix encoding of completename in logs

### DIFF
--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -159,9 +159,8 @@ class Dropdown {
          $params['condition'] = static::addNewCondition($params['condition']);
       }
 
-      if (!$item instanceof CommonTreeDropdown) {
-         $name = Toolbox::unclean_cross_side_scripting_deep($name);
-      }
+      $name = Toolbox::unclean_cross_side_scripting_deep($name);
+
       $p = ['value'                => $params['value'],
             'valuename'            => $name,
             'width'                => $params['width'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23704

Since #8818, result of `getTreeValueCompleteName()` conforms to handling of `<` and `>` special chars in GLPI (they are expected to be always encoded in HTML entities).

With this PR, we ensure that entries related to `completename` in `glpi_logs` table are also conforming to this rule.