### PR TITLE
Fix encoding issues in PDF export

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -7060,7 +7060,7 @@ JAVASCRIPT;
                             $count_display++;
 
 
-                            $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], false, true, true);
+                            $plaintext = RichText::getTextFromHtml($data[$ID][$k]['name'], false, true, self::$output_type == self::HTML_OUTPUT);
 
                             if (self::$output_type == self::HTML_OUTPUT && (Toolbox::strlen($plaintext) > $CFG_GLPI['cut'])) {
                                 $rand = mt_rand();
@@ -7318,7 +7318,10 @@ HTML;
                         if (isset($data[$ID][$k]['trans']) && !empty($data[$ID][$k]['trans'])) {
                             $out .= $data[$ID][$k]['trans'];
                         } else {
-                            $out .= $data[$ID][$k]['name'];
+                            $value = $data[$ID][$k]['name'];
+                            $out .= $value !== null && $so['field'] === 'completename'
+                                ? CommonTreeDropdown::sanitizeSeparatorInCompletename($value)
+                                : $value;
                         }
                     }
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Alternative to #11500 .

1. Entities encoding on `RichText::getTextFromHtml()` result should be done only when data is meant to be displayed in an HTML page.
2. `>` separator should be sanitized when value corresponds to a dropdown `completename`.