### PR TITLE
Automatically trim whitespaces around registration key

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -284,6 +284,11 @@ class Config extends CommonDBTM
             );
         }
 
+        // Automatically trim whitespaces around registration key.
+        if (array_key_exists('glpinetwork_registration_key', $input) && !empty($input['glpinetwork_registration_key'])) {
+            $input['glpinetwork_registration_key'] = trim($input['glpinetwork_registration_key']);
+        }
+
         $this->setConfigurationValues('core', $input);
 
         return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | see !23984

Having whitespaces around registration key may produce following error.
```
[2022-05-12 09:29:21] glpiphplog.CRITICAL: *** Uncaught Exception InvalidArgumentException: "aaaaaa==^M
^M
" is not valid header value in /var/www/glpi/vendor/guzzlehttp/psr7/src/MessageTrait.php at line 263
Backtrace :
vendor/guzzlehttp/psr7/src/MessageTrait.php:209 GuzzleHttp\Psr7\Request->assertValue()
: GuzzleHttp\Psr7\Request->GuzzleHttp\Psr7\{closure}()
vendor/guzzlehttp/psr7/src/MessageTrait.php:212 array_map()
vendor/guzzlehttp/psr7/src/MessageTrait.php:174 GuzzleHttp\Psr7\Request->trimAndValidateHeaderValues()
vendor/guzzlehttp/psr7/src/MessageTrait.php:154 GuzzleHttp\Psr7\Request->normalizeHeaderValue()
vendor/guzzlehttp/psr7/src/Request.php:49 GuzzleHttp\Psr7\Request->setHeaders()
vendor/guzzlehttp/guzzle/src/Client.php:164 GuzzleHttp\Psr7\Request->__construct()
vendor/guzzlehttp/guzzle/src/Client.php:187 GuzzleHttp\Client->requestAsync()
src/Marketplace/Api/Plugins.php:121 GuzzleHttp\Client->request()
src/Marketplace/Api/Plugins.php:166 Glpi\Marketplace\Api\Plugins->request()
src/Marketplace/Api/Plugins.php:211 Glpi\Marketplace\Api\Plugins->getPaginatedCollection()
src/Marketplace/View.php:217 Glpi\Marketplace\Api\Plugins->getAllPlugins()
src/Marketplace/View.php:120 Glpi\Marketplace\View::installed()
src/CommonGLPI.php:687 Glpi\Marketplace\View::displayTabContentForItem()
ajax/common.tabs.php:107 CommonGLPI::displayStandardTab()
```

I tried to add a migration for this, but as content is encrypted, logic is quiet complex to handle all cases (decryption fails, encryption key is not available, ...).