### PR TITLE
Allow downloading specific versions of plugins

### DIFF
--- a/src/Console/Marketplace/DownloadCommand.php
+++ b/src/Console/Marketplace/DownloadCommand.php
@@ -65,10 +65,20 @@ class DownloadCommand extends AbstractMarketplaceCommand
 
         $plugins = $input->getArgument('plugins');
 
+        $plugin_versions = [];
         foreach ($plugins as $plugin) {
             if (empty(trim($plugin))) {
                 continue;
             }
+            if (str_contains($plugin, ':')) {
+                [$plugin, $version] = explode(':', $plugin);
+                $plugin_versions[$plugin] = $version;
+            } else {
+                $plugin_versions[$plugin] = null;
+            }
+        }
+
+        foreach ($plugin_versions as $plugin => $version) {
             // If the plugin is already downloaded, refuse to download it again
             if (!$input->getOption('force') && is_dir(GLPI_MARKETPLACE_DIR . '/' . $plugin)) {
                 if (Controller::hasVcsDirectory($plugin)) {
@@ -81,8 +91,8 @@ class DownloadCommand extends AbstractMarketplaceCommand
                 continue;
             }
             $controller = new Controller($plugin);
-            if ($controller->canBeDownloaded()) {
-                $result = $controller->downloadPlugin(false);
+            if ($controller->canBeDownloaded($version)) {
+                $result = $controller->downloadPlugin(false, $version);
                 $success_msg = sprintf(__("Plugin %s downloaded successfully"), $plugin);
                 $error_msg = sprintf(__("Plugin %s could not be downloaded"), $plugin);
                 if ($result) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When downloading plugins from the marketplace (CLI or web) we are forced to use the latest version available for the current version of GLPI. Some plugins, like mine, follow semantic versioning though and there may be multiple versions supported for each GLPI version. There are times where someone may want to stay within the same minor version and only get bug fixes, but that is not currently possible with the marketplace.

This PR adds the ability to download specific versions of plugins using the `marketplace:download` CLI command.
This uses the existing `plugins` option but now you can now specify versions for each.
For example:
```
bin/console marketplace:download screenshot:1.1.6 jamf:2.1.5
```

If no version is specified for a plugin, it will use the latest compatible version as it did before.

Some more work could be done to expand this including adding some way in the web UI to select a different compatible version (Need to block downgrades?). It would also be nice to have a way to specify in the plugin XML the support status of each version, have that returned in the marketplace API, and be shown in the web UI.