### PR TITLE
Fix add column button tag and role

### DIFF
--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -523,7 +523,7 @@ class GLPIKanbanRights {
             $("<select name='kanban-board-switcher'></select>").appendTo(toolbar);
             let filter_input = $(`<input name='filter' class='form-control ms-1' type='text' placeholder="${__('Search or filter results')}" autocomplete="off"/>`).appendTo(toolbar);
             if (self.rights.canModifyView()) {
-                let add_column = "<buttom rome='button' class='kanban-add-column btn btn-outline-secondary ms-1'>" + __('Add column') + "</button>";
+                let add_column = "<button class='kanban-add-column btn btn-outline-secondary ms-1'>" + __('Add column') + "</button>";
                 toolbar.append(add_column);
             }
 
@@ -1842,7 +1842,7 @@ class GLPIKanbanRights {
             if (self.rights.canCreateColumn()) {
                 add_form += `
                <hr>${__('Or add a new status')}
-               <button role='button' class='btn btn-primary kanban-create-column d-block'>${__('Create status')}</button>
+               <button class='btn btn-primary kanban-create-column d-block'>${__('Create status')}</button>
             `;
             }
             add_form += "</form></div>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The button used to add/choose columns in the Kanban was using a custom element tag because of a typo. This didn't seem to break anything for me in Chrome even though it did not have a matching closing tag. Also, the role attribute was misnamed. On button elements, the role attribute is not needed. At one point, I think this button was a different type of element so it would have been needed before for accessibility reasons.