### PR TITLE
Fix classes fetching in tests

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -2557,6 +2557,11 @@ HTML;
                 $CFG_GLPI['root_doc'] = parse_url($url_base, PHP_URL_PATH) ?? '';
             }
         }
+
+        // Path for icon of document type (web mode only)
+        if (isset($CFG_GLPI['root_doc'])) {
+            $CFG_GLPI['typedoc_icon_dir'] = $CFG_GLPI['root_doc'] . '/pics/icones';
+        }
     }
 
 
@@ -3049,11 +3054,6 @@ HTML;
             $prof->getFromDB($CFG_GLPI['lock_lockprofile_id']);
             $prof->cleanProfile();
             $CFG_GLPI['lock_lockprofile'] = $prof->fields;
-        }
-
-       // Path for icon of document type (web mode only)
-        if (isset($CFG_GLPI['root_doc'])) {
-            $CFG_GLPI['typedoc_icon_dir'] = $CFG_GLPI['root_doc'] . '/pics/icones';
         }
 
         if (isset($CFG_GLPI['planning_work_days'])) {

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -154,17 +154,28 @@ class DbTestCase extends \GLPITestCase
             ]
         );
 
+        $files_iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(GLPI_ROOT . '/src'),
+            RecursiveIteratorIterator::SELF_FIRST
+        );
+
         $classes = [];
-        foreach (new \DirectoryIterator('src/') as $fileInfo) {
+        foreach ($files_iterator as $fileInfo) {
             if ($fileInfo->getExtension() !== 'php') {
                 continue;
             }
 
             $classname = $fileInfo->getBasename('.php');
+
+            $is_excluded = false;
             foreach ($excludes as $exclude) {
                 if ($classname === $exclude || @preg_match($exclude, $classname) === 1) {
-                     break 2; // Class is excluded from results, go to next file
+                     $is_excluded = true;
+                     break;
                 }
+            }
+            if ($is_excluded) {
+                continue;
             }
 
             if (!class_exists($classname)) {

--- a/tests/functionnal/Transfer.php
+++ b/tests/functionnal/Transfer.php
@@ -111,7 +111,8 @@ class Transfer extends DbTestCase
                 'PendingReasonCron',
                 'Database',
                 'Socket',
-                'Netpoint'
+                'Netpoint',
+                'Link_Itemtype',
             ]
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Classes fetching in tests was broken due to `break 2; // Class is excluded from results, go to next file`. Instead of ignoring current file, the whole files parsing was stopped. So, some classes were ignored, depending on the files reading order.
Thus, namespaced classes were not fetched, as their files were located in a subdirectory.

I moved  `$CFG_GLPI['typedoc_icon_dir']` initialization to fix following error in tests. Indeed, on CLI context, this variable was not correctly set as `$CFG_GLPI[root_doc]` is not defined yet when calling `Config::loadLegacyConfiguration()`.
```
> There is 1 error:
=> tests\units\Search::testSearchOptions():
==> Error E_WARNING in /var/www/glpi/tests/functionnal/Search.php on line 557, generated by file /var/www/glpi/src/Search.php on line 6434:
Undefined array key "typedoc_icon_dir"
```