### PR TITLE
Always use ID in socket location history

### DIFF
--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -376,7 +376,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
             $changes = [
                 0,
                 '',
-                addslashes($this->getNameID()),
+                addslashes($this->getNameID(['forceid' => true])),
             ];
             Log::history(
                 $parent,
@@ -407,11 +407,11 @@ abstract class CommonTreeDropdown extends CommonDropdown
                 $this->cleanParentsSons($oldParentID);
                 if ($history) {
                     if ($parent->getFromDB($oldParentID)) {
-                        $oldParentNameID = $parent->getNameID();
+                        $oldParentNameID = $parent->getNameID(['forceid' => true]);
                     }
                     $changes = [
                         '0',
-                        addslashes($this->getNameID()),
+                        addslashes($this->getNameID(['forceid' => true])),
                         '',
                     ];
                     Log::history(
@@ -429,12 +429,12 @@ abstract class CommonTreeDropdown extends CommonDropdown
                 $this->addSonInParents();
                 if ($history) {
                     if ($parent->getFromDB($newParentID)) {
-                        $newParentNameID = $parent->getNameID();
+                        $newParentNameID = $parent->getNameID(['forceid' => true]);
                     }
                     $changes = [
                         '0',
                         '',
-                        addslashes($this->getNameID()),
+                        addslashes($this->getNameID(['forceid' => true])),
                     ];
                     Log::history(
                         $newParentID,
@@ -472,7 +472,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
         if ($parent && $this->dohistory) {
             $changes = [
                 '0',
-                addslashes($this->getNameID()),
+                addslashes($this->getNameID(['forceid' => true])),
                 '',
             ];
             Log::history(

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -565,7 +565,7 @@ class Socket extends CommonDBChild
         if ($parent) {
             $changes[0] = '0';
             $changes[1] = '';
-            $changes[2] = addslashes($this->getNameID());
+            $changes[2] = addslashes($this->getNameID(['forceid' => true]));
             Log::history($parent, 'Location', $changes, $this->getType(), Log::HISTORY_ADD_SUBITEM);
         }
 

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -603,7 +603,7 @@ class Socket extends CommonDBChild
         $parent = $this->fields['locations_id'];
         if ($parent) {
             $changes[0] = '0';
-            $changes[1] = addslashes($this->getNameID());
+            $changes[1] = addslashes($this->getNameID(['forceid' => true]));
             $changes[2] = '';
             Log::history($parent, 'Location', $changes, $this->getType(), Log::HISTORY_DELETE_SUBITEM);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11843

During the 10.0 migration, sockets are added using the standard `add` method. In the `post_addItem`, a history entry is added to the related location using the socket's `getNameID` method. This uses a user preference to determine if the ID should be shown in the name or not but there is no session during CLI migration.

In similar use cases, the ID is always forced so that the logged data is consistent and this should bypass the need for a user session.