### PR TITLE
Fix selected items in reservation form

### DIFF
--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -666,6 +666,7 @@ class ReservationItem extends CommonDBChild
                 echo Html::getCheckbox([
                     'name'  => "item[" . $row["id"] . "]",
                     'value' => $row["id"],
+                    'zero_on_empty' => false,
                 ]);
                 echo "</td>";
                 $typename = $item->getTypeName();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11694

Form was receiving `0` value for each element that was not selected, and it was not handled correctly. When no element is selected, user is correctly redirected to items list due to following code:
https://github.com/glpi-project/glpi/blob/98cef2d8343554547fa3fb913c6ede49c4979375/front/reservation.form.php#L178-L183