### PR TITLE
Move crontask UI to twig templates

### DIFF
--- a/front/crontask.form.php
+++ b/front/crontask.form.php
@@ -39,11 +39,12 @@
 
 include('../inc/includes.php');
 
-Session::checkRight("config", UPDATE);
+Session::checkRight("config", READ);
 
 $crontask = new CronTask();
 
 if (isset($_POST['execute'])) {
+    Session::checkRight("config", UPDATE);
     if (is_numeric($_POST['execute'])) {
        // Execute button from list.
         $name = CronTask::launch(CronTask::MODE_INTERNAL, intval($_POST['execute']));

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -572,8 +572,6 @@ class CronTask extends CommonDBTM
      **/
     public function showForm($ID, array $options = [])
     {
-        global $CFG_GLPI;
-
         if (!Config::canView() || !$this->getFromDB($ID)) {
             return false;
         }
@@ -1110,17 +1108,16 @@ class CronTask extends CommonDBTM
             ])->current();
 
             $stats['datemin'] = $data['datemin'];
-            $stats['elapsedmin'] = number_format($data['elapsedmin'], 2);
-            $stats['elapsedmax'] = number_format($data['elapsedmax'], 2);
-            $stats['elapsedavg'] = number_format($data['elapsedavg'], 2);
-            $stats['elapsedtot'] = number_format($data['elapsedtot'], 2);
+            $stats['elapsedmin'] = $data['elapsedmin'];
+            $stats['elapsedmax'] = $data['elapsedmax'];
+            $stats['elapsedavg'] = $data['elapsedavg'];
+            $stats['elapsedtot'] = $data['elapsedtot'];
 
             if ($data['voltot'] > 0) {
                 $stats['volmin'] = $data['volmin'];
                 $stats['volmax'] = $data['volmax'];
-                $stats['volavg'] = number_format($data['volavg'], 2);
+                $stats['volavg'] = $data['volavg'];
                 $stats['voltot'] = $data['voltot'];
-                $stats['speedavg'] = number_format($data['voltot'] / $data['elapsedtot'], 2);
             }
         }
 

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -36,6 +36,7 @@
 // Needed for signal handler
 declare(ticks=1);
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\Event;
 
 /**
@@ -577,124 +578,9 @@ class CronTask extends CommonDBTM
             return false;
         }
         $options['candel'] = false;
-        $this->showFormHeader($options);
-
-        echo "<tr class='tab_bg_1'>";
-        echo "<td>" . __('Name') . "</td>";
-        echo "<td class ='b'>";
-        $name = $this->fields["name"];
-        if ($isplug = isPluginItemType($this->fields["itemtype"])) {
-            $name = sprintf(__('%1$s - %2$s'), $isplug["plugin"], $name);
-        }
-        echo $name . "</td>";
-        echo "<td rowspan='6' class='middle right'>" . __('Comments') . "</td>";
-        echo "<td class='center middle' rowspan='6'>";
-        echo "<textarea class='form-control' name='comment' >" . $this->fields["comment"] . "</textarea>";
-        echo "</td></tr>";
-
-        echo "<tr class='tab_bg_1'><td>" . __('Description') . "</td><td>";
-        echo $this->getDescription($ID);
-        echo "</td></tr>";
-
-        echo "<tr class='tab_bg_1'><td>" . __('Run frequency') . "</td><td>";
-        Dropdown::showFrequency('frequency', $this->fields["frequency"]);
-        echo "</td></tr>";
-
-        $tmpstate = $this->fields["state"];
-        echo "<tr class='tab_bg_1'><td>" . __('Status') . "</td><td>";
-        if (
-            is_file(GLPI_CRON_DIR . '/' . $this->fields["name"] . '.lock')
-            || is_file(GLPI_CRON_DIR . '/all.lock')
-        ) {
-            echo "<span class='b'>" . __('System lock') . "</span><br>";
-            $tmpstate = self::STATE_DISABLE;
-        }
-
-        if ($isplug) {
-            $plug = new Plugin();
-            if (!$plug->isActivated($isplug["plugin"])) {
-                echo "<span class='b'>" . __('Disabled plugin') . "</span><br>";
-                $tmpstate = self::STATE_DISABLE;
-            }
-        }
-
-        if ($this->fields["state"] == self::STATE_RUNNING) {
-            echo "<span class='b'>" . $this->getStateName(self::STATE_RUNNING) . "</span>";
-        } else {
-            self::dropdownState('state', $this->fields["state"]);
-        }
-        echo "</td></tr>";
-
-        echo "<tr class='tab_bg_1'><td>" . __('Run mode') . "</td><td>";
-        $modes = [];
-        if ($this->fields['allowmode'] & self::MODE_INTERNAL) {
-            $modes[self::MODE_INTERNAL] = self::getModeName(self::MODE_INTERNAL);
-        }
-        if ($this->fields['allowmode'] & self::MODE_EXTERNAL) {
-            $modes[self::MODE_EXTERNAL] = self::getModeName(self::MODE_EXTERNAL);
-        }
-        Dropdown::showFromArray('mode', $modes, ['value' => $this->fields['mode']]);
-        echo "</td></tr>";
-
-        echo "<tr class='tab_bg_1'><td>" . __('Run period') . "</td><td>";
-        Dropdown::showNumber('hourmin', ['value' => $this->fields['hourmin'],
-            'min'   => 0,
-            'max'   => 24
-        ]);
-        echo "&nbsp;->&nbsp;";
-        Dropdown::showNumber('hourmax', ['value' => $this->fields['hourmax'],
-            'min'   => 0,
-            'max'   => 24
-        ]);
-        echo "</td></tr>";
-
-        echo "<tr class='tab_bg_1'><td>" . __('Number of days this action logs are stored') . "</td><td>";
-        Dropdown::showNumber('logs_lifetime', ['value' => $this->fields['logs_lifetime'],
-            'min'   => 10,
-            'max'   => 360,
-            'step'  => 10,
-            'toadd' => [0 => __('Infinite')]
-        ]);
-        echo "</td><td>" . __('Last run') . "</td><td>";
 
         if (empty($this->fields['lastrun'])) {
-            echo __('Never');
-        } else {
-            echo Html::convDateTime($this->fields['lastrun']);
-            echo "&nbsp;";
-            Html::showSimpleForm(
-                static::getFormURL(),
-                'resetdate',
-                __('Blank'),
-                ['id' => $ID],
-                'fa-times-circle'
-            );
-        }
-        echo "</td></tr>";
-
-        $label = $this->getParameterDescription();
-        echo "<tr class='tab_bg_1'><td>";
-        if (empty($label)) {
-            echo "&nbsp;</td><td>&nbsp;";
-        } else {
-            echo $label . "&nbsp;</td><td>";
-            Dropdown::showNumber('param', ['value' => $this->fields['param'],
-                'min'   => 0,
-                'max'   => 10000
-            ]);
-        }
-        echo "</td><td>" . __('Next run') . "</td><td>";
-
-        if ($tmpstate == self::STATE_RUNNING) {
-            $launch = false;
-        } else {
-            $launch = $this->fields['allowmode'] & self::MODE_INTERNAL;
-        }
-
-        if ($tmpstate != self::STATE_WAITING) {
-            echo $this->getStateName($tmpstate);
-        } else if (empty($this->fields['lastrun'])) {
-            echo __('As soon as possible');
+            $next_run_display = __('As soon as possible');
         } else {
             $next = strtotime($this->fields['lastrun']) + $this->fields['frequency'];
             $h    = date('H', $next);
@@ -707,14 +593,14 @@ class CronTask extends CommonDBTM
                 ($deb < $fin)
                 && ($h < $deb)
             ) {
-                $disp = date('Y-m-d', $next) . " $deb:00:00";
-                $next = strtotime($disp);
+                $next_run_display = date('Y-m-d', $next) . " $deb:00:00";
+                $next = strtotime($next_run_display);
             } else if (
                 ($deb < $fin)
                     && ($h >= $this->fields['hourmax'])
             ) {
-                $disp = date('Y-m-d', $next + DAY_TIMESTAMP) . " $deb:00:00";
-                $next = strtotime($disp);
+                $next_run_display = date('Y-m-d', $next + DAY_TIMESTAMP) . " $deb:00:00";
+                $next = strtotime($next_run_display);
             }
 
             if (
@@ -722,44 +608,28 @@ class CronTask extends CommonDBTM
                 && ($h < $deb)
                 && ($h >= $fin)
             ) {
-                $disp = date('Y-m-d', $next) . " $deb:00:00";
-                $next = strtotime($disp);
+                $next_run_display = date('Y-m-d', $next) . " $deb:00:00";
+                $next = strtotime($next_run_display);
             } else {
-                $disp = date("Y-m-d H:i:s", $next);
+                $next_run_display = date("Y-m-d H:i:s", $next);
             }
 
             if ($next < time()) {
-                echo __('As soon as possible') . '<br>(' . Html::convDateTime($disp) . ') ';
+                $next_run_display = __('As soon as possible') . '<br>(' . Html::convDateTime($next_run_display) . ') ';
             } else {
-                echo Html::convDateTime($disp);
+                $next_run_display = Html::convDateTime($next_run_display);
             }
         }
 
-        if (isset($CFG_GLPI['maintenance_mode']) && $CFG_GLPI['maintenance_mode']) {
-            echo "<div class='warning'>" .
-              __('Maintenance mode enabled, running tasks is disabled') .
-              "</div>";
-        } else if ($launch) {
-            echo "&nbsp;";
-            Html::showSimpleForm(
-                static::getFormURL(),
-                ['execute' => $this->fields['name']],
-                __('Execute')
-            );
-        }
-        if ($tmpstate == self::STATE_RUNNING) {
-            Html::showSimpleForm(
-                static::getFormURL(),
-                'resetstate',
-                __('Blank'),
-                ['id' => $ID],
-                'fa-times-circle'
-            );
-        }
-        echo "</td></tr>";
-
-        $this->showFormButtons($options);
-
+        TemplateRenderer::getInstance()->display('pages/setup/crontask/crontask.html.twig', [
+            'item' => $this,
+            'params' => $options,
+            'plugin_info' => isPluginItemType($this->fields["itemtype"]),
+            'item_meta' => [
+                'next_run_display' => $next_run_display ?? __('As soon as possible'),
+                'param_description' => $this->getParameterDescription()
+            ]
+        ]);
         return true;
     }
 
@@ -1175,10 +1045,6 @@ class CronTask extends CommonDBTM
     {
         global $DB;
 
-        echo "<br><div class='center'>";
-        echo "<table class='tab_cadre'>";
-        echo "<tr><th colspan='2'>&nbsp;" . __('Statistics') . "</th></tr>\n";
-
         $nbstart = countElementsInTable(
             'glpi_crontasklogs',
             ['crontasks_id' => $this->fields['id'],
@@ -1198,21 +1064,22 @@ class CronTask extends CommonDBTM
             ]
         );
 
-        echo "<tr class='tab_bg_2'><td>" . __('Run count') . "</td><td class='right'>";
-        if ($nbstart == $nbstop) {
-            echo $nbstart;
-        } else {
-           // This should not appen => task crash ?
-           //TRANS: %s is the number of starts
-            printf(_n('%s start', '%s starts', $nbstart), $nbstart);
-            echo "<br>";
-           //TRANS: %s is the number of stops
-            printf(_n('%s stop', '%s stops', $nbstop), $nbstop);
-            echo "<br>";
-           //TRANS: %s is the number of errors
-            printf(_n('%s error', '%s errors', $nberror), $nberror);
-        }
-        echo "</td></tr>";
+        $stats = [
+            'runs' => [
+                'starts'    => $nbstart,
+                'stops'     => $nbstop,
+                'errors'    => $nberror,
+            ],
+            'datemin'       => 0,
+            'elapsedmin'    => 0,
+            'elapsedmax'    => 0,
+            'elapsedavg'    => 0,
+            'elapsedtot'    => 0,
+            'volmin'        => 0,
+            'volmax'        => 0,
+            'volavg'        => 0,
+            'voltot'        => 0,
+        ];
 
         if ($nbstop) {
             $data = $DB->request([
@@ -1242,72 +1109,24 @@ class CronTask extends CommonDBTM
                 ]
             ])->current();
 
-            echo "<tr class='tab_bg_1'><td>" . __('Start date') . "</td>";
-            echo "<td class='right'>" . Html::convDateTime($data['datemin']) . "</td></tr>";
-
-            echo "<tr class='tab_bg_2'><td>" . __('Minimal time') . "</td>";
-            echo "<td class='right'>" . sprintf(
-                _n('%s second', '%s seconds', $data['elapsedmin']),
-                number_format($data['elapsedmin'], 2)
-            );
-            echo "</td></tr>";
-
-            echo "<tr class='tab_bg_1'><td>" . __('Maximal time') . "</td>";
-            echo "<td class='right'>" . sprintf(
-                _n('%s second', '%s seconds', $data['elapsedmax']),
-                number_format($data['elapsedmax'], 2)
-            );
-            echo "</td></tr>";
-
-            echo "<tr class='tab_bg_2'><td>" . __('Average time') . "</td>";
-            echo "<td class='right b'>" . sprintf(
-                _n('%s second', '%s seconds', $data['elapsedavg']),
-                number_format($data['elapsedavg'], 2)
-            );
-            echo "</td></tr>";
-
-            echo "<tr class='tab_bg_1'><td>" . __('Total duration') . "</td>";
-            echo "<td class='right'>" . sprintf(
-                _n('%s second', '%s seconds', $data['elapsedtot']),
-                number_format($data['elapsedtot'], 2)
-            );
-            echo "</td></tr>";
+            $stats['datemin'] = $data['datemin'];
+            $stats['elapsedmin'] = number_format($data['elapsedmin'], 2);
+            $stats['elapsedmax'] = number_format($data['elapsedmax'], 2);
+            $stats['elapsedavg'] = number_format($data['elapsedavg'], 2);
+            $stats['elapsedtot'] = number_format($data['elapsedtot'], 2);
 
             if ($data['voltot'] > 0) {
-                echo "<tr class='tab_bg_2'><td>" . __('Minimal count') . "</td>";
-                echo "<td class='right'>" . sprintf(
-                    _n('%s item', '%s items', $data['volmin']),
-                    $data['volmin']
-                ) . "</td></tr>";
-
-                 echo "<tr class='tab_bg_1'><td>" . __('Maximal count') . "</td>";
-                 echo "<td class='right'>" . sprintf(
-                     _n('%s item', '%s items', $data['volmax']),
-                     $data['volmax']
-                 ) . "</td></tr>";
-
-                 echo "<tr class='tab_bg_2'><td>" . __('Average count') . "</td>";
-                 echo "<td class='right b'>" . sprintf(
-                     _n('%s item', '%s items', $data['volavg']),
-                     number_format($data['volavg'], 2)
-                 ) .
-                   "</td></tr>";
-
-                 echo "<tr class='tab_bg_1'><td>" . __('Total count') . "</td>";
-                 echo "<td class='right'>" . sprintf(
-                     _n('%s item', '%s items', $data['voltot']),
-                     $data['voltot']
-                 ) . "</td></tr>";
-
-                 echo "<tr class='tab_bg_2'><td>" . __('Average speed') . "</td>";
-                 echo "<td class='left'>" . sprintf(
-                     __('%s items/sec'),
-                     number_format($data['voltot'] / $data['elapsedtot'], 2)
-                 );
-                 echo "</td></tr>";
+                $stats['volmin'] = $data['volmin'];
+                $stats['volmax'] = $data['volmax'];
+                $stats['volavg'] = number_format($data['volavg'], 2);
+                $stats['voltot'] = $data['voltot'];
+                $stats['speedavg'] = number_format($data['voltot'] / $data['elapsedtot'], 2);
             }
         }
-        echo "</table></div>";
+
+        TemplateRenderer::getInstance()->display('pages/setup/crontask/statistics.html.twig', [
+            'stats' => $stats
+        ]);
     }
 
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2256,10 +2256,11 @@ class Dropdown
      *
      * @param string  $name   select name
      * @param integer $value  default value (default 0)
+     * @param array   $options
      *
      * @return string|integer HTML output, or random part of dropdown ID.
      **/
