### PR TITLE
Add interact prompt for marketplace commands

### DIFF
--- a/src/Console/Marketplace/AbstractMarketplaceCommand.php
+++ b/src/Console/Marketplace/AbstractMarketplaceCommand.php
@@ -42,7 +42,6 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 
 abstract class AbstractMarketplaceCommand extends AbstractCommand
 {
-
     /**
      * Get the available choices for the plugin selection
      *

--- a/src/Console/Marketplace/AbstractMarketplaceCommand.php
+++ b/src/Console/Marketplace/AbstractMarketplaceCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Marketplace;
+
+use Glpi\Console\AbstractCommand;
+use Glpi\Marketplace\Controller;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+
+abstract class AbstractMarketplaceCommand extends AbstractCommand
+{
+
+    protected function getPluginChoiceChoices()
+    {
+        $controller = new Controller();
+        $plugins = $controller::getAPI()->getAllPlugins();
+        $result = [];
+
+        foreach ($plugins as $plugin) {
+            $result[$plugin['key']] = $plugin['name'];
+        }
+        return $result;
+    }
+
+    abstract protected function getPluginChoiceQuestion();
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $plugin_arg_name = null;
+
+        if ($this->getDefinition()->hasArgument('plugin')) {
+            $plugin_arg_name = 'plugin';
+        } elseif ($this->getDefinition()->hasArgument('plugins')) {
+            $plugin_arg_name = 'plugins';
+        }
+        if ($plugin_arg_name === null) {
+            return;
+        }
+
+        $directories = $input->getArgument($plugin_arg_name);
+
+        if (empty($directories)) {
+            // Ask for plugin list if directory argument is empty
+            $choices = $this->getPluginChoiceChoices();
+
+            if (!empty($choices)) {
+                /** @var QuestionHelper $question_helper */
+                $question_helper = $this->getHelper('question');
+                $question = new ChoiceQuestion(
+                    $this->getPluginChoiceQuestion(),
+                    $choices
+                );
+                $question->setAutocompleterValues(array_keys($choices));
+                $question->setMultiselect($plugin_arg_name === 'plugins');
+                $answer = $question_helper->ask(
+                    $input,
+                    $output,
+                    $question
+                );
+                $input->setArgument($plugin_arg_name, $answer);
+            }
+        }
+    }
+}

--- a/src/Console/Marketplace/AbstractMarketplaceCommand.php
+++ b/src/Console/Marketplace/AbstractMarketplaceCommand.php
@@ -43,7 +43,12 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 abstract class AbstractMarketplaceCommand extends AbstractCommand
 {
 
-    protected function getPluginChoiceChoices()
+    /**
+     * Get the available choices for the plugin selection
+     *
+     * @return array Array of choices where the key is the plugin key and the value is the plugin name
+     */
+    protected function getPluginChoiceChoices(): array
     {
         $controller = new Controller();
         $plugins = $controller::getAPI()->getAllPlugins();
@@ -55,7 +60,11 @@ abstract class AbstractMarketplaceCommand extends AbstractCommand
         return $result;
     }
 
-    abstract protected function getPluginChoiceQuestion();
+    /**
+     * Get the plugin choice question prompt
+     * @return string
+     */
+    abstract protected function getPluginChoiceQuestion(): string;
 
     protected function interact(InputInterface $input, OutputInterface $output)
     {

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -92,7 +92,7 @@ class DownloadCommand extends AbstractMarketplaceCommand
         return 0; // Success
     }
 
-    protected function getPluginChoiceQuestion()
+    protected function getPluginChoiceQuestion(): string
     {
         return __('Which plugin(s) do you want to download (comma separated values)?');
     }

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -41,7 +41,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class DownloadCommand extends AbstractCommand
+class DownloadCommand extends AbstractMarketplaceCommand
 {
     protected function configure()
     {
@@ -90,5 +90,10 @@ class DownloadCommand extends AbstractCommand
         }
 
         return 0; // Success
+    }
+
+    protected function getPluginChoiceQuestion()
+    {
+        return __('Which plugin(s) do you want to download (comma separated values)?');
     }
 }

--- a/src/Console/Marketplace/InfoCommand.php
+++ b/src/Console/Marketplace/InfoCommand.php
@@ -78,7 +78,7 @@ class InfoCommand extends AbstractMarketplaceCommand
         return 0; // Success
     }
 
-    protected function getPluginChoiceQuestion()
+    protected function getPluginChoiceQuestion(): string
     {
         return __('Which plugin do you want information on?');
     }

--- a/src/Console/Marketplace/InfoCommand.php
+++ b/src/Console/Marketplace/InfoCommand.php
@@ -34,16 +34,12 @@
 namespace Glpi\Console\Marketplace;
 
 use GLPINetwork;
-use Glpi\Console\AbstractCommand;
-use Glpi\Marketplace\Api\Plugins;
 use Glpi\Marketplace\Controller;
-use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class InfoCommand extends AbstractCommand
+class InfoCommand extends AbstractMarketplaceCommand
 {
     protected function configure()
     {
@@ -80,5 +76,10 @@ class InfoCommand extends AbstractCommand
         $output->write(var_export($result, true));
 
         return 0; // Success
+    }
+
+    protected function getPluginChoiceQuestion()
+    {
+        return __('Which plugin do you want information on?');
     }
 }

--- a/src/Console/Marketplace/SearchCommand.php
+++ b/src/Console/Marketplace/SearchCommand.php
@@ -35,16 +35,14 @@ namespace Glpi\Console\Marketplace;
 
 use GLPINetwork;
 use Glpi\Console\AbstractCommand;
-use Glpi\Marketplace\Api\Plugins;
 use Glpi\Marketplace\Controller;
 use Glpi\RichText\RichText;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SearchCommand extends AbstractMarketplaceCommand
+class SearchCommand extends AbstractCommand
 {
     protected function configure()
     {
@@ -127,10 +125,5 @@ class SearchCommand extends AbstractMarketplaceCommand
         $table->render();
 
         return 0; // Success
-    }
-
-    protected function getPluginChoiceQuestion()
-    {
-        return '';
     }
 }

--- a/src/Console/Marketplace/SearchCommand.php
+++ b/src/Console/Marketplace/SearchCommand.php
@@ -44,7 +44,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SearchCommand extends AbstractCommand
+class SearchCommand extends AbstractMarketplaceCommand
 {
     protected function configure()
     {
@@ -127,5 +127,10 @@ class SearchCommand extends AbstractCommand
         $table->render();
 
         return 0; // Success
+    }
+
+    protected function getPluginChoiceQuestion()
+    {
+        return '';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add interact prompt for plugin suggestions when none are specified in the Marketplace CLI commands.
I also tried adding tab autocompletion which was added in Symfony Console 5.4 but I never got it to work properly.