### PR TITLE
Fix nosort column handling

### DIFF
--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -229,7 +229,10 @@ td.priority_block {
 }
 
 table.search-results {
-    thead th[data-searchopt-id]:not([data-searchopt-id=""]) {
+    thead th[data-searchopt-id][data-nosort] {
+        vertical-align: bottom !important;// Fix alignment for when no sorting indicator element is present
+    }
+    thead th[data-searchopt-id]:not([data-searchopt-id=""]):not([data-nosort]) {
         cursor: pointer;
 
         .sort-indicator {

--- a/js/modules/Search/Table.js
+++ b/js/modules/Search/Table.js
@@ -209,6 +209,10 @@ window.GLPI.Search.Table = class Table extends GenericView {
         $(ajax_container).on('click', 'table.search-results th[data-searchopt-id]', (e) => {
             e.stopPropagation();
             const target = $(e.target).closest('th').get(0);
+
+            if ($(target).data('nosort')) {
+                return;
+            }
             if (e.ctrlKey || e.metaKey) {
             // Multisort mode
                 this.onColumnSortClick(target, true);

--- a/src/Search.php
+++ b/src/Search.php
@@ -3516,6 +3516,9 @@ JAVASCRIPT;
 
         foreach ($sort_fields as $sort_field) {
             $ID = $sort_field['searchopt_id'];
+            if (isset($searchopt[$ID]['nosort']) && $searchopt[$ID]['nosort']) {
+                continue;
+            }
             $order = $sort_field['order'] ?? 'ASC';
            // Order security check
             if ($order != 'ASC') {
@@ -3651,6 +3654,9 @@ JAVASCRIPT;
             $orderby_criteria[] = $criterion ?? "`ITEM_{$itemtype}_{$ID}` $order";
         }
 
+        if (count($orderby_criteria) === 0) {
+            return;
+        }
         return ' ORDER BY ' . implode(', ', $orderby_criteria) . ' ';
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11326

First commit handles client-side behavior like ignoring the click event on unsortable columns.
Second commit adds logic to the search engine to filter out unsortable search options when building the ORDER BY part of the query.