### PR TITLE
Fix Ticket template for type

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -387,10 +387,14 @@ abstract class CommonITILObject extends CommonDBTM
             $options['noid'] = true;
         }
 
+        $type = null;
+        if (is_a($this, Ticket::class)) {
+            $type = ($ID ? $this->fields['type'] : $options['type']);
+        }
         // Load template if available
         $tt = $this->getITILTemplateToUse(
             $options['template_preview'] ?? 0,
-            $this->getType(),
+            $type,
             ($ID ? $this->fields['itilcategories_id'] : $options['itilcategories_id']),
             ($ID ? $this->fields['entities_id'] : $options['entities_id'])
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The `type` parameter of `CommonITILObject::getITILTemplateToUse` is supposed to be `INCIDENT` or `REQUEST` integers for Tickets or null otherwise, not the class name of the current object.