### PR TITLE
Add cartridge level search options

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -998,24 +998,57 @@ class Html
     public static function progressBar($id, array $options = [])
     {
 
-        $params            = [];
-        $params['create']  = false;
-        $params['message'] = null;
-        $params['percent'] = -1;
-        $params['display'] = true;
+        $params = [
+            'create'    => false,
+            'message'   => null,
+            'percent'   => -1,
+            'display'   => true,
+            'colors'    => null,
+        ];
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
-                $params[$key] = $val;
+                if ($key === 'colors' && $val !== null) {
+                    $params['colors'] = array_merge([
+                        'bg' => null,
+                        'fg' => null,
+                        'border' => null,
+                        'text' => null,
+                    ], $val);
+                } else {
+                    $params[$key] = $val;
+                }
             }
         }
 
         $out = '';
         if ($params['create']) {
+            $apply_custom_colors = $params['colors'] !== null;
+            $outer_style = 'height: 16px;';
+            if ($apply_custom_colors) {
+                if ($params['colors']['bg']) {
+                    $outer_style .= 'background-color: ' . $params['colors']['bg'] . ';';
+                }
+                if ($params['colors']['border']) {
+                    $outer_style .= 'border: 1px solid ' . $params['colors']['border'] . ';';
+                }
+            }
+            $inner_style = 'width: 0%;';
+            $inner_class = 'progress-bar';
+            if (!$apply_custom_colors) {
+                $inner_class .= ' progress-bar-striped bg-info';
+            } else {
+                if ($params['colors']['fg']) {
+                    $inner_style .= 'background-color: ' . $params['colors']['fg'] . ';';
+                }
+                if ($params['colors']['text']) {
+                    $inner_style .= 'color: ' . $params['colors']['text'] . ';';
+                }
+            }
             $out = <<<HTML
-            <div class="progress" style="height: 16px" id="{$id}">
-               <div class="progress-bar progress-bar-striped bg-info" role="progressbar"
-                     style="width: 0%;"
+            <div class="progress" style="$outer_style" id="{$id}">
+               <div class="$inner_class" role="progressbar"
+                     style="$inner_style"
                      aria-valuenow="0"
                      aria-valuemin="0" aria-valuemax="100"
                      id="{$id}_text">

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -648,6 +648,8 @@ class Printer extends CommonDBTM
 
         $tab = array_merge($tab, Socket::rawSearchOptionsToAdd(get_class($this)));
 
+        $tab = array_merge($tab, Printer_CartridgeInfo::rawSearchOptionsToAdd());
+
         return $tab;
     }
 

--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -261,6 +261,39 @@ class Printer_CartridgeInfo extends CommonDBChild
         return parent::getSpecificValueToSelect($field, $name, $values, $options);
     }
 
+    private static function getProgressColorsForColor($color)
+    {
+        $fg_transparency_hex = '80';
+        switch ($color) {
+            case 'cyan':
+            case 'light_cyan':
+                return [
+                    'fg' => '#00ffff'.$fg_transparency_hex,
+                    'text' => 'var(--tblr-body-color)'
+                ];
+            case 'magenta':
+            case 'light_magenta':
+                return [
+                    'fg' => '#ff00ff'.$fg_transparency_hex,
+                    'text' => 'var(--tblr-body-color)'
+                ];
+            case 'yellow':
+                return [
+                    'fg' => '#ffff00'.$fg_transparency_hex,
+                    'text' => 'var(--tblr-body-color)'
+                ];
+            case 'black':
+            case 'grey':
+            case 'darkgrey':
+                return [
+                    'fg' => '#303030'.$fg_transparency_hex,
+                    'text' => 'var(--tblr-body-color)'
+                ];
+        }
+
+        return null;
+    }
+
     public static function getSpecificValueToDisplay($field, $values, array $options = [])
     {
         $printer = new Printer();
@@ -299,7 +332,8 @@ class Printer_CartridgeInfo extends CommonDBChild
                         'percent' => $percent_remaining,
                         'message' => $percent_remaining.'%',
                         'display' => false,
-                        'create' => true
+                        'create' => true,
+                        'colors' => self::getProgressColorsForColor($color)
                     ]);
                 }
             }

