### PR TITLE
fix some firefox mobile issues with timeline

### DIFF
--- a/css/includes/components/itilobject/_footer.scss
+++ b/css/includes/components/itilobject/_footer.scss
@@ -33,6 +33,13 @@
     position: sticky;
     bottom: 0;
 
+    @include media-breakpoint-down(sm) {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 8px;
+    }
+
     .action-task {
         background-color: $timeline-task-bg;
         color: $timeline-task-fg;

--- a/css/includes/components/itilobject/_layout.scss
+++ b/css/includes/components/itilobject/_layout.scss
@@ -34,6 +34,10 @@
         display: none;
     }
 
+    @include media-breakpoint-down(sm) {
+        margin-bottom: 55px; // .itil-footer height
+    }
+
     @include media-breakpoint-up(sm) {
         height: calc(100vh - 187px);
 

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -431,7 +431,7 @@
       </div>
    {% endif %}
 
-    <button type="button" class="switch-panel-width btn btn-sm btn-square btn-icon btn-ghost-secondary position-absolute bottom-0 start-0 mb-2">
+    <button type="button" class="switch-panel-width btn btn-sm btn-square btn-icon btn-ghost-secondary position-absolute bottom-0 start-0 mb-2 d-none d-md-block">
         <i class="fas fa-caret-left"></i>
     </button>
 </div>

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -431,9 +431,11 @@
       </div>
    {% endif %}
 
-    <button type="button" class="switch-panel-width btn btn-sm btn-square btn-icon btn-ghost-secondary position-absolute bottom-0 start-0 mb-2 d-none d-md-block">
-        <i class="fas fa-caret-left"></i>
-    </button>
+    <span class="d-none d-md-block">
+        <button type="button" class="switch-panel-width btn btn-sm btn-square btn-icon btn-ghost-secondary position-absolute bottom-0 start-0 mb-2">
+            <i class="fas fa-caret-left"></i>
+        </button>
+    </span>
 </div>
 
 <script type="text/javascript">

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -107,7 +107,7 @@
                {% endif %}
             </div>
 
-            <div class="col-auto d-flex flex-column user-part {{ 'right' in item_position ? 'ms-auto ms-0 order-sm-last' : '' }}">
+            <div class="col-auto d-flex flex-column user-part {{ 'right' in item_position ? 'ms-auto ms-0 order-sm-last' : 'order-first' }}">
                {% set avatar_rand = random() %}
                {# log entries have no users_id #}
                {% set entry_user = users_id is defined and users_id is not null ? get_item('User', users_id) : null %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal ref !23893

Fix mainly issue with sticky bottom with firefox mobile (cf [mozilla-mobile/fenix#](https://github.com/mozilla-mobile/fenix/issues/19217)) -> moved to a fixed position 

+ some minor issues (position of left elements in timeline, layout switcher displayed in sm view)