### PR TITLE
Hide 'Add document' button in timeline

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6904,7 +6904,7 @@ abstract class CommonITILObject extends CommonDBTM
             'label'         => _x('button', 'Add a document'),
             'template'      => 'components/itilobject/timeline/form_document_item.html.twig',
             'item'          => new Document_Item(),
-            'hide_in_menu'  => !$canadd_document
+            'hide_in_menu'  => true
         ];
 
         if (isset($PLUGIN_HOOKS[Hooks::TIMELINE_ANSWER_ACTIONS])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23870 (partially)

See https://github.com/glpi-project/glpi/pull/11147/files#diff-f3f1bceed6f8cfef1bf2ac3e185202f061d1e65efb41329ce10ac866d4be2916R6864

I guess that this entry should not be proposed, as clicking it opens a blank form