### PR TITLE
Check for database integrity after update

### DIFF
--- a/src/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
+++ b/src/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
@@ -36,6 +36,7 @@
 namespace Glpi\System\Diagnostic;
 
 use DBmysql;
+use RuntimeException;
 use SebastianBergmann\Diff\Differ;
 
 /**
@@ -43,6 +44,24 @@ use SebastianBergmann\Diff\Differ;
  */
 class DatabaseSchemaIntegrityChecker
 {
+    /**
+     * Result type used when table is altered.
+     * @var string
+     */
+    public const RESULT_TYPE_ALTERED_TABLE = 'altered_table';
+
+    /**
+     * Result type used when table is missing.
+     * @var string
+     */
+    public const RESULT_TYPE_MISSING_TABLE = 'missing_table';
+
+    /**
+     * Result type used when an unknown table is found in database.
+     * @var string
+     */
+    public const RESULT_TYPE_UNKNOWN_TABLE = 'unknown_table';
+
     /**
      * DB instance.
      *
@@ -136,12 +155,7 @@ class DatabaseSchemaIntegrityChecker
      */
     public function hasDifferences(string $table_name, string $proper_create_table_sql): bool
     {
-        $effective_create_table_sql = $this->getEffectiveCreateTableSql($table_name);
-
-        $proper_create_table_sql    = $this->getNomalizedSql($proper_create_table_sql);
-        $effective_create_table_sql = $this->getNomalizedSql($effective_create_table_sql);
-
-        return $proper_create_table_sql !== $effective_create_table_sql;
+        return $this->getDiff($table_name, $proper_create_table_sql) !== '';
     }
 
     /**
@@ -168,6 +182,119 @@ class DatabaseSchemaIntegrityChecker
             $proper_create_table_sql,
             $effective_create_table_sql
         );
+    }
+
+    /**
+     * Extract the contents of the schema file.
+     *
+     * @param string $schema_path The absolute path to the schema file
+     *
+     * @return array    The parsed contents of the schema file.
+     *                  Keys contains table names and values contains CREATE TABLE SQL queries.
+     *
+     * @throws RuntimeException Thrown if the specified schema file cannot be read.
+     */
+    public function extractSchemaFromFile(string $schema_path): array
+    {
+        if (
+            !is_file($schema_path)
+            || !is_readable($schema_path)
+            || ($schema_sql = file_get_contents($schema_path)) === false
+        ) {
+            throw new RuntimeException(sprintf(__('Unable to read installation file "%s".'), $schema_path));
+        }
+
+        $matches = [];
+        preg_match_all('/CREATE TABLE[^`]*`(.+)`[^;]+/', $schema_sql, $matches);
+        $tables_names             = $matches[1];
+        $create_table_sql_queries = $matches[0];
+
+        $schema = [];
+        foreach ($create_table_sql_queries as $index => $create_table_sql_query) {
+            $schema[$tables_names[$index]] = $create_table_sql_query;
+        }
+        return $schema;
+    }
+
+    /**
+     * Check if there is differences between effective schema and schema contained in given file.
+     *
+     * @param string $schema_path           The absolute path to the schema file
+     * @param bool $include_unknown_tables  Indicates whether unknown existing tables should be include in results
+     * @param string $context               Context used for unknown tables identification (could be 'core' or 'plugin:plugin_key')
+     *
+     * @return array    List of tables that differs from the expected schema.
+     *                  Keys are table names, and each entry has following properties:
+     *                      - `type`:       difference type, see self::RESULT_TYPE_* constants;
+     *                      - `diff`:       diff string.
+     */
+    public function checkCompleteSchema(
+        string $schema_path,
+        bool $include_unknown_tables = false,
+        string $context = 'core'
+    ): array {
+        $schema = $this->extractSchemaFromFile($schema_path);
+
+        $this->db->clearSchemaCache(); // Ensure fetched table list is up-to-date
+
+        $differ = new Differ();
+        $result = [];
+
+        foreach ($schema as $table_name => $create_table_sql) {
+            $create_table_sql = $this->getNomalizedSql($create_table_sql);
+
+            if (!$this->db->tableExists($table_name)) {
+                $result[$table_name] = [
+                    'type' => self::RESULT_TYPE_MISSING_TABLE,
+                    'diff' => $differ->diff($create_table_sql, '')
+                ];
+                continue;
+            }
+
+            $effective_create_table_sql = $this->getNomalizedSql($this->getEffectiveCreateTableSql($table_name));
+            if ($create_table_sql !== $effective_create_table_sql) {
+                $result[$table_name] = [
+                    'type' => self::RESULT_TYPE_ALTERED_TABLE,
+                    'diff' => $differ->diff($create_table_sql, $effective_create_table_sql)
+                ];
+            }
+        }
+
+        if ($include_unknown_tables) {
+            $unknown_tables_criteria = [
+                [
+                    'NOT' => [
+                        'table_name' => array_keys($schema)
+                    ]
+                ],
+            ];
+            $is_context_valid = true;
+            if ($context === 'core') {
+                $unknown_tables_criteria[] = [
+                    'NOT' => [
+                        'table_name' => ['LIKE', 'glpi\_plugin\_%']
+                    ]
+                ];
+            } elseif (preg_match('/^plugin:\w+$/', $context) === 1) {
+                $unknown_tables_criteria[] = [
+                    'table_name' => ['LIKE', sprintf('glpi\_plugin\_%s_%%', str_replace('plugin:', '', $context))]
+                ];
+            } else {
+                trigger_error(sprintf('Invalid context "%s".', $context));
+                $is_context_valid = false;
+            }
+            $unknown_table_iterator = $is_context_valid ? $this->db->listTables('glpi\_%', $unknown_tables_criteria) : [];
+            foreach ($unknown_table_iterator as $unknown_table_data) {
+                $table_name = $unknown_table_data['TABLE_NAME'];
+                $effective_create_table_sql = $this->getNomalizedSql($this->getEffectiveCreateTableSql($table_name));
+                $result[$table_name] = [
+                    'type' => self::RESULT_TYPE_UNKNOWN_TABLE,
+                    'diff' => $differ->diff('', $effective_create_table_sql)
+                ];
+            }
+        }
+
+        return $result;
     }
 
     /**
@@ -233,7 +360,19 @@ class DatabaseSchemaIntegrityChecker
 
         // Normalize columns definitions
         if (!$this->strict) {
-            sort($columns);
+            usort(
+                $columns,
+                function (string $a, string $b) {
+                    // Move id / AUTO_INCREMENT column first
+                    if (preg_match('/(`id`|AUTO_INCREMENT)/', $a)) {
+                        return -1;
+                    }
+                    if (preg_match('/(`id`|AUTO_INCREMENT)/', $b)) {
+                        return 1;
+                    }
+                    return strcmp($a, $b);
+                }
+            );
         }
         $column_replacements = [
             // Remove comments
@@ -241,7 +380,7 @@ class DatabaseSchemaIntegrityChecker
             // Remove integer display width
             '/( (tiny|small|medium|big)?int)\(\d+\)/i' => '$1',
         ];
-        if ($db_server === 'MariaDB' && version_compare($db_version, '10.2', '>=')) {
+        if ($db_server === 'MariaDB') {
             // Add surrounding quotes on default numeric values (MySQL has quotes while MariaDB 10.2+ has not)
             $column_replacements['/(DEFAULT) ([-|+]?\d+(\.\d+)?)/i'] = '$1 \'$2\'';
             // Replace function current_timestamp() by CURRENT_TIMESTAMP (MySQL uses constant while MariaDB 10.2+ uses function)
@@ -275,7 +414,29 @@ class DatabaseSchemaIntegrityChecker
 
         // Normalize indexes definitions
         if (!$this->strict) {
-            sort($indexes);
+            usort(
+                $indexes,
+                function (string $a, string $b) {
+                    $order = [
+                        'PRIMARY KEY',
+                        'UNIQUE KEY',
+                        'FULLTEXT KEY',
+                        'KEY',
+                        'CONSTRAINT',
+                    ];
+                    $a_priority = array_search(
+                        preg_replace('/^(CONSTRAINT|(UNIQUE |PRIMARY |FULLTEXT )?KEY).+$/', '$1', $a),
+                        $order
+                    );
+                    $b_priority = array_search(
+                        preg_replace('/^(CONSTRAINT|(UNIQUE |PRIMARY |FULLTEXT )?KEY).+$/', '$1', $b),
+                        $order
+                    );
+                    return $a_priority !== $b_priority
+                        ? $a_priority - $b_priority // Index type is different, reorder by type
+                        : strcmp($a, $b); // Index type is similar, reorder by name
+                }
+            );
         }
 
         // Normalize properties
@@ -284,15 +445,10 @@ class DatabaseSchemaIntegrityChecker
         if ($this->ignore_dynamic_row_format_migration) {
             unset($properties['ROW_FORMAT']);
         }
-        if (
-            !$this->strict && ($properties['ROW_FORMAT'] ?? '') === 'DYNAMIC'
-            && (
-            ($db_server === 'MySQL' && version_compare($db_version, '5.7', '>='))
-            || ($db_server === 'MariaDB' && version_compare($db_version, '10.2', '>='))
-            )
-        ) {
+        if (!$this->strict && ($properties['ROW_FORMAT'] ?? '') === 'DYNAMIC') {
             // MySQL 5.7+ and MariaDB 10.2+ does not ouput ROW_FORMAT when ROW_FORMAT has not been specified in creation query
             // and so uses default value.
+            // Drop it if value is 'DYNAMIC' as we assume this is the default value.
             unset($properties['ROW_FORMAT']);
         }
         if ($this->ignore_innodb_migration) {

--- a/src/Update.php
+++ b/src/Update.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\System\Diagnostic\DatabaseSchemaIntegrityChecker;
 use Glpi\Toolbox\VersionParser;
 
 /**
@@ -42,6 +43,9 @@ class Update
 {
     private $args = [];
     private $DB;
+    /**
+     * @var Migration
+     */
     private $migration;
     private $version;
     private $dbversion;
@@ -154,6 +158,26 @@ class Update
         return $currents;
     }
 
