### PR TITLE
Add build script to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,6 +126,9 @@
         "post-update-cmd": [
             "@php -r \"file_put_contents('.composer.hash', sha1_file('composer.lock'));\"",
             "@php -f vendor/bin/build_hw_jsons"
+        ],
+        "build": [
+            "bin/console dependencies install && bin/console locales:compile"
         ]
     },
     "repositories": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Add `build` script to install dependencies and compile locales. This should make it much quicker and easier when switching between development branches.