### PR TITLE
Fix confusing Entity dropdown replacement message

### DIFF
--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -603,10 +603,12 @@ abstract class CommonDropdown extends CommonDBTM
                     value=\"" . _sx('button', 'Cancel') . "\">";
             echo "</td></tr></table>\n";
             Html::closeForm();
+            echo "<p>" . __('You can also replace all uses of this dropdown by another.') . "</p>";
+        } else {
+            echo "<p>" . __('You must replace all uses of this dropdown by another.') . "</p>";
         }
 
        // Replace form (set to new value)
-        echo "<p>" . __('You can also replace all uses of this dropdown by another.') . "</p>";
         echo "<form action='$target' method='post'>";
         echo "<table class='tab_cadre'><tr><td>";
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When deleting a dropdown type that must be replaced like Entity, the first message in the form says "You can also replace all uses of this dropdown by another". Use of "can also" is confusing when the first section (to remove references to the dropdown item) does not show in this case.
This PR changes the message to "You must replace all uses of this dropdown by another." when the replacement is required.