### PR TITLE
Handle both sanitized an raw values in Search::makeTextSearchValue()

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -8715,8 +8715,10 @@ HTML;
      **/
     public static function makeTextSearchValue($val)
     {
-       // Unclean to permit < and > search
-        $val = Sanitizer::decodeHtmlSpecialChars($val);
+        // `$val` will mostly comes from sanitized input, but may also be raw value.
+        // 1. Unsanitize value to be sure to use raw value.
+        // 2. Escape raw value to protect SQL special chars.
+        $val = Sanitizer::dbEscape(Sanitizer::unsanitize($val));
 
        // escape _ char used as wildcard in mysql likes
         $val = str_replace('_', '\\_', $val);

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -1615,7 +1615,13 @@ class Search extends DbTestCase
             ['rtim this   $', '%rtim this'],
             ['  extra spaces ', '%extra spaces%'],
             ['^ exactval $', 'exactval'],
-            ['quot\\\'ed', '%quot\\\'ed%']
+            ['snake_case', '%snake\\_case%'], // _ is a wildcard that must be escaped
+            ['quot\'ed', '%quot\\\'ed%'],
+            ['quot\\\'ed', '%quot\\\'ed%'], // already escaped value should not produce double escaping
+            ['^&#60;PROD-15&#62;', '<PROD-15>%'],
+            ['<PROD-15>$', '%<PROD-15>'],
+            ['A&#38;B', '%A&B%'],
+            ['A&B', '%A&B%'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Follows #11549 .

`Search::makeTextSearchValue()` may be indirectly used with values that were not previously sanitized, so it is safer to ensure that result will be correctly escaped, whenever the `$val` param was a sanitized or a raw value.