### PR TITLE
Rename static Twig function to fix locales extract

### DIFF
--- a/src/Application/View/Extension/PhpExtension.php
+++ b/src/Application/View/Extension/PhpExtension.php
@@ -48,7 +48,7 @@ class PhpExtension extends AbstractExtension
         return [
             new TwigFunction('php_config', [$this, 'phpConfig']),
             new TwigFunction('call', [$this, 'call']),
-            new TwigFunction('static', [$this, 'getStatic']),
+            new TwigFunction('get_static', [$this, 'getStatic']),
         ];
     }
 

--- a/templates/components/itilobject/fields/global_validation.html.twig
+++ b/templates/components/itilobject/fields/global_validation.html.twig
@@ -45,7 +45,7 @@
          {% set validation_right = 'validate_request' %}
       {% endif %}
    {% endif %}
-   {% set can_create = has_profile_right(static(validation, 'rightname'), create_right_val) %}
+   {% set can_create = has_profile_right(get_static(validation, 'rightname'), create_right_val) %}
 
    {% if item.isNewItem() %}
       {% if can_create %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`gettext` does not like the usage of a function named `static`. Indeed, compile template contains `$context["can_create"] = has_profile_right(static(($context["validation"] ?? null), "rightname"), ($context["create_right_val"] ?? null));`, and following error is triggered: `Parse error: syntax error, unexpected token "(", expecting ":" in /tmp/glpi-locales-GGXTLYli/templates/components/itilobject/fields/global_validation.html.twig on line 86`.

Renaming the function fixes this issue.