### PR TITLE
fix(planning): purge right on serie

### DIFF
--- a/src/PlanningExternalEvent.php
+++ b/src/PlanningExternalEvent.php
@@ -357,16 +357,18 @@ JAVASCRIPT;
 
         if ($is_ajax && $is_rrule) {
             $options['candel'] = false;
-            $options['addbuttons'] = [
-                'purge'          => [
-                    'text' => __("Delete serie"),
-                    'icon' => 'fas fa-trash-alt',
-                ],
-                'purge_instance' => [
-                    'text' => __("Delete instance"),
-                    'icon' => 'far fa-trash-alt',
-                ],
-            ];
+            if ($this->can($ID, PURGE)) {
+                $options['addbuttons'] = [
+                    'purge'          => [
+                        'text' => __("Delete serie"),
+                        'icon' => 'fas fa-trash-alt',
+                    ],
+                    'purge_instance' => [
+                        'text' => __("Delete instance"),
+                        'icon' => 'far fa-trash-alt',
+                    ],
+                ];
+            }
         }
 
         $this->showFormButtons($options);


### PR DESCRIPTION
The right to purge was not checked in the series, which made it possible to delete without having the right to do so.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23868
