### PR TITLE
Force api init endpoint

### DIFF
--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -331,8 +331,6 @@ abstract class API
      */
     protected function killSession()
     {
-
-        $this->initEndpoint(false, __FUNCTION__);
         Session::destroy();
         return true;
     }
@@ -379,9 +377,6 @@ abstract class API
      */
     protected function changeActiveEntities($params = [])
     {
-
-        $this->initEndpoint();
-
         if (!isset($params['entities_id'])) {
             $entities_id = 'all';
         } else {
@@ -412,9 +407,6 @@ abstract class API
      */
     protected function getMyEntities($params = [])
     {
-
-        $this->initEndpoint();
-
         if (!isset($params['is_recursive'])) {
             $params['is_recursive'] = false;
         }
@@ -457,9 +449,6 @@ abstract class API
      */
     protected function getActiveEntities()
     {
-
-        $this->initEndpoint();
-
         $actives_entities = [];
         foreach (array_values($_SESSION['glpiactiveentities']) as $active_entity) {
             $actives_entities[] = ['id' => $active_entity];
@@ -486,9 +475,6 @@ abstract class API
      */
     protected function changeActiveProfile($params = [])
     {
-
-        $this->initEndpoint();
-
         if (!isset($params['profiles_id'])) {
             $this->returnError();
         }
@@ -512,9 +498,6 @@ abstract class API
      */
     protected function getMyProfiles()
     {
-
-        $this->initEndpoint();
-
         $myprofiles = [];
         foreach ($_SESSION['glpiprofiles'] as $profiles_id => $profile) {
            // append if of the profile into values
@@ -539,8 +522,6 @@ abstract class API
      */
     protected function getActiveProfile()
     {
-
-        $this->initEndpoint();
         return ["active_profile" => $_SESSION['glpiactiveprofile']];
     }
 
@@ -554,8 +535,6 @@ abstract class API
      */
     protected function getFullSession()
     {
-
-        $this->initEndpoint();
         return ['session' => $_SESSION];
     }
 
@@ -568,8 +547,6 @@ abstract class API
      */
     protected function getGlpiConfig()
     {
-        $this->initEndpoint();
-
         return ['cfg_glpi' => Config::getSafeConfig()];
     }
 
@@ -604,7 +581,6 @@ abstract class API
     {
         global $CFG_GLPI, $DB;
 
-        $this->initEndpoint();
         $itemtype = $this->handleDepreciation($itemtype);
 
        // default params
@@ -1098,7 +1074,6 @@ abstract class API
     {
         global $DB;
 
-        $this->initEndpoint();
         $itemtype = $this->handleDepreciation($itemtype);
 
        // default params
@@ -1406,8 +1381,6 @@ abstract class API
         $params = [],
         bool $check_depreciation = true
     ) {
-        $this->initEndpoint();
-
         if ($check_depreciation) {
             $itemtype = $this->handleDepreciation($itemtype);
         }
@@ -1569,7 +1542,6 @@ abstract class API
     {
         global $DEBUG_SQL;
 
-        $this->initEndpoint();
         $itemtype = $this->handleDepreciation($itemtype);
 
        // check rights
@@ -1813,7 +1785,6 @@ abstract class API
      */
     protected function createItems($itemtype, $params = [])
     {
-        $this->initEndpoint();
         $itemtype = $this->handleDepreciation($itemtype);
 
         $input    = isset($params['input']) ? $params["input"] : null;
@@ -1937,7 +1908,6 @@ abstract class API
      */
     protected function updateItems($itemtype, $params = [])
     {
-        $this->initEndpoint();
         $itemtype = $this->handleDepreciation($itemtype);
 
         $input    = isset($params['input']) ? $params["input"] : null;
@@ -2052,8 +2022,6 @@ abstract class API
      */
     protected function deleteItems($itemtype, $params = [])
     {
-
-        $this->initEndpoint();
         $itemtype = $this->handleDepreciation($itemtype);
 
         $default  = ['force_purge' => false,
@@ -2217,7 +2185,7 @@ abstract class API
      *
      * @return void
      */
-    private function initEndpoint($unlock_session = true, $endpoint = "")
+    protected function initEndpoint($unlock_session = true, $endpoint = "")
     {
 
         if ($endpoint === "") {
@@ -3060,9 +3028,7 @@ abstract class API
      */
     protected function userPicture($user_id)
     {
-        $this->initEndpoint();
-
-       // Try to load target user
+        // Try to load target user
         $user = new User();
         if (!$user->getFromDB($user_id)) {
             $this->returnError("Bad request: user with id '$user_id' not found");
@@ -3177,7 +3143,7 @@ abstract class API
         string $itemtype,
         bool $is_deleted = false
     ): array {
-       // Return massive actions for a given itemtype
+        // Return massive actions for a given itemtype
         $actions = MassiveAction::getAllMassiveActions($itemtype, $is_deleted);
         if ($actions === false) {
             $this->returnError(
@@ -3365,5 +3331,33 @@ abstract class API
         }
 
         $this->returnResponse($results, $code);
+    }
+
+    /**
+     * List of API ressources for which a valid session isn't required
+     *
+     * @return array
+     */
+    protected function getRessourcesAllowedWithoutSession(): array
+    {
+        return [
+            "initSession",
+            "lostPassword",
+        ];
+    }
+
+    /**
+     * List of API ressources that may write php session data
+     *
+     * @return array
+     */
+    protected function getRessourcesWithSessionWrite(): array
+    {
+        return [
+            "initSession",
+            "killSession",
+            "changeActiveEntities",
+            "changeActiveProfile",
+        ];
     }
 }

--- a/src/Api/APIRest.php
+++ b/src/Api/APIRest.php
@@ -137,7 +137,7 @@ class APIRest extends API
         }
 
         // Check API session unless blacklisted (init session, ...)
-        if (!in_array($resource, $this->getRessourcesAllowedWithoutSession())) {
+        if (!$is_inline_doc && !in_array($resource, $this->getRessourcesAllowedWithoutSession())) {
             $this->initEndpoint(true, $resource);
         }
 

--- a/src/Api/APIRest.php
+++ b/src/Api/APIRest.php
@@ -93,23 +93,23 @@ class APIRest extends API
     public function call()
     {
 
-       //parse http request and find parts
+        //parse http request and find parts
         $this->request_uri  = $_SERVER['REQUEST_URI'];
         $this->verb         = $_SERVER['REQUEST_METHOD'];
         $path_info          = (isset($_SERVER['PATH_INFO'])) ? str_replace("api/", "", trim($_SERVER['PATH_INFO'], '/')) : '';
         $this->url_elements = explode('/', $path_info);
 
-       // retrieve requested resource
+        // retrieve requested resource
         $resource      = trim(strval($this->url_elements[0]));
         $is_inline_doc = (strlen($resource) == 0) || ($resource == "api");
 
-       // Add headers for CORS
+        // Add headers for CORS
         $this->cors($this->verb);
 
-       // retrieve paramaters (in body, query_string, headers)
+        // retrieve paramaters (in body, query_string, headers)
         $this->parseIncomingParams($is_inline_doc);
 
-       // show debug if required
+        // show debug if required
         if (isset($this->parameters['debug'])) {
             $this->debug = $this->parameters['debug'];
             if (empty($this->debug)) {
@@ -121,79 +121,83 @@ class APIRest extends API
             }
         }
 
-       // retrieve session (if exist)
+        // retrieve session (if exist)
         $this->retrieveSession();
         $this->initApi();
         $this->manageUploadedFiles();
 
-       // retrieve param who permit session writing
+        // retrieve param who permit session writing
         if (isset($this->parameters['session_write'])) {
             $this->session_write = (bool)$this->parameters['session_write'];
         }
 
-       // inline documentation (api/)
+        // Do not unlock the php session for ressources that may handle it
+        if (in_array($resource, $this->getRessourcesWithSessionWrite())) {
+            $this->session_write = true;
+        }
+
+        // Check API session unless blacklisted (init session, ...)
+        if (!in_array($resource, $this->getRessourcesAllowedWithoutSession())) {
+            $this->initEndpoint(true, $resource);
+        }
+
+        // inline documentation (api/)
         if ($is_inline_doc) {
             $this->inlineDocumentation("apirest.md");
-        } else if ($resource === "initSession") {
-           // ## DECLARE ALL ENDPOINTS ##
-           // login into glpi
-            $this->session_write = true;
+        } elseif ($resource === "initSession") {
+            // ## DECLARE ALL ENDPOINTS ##
+            // login into glpi
             $this->returnResponse($this->initSession($this->parameters));
-        } else if ($resource === "killSession") {
-           // logout from glpi
-            $this->session_write = true;
+        } elseif ($resource === "killSession") {
+            // logout from glpi
             $this->returnResponse($this->killSession());
-        } else if ($resource === "changeActiveEntities") {
-           // change active entities
-            $this->session_write = true;
+        } elseif ($resource === "changeActiveEntities") {
+            // change active entities
             $this->returnResponse($this->changeActiveEntities($this->parameters));
-        } else if ($resource === "getMyEntities") {
-           // get all entities of logged user
+        } elseif ($resource === "getMyEntities") {
+            // get all entities of logged user
             $this->returnResponse($this->getMyEntities($this->parameters));
-        } else if ($resource === "getActiveEntities") {
-           // get curent active entity
+        } elseif ($resource === "getActiveEntities") {
+            // get curent active entity
             $this->returnResponse($this->getActiveEntities($this->parameters));
-        } else if ($resource === "changeActiveProfile") {
-           // change active profile
-            $this->session_write = true;
+        } elseif ($resource === "changeActiveProfile") {
+            // change active profile
             $this->returnResponse($this->changeActiveProfile($this->parameters));
-        } else if ($resource === "getMyProfiles") {
-           // get all profiles of current logged user
+        } elseif ($resource === "getMyProfiles") {
+            // get all profiles of current logged user
             $this->returnResponse($this->getMyProfiles($this->parameters));
-        } else if ($resource === "getActiveProfile") {
-           // get current active profile
+        } elseif ($resource === "getActiveProfile") {
+            // get current active profile
             $this->returnResponse($this->getActiveProfile($this->parameters));
-        } else if ($resource === "getFullSession") {
-           // get complete php session
+        } elseif ($resource === "getFullSession") {
+            // get complete php session
             $this->returnResponse($this->getFullSession($this->parameters));
-        } else if ($resource === "getGlpiConfig") {
-           // get complete php var $CFG_GLPI
+        } elseif ($resource === "getGlpiConfig") {
+            // get complete php var $CFG_GLPI
             $this->returnResponse($this->getGlpiConfig($this->parameters));
-        } else if ($resource === "listSearchOptions") {
-           // list searchOptions of an itemtype
+        } elseif ($resource === "listSearchOptions") {
+            // list searchOptions of an itemtype
             $itemtype = $this->getItemtype(1);
             $this->returnResponse($this->listSearchOptions($itemtype, $this->parameters));
-        } else if ($resource === "getMultipleItems") {
-           // get multiple items (with various itemtype)
+        } elseif ($resource === "getMultipleItems") {
+            // get multiple items (with various itemtype)
             $this->returnResponse($this->getMultipleItems($this->parameters));
-        } else if ($resource === "search") {
-           // Search on itemtype
-            $this->checkSessionToken();
-
+        } elseif ($resource === "search") {
+            // Search on itemtype
             $itemtype = $this->getItemtype(1, true, true);
-           //clean stdObjects in parameter
+            // clean stdObjects in parameter
             $params   = json_decode(json_encode($this->parameters), true);
-           //search
+            // search
             $response =  $this->searchItems($itemtype, $params);
 
-           //add pagination headers
+            // add pagination headers
             $additionalheaders                  = [];
             $additionalheaders["Accept-Range"]  = $itemtype . " " . Toolbox::get_max_input_vars();
             if ($response['totalcount'] > 0) {
                 $additionalheaders["Content-Range"] = $response['content-range'];
             }
 
-           // diffent http return codes for complete or partial response
+            // different http return codes for complete or partial response
             if ($response['count'] >= $response['totalcount']) {
                 $code = 200; // full content
             } else {
@@ -201,13 +205,13 @@ class APIRest extends API
             }
 
             $this->returnResponse($response, $code, $additionalheaders);
-        } else if ($resource === "lostPassword") {
+        } elseif ($resource === "lostPassword") {
             if ($this->verb != 'PUT' && $this->verb != 'PATCH') {
-               // forbid password reset when HTTP verb is not PUT or PATCH
+                // forbid password reset when HTTP verb is not PUT or PATCH
                 $this->returnError(__("Only HTTP verb PUT is allowed"));
             }
             $this->returnResponse($this->lostPassword($this->parameters));
-        } else if ($resource == 'getMassiveActions') {
+        } elseif ($resource == 'getMassiveActions') {
             $this->returnResponse(
                 $this->getMassiveActions(
                     $this->getItemtype(1, false, false),
@@ -215,7 +219,7 @@ class APIRest extends API
                     json_decode(json_encode($this->parameters), true)['is_deleted'] ?? false,
                 )
             );
-        } else if ($resource == "getMassiveActionParameters") {
+        } elseif ($resource == "getMassiveActionParameters") {
             $this->returnResponse(
                 $this->getMassiveActionParameters(
                     $this->getItemtype(1, false, false),
@@ -223,7 +227,7 @@ class APIRest extends API
                     json_decode(json_encode($this->parameters), true)['is_deleted'] ?? false,
                 )
             );
-        } else if ($resource == "applyMassiveAction") {
+        } elseif ($resource == "applyMassiveAction") {
            // Parse parameters
             $params = json_decode(json_encode($this->parameters), true);
             $ids = $params['ids'] ?? [];
@@ -238,10 +242,10 @@ class APIRest extends API
                 $ids,
                 $params['input'] ?? []
             );
-        } else if (preg_match('%user/(\d+)/picture%i', $path_info, $matches)) {
+        } elseif (preg_match('%user/(\d+)/picture%i', $path_info, $matches)) {
             $this->userPicture($matches[1]);
         } else {
-           // commonDBTM manipulation
+            // commonDBTM manipulation
             $itemtype          = $this->getItemtype(0);
             $id                = $this->getId();
             $additionalheaders = [];
@@ -259,22 +263,22 @@ class APIRest extends API
                             $additionalheaders['Last-Modified'] = gmdate("D, d M Y H:i:s", $datemod) . " GMT";
                         }
                     } else {
-                     // return collection of items
+                        // return collection of items
                         $totalcount = 0;
                         $response = $this->getItems($itemtype, $this->parameters, $totalcount);
 
-                     //add pagination headers
+                        //add pagination headers
                         $range = [0, $_SESSION['glpilist_limit']];
                         if (isset($this->parameters['range'])) {
                             $range = explode("-", $this->parameters['range']);
                         }
 
-                     // fix end range
+                        // fix end range
                         if ($range[1] > $totalcount - 1) {
                             $range[1] = $totalcount - 1;
                         }
 
-                   // trigger partial content return code
+                        // trigger partial content return code
                         if ($range[1] - $range[0] + 1 < $totalcount) {
                             $code = 206; // partial content
                         }
@@ -293,7 +297,7 @@ class APIRest extends API
                         // add a location targetting created element
                         $additionalheaders['location'] = self::$api_url . "/$itemtype/" . $response['id'];
                     } else {
-                       // add a link header targetting created elements
+                        // add a link header targetting created elements
                         $additionalheaders['link'] = "";
                         foreach ($response as $created_item) {
                             if ($created_item['id']) {
@@ -301,7 +305,7 @@ class APIRest extends API
                                                      $created_item['id'] . ",";
                             }
                         }
-                       // remove last comma
+                        // remove last comma
                         $additionalheaders['link'] = trim($additionalheaders['link'], ",");
                     }
                     break;
@@ -311,7 +315,7 @@ class APIRest extends API
                     if (!isset($this->parameters['input'])) {
                         $this->messageBadArrayError();
                     }
-                   // if id is passed by query string, add it into input parameter
+                    // if id is passed by query string, add it into input parameter
                     $input = (array) ($this->parameters['input']);
                     if (
                         ($id > 0 || $id == 0 && $itemtype == "Entity")
@@ -323,9 +327,9 @@ class APIRest extends API
                     break;
 
                 case "DELETE": //delete item(s)
-                   // if id is passed by query string, construct an object with it
+                    // if id is passed by query string, construct an object with it
                     if ($id !== false) {
-                       //override input
+                        // override input
                         $this->parameters['input']     = new stdClass();
                         $this->parameters['input']->id = $id;
                     }

--- a/src/Api/APIXmlrpc.php
+++ b/src/Api/APIXmlrpc.php
@@ -82,7 +82,7 @@ class APIXmlrpc extends API
         $code = 200;
 
         // Do not unlock the php session for ressources that may handle it
-        if (in_array($resource, $this->getRessourcesAllowedWithoutSession())) {
+        if (in_array($resource, $this->getRessourcesWithSessionWrite())) {
             $this->session_write = true;
         }
 

--- a/src/Api/APIXmlrpc.php
+++ b/src/Api/APIXmlrpc.php
@@ -75,50 +75,56 @@ class APIXmlrpc extends API
 
         $resource = $this->parseIncomingParams();
 
-       // retrieve session (if exist)
+        // retrieve session (if exist)
         $this->retrieveSession();
         $this->initApi();
 
         $code = 200;
 
+        // Do not unlock the php session for ressources that may handle it
+        if (in_array($resource, $this->getRessourcesAllowedWithoutSession())) {
+            $this->session_write = true;
+        }
+
+        // Check API session unless blacklisted (init session, ...)
+        if (!in_array($resource, $this->getRessourcesAllowedWithoutSession())) {
+            $this->initEndpoint(true, $resource);
+        }
+
         if ($resource === "initSession") {
-            $this->session_write = true;
             $this->returnResponse($this->initSession($this->parameters));
-        } else if ($resource === "killSession") { // logout from glpi
-            $this->session_write = true;
+        } elseif ($resource === "killSession") { // logout from glpi
             $this->returnResponse($this->killSession());
-        } else if ($resource === "changeActiveEntities") { // change active entities
-            $this->session_write = true;
+        } elseif ($resource === "changeActiveEntities") { // change active entities
             $this->returnResponse($this->changeActiveEntities($this->parameters));
-        } else if ($resource === "getMyEntities") { // get all entities of logged user
+        } elseif ($resource === "getMyEntities") { // get all entities of logged user
             $this->returnResponse($this->getMyEntities($this->parameters));
-        } else if ($resource === "getActiveEntities") { // get curent active entity
+        } elseif ($resource === "getActiveEntities") { // get curent active entity
             $this->returnResponse($this->getActiveEntities($this->parameters));
-        } else if ($resource === "changeActiveProfile") { // change active profile
-            $this->session_write = true;
+        } elseif ($resource === "changeActiveProfile") { // change active profile
             $this->returnResponse($this->changeActiveProfile($this->parameters));
-        } else if ($resource === "getMyProfiles") { // get all profiles of current logged user
+        } elseif ($resource === "getMyProfiles") { // get all profiles of current logged user
             $this->returnResponse($this->getMyProfiles($this->parameters));
-        } else if ($resource === "getActiveProfile") { // get current active profile
+        } elseif ($resource === "getActiveProfile") { // get current active profile
             $this->returnResponse($this->getActiveProfile($this->parameters));
-        } else if ($resource === "getFullSession") { // get complete php session
+        } elseif ($resource === "getFullSession") { // get complete php session
             $this->returnResponse($this->getFullSession($this->parameters));
-        } else if ($resource === "getGlpiConfig") { // get complete php var $CFG_GLPI
+        } elseif ($resource === "getGlpiConfig") { // get complete php var $CFG_GLPI
             $this->returnResponse($this->getGlpiConfig($this->parameters));
-        } else if ($resource === "getMultipleItems") { // get multiple items (with various itemtype)
+        } elseif ($resource === "getMultipleItems") { // get multiple items (with various itemtype)
             $this->returnResponse($this->getMultipleItems($this->parameters));
-        } else if ($resource === "listSearchOptions") { // list searchOptions of an itemtype
+        } elseif ($resource === "listSearchOptions") { // list searchOptions of an itemtype
             $this->returnResponse($this->listSearchOptions(
                 $this->parameters['itemtype'],
                 $this->parameters
             ));
-        } else if ($resource === "search") { // Search on itemtype
+        } elseif ($resource === "search") { // Search on itemtype
             $this->checkSessionToken();
 
-           //search
+            // search
             $response =  $this->searchItems($this->parameters['itemtype'], $this->parameters);
 
-           //add pagination headers
+            // add pagination headers
             $additionalheaders                  = [];
             $additionalheaders["Accept-Range"]  = $this->parameters['itemtype'] . " "
                                                . Toolbox::get_max_input_vars();
@@ -126,23 +132,23 @@ class APIXmlrpc extends API
                 $additionalheaders["Content-Range"] = $response['content-range'];
             }
 
-           // diffent http return codes for complete or partial response
+            // different http return codes for complete or partial response
             if ($response['count'] < $response['totalcount']) {
                 $code = 206; // partial content
             }
 
             $this->returnResponse($response, $code, $additionalheaders);
-        } else if ($resource === "lostPassword") {
+        } elseif ($resource === "lostPassword") {
             $this->returnResponse($this->lostPassword($this->parameters));
-        } else if (
+        } elseif (
             in_array(
                 $resource,
                 ["getItem", "getItems", "createItems", "updateItems", "deleteItems"]
             )
         ) {
-           // commonDBTM manipulation
+            // commonDBTM manipulation
 
-           // check itemtype parameter
+            // check itemtype parameter
             if (!isset($this->parameters['itemtype'])) {
                 $this->returnError(__("missing itemtype"), 400, "ITEMTYPE_RESOURCE_MISSING");
             }
@@ -155,8 +161,8 @@ class APIXmlrpc extends API
                     400,
                     "ERROR_ITEMTYPE_NOT_FOUND_NOR_COMMONDBTM"
                 );
-            } else if ($resource === "getItem") { // get an CommonDBTM item
-               // check id parameter
+            } elseif ($resource === "getItem") { // get an CommonDBTM item
+                // check id parameter
                 if (!isset($this->parameters['id'])) {
                     $this->returnError(__("missing id"), 400, "ID_RESOURCE_MISSING");
                 }
@@ -169,8 +175,8 @@ class APIXmlrpc extends API
                     $additionalheaders['Last-Modified'] = gmdate("D, d M Y H:i:s", $datemod) . " GMT";
                 }
                 $this->returnResponse($response, 200, $additionalheaders);
-            } else if ($resource === "getItems") { // get a collection of a CommonDBTM item
-               // return collection of items
+            } elseif ($resource === "getItems") { // get a collection of a CommonDBTM item
+                // return collection of items
                 $totalcount = 0;
                 $response = $this->getItems($this->parameters['itemtype'], $this->parameters, $totalcount);
 
@@ -180,12 +186,12 @@ class APIXmlrpc extends API
                     $range = explode("-", $this->parameters['range']);
                 }
 
-               // fix end range
+                // fix end range
                 if ($range[1] > $totalcount - 1) {
                     $range[1] = $totalcount - 1;
                 }
 
-               // trigger partial content return code
+                // trigger partial content return code
                 if ($range[1] - $range[0] + 1 < $totalcount) {
                     $code = 206; // partial content
                 }
@@ -198,15 +204,15 @@ class APIXmlrpc extends API
                 }
 
                 $this->returnResponse($response, $code, $additionalheaders);
-            } else if ($resource === "createItems") { // create one or many CommonDBTM items
+            } elseif ($resource === "createItems") { // create one or many CommonDBTM items
                 $response = $this->createItems($this->parameters['itemtype'], $this->parameters);
 
                 $additionalheaders = [];
                 if (isset($response['id'])) {
-                   // add a location targetting created element
+                    // add a location targetting created element
                     $additionalheaders['location'] = self::$api_url . "/" . $this->parameters['itemtype'] . "/" . $response['id'];
                 } else {
-                  // add a link header targetting created elements
+                    // add a link header targetting created elements
                     $additionalheaders['link'] = "";
                     foreach ($response as $created_item) {
                         if ($created_item['id']) {
@@ -214,18 +220,18 @@ class APIXmlrpc extends API
                                                   "/" . $created_item['id'] . ",";
                         }
                     }
-                  // remove last comma
+                    // remove last comma
                     $additionalheaders['link'] = trim($additionalheaders['link'], ",");
                 }
                 $this->returnResponse($response, 201);
-            } else if ($resource === "updateItems") { // update one or many CommonDBTM items
+            } elseif ($resource === "updateItems") { // update one or many CommonDBTM items
                 $this->returnResponse($this->updateItems(
                     $this->parameters['itemtype'],
                     $this->parameters
                 ));
-            } else if ($resource === "deleteItems") { // delete one or many CommonDBTM items
+            } elseif ($resource === "deleteItems") { // delete one or many CommonDBTM items
                 if (isset($this->parameters['id'])) {
-                   //override input
+                    // override input
                     $this->parameters['input'] = new \stdClass();
                     $this->parameters['input']->id = $this->parameters['id'];
                 }


### PR DESCRIPTION
Instead of having to run `$this->initEndpoint()` for every endpoint expect `initSession` and `lostPassword`, it is now executed automatically unless the target resources is defined in  `API::getRessourcesAllowedWithoutSession()`.

Resources that may modify session data must also be defined in `API::getRessourcesWithSessionWrite()` as a specific flag must be set before running `$this->initEndpoint()`.

Also contains some CS fix (`elseif` + missaligned comments).

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
