### PR TITLE
Bypass updates

### DIFF
--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -1528,3 +1528,11 @@ div.banner-impersonate button {
    margin-left: 5px;
    text-decoration: underline;
 }
+
+div.banner-need-update {
+   background: #f7c626;
+   color: #fff;
+   font-weight: bold;
+   padding: 10px;
+   text-align: right;
+}

--- a/inc/config.php
+++ b/inc/config.php
@@ -184,6 +184,16 @@ if (!isset($skip_db_check) && !file_exists(GLPI_CONFIG_DIR . "/config_db.php")) 
         if (isCommandLine()) {
             echo __('The version of the database is not compatible with the version of the installed files. An update is necessary.');
             echo "\n";
+            exit();
+        }
+
+        if (defined('SKIP_UPDATES')) {
+            // Show warning for the main request
+            if (!Toolbox::isAjax()) {
+                echo "<div class='banner-need-update'>";
+                echo __("You are bypassing a needed update");
+                echo "</div>";
+            }
         } else {
             Html::nullHeader(__('Update needed'), $CFG_GLPI["root_doc"]);
             echo "<div class='container-fluid mb-4'>";
@@ -216,21 +226,21 @@ if (!isset($skip_db_check) && !file_exists(GLPI_CONFIG_DIR . "/config_db.php")) 
                 );
 
                 if ($outdated !== true) {
-                     echo "<form method='post' action='" . $CFG_GLPI["root_doc"] . "/install/update.php'>";
+                    echo "<form method='post' action='" . $CFG_GLPI["root_doc"] . "/install/update.php'>";
                     if (!VersionParser::isStableRelease(GLPI_VERSION)) {
                         echo Config::agreeUnstableMessage(VersionParser::isDevVersion(GLPI_VERSION));
                     }
-                     echo "<p class='mt-2 mb-n2 alert alert-important alert-warning'>";
-                     echo __('The version of the database is not compatible with the version of the installed files. An update is necessary.') . "</p>";
-                     echo Html::submit(_sx('button', 'Upgrade'), [
-                         'name'  => 'from_update',
-                         'class' => "btn btn-primary",
-                         'icon'  => "fas fa-check",
-                     ]);
-                     Html::closeForm();
+                    echo "<p class='mt-2 mb-n2 alert alert-important alert-warning'>";
+                    echo __('The version of the database is not compatible with the version of the installed files. An update is necessary.') . "</p>";
+                    echo Html::submit(_sx('button', 'Upgrade'), [
+                        'name'  => 'from_update',
+                        'class' => "btn btn-primary",
+                        'icon'  => "fas fa-check",
+                    ]);
+                    Html::closeForm();
                 } else {
                     echo "<p class='mt-2 mb-n2 alert alert-important alert-warning'>" .
-                     __('You are trying to use GLPI with outdated files compared to the version of the database. Please install the correct GLPI files corresponding to the version of your database.') . "</p>";
+                        __('You are trying to use GLPI with outdated files compared to the version of the database. Please install the correct GLPI files corresponding to the version of your database.') . "</p>";
                 }
             }
 
@@ -239,8 +249,8 @@ if (!isset($skip_db_check) && !file_exists(GLPI_CONFIG_DIR . "/config_db.php")) 
             echo "</div>";
             echo "</div>";
             Html::nullFooter();
+            exit();
         }
-        exit();
     }
 }
 


### PR DESCRIPTION
It would be useful to have a way to temporarily bypass updates when doing certain devs operation like `git bisect`.

There already is a specific `$_GET["donotcheckversion"]` parameter but it only works for the main request.
I think this parameter is only meant to force loading of css or locales through PHP even if the DB version doesn't match, it isn't intended to be used to actually bypass an update.

This proposal would allow to do so using a new option in the `local_define.php` file :

![image](https://user-images.githubusercontent.com/42734840/169307518-27611caf-c137-44e8-9c35-cf0565342002.png)

A banner would be added at the top of the page to make sure we don't forget to turn this option off when we no longer need it.

![image](https://user-images.githubusercontent.com/42734840/169307374-e3090a32-4f67-4244-8216-60018718c398.png)

What do you think of this ?

It would be a new dev feature but I think integrating it in the bugfixes branch would be better as the sooner it is integrated, the more commits will be supported when "git bisecting" in the past 😉 

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
