### PR TITLE
Fix truncated DOUBLE warning for new LDAP server

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -4300,6 +4300,9 @@ class AuthLDAP extends CommonDBTM
      */
     public function isSyncFieldUsed()
     {
+        if ($this->getID() <= 0) {
+            return false;
+        }
         $count = countElementsInTable(
             'glpi_users',
             [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When creating a new LDAP directory in GLPI, a SQL warning shows at the bottom of the form stating:
```
*** MySQL query warnings:
  SQL: SELECT COUNT(*) AS cpt FROM `glpi_users` WHERE `auths_id` = '' AND  NOT (`sync_field` IS NULL)
  Warnings: 
1292: Truncated incorrect DOUBLE value: ''
```

`AuthLDAP::isSyncFieldUsed` should return false and not query the DB if this is a new item. The return type for the `getID` field isn't enforced as an integer and in this case, it is an empty string.

The first commit addresses the specific SQL warning. The second adds a check that will return `-1` from `getID` if the value is an empty string. With the second commit, the first is still useful as it avoids a SQL query that isn't needed.