### PR TITLE
Do not run stale auto-close on forks

### DIFF
--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   stale:
+    if: github.repository == 'glpi-project/glpi'
     permissions:
       issues: write  # for actions/stale to close stale issues
     runs-on: ubuntu-latest


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The auto-close issue workflow should not run on forks.