### PR TITLE
make search header/footer components sticking horinzontally

### DIFF
--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -100,6 +100,11 @@
                     top: -1px;
                     background-color: inherit;
                     z-index: #{$zindex-sticky + 1};
+
+                    .search-controls {
+                        position: sticky;
+                        left: 22px;
+                    }
                 }
             }
 
@@ -120,7 +125,7 @@
                         th {
                             z-index: $zindex-sticky;
                             position: sticky;
-                            top: 49px;
+                            top: 59px;
                             border: 1px solid $card-border-color;
                             border-left: 0;
                             border-right: 0;
@@ -150,14 +155,20 @@
 
                 @include media-breakpoint-up(sm) {
                     .search-pager {
+                        .search-limit {
+                            position: sticky;
+                            left: 22px;
+                        }
+
                         .page-infos {
                             position: sticky;
-                            left: 10px;
+                            left: 250px;
+                            right: 250px;
                         }
 
                         .pagination {
                             position: sticky;
-                            right: 10px;
+                            right: 22px;
                         }
                     }
                 }

--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -163,7 +163,7 @@
                         .page-infos {
                             position: sticky;
                             left: 250px;
-                            right: 250px;
+                            right: 270px;
                         }
 
                         .pagination {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Follow #11521 

Last thing i need (try) to fix, is `.page-infos` div scrolling due to the `.justify-content-between` class of its parent.
It's annonying, but not blocking i think, i contained it at 250px left/right

@cconard96 Do you see any remaining bugs  ?
