### PR TITLE
Fix mandatory impact field

### DIFF
--- a/templates/components/itilobject/fields/priority_matrix.html.twig
+++ b/templates/components/itilobject/fields/priority_matrix.html.twig
@@ -55,7 +55,7 @@
 
 {% set impact_options = field_options %}
 {% if field_options.fields_template.isMandatoryField('impact') %}
-   {% set impact_options = impact_option|merge({
+   {% set impact_options = impact_options|merge({
       'required': true,
    }) %}
 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | May fix #11379

Incorrect twig variable name causes an error when the impact field is mandatory.