### PR TITLE
Restore max task duration to old value

### DIFF
--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -286,7 +286,8 @@
                         'min': 0,
                         'max': 8 * constant('HOUR_TIMESTAMP'),
                         'addfirstminutes': true,
-                        'inhours': true
+                        'inhours': true,
+                        'toadd': range(9, 100)|map(i => i * constant('HOUR_TIMESTAMP')),
                      }) }}
 
                      {# User #}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11501

`toadd` option was missing for task duration field so 8 hours was the max duration that could be set (Options included minutes up to 8 hours. The toadd option added the remaining hour-only values).