### PR TITLE
fix(change): editable fields in closed status

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -379,6 +379,12 @@ abstract class CommonITILObject extends CommonDBTM
 
         $canupdate = !$ID || (Session::getCurrentInterface() == "central" && $this->canUpdateItem());
 
+        if ($ID && in_array($this->fields['status'], $this->getClosedStatusArray())) {
+            $canupdate = false;
+            // No update for actors
+            $options['_noupdate'] = true;
+        }
+
         if (!$this->isNewItem()) {
             $options['formtitle'] = sprintf(
                 __('%1$s - ID %2$d'),


### PR DESCRIPTION
The header fields were editable while the change is closed.
Same with the problems.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23978
