### PR TITLE
Hide finished projects when adding new task in Kanban

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2593,8 +2593,18 @@ class Dropdown
             $toadd = [];
         }
 
-        if (isset($post['condition']) && ($post['condition'] != '')) {
-            $where = array_merge($where, $post['condition']);
+        $ljoin = [];
+
+        if (isset($post['condition']) && !empty($post['condition'])) {
+            if (isset($post['condition']['LEFT JOIN'])) {
+                $ljoin = $post['condition']['LEFT JOIN'];
+                unset($post['condition']['LEFT JOIN']);
+            }
+            if (isset($post['condition']['WHERE'])) {
+                $where = array_merge($where, $post['condition']['WHERE']);
+            } else {
+                $where = array_merge($where, $post['condition']);
+            }
         }
 
         $one_item = -1;
@@ -2697,7 +2707,6 @@ class Dropdown
             }
 
             $addselect = [];
-            $ljoin = [];
             if (Session::haveTranslations($post['itemtype'], 'completename')) {
                 $addselect[] = "namet.value AS transcompletename";
                 $ljoin['glpi_dropdowntranslations AS namet'] = [
@@ -3039,7 +3048,7 @@ class Dropdown
                 $where[] = ['OR' => $orwhere];
             }
             $addselect = [];
-            $ljoin = [];
+
             if (Session::haveTranslations($post['itemtype'], $field)) {
                 $addselect[] = "namet.value AS transname";
                 $ljoin['glpi_dropdowntranslations AS namet'] = [

--- a/src/Project.php
+++ b/src/Project.php
@@ -2397,7 +2397,23 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             if ($ID <= 0) {
                 $supported_itemtypes['ProjectTask']['fields']['projects_id'] = [
                     'type'   => 'raw',
-                    'value'  => Project::dropdown(['display' => false, 'width' => '90%'])
+                    'value'  => Project::dropdown([
+                        'display' => false,
+                        'width' => '90%',
+                        'condition' => [
+                            'LEFT JOIN' => [
+                                ProjectState::getTable() => [
+                                    'ON' => [
+                                        ProjectState::getTable() => 'id',
+                                        self::getTable() => 'projectstates_id'
+                                    ]
+                                ]
+                            ],
+                            'WHERE' => [
+                                'is_finished'   => false
+                            ]
+                        ]
+                    ])
                 ];
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Ref #11802

Since tasks of projects with a finished state are hidden from the global Project Kanban, it seems better to hide them from the dropdown on the new task form as the creation of the task would work, but the new task would never show in the Kanban,

I had to add support for Left Joins in the `condition` option of `getDropdownValue` in order to support this. The commits should probably remain separate.
