### PR TITLE
Fix finding ITIL Object class from template

### DIFF
--- a/src/ITILTemplate.php
+++ b/src/ITILTemplate.php
@@ -897,6 +897,6 @@ abstract class ITILTemplate extends CommonDropdown
      */
     public static function getITILObjectClass(): string
     {
-        return str_replace('Template', '', static::getType());
+        return preg_replace("/Template$/i", "", static::getType());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23923

Some plugins like Releases have their class names with odd capitalization like "PluginReleasesReleasetemplate" instead of "PluginReleasesReleaseTemplate" or just "ReleaseTemplate" with a namespace (not really supported until now). The previous replacement was case-sensitive, so it would return the template class itself as the ITIL Object class instead of "PluginReleasesRelease".