### PR TITLE
fix(user): empty tab

### DIFF
--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -771,7 +771,7 @@ class Profile_User extends CommonDBRelation
         $profiles = [];
 
         $where = ['users_id' => $user_ID];
-        if (count($sqlfilter) > 0) {
+        if (is_array($sqlfilter) && count($sqlfilter) > 0) {
             $where = $where + $sqlfilter;
         }
 


### PR DESCRIPTION
The User tab is blank and in debug mode, we see this error:

```
Parameter must be an array or an object that implements Countable in Profile_User.php at line 774
```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | portal 6709
