### PR TITLE
[GLPI 10.0 Bugfixes] Fix load Templates for Plugins

### DIFF
--- a/src/ContentTemplates/Parameters/AssetParameters.php
+++ b/src/ContentTemplates/Parameters/AssetParameters.php
@@ -77,7 +77,6 @@ class AssetParameters extends AbstractParameters
 
     protected function defineValues(CommonDBTM $asset): array
     {
-        global $CFG_GLPI;
 
        // Output "unsanitized" values
         $fields = Sanitizer::unsanitize($asset->fields);

--- a/src/ContentTemplates/Parameters/AssetParameters.php
+++ b/src/ContentTemplates/Parameters/AssetParameters.php
@@ -61,7 +61,7 @@ class AssetParameters extends AbstractParameters
     protected function getTargetClasses(): array
     {
         global $CFG_GLPI;
-        return $CFG_GLPI["ticket_types"];
+        return $CFG_GLPI["asset_types"];
     }
 
     public function getAvailableParameters(): array
@@ -82,14 +82,12 @@ class AssetParameters extends AbstractParameters
        // Output "unsanitized" values
         $fields = Sanitizer::unsanitize($asset->fields);
 
-        if (in_array($asset->getType(), $CFG_GLPI["asset_types"])) {
-            $values = [
-                'id'       => $fields['id'],
-                'name'     => $fields['name'],
-                'itemtype' => $asset->getType(),
-                'serial'   => $fields['serial'],
-            ];
-        }
+        $values = [
+            'id'       => $fields['id'],
+            'name'     => $fields['name'],
+            'itemtype' => $asset->getType(),
+            'serial'   => $fields['serial'],
+        ];
 
        // Add asset's entity
         if ($entity = Entity::getById($fields['entities_id'])) {

--- a/src/ContentTemplates/Parameters/AssetParameters.php
+++ b/src/ContentTemplates/Parameters/AssetParameters.php
@@ -61,7 +61,7 @@ class AssetParameters extends AbstractParameters
     protected function getTargetClasses(): array
     {
         global $CFG_GLPI;
-        return $CFG_GLPI["asset_types"];
+        return $CFG_GLPI["ticket_types"];
     }
 
     public function getAvailableParameters(): array
@@ -77,16 +77,19 @@ class AssetParameters extends AbstractParameters
 
     protected function defineValues(CommonDBTM $asset): array
     {
+       global $CFG_GLPI;
 
        // Output "unsanitized" values
         $fields = Sanitizer::unsanitize($asset->fields);
 
-        $values = [
-            'id'       => $fields['id'],
-            'name'     => $fields['name'],
-            'itemtype' => $asset->getType(),
-            'serial'   => $fields['serial'],
-        ];
+        if (in_array($asset->getType(), $CFG_GLPI["asset_types"])) {
+           $values = [
+              'id'       => $fields['id'],
+              'name'     => $fields['name'],
+              'itemtype' => $asset->getType(),
+              'serial'   => $fields['serial'],
+           ];
+        }
 
        // Add asset's entity
         if ($entity = Entity::getById($fields['entities_id'])) {

--- a/src/ContentTemplates/Parameters/AssetParameters.php
+++ b/src/ContentTemplates/Parameters/AssetParameters.php
@@ -77,18 +77,18 @@ class AssetParameters extends AbstractParameters
 
     protected function defineValues(CommonDBTM $asset): array
     {
-       global $CFG_GLPI;
+        global $CFG_GLPI;
 
        // Output "unsanitized" values
         $fields = Sanitizer::unsanitize($asset->fields);
 
         if (in_array($asset->getType(), $CFG_GLPI["asset_types"])) {
-           $values = [
-              'id'       => $fields['id'],
-              'name'     => $fields['name'],
-              'itemtype' => $asset->getType(),
-              'serial'   => $fields['serial'],
-           ];
+            $values = [
+                'id'       => $fields['id'],
+                'name'     => $fields['name'],
+                'itemtype' => $asset->getType(),
+                'serial'   => $fields['serial'],
+            ];
         }
 
        // Add asset's entity

--- a/src/ContentTemplates/Parameters/TicketParameters.php
+++ b/src/ContentTemplates/Parameters/TicketParameters.php
@@ -94,7 +94,7 @@ class TicketParameters extends CommonITILObjectParameters
     protected function defineValues(CommonDBTM $ticket): array
     {
         /** @var Ticket $ticket  */
-
+        global $CFG_GLPI;
        // Output "unsanitized" values
         $fields = Sanitizer::unsanitize($ticket->fields);
 
@@ -148,6 +148,9 @@ class TicketParameters extends CommonITILObjectParameters
         $items_ticket = Item_Ticket::getItemsAssociatedTo($ticket::getType(), $fields['id']);
         foreach ($items_ticket as $item_ticket) {
             $itemtype = $item_ticket->fields['itemtype'];
+            if (!in_array($itemtype, $CFG_GLPI["asset_types"])) {
+                continue;
+            }
             if (!class_exists($itemtype)) {
                 trigger_error(sprintf('No class found for type %s', $itemtype), E_USER_WARNING);
                 // May happen if the itemtype belongs to a plugin and this plugin is inactive


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

When a plugin object is linked with a ticket, the templates of followups, tasks and solutions don't loading.

And we have php-errors

```
[2022-06-07 11:15:57] glpiphplog.WARNING:   *** PHP User Warning (512): PluginBadgesBadge is not allowed for this parameter type. in C:\wamp64\www\glpi\src\ContentTemplates\Parameters\AbstractParameters.php at line 77
  Backtrace :
  ...tTemplates\Parameters\AbstractParameters.php:77 trigger_error()
  ...ntTemplates\Parameters\TicketParameters.php:158 Glpi\ContentTemplates\Parameters\AbstractParameters->getValues()
  ...tTemplates\Parameters\AbstractParameters.php:81 Glpi\ContentTemplates\Parameters\TicketParameters->defineValues()
  src\ContentTemplates\TemplateManager.php:107       Glpi\ContentTemplates\Parameters\AbstractParameters->getValues()
  src\AbstractITILChildTemplate.php:142              Glpi\ContentTemplates\TemplateManager::renderContentForCommonITIL()
  ajax\itilfollowup.php:87                           AbstractITILChildTemplate->getRenderedContent()
```

```
[2022-06-07 11:26:13] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "serial" in C:\wamp64\www\glpi\src\ContentTemplates\Parameters\AssetParameters.php at line 88
  Backtrace :
  ...tTemplates\Parameters\AbstractParameters.php:81 Glpi\ContentTemplates\Parameters\AssetParameters->defineValues()
  ...ntTemplates\Parameters\TicketParameters.php:158 Glpi\ContentTemplates\Parameters\AbstractParameters->getValues()
  ...tTemplates\Parameters\AbstractParameters.php:81 Glpi\ContentTemplates\Parameters\TicketParameters->defineValues()
  src\ContentTemplates\TemplateManager.php:107       Glpi\ContentTemplates\Parameters\AbstractParameters->getValues()
  src\AbstractITILChildTemplate.php:142              Glpi\ContentTemplates\TemplateManager::renderContentForCommonITIL()
  ajax\solution.php:90                               AbstractITILChildTemplate->getRenderedContent()
```