### PR TITLE
feat(dashboard label): set min font-size

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -791,7 +791,7 @@ var Dashboard = {
 
         parent_item
             .find('.big-number')
-            .find('.label').fitText(text_offset - 0.2);
+            .find('.label').fitText(text_offset - 0.2, { minFontSize: '12px'});
 
         // Remove temporary width
         this.resetComputedWidth(parent_item.find('.big-number').find('.formatted-number'));


### PR DESCRIPTION
Set min ```font-size``` for ```big-number``` card

Useful for single  ```big-number``` cards

Before 
![image](https://user-images.githubusercontent.com/7335054/167389999-f6d4b789-3051-4cf1-9796-5949d26145dd.png)


After
![image](https://user-images.githubusercontent.com/7335054/167390015-f13ecee8-881b-4558-a818-8e254aa97167.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
