### PR TITLE
Notifications: handle plugin namespaces

### DIFF
--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -316,16 +316,16 @@ class NotificationTarget extends CommonDBChild
     {
 
         $itemtype = $item->getType();
-        if ($plug = isPluginItemType($itemtype)) {
-           // plugins case
-            $name = 'Plugin' . $plug['plugin'] . 'NotificationTarget' . $plug['class'];
-        } else if (strpos($itemtype, "\\") != false) {
-           // namespace case
+        if (strpos($itemtype, "\\") != false) {
+            // namespace case
             $ns_parts = explode("\\", $itemtype);
             $classname = array_pop($ns_parts);
             $name = implode("\\", $ns_parts) . "\\NotificationTarget$classname";
+        } elseif ($plug = isPluginItemType($itemtype)) {
+            // plugins case
+            $name = 'Plugin' . $plug['plugin'] . 'NotificationTarget' . $plug['class'];
         } else {
-           // simple class (without namespace)
+            // simple class (without namespace)
             $name = "NotificationTarget$itemtype";
         }
 

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -314,20 +314,7 @@ class NotificationTarget extends CommonDBChild
      **/
     public static function getInstance($item, $event = '', $options = [])
     {
-
-        $itemtype = $item->getType();
-        if (strpos($itemtype, "\\") != false) {
-            // namespace case
-            $ns_parts = explode("\\", $itemtype);
-            $classname = array_pop($ns_parts);
-            $name = implode("\\", $ns_parts) . "\\NotificationTarget$classname";
-        } elseif ($plug = isPluginItemType($itemtype)) {
-            // plugins case
-            $name = 'Plugin' . $plug['plugin'] . 'NotificationTarget' . $plug['class'];
-        } else {
-            // simple class (without namespace)
-            $name = "NotificationTarget$itemtype";
-        }
+        $name = self::getInstanceClass($item->getType());
 
         $entity = 0;
         if (class_exists($name)) {
@@ -344,6 +331,30 @@ class NotificationTarget extends CommonDBChild
         return false;
     }
 
+    /**
+     * Get the expected notification target class name for a given itemtype
+     *
+     * @param string $itemtype
+     *
+     * @return string
+     */
+    public static function getInstanceClass(string $itemtype): string
+    {
+        if (strpos($itemtype, "\\") != false) {
+            // namespace case
+            $ns_parts = explode("\\", $itemtype);
+            $classname = array_pop($ns_parts);
+            $name = implode("\\", $ns_parts) . "\\NotificationTarget$classname";
+        } elseif ($plug = isPluginItemType($itemtype)) {
+            // plugins case
+            $name = 'Plugin' . $plug['plugin'] . 'NotificationTarget' . $plug['class'];
+        } else {
+            // simple class (without namespace)
+            $name = "NotificationTarget$itemtype";
+        }
+
+        return $name;
+    }
 
     /**
      * Get a notificationtarget class by giving an itemtype

--- a/tests/functionnal/NotificationTarget.php
+++ b/tests/functionnal/NotificationTarget.php
@@ -328,4 +328,33 @@ class NotificationTarget extends DbTestCase
                 ->exists();
         }
     }
+
+    protected function testGetInstanceClassProvider(): Generator
+    {
+        yield [
+            'itemtype' => 'Test',
+            'class'    => 'NotificationTargetTest',
+        ];
+
+        yield [
+            'itemtype' => 'PluginPluginameTest',
+            'class'    => 'PluginPluginameNotificationTargetTest',
+        ];
+
+        yield [
+            'itemtype' => 'GlpiPlugin\Namespace\Test',
+            'class'    => 'GlpiPlugin\Namespace\NotificationTargetTest',
+        ];
+    }
+
+    /**
+     * Tests for NotificationTarget::getInstanceClass
+     *
+     * @dataProvider testGetInstanceClassProvider
+     */
+    public function testGetInstanceClass(string $itemtype, string $class): void
+    {
+        $output = \NotificationTarget::getInstanceClass($itemtype);
+        $this->string($output)->isEqualTo($class);
+    }
 }


### PR DESCRIPTION
Before these changes, a plugin itemtype with a namespace would not be loaded correctly.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
