### PR TITLE
Fix group central view

### DIFF
--- a/ajax/central.php
+++ b/ajax/central.php
@@ -73,8 +73,8 @@ switch ($_REQUEST['widget']) {
     case 'central_list':
         if (method_exists($itemtype, 'showCentralList')) {
             if (is_subclass_of($itemtype, CommonITILObject::class)) {
-                $showgroupproblems = isset($params['showgroupproblems']) ? ($params['showgroupproblems'] !== 'false') : false;
-                $itemtype::showCentralList($params['start'], $params['status'] ?? 'process', $showgroupproblems);
+                $showgrouptickets = isset($params['showgrouptickets']) ? ($params['showgrouptickets'] !== 'false') : false;
+                $itemtype::showCentralList($params['start'], $params['status'] ?? 'process', $showgrouptickets);
             }
         } else if ($itemtype === RSSFeed::class) {
             $personal = $params['personal'] !== 'false';

--- a/src/Central.php
+++ b/src/Central.php
@@ -425,9 +425,9 @@ class Central extends CommonGLPI
         ];
         foreach ($lists as $list) {
             $card_params = [
-                'start'              => 0,
-                'status'             => $list['status'],
-                'showgrouptickets'   => 'true'
+                'start'             => 0,
+                'status'            => $list['status'],
+                'showgrouptickets'  => 'true'
             ];
             $idor = Session::getNewIDORToken($list['itemtype'], $card_params);
             $twig_params['cards'][] = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11332

The group tab in central was looking for the wrong property to determine if the list widget should show data for groups or not.