### PR TITLE
Remove ability to disable CSRF checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The present file will list all changes made to the project; according to the
 #### Changes
 
 #### Deprecated
+- Usage of `GLPI_USE_CSRF_CHECK` constant.
 - `Glpi\Features\DCBreadcrumb::getDcBreadcrumb()`
 - `Glpi\Features\DCBreadcrumb::getDcBreadcrumbSpecificValueToDisplay()`
 - `Glpi\Features\DCBreadcrumb::isEnclosurePart()`
@@ -29,6 +30,7 @@ The present file will list all changes made to the project; according to the
 - `ajax/knowbase.php` script usage.
 - `Glpi\Event::showList()`
 - `Html::displayAjaxMessageAfterRedirect()`
+- `HookManager::enableCSRF()`
 - `Knowbase::getTreeCategoryList()`
 - `Knowbase::showBrowseView()`
 - `Knowbase::showManageView()`
@@ -36,6 +38,7 @@ The present file will list all changes made to the project; according to the
 - `Toolbox::seems_utf8()`
 
 #### Removed
+- Usage of `csrf_compliant` plugins hook.
 
 ## [10.0.1] unreleased
 

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -149,11 +149,7 @@ if (
 }
 
 // Security : check CSRF token
-if (
-    GLPI_USE_CSRF_CHECK
-    && !isAPI()
-    && isset($_POST) && is_array($_POST) && count($_POST)
-) {
+if (!isAPI() && isset($_POST) && is_array($_POST) && count($_POST)) {
     if (preg_match(':' . $CFG_GLPI['root_doc'] . '(/(plugins|marketplace)/[^/]*|)/ajax/:', $_SERVER['REQUEST_URI']) === 1) {
        // Keep CSRF token as many AJAX requests may be made at the same time.
        // This is due to the fact that read operations are often made using POST method (see #277).

--- a/src/Html.php
+++ b/src/Html.php
@@ -4467,9 +4467,7 @@ JAVASCRIPT
         $confirm = ''
     ) {
 
-        if (GLPI_USE_CSRF_CHECK) {
-            $fields['_glpi_csrf_token'] = Session::getNewCSRFToken();
-        }
+        $fields['_glpi_csrf_token'] = Session::getNewCSRFToken();
         $fields['_glpi_simple_form'] = 1;
         $button                      = $btname;
         if (!is_array($btname)) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -836,19 +836,6 @@ class Plugin extends CommonDBTM
            // Enable autoloader and load plugin hooks
             self::load($this->fields['directory'], true);
 
-           // No activation if not CSRF compliant
-            if (
-                !isset($PLUGIN_HOOKS[Hooks::CSRF_COMPLIANT][$this->fields['directory']])
-                || !$PLUGIN_HOOKS[Hooks::CSRF_COMPLIANT][$this->fields['directory']]
-            ) {
-                Session::addMessageAfterRedirect(
-                    sprintf(__('Plugin %1$s is not CSRF compliant!'), $this->fields['name']),
-                    true,
-                    ERROR
-                );
-                return false;
-            }
-
             $function = 'plugin_' . $this->fields['directory'] . '_check_prerequisites';
             if (function_exists($function)) {
                 ob_start();
@@ -2397,13 +2384,7 @@ class Plugin extends CommonDBTM
                     }
                     ob_end_clean();
                     $function = 'plugin_' . $directory . '_check_prerequisites';
-                    if (
-                        !isset($PLUGIN_HOOKS[Hooks::CSRF_COMPLIANT][$directory])
-                        || !$PLUGIN_HOOKS[Hooks::CSRF_COMPLIANT][$directory]
-                    ) {
-                        $output .= "<span class='error'>" . __('Not CSRF compliant') . "</span>";
-                        $do_activate = false;
-                    } else if (function_exists($function) && $do_activate) {
+                    if (function_exists($function) && $do_activate) {
                         ob_start();
                         $do_activate = $function();
                         if (!$do_activate) {

--- a/src/Plugin/HookManager.php
+++ b/src/Plugin/HookManager.php
@@ -35,6 +35,8 @@
 
 namespace Glpi\Plugin;
 
+use Toolbox;
+
 class HookManager
 {
     protected string $plugin;

--- a/src/Plugin/HookManager.php
+++ b/src/Plugin/HookManager.php
@@ -49,6 +49,7 @@ class HookManager
      */
     public function enableCSRF(): void
     {
+        Toolbox::deprecated();
         $PLUGIN_HOOKS[Hooks::CSRF_COMPLIANT][$this->plugin] = true;
     }
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -1428,11 +1428,14 @@ class Session
      **/
     public static function checkCSRF($data)
     {
+        if (!GLPI_USE_CSRF_CHECK) {
+            trigger_error(
+                'Definition of "GLPI_USE_CSRF_CHECK" constant is deprecated and is ignore for security reasons.',
+                E_USER_WARNING
+            );
+        }
 
-        if (
-            GLPI_USE_CSRF_CHECK
-            && (!Session::validateCSRF($data))
-        ) {
+        if (!Session::validateCSRF($data)) {
            // Output JSON if requested by client
             if (strpos($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json') !== false) {
                 http_response_code(403);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

For security reasons, disabling CSRF checks should not be allowed. Also, plugins have to be compliant with CSRF checks since 0.84 version of GLPI (see 519db4b6cc754a82d7aa2a4bffc1c72cf780e295), so I guess checking compliance of plugins with CSRF checks is no longer needed.
