### PR TITLE
Clean output of imap tests

### DIFF
--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -583,19 +583,25 @@ class MailCollector extends DbTestCase
        // Collect all mails
         $this->doConnect();
         $this->collector->maxfetch_emails = 1000; // Be sure to fetch all mails from test suite
-        $msg = $this->collector->collect($this->mailgate_id);
+
+        $expected_errors = [
+            // 05-empty-from.eml
+            'The input is not a valid email address. Use the basic format local-part@hostname' => LogLevel::CRITICAL,
+            // 17-malformed-email.eml
+            'Header with Name date or date not found' => LogLevel::CRITICAL,
+        ];
+
+        $msg = null;
+        $this->output(
+            function () use (&$msg) {
+                $msg = $this->collector->collect($this->mailgate_id);
+            }
+        )->matches('/^(.*\n){' . count($expected_errors) . '}$/'); // Ensure that output has same count of lines than expected error count
 
         // Check error log and clean it (to prevent test failure, see GLPITestCase::afterTestMethod()).
-        // 05-empty-from.eml
-        $this->hasPhpLogRecordThatContains(
-            'The input is not a valid email address. Use the basic format local-part@hostname',
-            LogLevel::CRITICAL
-        );
-        // 17-malformed-email.eml
-        $this->hasPhpLogRecordThatContains(
-            'Header with Name date or date not found',
-            LogLevel::CRITICAL
-        );
+        foreach ($expected_errors as $error_message => $error_level) {
+            $this->hasPhpLogRecordThatContains($error_message, $error_level);
+        }
 
         $total_count                     = count(glob(GLPI_ROOT . '/tests/emails-tests/*.eml'));
         $expected_refused_count          = 3;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Follows #11213.

Usage of `$this->output()` catches the output and prevent it to be displayed in test results. We could test that it contains expected messages, but test will not fail if output contains something else than expected errors. As error messages are containing line number and path of file related to error, using `$this->output()->isIdenticalTo()` is not a solution.
So here I just added a check to ensure that output contains the same number of lines than the expected error count.