### PR TITLE
fix bad sql query

### DIFF
--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1411,7 +1411,13 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         }
 
         if ($params['knowbaseitemcategories_id'] > 0) {
-            $criteria['WHERE']['glpi_knowbaseitemcategories.id'] = $params['knowbaseitemcategories_id'];
+            $criteria['LEFT JOIN'][KnowbaseItem_KnowbaseItemCategory::getTable()] = [
+                'FKEY' => [
+                    KnowbaseItem_KnowbaseItemCategory::getTable() => KnowbaseItem::getForeignKeyField(),
+                    KnowbaseItem::getTable() => 'id',
+                ],
+            ];
+            $criteria['WHERE'][KnowbaseItem_KnowbaseItemCategory::getTableField('knowbaseitemcategories_id')] = $params['knowbaseitemcategories_id'];
         }
 
         if (


### PR DESCRIPTION
With Formcereator, viewing KB in the service catalog : 

```
glpisqllog.ERROR: DBmysql::query() in /home/bugier/public_html/glpi-100a/src/DBmysql.php line 368
  *** MySQL query error:
  SQL: SELECT COUNT(*) AS cpt FROM `glpi_knowbaseitems` LEFT JOIN `glpi_knowbaseitems_users` ON (`glpi_knowbaseitems_users`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_groups_knowbaseitems` ON (`glpi_groups_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_knowbaseitems_profiles` ON (`glpi_knowbaseitems_profiles`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_entities_knowbaseitems` ON (`glpi_entities_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) LEFT JOIN `glpi_knowbaseitems_knowbaseitemcategories` ON (`glpi_knowbaseitems_knowbaseitemcategories`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`) WHERE (`glpi_knowbaseitems`.`users_id` = '2' OR `glpi_knowbaseitems_users`.`users_id` = '2' OR `glpi_knowbaseitems`.`is_faq` = '1' OR (`glpi_groups_knowbaseitems`.`groups_id` IN ('1') AND (`glpi_groups_knowbaseitems`.`no_entity_restriction` = '1' OR (`glpi_groups_knowbaseitems`.`entities_id` IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14')))) OR (`glpi_knowbaseitems_profiles`.`profiles_id` = '1' AND (`glpi_knowbaseitems_profiles`.`no_entity_restriction` = '1' OR ((`glpi_knowbaseitems_profiles`.`entities_id` IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14'))))) OR (`glpi_entities_knowbaseitems`.`entities_id` IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14'))) AND ((`glpi_knowbaseitems`.`is_faq` = '1' OR `glpi_knowbaseitems_users`.`users_id` = '2')) AND `glpi_knowbaseitemcategories`.`id` IN ('0', '1', '2', '3', '4') AND ((MATCH(`glpi_knowbaseitems`.`name`,
                        `glpi_knowbaseitems`.`answer`)
                        AGAINST('faq*' IN BOOLEAN MODE))) AND ((((`glpi_knowbaseitems`.`begin_date` IS NULL) OR (`glpi_knowbaseitems`.`begin_date` < NOW()))) AND (((`glpi_knowbaseitems`.`end_date` IS NULL) OR (`glpi_knowbaseitems`.`end_date` > NOW()))))
  Error: Unknown column 'glpi_knowbaseitemcategories.id' in 'where clause'
  Backtrace :
  src/DBmysqlIterator.php:108                        
  src/DBmysql.php:1046                               DBmysqlIterator->execute()
  src/KnowbaseItem.php:1551                          DBmysql->request()
  plugins/formcreator/inc/knowbase.class.php:208     KnowbaseItem::getListRequest()
  plugins/formcreator/ajax/knowbaseitem.php:51       PluginFormcreatorKnowbase::getFaqItems()
  {"user":"2@Inspiron-5515"} 

```

Two problems found : 
- the forekgn key to filter by category is wrong : KB items are no longer directly associated to a KB category.
- using the new N-N relatin, we need to add a JOIN on the relation table.