### PR TITLE
Enhance errors handling on update

### DIFF
--- a/config/_config_db.php
+++ b/config/_config_db.php
@@ -1,0 +1,13 @@
+<?php
+class DB extends DBmysql {
+   public $dbhost = 'db';
+   public $dbuser = 'glpi';
+   public $dbpassword = 'glpi';
+   public $dbdefault = '';
+   public $log_deprecation_warnings = true;
+   public $use_utf8mb4 = true;
+   public $allow_datetime = false;
+   public $allow_myisam = false;
+   public $allow_signed_keys = false;
+   public $use_timezones = true;
+}

--- a/install/install.php
+++ b/install/install.php
@@ -448,37 +448,45 @@ function step8()
 }
 
 
-function update1($DBname)
+function update1($dbname)
 {
 
     $host     = $_SESSION['db_access']['host'];
     $user     = $_SESSION['db_access']['user'];
     $password = $_SESSION['db_access']['password'];
 
-    if ($success = DBConnection::createMainConfig($host, $user, $password, $DBname) && !empty($DBname)) {
-        include_once(GLPI_CONFIG_DIR . "/config_db.php");
+    $error = null;
+    if (empty($dbname)) {
+        $error = __('Please select a database.');
+    } else {
         global $DB;
-        $DB = new DB();
-
-        $success = DBConnection::updateConfigProperties($DB->getComputedConfigBooleanFlags());
+        $DB = DBConnection::getDbInstanceUsingParameters($host, $user, $password, $dbname);
+        $update = new Update($DB);
+        if ($update->getCurrents()['version'] === null) {
+            $error = sprintf(__('Current GLPI version not found for database named "%s". Update cannot be done.'), $dbname);
+        } elseif (
+            !DBConnection::createMainConfig($host, $user, $password, $dbname)
+            || !DBConnection::updateConfigProperties($DB->getComputedConfigBooleanFlags())
+        ) {
+            $error = __("Can't create the database connection file, please verify file permissions.");
+        }
     }
-    if ($success) {
+
+    if ($error !== null) {
+        header_html(__('Upgrade'));
+        TemplateRenderer::getInstance()->display(
+            'install/update.invalid_database.html.twig',
+            [
+                'message' => $error,
+                'db_host' => $host,
+                'db_user' => $user,
+                'db_pass' => rawurlencode($password),
+            ]
+        );
+        footer_html();
+    } else {
         $from_install = true;
         include_once(GLPI_ROOT . "/install/update.php");
-    } else { // can't create config_db file
-        header_html('');
-        echo __("Can't create the database connection file, please verify file permissions.");
-        echo "<h3>" . __('Do you want to continue?') . "</h3>";
-        echo "<form action='install.php' method='post'>";
-        echo "<input type='hidden' name='update' value='yes'>";
-        echo "<p class='submit'><input type='hidden' name='install' value='Etape_0'>";
-        echo "<button type='submit' name='submit' class='btn btn-primary'>
-         " . __('Continue') . "
-         <i class='fas fa-chevron-right ms-1'></i>
-      </button>";
-        echo "</p>";
-        Html::closeForm();
-        footer_html();
     }
 }
 

--- a/src/Console/Database/UpdateCommand.php
+++ b/src/Console/Database/UpdateCommand.php
@@ -64,6 +64,13 @@ class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionComma
      */
     const ERROR_MISSING_SECURITY_KEY_FILE = 2;
 
+    /**
+     * Error code returned when database is not a valid GLPI database.
+     *
+     * @var integer
+     */
+    const ERROR_INVALID_DATABASE = 3;
+
     protected $requires_db_up_to_date = false;
 
     protected function configure()
@@ -122,6 +129,15 @@ class UpdateCommand extends AbstractCommand implements ForceNoPluginsOptionComma
         $currents            = $update->getCurrents();
         $current_version     = $currents['version'];
         $current_db_version  = $currents['dbversion'];
+
+        if ($current_version === null) {
+            $msg = sprintf(
+                __('Current GLPI version not found for database named "%s". Update cannot be done.'),
+                $this->db->dbdefault
+            );
+            $output->writeln('<error>' . $msg . '</error>');
+            return self::ERROR_INVALID_DATABASE;
+        }
 
         global $migration; // Migration scripts are using global migrations
         $migration = new Migration(GLPI_VERSION);

--- a/src/DBConnection.php
+++ b/src/DBConnection.php
@@ -830,4 +830,28 @@ class DBConnection extends CommonDBTM
 
         return 'unsigned';
     }
+
+    /**
+     * Return a DB instance using given connection parameters.
+     *
+     * @param string $host
+     * @param string $user
+     * @param string $password
+     * @param string $dbname
+     *
+     * @return DBmysql
+     */
+    public static function getDbInstanceUsingParameters(string $host, string $user, string $password, string $dbname): DBmysql
+    {
+        return new class ($host, $user, $password, $dbname) extends DBmysql {
+            public function __construct($host, $user, $password, $dbname)
+            {
+                  $this->dbhost     = $host;
+                  $this->dbuser     = $user;
+                  $this->dbpassword = $password;
+                  $this->dbdefault  = $dbname;
+                  parent::__construct();
+            }
+        };
+    }
 }

