### PR TITLE
Fix with_contracts API option

### DIFF
--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -841,8 +841,8 @@ abstract class API
                         ],
                         'glpi_entities'   => [
                             'ON' => [
-                                'glpi_contracts_items'  => 'entities_id',
-                                'glpi_entities'         => 'id'
+                                'glpi_contracts'    => 'entities_id',
+                                'glpi_entities'     => 'id'
                             ]
                         ]
                     ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

A SQL join was trying to use `entities_id` column on the wrong table.
This was like this since the query was converted to use the iterator array format in 2018.