### PR TITLE
fix(export PDF): html entities

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -8153,7 +8153,7 @@ HTML;
             case self::PDF_OUTPUT_PORTRAIT:
                 global $PDF_TABLE;
                 $value = DataExport::normalizeValueForTextExport($value ?? '');
-                $value = htmlspecialchars($value);
+                $value = htmlspecialchars($value, ENT_QUOTES, null, false);
                 $value = preg_replace('/' . self::LBBR . '/', '<br>', $value);
                 $value = preg_replace('/' . self::LBHR . '/', '<hr>', $value);
                 $PDF_TABLE .= "<td $extraparam valign='top'>";


### PR DESCRIPTION
In a PDF export, the HTML entities were shown instead of the special characters.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23945
