### PR TITLE
Add missing glpi_slas.calendars_id field

### DIFF
--- a/install/migrations/update_9.5.x_to_10.0.0/slm.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/slm.php
@@ -40,6 +40,16 @@ if (!defined('GLPI_ROOT')) {
  * @var Migration $migration
  */
 
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
+
+// `glpi_slas.calendars_id` will not exist if GLPI has been initialized on a 9.1.x version.
+// Indeed, field was not present in `glpi-empty.sql` file, but was present in 0.90.x->9.1.0 migration.
+// It has been added in `glpi-empty.sql` file on GLPI 9.2.0 (see commit ebd8c6f097fd0461e4f9840221224cbb5e89a7a1).
+if (!$DB->fieldExists('glpi_slas', 'calendars_id')) {
+    $migration->addField('glpi_slas', 'calendars_id', "int {$default_key_sign} NOT NULL DEFAULT 0");
+    $migration->addKey('glpi_slas', 'calendars_id');
+}
+
 // Replace usage of negative values in `calendars_id` fields
 foreach (['glpi_slms', 'glpi_olas', 'glpi_slas'] as $table) {
     if (!$DB->fieldExists($table, 'use_ticket_calendar')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11331

`glpi_slas.calendars_id` will not exist if GLPI has been initialized on a 9.1.x version.
Indeed, field was not present in `glpi-empty.sql` file, but was present in 0.90.x->9.1.0 migration.
It has been added in `glpi-empty.sql` file in GLPI 9.2.0 (see commit ebd8c6f097fd0461e4f9840221224cbb5e89a7a1).