### PR TITLE
fix secondary bar top offset when in responsive mode and horizontal l…

### DIFF
--- a/css/includes/components/_saved-searches.scss
+++ b/css/includes/components/_saved-searches.scss
@@ -124,6 +124,10 @@ body.horizontal-layout {
     .secondary-bar {
         top: $topbar-height;
         z-index: 1010;
+
+        @include media-breakpoint-down(md) {
+            top: 0;
+        }
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Remove this spacing when in responsive mode (< medium sized screen) and in horizontal layout:

![image](https://user-images.githubusercontent.com/418844/166898331-cf847147-7ade-4ffa-8e71-e9d4d4ec6a2a.png)

