### PR TITLE
Add plugin activate and deactivate hooks handling

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -873,6 +873,11 @@ class Plugin extends CommonDBTM
 
             $function = 'plugin_' . $this->fields['directory'] . '_check_config';
             if (!function_exists($function) || $function()) {
+                $activate_function = 'plugin_' . $this->fields['directory'] . '_activate';
+                if (function_exists($activate_function)) {
+                    $activate_function();
+                }
+
                 $this->update(['id'    => $ID,
                     'state' => self::ACTIVATED
                 ]);
@@ -937,6 +942,11 @@ class Plugin extends CommonDBTM
     {
 
         if ($this->getFromDB($ID)) {
+            $deactivate_function = 'plugin_' . $this->fields['directory'] . '_deactivate';
+            if (function_exists($deactivate_function)) {
+                $deactivate_function();
+            }
+
             $this->update([
                 'id'    => $ID,
                 'state' => self::NOTACTIVATED


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Plugins may want to be able to do a specific action when they are activate/deactivated, and there currently no simple way to do it.
