### PR TITLE
feat(marketplace): disable download if plugin contains git directory

### DIFF
--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -69,7 +69,7 @@ class DownloadCommand extends AbstractMarketplaceCommand
             }
             // If the plugin is already downloaded, refuse to download it again
             if (!$input->getOption('force') && is_dir(GLPI_MARKETPLACE_DIR . '/' . $plugin)) {
-                if (Controller::hasGitDirectory($plugin)) {
+                if (Controller::hasVcsDirectory($plugin)) {
                     $error_msg = sprintf("Plugin '%s' as a local .git directory.\n", $plugin);
                     $error_msg .= __s("To avoid overwriting a potential branch under development, downloading is disabled.");
                 } else {

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -70,8 +70,8 @@ class DownloadCommand extends AbstractMarketplaceCommand
             // If the plugin is already downloaded, refuse to download it again
             if (!$input->getOption('force') && is_dir(GLPI_MARKETPLACE_DIR . '/' . $plugin)) {
                 if (Controller::hasVcsDirectory($plugin)) {
-                    $error_msg = sprintf("Plugin '%s' as a local source versioning directory.\n", $plugin);
-                    $error_msg .= __s("To avoid overwriting a potential branch under development, downloading is disabled.");
+                    $error_msg = sprintf(__('Plugin "%s" as a local source versioning directory.'), $plugin);
+                    $error_msg .=  "\n" . __s('To avoid overwriting a potential branch under development, downloading is disabled.');
                 } else {
                     $error_msg = sprintf(__('Plugin "%s" is already downloaded. Use --force to force it to re-download.'), $plugin);
                 }

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -71,7 +71,7 @@ class DownloadCommand extends AbstractMarketplaceCommand
             if (!$input->getOption('force') && is_dir(GLPI_MARKETPLACE_DIR . '/' . $plugin)) {
                 if (Controller::hasVcsDirectory($plugin)) {
                     $error_msg = sprintf(__('Plugin "%s" as a local source versioning directory.'), $plugin);
-                    $error_msg .=  "\n" . __s('To avoid overwriting a potential branch under development, downloading is disabled.');
+                    $error_msg .=  "\n" . __('To avoid overwriting a potential branch under development, downloading is disabled.');
                 } else {
                     $error_msg = sprintf(__('Plugin "%s" is already downloaded. Use --force to force it to re-download.'), $plugin);
                 }

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -67,10 +67,9 @@ class DownloadCommand extends AbstractMarketplaceCommand
             if (empty(trim($plugin))) {
                 continue;
             }
-            $controller = new Controller($plugin);
             // If the plugin is already downloaded, refuse to download it again
             if (!$input->getOption('force') && is_dir(GLPI_MARKETPLACE_DIR . '/' . $plugin)) {
-                if ($controller->hasGitDirectory($plugin)) {
+                if (Controller::hasGitDirectory($plugin)) {
                     $error_msg = sprintf("Plugin '%s' as a local .git directory.\n", $plugin);
                     $error_msg .= __s("To avoid overwriting a potential branch under development, downloading is disabled.");
                 } else {
@@ -79,6 +78,7 @@ class DownloadCommand extends AbstractMarketplaceCommand
                 $output->writeln("<error>$error_msg</error>");
                 continue;
             }
+            $controller = new Controller($plugin);
             if ($controller->canBeDownloaded()) {
                 $result = $controller->downloadPlugin(false);
                 $success_msg = sprintf(__("Plugin %s downloaded successfully"), $plugin);

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -70,7 +70,7 @@ class DownloadCommand extends AbstractMarketplaceCommand
             // If the plugin is already downloaded, refuse to download it again
             if (!$input->getOption('force') && is_dir(GLPI_MARKETPLACE_DIR . '/' . $plugin)) {
                 if (Controller::hasVcsDirectory($plugin)) {
-                    $error_msg = sprintf("Plugin '%s' as a local .git directory.\n", $plugin);
+                    $error_msg = sprintf("Plugin '%s' as a local source versioning directory.\n", $plugin);
                     $error_msg .= __s("To avoid overwriting a potential branch under development, downloading is disabled.");
                 } else {
                     $error_msg = sprintf(__('Plugin "%s" is already downloaded. Use --force to force it to re-download.'), $plugin);

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -67,13 +67,18 @@ class DownloadCommand extends AbstractMarketplaceCommand
             if (empty(trim($plugin))) {
                 continue;
             }
+            $controller = new Controller($plugin);
             // If the plugin is already downloaded, refuse to download it again
             if (!$input->getOption('force') && is_dir(GLPI_MARKETPLACE_DIR . '/' . $plugin)) {
-                $error_msg = sprintf(__('Plugin "%s" is already downloaded. Use --force to force it to re-download.'), $plugin);
+                if ($controller->hasGitDirectory($plugin)) {
+                    $error_msg = sprintf('Plugin "%s" as a local .git directory.'."\n", $plugin);
+                    $error_msg .= __s("To avoid overwriting a potential branch under development, downloading is disabled.");
+                } else {
+                    $error_msg = sprintf(__('Plugin "%s" is already downloaded. Use --force to force it to re-download.'), $plugin);
+                }
                 $output->writeln("<error>$error_msg</error>");
                 continue;
             }
-            $controller = new Controller($plugin);
             if ($controller->canBeDownloaded()) {
                 $result = $controller->downloadPlugin(false);
                 $success_msg = sprintf(__("Plugin %s downloaded successfully"), $plugin);

--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -71,7 +71,7 @@ class DownloadCommand extends AbstractMarketplaceCommand
             // If the plugin is already downloaded, refuse to download it again
             if (!$input->getOption('force') && is_dir(GLPI_MARKETPLACE_DIR . '/' . $plugin)) {
                 if ($controller->hasGitDirectory($plugin)) {
-                    $error_msg = sprintf('Plugin "%s" as a local .git directory.'."\n", $plugin);
+                    $error_msg = sprintf("Plugin '%s' as a local .git directory.\n", $plugin);
                     $error_msg .= __s("To avoid overwriting a potential branch under development, downloading is disabled.");
                 } else {
                     $error_msg = sprintf(__('Plugin "%s" is already downloaded. Use --force to force it to re-download.'), $plugin);

--- a/src/Marketplace/Controller.php
+++ b/src/Marketplace/Controller.php
@@ -509,9 +509,20 @@ class Controller extends CommonGLPI
      *
      * @return bool
      */
-    public static function hasGitDirectory(string $plugin_key = ""): bool
+    public static function hasVcsDirectory(string $plugin_key): bool
     {
-        return is_dir(GLPI_MARKETPLACE_DIR . "/" . $plugin_key . "/.git");
+        $vcs_dirs = [
+            '.git',
+            '.hg', // Mercurial
+            '.svn',
+        ];
+        foreach ($vcs_dirs as $vcs_dir) {
+            if (is_dir(GLPI_MARKETPLACE_DIR . '/' . $plugin_key . '/' . $vcs_dir)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 

--- a/src/Marketplace/Controller.php
+++ b/src/Marketplace/Controller.php
@@ -244,11 +244,11 @@ class Controller extends CommonGLPI
             } else if ($found_in_marketplace_dir) {
                 // Plugin has been found on marketplace and marketplace priority is higher than other location
                 // -> allow plugin update from marketplace as it is already loaded from there.
-                return is_writable(GLPI_MARKETPLACE_DIR . '/' . $this->plugin_key) && !self::hasGitDirectory($this->plugin_key);
+                return is_writable(GLPI_MARKETPLACE_DIR . '/' . $this->plugin_key) && !self::hasVcsDirectory($this->plugin_key);
             } else {
                 // Plugin has been found outside marketplace and does not exist in marketplace
                 // -> allow plugin update unless GLPI_MARKETPLACE_ALLOW_OVERRIDE is false.
-                return GLPI_MARKETPLACE_ALLOW_OVERRIDE && self::hasWriteAccess() && !self::hasGitDirectory($this->plugin_key);
+                return GLPI_MARKETPLACE_ALLOW_OVERRIDE && self::hasWriteAccess() && !self::hasVcsDirectory($this->plugin_key);
             }
         }
 
@@ -503,7 +503,7 @@ class Controller extends CommonGLPI
     }
 
     /**
-     * Check if a directory ".git" is present in plugins source code.
+     * Check if a directory ".git|.hg|.svn" is present in plugins source code.
      *
      * @param string $plugin_key
      *

--- a/src/Marketplace/Controller.php
+++ b/src/Marketplace/Controller.php
@@ -244,11 +244,11 @@ class Controller extends CommonGLPI
             } else if ($found_in_marketplace_dir) {
                 // Plugin has been found on marketplace and marketplace priority is higher than other location
                 // -> allow plugin update from marketplace as it is already loaded from there.
-                return is_writable(GLPI_MARKETPLACE_DIR . '/' . $this->plugin_key);
+                return is_writable(GLPI_MARKETPLACE_DIR . '/' . $this->plugin_key) && !self::hasGitDirectory($this->plugin_key);
             } else {
                 // Plugin has been found outside marketplace and does not exist in marketplace
                 // -> allow plugin update unless GLPI_MARKETPLACE_ALLOW_OVERRIDE is false.
-                return GLPI_MARKETPLACE_ALLOW_OVERRIDE && self::hasWriteAccess();
+                return GLPI_MARKETPLACE_ALLOW_OVERRIDE && self::hasWriteAccess() && !self::hasGitDirectory($this->plugin_key);
             }
         }
 
@@ -500,6 +500,18 @@ class Controller extends CommonGLPI
     public static function hasWriteAccess(): bool
     {
         return is_dir(GLPI_MARKETPLACE_DIR) && is_writable(GLPI_MARKETPLACE_DIR);
+    }
+
+    /**
+     * Check if a directory ".git" is present in plugins source code.
+     *
+     * @param string $plugin_key
+     *
+     * @return bool
+     */
+    public static function hasGitDirectory(string $plugin_key = ""): bool
+    {
+        return is_dir(GLPI_MARKETPLACE_DIR . "/" . $plugin_key . "/.git");
     }
 
 

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -723,7 +723,6 @@ HTML;
                 $warning = "";
 
                 if (!$mk_controller->hasGitDirectory($plugin_key)) {
-
                     if ($has_web_update) {
                         $warning = __s("The plugin has an available update but its directory is not writable.") . "<br>";
                     }

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -742,7 +742,7 @@ HTML;
                             <button title='$warning' class='add_tooltip download_manually'><i class='fas fa-archive'></i></button>
                         </a>";
                 } else {
-                    $warning = __s("The plugin has an available update but its local directory contains a .git") . "<br>";
+                    $warning = __s("The plugin has an available update but its local directory contains VCS files") . "<br>";
                     $warning .= __s("To avoid overwriting a potential branch under development, downloading is disabled.");
 
                     $buttons .= "<button title='$warning' class='add_tooltip download_manually'>

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -722,7 +722,7 @@ HTML;
             if (array_key_exists('installation_url', $plugin_data) && $can_be_downloaded) {
                 $warning = "";
 
-                if (!Controller::hasGitDirectory($plugin_key)) {
+                if (!Controller::hasVcsDirectory($plugin_key)) {
                     if ($has_web_update) {
                         $warning = __s("The plugin has an available update but its directory is not writable.") . "<br>";
                     }

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -721,24 +721,35 @@ HTML;
             $plugin_data = $mk_controller->getAPI()->getPlugin($plugin_key);
             if (array_key_exists('installation_url', $plugin_data) && $can_be_downloaded) {
                 $warning = "";
-                if ($has_web_update) {
-                    $warning = __s("The plugin has an available update but its directory is not writable.") . "<br>";
+
+                if (!$mk_controller->hasGitDirectory($plugin_key)) {
+
+                    if ($has_web_update) {
+                        $warning = __s("The plugin has an available update but its directory is not writable.") . "<br>";
+                    }
+
+                    $warning .= sprintf(
+                        __s("Download archive manually, you must uncompress it in plugins directory (%s)"),
+                        GLPI_ROOT . '/plugins'
+                    );
+
+                    // Use "marketplace.download.php" proxy if archive is downloadable from GLPI marketplace plugins API
+                    // as this API will refuse to serve the archive if registration key is not set in headers.
+                    $download_url = str_starts_with($plugin_data['installation_url'], GLPI_MARKETPLACE_PLUGINS_API_URI)
+                        ? $CFG_GLPI['root_doc'] . '/front/marketplace.download.php?key=' . $plugin_key
+                        : $plugin_data['installation_url'];
+
+                    $buttons .= "<a href='{$download_url}' target='_blank'>
+                            <button title='$warning' class='add_tooltip download_manually'><i class='fas fa-archive'></i></button>
+                        </a>";
+                } else {
+                    $warning = __s("The plugin has an available update but its local directory contains a .git") . "<br>";
+                    $warning .= __s("To avoid overwriting a potential branch under development, downloading is disabled.");
+
+                    $buttons .= "<button title='$warning' class='add_tooltip download_manually'>
+                        <i class='fas fa-ban'></i>
+                    </button>";
                 }
-
-                $warning .= sprintf(
-                    __s("Download archive manually, you must uncompress it in plugins directory (%s)"),
-                    GLPI_ROOT . '/plugins'
-                );
-
-                // Use "marketplace.download.php" proxy if archive is downloadable from GLPI marketplace plugins API
-                // as this API will refuse to serve the archive if registration key is not set in headers.
-                $download_url = str_starts_with($plugin_data['installation_url'], GLPI_MARKETPLACE_PLUGINS_API_URI)
-                    ? $CFG_GLPI['root_doc'] . '/front/marketplace.download.php?key=' . $plugin_key
-                    : $plugin_data['installation_url'];
-
-                $buttons .= "<a href='{$download_url}' target='_blank'>
-                        <button title='$warning' class='add_tooltip download_manually'><i class='fas fa-archive'></i></button>
-                    </a>";
             }
         } else if ($can_be_downloaded) {
             if (!$exists) {

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -722,7 +722,7 @@ HTML;
             if (array_key_exists('installation_url', $plugin_data) && $can_be_downloaded) {
                 $warning = "";
 
-                if (!$mk_controller->hasGitDirectory($plugin_key)) {
+                if (!Controller::hasGitDirectory($plugin_key)) {
                     if ($has_web_update) {
                         $warning = __s("The plugin has an available update but its directory is not writable.") . "<br>";
                     }

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -742,7 +742,7 @@ HTML;
                             <button title='$warning' class='add_tooltip download_manually'><i class='fas fa-archive'></i></button>
                         </a>";
                 } else {
-                    $warning = __s("The plugin has an available update but its local directory contains VCS files") . "<br>";
+                    $warning = __s("The plugin has an available update but its local directory contains source versioning.") . "<br>";
                     $warning .= __s("To avoid overwriting a potential branch under development, downloading is disabled.");
 
                     $buttons .= "<button title='$warning' class='add_tooltip download_manually'>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

I don't know if it's the best way to do it, but it avoids losing code... when you accidentally click on the "update" button of a cloned git plugin (with therefore a .git folder) for which we have a local branch.
