### PR TITLE
Prevent htmlawed to trasnform deprecated attributes into styles

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -311,12 +311,13 @@ class Toolbox
     public static function getHtmLawedSafeConfig(): array
     {
         $config = [
-            'elements'         => '* -applet -canvas -embed -form -object -script -link',
-            'deny_attribute'   => 'on*, srcdoc',
-            'comment'          => 1, // 1: remove HTML comments (and do not display their contents)
-            'cdata'            => 1, // 1: remove CDATA sections (and do not display their contents)
-            'direct_list_nest' => 1, // 1: Allow usage of ul/ol tags nested in other ul/ol tags
-            'schemes'          => '*: aim, app, feed, file, ftp, gopher, http, https, irc, mailto, news, nntp, sftp, ssh, tel, telnet, notes'
+            'elements'           => '* -applet -canvas -embed -form -object -script -link',
+            'deny_attribute'     => 'on*, srcdoc',
+            'comment'            => 1, // 1: remove HTML comments (and do not display their contents)
+            'cdata'              => 1, // 1: remove CDATA sections (and do not display their contents)
+            'direct_list_nest'   => 1, // 1: Allow usage of ul/ol tags nested in other ul/ol tags
+            'schemes'            => '*: aim, app, feed, file, ftp, gopher, http, https, irc, mailto, news, nntp, sftp, ssh, tel, telnet, notes',
+            'no_deprecated_attr' => 0, // 0: do not transform deprecated HTML attributes
         ];
         if (!GLPI_ALLOW_IFRAME_IN_RICH_TEXT) {
             $config['elements'] .= '-iframe';

--- a/tests/units/Glpi/RichText/RichText.php
+++ b/tests/units/Glpi/RichText/RichText.php
@@ -317,6 +317,14 @@ HTML,
 </div>
 HTML,
         ];
+
+        // Deprecated html attibutes should not be transformed into styles
+        // see #11580
+        yield [
+            'content'                => '<table width=0 align="left" cellspacing=10 style="width: 100%;"><tr><td>Test</td></tr></table>',
+            'encode_output_entities' => false,
+            'expected_result'        => '<table width="0" align="left" cellspacing="10" style="width: 100%;"><tr><td>Test</td></tr></table>',
+        ];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11580

Looks like Microsoft Outlook 2016 produces inconsistent table declaration, with both `width="0"` attribute and `style="width:346.9pt;"` attribute: `<table class="Tabellenraster1" border="0" cellspacing="0" cellpadding="0" width="0" style="width:346.9pt;border-collapse:collapse;border:none">`.

By default, `htmlawed` transform deprecated attributes into, mainly, styles, and result was `style="width:346.9pt; width:0px;"` and expected width was overriden by 0.

IMHO, we should disable this transformation. It is not our responsability to handle the fact that source of ticket (email client, external app using API, ...) produces HTML with deprecated attributes/elements. I am pretty comfortable to explain that GLPI does not transform those deprecated stuffs, but I am less comfortable to explain that #11580 behaviour is an accepted side effect. Thus, I guess any other library that would be used to replace `htmlawed` in the future would not handle this transformation.