### PR TITLE
Do not try retrieving timeline items for new items

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6982,6 +6982,10 @@ abstract class CommonITILObject extends CommonDBTM
         $foreignKey = static::getForeignKeyField();
         $timeline = [];
 
+        if ($this->isNewItem()) {
+            return $timeline;
+        }
+
         $canupdate_parent = $this->canUpdateItem() && !in_array($this->fields['status'], $this->getClosedStatusArray());
 
        //checks rights


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11341

Do not try retrieving timeline items for new ITIL Objects. I cannot think of when this would be needed. When creating from a template with predefined items, they didn't show in the new item form and weren't handled here anyways. Doing anything except immediately returning an empty array seems to just waste time with uneeded SQL queries and leads to potentially "invalid" queries because sometime new items use an empty string for the ID even though that field is numeric in the DB.