### PR TITLE
Dashboard filters: under category

### DIFF
--- a/src/Dashboard/Provider.php
+++ b/src/Dashboard/Provider.php
@@ -44,6 +44,7 @@ use Config;
 use DBConnection;
 use Group;
 use Group_Ticket;
+use ITILCategory;
 use Problem;
 use Profile_User;
 use QueryExpression;
@@ -1676,7 +1677,7 @@ class Provider
             $s_criteria['criteria'][] = [
                 'link'       => 'AND',
                 'field'      => self::getSearchOptionID($table, 'itilcategories_id', 'glpi_itilcategories'), // itilcategory
-                'searchtype' => 'equals',
+                'searchtype' => 'under',
                 'value'      => (int) $apply_filters['itilcategory']
             ];
         }
@@ -1825,7 +1826,7 @@ class Provider
             && (int) $apply_filters['itilcategory'] > 0
         ) {
             $where += [
-                "$table.itilcategories_id" => (int) $apply_filters['itilcategory']
+                "$table.itilcategories_id" => getSonsOf(ITILCategory::getTable(), (int) $apply_filters['itilcategory'])
             ];
         }
 


### PR DESCRIPTION
### Issue

I have the following tickets: 

![image](https://user-images.githubusercontent.com/42734840/164441188-7d917acb-94a8-488a-b329-b2275edb6fcd.png)

Filtering on the "Root" category will only find the first ticket:

![image](https://user-images.githubusercontent.com/42734840/164441284-b41a791f-3ac6-42e1-b8cb-3647181c9e15.png)

And, when clicking on the widget to open the search page, the criteria only filter the tickets directly in the root category:

![image](https://user-images.githubusercontent.com/42734840/164441384-80745fdc-407a-400c-a2b7-11d9b3b90b11.png)

Since categories are a hierarchical structure, users might expect this kind of filter to show any tickets **under** the root category.

### Fix

I've modified this filter to make it work as "under X category" instead of "equals X category".

The second ticket is now detected correctly:

![image](https://user-images.githubusercontent.com/42734840/164441868-864bbdae-7858-4a36-a4e3-b465e2ee7918.png)

And the search criteria has been updated: 

![image](https://user-images.githubusercontent.com/42734840/164441956-d6d2b255-82c5-4c46-96ab-f8d065e1ae0c.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23842
