### PR TITLE
avoid notices in ticket's stats tab

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -6280,12 +6280,12 @@ JAVASCRIPT;
         if ($date_takeintoaccount == $date_creation) {
             $date_takeintoaccount  = 0;
         }
-        $internal_time_to_own     = strtotime($this->fields['internal_time_to_own']);
-        $time_to_own              = strtotime($this->fields['time_to_own']);
-        $internal_time_to_resolve = strtotime($this->fields['internal_time_to_resolve']);
-        $time_to_resolve          = strtotime($this->fields['time_to_resolve']);
-        $solvedate                = strtotime($this->fields['solvedate']);
-        $closedate                = strtotime($this->fields['closedate']);
+        $internal_time_to_own     = strtotime($this->fields['internal_time_to_own'] ?? "");
+        $time_to_own              = strtotime($this->fields['time_to_own'] ?? "");
+        $internal_time_to_resolve = strtotime($this->fields['internal_time_to_resolve'] ?? "");
+        $time_to_resolve          = strtotime($this->fields['time_to_resolve'] ?? "");
+        $solvedate                = strtotime($this->fields['solvedate'] ?? "");
+        $closedate                = strtotime($this->fields['closedate'] ?? "");
         $goal_takeintoaccount     = ($date_takeintoaccount > 0 ? $date_takeintoaccount : $now);
         $goal_solvedate           = ($solvedate > 0 ? $solvedate : $now);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Avoid:

```
[2022-04-28 13:56:56] glpiphplog.NOTICE:   *** PHP Deprecated function (8192): strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated in .../src/Ticket.php at line 6285
```
