### PR TITLE
Add Time to resolve to Change Template

### DIFF
--- a/src/ChangeTemplate.php
+++ b/src/ChangeTemplate.php
@@ -63,6 +63,7 @@ class ChangeTemplate extends ITILTemplate
     {
         $change = new Change();
         return [
+            $change->getSearchOptionIDByField('field', 'time_to_resolve', 'glpi_changes') => 'time_to_resolve',
             $change->getSearchOptionIDByField('field', 'impactcontent', 'glpi_changes')      => 'impactcontent',
             $change->getSearchOptionIDByField('field', 'controlistcontent', 'glpi_changes')  => 'controlistcontent',
             $change->getSearchOptionIDByField('field', 'rolloutplancontent', 'glpi_changes') => 'rolloutplancontent',

--- a/tests/functionnal/ITILTemplate.php
+++ b/tests/functionnal/ITILTemplate.php
@@ -252,11 +252,12 @@ class ITILTemplate extends DbTestCase
                     13 => 'Associated elements',
                     -2 => 'Approval request',
                     142 => 'Documents',
+                    18 => 'Time to resolve',
                     60 => 'Analysis impact',
                     61 => 'Control list',
                     62 => 'Deployment plan',
                     63 => 'Backup plan',
-                    67 => 'Checklist'
+                    67 => 'Checklist',
                 ]
             ], [
                 'Problem',


### PR DESCRIPTION
Currently Time to Resolve field is available just Ticket Templates.
We received request to make it mandatory also for Changes. 

Also in TicketTemplates it is added in TicketTemplate::getExtraAllowedFields()
https://github.com/glpi-project/glpi/blob/0393d8e2cfe4e86bff22c3c648476e92988704da/src/TicketTemplate.php#L99
I would like to propose the same for Changes.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
