### PR TITLE
Dictionaries: fix assign category action

### DIFF
--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -161,6 +161,10 @@ class Software extends InventoryAsset
                     $val->version = $res_rule["version"];
                 }
 
+                if (isset($res_rule["softwarecategories_id"])) {
+                    $val->softwarecategories_id = $res_rule["softwarecategories_id"];
+                }
+
                 //If the manufacturer has been modified or set by the rules engine
                 if (isset($res_rule["manufacturer"])) {
                     $val->manufacturers_id = Dropdown::import(


### PR DESCRIPTION
This is an issue I've found on fusioninventory, seems like it also exist in the native inventory.

Dictionaries support a "Category" action:

![image](https://user-images.githubusercontent.com/42734840/172589836-38b2a533-b59e-4ff5-aa4d-595120e9fc31.png)

But there is no code to handle it as `$res_rule['softwarecategories_id']` is never used anywhere.

I'm not sure how this action ever worked as I can't find any code on fusion that handled this specific rule result value even in older version (but I'm told that the criteria was indeed working a couple version ago so if someone has more details on that... I've tried multiple older versions of glpi and/or fusion and I was never able to make it work).

Kinda related fix done by @cedric-anne for the "replay dictionaries rules"  action that also needed this value to be taken into account properly: https://github.com/glpi-project/glpi/pull/7961.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24151
