### PR TITLE
Fix HTML head when bypassing updates

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -187,10 +187,6 @@ if (!isset($skip_db_check) && !file_exists(GLPI_CONFIG_DIR . "/config_db.php")) 
             exit();
         }
 
-        // Show warning for the main request
-        if (defined('SKIP_UPDATES') && !defined('BYPASSING_UPDATES') && !Toolbox::isAjax()) {
-            define('BYPASSING_UPDATES', true);
-        }
         if (!defined('SKIP_UPDATES')) {
             Html::nullHeader(__('Update needed'), $CFG_GLPI["root_doc"]);
             echo "<div class='container-fluid mb-4'>";

--- a/inc/config.php
+++ b/inc/config.php
@@ -187,14 +187,11 @@ if (!isset($skip_db_check) && !file_exists(GLPI_CONFIG_DIR . "/config_db.php")) 
             exit();
         }
 
-        if (defined('SKIP_UPDATES')) {
-            // Show warning for the main request
-            if (!Toolbox::isAjax()) {
-                echo "<div class='banner-need-update'>";
-                echo __("You are bypassing a needed update");
-                echo "</div>";
-            }
-        } else {
+        // Show warning for the main request
+        if (defined('SKIP_UPDATES') && !defined('BYPASSING_UPDATES') && !Toolbox::isAjax()) {
+            define('BYPASSING_UPDATES', true);
+        }
+        if (!defined('SKIP_UPDATES')) {
             Html::nullHeader(__('Update needed'), $CFG_GLPI["root_doc"]);
             echo "<div class='container-fluid mb-4'>";
             echo "<div class='row justify-content-evenly'>";

--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -36,7 +36,7 @@
 {% set is_vertical = user_pref('page_layout') == 'vertical' %}
 
 <body class="{{ user_pref('fold_menu') and is_vertical ? 'navbar-collapsed' : '' }} {{ is_vertical ? 'vertical-layout' : 'horizontal-layout' }} {{ is_debug_active ? 'debug-active' : '' }}">
-   {% if constant('BYPASSING_UPDATES') %}
+   {% if constant('SKIP_UPDATES') is defined and call('Update::isDbUpToDate') %}
       <div class="banner-need-update">
          {{ __("You are bypassing a needed update") }}
       </div>

--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -36,6 +36,11 @@
 {% set is_vertical = user_pref('page_layout') == 'vertical' %}
 
 <body class="{{ user_pref('fold_menu') and is_vertical ? 'navbar-collapsed' : '' }} {{ is_vertical ? 'vertical-layout' : 'horizontal-layout' }} {{ is_debug_active ? 'debug-active' : '' }}">
+   {% if constant('BYPASSING_UPDATES') %}
+      <div class="banner-need-update">
+         {{ __("You are bypassing a needed update") }}
+      </div>
+   {% endif %}
    {{ include('layout/parts/impersonate_banner.html.twig') }}
    {{ include('components/messages_after_redirect_toasts.html.twig', {'display_container': true}) }}
 

--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -36,7 +36,7 @@
 {% set is_vertical = user_pref('page_layout') == 'vertical' %}
 
 <body class="{{ user_pref('fold_menu') and is_vertical ? 'navbar-collapsed' : '' }} {{ is_vertical ? 'vertical-layout' : 'horizontal-layout' }} {{ is_debug_active ? 'debug-active' : '' }}">
-   {% if constant('SKIP_UPDATES') is defined and call('Update::isDbUpToDate') %}
+   {% if constant('SKIP_UPDATES') is defined and call('Update::isDbUpToDate') == false %}
       <div class="banner-need-update">
          {{ __("You are bypassing a needed update") }}
       </div>

--- a/templates/layout/parts/page_header_empty.html.twig
+++ b/templates/layout/parts/page_header_empty.html.twig
@@ -32,7 +32,7 @@
  #}
 
 <body class="horizontal-layout">
-   {% if constant('BYPASSING_UPDATES') %}
+   {% if constant('SKIP_UPDATES') is defined and call('Update::isDbUpToDate') %}
       <div class="banner-need-update">
          {{ __("You are bypassing a needed update") }}
       </div>

--- a/templates/layout/parts/page_header_empty.html.twig
+++ b/templates/layout/parts/page_header_empty.html.twig
@@ -32,7 +32,7 @@
  #}
 
 <body class="horizontal-layout">
-   {% if constant('SKIP_UPDATES') is defined and call('Update::isDbUpToDate') %}
+   {% if constant('SKIP_UPDATES') is defined and call('Update::isDbUpToDate') == false %}
       <div class="banner-need-update">
          {{ __("You are bypassing a needed update") }}
       </div>

--- a/templates/layout/parts/page_header_empty.html.twig
+++ b/templates/layout/parts/page_header_empty.html.twig
@@ -32,6 +32,11 @@
  #}
 
 <body class="horizontal-layout">
+   {% if constant('BYPASSING_UPDATES') %}
+      <div class="banner-need-update">
+         {{ __("You are bypassing a needed update") }}
+      </div>
+   {% endif %}
    <div class="page">
 
       <header class="navbar d-print-none sticky-lg-top shadow-sm topbar">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The warning header when skipping/bypassing database updates breaks the entire `head` section because we are trying to add a `div` element in it instead of the body. The `head` gets ended immediately and the body starts with the banner div followed by the usual `head` content. In Chrome at least, some of the usual head content worked like CSS and JS links and the title, but the favicon was not working.