### PR TITLE
Asset rules: add last inventory update criteria

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5564,6 +5564,11 @@ class CommonDBTM extends CommonGLPI
                 $input['_auto'] = 0;
             }
 
+            // Add last_inventory_update
+            if (!isset($this->input['last_inventory_update']) && isset($this->fields['last_inventory_update'])) {
+                $input['last_inventory_update'] = $this->fields['last_inventory_update'];
+            }
+
             // Set the condition (add or update)
             $output = $ruleasset->processAllRules($input, [], [], [
                 'condition' => $condition

--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -148,6 +148,16 @@ class RuleAsset extends Rule
         $criterias['_groups_id_of_user']['linkfield']    = '_groups_id_of_user';
         $criterias['_groups_id_of_user']['type']         = 'dropdown';
 
+        $criterias['last_inventory_update']['name']            = __('Last inventory update');
+        $criterias['last_inventory_update']['type']            = 'datetime';
+        $criterias['last_inventory_update']['table']           = '';
+        $criterias['last_inventory_update']['allow_condition'] = [
+            Rule::PATTERN_DATE_IS_BEFORE,
+            Rule::PATTERN_DATE_IS_AFTER,
+            Rule::PATTERN_DATE_IS_EQUAL,
+            Rule::PATTERN_DATE_IS_NOT_EQUAL,
+        ];
+
         return $criterias;
     }
 

--- a/src/RuleCriteria.php
+++ b/src/RuleCriteria.php
@@ -379,7 +379,6 @@ class RuleCriteria extends CommonDBChild
         $condition = $criterion->fields['condition'];
         $pattern   = $criterion->fields['pattern'];
         $criteria  = $criterion->fields['criteria'];
-
        //If pattern is wildcard, don't check the rule and return true
        //or if the condition is "already present in GLPI" : will be processed later
         if (
@@ -549,6 +548,47 @@ class RuleCriteria extends CommonDBChild
                         }
                     }
                 }
+                break;
+
+            case Rule::PATTERN_DATE_IS_NOT_EQUAL:
+                $target_date = Html::computeGenericDateTimeSearch($pattern);
+
+                if (
+                    $target_date != $pattern
+                    && !str_contains("MINUTE", $pattern)
+                    && !str_contains("HOUR", $pattern)
+                ) {
+                    // We are using a dynamic date with a precision of at least
+                    // one day (e.g. 2 days ago).
+                    // In this case we must compare using date instead of datetime
+                    $field = substr($field, 0, 10);
+                    $target_date = substr($field, 0, 10);
+                }
+
+                return $field != $target_date;
+
+            case Rule::PATTERN_DATE_IS_EQUAL:
+                $target_date = Html::computeGenericDateTimeSearch($pattern);
+
+                if (
+                    $target_date != $pattern
+                    && !str_contains("MINUTE", $pattern)
+                    && !str_contains("HOUR", $pattern)
+                ) {
+                    // We are using a dynamic date with a precision of at least
+                    // one day (e.g. 2 days ago).
+                    // In this case we must compare using date instead of datetime
+                    $field = substr($field, 0, 10);
+                    $target_date = substr($target_date, 0, 10);
+                }
+
+                return $field == $target_date;
+
+            case Rule::PATTERN_DATE_IS_BEFORE:
+                return $field < Html::computeGenericDateTimeSearch($pattern);
+
+            case Rule::PATTERN_DATE_IS_AFTER:
+                return $field > Html::computeGenericDateTimeSearch($pattern);
         }
         return false;
     }
