### PR TITLE
Fix JSTree not implemented warning

### DIFF
--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -138,9 +138,10 @@
          table: {
             indentation: 20,       // indent 20px per node level
             nodeColumnIdx: 0,      // render the node title into the 1st column
+            mergeStatusColumns: false,
          },
          grid: {
-            mergeStatusColumns: false
+            mergeStatusColumns: false,
          },
          viewport: {
             enabled: true,

--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -139,6 +139,9 @@
             indentation: 20,       // indent 20px per node level
             nodeColumnIdx: 0,      // render the node title into the 1st column
          },
+         grid: {
+            mergeStatusColumns: false
+         },
          viewport: {
             enabled: true,
             count: 15, // number of items to display at once


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

On every page, there are 2 warnings in the browser console stating "mergeStatusColumns is not yet implemented." from JSTree. The implementation of this feature in the newer grid extension was replaced with this warning 3 years ago so I don't know that it will be added anytime soon. For now, I explicitly set the option to false.

Also, for some reason, the `mergeStatusColumns`option has to be declared under the new `grid` property even though it existed in the older `table` extension. This is the only option I found that needs declared there. Just in case this is a bug that gets fixed later, I set the option to false in both places.