### PR TITLE
fix(planning): multiple guests

### DIFF
--- a/src/PlanningExternalEvent.php
+++ b/src/PlanningExternalEvent.php
@@ -267,10 +267,8 @@ JAVASCRIPT;
         User::dropdown([
             'name'          => 'users_id_guests[]',
             'right'         => 'all',
-            'values'        => $this->fields['users_id_guests'],
-            'specific_tags' => [
-                'multiple' => true
-            ],
+            'value'         => $this->fields['users_id_guests'],
+            'multiple'      => true,
         ]);
         echo "<div style='font-style: italic'>" .
             __("Each guest will have a read-only copy of this event") .


### PR DESCRIPTION
The "Guests" field no longer allowed multiple users to be added.

![image](https://user-images.githubusercontent.com/8530352/171864072-673c2f2d-4d75-4fea-95ac-93c380ea2ef3.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24165
