### PR TITLE
Fix strtotime deprecation messages in Ticket stats timeline

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -6275,17 +6275,17 @@ JAVASCRIPT;
     public function showStatsDates()
     {
         $now                      = time();
-        $date_creation            = strtotime($this->fields['date']);
+        $date_creation            = strtotime($this->fields['date'] ?? '');
         $date_takeintoaccount     = $date_creation + $this->fields['takeintoaccount_delay_stat'];
         if ($date_takeintoaccount == $date_creation) {
             $date_takeintoaccount  = 0;
         }
-        $internal_time_to_own     = strtotime($this->fields['internal_time_to_own']);
-        $time_to_own              = strtotime($this->fields['time_to_own']);
-        $internal_time_to_resolve = strtotime($this->fields['internal_time_to_resolve']);
-        $time_to_resolve          = strtotime($this->fields['time_to_resolve']);
-        $solvedate                = strtotime($this->fields['solvedate']);
-        $closedate                = strtotime($this->fields['closedate']);
+        $internal_time_to_own     = strtotime($this->fields['internal_time_to_own'] ?? '');
+        $time_to_own              = strtotime($this->fields['time_to_own'] ?? '');
+        $internal_time_to_resolve = strtotime($this->fields['internal_time_to_resolve'] ?? '');
+        $time_to_resolve          = strtotime($this->fields['time_to_resolve'] ?? '');
+        $solvedate                = strtotime($this->fields['solvedate'] ?? '');
+        $closedate                = strtotime($this->fields['closedate'] ?? '');
         $goal_takeintoaccount     = ($date_takeintoaccount > 0 ? $date_takeintoaccount : $now);
         $goal_solvedate           = ($solvedate > 0 ? $solvedate : $now);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

In PHP 8.1, passing null to `strtotime` is deprecated. If a date field is not set, it is null by default. The solution is to use `?? ''` as an invalid date string will return false still. The only change is that the argument must be a string.