### PR TITLE
[GLPI 10.0 Bugfixes] Fix Count Linked Tickets

### DIFF
--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -417,7 +417,7 @@
                <i class="ti ti-link me-1"></i>
                {% set linked_tickets = ticket_ticket.getLinkedTicketsTo(item.fields['id']) %}
                {% set nb_linked_tickets = linked_tickets|length %}
-               {% if item.isNewItem() and params['_link']['tickets_id_2']|length > 0 %}
+               {% if item.isNewItem() and params['_link']['tickets_id_2'] > 0 %}
                   {% set nb_linked_tickets = 1 %}
                {% endif %}
                <span class="item-title">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

When you select category on a new ticket, the count of linked tickets shows 1 : 

![image](https://user-images.githubusercontent.com/13178158/172319404-e8bb268d-7ee0-4a03-b0a8-70ea42c0c865.png)
