### PR TITLE
Fix autoname when using mbstring polyfill

### DIFF
--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -1708,7 +1708,7 @@ final class DbUtils
         }
 
         $matches = [];
-        if (mb_ereg('^<[^#]*(#{1,10})[^#]*>$', $objectName, $matches) === false) {
+        if (preg_match('/^<[^#]*(#{1,10})[^#]*>$/', $objectName, $matches) !== 1) {
             return $base_name;
         }
 

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -1197,6 +1197,22 @@ class DbUtils extends DbTestCase
                 'expected'     => '_test_pc01',
                 'deprecated'   => true,
             ], [
+            // not existing on entity, with multibyte strings
+                'name'         => '<自動名稱測試_##>',
+                'field'       => 'name',
+                'is_template'  => true,
+                'itemtype'     => 'Computer',
+                'entities_id'  => 0,
+                'expected'     => '自動名稱測試_01'
+            ], [
+            // not existing on entity, with multibyte strings
+                'name'         => '<自動名稱—####—測試>',
+                'field'       => 'name',
+                'is_template'  => true,
+                'itemtype'     => 'Computer',
+                'entities_id'  => 0,
+                'expected'     => '自動名稱—0001—測試'
+            ], [
             //existing on entity
                 'name'         => '&lt;_test_pc##&gt;',
                 'field'       => 'name',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11721

Since #9723, `mbstring` extension is optional as we embed the corresponding polyfill in GLPI package.

Before GLPI 10, `autoName` was using `preg_match` instead of `mb_ereg` (see 2a2b34e8bee57d9c061549d73ad1afabc10748ef). I do not remember why I choosed to switch to `mb_ereg`, but it does not really make sense as the regex pattern does not contains any multi-byte char, and as replacements done in method are not using multi-byte functions.

I put back usage of `preg_match` and add a test on multy-byte strings. I also check that we are not using any other non implemented function (list is here: https://github.com/symfony/polyfill-mbstring/blob/9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e/Mbstring.php#L52).