### PR TITLE
Keep only <body> content on collected emails

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1739,7 +1739,14 @@ class MailCollector extends CommonDBTM
             if ($content_type->getType() == 'text/html') {
                 $this->body_is_html = true;
                 $content = $this->getDecodedContent($part);
-               //do not check for text part if we found html one.
+
+                // Keep only HTML body content
+                $body_matches = [];
+                if (preg_match('/<body>\s*(?<body>.+?)\s*<\/body>/is', $content, $body_matches) === 1) {
+                    $content = $body_matches['body'];
+                }
+
+                // do not check for text part if we found html one.
                 break;
             }
             if ($content_type->getType() == 'text/plain' && $content === null) {

--- a/tests/emails-tests/31-html-without-body.eml
+++ b/tests/emails-tests/31-html-without-body.eml
@@ -1,0 +1,10 @@
+Date: Thu, 7 Jun 2018 12:05:51 +0200 (CEST)
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <1695134010.1757889.1528365951040.JavaMail.zimbra@glpi-project.org>
+Subject: 31 - HTML message without body
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+This HTML message does not have a <i>body</i> tag.

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -696,6 +696,7 @@ class MailCollector extends DbTestCase
                     '26 Illegal char in body',
                     '28 Multiple attachments no extension',
                     '30 - &#60;GLPI&#62; Special &#38; chars',
+                    '31 - HTML message without body',
                 ]
             ],
          // Mails having "normal" user as observer (add_cc_to_observer = true)
@@ -722,25 +723,19 @@ Best regards,
 PLAINTEXT,
          // HTML on multi-part email
             'Re: [GLPI #0038927] Update - Issues with new Windows 10 machine' => <<<HTML
-<html>
-<body>
 <p>This message have reply to header, requester should be get from this header.</p>
-</body>
-</html>
 HTML,
             'Mono-part HTML message' => <<<HTML
-<html>
-<body>
 <p>This HTML message does not use <strong>"multipart/alternative"</strong> format.</p>
-</body>
-</html>
 HTML,
             '26 Illegal char in body' => <<<PLAINTEXT
 这是很坏的Minus C Blabla
 PLAINTEXT,
             '28 Multiple attachments no extension' => <<<HTML
-
-<HTML><BODY><div>&nbsp;</div><div>Test</div><div>&nbsp;</div></BODY></HTML>
+<div>&nbsp;</div><div>Test</div><div>&nbsp;</div>
+HTML,
+            '31 - HTML message without body' => <<<HTML
+This HTML message does not have a <i>body</i> tag.
 HTML,
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11349

Some application may generate HTML emails that does not respect the HTML doctype.
For instance, following cases may happen:
 - root tag is `body` (it should be `html`);
 - `<body>` tag contains a text node that is not embed in a block node (e.g. `<body>This text should be in a "div" or a "p" tag</body>`;
 - there is no `<body>` tag;
 - ...

However, we should only keep the "real" content, i.e. the content of the `<body>` tag, and this is what is done by proposed changes. Also, to be sure that malformed HTML will still be handled properly, if `<body>` tag is missing, the whole HTML is preserved.