### PR TITLE
Add rule action to send group approval

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8445,7 +8445,14 @@ abstract class CommonITILObject extends CommonDBTM
                                     ];
                                 }
                             }
-                        } else {
+                        } else if ($key === 'group_any') {
+                            foreach ($value as $groups_id) {
+                                $validations_to_send[] = [
+                                    'itemtype_target' => Group::class,
+                                    'items_id_target' => $groups_id,
+                                ];
+                            }
+                        } else if ((int) $value > 0) {
                             $validations_to_send[] = [
                                 'itemtype_target' => User::class,
                                 'items_id_target' => $value,

--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -150,6 +150,10 @@ abstract class RuleCommonITILObject extends Rule
                                 $output['_add_validation']['group'][] = $action->fields["value"];
                                 break;
 
+                            case 'groups_id_validate_any':
+                                $output['_add_validation']['group_any'][] = $action->fields["value"];
+                                break;
+
                             case 'users_id_validate':
                                 $output['_add_validation'][] = $action->fields["value"];
                                 break;
@@ -688,6 +692,7 @@ abstract class RuleCommonITILObject extends Rule
         $actions['responsible_id_validate']['type']                 = 'yesno';
         $actions['responsible_id_validate']['force_actions']        = ['add_validation'];
 
+        // Send approval to all valid users in a group where each user has their own approval
         $actions['groups_id_validate']['name']                      = sprintf(
             __('%1$s - %2$s'),
             __('Send an approval request'),
@@ -695,6 +700,15 @@ abstract class RuleCommonITILObject extends Rule
         );
         $actions['groups_id_validate']['type']                      = 'dropdown_groups_validate';
         $actions['groups_id_validate']['force_actions']             = ['add_validation'];
+
+        // Send approval to a group itself where any member can answer
+        $actions['groups_id_validate_any']['name']                      = sprintf(
+            __('%1$s - %2$s'),
+            __('Send an approval request'),
+            __('Group')
+        );
+        $actions['groups_id_validate_any']['type']                      = 'dropdown_groups_validate';
+        $actions['groups_id_validate_any']['force_actions']             = ['add_validation'];
 
         $actions['validation_percent']['name']                      = sprintf(
             __('%1$s - %2$s'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23911

Since the existing rule action for sending an approval to every user in a group already uses the key `groups_id_validate` the new action was added under `groups_id_validate_any` to avoid adding a breaking change and having to change rules during migration.

This also contains a bug fix where an invalid user validation could be added (ID 0).