### PR TITLE
fix(check all): on footer not work

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -155,9 +155,9 @@ function displayOtherSelectOptions(select_object, other_option_name) {
  * @param    reference_id    DOM element
  * @param    container_id    DOM element
 **/
-function checkAsCheckboxes(reference_id, container_id) {
+function checkAsCheckboxes(reference, container_id) {
     $('#' + container_id + ' input[type="checkbox"]:enabled')
-        .prop('checked', $('#' + reference_id).is(':checked'));
+        .prop('checked', $(reference).is(':checked'));
 
     return true;
 }

--- a/js/common.js
+++ b/js/common.js
@@ -152,10 +152,11 @@ function displayOtherSelectOptions(select_object, other_option_name) {
  * Check all checkboxes inside the given element as the same state as a reference one (toggle this one before)
  * the given element is usaly a table or a div containing the table or tables
  *
- * @param    reference_id    DOM element
- * @param    container_id    DOM element
+ * @param {HTMLElement} reference
+ * @param {string} container_id
 **/
 function checkAsCheckboxes(reference, container_id) {
+    reference = typeof(reference) === 'string' ? document.getElementById(reference) : reference;
     $('#' + container_id + ' input[type="checkbox"]:enabled')
         .prop('checked', $(reference).is(':checked'));
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -2310,7 +2310,7 @@ HTML;
         $out  = "<input title='" . __s('Check all as') . "' type='checkbox' class='form-check-input'
                       title='" . __s('Check all as') . "'
                       name='_checkall_$rand' id='checkall_$rand'
-                      onclick= \"if ( checkAsCheckboxes('checkall_$rand', '$container_id')) {return true;}\">";
+                      onclick= \"if ( checkAsCheckboxes(this, '$container_id')) {return true;}\">";
 
        // permit to shift select checkboxes
         $out .= Html::scriptBlock("\$(function() {\$('#$container_id input[type=\"checkbox\"]').shiftSelectable();});");

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -43,7 +43,7 @@
                <div>
                   <input class="form-check-input" type="checkbox" id="checkall_{{ rand }}"
                         value="" aria-label="{{ __('Check all as') }}"
-                        onclick="checkAsCheckboxes('checkall_{{ rand }}', '{{ searchform_id }}');" />
+                        onclick="checkAsCheckboxes(this, '{{ searchform_id }}');" />
                </div>
             </th>
             {% endif %}


### PR DESCRIPTION
"Check all" in the footer had no effect (in the header it worked).

![image](https://user-images.githubusercontent.com/8530352/172333213-955dd86c-c4d0-4886-85b4-994a9b22fabc.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24170