+    /**
+     * Verify the database schema integrity.
+     *
+     * @return void
+     */
+    private function checkSchemaIntegrity(): void
+    {
+        global $DB;
+
+        $checker = new DatabaseSchemaIntegrityChecker($DB, false);
+        $differences = $checker->checkCompleteSchema(GLPI_ROOT . '/install/mysql/glpi-empty.sql', true);
+
+        if (count($differences) > 0) {
+            $this->migration->displayError(
+                __('The database schema is not consistent with the current GLPI version.')
+                . "\n"
+                . __('It is recommended to run the "php bin/console glpi:database:check_schema_integrity" command to see the differences.')
+            );
+        }
+    }
 
     /**
      * Run updates
@@ -306,6 +330,9 @@ class Update
         if (!$glpikey->keyExists() && !$glpikey->generate()) {
             $this->migration->displayWarning(__('Unable to create security key file! You have to run "php bin/console glpi:security:change_key" command to manually create this file.'), true);
         }
+
+        // Check if schema has differences from the expected one but do not block the upgrade
+        $this->checkSchemaIntegrity();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Based on #11576 .

I had in mind to add detection of "unkown" tables in database (i.e. tables name `glpi_*` but not present in `glpi-empty.sql`), so I refactored a little the `checkCompleteSchema()` method proposed in #11576 . It was not a bg deal, but then I wanted to add tests coverage on this method (and on other non tested methods of the class), and, to do so, I had to rewrite the existing data provider in order to provide . Diff is huge, but is mainly due to grouping/reordering of test cases.

There is now 3 types of diff: altered table, missing table and unknown table.
Example:
![image](https://user-images.githubusercontent.com/33253653/169510959-ebc5f6c4-f758-4a73-97cc-36955418ff91.png)

When differences are found during update in CLI:
![image](https://user-images.githubusercontent.com/33253653/169511435-48985a0d-87ce-4a75-8c89-1618cc9ccbcc.png)

When differences are found during update in UI:
![image](https://user-images.githubusercontent.com/33253653/169511366-400b5a02-afbf-4e26-b166-c8853a8b2029.png)

Other changes are :
 - removal of some MariaDB / MySQL version checks that were related to unsupported versions (MariaDB < 10.2, MySQL < 5.7);
 - better reordering of fields in "non-strict" mode (`id`/`AUTO_INCREMENT` field on top),
 - better reordering of indexes in "non-strict" mode (order will be `PRIMARY`, then `UNIQUE`, then `FULLTEXT` then `KEY`).