### PR TITLE
Fix TinyMCE completion plugins

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     ],
     "env": {
         "browser": true,
+        "es6": true,
         "jquery": true
     },
     "extends": "eslint:recommended",

--- a/js/RichText/ContentTemplatesParameters.js
+++ b/js/RichText/ContentTemplatesParameters.js
@@ -83,12 +83,12 @@ GLPI.RichText.ContentTemplatesParameters = class {
     *
     * @param {string} pattern
     *
-    * @returns {tinymce.util.Promise}
+    * @returns {Promise}
     */
     fetchItems(pattern) {
         const that = this;
 
-        return new tinymce.util.Promise(
+        return new Promise(
             function (resolve) {
                 const items = that.values.filter(
                     function(item) {

--- a/js/RichText/UserMention.js
+++ b/js/RichText/UserMention.js
@@ -85,11 +85,11 @@ GLPI.RichText.UserMention = class {
     *
     * @param {string} pattern
     *
-    * @returns {tinymce.util.Promise}
+    * @returns {Promise}
     */
     fetchItems(pattern) {
         const that = this;
-        return new tinymce.util.Promise(
+        return new Promise(
             function (resolve) {
                 $.post(
                     CFG_GLPI.root_doc + '/ajax/getDropdownUsers.php',

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -31,7 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
-/* global getExtIcon, getSize, isImage, stopEvent, Uint8Array */
+/* global getExtIcon, getSize, isImage, stopEvent */
 
 var insertIntoEditor = []; // contains flags that indicate if uploaded file (image) should be added to editor contents
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`Promise` polyfill has been removed from TinyMCE in version 6.x. Using native ES6 `Promise` API is safe now.