### PR TITLE
Delete temporary inventory file via destructor

### DIFF
--- a/src/Inventory/Inventory.php
+++ b/src/Inventory/Inventory.php
@@ -103,7 +103,8 @@ class Inventory
      * Destructor of the object
      * Remove temporary inventory if it exists
      **/
-    public function __destruct() {
+    public function __destruct()
+    {
         if (isset($this->inventory_id)) {
             $ext = (Request::XML_MODE === $this->inventory_format ? 'xml' : 'json');
             $tmpfile = sprintf('%s/%s.%s', GLPI_INVENTORY_DIR, $this->inventory_id, $ext);

--- a/src/Inventory/Inventory.php
+++ b/src/Inventory/Inventory.php
@@ -114,7 +114,7 @@ class Inventory
         }
     }
 
-    private function tempInventoryFilename()
+    private function tempInventoryFilename(): string
     {
         $ext = (Request::XML_MODE === $this->inventory_format ? 'xml' : 'json');
         // even if tmpfile shouldn't exist, it's safer to check it really doesn't


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10356,#11405

This implements the deletion of temporary inventory file using Inventory object destructor.

I tested this patch with the case reported in #10356 and it worked as expected.