### PR TITLE
Ignore optionnal migrations in DB integrity check done after migration

### DIFF
--- a/src/Update.php
+++ b/src/Update.php
@@ -167,7 +167,7 @@ class Update
     {
         global $DB;
 
-        $checker = new DatabaseSchemaIntegrityChecker($DB, false);
+        $checker = new DatabaseSchemaIntegrityChecker($DB, false, true, true, true, true, true);
         $differences = $checker->checkCompleteSchema(GLPI_ROOT . '/install/mysql/glpi-empty.sql', true);
 
         if (count($differences) > 0) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Follows #11576 .
