### PR TITLE
Show public reminders by self on Central

### DIFF
--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -933,11 +933,6 @@ class Reminder extends CommonDBVisible implements
                 self::getVisibilityCriteria()
             );
 
-           // Only personal on central so do not keep it
-            if (Session::getCurrentInterface() == 'central') {
-                $criteria['WHERE']['glpi_reminders.users_id'] = ['<>', $users_id];
-            }
-
             if (Session::getCurrentInterface() != 'helpdesk') {
                 $titre = "<a href=\"" . $CFG_GLPI["root_doc"] . "/front/reminder.php\">" .
                        _n('Public reminder', 'Public reminders', Session::getPluralNumber()) . "</a>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Ref #10654

If a public reminder was created by the current user, it would never show on the public reminders central widget. Instead, it would only show on the personal reminders widget.

This PR allows those public reminders to appear in the public reminders widget.
It does not handle filtering those public reminders from the personal reminders list.

Another PR was made to handle which reminders are shown in each widget.
This PR targets 10.0.1 while the other targets 10.1.0 as it was more likely to cause issues (query changes).