### PR TITLE
delete ticket button may show when no right to delete

### DIFF
--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -104,7 +104,7 @@
          {% else %}
 
             <div class="btn-group" role="group">
-               {% if item.canDelete() %}
+               {% if item.canDeleteItem() %}
                   {% if item.isDeleted() %}
                      <button class="btn btn-outline-secondary" type="submit" name="restore" form="itil-form"
                            title="{{ _x('button', 'Restore') }}">


### PR DESCRIPTION
As a self service user, create a ticket. Add a followup. When a ticket has a followup, the self-service user is no longer allowed to delete the ticket. However the delete button is visible. Clicking on it leads to an error message .

![image](https://user-images.githubusercontent.com/14139801/171598830-d7f643a1-9aa0-44d8-b57f-37d8883c0343.png)


![image](https://user-images.githubusercontent.com/14139801/171598858-ded07fc4-45b5-4797-9607-1fd7bb5f915e.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
