### PR TITLE
Prevent unwanted switching from update to install

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -569,7 +569,7 @@ if (!isset($_SESSION['can_process_install']) || !isset($_POST["install"])) {
             Toolbox::setDebugMode(Session::DEBUG_MODE, 0, 0, 1);
 
             header_html(sprintf(__('Step %d'), 1));
-            step2($_POST["update"] ?? 'no');
+            step2($_POST["update"]);
             break;
 
         case "Etape_2": // mysql settings ok, go test mysql settings and select database.

--- a/templates/install/step3.html.twig
+++ b/templates/install/step3.html.twig
@@ -46,6 +46,7 @@
          {{ __("Back") }}
       </button>
 
+      <input type="hidden" name="update" value="{{ update }}">
       <input type="hidden" name="install" value="Etape_1">
       <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}">
    </form>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Since b1e199cdfc529d0eb5b662b9a7abe2061bdacd17, when DB connection checks fails during step 2 of update process, user is redirected to install process but he probably won't notice.
As the install process drops all tables before recreating them, all existing data will be erased.