### PR TITLE
Bump ECMA version to 2021 (ES12)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,8 @@
     ],
     "env": {
         "browser": true,
-        "jquery": true
+        "jquery": true,
+        "es2021": true
     },
     "extends": "eslint:recommended",
     "globals": {
@@ -27,7 +28,7 @@
         "_nx": true
     },
     "parserOptions": {
-        "ecmaVersion": 6
+        "ecmaVersion": 12
     },
     "rules": {
         "eol-last": [

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -29,7 +29,7 @@
  * ---------------------------------------------------------------------
  */
 
-/* global getExtIcon, getSize, isImage, stopEvent, Uint8Array */
+/* global getExtIcon, getSize, isImage, stopEvent */
 
 var insertIntoEditor = []; // contains flags that indicate if uploaded file (image) should be added to editor contents
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

See comments on #11360 for discussion on raising the version in the linter from ES 6 to ES 12. This would allow many modern features of JavaScript. The features are supported on all desktop browsers that GLPI supports and most features are supported on their mobile equivalents.