### PR TITLE
displayMessageAfterRedirect without ajax was broken

### DIFF
--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -37,7 +37,7 @@
 
 <body class="{{ user_pref('fold_menu') and is_vertical ? 'navbar-collapsed' : '' }} {{ is_vertical ? 'vertical-layout' : 'horizontal-layout' }} {{ is_debug_active ? 'debug-active' : '' }}">
    {{ include('layout/parts/impersonate_banner.html.twig') }}
-   {% include 'components/messages_after_redirect_toasts.html.twig' with {'display_container': true} %}
+   {{ include('components/messages_after_redirect_toasts.html.twig', {'display_container': true}) }}
 
    <div class="page">
 

--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -37,7 +37,7 @@
 
 <body class="{{ user_pref('fold_menu') and is_vertical ? 'navbar-collapsed' : '' }} {{ is_vertical ? 'vertical-layout' : 'horizontal-layout' }} {{ is_debug_active ? 'debug-active' : '' }}">
    {{ include('layout/parts/impersonate_banner.html.twig') }}
-   {{ include('components/messages_after_redirect_toasts.html.twig') }}
+   {% include 'components/messages_after_redirect_toasts.html.twig' with {'display_container': true} %}
 
    <div class="page">
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Follow #11512 which fixed ajax toasts but broked standard toasts
