### PR TITLE
Fix password reset form

### DIFF
--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -29,6 +29,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% set anonymous = session('glpiactiveprofile') is null %}
+
 {% set is_vertical = user_pref('page_layout') == 'vertical' %}
 
 <body class="{{ user_pref('fold_menu') and is_vertical ? 'navbar-collapsed' : '' }} {{ is_vertical ? 'vertical-layout' : 'horizontal-layout' }} {{ is_debug_active ? 'debug-active' : '' }}">
@@ -49,27 +51,34 @@
                <span class="glpi-logo"></span>
             </a>
 
-            <span class="d-none d-lg-inline-block">
-                {{ include('layout/parts/goto_button.html.twig') }}
-            </span>
+            {% if not anonymous %}
+               <span class="d-none d-lg-inline-block">
+                   {{ include('layout/parts/goto_button.html.twig') }}
+               </span>
+            {% endif %}
 
-            <div class="d-lg-none">
-               {{ include('layout/parts/user_header.html.twig') }}
-            </div>
+            {% if user is not null %}
+               {# There may still be a user logged in without a profile or entity. This is seen when they need to reset their password. #}
+               <div class="d-lg-none">
+                  {{ include('layout/parts/user_header.html.twig') }}
+               </div>
+            {% endif %}
 
-            <div class="collapse navbar-collapse" id="navbar-menu">
-                <span class="d-inline-block d-lg-none ms-2">
-                    {{ include('layout/parts/goto_button.html.twig') }}
-                </span>
-                {{ include('layout/parts/menu.html.twig') }}
+            {% if not anonymous %}
+               <div class="collapse navbar-collapse" id="navbar-menu">
+                   <span class="d-inline-block d-lg-none ms-2">
+                       {{ include('layout/parts/goto_button.html.twig') }}
+                   </span>
+                   {{ include('layout/parts/menu.html.twig') }}
 
 
-               <p class="text-start">
-                  <button class="btn btn-sm btn-ghost-secondary mb-2 reduce-menu d-none d-md-block">
-                     <span class="menu-label">{{ __('Collapse menu') }}</span>
-                  </button>
-               </p>
-            </div>
+                  <p class="text-start">
+                     <button class="btn btn-sm btn-ghost-secondary mb-2 reduce-menu d-none d-md-block">
+                        <span class="menu-label">{{ __('Collapse menu') }}</span>
+                     </button>
+                  </p>
+               </div>
+            {% endif %}
          </div>
       </aside>
       {% endif %}

--- a/templates/layout/parts/user_header.html.twig
+++ b/templates/layout/parts/user_header.html.twig
@@ -45,35 +45,39 @@
          <div class="nav-item dropdown">
             <a href="#" class="nav-link d-flex lh-1 text-reset p-1 dropdown-toggle {% if is_debug_active %}bg-red-lt{% endif %}"
                data-bs-toggle="dropdown" data-bs-auto-close="outside">
-               <div class="pe-2 d-none d-xl-block">
-                  <div>{{ (session('glpiactiveprofile')['name'] ?? '')|verbatim_value|u.truncate(35, '...') }}</div>
-                  {% set entity_completename = session('glpiactive_entity_name')|verbatim_value %}
-                  <div class="mt-1 small text-muted" title="{{ entity_completename }}"
-                       data-bs-toggle="tooltip" data-bs-placement="bottom">
-                    {{ entity_completename|truncate_left }}
+               {% if not anonymous %}
+                  <div class="pe-2 d-none d-xl-block">
+                     <div>{{ (session('glpiactiveprofile')['name'] ?? '')|verbatim_value|u.truncate(35, '...') }}</div>
+                     {% set entity_completename = session('glpiactive_entity_name')|verbatim_value %}
+                     <div class="mt-1 small text-muted" title="{{ entity_completename }}"
+                          data-bs-toggle="tooltip" data-bs-placement="bottom">
+                        {{ entity_completename|truncate_left }}
+                     </div>
                   </div>
-               </div>
 
-                {{ include('components/user/picture.html.twig', {
-                    'users_id': user.fields['id'],
-                    'with_link': false,
-                    'avatar_size': '',
-                }) }}
+                  {{ include('components/user/picture.html.twig', {
+                     'users_id': user.fields['id'],
+                     'with_link': false,
+                     'avatar_size': '',
+                  }) }}
+               {% endif %}
             </a>
             <div class="dropdown-menu dropdown-menu-end mt-1 dropdown-menu-arrow animate__animated animate__fadeInRight">
                <h6 class="dropdown-header">{{ get_item_name(user) }}</h6>
 
-               {{ include('layout/parts/profile_selector.html.twig') }}
+               {% if not anonymous %}
+                  {{ include('layout/parts/profile_selector.html.twig') }}
 
-               <div class="dropdown-divider"></div>
+                  <div class="dropdown-divider"></div>
 
-               {% if has_itemtype_right('Config', constant('UPDATE')) %}
-                  <a href="{{ path('/ajax/switchdebug.php') }}"
-                     class="dropdown-item {% if is_debug_active %}bg-red-lt{% endif %}"
-                     title="{{ __('Change mode') }}">
-                     <i class="ti fa-fw ti-bug debug"></i>
-                     {{ is_debug_active ? __('Debug mode enabled') : __('Debug mode disabled') }}
-                  </a>
+                  {% if has_itemtype_right('Config', constant('UPDATE')) %}
+                     <a href="{{ path('/ajax/switchdebug.php') }}"
+                        class="dropdown-item {% if is_debug_active %}bg-red-lt{% endif %}"
+                        title="{{ __('Change mode') }}">
+                        <i class="ti fa-fw ti-bug debug"></i>
+                        {{ is_debug_active ? __('Debug mode enabled') : __('Debug mode disabled') }}
+                     </a>
+                  {% endif %}
                {% endif %}
 
                {# @TODO Saved searches panel #}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11426

The password reset form seems unique in that there is a user session but no active profile or entity. Parts of the simple header used are reliant on at least an active entity when they weren't before in GLPI 9.5 and older. This PR tries detecting when the user is logged in like this and show a similar interface as before (`Html::simpleHeader`).

For example when needing to reset the password:
![Screenshot from 2022-04-29 21-09-04](https://user-images.githubusercontent.com/17678637/166084643-7bfe9609-ce2a-4cf4-82f4-0134b73caa6a.png)

Reference to previous `Html::simpleHeader` implementation:
https://github.com/glpi-project/glpi/blame/9.5/bugfixes/inc/html.class.php#L1844