### PR TITLE
fix(ticket template): contract in predefined field

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4171,6 +4171,7 @@ JAVASCRIPT;
             '_filename'                 => [],
             '_tag_filename'             => [],
             '_actors'                   => [],
+            '_contracts_id'             => 0,
         ];
     }
 

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -221,7 +221,7 @@
                {{ fields.dropdownField(
                   'Contract',
                   '_contracts_id',
-                  0,
+                  item.fields['_contracts_id'],
                   'Contract'|itemtype_name,
                   field_options|merge({
                      'entity': item.fields['entities_id'],


### PR DESCRIPTION
The contract value was not retrieved from the predefined fields of a ticket template.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23906
