### PR TITLE
Clarify template preview tab names

### DIFF
--- a/src/ITILTemplate.php
+++ b/src/ITILTemplate.php
@@ -396,8 +396,8 @@ abstract class ITILTemplate extends CommonDropdown
             switch ($item->getType()) {
                 case 'TicketTemplate':
                     return [
-                        1 => __('Standard interface'),
-                        2 => __('Simplified interface')
+                        1 => __('Preview (Standard interface)'),
+                        2 => __('Preview (Simplified interface)')
                     ];
                 case 'ChangeTemplate':
                 case 'ProblemTemplate':

--- a/tests/functionnal/ITILTemplate.php
+++ b/tests/functionnal/ITILTemplate.php
@@ -310,8 +310,8 @@ class ITILTemplate extends DbTestCase
         switch ($itiltype) {
             case 'Ticket':
                 $expected = [
-                    1 => 'Standard interface',
-                    2 => 'Simplified interface'
+                    1 => 'Preview (Standard interface)',
+                    2 => 'Preview (Simplified interface)'
                 ];
                 break;
             default:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11555

Change preview tab names in Ticket templates to clarify that they are only previews. The other ITIL templates already name the tab "Preview".