### PR TITLE
Use correct root for picture URLs

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5973,7 +5973,7 @@ class CommonDBTM extends CommonGLPI
         foreach ($urls as $url) {
             if (!empty($url)) {
                 $resolved_url = \Toolbox::getPictureUrl($url);
-                $src_file = GLPI_DOC_DIR . '/_pictures/' . '/' . $url;
+                $src_file = GLPI_PICTURE_DIR . '/' . $url;
                 if (file_exists($src_file)) {
                     $size = getimagesize($src_file);
                     $pictures[] = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11466

Use correct environment variable for the picture path. In default configurations, this was still able to work because `GLPI_DOC_DIR` was set to `GLPI_VAR_DIR` and the picture URL here used `GLPI_DOC_DIR` with `_pictures` appended. The correct thing to use here is `GLPI_PICTURE_DIR`. The pictures already exist in the correct location and this only affected the retrieval and only if the document directory was changed to be something other than the var directory.