### PR TITLE
Fix missing entity info

### DIFF
--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -47,11 +47,11 @@
    {% if item.getType() == 'Entity' and item.fields['id'] == 0 %}
       {% set entity_id = null %}
    {% else %}
-      {% set entity_id = params['entities_id'] ?? item.getEntityId() ?? session('glpiactive_entity') %}
+      {% set entity_id = params['entities_id'] ?? item.getEntityID() ?? session('glpiactive_entity') %}
    {% endif %}
 
    {% if is_multi_entities_mode() %}
-      {% set entity_name = get_item_name('Entity', item.getEntityId()) %}
+      {% set entity_name = get_item_name('Entity', item.getEntityID()) %}
    {% endif %}
 {% endif %}
 

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -47,11 +47,11 @@
    {% if item.getType() == 'Entity' and item.fields['id'] == 0 %}
       {% set entity_id = null %}
    {% else %}
-      {% set entity_id = params['entities_id'] ?? item.fields['entities_id'] ?? session('glpiactive_entity') %}
+      {% set entity_id = params['entities_id'] ?? item.getEntityId() ?? session('glpiactive_entity') %}
    {% endif %}
 
    {% if is_multi_entities_mode() %}
-      {% set entity_name = get_item_name('Entity', item.fields['entities_id']) %}
+      {% set entity_name = get_item_name('Entity', item.getEntityId()) %}
    {% endif %}
 {% endif %}
 


### PR DESCRIPTION
Some items have an empty entity header:

![image](https://user-images.githubusercontent.com/42734840/171113361-7e736f58-c5f2-4849-90dd-0652815052dc.png)

This is because we are trying to load the `entities_id` fields on items that don't have it but still support entities.
For example, items that extends `CommonDBChild` may not have an `entities_id` field but they still support entities if their parent item does:

![image](https://user-images.githubusercontent.com/42734840/171113801-f96cc9a1-bb64-484a-a6b9-fd8874577acf.png)

The fix is to use the `getEntityID` method instead of reading the `entities_id` property.
This method will handle special cases like `CommonDBChild` and return the correct entity id.

After: 
![image](https://user-images.githubusercontent.com/42734840/171114019-4909dec7-c3d5-4525-944a-6be4d8d1d9ca.png)



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
