### PR TITLE
Ticket: fix creation from project task

### DIFF
--- a/templates/components/itilobject/mainform_open.html.twig
+++ b/templates/components/itilobject/mainform_open.html.twig
@@ -89,6 +89,11 @@
       <input type="hidden" name="_skip_promoted_fields" value="{{ params['_skip_promoted_fields'] }}" />
    {% endif %}
 
+   {# Ticket specific: created from project task, need to keep track of task id #}
+   {% if params['_projecttasks_id'] is defined and params['_projecttasks_id'] > 0 %}
+      <input type="hidden" name="_projecttasks_id" value="{{ params['_projecttasks_id'] }}" />
+   {% endif %}
+
    {% if params['_tasktemplates_id'] is defined and params['_tasktemplates_id']|length > 0 %}
       {% for tasktemplate_id in params['_tasktemplates_id'] %}
          <input type="hidden" name="_tasktemplates_id[]" value="{{ tasktemplate_id }}" />


### PR DESCRIPTION
It is possible to create a ticket from a project task :

![image](https://user-images.githubusercontent.com/42734840/169301277-7a3f6901-8c53-47c7-826e-cde12e124c74.png)

When doing so, the ticket creation form is open with a the project task id stored as a  `GET` param:

![image](https://user-images.githubusercontent.com/42734840/169301571-32e5a44b-cd5c-4bed-b136-37b8165fef55.png)

In GLPI 9.5, this parameter was then converted to an hidden input:

![image](https://user-images.githubusercontent.com/42734840/169301712-346f91c4-5e8b-426e-b689-72f47a4d54c7.png)

It seems this code was forgotten when porting the forms to twig.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24018