-    public static function showFrequency($name, $value = 0)
+    public static function showFrequency($name, $value = 0, $options = [])
     {
 
         $tab = [];
@@ -2285,7 +2286,9 @@ class Dropdown
         $tab[WEEK_TIMESTAMP]  = __('Each week');
         $tab[MONTH_TIMESTAMP] = __('Each month');
 
-        Dropdown::showFromArray($name, $tab, ['value' => $value]);
+        Dropdown::showFromArray($name, $tab, $options + [
+            'value' => $value
+        ]);
     }
 
     /**

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -647,6 +647,27 @@
    {{ _self.field(name, field, label, options|merge({'id': 'dropdown_' ~ name ~ '_' ~ options.rand})) }}
 {% endmacro %}
 
+{% macro dropdownFrequency(name, value, label = '', options = {}) %}
+   {% set options = {'rand': random()}|merge(options) %}
+   {% if options.fields_template.isMandatoryField(name) %}
+      {% set options = {'required': true}|merge(options) %}
+   {% endif %}
+
+   {% if options.disabled %}
+      {% set options = options|merge({specific_tags: {'disabled': 'disabled'}}) %}
+   {% endif %}
+
+   {% set field %}
+      {% do call('Dropdown::showFrequency', [name, value, {
+         'rand': rand,
+         'width': '100%',
+         'value': value
+      }|merge(options)]) %}
+   {% endset %}
+
+   {{ _self.field(name, field, label, options|merge({'id': 'dropdown_' ~ name ~ '_' ~ options.rand})) }}
+{% endmacro %}
+
 {% macro dropdownField(itemtype, name, value, label = '', options = {}) %}
    {% if options.multiple %}
       {# Needed for empty value as the input wont be sent in this case... we need something to know the input was displayed AND empty #}

--- a/templates/pages/setup/crontask/crontask.html.twig
+++ b/templates/pages/setup/crontask/crontask.html.twig
@@ -1,35 +1,35 @@
 {#
-# ---------------------------------------------------------------------
-#
-# GLPI - Gestionnaire Libre de Parc Informatique
-#
-# http://glpi-project.org
-#
-# @copyright 2015-2022 Teclib' and contributors.
-# @copyright 2003-2014 by the INDEPNET Development Team.
-# @licence   https://www.gnu.org/licenses/gpl-3.0.html
-#
-# ---------------------------------------------------------------------
-#
-# LICENSE
-#
-# This file is part of GLPI.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-# ---------------------------------------------------------------------
-#}
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2022 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 

--- a/templates/pages/setup/crontask/crontask.html.twig
+++ b/templates/pages/setup/crontask/crontask.html.twig
@@ -87,13 +87,15 @@
                            {{ fields.dropdownNumberField('hourmin', item.fields['hourmin'], null, {
                               min: 0,
                               max: 24,
-                              no_label: true
+                              no_label: true,
+                              field_class: ''
                            }) }}
                            <span class="mx-2 text-nowrap">-></span>
                            {{ fields.dropdownNumberField('hourmax', item.fields['hourmax'], null, {
                               min: 0,
                               max: 24,
-                              no_label: true
+                              no_label: true,
+                              field_class: ''
                            }) }}
                         </div>
                      {% endset %}

--- a/templates/pages/setup/crontask/crontask.html.twig
+++ b/templates/pages/setup/crontask/crontask.html.twig
@@ -42,6 +42,7 @@
    {% set withtemplate = params['withtemplate'] ?? '' %}
    {% set item_type = item.getType() %}
    {% set field_options = {} %}
+   {% set can_execute = item.canEdit(item.fields['id']) %}
 
    <div class="card-body d-flex flex-wrap">
       <div class="col-12 col-xxl-{{ item_has_pictures ? '9' : '12' }} flex-column">
@@ -90,7 +91,7 @@
                               no_label: true,
                               field_class: ''
                            }) }}
-                           <span class="mx-2 text-nowrap">-></span>
+                           <span class="mx-2 text-nowrap">-&gt;</span>
                            {{ fields.dropdownNumberField('hourmax', item.fields['hourmax'], null, {
                               min: 0,
                               max: 24,
@@ -126,12 +127,12 @@
                               {{ __('Never') }}
                            {% else %}
                               {{ item.fields['lastrun']|formatted_datetime }}
-                              <form action="{{ 'CronTask'|itemtype_form_path }}" method="post">
-                                 {# ID and CSRF token fields submitted from the parent form #}
+                              {% if can_execute %}
+                                 {# ID and CSRF token fields are defined in components/form/buttons.html.twig #}
                                  <button class="btn btn-icon border-0" type="submit" name="resetdate" title="{{ __('Blank') }}">
                                     <i class="fas fa-times-circle me-1"></i>
                                  </button>
-                              </form>
+                              {% endif %}
                            {% endif %}
                         {% endset %}
                         {{ fields.htmlField('last_run', last_run_field, __('Last run')) }}
@@ -148,22 +149,17 @@
                               <div class="alert alert-warning">
                                  {{ __('Maintenance mode enabled, running tasks is disabled') }}
                               </div>
-                           {% elseif launch %}
-                              <form action="{{ 'CronTask'|itemtype_form_path }}" method="post">
-                                 {# CSRF token field submitted from the parent form #}
-                                 <button class="btn btn-primary" type="submit" name="execute" value="{{ item.fields['name'] }}">{{ __('Execute') }}</button>
-                              </form>
+                           {% elseif can_execute and launch %}
+                              {# ID and CSRF token fields are defined in components/form/buttons.html.twig #}
+                              <button class="btn btn-primary" type="submit" name="execute" value="{{ item.fields['name'] }}">{{ __('Execute') }}</button>
                            {% endif %}
 
-                           {% if item.fields['state'] == constant('CronTask::STATE_RUNNING') %}
-                              <form action="{{ 'CronTask'|itemtype_form_path }}" method="post">
-                                 <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
-                                 <input type="hidden" name="id" value="{{ item.getID() }}"/>
-                                 <button class="btn btn-primary" type="submit" name="resetstate">
-                                    <i class="fas fa-times-circle me-1"></i>
-                                    {{ __('Blank') }}
-                                 </button>
-                              </form>
+                           {% if can_execute and item.fields['state'] == constant('CronTask::STATE_RUNNING') %}
+                              {# ID and CSRF token fields are defined in components/form/buttons.html.twig #}
+                              <button class="btn btn-primary" type="submit" name="resetstate">
+                                 <i class="fas fa-times-circle me-1"></i>
+                                 {{ __('Blank') }}
+                              </button>
                            {% endif %}
                         {% endset %}
                         {{ fields.htmlField('next_run', next_run_field, __('Next run')) }}

--- a/templates/pages/setup/crontask/crontask.html.twig
+++ b/templates/pages/setup/crontask/crontask.html.twig
@@ -1,0 +1,179 @@
+{#
+# ---------------------------------------------------------------------
+#
+# GLPI - Gestionnaire Libre de Parc Informatique
+#
+# http://glpi-project.org
+#
+# @copyright 2015-2022 Teclib' and contributors.
+# @copyright 2003-2014 by the INDEPNET Development Team.
+# @licence   https://www.gnu.org/licenses/gpl-3.0.html
+#
+# ---------------------------------------------------------------------
+#
+# LICENSE
+#
+# This file is part of GLPI.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# ---------------------------------------------------------------------
+#}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+<div class="asset {{ bg }}">
+   {{ include('components/form/header.html.twig') }}
+
+   {% set rand = random() %}
+   {% set params  = params ?? [] %}
+   {% set target       = params['target'] ?? item.getFormURL() %}
+   {% set withtemplate = params['withtemplate'] ?? '' %}
+   {% set item_type = item.getType() %}
+   {% set field_options = {} %}
+
+   <div class="card-body d-flex flex-wrap">
+      <div class="col-12 col-xxl-{{ item_has_pictures ? '9' : '12' }} flex-column">
+         <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
+            <div class="row flex-row align-items-start flex-grow-1">
+               <div class="row flex-row">
+                  {% block form_fields %}
+                     {% set name = item.fields['name'] %}
+                     {% if plugin_info %}
+                        {% set name = __('%1$s - %2$s')|format(plugin_info['plugin'], name) %}
+                     {% endif %}
+                     {% set name_field %}
+                        <span class="fw-bold">{{ name }}</span>
+                     {% endset %}
+                     {{ fields.htmlField('name', name_field, __('Name')) }}
+
+                     {{ fields.textareaField(
+                        'comment',
+                        item.fields['comment'],
+                        _n('Comment', 'Comments', get_plural_number()),
+                        field_options
+                     ) }}
+
+                     {{ fields.htmlField('description', item.getDescription(item.getID), __('Description')) }}
+
+                     {{ fields.dropdownFrequency('frequency', item.fields['frequency'], __('Run frequency')) }}
+
+                     {# Status #}
+                     {{ fields.dropdownArrayField('state', item.fields['state'], {
+                        (constant('CronTask::STATE_DISABLE')): __('Disabled'),
+                        (constant('CronTask::STATE_WAITING')): __('Scheduled')
+                     }, __('Status')) }}
+
+                     {# Run mode #}
+                     {{ fields.dropdownArrayField('mode', item.fields['mode'], {
+                        (constant('CronTask::MODE_INTERNAL')): __('GLPI'),
+                        (constant('CronTask::MODE_EXTERNAL')): __('CLI')
+                     }, __('Run mode')) }}
+
+                     {# Run period #}
+                     {% set run_period_field %}
+                        <div class="d-flex">
+                           {{ fields.dropdownNumberField('hourmin', item.fields['hourmin'], null, {
+                              min: 0,
+                              max: 24,
+                              no_label: true
+                           }) }}
+                           <span class="mx-2 text-nowrap">-></span>
+                           {{ fields.dropdownNumberField('hourmax', item.fields['hourmax'], null, {
+                              min: 0,
+                              max: 24,
+                              no_label: true
+                           }) }}
+                        </div>
+                     {% endset %}
+                     {{ fields.htmlField('run_period', run_period_field, __('Run period')) }}
+
+                     {# Number of days this action logs are stored #}
+                     {{ fields.dropdownNumberField('logs_lifetime', item.fields['logs_lifetime'], __('Number of days this action logs are stored'), {
+                        min: 10,
+                        max: 360,
+                        step: 10,
+                        toadd: {
+                           0: __('Infinite')
+                        }
+                     }) }}
+
+                     {# Param #}
+                     {% if item_meta.param_description is not empty %}
+                        {{ fields.dropdownNumberField('param', item.fields['param'], item_meta.param_description, {
+                           min: 0,
+                           max: 10000
+                        }) }}
+                     {% endif %}
+
+                     <div class="row flex-row">
+                        {# Last run #}
+                        {% set last_run_field %}
+                           {% if item.fields['lastrun'] is empty %}
+                              {{ __('Never') }}
+                           {% else %}
+                              {{ item.fields['lastrun']|formatted_datetime }}
+                              <form action="{{ 'CronTask'|itemtype_form_path }}" method="post">
+                                 <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
+                                 <input type="hidden" name="id" value="{{ item.getID() }}"/>
+                                 <button class="btn btn-primary" type="submit" name="resetdate">
+                                    <i class="fas fa-times-circle me-1"></i>
+                                    {{ __('Blank') }}
+                                 </button>
+                              </form>
+                           {% endif %}
+                        {% endset %}
+                        {{ fields.htmlField('last_run', last_run_field, __('Last run')) }}
+
+                        {# Next run #}
+                        {% set launch = item.fields['state'] != constant('CronTask::STATE_RUNNING') and (item.fields['allowmode'] b-and constant('CronTask::MODE_INTERNAL')) %}
+                        {% set next_run_field %}
+                           {% if item.fields['state'] != constant('CronTask::STATE_WAITING') %}
+                              {{ item.getStateName(item.fields['state']) }}
+                           {% else %}
+                              {{ item_meta.next_run_display|raw }}
+                           {% endif %}
+                           {% if config('maintenance_mode') %}
+                              <div class="alert alert-warning">
+                                 {{ __('Maintenance mode enabled, running tasks is disabled') }}
+                              </div>
+                           {% elseif launch %}
+                              <form action="{{ 'CronTask'|itemtype_form_path }}" method="post">
+                                 <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
+                                 <button class="btn btn-primary" type="submit" name="execute" value="{{ item.fields['name'] }}">{{ __('Execute') }}</button>
+                              </form>
+                           {% endif %}
+
+                           {% if item.fields['state'] == constant('CronTask::STATE_RUNNING') %}
+                              <form action="{{ 'CronTask'|itemtype_form_path }}" method="post">
+                                 <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
+                                 <input type="hidden" name="id" value="{{ item.getID() }}"/>
+                                 <button class="btn btn-primary" type="submit" name="resetstate">
+                                    <i class="fas fa-times-circle me-1"></i>
+                                    {{ __('Blank') }}
+                                 </button>
+                              </form>
+                           {% endif %}
+                        {% endset %}
+                        {{ fields.htmlField('next_run', next_run_field, __('Next run')) }}
+                     </div>
+                  {% endblock %}
+               </div> {# .row #}
+            </div> {# .row #}
+         </div> {# .flex-row #}
+      </div>
+   </div> {# .card-body #}
+
+   {{ include('components/form/buttons.html.twig') }}
+</div>

--- a/templates/pages/setup/crontask/crontask.html.twig
+++ b/templates/pages/setup/crontask/crontask.html.twig
@@ -125,11 +125,9 @@
                            {% else %}
                               {{ item.fields['lastrun']|formatted_datetime }}
                               <form action="{{ 'CronTask'|itemtype_form_path }}" method="post">
-                                 <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
-                                 <input type="hidden" name="id" value="{{ item.getID() }}"/>
-                                 <button class="btn btn-primary" type="submit" name="resetdate">
+                                 {# ID and CSRF token fields submitted from the parent form #}
+                                 <button class="btn btn-icon border-0" type="submit" name="resetdate" title="{{ __('Blank') }}">
                                     <i class="fas fa-times-circle me-1"></i>
-                                    {{ __('Blank') }}
                                  </button>
                               </form>
                            {% endif %}
@@ -150,7 +148,7 @@
                               </div>
                            {% elseif launch %}
                               <form action="{{ 'CronTask'|itemtype_form_path }}" method="post">
-                                 <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
+                                 {# CSRF token field submitted from the parent form #}
                                  <button class="btn btn-primary" type="submit" name="execute" value="{{ item.fields['name'] }}">{{ __('Execute') }}</button>
                               </form>
                            {% endif %}

--- a/templates/pages/setup/crontask/statistics.html.twig
+++ b/templates/pages/setup/crontask/statistics.html.twig
@@ -54,19 +54,19 @@
             </div>
             <div class="row list-group-item d-flex">
                <div class="col">{{ __('Minimal time') }}</div>
-               <div class="col text-end">{{ _n('%s second', '%s seconds', stats.elapsedmin)|format(stats.elapsedmin) }}</div>
+               <div class="col text-end">{{ _n('%s second', '%s seconds', stats.elapsedmin)|format(stats.elapsedmin|formatted_number) }}</div>
             </div>
             <div class="row list-group-item d-flex">
                <div class="col">{{ __('Maximal time') }}</div>
-               <div class="col text-end">{{ _n('%s second', '%s seconds', stats.elapsedmax)|format(stats.elapsedmax) }}</div>
+               <div class="col text-end">{{ _n('%s second', '%s seconds', stats.elapsedmax)|format(stats.elapsedmax|formatted_number) }}</div>
             </div>
             <div class="row list-group-item d-flex">
                <div class="col">{{ __('Average time') }}</div>
-               <div class="col text-end fw-bold">{{ _n('%s second', '%s seconds', stats.elapsedavg)|format(stats.elapsedavg) }}</div>
+               <div class="col text-end fw-bold">{{ _n('%s second', '%s seconds', stats.elapsedavg)|format(stats.elapsedavg|formatted_number) }}</div>
             </div>
             <div class="row list-group-item d-flex">
                <div class="col">{{ __('Total duration') }}</div>
-               <div class="col text-end">{{ _n('%s second', '%s seconds', stats.elapsedtot)|format(stats.elapsedtot) }}</div>
+               <div class="col text-end">{{ _n('%s second', '%s seconds', stats.elapsedtot)|format(stats.elapsedtot|formatted_number) }}</div>
             </div>
             {% if stats.voltot > 0 %}
                <div class="row list-group-item d-flex">
@@ -79,7 +79,7 @@
                </div>
                <div class="row list-group-item d-flex">
                   <div class="col">{{ __('Average count') }}</div>
-                  <div class="col text-end fw-bold">{{ _n('%s item', '%s items', stats.volavg)|format(stats.volavg) }}</div>
+                  <div class="col text-end fw-bold">{{ _n('%s item', '%s items', stats.volavg)|format(stats.volavg|formatted_number) }}</div>
                </div>
                <div class="row list-group-item d-flex">
                   <div class="col">{{ __('Total count') }}</div>
@@ -87,7 +87,7 @@
                </div>
                <div class="row list-group-item d-flex">
                   <div class="col">{{ __('Average speed') }}</div>
-                  <div class="col text-end">{{ __('%s items/sec')|format(stats.speedavg) }}</div>
+                  <div class="col text-end">{{ __('%s items/sec')|format((stats.voltot / stats.elapsedtot)|formatted_number) }}</div>
                </div>
             {% endif %}
          {% endif %}

--- a/templates/pages/setup/crontask/statistics.html.twig
+++ b/templates/pages/setup/crontask/statistics.html.twig
@@ -1,0 +1,98 @@
+{#
+# ---------------------------------------------------------------------
+#
+# GLPI - Gestionnaire Libre de Parc Informatique
+#
+# http://glpi-project.org
+#
+# @copyright 2015-2022 Teclib' and contributors.
+# @copyright 2003-2014 by the INDEPNET Development Team.
+# @licence   https://www.gnu.org/licenses/gpl-3.0.html
+#
+# ---------------------------------------------------------------------
+#
+# LICENSE
+#
+# This file is part of GLPI.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# ---------------------------------------------------------------------
+#}
+
+<div class="d-flex justify-content-center">
+   <div class="col-sm-8 col-md-6 col-xlg-4 col-12 mx-2 mw-50">
+      <table class="table table-striped">
+         <thead>
+            <tr><th colspan="2">{{ __('Statistics') }}</th></tr>
+         </thead>
+         <tbody>
+            <tr>
+               <td>{{ __('Run count') }}</td>
+               <td class="text-end">
+                  {{ _n('%s start', '%s starts', stats.runs.starts)|format(stats.runs.starts) }}
+                  <br>
+                  {{ _n('%s stop', '%s stops', stats.runs.stops)|format(stats.runs.stops) }}
+                  <br>
+                  {{ _n('%s error', '%s errors', stats.runs.errors)|format(stats.runs.errors) }}
+               </td>
+            </tr>
+            {% if stats.runs.stops > 0 %}
+               <tr>
+                  <td>{{ __('Start date') }}</td>
+                  <td class="text-end">{{ stats.datemin|formatted_datetime }}</td>
+               </tr>
+               <tr>
+                  <td>{{ __('Minimal time') }}</td>
+                  <td class="text-end">{{ _n('%s second', '%s seconds', stats.elapsedmin)|format(stats.elapsedmin) }}</td>
+               </tr>
+               <tr>
+                  <td>{{ __('Maximal time') }}</td>
+                  <td class="text-end">{{ _n('%s second', '%s seconds', stats.elapsedmax)|format(stats.elapsedmax) }}</td>
+               </tr>
+               <tr>
+                  <td>{{ __('Average time') }}</td>
+                  <td class="text-end fw-bold">{{ _n('%s second', '%s seconds', stats.elapsedavg)|format(stats.elapsedavg) }}</td>
+               </tr>
+               <tr>
+                  <td>{{ __('Total duration') }}</td>
+                  <td class="text-end">{{ _n('%s second', '%s seconds', stats.elapsedtot)|format(stats.elapsedtot) }}</td>
+               </tr>
+               {% if stats.voltot > 0 %}
+                  <tr>
+                     <td>{{ __('Minimal count') }}</td>
+                     <td class="text-end">{{ _n('%s item', '%s items', stats.volmin)|format(stats.volmin) }}</td>
+                  </tr>
+                  <tr>
+                     <td>{{ __('Maximal count') }}</td>
+                     <td class="text-end">{{ _n('%s item', '%s items', stats.volmax)|format(stats.volmax) }}</td>
+                  </tr>
+                  <tr>
+                     <td>{{ __('Average count') }}</td>
+                     <td class="text-end fw-bold">{{ _n('%s item', '%s items', stats.volavg)|format(stats.volavg) }}</td>
+                  </tr>
+                  <tr>
+                     <td>{{ __('Total count') }}</td>
+                     <td class="text-end">{{ _n('%s item', '%s items', stats.voltot)|format(stats.voltot) }}</td>
+                  </tr>
+                  <tr>
+                     <td>{{ __('Average speed') }}</td>
+                     <td class="text-end">{{ __('%s items/sec')|format(stats.speedavg) }}</td>
+                  </tr>
+               {% endif %}
+            {% endif %}
+         </tbody>
+      </table>
+   </div>
+</div>

--- a/templates/pages/setup/crontask/statistics.html.twig
+++ b/templates/pages/setup/crontask/statistics.html.twig
@@ -33,66 +33,64 @@
 
 <div class="d-flex justify-content-center">
    <div class="col-sm-8 col-md-6 col-xlg-4 col-12 mx-2 mw-50">
-      <table class="table table-striped">
-         <thead>
-            <tr><th colspan="2">{{ __('Statistics') }}</th></tr>
-         </thead>
-         <tbody>
-            <tr>
-               <td>{{ __('Run count') }}</td>
-               <td class="text-end">
-                  {{ _n('%s start', '%s starts', stats.runs.starts)|format(stats.runs.starts) }}
-                  <br>
-                  {{ _n('%s stop', '%s stops', stats.runs.stops)|format(stats.runs.stops) }}
-                  <br>
-                  {{ _n('%s error', '%s errors', stats.runs.errors)|format(stats.runs.errors) }}
-               </td>
-            </tr>
-            {% if stats.runs.stops > 0 %}
-               <tr>
-                  <td>{{ __('Start date') }}</td>
-                  <td class="text-end">{{ stats.datemin|formatted_datetime }}</td>
-               </tr>
-               <tr>
-                  <td>{{ __('Minimal time') }}</td>
-                  <td class="text-end">{{ _n('%s second', '%s seconds', stats.elapsedmin)|format(stats.elapsedmin) }}</td>
-               </tr>
-               <tr>
-                  <td>{{ __('Maximal time') }}</td>
-                  <td class="text-end">{{ _n('%s second', '%s seconds', stats.elapsedmax)|format(stats.elapsedmax) }}</td>
-               </tr>
-               <tr>
-                  <td>{{ __('Average time') }}</td>
-                  <td class="text-end fw-bold">{{ _n('%s second', '%s seconds', stats.elapsedavg)|format(stats.elapsedavg) }}</td>
-               </tr>
-               <tr>
-                  <td>{{ __('Total duration') }}</td>
-                  <td class="text-end">{{ _n('%s second', '%s seconds', stats.elapsedtot)|format(stats.elapsedtot) }}</td>
-               </tr>
-               {% if stats.voltot > 0 %}
-                  <tr>
-                     <td>{{ __('Minimal count') }}</td>
-                     <td class="text-end">{{ _n('%s item', '%s items', stats.volmin)|format(stats.volmin) }}</td>
-                  </tr>
-                  <tr>
-                     <td>{{ __('Maximal count') }}</td>
-                     <td class="text-end">{{ _n('%s item', '%s items', stats.volmax)|format(stats.volmax) }}</td>
-                  </tr>
-                  <tr>
-                     <td>{{ __('Average count') }}</td>
-                     <td class="text-end fw-bold">{{ _n('%s item', '%s items', stats.volavg)|format(stats.volavg) }}</td>
-                  </tr>
-                  <tr>
-                     <td>{{ __('Total count') }}</td>
-                     <td class="text-end">{{ _n('%s item', '%s items', stats.voltot)|format(stats.voltot) }}</td>
-                  </tr>
-                  <tr>
-                     <td>{{ __('Average speed') }}</td>
-                     <td class="text-end">{{ __('%s items/sec')|format(stats.speedavg) }}</td>
-                  </tr>
-               {% endif %}
+      <div class="row">
+         <h1>{{ __('Statistics') }}</h1>
+      </div>
+      <div class="list-group divide-y">
+         <div class="row list-group-item d-flex">
+            <div class="col">{{ __('Run count') }}</div>
+            <div class="col text-end">
+               <ul class="list-unstyled">
+                  <li>{{ _n('%s start', '%s starts', stats.runs.starts)|format(stats.runs.starts) }}</li>
+                  <li>{{ _n('%s stop', '%s stops', stats.runs.stops)|format(stats.runs.stops) }}</li>
+                  <li>{{ _n('%s error', '%s errors', stats.runs.errors)|format(stats.runs.errors) }}</li>
+               </ul>
+            </div>
+         </div>
+         {% if stats.runs.stops > 0 %}
+            <div class="row list-group-item d-flex">
+               <div class="col">{{ __('Start date') }}</div>
+               <div class="col text-end">{{ stats.datemin|formatted_datetime }}</div>
+            </div>
+            <div class="row list-group-item d-flex">
+               <div class="col">{{ __('Minimal time') }}</div>
+               <div class="col text-end">{{ _n('%s second', '%s seconds', stats.elapsedmin)|format(stats.elapsedmin) }}</div>
+            </div>
+            <div class="row list-group-item d-flex">
+               <div class="col">{{ __('Maximal time') }}</div>
+               <div class="col text-end">{{ _n('%s second', '%s seconds', stats.elapsedmax)|format(stats.elapsedmax) }}</div>
+            </div>
+            <div class="row list-group-item d-flex">
+               <div class="col">{{ __('Average time') }}</div>
+               <div class="col text-end fw-bold">{{ _n('%s second', '%s seconds', stats.elapsedavg)|format(stats.elapsedavg) }}</div>
+            </div>
+            <div class="row list-group-item d-flex">
+               <div class="col">{{ __('Total duration') }}</div>
+               <div class="col text-end">{{ _n('%s second', '%s seconds', stats.elapsedtot)|format(stats.elapsedtot) }}</div>
+            </div>
+            {% if stats.voltot > 0 %}
+               <div class="row list-group-item d-flex">
+                  <div class="col">{{ __('Minimal count') }}</div>
+                  <div class="col text-end">{{ _n('%s item', '%s items', stats.volmin)|format(stats.volmin) }}</div>
+               </div>
+               <div class="row list-group-item d-flex">
+                  <div class="col">{{ __('Maximal count') }}</div>
+                  <div class="col text-end">{{ _n('%s item', '%s items', stats.volmax)|format(stats.volmax) }}</div>
+               </div>
+               <div class="row list-group-item d-flex">
+                  <div class="col">{{ __('Average count') }}</div>
+                  <div class="col text-end fw-bold">{{ _n('%s item', '%s items', stats.volavg)|format(stats.volavg) }}</div>
+               </div>
+               <div class="row list-group-item d-flex">
+                  <div class="col">{{ __('Total count') }}</div>
+                  <div class="col text-end">{{ _n('%s item', '%s items', stats.voltot)|format(stats.voltot) }}</div>
+               </div>
+               <div class="row list-group-item d-flex">
+                  <div class="col">{{ __('Average speed') }}</div>
+                  <div class="col text-end">{{ __('%s items/sec')|format(stats.speedavg) }}</div>
+               </div>
             {% endif %}
-         </tbody>
-      </table>
+         {% endif %}
+      </div>
    </div>
 </div>

--- a/templates/pages/setup/crontask/statistics.html.twig
+++ b/templates/pages/setup/crontask/statistics.html.twig
@@ -1,35 +1,35 @@
 {#
-# ---------------------------------------------------------------------
-#
-# GLPI - Gestionnaire Libre de Parc Informatique
-#
-# http://glpi-project.org
-#
-# @copyright 2015-2022 Teclib' and contributors.
-# @copyright 2003-2014 by the INDEPNET Development Team.
-# @licence   https://www.gnu.org/licenses/gpl-3.0.html
-#
-# ---------------------------------------------------------------------
-#
-# LICENSE
-#
-# This file is part of GLPI.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-# ---------------------------------------------------------------------
-#}
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2022 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
 
 <div class="d-flex justify-content-center">
    <div class="col-sm-8 col-md-6 col-xlg-4 col-12 mx-2 mw-50">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Move automatic action (crontask) UI to twig templates.

Main form:
![Selection_078](https://user-images.githubusercontent.com/17678637/172067722-69c7fd78-7b12-46a4-8c47-cb194df41197.png)


Statistics tab (just a table; nothing special):
![Selection_077](https://user-images.githubusercontent.com/17678637/172067565-9fecdce0-b2d9-4880-8148-5a9fe6306e20.png)