### PR TITLE
ignore non existent classes

### DIFF
--- a/src/ContentTemplates/Parameters/TicketParameters.php
+++ b/src/ContentTemplates/Parameters/TicketParameters.php
@@ -149,6 +149,7 @@ class TicketParameters extends CommonITILObjectParameters
         foreach ($items_ticket as $item_ticket) {
             $itemtype = $item_ticket->fields['itemtype'];
             if (!class_exists($itemtype)) {
+                trigger_error(sprintf('No class found for type %s', $itemtype), E_USER_WARNING);
                 // May happen if the itemtype belongs to a plugin and this plugin is inactive
                 continue;
             }

--- a/src/ContentTemplates/Parameters/TicketParameters.php
+++ b/src/ContentTemplates/Parameters/TicketParameters.php
@@ -148,6 +148,10 @@ class TicketParameters extends CommonITILObjectParameters
         $items_ticket = Item_Ticket::getItemsAssociatedTo($ticket::getType(), $fields['id']);
         foreach ($items_ticket as $item_ticket) {
             $itemtype = $item_ticket->fields['itemtype'];
+            if (!class_exists($itemtype)) {
+                // May happen if the itemtype belongs to a plugin and this plugin is inactive
+                continue;
+            }
             if ($item = $itemtype::getById($item_ticket->fields['items_id'])) {
                 $asset_parameters = new AssetParameters();
                 $values['assets'][] = $asset_parameters->getValues($item);


### PR DESCRIPTION
If a class does not exists, a fatal error occurs.

```
[2022-05-25 09:04:49] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Class 'PluginFormcreatorFormAnswer' not found in glpi-100a/src/ContentTemplates/Parameters/TicketParameters.php at line 151
  Backtrace :
  ...tTemplates/Parameters/AbstractParameters.php:81 Glpi\ContentTemplates\Parameters\TicketParameters->defineValues()
  src/ContentTemplates/TemplateManager.php:107       Glpi\ContentTemplates\Parameters\AbstractParameters->getValues()
  src/AbstractITILChildTemplate.php:142              Glpi\ContentTemplates\TemplateManager::renderContentForCommonITIL()
  ajax/task.php:87                                   AbstractITILChildTemplate->getRenderedContent()
```

Observed when adding a task from a template to a ticket, and the ticket is associated to a item from an inactive plugin.

