### PR TITLE
Fix ITIL Object Rule Detection

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2360,7 +2360,7 @@ class Rule extends CommonDBTM
                         break;
 
                     case "dropdown_status":
-                        if (is_a(static::class, RuleCommonITILObject::class)) {
+                        if (is_a(static::class, RuleCommonITILObject::class, true)) {
                             $itil = static::getItemtype();
                             return $itil::getStatus($pattern);
                         } else {
@@ -2502,7 +2502,7 @@ class Rule extends CommonDBTM
                     break;
 
                 case "dropdown_status":
-                    if (is_a(static::class, RuleCommonITILObject::class)) {
+                    if (is_a(static::class, RuleCommonITILObject::class, true)) {
                         $itil = static::getItemtype();
                         $itil::dropdownStatus(['name' => $name,
                             'value' => $value
@@ -2587,7 +2587,7 @@ class Rule extends CommonDBTM
                     return (($name == '&nbsp;') ? NOT_AVAILABLE : $name);
 
                 case "dropdown_status":
-                    if (is_a(static::class, RuleCommonITILObject::class)) {
+                    if (is_a(static::class, RuleCommonITILObject::class, true)) {
                         $itil = static::getItemtype();
                         return $itil::getStatus($value);
                     } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23912

`is_a` must be set allow strings and is not default unlike `is_subclass_of`. In some cases these checks seemed to work just fine without allowing strings but I think that is an undefined behavior because it was always using a class string as the object (`static::class`).