### PR TITLE
remove annoying branding

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3834,6 +3834,7 @@ JS;
 
             // init editor
             tinyMCE.init(Object.assign({
+               branding: false,
                selector: '#{$name}',
 
                plugins: {$pluginsjs},


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Current licence is lgpl2 and soon mit, none can enforce the display of the "ad".
The branding is really annoying and before 10, we never displayed it.

Suggestion is done we can add a specific page to mentions our usage of opensource libraries maybe