### PR TITLE
Fix central widget layout after removing an item

### DIFF
--- a/templates/central/widget_tab.html.twig
+++ b/templates/central/widget_tab.html.twig
@@ -71,10 +71,10 @@
          this_obj.html('<i class="fas fa-3x fa-spinner fa-spin ms-auto"></i>')
             .load('{{ path('/ajax/central.php') }}', params, function(response, status, xhr) {
                if (status === 'error' || !response) {
-                  this_obj.closest('.grid-item').remove();
+                   window.msnry.remove(this_obj.closest('.grid-item'));
                }
 
-               $(document).trigger('masonry_grid:layout');
+               window.msnry.layout();
             });
       });
    });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11568

Switch from using jQuery remove method to masonry remove.
Switch from using a DOM event to trigger a layout update to calling the layout method directly.
