### PR TITLE
Fix dashboard animated number ending with wrong values

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -818,7 +818,7 @@ var Dashboard = {
                         number.text(this.Counter.toFixed(precision))+suffix;
                     },
                     complete: function () {
-                        number.text(targetNumber.text())+suffix;
+                        number.text(targetNumber)+suffix;
                     }
                 });
             });

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -800,10 +800,11 @@ var Dashboard = {
             .find('.multiple-numbers, .summary-numbers, .big-number')
             .find('.formatted-number')
             .each(function () {
-                var count     = $(this);
-                var precision = count.data('precision');
-                var number    = count.children('.number');
-                var suffix    = count.children('.suffix').text();
+                var count        = $(this);
+                var precision    = count.data('precision');
+                var number       = count.children('.number');
+                var suffix       = count.children('.suffix').text();
+				var targetNumber = number.text();
 
                 // Some custom formats may contain text in the number field, no animation in this case
                 if (isNaN(number.text())) {
@@ -815,7 +816,10 @@ var Dashboard = {
                     easing: 'swing',
                     step: function () {
                         number.text(this.Counter.toFixed(precision))+suffix;
-                    }
+                    },
+					complete: function () {
+						number.text(targetNumber.text())+suffix;
+					}
                 });
             });
     },

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -804,7 +804,7 @@ var Dashboard = {
                 var precision    = count.data('precision');
                 var number       = count.children('.number');
                 var suffix       = count.children('.suffix').text();
-				var targetNumber = number.text();
+                var targetNumber = number.text();
 
                 // Some custom formats may contain text in the number field, no animation in this case
                 if (isNaN(number.text())) {
@@ -817,9 +817,9 @@ var Dashboard = {
                     step: function () {
                         number.text(this.Counter.toFixed(precision))+suffix;
                     },
-					complete: function () {
-						number.text(targetNumber.text())+suffix;
-					}
+                    complete: function () {
+                        number.text(targetNumber.text())+suffix;
+                    }
                 });
             });
     },


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

Most of the time, when animation finishes, numbers in dashboard are wrong. It occurs for me on Brave so probably on other browser too. My change ensure numbers are valid at the end of the animation.

If I remember, the bug was already there in 9.5.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