--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -125,7 +125,7 @@ class Printer_CartridgeInfo extends CommonDBChild
             'name' => self::getTypeName(1)
         ];
 
-        $create_toner_percent_option = static function(int $ID, string $color_key, string $color_name): array {
+        $create_toner_percent_option = static function (int $ID, string $color_key, string $color_name): array {
             return [
                 'id'                => (string) $ID,
                 'table'             => self::getTable(),
@@ -169,25 +169,25 @@ class Printer_CartridgeInfo extends CommonDBChild
             case 'cyan':
             case 'light_cyan':
                 return [
-                    'fg' => '#00ffff'.$fg_transparency_hex,
+                    'fg' => '#00ffff' . $fg_transparency_hex,
                     'text' => 'inherit'
                 ];
             case 'magenta':
             case 'light_magenta':
                 return [
-                    'fg' => '#ff00ff'.$fg_transparency_hex,
+                    'fg' => '#ff00ff' . $fg_transparency_hex,
                     'text' => 'inherit'
                 ];
             case 'yellow':
                 return [
-                    'fg' => '#ffff00'.$fg_transparency_hex,
+                    'fg' => '#ffff00' . $fg_transparency_hex,
                     'text' => 'inherit'
                 ];
             case 'black':
             case 'grey':
             case 'darkgrey':
                 return [
-                    'fg' => '#303030'.$fg_transparency_hex,
+                    'fg' => '#303030' . $fg_transparency_hex,
                     'text' => 'inherit'
                 ];
         }
@@ -205,7 +205,7 @@ class Printer_CartridgeInfo extends CommonDBChild
             $remaining_field = "toner{$color}remaining";
             $search_option_id = $printer->getSearchOptionIDByField('field', $field);
 
-            $raw_search_opt_values = $options['raw_data']['Printer_'.$search_option_id];
+            $raw_search_opt_values = $options['raw_data']['Printer_' . $search_option_id];
             if ($raw_search_opt_values !== null) {
                 unset($raw_search_opt_values['count']);
                 // Get the max and used values (stored in property key and value key of elements)
@@ -229,9 +229,9 @@ class Printer_CartridgeInfo extends CommonDBChild
                     }
                     $percent_remaining = round(($remaining_value / $max_value) * 100);
 
-                    return Html::progressBar('pb'.mt_rand(), [
+                    return Html::progressBar('pb' . mt_rand(), [
                         'percent' => $percent_remaining,
-                        'message' => $percent_remaining.'%',
+                        'message' => $percent_remaining . '%',
                         'display' => false,
                         'create' => true,
                         'colors' => self::getProgressColorsForColor($color)

--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -269,25 +269,25 @@ class Printer_CartridgeInfo extends CommonDBChild
             case 'light_cyan':
                 return [
                     'fg' => '#00ffff'.$fg_transparency_hex,
-                    'text' => 'var(--tblr-body-color)'
+                    'text' => 'inherit'
                 ];
             case 'magenta':
             case 'light_magenta':
                 return [
                     'fg' => '#ff00ff'.$fg_transparency_hex,
-                    'text' => 'var(--tblr-body-color)'
+                    'text' => 'inherit'
                 ];
             case 'yellow':
                 return [
                     'fg' => '#ffff00'.$fg_transparency_hex,
-                    'text' => 'var(--tblr-body-color)'
+                    'text' => 'inherit'
                 ];
             case 'black':
             case 'grey':
             case 'darkgrey':
                 return [
                     'fg' => '#303030'.$fg_transparency_hex,
-                    'text' => 'var(--tblr-body-color)'
+                    'text' => 'inherit'
                 ];
         }
 

--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -115,4 +115,197 @@ class Printer_CartridgeInfo extends CommonDBChild
         }
         echo "</table>";
     }
+
+    public static function rawSearchOptionsToAdd()
+    {
+        $tab = [];
+
+        $tab[] = [
+            'id' => strtolower(self::getType()),
+            'name' => self::getTypeName(1)
+        ];
+
+        $tab[] = [
+            'id'                 => '1400',
+            'table'              => self::getTable(),
+            'field'              => '_virtual_toner_black_percent',
+            'name'               => sprintf(__('%s toner percentage'), __('Black')),
+            'datatype'           => 'specific',
+            'massiveaction'      => false,
+            'nosearch'           => false,
+            'joinparams'         => [
+                'jointype'           => 'child'
+            ],
+            'additionalfields'   => ['property', 'value'],
+            'forcegroupby'       => true,
+            'aggregate'          => true
+        ];
+
+        $tab[] = [
+            'id'                 => '1401',
+            'table'              => self::getTable(),
+            'field'              => '_virtual_toner_cyan_percent',
+            'name'               => sprintf(__('%s toner percentage'), __('Cyan')),
+            'datatype'           => 'specific',
+            'massiveaction'      => false,
+            'nosearch'           => false,
+            'joinparams'         => [
+                'jointype'           => 'child'
+            ],
+            'additionalfields'   => ['property', 'value'],
+            'forcegroupby'       => true,
+            'aggregate'          => true
+        ];
+
+        $tab[] = [
+            'id'                 => '1402',
+            'table'              => self::getTable(),
+            'field'              => '_virtual_toner_cyanlight_percent',
+            'name'               => sprintf(__('%s toner percentage'), __('Light cyan')),
+            'datatype'           => 'specific',
+            'massiveaction'      => false,
+            'nosearch'           => false,
+            'joinparams'         => [
+                'jointype'           => 'child'
+            ],
+            'additionalfields'   => ['property', 'value'],
+            'forcegroupby'       => true,
+            'aggregate'          => true
+        ];
+
+        $tab[] = [
+            'id'                 => '1403',
+            'table'              => self::getTable(),
+            'field'              => '_virtual_toner_magenta_percent',
+            'name'               => sprintf(__('%s toner percentage'), __('Magenta')),
+            'datatype'           => 'specific',
+            'massiveaction'      => false,
+            'nosearch'           => false,
+            'joinparams'         => [
+                'jointype'           => 'child'
+            ],
+            'additionalfields'   => ['property', 'value'],
+            'forcegroupby'       => true,
+            'aggregate'          => true
+        ];
+
+        $tab[] = [
+            'id'                 => '1404',
+            'table'              => self::getTable(),
+            'field'              => '_virtual_toner_magentalight_percent',
+            'name'               => sprintf(__('%s toner percentage'), __('Light magenta')),
+            'datatype'           => 'specific',
+            'massiveaction'      => false,
+            'nosearch'           => false,
+            'joinparams'         => [
+                'jointype'           => 'child'
+            ],
+            'additionalfields'   => ['property', 'value'],
+            'forcegroupby'       => true,
+            'aggregate'          => true
+        ];
+
+        $tab[] = [
+            'id'                 => '1405',
+            'table'              => self::getTable(),
+            'field'              => '_virtual_toner_yellow_percent',
+            'name'               => sprintf(__('%s toner percentage'), __('Yellow')),
+            'datatype'           => 'specific',
+            'massiveaction'      => false,
+            'nosearch'           => false,
+            'joinparams'         => [
+                'jointype'           => 'child'
+            ],
+            'additionalfields'   => ['property', 'value'],
+            'forcegroupby'       => true,
+            'aggregate'          => true
+        ];
+
+        $tab[] = [
+            'id'                 => '1406',
+            'table'              => self::getTable(),
+            'field'              => '_virtual_toner_grey_percent',
+            'name'               => sprintf(__('%s toner percentage'), __('Grey')),
+            'datatype'           => 'specific',
+            'massiveaction'      => false,
+            'nosearch'           => false,
+            'joinparams'         => [
+                'jointype'           => 'child'
+            ],
+            'additionalfields'   => ['property', 'value'],
+            'forcegroupby'       => true,
+            'aggregate'          => true
+        ];
+
+        $tab[] = [
+            'id'                 => '1407',
+            'table'              => self::getTable(),
+            'field'              => '_virtual_toner_darkgrey_percent',
+            'name'               => sprintf(__('%s toner percentage'), __('Dark grey')),
+            'datatype'           => 'specific',
+            'massiveaction'      => false,
+            'nosearch'           => false,
+            'joinparams'         => [
+                'jointype'           => 'child'
+            ],
+            'additionalfields'   => ['property', 'value'],
+            'forcegroupby'       => true,
+            'aggregate'          => true
+        ];
+
+        return $tab;
+    }
+
+    public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
+    {
+        return parent::getSpecificValueToSelect($field, $name, $values, $options);
+    }
+
+    public static function getSpecificValueToDisplay($field, $values, array $options = [])
+    {
+        $printer = new Printer();
+        if (strpos($field, '_virtual_toner') === 0) {
+            $color = preg_match('/_virtual_toner_(.*)_percent/', $field, $matches) ? $matches[1] : '';
+            $max_field = "toner{$color}max";
+            $used_field = "toner{$color}used";
+            $remaining_field = "toner{$color}remaining";
+            $search_option_id = $printer->getSearchOptionIDByField('field', $field);
+
+            $raw_search_opt_values = $options['raw_data']['Printer_'.$search_option_id];
+            if ($raw_search_opt_values !== null) {
+                unset($raw_search_opt_values['count']);
+                // Get the max and used values (stored in property key and value key of elements)
+                $max_value = null;
+                $used_value = null;
+                $remaining_value = null;
+                foreach ($raw_search_opt_values as $raw_search_opt_value) {
+                    if ($raw_search_opt_value['property'] === $max_field) {
+                        $max_value = $raw_search_opt_value['value'];
+                    } elseif ($raw_search_opt_value['property'] === $used_field) {
+                        $used_value = $raw_search_opt_value['value'];
+                    } elseif ($raw_search_opt_value['property'] === $remaining_field) {
+                        $remaining_value = $raw_search_opt_value['value'];
+                    }
+                }
+                // If max is not set or 0, we cannot display anything
+                if ($max_value !== null && (int)$max_value > 0) {
+                    // If remaining is not set, we can calculate it from used
+                    if ($remaining_value === null && $used_value !== null) {
+                        $remaining_value = $max_value - $used_value;
+                    }
+                    $percent_remaining = round(($remaining_value / $max_value) * 100);
+
+                    return Html::progressBar('pb'.mt_rand(), [
+                        'percent' => $percent_remaining,
+                        'message' => $percent_remaining.'%',
+                        'display' => false,
+                        'create' => true
+                    ]);
+                }
+            }
+            // Need to return some non-empty value otherwise Search engine will throw errors.
+            return NOT_AVAILABLE;
+        }
+        return parent::getSpecificValueToDisplay($field, $values, $options);
+    }
 }

--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -133,7 +133,7 @@ class Printer_CartridgeInfo extends CommonDBChild
                 'name'              => sprintf(__('%s toner percentage'), $color_name),
                 'datatype'          => 'specific',
                 'massiveaction'     => false,
-                'nosearch'          => false,
+                'nosearch'          => true,
                 'joinparams'        => [
                     'jointype' => 'child'
                 ],

--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -125,133 +125,34 @@ class Printer_CartridgeInfo extends CommonDBChild
             'name' => self::getTypeName(1)
         ];
 
-        $tab[] = [
-            'id'                 => '1400',
-            'table'              => self::getTable(),
-            'field'              => '_virtual_toner_black_percent',
-            'name'               => sprintf(__('%s toner percentage'), __('Black')),
-            'datatype'           => 'specific',
-            'massiveaction'      => false,
-            'nosearch'           => false,
-            'joinparams'         => [
-                'jointype'           => 'child'
-            ],
-            'additionalfields'   => ['property', 'value'],
-            'forcegroupby'       => true,
-            'aggregate'          => true
-        ];
+        $create_toner_percent_option = static function(int $ID, string $color_key, string $color_name): array {
+            return [
+                'id'                => (string) $ID,
+                'table'             => self::getTable(),
+                'field'             => "_virtual_toner_{$color_key}_percent",
+                'name'              => sprintf(__('%s toner percentage'), $color_name),
+                'datatype'          => 'specific',
+                'massiveaction'     => false,
+                'nosearch'          => false,
+                'joinparams'        => [
+                    'jointype' => 'child'
+                ],
+                'additionalfields'  => ['property', 'value'],
+                'forcegroupby'      => true,
+                'aggregate'         => true,
+                'searchtype'        => ['contains'],
+                'nosort'            => true
+            ];
+        };
 
-        $tab[] = [
-            'id'                 => '1401',
-            'table'              => self::getTable(),
-            'field'              => '_virtual_toner_cyan_percent',
-            'name'               => sprintf(__('%s toner percentage'), __('Cyan')),
-            'datatype'           => 'specific',
-            'massiveaction'      => false,
-            'nosearch'           => false,
-            'joinparams'         => [
-                'jointype'           => 'child'
-            ],
-            'additionalfields'   => ['property', 'value'],
-            'forcegroupby'       => true,
-            'aggregate'          => true
-        ];
-
-        $tab[] = [
-            'id'                 => '1402',
-            'table'              => self::getTable(),
-            'field'              => '_virtual_toner_cyanlight_percent',
-            'name'               => sprintf(__('%s toner percentage'), __('Light cyan')),
-            'datatype'           => 'specific',
-            'massiveaction'      => false,
-            'nosearch'           => false,
-            'joinparams'         => [
-                'jointype'           => 'child'
-            ],
-            'additionalfields'   => ['property', 'value'],
-            'forcegroupby'       => true,
-            'aggregate'          => true
-        ];
-
-        $tab[] = [
-            'id'                 => '1403',
-            'table'              => self::getTable(),
-            'field'              => '_virtual_toner_magenta_percent',
-            'name'               => sprintf(__('%s toner percentage'), __('Magenta')),
-            'datatype'           => 'specific',
-            'massiveaction'      => false,
-            'nosearch'           => false,
-            'joinparams'         => [
-                'jointype'           => 'child'
-            ],
-            'additionalfields'   => ['property', 'value'],
-            'forcegroupby'       => true,
-            'aggregate'          => true
-        ];
-
-        $tab[] = [
-            'id'                 => '1404',
-            'table'              => self::getTable(),
-            'field'              => '_virtual_toner_magentalight_percent',
-            'name'               => sprintf(__('%s toner percentage'), __('Light magenta')),
-            'datatype'           => 'specific',
-            'massiveaction'      => false,
-            'nosearch'           => false,
-            'joinparams'         => [
-                'jointype'           => 'child'
-            ],
-            'additionalfields'   => ['property', 'value'],
-            'forcegroupby'       => true,
-            'aggregate'          => true
-        ];
-
-        $tab[] = [
-            'id'                 => '1405',
-            'table'              => self::getTable(),
-            'field'              => '_virtual_toner_yellow_percent',
-            'name'               => sprintf(__('%s toner percentage'), __('Yellow')),
-            'datatype'           => 'specific',
-            'massiveaction'      => false,
-            'nosearch'           => false,
-            'joinparams'         => [
-                'jointype'           => 'child'
-            ],
-            'additionalfields'   => ['property', 'value'],
-            'forcegroupby'       => true,
-            'aggregate'          => true
-        ];
-
-        $tab[] = [
-            'id'                 => '1406',
-            'table'              => self::getTable(),
-            'field'              => '_virtual_toner_grey_percent',
-            'name'               => sprintf(__('%s toner percentage'), __('Grey')),
-            'datatype'           => 'specific',
-            'massiveaction'      => false,
-            'nosearch'           => false,
-            'joinparams'         => [
-                'jointype'           => 'child'
-            ],
-            'additionalfields'   => ['property', 'value'],
-            'forcegroupby'       => true,
-            'aggregate'          => true
-        ];
-
-        $tab[] = [
-            'id'                 => '1407',
-            'table'              => self::getTable(),
-            'field'              => '_virtual_toner_darkgrey_percent',
-            'name'               => sprintf(__('%s toner percentage'), __('Dark grey')),
-            'datatype'           => 'specific',
-            'massiveaction'      => false,
-            'nosearch'           => false,
-            'joinparams'         => [
-                'jointype'           => 'child'
-            ],
-            'additionalfields'   => ['property', 'value'],
-            'forcegroupby'       => true,
-            'aggregate'          => true
-        ];
+        $tab[] = $create_toner_percent_option(1400, 'black', __('Black'));
+        $tab[] = $create_toner_percent_option(1401, 'cyan', __('Cyan'));
+        $tab[] = $create_toner_percent_option(1402, 'cyanlight', __('Light cyan'));
+        $tab[] = $create_toner_percent_option(1403, 'magenta', __('Magenta'));
+        $tab[] = $create_toner_percent_option(1404, 'magentalight', __('Light magenta'));
+        $tab[] = $create_toner_percent_option(1405, 'yellow', __('Yellow'));
+        $tab[] = $create_toner_percent_option(1406, 'grey', __('Grey'));
+        $tab[] = $create_toner_percent_option(1407, 'darkgrey', __('Dark grey'));
 
         return $tab;
     }

