### PR TITLE
Handle massive action method return better

### DIFF
--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -3150,6 +3150,11 @@ abstract class API
             $actions = $this->getMassiveActionsForItem($item);
         }
 
+        if (count($actions) === 0) {
+            // An error occurred
+            return;
+        }
+
        // Build response array
         $response = [];
         foreach ($actions as $key => $label) {
@@ -3173,7 +3178,16 @@ abstract class API
         bool $is_deleted = false
     ): array {
        // Return massive actions for a given itemtype
-        return MassiveAction::getAllMassiveActions($itemtype, $is_deleted);
+        $actions = MassiveAction::getAllMassiveActions($itemtype, $is_deleted);
+        if ($actions === false) {
+            $this->returnError(
+                "Unable to get massive actions for itemtype '$itemtype'. Please check that it is a valid itemtype.",
+                400,
+                "ERROR_MASSIVEACTION_NOT_FOUND"
+            );
+            return [];
+        }
+        return $actions;
     }
 
     /**
@@ -3185,12 +3199,21 @@ abstract class API
     public function getMassiveActionsForItem(CommonDBTM $item): array
     {
        // Return massive actions for a given item
-        return MassiveAction::getAllMassiveActions(
+        $actions = MassiveAction::getAllMassiveActions(
             $item::getType(),
             $item->isDeleted(),
             $item,
             $item->getID()
         );
+        if ($actions === false) {
+            $this->returnError(
+                "Unable to get massive actions for item of type '{$item::getType()}'. Please check that it is a valid itemtype.",
+                400,
+                "ERROR_MASSIVEACTION_NOT_FOUND"
+            );
+            return [];
+        }
+        return $actions;
     }
 
     /**
@@ -3223,6 +3246,15 @@ abstract class API
         }
 
         $actions = MassiveAction::getAllMassiveActions($itemtype, $is_deleted);
+        if ($actions === false) {
+            $this->returnError(
+                "Unable to get massive actions for itemtype '$itemtype'. Please check that it is a valid itemtype.",
+                400,
+                "ERROR_MASSIVEACTION_NOT_FOUND"
+            );
+            return;
+        }
+
         if (!isset($actions[$action_key])) {
             $this->returnError(
                 "Invalid action key parameter, run 'getMassiveActions' endpoint to see available keys",
@@ -3231,7 +3263,7 @@ abstract class API
             );
         }
 
-       // Get massive action for the given key
+        // Get massive action for the given key
         $ma = new MassiveAction([
             'action'     => $action_key,
             'actions'    => $actions,

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -712,7 +712,7 @@ class MassiveAction
      * @param CommonDBTM        $checkitem   link item to check right              (default NULL)
      * @param int|null          $items_id    Get actions for a single item
      *
-     * @return array of massive actions or false if $item is not valid
+     * @return array|false Array of massive actions or false if $item is not valid
      **/
     public static function getAllMassiveActions($item, $is_deleted = 0, CommonDBTM $checkitem = null, ?int $items_id = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`MassiveAction::getAllMassiveActions` can return false when an error occurs but this was missing from the PHPDoc return types. I added the missing return type and improved its handling in the API functions.

Related to #11404. This does not specifically address the issue (I cannot recreate) but this was noticed while I was looking into how the issue could have possibly happened.