### PR TITLE
Cleanup ITIL Object Kanban closed column warning

### DIFF
--- a/css/includes/components/_kanban.scss
+++ b/css/includes/components/_kanban.scss
@@ -268,6 +268,7 @@
                     height: calc(100% - (1.2em + 35px));
                     overflow-y: auto;
                     overflow-x: hidden;
+                    list-style: none;
 
                     .kanban-add-form {
                         padding-top: 10px !important;

--- a/js/modules/Kanban/Kanban.js
+++ b/js/modules/Kanban/Kanban.js
@@ -2043,7 +2043,7 @@ class GLPIKanbanRights {
                 });
             } else {
                 $(`
-               <li class="position-relative" style="width: 250px">
+               <li class="position-relative mx-auto mt-2" style="width: 250px">
                   ${__('This column cannot support showing cards due to how many cards would be shown. You can still drag cards into this column.')}
                </li>
             `).appendTo(column_body);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Small cleanup of the message shown in drop-only columns in the Kanban such as the Closed column for ITIL Objects.

Removes list style, centers the message, and adds a small space between the top of the column and the message.