### PR TITLE
don't display 'assign to me' button on new ticket form

### DIFF
--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -65,7 +65,7 @@
    {% endfor %}
    </select>
 
-   {% if not params['template_preview'] and not disable_assign_to_me and canupdate %}
+   {% if not item.isNewItem() and not params['template_preview'] and not disable_assign_to_me and canupdate %}
       {{ include('components/itilobject/actors/assign_to_me.html.twig') }}
    {% endif %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

The control doesn't work well in creation process, the actor is not added, and the data in the original form are lost
