### PR TITLE
Recalculate template used after rules

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1848,6 +1848,15 @@ abstract class CommonITILObject extends CommonDBTM
             PendingReason_Item::deleteForItem($this);
         }
 
+        // Re-compute template
+        $template = $this->getITILTemplateToUse(
+            0,
+            $this::getType(),
+            ($input['itilcategories_id'] ?? $this->fields['itilcategories_id']),
+            ($input['entities_id'] ?? $this->fields['entities_id'])
+        );
+        $input[$template::getForeignKeyField()] = $template->getID();
+
         return $input;
     }
 
@@ -2628,6 +2637,16 @@ abstract class CommonITILObject extends CommonDBTM
        // Set begin waiting time if status is waiting
         if (isset($input["status"]) && ($input["status"] == self::WAITING)) {
             $input['begin_waiting_date'] = $input['date'];
+        }
+
+        if (isset($input['itilcategories_id'], $input['entities_id'])) {
+            $template = $this->getITILTemplateToUse(
+                0,
+                $this->getType(),
+                $input['itilcategories_id'],
+                $input['entities_id']
+            );
+            $input[$template::getForeignKeyField()] = $template->getID();
         }
 
         return $input;

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1848,10 +1848,14 @@ abstract class CommonITILObject extends CommonDBTM
             PendingReason_Item::deleteForItem($this);
         }
 
+        $type = null;
+        if (is_a($this, Ticket::class)) {
+            $type = $input['type'] ?? $this->fields['type'];
+        }
         // Re-compute template
         $template = $this->getITILTemplateToUse(
             0,
-            $this::getType(),
+            $type,
             ($input['itilcategories_id'] ?? $this->fields['itilcategories_id']),
             ($input['entities_id'] ?? $this->fields['entities_id'])
         );
@@ -2639,12 +2643,16 @@ abstract class CommonITILObject extends CommonDBTM
             $input['begin_waiting_date'] = $input['date'];
         }
 
-        if (isset($input['itilcategories_id'], $input['entities_id'])) {
+        if (isset($input['itilcategories_id']) || isset($input['entities_id'])) {
+            $type = null;
+            if (is_a($this, Ticket::class)) {
+                $type = $input['type'] ?? Ticket::INCIDENT_TYPE;
+            }
             $template = $this->getITILTemplateToUse(
                 0,
-                $this->getType(),
-                $input['itilcategories_id'],
-                $input['entities_id']
+                $type,
+                $input['itilcategories_id'] ?? 0,
+                $input['entities_id'] ?? -1
             );
             $input[$template::getForeignKeyField()] = $template->getID();
         }

--- a/tests/functionnal/Change.php
+++ b/tests/functionnal/Change.php
@@ -274,4 +274,73 @@ class Change extends DbTestCase
         ]);
         $this->boolean($result)->isTrue();
     }
