### PR TITLE
Improve offline marketplace handling

### DIFF
--- a/src/Marketplace/Api/Plugins.php
+++ b/src/Marketplace/Api/Plugins.php
@@ -122,7 +122,7 @@ class Plugins
         try {
             $response = $this->httpClient->request($method, $endpoint, $options);
             $this->last_error = null; // Reset error buffer
-        } catch (RequestException|ConnectException $e) {
+        } catch (RequestException | ConnectException $e) {
             $this->last_error = [
                 'title'     => "Plugins API error",
                 'exception' => $e->getMessage(),

--- a/src/Marketplace/Api/Plugins.php
+++ b/src/Marketplace/Api/Plugins.php
@@ -35,6 +35,8 @@ namespace Glpi\Marketplace\Api;
 
 use GLPINetwork;
 use GuzzleHttp\Client as Guzzle_Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Message;
 use GuzzleHttp\Psr7\Response;
 use Session;
@@ -120,13 +122,13 @@ class Plugins
         try {
             $response = $this->httpClient->request($method, $endpoint, $options);
             $this->last_error = null; // Reset error buffer
-        } catch (\GuzzleHttp\Exception\RequestException $e) {
+        } catch (RequestException|ConnectException $e) {
             $this->last_error = [
                 'title'     => "Plugins API error",
                 'exception' => $e->getMessage(),
                 'request'   => Message::toString($e->getRequest()),
             ];
-            if ($e->hasResponse()) {
+            if ($e instanceof RequestException && $e->hasResponse()) {
                 $this->last_error['response'] = Message::toString($e->getResponse());
             }
 

--- a/src/Marketplace/View.php
+++ b/src/Marketplace/View.php
@@ -51,6 +51,8 @@ class View extends CommonGLPI
 
     public const COL_PAGE = 12;
 
+    protected static bool $offline_mode = false;
+
     /**
      * singleton return the current api instance
      *
@@ -133,10 +135,14 @@ class View extends CommonGLPI
     /**
      * Check current registration status and display warning messages
      *
+     * @param bool $force Force re-check the registration status even if it was already checked
      * @return bool
      */
-    public static function checkRegistrationStatus()
+    public static function checkRegistrationStatus(bool $force = false)
     {
+        if (!$force && static::$offline_mode) {
+            return false;
+        }
         global $CFG_GLPI;
 
         $messages   = [];
@@ -187,6 +193,7 @@ class View extends CommonGLPI
             echo "</div>";
         }
 
+        static::$offline_mode = !$valid;
         return $valid;
     }
 
@@ -289,6 +296,10 @@ class View extends CommonGLPI
             $nb_plugins = $api->getNbPlugins($tag_filter);
         }
 
+        // Clear all output buffers
+        while (ob_get_level()) {
+            ob_end_clean();
+        }
         header("X-GLPI-Marketplace-Total: $nb_plugins");
         self::displayList($plugins, "discover", $only_lis, $nb_plugins, $sort, $api->isListTruncated());
     }
@@ -340,9 +351,12 @@ class View extends CommonGLPI
 
         $messages = '';
         if ($is_list_truncated) {
-            $msg = count($plugins) === 0
-                ? sprintf(__('Unable to fetch plugin list due to %s services website unavailability. Please try again later.'), 'GLPI Network')
-                : sprintf(__('Plugin list may be truncated due to %s services website unavailability. Please try again later.'), 'GLPI Network');
+            if (count($plugins) === 0) {
+                $msg = sprintf(__('Unable to fetch plugin list due to %s services website unavailability. Please try again later.'), 'GLPI Network');
+            } else {
+                // Not completely offline. Do not treat as fully offline.
+                $msg = sprintf(__('Plugin list may be truncated due to %s services website unavailability. Please try again later.'), 'GLPI Network');
+            }
             $messages = '<li class="warning"><i class="fa fa-exclamation-triangle fa-3x"></i>' . $msg . '</li>';
         }
 
@@ -366,6 +380,24 @@ class View extends CommonGLPI
                       . "</div>";
             }
 
+            if (static::$offline_mode && $tab !== 'installed') {
+                $marketplace  = <<<HTML
+                <div class='marketplace $tab' data-tab='{$tab}'>
+                    <div class='left-panel'></div>
+                    <div class='right-panel'>
+                        <div class='top-panel'>
+                            <div class='controls'></div>
+                        </div>
+                        <ul class='plugins'>
+                            {$messages}
+                            {$plugins_li}
+                        </ul>
+                    </div>
+                </div>
+HTML;
+                echo $marketplace;
+                return;
+            }
             $tags_list    = $tab != "installed"
                 ? "<div class='left-panel'>" . self::getTagsHtml() . "</div>"
                 : "";
@@ -536,7 +568,7 @@ JS;
                </a>"
              : "";
         $icon    = self::getPluginIcon($plugin);
-        $network = self::getNetworkInformations($plugin);
+        $network = !static::$offline_mode ? self::getNetworkInformations($plugin) : '';
 
         if ($tab === "discover") {
             $card = <<<HTML
@@ -645,14 +677,17 @@ HTML;
         $exists             = $plugin_inst->getFromDBbyDir($plugin_key);
         $is_installed       = $plugin_inst->isInstalled($plugin_key);
         $is_actived         = $plugin_inst->isActivated($plugin_key);
-        $mk_controller      = new Controller($plugin_key);
-        $web_update_version = $mk_controller->checkUpdate($plugin_inst);
-        $has_web_update     = $web_update_version !== false;
-        $is_available       = $mk_controller->isAvailable();
-        $can_be_overwritten = $mk_controller->canBeOverwritten();
-        $can_be_downloaded  = $mk_controller->canBeDownloaded();
-        $required_offers    = $mk_controller->getRequiredOffers();
-        $can_be_updated     = $has_web_update && $can_be_overwritten;
+
+        // The following block of buttons require the marketplace to be online
+        $mk_controller = !static::$offline_mode ? new Controller($plugin_key) : null;
+        $web_update_version = $mk_controller ? $mk_controller->checkUpdate($plugin_inst) : false;
+        $has_web_update = $web_update_version !== false;
+        $is_available = $mk_controller && $mk_controller->isAvailable();
+        $can_be_overwritten = $mk_controller && $mk_controller->canBeOverwritten();
+        $can_be_downloaded = $mk_controller && $mk_controller->canBeDownloaded();
+        $required_offers = $mk_controller ? $mk_controller->getRequiredOffers() : false;
+        $can_be_updated = $has_web_update && $can_be_overwritten;
+
         $config_page        = $PLUGIN_HOOKS['config_page'][$plugin_key] ?? "";
         $must_be_cleaned   = $exists && !$plugin_inst->isLoadable($plugin_key);
         $has_local_install = $exists && !$must_be_cleaned && !$is_installed;
@@ -760,7 +795,7 @@ HTML;
             }
         }
 
-        if ($mk_controller->requiresHigherOffer()) {
+        if (!static::$offline_mode && $mk_controller->requiresHigherOffer()) {
             $warning = sprintf(
                 __s("You need a superior GLPI-Network offer to access to this plugin (%s)"),
                 implode(', ', $required_offers)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add improved error handling to try and avoid a blank page being shown when an API connection timeout occurs.
This also improves the usability of the installed plugins tab when the GLPI Network Services are not available by checking the status once and then relying on a static `offline_mode` variable in the View to determine what parts of the marketplace could be shown without trying to make extra API calls.