### PR TITLE
Fix menu links from helpdesk_menu_entry hook

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -1665,8 +1665,19 @@ HTML;
                     $link = "";
                     if (is_string($PLUGIN_HOOKS["helpdesk_menu_entry"][$plugin])) {
                         $link = $PLUGIN_HOOKS["helpdesk_menu_entry"][$plugin];
+
+                        // Ensure menu entries have all a starting `/`
+                        if (!str_starts_with($link, '/')) {
+                            $link = '/' . $link;
+                        }
+
+                        // Prefix with plugin path if plugin path is missing
+                        $plugin_dir = Plugin::getWebDir($plugin, false);
+                        if (!str_starts_with($link, '/' . $plugin_dir)) {
+                            $link = '/' . $plugin_dir . $link;
+                        }
                     }
-                    $infos['page'] = Plugin::getWebDir($plugin, false) . $link;
+                    $infos['page'] = $link;
                     $infos['title'] = $infos['name'];
                     if (isset($PLUGIN_HOOKS["helpdesk_menu_entry_icon"][$plugin])) {
                         $infos['icon'] = $PLUGIN_HOOKS["helpdesk_menu_entry_icon"][$plugin];

--- a/src/Html.php
+++ b/src/Html.php
@@ -1666,7 +1666,7 @@ HTML;
                     if (is_string($PLUGIN_HOOKS["helpdesk_menu_entry"][$plugin])) {
                         $link = $PLUGIN_HOOKS["helpdesk_menu_entry"][$plugin];
                     }
-                    $infos['page'] = Plugin::getWebDir($plugin) . $link;
+                    $infos['page'] = Plugin::getWebDir($plugin, false) . $link;
                     $infos['title'] = $infos['name'];
                     if (isset($PLUGIN_HOOKS["helpdesk_menu_entry_icon"][$plugin])) {
                         $infos['icon'] = $PLUGIN_HOOKS["helpdesk_menu_entry_icon"][$plugin];

--- a/src/Html.php
+++ b/src/Html.php
@@ -1666,7 +1666,7 @@ HTML;
                     if (is_string($PLUGIN_HOOKS["helpdesk_menu_entry"][$plugin])) {
                         $link = $PLUGIN_HOOKS["helpdesk_menu_entry"][$plugin];
                     }
-                    $infos['page'] = $link;
+                    $infos['page'] = Plugin::getWebDir($plugin) . $link;
                     $infos['title'] = $infos['name'];
                     if (isset($PLUGIN_HOOKS["helpdesk_menu_entry_icon"][$plugin])) {
                         $infos['icon'] = $PLUGIN_HOOKS["helpdesk_menu_entry_icon"][$plugin];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Previously, the links had the plugin's web directory prefixed automatically but since the UI rework, this is not the case anymore.