### PR TITLE
Move post_item hook before self service buttons

### DIFF
--- a/templates/components/itilobject/selfservice.html.twig
+++ b/templates/components/itilobject/selfservice.html.twig
@@ -244,6 +244,8 @@
             </div>
         </div>
 
+      {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
+
         <div class="card-footer text-center">
             <input type="hidden" name="entities_id" value="{{ params['entities_id'] }}" />
             <button type="submit" class="btn btn-primary" name="add">
@@ -252,8 +254,6 @@
             </button>
         </div>
     </div>
-
-   {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
 
    {{ include('components/itilobject/mainform_close.html.twig') }}
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The `post_item` hook should be called just before the form buttons are displayed, not after.