### PR TITLE
Handle translator exceptions

### DIFF
--- a/front/locale.php
+++ b/front/locale.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\ErrorHandler;
+
 $_GET['donotcheckversion']   = true;
 $dont_check_maintenance_mode = true;
 
@@ -68,7 +70,13 @@ $default_response = json_encode(
 );
 
 // Get messages from translator component
-$messages = $TRANSLATE->getAllMessages($_GET['domain']);
+$messages = null;
+try {
+    $messages = $TRANSLATE->getAllMessages($_GET['domain']);
+} catch (\Throwable $e) {
+    // Error may happen when overrided translation files does not use same plural rules as GLPI.
+    ErrorHandler::getInstance()->handleException($e, true);
+}
 if (!($messages instanceof \Laminas\I18n\Translator\TextDomain)) {
    // No TextDomain found means that there is no translations for given domain.
    // It is mostly related to plugins that does not provide any translations.

--- a/inc/autoload.function.php
+++ b/inc/autoload.function.php
@@ -124,15 +124,23 @@ function __($str, $domain = 'glpi')
 {
     global $TRANSLATE;
 
-    if (is_null($TRANSLATE)) { // before login
-        return $str;
+    $trans = null;
+
+    if ($TRANSLATE !== null) {
+        try {
+            $trans = $TRANSLATE->translate($str, $domain);
+
+            if (is_array($trans)) {
+                // Wrong call when plural defined
+                $trans = $trans[0];
+            }
+        } catch (\Throwable $e) {
+            // Error may happen when overrided translation files does not use same plural rules as GLPI.
+            // Silently fail to not flood error log.
+        }
     }
-    $trans = $TRANSLATE->translate($str, $domain);
-   // Wrong call when plural defined
-    if (is_array($trans)) {
-        return $trans[0];
-    }
-    return  $trans;
+
+    return $trans ?? $str;
 }
 
 
@@ -185,15 +193,18 @@ function _n($sing, $plural, $nb, $domain = 'glpi')
 {
     global $TRANSLATE;
 
-    if (is_null($TRANSLATE)) { // before login
-        if ($nb == 0 || $nb > 1) {
-            return $plural;
-        } else {
-            return $sing;
+    $trans = null;
+
+    if ($TRANSLATE !== null) {
+        try {
+            $trans = $TRANSLATE->translatePlural($sing, $plural, $nb, $domain);
+        } catch (\Throwable $e) {
+            // Error may happen when overrided translation files does not use same plural rules as GLPI.
+            // Silently fail to not flood error log.
         }
     }
 
-    return $TRANSLATE->translatePlural($sing, $plural, $nb, $domain);
+    return $trans ?? (($nb == 0 || $nb > 1) ? $plural : $sing);
 }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Recently, transifex updated plural rules for many languages (see https://docs.transifex.com/whats-new/all#section-may-2022).

Problem is that locales overrides (using #5907 feature or generated by `localeoverride` plugin) may use previous plural rules. In this case, translator component will trigger an exception, and GLPI will be unusable.

With proposed changes, exception will be catched and a log entry will be generated (see below). Thus, I do not understand why, but it seems that the base GLPI translations are still working, so only overrides are not taken into account.

```
==> files/_log/php-errors.log <==
[2022-06-02 07:56:41] glpiphplog.CRITICAL:   *** Uncaught Exception Laminas\I18n\Exception\RuntimeException: Plural rule of merging text domain is not compatible with the current one in /var/www/glpi/vendor/laminas/laminas-i18n/src/Translator/TextDomain.php at line 94
  Backtrace :
  .../laminas-i18n/src/Translator/Translator.php:736 Laminas\I18n\Translator\TextDomain->merge()
  .../laminas-i18n/src/Translator/Translator.php:612 Laminas\I18n\Translator\Translator->loadMessagesFromFiles()
  .../laminas-i18n/src/Translator/Translator.php:762 Laminas\I18n\Translator\Translator->loadMessages()
  front/locale.php:75                                Laminas\I18n\Translator\Translator->getAllMessages()
```