### PR TITLE
Handle AJAX search failure better

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -87,10 +87,10 @@
             "env": {
                 "node": true,
                 "jest": true,
-                "es6": true
+                "es2021": true
             },
             "parserOptions": {
-                "ecmaVersion": 7,
+                "ecmaVersion": 12,
                 "sourceType": "module"
             }
         }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -86,7 +86,8 @@
             "files": ["tests/js/**"],
             "env": {
                 "node": true,
-                "jest": true
+                "jest": true,
+                "es6": true
             },
             "parserOptions": {
                 "sourceType": "module"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -90,6 +90,7 @@
                 "es6": true
             },
             "parserOptions": {
+                "ecmaVersion": 7,
                 "sourceType": "module"
             }
         }

--- a/js/modules/Search/Table.js
+++ b/js/modules/Search/Table.js
@@ -186,7 +186,7 @@ window.GLPI.Search.Table = class Table extends GenericView {
                 this.getElement().trigger('search_refresh', [this.getElement()]);
                 this.hideLoadingSpinner();
                 this.shiftSelectAllCheckbox();
-            }).fail(() => {
+            }, () => {
                 handle_search_failure();
             });
         } catch (error) {

--- a/tests/js/Search/Table.test.js
+++ b/tests/js/Search/Table.test.js
@@ -36,6 +36,18 @@ require('../../../js/modules/Search/Table.js');
 describe('Search Table', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        // Mock reload function
+        delete window.location;
+        Object.defineProperty(window, 'location', {
+            value: {
+                href: '',
+                reload: jest.fn().mockImplementation(() => {})
+            },
+            writable: true,
+            configurable: true,
+        });
+        window_reload_spy = jest.spyOn(window.location, 'reload');
+        window.AjaxMock.start();
     });
     $(document.body).append(`
     <div class="search-container">
@@ -51,56 +63,58 @@ describe('Search Table', () => {
         </form>
         <div class="ajax-container search-display-data">
             <form id="massformComputer" data-search-itemtype="Computer">
-                <select class="search-limit-dropdown">
-                    <option value="5">5</option>
-                    <option value="10">10</option>
-                    <option value="15" selected="selected">15</option>
-                    <option value="20">20</option>
-                </select>
-                <div class="table-responsive-md">
-                    <table id="search_9439839" class="search-results">
-                        <thead>
-                            <th data-searchopt-id="1" data-sort-order="ASC" data-sort-num="0"></th>
-                            <th data-searchopt-id="2" data-sort-order="nosort"></th>
-                            <th data-searchopt-id="3" data-sort-order="nosort"></th>
-                            <th data-searchopt-id="4" data-sort-order="nosort"></th>
-                        </thead>
-                    </table>
+                <div class="search-card">
+                    <select class="search-limit-dropdown">
+                        <option value="5">5</option>
+                        <option value="10">10</option>
+                        <option value="15" selected="selected">15</option>
+                        <option value="20">20</option>
+                    </select>
+                    <div class="table-responsive-md">
+                        <table id="search_9439839" class="search-results">
+                            <thead>
+                                <th data-searchopt-id="1" data-sort-order="ASC" data-sort-num="0"></th>
+                                <th data-searchopt-id="2" data-sort-order="nosort"></th>
+                                <th data-searchopt-id="3" data-sort-order="nosort"></th>
+                                <th data-searchopt-id="4" data-sort-order="nosort"></th>
+                            </thead>
+                        </table>
+                    </div>
+                    <select class="search-limit-dropdown">
+                        <option value="5">5</option>
+                        <option value="10">10</option>
+                        <option value="15" selected="selected">15</option>
+                        <option value="20">20</option>
+                    </select>
+                    <ul class="pagination">
+                        <li class="page-item">
+                            <a class="page-link page-link-start" href="#" data-start="0">
+                                <i class="fas fa-angle-double-left"></i>
+                            </a>
+                        </li>
+                        <li class="page-item">
+                            <a class="page-link page-link-prev" href="#" data-start="15">
+                                <i class="fas fa-angle-left"></i>
+                            </a>
+                        </li>
+                        <li class="page-item active">
+                            <a class="page-link page-link-num" href="#" data-start="30">30</a>
+                        </li>
+                        <li class="page-item">
+                            <a class="page-link page-link-num" href="#" data-start="45">45</a>
+                        </li>
+                        <li class="page-item">
+                            <a class="page-link page-link-next" href="#" data-start="60">
+                                <i class="fas fa-angle-right"></i>
+                            </a>
+                        </li>
+                        <li class="page-item">
+                            <a class="page-link page-link-last" href="#" data-start="75">
+                            <i class="fas fa-angle-double-right"></i>
+                            </a>
+                        </li>
+                    </ul>
                 </div>
-                <select class="search-limit-dropdown">
-                    <option value="5">5</option>
-                    <option value="10">10</option>
-                    <option value="15" selected="selected">15</option>
-                    <option value="20">20</option>
-                </select>
-                <ul class="pagination">
-                    <li class="page-item">
-                        <a class="page-link page-link-start" href="#" data-start="0">
-                            <i class="fas fa-angle-double-left"></i>
-                        </a>
-                    </li>
-                    <li class="page-item">
-                        <a class="page-link page-link-prev" href="#" data-start="15">
-                            <i class="fas fa-angle-left"></i>
-                        </a>
-                    </li>
-                    <li class="page-item active">
-                        <a class="page-link page-link-num" href="#" data-start="30">30</a>
-                    </li>
-                    <li class="page-item">
-                        <a class="page-link page-link-num" href="#" data-start="45">45</a>
-                    </li>
-                    <li class="page-item">
-                        <a class="page-link page-link-next" href="#" data-start="60">
-                            <i class="fas fa-angle-right"></i>
-                        </a>
-                    </li>
-                    <li class="page-item">
-                        <a class="page-link page-link-last" href="#" data-start="75">
-                        <i class="fas fa-angle-double-right"></i>
-                        </a>
-                    </li>
-                </ul>
             </form>
         </div>
     </div>
@@ -121,11 +135,12 @@ describe('Search Table', () => {
         callback();
     });
 
-    const jquery_load = jest.spyOn($.fn, 'load');
+    let window_reload_spy = null;
     const table_showSpinner = jest.spyOn(real_table, 'showLoadingSpinner');
     const table_hideSpinner = jest.spyOn(real_table, 'hideLoadingSpinner');
     const table_onLimitChange = jest.spyOn(real_table, 'onLimitChange');
     const table_onSearch = jest.spyOn(real_table, 'onSearch');
+    const table_onPageChange = jest.spyOn(real_table, 'onPageChange');
 
     const table_el = real_table.getElement();
     const restore_initial_sort_state = () => {
@@ -217,48 +232,57 @@ describe('Search Table', () => {
         restore_initial_sort_state();
         verify_initial_sort_state();
     });
-    test('AJAX refresh on sort', () => {
+    test('AJAX refresh on sort', async () => {
         restore_initial_sort_state();
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/search.php', 'GET', {}, () => {
+            return $('div.ajax-container').html();
+        }));
+
         real_table.getElement().find('th').eq(0).click();
+        // Wait for mocked AJAX response to resolve
+        await new Promise(process.nextTick);
         expect(table_showSpinner).toHaveBeenCalledTimes(1);
-        expect(jquery_load).toHaveBeenCalledTimes(1);
+        expect(window.AjaxMock.isResponseStackEmpty()).toBeTrue();
         expect(table_hideSpinner).toHaveBeenCalledTimes(1);
         restore_initial_sort_state();
     });
-    test('AJAX refresh on limit change', () => {
+    test('AJAX refresh on limit change', async () => {
+        const history_push_spy = jest.spyOn(window.history, 'pushState');
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/search.php', 'GET', {
+            glpilist_limit: '10',
+        }, () => {
+            return $('div.ajax-container').html();
+        }));
         real_table.getElement().closest('form').find('select.search-limit-dropdown').first().val(10).trigger('change');
+
+        // Wait for mocked AJAX response to resolve
+        await new Promise(process.nextTick);
         expect(table_showSpinner).toHaveBeenCalledTimes(1);
-        expect(jquery_load).toHaveBeenCalledTimes(1);
+        expect(window.AjaxMock.isResponseStackEmpty()).toBeTrue();
         expect(table_hideSpinner).toHaveBeenCalledTimes(1);
         expect(table_onLimitChange).toHaveBeenCalledTimes(1);
-        const dropdowns = real_table.getElement().closest('form').find('.search-limit-dropdown');
-        expect(dropdowns.length).toBe(2);
-        dropdowns.each(function () {
-            expect($(this).val()).toBe("10");
-        });
+        expect(history_push_spy).toHaveBeenCalledTimes(1);
     });
-    test('AJAX refresh on search', () => {
+    test('AJAX refresh on search', async () => {
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/search.php', 'GET', {
+            'criteria[0][link]': 'AND',
+            'criteria[0][field]': 'view',
+            'criteria[0][searchtype]': 'contains',
+            'criteria[0][value]': 'criteria_test',
+            'is_deleted': '0',
+            'as_map': '0',
+        }, () => {
+            return $('div.ajax-container').html();
+        }));
         real_table.getElement().closest('.search-container').find('form.search-form-container button[name="search"]').trigger('click');
+        // Wait for mocked AJAX response to resolve
+        await new Promise(process.nextTick);
         expect(table_showSpinner).toHaveBeenCalledTimes(1);
-        expect(jquery_load).toHaveBeenCalledTimes(1);
+        expect(window.AjaxMock.isResponseStackEmpty()).toBeTrue();
         expect(table_hideSpinner).toHaveBeenCalledTimes(1);
         expect(table_onSearch).toHaveBeenCalledTimes(1);
-
-        const load_data = jquery_load.mock.calls[0][1];
-        expect( 'criteria[0][link]' in load_data).toBeTrue();
-        expect(load_data['criteria[0][link]']).toBe('AND');
-        expect( 'criteria[0][field]' in load_data).toBeTrue();
-        expect(load_data['criteria[0][field]']).toBe('view');
-        expect( 'criteria[0][searchtype]' in load_data).toBeTrue();
-        expect(load_data['criteria[0][searchtype]']).toBe('contains');
-        expect( 'criteria[0][value]' in load_data).toBeTrue();
-        expect(load_data['criteria[0][value]']).toBe('criteria_test');
-        expect(load_data).toHaveProperty('is_deleted');
-        expect(load_data['is_deleted']).toBe('0');
-        expect(load_data).toHaveProperty('as_map');
-        expect(load_data['as_map']).toBe('0');
     });
-    test('AJAX refresh on page change', () => {
+    test('AJAX refresh on page change', async () => {
         const pagination = real_table.getElement().closest('.search-container').find('.pagination');
         const pagination_items = pagination.find('li');
 
@@ -266,9 +290,6 @@ describe('Search Table', () => {
             for (let i = 0; i < pagination_items.length; i++) {
                 expect(pagination_items.eq(i).hasClass('selected')).toBe(i === index);
             }
-        };
-        const expectResultStart = (start) => {
-            expect(jquery_load.mock.calls[jquery_load.mock.calls.length - 1][1]['start']).toBe(start);
         };
 
         // This is more to test that no other test changes the active item
@@ -278,8 +299,9 @@ describe('Search Table', () => {
         for (let i = 0; i < click_order.length; i++) {
             const p = click_order[i];
             pagination_items.eq(p).find('.page-link').click();
+            // Wait for mocked AJAX response to resolve
+            expect(table_onPageChange).toHaveBeenCalledTimes(i + 1);
             expectOnlyActive(p);
-            expectResultStart(String(p * 15));
         }
     });
     test('Show and Hide loading spinner', () => {
@@ -298,13 +320,20 @@ describe('Search Table', () => {
         expect(overlay.length).toBe(1);
         expect(overlay.css('visibility')).toBe('visible');
     });
-    test('Hide loading spinner after refresh exception', () => {
+    test('Reload after refresh exception', async () => {
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/search.php', 'GET', {}, () => {
+            return $('div.ajax-container').html();
+        }));
         const get_sort = jest.spyOn(real_table, 'getSortState');
         get_sort.mockImplementation(() => {
             throw 'Test exception';
         });
         real_table.refreshResults();
-        expect(table_hideSpinner).toHaveBeenCalledTimes(1);
-        expect(jquery_load).toHaveBeenCalledTimes(0);
+        // Wait for mocked AJAX response to resolve
+        await new Promise(process.nextTick);
+        expect(table_hideSpinner).toHaveBeenCalledTimes(0);
+        // We expect the refresh to fail before the AJAX call
+        expect(window.AjaxMock.isResponseStackEmpty()).toBeFalse();
+        expect(window_reload_spy).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/js/bootstrap.js
+++ b/tests/js/bootstrap.js
@@ -59,4 +59,98 @@ window._nx = function (msgctxt, msgid, msgid_plural, n = 1, domain /* , extra */
     return n === 1 ? msgid : msgid_plural;
 };
 
+window.AjaxMockResponse = class {
+
+    constructor(url, method = 'GET', data = {}, response, is_persistent = false) {
+        /**
+         * The URL
+         * @type string
+         */
+        this.url = url;
+        this.method = method;
+        this.data = data;
+        this.response = response;
+        this.is_persistent = is_persistent;
+    }
+
+    isMatch(url, method = 'GET', data = {}) {
+        if (this.url !== url || this.method !== method) {
+            return false;
+        }
+        let data_match = true;
+        $.each(data, (k, v) => {
+            // We specifically allow type coercion in the comparison
+            if (this.data[k] !== undefined && this.data[k] != v) {
+                data_match = false;
+                return false;
+            }
+        });
+        return data_match;
+    }
+
+    call(data) {
+        return this.response(data);
+    }
+};
+
+class AjaxMock {
+
+    constructor() {
+        /**
+         * @type {AjaxMockResponse[]}
+         */
+        this.response_stack = [];
+        $._ajax = $.ajax;
+    }
+
+    start() {
+        this.response_stack = [];
+        $.ajax = this.ajax;
+    }
+
+    end() {
+        this.response_stack = [];
+        $.ajax = $._ajax;
+    }
+
+    addMockResponse(response) {
+        this.response_stack.push(response);
+    }
+
+    isResponseStackEmpty() {
+        return this.response_stack.length === 0;
+    }
+
+    ajax() {
+        let url, settings;
+
+        if (arguments.length === 2) {
+            [url, settings] = arguments;
+        } else {
+            settings = arguments[0];
+            url = settings.url;
+        }
+
+        if (window.AjaxMock.isResponseStackEmpty()) {
+            throw new Error('No mock responses in stack');
+        }
+        let result = undefined;
+        for (let i = 0; i < window.AjaxMock.response_stack.length; i++) {
+            const response = window.AjaxMock.response_stack[i];
+            if (response.isMatch(url, settings.method, settings.data)) {
+                result = response.call(settings.data);
+                if (!response.is_persistent) {
+                    window.AjaxMock.response_stack.splice(i, 1);
+                }
+            }
+        }
+        if (result !== undefined) {
+            return Promise.resolve(result);
+        } else {
+            throw "No mock response found for " + url;
+        }
+    }
+}
+window.AjaxMock = new AjaxMock();
+
 require('../../js/common.js');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The biggest case I notice is with the short lifespans the CSRF tokens have by default and having auto-refresh of the ticket list enabled. If you leave the ticket list open for more than 2 hours, the refresh will fail and show "The action you have requested is not allowed." instead of the search results.

If the refresh fails, it seems better to fall back on a page reload after updating the search URL as the initial results are sent with the page request and not done async.