### PR TITLE
Fix gantt tooltip linebreaks

### DIFF
--- a/css/includes/components/_gantt.scss
+++ b/css/includes/components/_gantt.scss
@@ -151,7 +151,6 @@
 
 .gantt_tooltip {
     box-sizing: border-box;
-    white-space: pre-line;
     overflow-wrap: break-word;
 
     .capitalize {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11296

Fix issue with extra linebreaks