### PR TITLE
Fix search table horizontal scroll

### DIFF
--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -90,7 +90,6 @@
         .search-card {
             @include media-breakpoint-up(sm) {
                 min-width: 100%;
-                width: min-content;
 
                 .search-header {
                     border-bottom: 0;

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -31,7 +31,7 @@
 
 {% set searchform_id = data['searchform_id']|default('search_' ~ rand) %}
 
-<div class="table-responsive-md">
+<div class="table-responsive">
    <table class="search-results table card-table table-hover {{ data['search']['is_deleted'] ? "table-danger deleted-results" : "table-striped" }}"
           id="{{ searchform_id }}">
       <thead>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11492

Instead of the table scrolling horizontally when there are more columns than can be displayed at once, the parent card element was scrolling instead.