--- a/templates/install/update.invalid_database.html.twig
+++ b/templates/install/update.invalid_database.html.twig
@@ -1,0 +1,46 @@
+{#
+ # ---------------------------------------------------------------------
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ # Copyright (C) 2015-2022 Teclib' and contributors.
+ #
+ # http://glpi-project.org
+ #
+ # based on GLPI - Gestionnaire Libre de Parc Informatique
+ # Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # GLPI is free software; you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation; either version 2 of the License, or
+ # (at your option) any later version.
+ #
+ # GLPI is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ # ---------------------------------------------------------------------
+ #}
+
+<div class="alert alert-warning"><strong>{{ message }}</strong></div>
+
+<form action="install.php" method="post" class="d-inline" data-submit-once>
+    <button type="submit" name="submit" class="btn btn-warning">
+        <i class="fas fa-chevron-left me-1 fa-2x alert-icon"></i>
+        {{ __("Back") }}
+    </button>
+
+    <input type="hidden" name="update" value="yes" />
+    <input type="hidden" name="install" value="Etape_2" />
+    <input type="hidden" name="db_host" value="{{ db_host }}" />
+    <input type="hidden" name="db_user" value="{{ db_user }}" />
+    <input type="hidden" name="db_pass" value="{{ db_pass }}" />
+    <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+</form>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11239

While investigation on #11239, I figured out that handling of errors on update was not really user friendly.

1. When user was not selecting a database, a `Can't create the database connection file, please verify file permissions.` message was display. Besides of having an irrelevant message, user was redirected to first step of installation process, and had to redo all steps. Now, a proper message will be shown and user will proposed to go to previous step.
![Capture d’écran du 2022-04-14 11-10-37](https://user-images.githubusercontent.com/33253653/163357766-4f97c067-9562-4f22-9fea-6b3ef8a9c456.png)

2. When current version of selected database was not found, an exception was trigerred (see #11239) in following steps. Thus, as configuration file was created, the only way to be able to retry the update process was to manually delete this file. Now, a proper message will be shown and user will proposed to go to previous step, also, config file will not be created.
![Capture d’écran du 2022-04-14 11-11-19](https://user-images.githubusercontent.com/33253653/163361338-6a14678e-8bc5-47e8-949d-cbfd5fe8d8a7.png)

3. When database config file creation/update failed, user was redirected to first step of installation process. Now, user will proposed to go to previous step.
![Capture d’écran du 2022-04-14 11-13-16](https://user-images.githubusercontent.com/33253653/163362332-d8d46cf9-3459-46dc-8d26-f48a03972240.png)

4. When user selects a database that does not contains any `glpi_*` tables, it is currently detected as GLPI 0.1 version. In most cases, I guess, it corresponds to a wrong database selection. Now it will handle the same as case 2.