### PR TITLE
in followup form, content is not marked as required when needed

### DIFF
--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -84,7 +84,8 @@
             <input type="hidden" name="items_id" value="{{ item.fields['id'] }}" />
             {{ call_plugin_hook('pre_item_form', {"item": subitem, 'options': params}) }}
 
-            {% if (_get['_openfollowup'] ?? false) or item.needReopen() %}
+            {% set add_reopen = (_get['_openfollowup'] ?? false) or item.needReopen() %}
+            {% if add_reopen %}
                <input type="hidden" name="add_reopen" value="1" />
             {% endif %}
 
@@ -102,6 +103,7 @@
                         'enable_fileupload': true,
                         'enable_mentions': true,
                         'rand': rand,
+                        'required': add_reopen
                      }
                   ) }}
                </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

