### PR TITLE
Fix search result dashboard widget

### DIFF
--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -39,6 +39,7 @@ use Mexitek\PHPColors\Color;
 use Michelf\MarkdownExtra;
 use Plugin;
 use ScssPhp\ScssPhp\Compiler;
+use Symfony\Component\DomCrawler\Crawler;
 use Search;
 use Toolbox;
 
@@ -1784,7 +1785,9 @@ HTML;
             'list_limit'         => $p['limit']
         ]);
         Search::showList($p['itemtype'], $params);
-        $search_result = ob_get_clean();
+
+        $crawler = new Crawler(ob_get_clean());
+        $search_result = $crawler->filter('.search-results')->outerHtml();
 
         $html = <<<HTML
       <style>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`Search::showList()` method now returns controls and pager. This is a quick and dirty fix. A more appropriate fix would be to review the way params are passed to display method.

Before:
![image](https://user-images.githubusercontent.com/33253653/162453256-08f7f916-e1e4-45a5-9f70-7c473d6ad280.png)

After:
![image](https://user-images.githubusercontent.com/33253653/162453125-22676a7a-ee37-4f7c-94b3-ec828e7e8280.png)
