### PR TITLE
Fix null entity in self service form

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -408,6 +408,7 @@ abstract class CommonITILObject extends CommonDBTM
             'timeline_itemtypes'      => $this->getTimelineItemtypes(),
             'legacy_timeline_actions' => $this->getLegacyTimelineActionsHTML(),
             'params'                  => $options,
+            'entities_id'             => $ID ? $this->fields['entities_id'] : $options['entities_id'],
             'timeline'                => $this->getTimelineItems(),
             'itiltemplate_key'        => static::getTemplateFormFieldName(),
             'itiltemplate'            => $tt,

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4383,6 +4383,7 @@ JAVASCRIPT;
             'timeline_itemtypes' => $this->getTimelineItemtypes(),
             'legacy_timeline_actions'  => $this->getLegacyTimelineActionsHTML(),
             'params'             => $options,
+            'entities_id'        => $ID ? $this->fields['entities_id'] : $options['entities_id'],
             'timeline'           => $this->getTimelineItems(),
             'itiltemplate_key'   => self::getTemplateFormFieldName(),
             'itiltemplate'       => $tt,

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -209,7 +209,7 @@
                   action: 'getActors',
                   actortype: actorytype,
                   users_right: '{{ users_right ?? 'all' }}',
-                  entity_restrict: {{ item.fields['entities_id'] }},
+                  entity_restrict: {{ entities_id }},
                   searchText: params.term,
                   _idor_token: '{{ idor_token() }}',
                   itiltemplate_class: '{{ itiltemplate.getType() }}',

--- a/templates/components/itilobject/actors/main.html.twig
+++ b/templates/components/itilobject/actors/main.html.twig
@@ -48,6 +48,10 @@
 {% if item.isNewItem() %}
    {% set can_admin = true %}
 {% endif %}
+
+{# entities_id would be set for new tickets in selfservice but not for new tickets in standard interface #}
+{% set entities_id = entities_id|default(item.fields['entities_id']) %}
+
 {# TODO can_admin is usefull for "assign to me" shortcut #}
 
 {# TODO check allow_email params #}
@@ -58,7 +62,7 @@
          'item': item,
          'actortypeint': constant('CommonITILActor::REQUESTER'),
          'actortype': 'requester',
-         'entities_id': item.fields['entities_id'],
+         'entities_id': entities_id,
          'itiltemplate': itiltemplate,
          'params': params,
          'canupdate': canupdate,
@@ -86,7 +90,7 @@
          'item': item,
          'actortypeint': constant('CommonITILActor::OBSERVER'),
          'actortype': 'observer',
-         'entities_id': item.fields['entities_id'],
+         'entities_id': entities_id,
          'itiltemplate': itiltemplate,
          'params': params,
          'canupdate': canupdate,
@@ -115,7 +119,7 @@
          'actortypeint': constant('CommonITILActor::ASSIGN'),
          'actortype': 'assign',
          'users_right': 'own_ticket',
-         'entities_id': item.fields['entities_id'],
+         'entities_id': entities_id,
          'itiltemplate': itiltemplate,
          'params': params,
          'canupdate': (canupdate or canassign),

--- a/templates/components/itilobject/actors/main.html.twig
+++ b/templates/components/itilobject/actors/main.html.twig
@@ -49,9 +49,6 @@
    {% set can_admin = true %}
 {% endif %}
 
-{# entities_id would be set for new tickets in selfservice but not for new tickets in standard interface #}
-{% set entities_id = entities_id|default(item.fields['entities_id']) %}
-
 {# TODO can_admin is usefull for "assign to me" shortcut #}
 
 {# TODO check allow_email params #}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10570 

The template that shows actor fields uses the entity from the item (or empty item is case of a new ticket). When using the self service form to create a ticket, the entity information is not set in the item fields (It wasn't in old versions either). This shouldn't have mattered since the entity is instead passed into the self service template in the `params` variable and then into the `main` actor template as `entities_id`. However, since the `main` actor template and child `field` template only checked the item fields, it was using a null value.

The solution is to set `entities_id` to the value in the item fields only if the `entities_id` variable isn't already set. Then in that template and `field`, use the `entities_id` variable instead of using the item field directly.