--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -338,7 +338,7 @@ class Printer_CartridgeInfo extends CommonDBChild
                 }
             }
             // Need to return some non-empty value otherwise Search engine will throw errors.
-            return NOT_AVAILABLE;
+            return null;
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }

--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -202,7 +202,7 @@ class Printer_CartridgeInfo extends CommonDBChild
             'darkgrey'  => 'darkgray'
         ];
         $printer = new Printer();
-        if (strpos($field, '_virtual_toner') === 0) {
+        if (str_starts_with($field, '_virtual_toner')) {
             $color = preg_match('/_virtual_toner_(.*)_percent/', $field, $matches) ? $matches[1] : '';
             $search_option_id = $printer->getSearchOptionIDByField('field', $field);
             $raw_search_opt_values = $options['raw_data']['Printer_' . $search_option_id];

--- a/src/Search.php
+++ b/src/Search.php
@@ -7284,7 +7284,7 @@ HTML;
 
         $aggregate = (isset($so['aggregate']) && $so['aggregate']);
 
-        $append_specific = static function($specific, $field_data, &$out) use ($so) {
+        $append_specific = static function ($specific, $field_data, &$out) use ($so) {
             if (!empty($specific)) {
                 $out .= $specific;
             } else if (isset($field_data['values'])) {

--- a/src/Search.php
+++ b/src/Search.php
@@ -3848,7 +3848,7 @@ JAVASCRIPT;
         }
 
        // Virtual display no select : only get additional fields
-        if (strpos($field, '_virtual') === 0) {
+        if (self::isVirtualField($field)) {
             return $ADDITONALFIELDS;
         }
 
@@ -4448,7 +4448,7 @@ JAVASCRIPT;
      * @param string  $val          Item num in the request
      * @param integer $meta         Is a meta search (meta=2 in search.class.php) (default 0)
      *
-     * @return string Where string
+     * @return string|false Where string or false if an error occured or if there was no valid WHERE string that could be created.
      **/
     public static function addWhere($link, $nott, $itemtype, $ID, $searchtype, $val, $meta = 0)
     {
@@ -5462,13 +5462,13 @@ JAVASCRIPT;
         $field = ''
     ) {
 
-       // Rename table for meta left join
+        // Rename table for meta left join
         $AS = "";
         $nt = $new_table;
         $cleannt    = $nt;
 
-       // Virtual field no link
-        if (strpos($linkfield, '_virtual') === 0) {
+        // Virtual field no link
+        if (self::isVirtualField($linkfield)) {
             return '';
         }
 
@@ -5477,7 +5477,7 @@ JAVASCRIPT;
         $is_fkey_composite_on_self = getTableNameForForeignKeyField($linkfield) == $ref_table
          && $linkfield != getForeignKeyFieldForTable($ref_table);
 
-       // Auto link
+        // Auto link
         if (
             ($ref_table == $new_table)
             && empty($complexjoin)
@@ -8876,5 +8876,15 @@ HTML;
     public static function getOrigTableName(string $itemtype): string
     {
         return (is_a($itemtype, CommonDBTM::class, true)) ? $itemtype::getTable() : getTableForItemType($itemtype);
+    }
+
+    /**
+     * Check if the given field is virtual (not mapped directly with the database schema)
+     * @param string $field The field name
+     * @return bool
+     */
+    public static function isVirtualField(string $field): bool
+    {
+        return strpos($field, '_virtual') === 0;
     }
 }

--- a/src/Search.php
+++ b/src/Search.php
@@ -7284,12 +7284,12 @@ HTML;
 
         $aggregate = (isset($so['aggregate']) && $so['aggregate']);
 
-        $append_specific = function($specific, $field_data, &$out) {
+        $append_specific = static function($specific, $field_data, &$out) use ($so) {
             if (!empty($specific)) {
                 $out .= $specific;
             } else if (isset($field_data['values'])) {
                 // Aggregate values; No special handling
-                $out .= '';
+                return;
             } else {
                 if (
                     isset($so['toadd'])

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -2147,6 +2147,12 @@ class Search extends DbTestCase
         ];
     }
 
+    /**
+     * @param string $field
+     * @param bool $expected
+     * @return void
+     * @dataProvider isVirtualFieldProvider
+     */
     public function testIsVirtualField(string $field, bool $expected): void
     {
         $this->boolean(\Search::isVirtualField($field))->isEqualTo($expected);

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -2137,7 +2137,7 @@ class Search extends DbTestCase
         $this->array($names)->isEqualTo($expected);
     }
 
-    private function isVirtualFieldProvider(): array
+    protected function isVirtualFieldProvider(): array
     {
         return [
             ['name', false],

--- a/tests/functionnal/Search.php
+++ b/tests/functionnal/Search.php
@@ -2136,6 +2136,21 @@ class Search extends DbTestCase
        // Check results
         $this->array($names)->isEqualTo($expected);
     }
+
+    private function isVirtualFieldProvider(): array
+    {
+        return [
+            ['name', false],
+            ['name_virtual', false],
+            ['_virtual', true],
+            ['_virtual_name', true]
+        ];
+    }
+
+    public function testIsVirtualField(string $field, bool $expected): void
+    {
+        $this->boolean(\Search::isVirtualField($field))->isEqualTo($expected);
+    }
 }
 
 // @codingStandardsIgnoreStart


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23397

Add search options for toner percentages which are stored in `glpi_printers_cartridgeinfos` and gathered by inventory agents.

This required an addition to the search engine since the data is not stored in a structured schema (just property => value pairs) and the use of additionalfields (which isn't great because it seems like it will grab all properties for the printer for every search option) would would cause extra values to display. I had to add an `aggregate` property to search options and change how the specific value display gets handled so that multiple values can be combined to one displayed value.