### PR TITLE
Fix masonry grids on Firefox

### DIFF
--- a/templates/components/masonry_grid.html.twig
+++ b/templates/components/masonry_grid.html.twig
@@ -48,17 +48,17 @@
 
 <script type="text/javascript">
 $(function() {
-   var msnry = new Masonry('#grid_{{ rand }}', {
+   window.msnry = new Masonry('#grid_{{ rand }}', {
       "percentPosition": true,
       "horizontalOrder": true,
    });
 
    $('#grid_{{ rand }}').on("layout:refresh", function() {
-      msnry.layout();
+       window.msnry.layout();
    });
 
    $(document).on('masonry_grid:layout', function() {
-       msnry.layout();
+       window.msnry.layout();
    })
 });
 </script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11688

Chrome and Firefox handle the `msnry` variable differently. Chrome treats it as a global and adds it to `window` while Firefox does not. Firefox handles it more like it was declared with `let`.