### PR TITLE
fix(ldap): force delete policy to be applied

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -5036,11 +5036,6 @@ HTML;
         $myuser = new self();
         $myuser->getFromDB($users_id);
 
-       //User is already considered as delete from ldap
-        if ($myuser->fields['is_deleted_ldap'] == 1) {
-            return;
-        }
-
         switch ($CFG_GLPI['user_deleted_ldap']) {
            //DO nothing
             default:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23730

It may happen that you want to change the policy for managing "not found" (or deleted) users in LDAP directories, example from "DELETED_USER_DISABLE" to "DELETED_USER_DISABLEANDWITHDRAWDYNINFO".

Example steps:
- Policy set to "DELETED_USER_DISABLE"
- LDAP synchronization > disable users not found
- Change policy and put "DELETED_USER_DISABLEANDWITHDRAWDYNINFO"
- The second synchronization will not delete the profiles / groups of the users, even if I explicitly asked to do so.

