### PR TITLE
Ammend #11708

### DIFF
--- a/src/Features/Clonable.php
+++ b/src/Features/Clonable.php
@@ -123,7 +123,7 @@ trait Clonable
             $relation_items = $classname::getItemsAssociatedTo($this->getType(), $source->getID());
             /** @var CommonDBTM $relation_item */
             foreach ($relation_items as $relation_item) {
-                if (!isset($override_input['name']) && $source->isTemplate() && isset($relation_item->fields['name'])) {
+                if ($source->isTemplate() && isset($relation_item->fields['name'])) {
                     // Force-set name to avoid adding a "(copy)" suffix to the cloned item
                     $override_input['name'] = $relation_item->fields['name'];
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The previous patch didn't handle multiple relation items properly and was copying the first name to all other items.