### PR TITLE
Fix adding actors to ITIL Objects

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1255,16 +1255,38 @@ class Ticket extends CommonITILObject
         $actortypes = ['user','group','supplier'];
         foreach ($usertypes as $t) {
             foreach ($actortypes as $a) {
-                if (isset($input['_' . $a . 's_id_' . $t])) {
+                $k = '_' . $a . 's_id_' . $t;
+                if (isset($input[$k])) {
                     switch ($a) {
                         case 'user':
-                             $additionalfield           = '_additional_' . $t . 's';
-                             $input[$additionalfield][] = ['users_id' => $input['_' . $a . 's_id_' . $t]];
+                            $additionalfield           = '_additional_' . $t . 's';
+                            if (!isset($input[$additionalfield])) {
+                                $input[$additionalfield] = [];
+                            }
+                            if (!isset($input[$additionalfield]['users_id'])) {
+                                $input[$additionalfield]['users_id'] = [];
+                            }
+                            if (!is_array($input[$k])) {
+                                $input[$k] = [$input[$k]];
+                            }
+                            if (!is_array($input[$additionalfield]['users_id'])) {
+                                $input[$additionalfield]['users_id'] = [$input[$additionalfield]['users_id']];
+                            }
+                            $input[$additionalfield]['users_id'] = array_merge($input[$additionalfield]['users_id'] ?? [], $input[$k] ?? []);
                             break;
 
                         default:
                             $additionalfield           = '_additional_' . $a . 's_' . $t . 's';
-                            $input[$additionalfield][] = $input['_' . $a . 's_id_' . $t];
+                            if (!isset($input[$additionalfield])) {
+                                $input[$additionalfield] = [];
+                            }
+                            if (!is_array($input[$k])) {
+                                $input[$k] = [$input[$k]];
+                            }
+                            if (!is_array($input[$additionalfield])) {
+                                $input[$additionalfield] = [$input[$additionalfield]];
+                            }
+                            $input[$additionalfield] = array_merge($input[$additionalfield] ?? [], $input[$k] ?? []);
                             break;
                     }
                 }

--- a/tests/functionnal/RuleTicket.php
+++ b/tests/functionnal/RuleTicket.php
@@ -2440,11 +2440,36 @@ class RuleTicket extends DbTestCase
             ])
         )->isFalse();
 
+        $user2 = new \User();
+        $user_id2 = $user2->add($user_input2 = [
+            "name" => "user2",
+        ]);
+        $this->checkInput($user2, $user_id2, $user_input2);
+
         // Test updating ticket
-        $this->boolean($ticket->update(['id' => $tickets_id, 'content' => 'test2']))->isTrue();
+        $this->boolean($ticket->update([
+            'id' => $tickets_id,
+            'content' => 'test2',
+            '_actors' => [
+                'requester' => [
+                    [
+                        'itemtype' => 'User',
+                        'items_id' => $user_id2,
+                    ]
+                ]
+            ]
+        ]))->isTrue();
         $result = $ticketUser->getFromDBByCrit([
             'tickets_id'    => $tickets_id,
             'users_id'      => $user_id,
+            'type'          => \CommonITILActor::REQUESTER
+        ]);
+        $this->boolean($result)->isTrue();
+
+        // Ensure existing user is still there
+        $result = $ticketUser->getFromDBByCrit([
+            'tickets_id'    => $tickets_id,
+            'users_id'      => $user_id2,
             'type'          => \CommonITILActor::REQUESTER
         ]);
         $this->boolean($result)->isTrue();
@@ -2524,11 +2549,37 @@ class RuleTicket extends DbTestCase
             ])
         )->isFalse();
 
+        $group2 = new \Group();
+        $group_id2 = $group2->add($group_input2 = [
+            "name" => "group2",
+            "is_requester" => true
+        ]);
+        $this->checkInput($group2, $group_id2, $group_input2);
+
         // Test updating ticket
-        $this->boolean($ticket->update(['id' => $tickets_id, 'content' => 'test2']))->isTrue();
+        $this->boolean($ticket->update([
+            'id' => $tickets_id,
+            'content' => 'test2',
+            '_actors' => [
+                'requester' => [
+                    [
+                        'itemtype' => 'Group',
+                        'items_id' => $group_id2,
+                    ]
+                ]
+            ]
+        ]))->isTrue();
         $result = $ticketGroup->getFromDBByCrit([
             'tickets_id'         => $tickets_id,
             'groups_id'          => $group_id1,
+            'type'               => \CommonITILActor::REQUESTER
+        ]);
+        $this->boolean($result)->isTrue();
+
+        // Ensure existing group is still there
+        $result = $ticketGroup->getFromDBByCrit([
+            'tickets_id'         => $tickets_id,
+            'groups_id'          => $group_id2,
             'type'               => \CommonITILActor::REQUESTER
         ]);
         $this->boolean($result)->isTrue();

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -4509,4 +4509,69 @@ HTML
         $this->integer($ticket->fields['status'])->isEqualTo(\Ticket::ASSIGNED);
         $this->boolean((bool)$ticket->needReopen())->isFalse();
     }
+
+    protected function prepareInputForUpdateHandleActorChangesProvider()
+    {
+        return [
+            [
+                'input' => [
+                    '_additional_requesters' => [
+                        'users_id' => 1
+                    ],
+                    '_users_id_requester' => 2,
+                    '_additional_observers' => [
+                        'users_id'  => 1
+                    ],
+                    '_users_id_observer'  => 3,
+                    '_users_id_assign'    => 4,
+                    '_additional_groups_assigns' => [1],
+                    '_groups_id_assign'      => [2],
+                    '_suppliers_id_assign'      => [4],
+                ],
+                'changes' => [
+                    '_additional_requesters' => [
+                        'users_id' => ['1', '2'],
+                    ],
+                    '_additional_observers' => [
+                        'users_id' => ['1', '3'],
+                    ],
+                    '_additional_assigns' => [
+                        'users_id' => ['4'],
+                    ],
+                    '_additional_groups_assigns' => [
+                        '1', '2'
+                    ],
+                    '_additional_suppliers_assigns' => [
+                        '4'
+                    ],
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider prepareInputForUpdateHandleActorChangesProvider
+     */
+    public function testPrepareInputForUpdateHandleActorChanges($input, $changes)
+    {
+        $this->login();
+        $ticket = new \Ticket();
+        $ticket->fields = [
+            'id' => 45645, //Random
+            'name'  => __FUNCTION__,
+            'content' => __FUNCTION__,
+            'status' => \CommonITILObject::ASSIGNED,
+            'users_id_recipient' => getItemByTypeName('User', TU_USER, true),
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+            'itilcategories_id' => getItemByTypeName('ITILCategory', '_test_category_1', true),
+        ];
+        $input = array_merge($ticket->fields, $input);
+        $result = $ticket->prepareInputForUpdate($input);
+
+        $this->array($result['_additional_requesters'])->isEqualTo($changes['_additional_requesters']);
+        $this->array($result['_additional_observers'])->isEqualTo($changes['_additional_observers']);
+        $this->array($result['_additional_assigns'])->isEqualTo($changes['_additional_assigns']);
+        $this->array($result['_additional_groups_assigns'])->isEqualTo($changes['_additional_groups_assigns']);
+        $this->array($result['_additional_suppliers_assigns'])->isEqualTo($changes['_additional_suppliers_assigns']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11796

Fix bug that prevented adding any actors to ITIL Objects if you have business rules. For 10.0, this means just Ticket rules.