### PR TITLE
Fix tab tracking

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -359,7 +359,19 @@ JAVASCRIPT;
             var url = tablink.attr('href');
             var target = tablink.attr('data-bs-target');
             var index = tablink.closest('.nav-item').index();
+
+            const updateCurrentTab = () => {
+                $.get(
+                  '{$CFG_GLPI['root_doc']}/ajax/updatecurrenttab.php',
+                  {
+                     itemtype: '" . addslashes($type) . "',
+                     id: '$ID',
+                     tab: index,
+                  }
+               );
+            }
             if ($(target).html() && !force_reload) {
+                updateCurrentTab();
                 return;
             }
             $(target).html('<i class=\"fas fa-3x fa-spinner fa-pulse position-absolute m-5 start-50\"></i>');
@@ -369,14 +381,7 @@ JAVASCRIPT;
 
                $(target).closest('main').trigger('glpi.tab.loaded');
 
-               $.get(
-                  '{$CFG_GLPI['root_doc']}/ajax/updatecurrenttab.php',
-                  {
-                     itemtype: '" . addslashes($type) . "',
-                     id: '$ID',
-                     tab: index,
-                  }
-               );
+               updateCurrentTab();
             });
          };
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When a page reloads, the initially loaded tab is always the one that was last loaded before the page refresh rather than the one that was last switched to. Since tabs are almost always loaded once per page load, tab tracking wasn't working properly.