### PR TITLE
clear timer when select a dropdown in logs filter

### DIFF
--- a/js/log_filters.js
+++ b/js/log_filters.js
@@ -49,6 +49,8 @@ $(function() {
         }
     };
 
+    var delay_timer = null;
+
     var bindFilterChange = function () {
         // Workaround to prevent opening of dropdown when removing item using the "x" button.
         // Without this workaround, orphan dropdowns remains in page when reloading tab.
@@ -58,7 +60,6 @@ $(function() {
             }
         });
 
-        var delay_timer = null;
         $('.log_history_filter_row [name^="filters\\["]').on('input', function() {
             clearTimeout(delay_timer);
             delay_timer = setTimeout(function() {
@@ -77,6 +78,9 @@ $(function() {
     };
 
     var handleFilterChange = function () {
+        if (delay_timer !== null) {
+            clearTimeout(delay_timer);
+        }
         // Prevent dropdown to remain in page after tab has been reload.
         $('.log_history_filter_row .select2-hidden-accessible').select2('close');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

In history tab of an asset, after enabling logs filtering, if we select a value in the "Field" column, the filter action triggered twice:
- at selection
- after the timer (normally dedicated to text inputs)