+
+    public function testCalculateTemplateOnAdd()
+    {
+        $template = new \ChangeTemplate();
+        $templates_id = $template->add([
+            'name'          => __FUNCTION__,
+            'content'       => __FUNCTION__,
+            'entities_id'   => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+        $this->integer($templates_id)->isGreaterThan(0);
+
+        $category = new \ITILCategory();
+        $category_id = $category->add([
+            'name'                  => __FUNCTION__,
+            'entities_id'           => getItemByTypeName('Entity', '_test_root_entity', true),
+            'changetemplates_id'    => $templates_id,
+        ]);
+        $this->integer($category_id)->isGreaterThan(0);
+
+        $change = new \Change();
+        $result = $change->prepareInputForAdd([
+            'name'                  => __FUNCTION__,
+            'content'               => __FUNCTION__,
+            'changetemplates_id'    => 1,
+            'itilcategories_id'     => $category_id,
+        ]);
+
+        $this->integer((int) $result['changetemplates_id'])->isEqualTo($templates_id);
+    }
+
+    public function testCalculateTemplateOnUpdate()
+    {
+        $template = new \ChangeTemplate();
+        $templates_id = $template->add([
+            'name'          => __FUNCTION__,
+            'content'       => __FUNCTION__,
+            'entities_id'   => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+        $this->integer($templates_id)->isGreaterThan(0);
+
+        $category = new \ITILCategory();
+        $category_id = $category->add([
+            'name'                  => __FUNCTION__,
+            'entities_id'           => getItemByTypeName('Entity', '_test_root_entity', true),
+            'changetemplates_id'    => $templates_id,
+        ]);
+        $this->integer($category_id)->isGreaterThan(0);
+
+        $existing_fields = [
+            'id'                    => 1,
+            'name'                  => __FUNCTION__,
+            'content'               => __FUNCTION__,
+            'changetemplates_id'    => 1,
+            'entities_id'           => getItemByTypeName('Entity', '_test_root_entity', true),
+            'status'                => \CommonITILObject::INCOMING,
+            'users_id_recipient'    => getItemByTypeName('User', TU_USER, true),
+        ];
+        $update_input = [
+            'id'                    => 1,
+            'itilcategories_id'     => $category_id,
+        ];
+        $change = new \Change();
+        $change->fields = $existing_fields;
+        $change->input = $update_input;
+        $this->login();
+        $result = $change->prepareInputForUpdate($update_input);
+
+        $this->integer((int) $result['changetemplates_id'])->isEqualTo($templates_id);
+    }
 }

--- a/tests/functionnal/Problem.php
+++ b/tests/functionnal/Problem.php
@@ -194,4 +194,73 @@ class Problem extends DbTestCase
             $this->string(\Problem::getTeamRoleName($role))->isNotEmpty();
         }
     }
+
+    public function testCalculateTemplateOnAdd()
+    {
+        $template = new \ProblemTemplate();
+        $templates_id = $template->add([
+            'name'          => __FUNCTION__,
+            'content'       => __FUNCTION__,
+            'entities_id'   => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+        $this->integer($templates_id)->isGreaterThan(0);
+
+        $category = new \ITILCategory();
+        $category_id = $category->add([
+            'name'                  => __FUNCTION__,
+            'entities_id'           => getItemByTypeName('Entity', '_test_root_entity', true),
+            'problemtemplates_id'   => $templates_id,
+        ]);
+        $this->integer($category_id)->isGreaterThan(0);
+
+        $problem = new \Problem();
+        $result = $problem->prepareInputForAdd([
+            'name'                  => __FUNCTION__,
+            'content'               => __FUNCTION__,
+            'problemtemplates_id'   => 1,
+            'itilcategories_id'     => $category_id,
+        ]);
+
+        $this->integer((int) $result['problemtemplates_id'])->isEqualTo($templates_id);
+    }
+
+    public function testCalculateTemplateOnUpdate()
+    {
+        $template = new \ProblemTemplate();
+        $templates_id = $template->add([
+            'name'          => __FUNCTION__,
+            'content'       => __FUNCTION__,
+            'entities_id'   => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+        $this->integer($templates_id)->isGreaterThan(0);
+
+        $category = new \ITILCategory();
+        $category_id = $category->add([
+            'name'                  => __FUNCTION__,
+            'entities_id'           => getItemByTypeName('Entity', '_test_root_entity', true),
+            'problemtemplates_id'   => $templates_id,
+        ]);
+        $this->integer($category_id)->isGreaterThan(0);
+
+        $existing_fields = [
+            'id'                    => 1,
+            'name'                  => __FUNCTION__,
+            'content'               => __FUNCTION__,
+            'problemtemplates_id'   => 1,
+            'entities_id'           => getItemByTypeName('Entity', '_test_root_entity', true),
+            'status'                => \CommonITILObject::INCOMING,
+            'users_id_recipient'    => getItemByTypeName('User', TU_USER, true),
+        ];
+        $update_input = [
+            'id'                    => 1,
+            'itilcategories_id'     => $category_id,
+        ];
+        $problem = new \Problem();
+        $problem->fields = $existing_fields;
+        $problem->input = $update_input;
+        $this->login();
+        $result = $problem->prepareInputForUpdate($update_input);
+
+        $this->integer((int) $result['problemtemplates_id'])->isEqualTo($templates_id);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23917

If the applicable ITIL template changes based on changes from rules, the value in the DB would not be updated right away. Instead, it would update after the item is saved manually since the template would get recalculated when displaying the form and set a hidden input.

This PR updates the template field during the add/update process after rules have run so that the field is always up to date.