### PR TITLE
Paginate cartridge lists

### DIFF
--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -724,6 +724,12 @@ class Cartridge extends CommonDBRelation
         if (!$cartitem->can($tID, READ)) {
             return false;
         }
+        if (isset($_GET["start"])) {
+            $start = $_GET["start"];
+        } else {
+            $start = 0;
+        }
+
         $canedit = $cartitem->can($tID, UPDATE);
 
         $where = ['glpi_cartridges.cartridgeitems_id' => $tID];
@@ -749,6 +755,12 @@ class Cartridge extends CommonDBRelation
         $pages_printed    = 0;
         $nb_pages_printed = 0;
 
+        $total_number = countElementsInTable(
+            self::getTable(),
+            [
+                'WHERE'     => $where
+            ]
+        );
         $iterator = $DB->request([
             'SELECT' => [
                 'glpi_cartridges.*',
@@ -766,12 +778,16 @@ class Cartridge extends CommonDBRelation
                 ]
             ],
             'WHERE'     => $where,
-            'ORDER'     => $order
+            'ORDER'     => $order,
+            'START'     => (int) $start,
+            'LIMIT'     => (int) $_SESSION['glpilist_limit']
         ]);
 
         $number = count($iterator);
 
         echo "<div class='spaced'>";
+        // Display the pager
+        Html::printAjaxPager(Consumable::getTypeName(Session::getPluralNumber()), $start, $total_number);
         if ($canedit && $number) {
             $rand = mt_rand();
             Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |

Partially addresses performance issues reported in #11773.
I'm not sure why this wasn't already paginated as the consumable lists were already paginated.