### PR TITLE
fix(certificate/domain): delete alert after date_expiration update

### DIFF
--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -805,4 +805,11 @@ class Certificate extends CommonDBTM
     {
         return "ti ti-certificate";
     }
+
+
+    public function post_updateItem($history = 1)
+    {
+        $this->cleanAlerts([Alert::END]);
+        parent::post_updateItem($history);
+    }
 }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1859,6 +1859,15 @@ class CommonDBTM extends CommonGLPI
      **/
     public function post_updateItem($history = 1)
     {
+        if (in_array('date_expiration', $this->updates)) {
+            $input = [
+                'type'     => Alert::END,
+                'itemtype' => $this->getType(),
+                'items_id' => $this->fields['id'],
+            ];
+            $alert = new Alert();
+            $alert->deleteByCriteria($input, 1);
+        }
 
         UserMention::handleUserMentions($this);
     }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6370,7 +6370,16 @@ class CommonDBTM extends CommonGLPI
         );
     }
 
-    final public function cleanAlerts(array $types)
+    /**
+     * Delete alerts of given types related to current item.
+     *
+     * @param array $types
+     *
+     * @return void
+     *
+     * @since 10.0.0
+     */
+    final public function cleanAlerts(array $types): void
     {
         if (in_array('date_expiration', $this->updates)) {
             $input = [

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1859,15 +1859,6 @@ class CommonDBTM extends CommonGLPI
      **/
     public function post_updateItem($history = 1)
     {
-        if (in_array('date_expiration', $this->updates)) {
-            $input = [
-                'type'     => Alert::END,
-                'itemtype' => $this->getType(),
-                'items_id' => $this->fields['id'],
-            ];
-            $alert = new Alert();
-            $alert->deleteByCriteria($input, 1);
-        }
 
         UserMention::handleUserMentions($this);
     }
@@ -6377,5 +6368,18 @@ class CommonDBTM extends CommonGLPI
             $menus[2] ?? '',
             false
         );
+    }
+
+    final public function cleanAlerts(array $types)
+    {
+        if (in_array('date_expiration', $this->updates)) {
+            $input = [
+                'type'     => $types,
+                'itemtype' => $this->getType(),
+                'items_id' => $this->fields['id'],
+            ];
+            $alert = new Alert();
+            $alert->deleteByCriteria($input, 1);
+        }
     }
 }

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -833,4 +833,10 @@ class Domain extends CommonDBTM
     {
         return "fas fa-globe-americas";
     }
+
+    public function post_updateItem($history = 1)
+    {
+        $this->cleanAlerts([Alert::END, Alert::NOTICE]);
+        parent::post_updateItem($history);
+    }
 }


### PR DESCRIPTION
When a certificate is expired and generates an alert, if the expiry date is updated afterwards, the alert is no longer sent (as it is considered as already sent).
Same behaviour with domains.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23755
