### PR TITLE
Fix missing last update when using todo checkbox in timeline

### DIFF
--- a/ajax/timeline.php
+++ b/ajax/timeline.php
@@ -64,7 +64,8 @@ if (($_POST['action'] ?? null) === 'change_task_state') {
         $task->update([
             'id'        => intval($_POST['tasks_id']),
             $foreignKey => intval($_POST[$foreignKey]),
-            'state'     => $new_state
+            'state'     => $new_state,
+            'users_id_editor' => Session::getLoginUserID()
         ]);
     }
 } else if (($_REQUEST['action'] ?? null) === 'viewsubitem') {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11208

Changing the state of a task using the checkbox doesn't set the `users_id_editor` field so it won't show the Last Update by in the item header until someone edits the form normally. After that, the field remains set so the header will update properly when changing the state with the checkbox.