### PR TITLE
Fix initial multi-entity mode check

### DIFF
--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -60,7 +60,7 @@
 {% if current_entity != current_entity_short %}
    {% set current_entity_short = '... > ' ~ current_entity_short %}
 {% endif %}
-{% if session('glpi_multientitiesmode') == 0 %}
+{% if not is_multi_entities_mode() %}
    <span class="dropdown-item dropdown-item-text" title="{{ current_entity }}">
       <i class="fa-fw ti ti-stack"></i>
       {{ current_entity_short|u.truncate(35, '...') }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11799

The `glpi_multientitiesmode` property in the `$_SESSION` array is used as a cache that is not set until the first call to `Session::isMultiEntitiesMode`. Direct access to this property should not be relied on. In this case, it seems that the twig template can get rendered before anything calls the method in some cases.