### PR TITLE
Do not pass null values to string functions

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -8146,6 +8146,11 @@ HTML;
     {
 
         $out = "";
+        // Handle null values
+        if ($value === null) {
+            $value = '';
+        }
+
         switch ($type) {
             case self::PDF_OUTPUT_LANDSCAPE: //pdf
             case self::PDF_OUTPUT_PORTRAIT:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

PHP 8.1 starts throwing deprecations when you pass null as the subject of several string functions such as `preg_split`. The `Search::showItem` function does not enforce any type for the `value` parameter. Null values are now replaced with an empty string.