### PR TITLE
never change status to assigned when actor added is not an assignee; …

### DIFF
--- a/src/CommonITILActor.php
+++ b/src/CommonITILActor.php
@@ -418,7 +418,8 @@ abstract class CommonITILActor extends CommonDBRelation
         if ($item->getFromDB($this->fields[static::getItilObjectForeignKey()])) {
            // Check object status and update it if needed
             if (
-                !isset($this->input['_from_object'])
+                $this->input['type'] == CommonITILActor::ASSIGN
+                && !isset($this->input['_from_object'])
                 && in_array($item->fields["status"], $item->getNewStatusArray())
                 && in_array(CommonITILObject::ASSIGNED, array_keys($item->getAllStatusArray()))
             ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11384

The original issue should be fixed by #11363 (missing `_from_object` input key) , but to completely avoid status change on actor addition, we should check we are currently adding an assignee
