### PR TITLE
Fix ITIL footer z-index on mobile

### DIFF
--- a/css/includes/components/itilobject/_footer.scss
+++ b/css/includes/components/itilobject/_footer.scss
@@ -38,6 +38,7 @@
         left: 0;
         right: 0;
         bottom: 8px;
+        z-index: $zindex-fixed;
     }
 
     .action-task {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Fixed z-index for the ITIL footer on small screens. It was being overlapped by other elements like the buttons in the timeline forms, the TinyMCE toolbar for timeline items, etc.