### PR TITLE
Fix simplified interface help link

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -2001,7 +2001,7 @@ HTML;
         string $option = "",
         bool $add_id = true
     ) {
-        global $HEADER_LOADED;
+        global $HEADER_LOADED, $CFG_GLPI;
 
         // Print a nice HTML-head for help page
         if ($HEADER_LOADED) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11814

Missing global statement caused the help URL in the simplified interface to always be the default one.