### PR TITLE
Hide self service add ticket button without permissions

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -1622,13 +1622,16 @@ HTML;
                 'content' => [
                     'ticket' => [
                         'links' => [
-                            'add'       => '/front/helpdesk.public.php?create_ticket=1',
                             'search'    => Ticket::getSearchURL(),
                             'lists'     => '',
                         ]
                     ]
                 ]
             ];
+
+            if (Session::haveRight("ticket", CREATE)) {
+                $menu['tickets']['content']['ticket']['links']['add'] = '/front/helpdesk.public.php?create_ticket=1';
+            }
         }
 
         if (Session::haveRight("reservation", ReservationItem::RESERVEANITEM)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11584

Hide the button to add a ticket in the simplified interface when the user does not have permission to create tickets.