### PR TITLE
Mini dashboard fixes

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -94,7 +94,7 @@ var Dashboard = {
 
         Dashboard.grid = GridStack.init({
             column: options.cols,
-            maxRow: (options.rows + 1), // +1 for a hidden item at bottom (to fix height)
+            maxRow: options.rows,
             margin : this.cell_margin,
             float: true, // widget can be placed anywhere on the grid, not only on top
             animate: false, // as we don't move widget automatically, we don't need animation

--- a/src/Search.php
+++ b/src/Search.php
@@ -87,7 +87,7 @@ class Search
             $itemtype == "Ticket"
             && $default = Glpi\Dashboard\Grid::getDefaultDashboardForMenu('mini_ticket', true)
         ) {
-            $dashboard = new Glpi\Dashboard\Grid($default, 33, 1);
+            $dashboard = new Glpi\Dashboard\Grid($default, 33, 2);
             $dashboard->show(true);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixed issue where the second row of the mini dashboard was non-functional and only worked to fit the display of cards two rows tall.
There is also an issue with dragging cards to the left but I haven't determined the cause. The dragging seems to be handled by jQuery UI in GridStack but it also seems to work properly for full size dashboards so I can't tell if the issue in on our end or not. In some cases when moving a card to an empty space on the left there are areas that don't get highlighted as if they are not valid drop areas.