### PR TITLE
fix(ticket): predefined field always loaded

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -491,8 +491,7 @@ abstract class CommonITILObject extends CommonDBTM
         $predefined_fields = [];
         $tpl_key = static::getTemplateFormFieldName();
 
-        // Change and Problem can have predefined fields only on creation
-        if ($this->getType() == "Ticket" || $this->isNewItem()) {
+        if ($this->isNewItem()) {
             if (isset($tt->predefined) && count($tt->predefined)) {
                 foreach ($tt->predefined as $predeffield => $predefvalue) {
                     if (isset($options[$predeffield]) && isset($default_values[$predeffield])) {
@@ -520,12 +519,7 @@ abstract class CommonITILObject extends CommonDBTM
                         ) {
                             $options[$predeffield]           = $predefvalue;
                             $predefined_fields[$predeffield] = $predefvalue;
-                            if (
-                                ($this->isNewItem())
-                                && (!array_key_exists($predeffield, $this->fields) || empty($this->fields[$predeffield]))
-                            ) {
-                                $this->fields[$predeffield] = $predefvalue;
-                            }
+                            $this->fields[$predeffield]      = $predefvalue;
                         }
                     } else { // Not defined options set as hidden field
                         $options['_hidden_fields'][$predeffield] = $predefvalue;

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -520,7 +520,9 @@ abstract class CommonITILObject extends CommonDBTM
                         ) {
                             $options[$predeffield]           = $predefvalue;
                             $predefined_fields[$predeffield] = $predefvalue;
-                            $this->fields[$predeffield]      = $predefvalue;
+                            if (!array_key_exists($predeffield, $this->fields) || empty($this->fields[$predeffield])) {
+                                $this->fields[$predeffield] = $predefvalue;
+                            }
                         }
                     } else { // Not defined options set as hidden field
                         $options['_hidden_fields'][$predeffield] = $predefvalue;

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -520,7 +520,10 @@ abstract class CommonITILObject extends CommonDBTM
                         ) {
                             $options[$predeffield]           = $predefvalue;
                             $predefined_fields[$predeffield] = $predefvalue;
-                            if (!array_key_exists($predeffield, $this->fields) || empty($this->fields[$predeffield])) {
+                            if (
+                                ($this->isNewItem())
+                                && (!array_key_exists($predeffield, $this->fields) || empty($this->fields[$predeffield]))
+                            ) {
                                 $this->fields[$predeffield] = $predefvalue;
                             }
                         }


### PR DESCRIPTION
The values of the predefined fields in the template were displayed instead of the values recorded in the ticket.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24947

Possibly related to PR #11421
