### PR TITLE
fix requester group search

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4505,7 +4505,7 @@ abstract class CommonITILObject extends CommonDBTM
         ) {
             $newtab['condition'] = array_merge(
                 $newtab['condition'],
-                ['id' => [$_SESSION['glpigroups']]]
+                ['id' => $_SESSION['glpigroups']]
             );
         }
         $tab[] = $newtab;


### PR DESCRIPTION
Found an error whentying to use requester group search option from self service

[2022-05-20 08:57:00] glpiphplog.CRITICAL:   *** Uncaught Exception TypeError: Argument 1 passed to Glpi\Toolbox\Sanitizer::isNsClassOrCallableIdentifier() must be of the type string, array given, called in /glpi-100a/src/DBmysql.php on line 1257 in /glpi-100a/src/Toolbox/Sanitizer.php at line 228
  Backtrace :
  src/DBmysql.php:1257                               Glpi\Toolbox\Sanitizer::isNsClassOrCallableIdentifier()
  src/DBmysqlIterator.php:633                        DBmysql::quoteValue()
  src/DBmysqlIterator.php:589                        DBmysqlIterator->analyseCriterionValue()
  src/DBmysqlIterator.php:557                        DBmysqlIterator->analyseCriterion()
  src/DBmysqlIterator.php:312                        DBmysqlIterator->analyseCrit()
  src/DBmysqlIterator.php:109                        DBmysqlIterator->buildQuery()
  src/DBmysql.php:1048                               DBmysqlIterator->execute()
  src/Dropdown.php:2766                              DBmysql->request()
  ajax/getDropdownValue.php:50                       Dropdown::getDropdownValue()