### PR TITLE
Fix some migrations

### DIFF
--- a/install/migrations/update_10.0.0_to_10.0.1/schema_fixes.php
+++ b/install/migrations/update_10.0.0_to_10.0.1/schema_fixes.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+
+// Remove '' default values on glpi_impactcontexts.positions
+// MySQL does not allow default values on TEXT fields, while MariaDB does
+// Default was removed in installation file GLPI 9.5.4, see #8415
+$migration->changeField('glpi_impactcontexts', 'positions', 'positions', 'mediumtext NOT NULL');

--- a/install/migrations/update_9.5.x_to_10.0.0/cable.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/cable.php
@@ -132,13 +132,12 @@ if (!$DB->tableExists('glpi_cables')) {
       KEY `date_creation` (`date_creation`)
     ) ENGINE=InnoDB DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation} ROW_FORMAT=DYNAMIC;";
     $DB->queryOrDie($query, "10.0 add table glpi_cables");
-
-    $migration->addField('glpi_states', 'is_visible_cable', 'bool', [
-        'value' => 1,
-        'after' => 'is_visible_appliance'
-    ]);
-    $migration->addKey('glpi_states', 'is_visible_cable');
 }
+$migration->addField('glpi_states', 'is_visible_cable', 'bool', [
+    'value' => 1,
+    'after' => 'is_visible_appliance'
+]);
+$migration->addKey('glpi_states', 'is_visible_cable');
 
 if (!$DB->tableExists('glpi_sockets')) {
    //create socket table


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. On DB initialized in GLPI 9.5.0 to 9.5.3 on MariaDB, `glpi_impactcontexts.positions` has a still default value, but it should not (see #8415).
2. On GLPI 10.0.0 migration, if `glpi_cables` table exists, the `glpi_states.is_visible_cable` field will not be created. It may happen on really edge case (I found this after reinstalling a GLPI 9.5.7 DB over a GLPI 10.0.0 DB, without dropping tables first).