### PR TITLE
Fix convert unmanaged dropdown itemtype names

### DIFF
--- a/src/Unmanaged.php
+++ b/src/Unmanaged.php
@@ -232,7 +232,9 @@ class Unmanaged extends CommonDBTM
         switch ($ma->getAction()) {
             case 'convert':
                 echo __('Select an itemtype: ') . ' ';
-                Dropdown::showFromArray('itemtype', array_combine($CFG_GLPI['inventory_types'], $CFG_GLPI['inventory_types']));
+                Dropdown::showItemType($CFG_GLPI['inventory_types'], [
+                    'display_emptychoice' => false,
+                ]);
                 break;
         }
         return parent::showMassiveActionsSubForm($ma);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The item type dropdown for Unmanaged convert massive action was using the internal class names as the display value for the item types instead of the localized name.