@@ -582,17 +622,22 @@ class RuleCriteria extends CommonDBChild
      **/
     public static function getConditions($itemtype, $criterion = '')
     {
+
         $criteria =  [
-            Rule::PATTERN_IS              => __('is'),
-            Rule::PATTERN_IS_NOT          => __('is not'),
-            Rule::PATTERN_CONTAIN         => __('contains'),
-            Rule::PATTERN_NOT_CONTAIN     => __('does not contain'),
-            Rule::PATTERN_BEGIN           => __('starting with'),
-            Rule::PATTERN_END             => __('finished by'),
-            Rule::REGEX_MATCH             => __('regular expression matches'),
-            Rule::REGEX_NOT_MATCH         => __('regular expression does not match'),
-            Rule::PATTERN_EXISTS          => __('exists'),
-            Rule::PATTERN_DOES_NOT_EXISTS => __('does not exist')
+            Rule::PATTERN_IS                => __('is'),
+            Rule::PATTERN_IS_NOT            => __('is not'),
+            Rule::PATTERN_CONTAIN           => __('contains'),
+            Rule::PATTERN_NOT_CONTAIN       => __('does not contain'),
+            Rule::PATTERN_BEGIN             => __('starting with'),
+            Rule::PATTERN_END               => __('finished by'),
+            Rule::REGEX_MATCH               => __('regular expression matches'),
+            Rule::REGEX_NOT_MATCH           => __('regular expression does not match'),
+            Rule::PATTERN_EXISTS            => __('exists'),
+            Rule::PATTERN_DOES_NOT_EXISTS   => __('does not exist'),
+            Rule::PATTERN_DATE_IS_BEFORE    => __('before'),
+            Rule::PATTERN_DATE_IS_AFTER     => __('after'),
+            Rule::PATTERN_DATE_IS_EQUAL     => __('is'),
+            Rule::PATTERN_DATE_IS_NOT_EQUAL => __('is not'),
         ];
 
         if (in_array($criterion, ['ip', 'subnet'])) {

--- a/src/RuleCriteria.php
+++ b/src/RuleCriteria.php
@@ -551,22 +551,6 @@ class RuleCriteria extends CommonDBChild
                 break;
 
             case Rule::PATTERN_DATE_IS_NOT_EQUAL:
-                $target_date = Html::computeGenericDateTimeSearch($pattern);
-
-                if (
-                    $target_date != $pattern
-                    && !str_contains("MINUTE", $pattern)
-                    && !str_contains("HOUR", $pattern)
-                ) {
-                    // We are using a dynamic date with a precision of at least
-                    // one day (e.g. 2 days ago).
-                    // In this case we must compare using date instead of datetime
-                    $field = substr($field, 0, 10);
-                    $target_date = substr($field, 0, 10);
-                }
-
-                return $field != $target_date;
-
             case Rule::PATTERN_DATE_IS_EQUAL:
                 $target_date = Html::computeGenericDateTimeSearch($pattern);
 
@@ -582,7 +566,9 @@ class RuleCriteria extends CommonDBChild
                     $target_date = substr($target_date, 0, 10);
                 }
 
-                return $field == $target_date;
+                return $condition == Rule::PATTERN_DATE_IS_EQUAL
+                    ? $field == $target_date
+                    : $field != $target_date;
 
             case Rule::PATTERN_DATE_IS_BEFORE:
                 return $field < Html::computeGenericDateTimeSearch($pattern);

--- a/tests/functionnal/RuleAsset.php
+++ b/tests/functionnal/RuleAsset.php
@@ -1,0 +1,261 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Computer;
+use DbTestCase;
+use Generator;
+use Rule;
+use RuleAction;
+use RuleCriteria;
+use SingletonRuleList;
+
+class RuleAsset extends DbTestCase
+{
+    protected function testCriteriaProvider(): Generator
+    {
+        // Test case 1 for last_inventory_update -> Precise date
+        yield [
+            'itemtype' => Computer::getType(),
+            'input' => [
+                'name'                  => 'testLastInventoryUpdateCriteria1',
+                'last_inventory_update' => "2022-02-28 22:05:30",
+                'entities_id'           => 0,
+            ],
+            'criteria_field' => 'last_inventory_update',
+            'criteria_value' => '2022-02-28 22:05:30',
+            'action_field'   => 'comment',
+            'condition'      => Rule::PATTERN_DATE_IS_EQUAL,
+            'success'        => true,
+        ];
+
+        // Test case 2 for last_inventory_update -> Precise date
+        yield [
+            'itemtype' => Computer::getType(),
+            'input' => [
+                'name'                  => 'testLastInventoryUpdateCriteria1',
+                'last_inventory_update' => "2022-02-28 22:05:30",
+                'entities_id'           => 0,
+            ],
+            'criteria_field' => 'last_inventory_update',
+            'criteria_value' => '2022-02-28 22:05:31',
+            'action_field'   => 'comment',
+            'condition'      => Rule::PATTERN_DATE_IS_EQUAL,
+            'success'        => false,
+        ];
+
+        // Test case 3 for last_inventory_update -> Today
+        yield [
+            'itemtype' => Computer::getType(),
+            'input' => [
+                'name'                  => 'testLastInventoryUpdateCriteria1',
+                'last_inventory_update' => $_SESSION["glpi_currenttime"],
+                'entities_id'           => 0,
+            ],
+            'criteria_field' => 'last_inventory_update',
+            'criteria_value' => 'TODAY',
+            'action_field'   => 'comment',
+            'condition'      => Rule::PATTERN_DATE_IS_EQUAL,
+            'success'        => true,
+        ];
+
+        // Test case 4 for last_inventory_update -> Today
+        yield [
+            'itemtype' => Computer::getType(),
+            'input' => [
+                'name'                  => 'testLastInventoryUpdateCriteria1',
+                'last_inventory_update' => "2022-02-28 22:05:30",
+                'entities_id'           => 0,
+            ],
+            'criteria_field' => 'last_inventory_update',
+            'criteria_value' => 'TODAY',
+            'action_field'   => 'comment',
+            'condition'      => Rule::PATTERN_DATE_IS_EQUAL,
+            'success'        => false,
+        ];
+
+        // Test case 5 for last_inventory_update -> before relative date
+        yield [
+            'itemtype' => Computer::getType(),
+            'input' => [
+                'name'                  => 'testLastInventoryUpdateCriteria1',
+                'last_inventory_update' => date('Y-m-d H:i:s', time() - 18000),
+                'entities_id'           => 0,
+            ],
+            'criteria_field' => 'last_inventory_update',
+            'criteria_value' => '-2HOUR',
+            'action_field'   => 'comment',
+            'condition'      => Rule::PATTERN_DATE_IS_BEFORE,
+            'success'        => true,
+        ];
+
+        // Test case 6 for last_inventory_update -> before relative date
+        yield [
+            'itemtype' => Computer::getType(),
+            'input' => [
+                'name'                  => 'testLastInventoryUpdateCriteria1',
+                'last_inventory_update' => $_SESSION["glpi_currenttime"],
+                'entities_id'           => 0,
+            ],
+            'criteria_field' => 'last_inventory_update',
+            'criteria_value' => '-2DAY',
+            'action_field'   => 'comment',
+            'condition'      => Rule::PATTERN_DATE_IS_BEFORE,
+            'success'        => false,
+        ];
+
+        // Test case 7 for last_inventory_update -> after fixed date
+        yield [
+            'itemtype' => Computer::getType(),
+            'input' => [
+                'name'                  => 'testLastInventoryUpdateCriteria1',
+                'last_inventory_update' => "2022-04-15 17:34:47",
+                'entities_id'           => 0,
+            ],
+            'criteria_field' => 'last_inventory_update',
+            'criteria_value' => "2022-02-28 22:05:30",
+            'action_field'   => 'comment',
+            'condition'      => Rule::PATTERN_DATE_IS_AFTER,
+            'success'        => true,
+        ];
+
+        // Test case 8 for last_inventory_update -> after fixed date
+        yield [
+            'itemtype' => Computer::getType(),
+            'input' => [
+                'name'                  => 'testLastInventoryUpdateCriteria1',
+                'last_inventory_update' => "2022-02-26 20:23:18",
+                'entities_id'           => 0,
+            ],
+            'criteria_field' => 'last_inventory_update',
+            'criteria_value' => "2022-02-28 22:05:30",
+            'action_field'   => 'comment',
+            'condition'      => Rule::PATTERN_DATE_IS_AFTER,
+            'success'        => false,
+        ];
+    }
+
+    /**
+     * Test a given criteria
+     *
+     * @dataprovider testCriteriaProvider
+     *
+     * @param string $itemtype          Test subject's type
+     * @param array  $input             Input used to create the test subject
+     * @param string $criteria_field    The tested criteria name
+     * @param string $criteria_value    The tested criteria value
+     * @param string $action_field      Field used in the action to test the
+     *                                  results.
+     *                                  Must be a string or text field and be
+     *                                  different that $criteria_field
+     * @param int    $condition         Condition operator (is, is not, ...)
+     * @param bool   $success           Is the rule expected to succeed ?
+     */
+    public function testCriteria(
+        string $itemtype,
+        array $input,
+        string $criteria_field,
+        string $criteria_value,
+        string $action_field,
+        int $condition,
+        bool $success
+    ) {
+        global $DB;
+
+        $this->login();
+
+        // Disable all others rules before running the test
+        $DB->update(Rule::getTable(), ['is_active' => false], [
+            'sub_type' => "RuleAsset"
+        ]);
+        $active_rules = countElementsInTable(Rule::getTable(), [
+            'is_active' => true,
+            'sub_type'  => "RuleAsset",
+        ]);
+        $this->integer($active_rules)->isEqualTo(0);
+
+        // Create the rule
+        $rule_asset = $this->createItem(\RuleAsset::getType(), [
+            'name'      => 'testLastInventoryUpdateCriteria',
+            'match'     => 'AND',
+            'is_active' => true,
+            'sub_type'  => 'RuleAsset',
+            'condition' => \RuleAsset::ONUPDATE,
+        ]);
+
+        // Add the condition
+        $this->createItem(RuleCriteria::getType(), [
+            'rules_id'  => $rule_asset->getID(),
+            'criteria'  => $criteria_field,
+            'condition' => $condition,
+            'pattern'   => $criteria_value,
+        ]);
+
+        // Add the action
+        $this->createItem(RuleAction::getType(), [
+            'rules_id'    => $rule_asset->getID(),
+            'action_type' => "assign",
+            'field'       => $action_field,
+            'value'       => "value_changed",
+        ]);
+
+        // Reset rule cache
+        SingletonRuleList::getInstance("RuleAsset", 0)->load = 0;
+        SingletonRuleList::getInstance("RuleAsset", 0)->list = [];
+
+        // Creat the test subject
+        $item = $this->createItem($itemtype, $input);
+
+        // Safety check before test
+        $this->variable($item->fields[$action_field])->isNotEqualTo("value_changed");
+
+        // Execute the test
+        $update = $item->update([
+            'id'          => $item->getID(),
+            $action_field => 'value_not_changed',
+        ]);
+        $this->boolean($update)->isTrue();
+        $this->boolean($item->getFromDB($item->getID()))->isTrue();
+
+        // Check whether or not the rule affected our item
+        $value = $item->fields[$action_field];
+        if ($success == true) {
+            $this->string($value)->isEqualTo("value_changed");
+        } else {
+            $this->string($value)->isEqualTo("value_not_changed");
+        }
+    }
+}

--- a/tests/functionnal/RuleCriteria.php
+++ b/tests/functionnal/RuleCriteria.php
@@ -808,10 +808,10 @@ class RuleCriteria extends DbTestCase
     public function testGetConditions()
     {
         $conditions = \RuleCriteria::getConditions('RuleDictionnarySoftware');
-        $this->array($conditions)->hasSize(10);
+        $this->array($conditions)->hasSize(14);
 
         $conditions = \RuleCriteria::getConditions('RuleTicket', 'locations_id');
-        $this->array($conditions)->hasSize(12);
+        $this->array($conditions)->hasSize(16);
     }
 
     public function testGetConditionByID()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42734840/171004848-915f041b-72a4-490c-80cf-5701601d7a13.png)

This new criteria required quite a bit of code as there was no support for dates

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23959
