### PR TITLE
improve ajax display of legacy forms in planning

### DIFF
--- a/src/Planning.php
+++ b/src/Planning.php
@@ -1270,7 +1270,10 @@ class Planning extends CommonGLPI
     {
         if (!$params['itemtype'] instanceof CommonDBTM) {
             echo "<div class='center'>";
-            echo "<a href='" . $params['url'] . "'>" . __("View this item in his context") . "</a>";
+            echo "<a href='" . $params['url'] . "' class='btn btn-outline-secondary'>" .
+                "<i class='ti ti-eye'></i>" .
+                "<span>" . __("View this item in his context") . "</span>" .
+            "</a>";
             echo "</div>";
             echo "<hr>";
             $rand = mt_rand();

--- a/src/PlanningExternalEvent.php
+++ b/src/PlanningExternalEvent.php
@@ -147,6 +147,11 @@ class PlanningExternalEvent extends CommonDBTM implements CalDAVCompatibleItemIn
         $rand_plan  = mt_rand();
         $rand_rrule = mt_rand();
 
+        if (
+            ($options['from_planning_ajax'] ?? false)
+            || ($options['from_planning_edit_ajax'] ?? false)) {
+            $options['no_header'] = true;
+        }
         $this->initForm($ID, $options);
         $this->showFormHeader($options);
 

--- a/src/PlanningExternalEvent.php
+++ b/src/PlanningExternalEvent.php
@@ -149,7 +149,8 @@ class PlanningExternalEvent extends CommonDBTM implements CalDAVCompatibleItemIn
 
         if (
             ($options['from_planning_ajax'] ?? false)
-            || ($options['from_planning_edit_ajax'] ?? false)) {
+            || ($options['from_planning_edit_ajax'] ?? false)
+        ) {
             $options['no_header'] = true;
         }
         $this->initForm($ID, $options);

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -611,7 +611,8 @@ class Reminder extends CommonDBVisible implements
 
         if (
             ($options['from_planning_ajax'] ?? false)
-            || ($options['from_planning_edit_ajax'] ?? false)) {
+            || ($options['from_planning_edit_ajax'] ?? false)
+        ) {
             $options['no_header'] = true;
         }
         $this->showFormHeader($options);

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -607,10 +607,13 @@ class Reminder extends CommonDBVisible implements
         $this->initForm($ID, $options);
         $rand = mt_rand();
 
-       // Show Reminder or blank form
-
         $canedit = $this->can($ID, UPDATE);
 
+        if (
+            ($options['from_planning_ajax'] ?? false)
+            || ($options['from_planning_edit_ajax'] ?? false)) {
+            $options['no_header'] = true;
+        }
         $this->showFormHeader($options);
 
         echo "<tr class='tab_bg_2'><td>" . __('Title') . "</td>";
@@ -623,7 +626,6 @@ class Reminder extends CommonDBVisible implements
                 'name',
                 [
                     'value'   => $this->fields['name'],
-                    'size'    => '80',
                 ]
             );
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | internal ref !23870

- Avoid overflow of inputs
- better header integration

For this last, when we'll transform legacy form into twig template, the ajax double header is already managed
