### PR TITLE
Templates: Fix name display

### DIFF
--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -72,9 +72,6 @@
          {% set nametype = __('Created from the template %s')|format(template_name) %}
       {% elseif withtemplate == 1 %}
          <input type="hidden" name="is_template" value="1" />
-         <input type="text" class="form-control ms-4 mb-2" placeholder="{{ __('Template name') }}"
-                name="template_name" id="textfield_template_name{{ rand }}"
-                value="{{ template_name }}" />
       {% elseif item.isNewItem() %}
          {% set nametype = __('%1$s - %2$s')|format(__('New item'), nametype) %}
       {% else %}
@@ -85,6 +82,11 @@
 
       {% if no_header is not defined or no_header == false %}
          <div class="card-header main-header d-flex flex-wrap mx-n2 mt-n2 align-items-stretch">
+            {% if withtemplate == 1 %}
+               <input type="text" class="form-control ms-4 mb-2" placeholder="{{ __('Template name') }}"
+                  name="template_name" id="textfield_template_name{{ rand }}"
+                  value="{{ template_name }}" />
+            {% endif %}
             <h3 class="card-title d-flex align-items-center ps-4">
                {% set icon = item.getIcon() %}
                {% if icon|length > 0 %}


### PR DESCRIPTION
The "template name" input seems a bit out of place:

![image](https://user-images.githubusercontent.com/42734840/173058318-cf1929b5-480c-4771-837e-618ebbf6ad96.png)

A simple solution would be to move it inside the header:

![image](https://user-images.githubusercontent.com/42734840/173058376-0072e5e4-fe81-4e8a-b471-cb5dfdaf34c4.png)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
