### PR TITLE
Bump ecmaVersion 6 to 8

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,7 @@
         "_nx": true
     },
     "parserOptions": {
-        "ecmaVersion": 7
+        "ecmaVersion": 8
     },
     "rules": {
         "eol-last": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,7 @@
         "_nx": true
     },
     "parserOptions": {
-        "ecmaVersion": 6
+        "ecmaVersion": 7
     },
     "rules": {
         "eol-last": [


### PR DESCRIPTION
As seen here
https://github.com/glpi-project/glpi/pull/11487

Bump ecmaversion to 7 for javascript ```async function```


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
