### PR TITLE
Put back strictness on composer config validation

### DIFF
--- a/.github/actions/init_build.sh
+++ b/.github/actions/init_build.sh
@@ -5,8 +5,7 @@
 STABLE_REGEX="^[0-9]+\.[0-9]+\.[0-9]+$"
 
 # Validate composer config
-# Cannot use `--strict` mode due to following warning: "Defining autoload.psr-4 with an empty namespace prefix is a bad idea for performance"
-composer validate
+composer validate --strict
 if [[ "$PHP_VERSION" =~ $STABLE_REGEX ]]; then
   composer check-platform-reqs;
 fi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

PSR-4 autoload on empty namespace has been removed in #10715 .