### PR TITLE
fix issues with responsive and sticky positioning

### DIFF
--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -92,6 +92,7 @@
         .search-card {
             @include media-breakpoint-up(sm) {
                 min-width: 100%;
+                width: fit-content;
 
                 .search-header {
                     border-bottom: 0;
@@ -103,6 +104,8 @@
             }
 
             .table-responsive-md {
+                width: fit-content;
+
                 @include media-breakpoint-down(md) {
                     max-width: calc(100vw - 2rem);
                 }
@@ -122,6 +125,8 @@
                             border-left: 0;
                             border-right: 0;
                             background-color: $table_header_bg;
+                            min-width: max-content;
+                            vertical-align: top;
                         }
                     }
                 }

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -33,7 +33,7 @@
 
 {% set searchform_id = data['searchform_id']|default('search_' ~ rand) %}
 
-<div class="table-responsive">
+<div class="table-responsive-md">
    <table class="search-results table card-table table-hover {{ data['search']['is_deleted'] ? "table-danger deleted-results" : "table-striped" }}"
           id="{{ searchform_id }}">
       <thead>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11520, #11492

relate to #11506

Moved again to responsive-md to trigger the horizontal scroll only on screens < medium size. Under this breakpoint we already remove sticky elements. This fixes the spacing bug when responsive and sticky are enabled at the time (like mentioned in #11520).

To fix #11492, i now set `width: fit-content` on intermediate containers to apply the background.

The last part for th (`min-width: max-content`) is to have a better reading for column (they take more space and the text is less compacted).

