### PR TITLE
no requester when a ticket created by self-service

### DIFF
--- a/templates/components/itilobject/selfservice.html.twig
+++ b/templates/components/itilobject/selfservice.html.twig
@@ -113,6 +113,8 @@
                     </div>
                 </div>
 
+            {% else %}
+                <input type="hidden" name="_users_id_requester" value="{{ session('glpiID') }}">
             {% endif %}
         </div>
         <div class="card-body row mx-0">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal ref !23728

When a self-service user create a ticket, if he is **not delegatee** for its groups, no requester will be set in the resulting ticket
