### PR TITLE
Upgrade TinyMCE to 6.x

### DIFF
--- a/lib/bundles/tinymce.js
+++ b/lib/bundles/tinymce.js
@@ -35,13 +35,15 @@ window.tinymce = window.tinyMCE = require('tinymce/tinymce');
 // Default icons
 require('tinymce/icons/default/icons');
 
+// Default model
+require('tinymce/models/dom');
+
 // Base theme / skin
 require('tinymce/themes/silver/theme');
 
 // Used plugins
 require('tinymce/plugins/autoresize');
 require('tinymce/plugins/code');
-require('tinymce/plugins/colorpicker');
 require('tinymce/plugins/directionality');
 require('tinymce/plugins/emoticons');
 require('tinymce/plugins/emoticons/js/emojis');
@@ -49,9 +51,6 @@ require('tinymce/plugins/fullscreen');
 require('tinymce/plugins/image');
 require('tinymce/plugins/link');
 require('tinymce/plugins/lists');
-require('tinymce/plugins/paste');
 require('tinymce/plugins/quickbars');
 require('tinymce/plugins/searchreplace');
-require('tinymce/plugins/tabfocus');
 require('tinymce/plugins/table');
-require('tinymce/plugins/textcolor');

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
                 "rrule": "^2.6.3",
                 "select2": "^4.0.13",
                 "spin.js": "^4.1.0",
-                "tinymce": "^5.7.0",
+                "tinymce": "^6.0.2",
                 "tinymce-i18n": "^22.2.11"
             },
             "devDependencies": {
@@ -10542,9 +10542,9 @@
             "dev": true
         },
         "node_modules/tinymce": {
-            "version": "5.10.3",
-            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.3.tgz",
-            "integrity": "sha512-O59ssHNnujWvSk5Gt8hIGrdNCMKVWVQv9F8siAgLTRgTh0t3NDHrP1UlLtCxArUi9DPWZvlBeUz8D5fJTu7vnA=="
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.0.2.tgz",
+            "integrity": "sha512-i4OEzcTF6mGxZ+scumOoWiaI9HYn6uya980hJ+9jwnhgLbhBb+73ar2t9Ewfkns3DTl2Ez3r1pQs2tpT+ka29Q=="
         },
         "node_modules/tinymce-i18n": {
             "version": "22.2.11",
@@ -17903,7 +17903,7 @@
         "plain-scrollbar": {
             "version": "git+ssh://git@github.com/ewya/PlainScrollbar.git#35221e7c7fa9633d6f61bcd9d7b418b6de6da73b",
             "integrity": "sha512-54M01mOeA9VfJjAEXkM6U5wpH0TGVKiftF/jQYM97U019vKKNc5FDtDq6kUTbCLFB0ABDtwHQ53ooMi7vRaJRQ==",
-            "from": "plain-scrollbar@https://github.com/ewya/PlainScrollbar.git#35221e7c7fa9633d6f61bcd9d7b418b6de6da73b"
+            "from": "plain-scrollbar@github:ewya/PlainScrollbar#35221e7c7fa9633d6f61bcd9d7b418b6de6da73b"
         },
         "po2json": {
             "version": "0.4.5",
@@ -19037,9 +19037,9 @@
             "dev": true
         },
         "tinymce": {
-            "version": "5.10.3",
-            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.3.tgz",
-            "integrity": "sha512-O59ssHNnujWvSk5Gt8hIGrdNCMKVWVQv9F8siAgLTRgTh0t3NDHrP1UlLtCxArUi9DPWZvlBeUz8D5fJTu7vnA=="
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.0.2.tgz",
+            "integrity": "sha512-i4OEzcTF6mGxZ+scumOoWiaI9HYn6uya980hJ+9jwnhgLbhBb+73ar2t9Ewfkns3DTl2Ez3r1pQs2tpT+ka29Q=="
         },
         "tinymce-i18n": {
             "version": "22.2.11",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "rrule": "^2.6.3",
         "select2": "^4.0.13",
         "spin.js": "^4.1.0",
-        "tinymce": "^5.7.0",
+        "tinymce": "^6.0.2",
         "tinymce-i18n": "^22.2.11"
     },
     "scripts": {

--- a/src/Html.php
+++ b/src/Html.php
@@ -3816,10 +3816,8 @@ JS;
             'fullscreen',
             'link',
             'lists',
-            'paste',
             'quickbars',
             'searchreplace',
-            'tabfocus',
             'table',
         ];
         if ($enable_images) {
@@ -3867,20 +3865,19 @@ JS;
                // inline toolbar configuration
                menubar: false,
                toolbar: richtext_layout == 'classic'
-                  ? 'styleselect | bold italic | forecolor backcolor | bullist numlist outdent indent | emoticons table link image | code fullscreen'
+                  ? 'styles | bold italic | forecolor backcolor | bullist numlist outdent indent | emoticons table link image | code fullscreen'
                   : false,
                quickbars_insert_toolbar: richtext_layout == 'inline'
                   ? 'emoticons quicktable quickimage quicklink | bullist numlist | outdent indent '
                   : false,
                quickbars_selection_toolbar: richtext_layout == 'inline'
-                  ? 'bold italic | styleselect | forecolor backcolor '
+                  ? 'bold italic | styles | forecolor backcolor '
                   : false,
                contextmenu: 'emoticons table image link | undo redo | code fullscreen',
 
                // Content settings
                entity_encoding: 'raw',
                invalid_elements: '{$invalid_elements}',
-               paste_data_images: true,
                readonly: {$readonlyjs},
                relative_urls: false,
                remove_script_host: false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

- `tabfocus` plugin was bundled but not used.
- `colorpicker` and `textcolor` were empty stub plugins since TinyMCE 5.0.
- `paste` plugin is now integrated into TinyMCE core.
- `styleselect` menu item has been renamed to `styles`
- `paste_data_images` is now `true` by default.