### PR TITLE
Fix quotes handling in rich-text images replacement

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2632,7 +2632,7 @@ class Toolbox
 
                          // 2 - Replace img with tag in id attribute by the image
                         $regex = '/<img[^>]+' . preg_quote($image['tag'], '/') . '[^<]+>/im';
-                        preg_match_all($regex, Sanitizer::unsanitize($content_text), $matches);
+                        preg_match_all($regex, Sanitizer::decodeHtmlSpecialChars($content_text), $matches);
                         foreach ($matches[0] as $match_img) {
                             //retrieve dimensions
                             $width = $height = null;
@@ -2666,7 +2666,7 @@ class Toolbox
                             $content_text = str_replace(
                                 $match_img,
                                 $new_image,
-                                Sanitizer::unsanitize($content_text)
+                                Sanitizer::decodeHtmlSpecialChars($content_text)
                             );
                             $content_text = Sanitizer::encodeHtmlSpecialChars($content_text);
                         }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2641,7 +2641,6 @@ class Toolbox
 
                          // 2 - Replace img with tag in id attribute by the image
                         $regex = '/<img[^>]+' . preg_quote($image['tag'], '/') . '[^<]+>/im';
-
                         preg_match_all($regex, $content_text, $matches);
                         foreach ($matches[0] as $match_img) {
                             //retrieve dimensions

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2600,6 +2600,15 @@ class Toolbox
         if (count($doc_data)) {
             $base_path = $CFG_GLPI['root_doc'];
 
+            $was_html_encoded = Sanitizer::isHtmlEncoded($content_text);
+            $was_escaped      = Sanitizer::isDbEscaped($content_text);
+            if ($was_html_encoded) {
+                $content_text = Sanitizer::decodeHtmlSpecialChars($content_text);
+            }
+            if ($was_escaped) {
+                $content_text = Sanitizer::dbUnescape($content_text);
+            }
+
             foreach ($doc_data as $id => $image) {
                 if (isset($image['tag'])) {
                    // Add only image files : try to detect mime type
@@ -2626,13 +2635,14 @@ class Toolbox
                       // 1 - Replace direct tag (with prefix and suffix) by the image
                         $content_text = preg_replace(
                             '/' . Document::getImageTag($image['tag']) . '/',
-                            Sanitizer::encodeHtmlSpecialChars($img),
+                            $img,
                             $content_text
                         );
 
                          // 2 - Replace img with tag in id attribute by the image
                         $regex = '/<img[^>]+' . preg_quote($image['tag'], '/') . '[^<]+>/im';
-                        preg_match_all($regex, Sanitizer::decodeHtmlSpecialChars($content_text), $matches);
+
+                        preg_match_all($regex, $content_text, $matches);
                         foreach ($matches[0] as $match_img) {
                             //retrieve dimensions
                             $width = $height = null;
@@ -2666,9 +2676,9 @@ class Toolbox
                             $content_text = str_replace(
                                 $match_img,
                                 $new_image,
-                                Sanitizer::decodeHtmlSpecialChars($content_text)
+                                $content_text
                             );
-                            $content_text = Sanitizer::encodeHtmlSpecialChars($content_text);
+                            $content_text = $content_text;
                         }
 
                         // If the tag is from another ticket : link document to ticket
@@ -2695,6 +2705,13 @@ class Toolbox
                         );
                     }
                 }
+            }
+
+            if ($was_html_encoded) {
+                $content_text = Sanitizer::encodeHtmlSpecialChars($content_text);
+            }
+            if ($was_escaped) {
+                $content_text = Sanitizer::dbEscape($content_text);
             }
         }
 

--- a/tests/functionnal/ITILFollowup.php
+++ b/tests/functionnal/ITILFollowup.php
@@ -435,7 +435,7 @@ HTML
 
         $instance->add($input);
         $this->boolean($instance->isNewItem())->isFalse();
-        $expected = 'a href="/front/document.send.php?docid=';
+        $expected = 'a href=\"/front/document.send.php?docid=';
         $this->string($instance->fields['content'])->contains($expected);
 
        // Test uploads for item update
@@ -460,7 +460,7 @@ HTML
             ]
         ]);
         $this->boolean($success)->isTrue();
-        $expected = 'a href="/front/document.send.php?docid=';
+        $expected = 'a href=\"/front/document.send.php?docid=';
         $this->string($instance->fields['content'])->contains($expected);
     }
 

--- a/tests/functionnal/ITILFollowup.php
+++ b/tests/functionnal/ITILFollowup.php
@@ -435,7 +435,8 @@ HTML
 
         $instance->add($input);
         $this->boolean($instance->isNewItem())->isFalse();
-        $expected = 'a href=\"/front/document.send.php?docid=';
+        $this->boolean($instance->getFromDB($instance->getId()))->isTrue();
+        $expected = 'a href="/front/document.send.php?docid=';
         $this->string($instance->fields['content'])->contains($expected);
 
        // Test uploads for item update
@@ -460,7 +461,8 @@ HTML
             ]
         ]);
         $this->boolean($success)->isTrue();
-        $expected = 'a href=\"/front/document.send.php?docid=';
+        $this->boolean($instance->getFromDB($instance->getId()))->isTrue();
+        $expected = 'a href="/front/document.send.php?docid=';
         $this->string($instance->fields['content'])->contains($expected);
     }
 

--- a/tests/functionnal/ITILFollowup.php
+++ b/tests/functionnal/ITILFollowup.php
@@ -416,8 +416,11 @@ class ITILFollowup extends DbTestCase
             'items_id' => $ticket->getID(),
             'itemtype' => 'Ticket',
             'name'    => 'a followup',
-            'content' => '&lt;p&gt; &lt;/p&gt;&lt;p&gt;&lt;img id="3e29dffe-0237ea21-5e5e7034b1d1a1.00000000"'
-         . ' src="data:image/png;base64,' . $base64Image . '" width="12" height="12" /&gt;&lt;/p&gt;',
+            'content' => Sanitizer::sanitize(<<<HTML
+<p>Test with a ' (add)</p>
+<p><img id="3e29dffe-0237ea21-5e5e7034b1d1a1.00000000" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
+HTML
+            ),
             '_content' => [
                 $filename,
             ],
@@ -441,8 +444,11 @@ class ITILFollowup extends DbTestCase
         copy(__DIR__ . '/../fixtures/uploads/bar.png', GLPI_TMP_DIR . '/' . $filename);
         $success = $instance->update([
             'id' => $instance->getID(),
-            'content' => '&lt;p&gt; &lt;/p&gt;&lt;p&gt;&lt;img id="3e29dffe-0237ea21-5e5e7034b1d1a1.33333333"'
-         . ' src="data:image/png;base64,' . $base64Image . '" width="12" height="12" /&gt;&lt;/p&gt;',
+            'content' => Sanitizer::sanitize(<<<HTML
+<p>Test with a ' (update)</p>
+<p><img id="3e29dffe-0237ea21-5e5e7034b1d1a1.33333333" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
+HTML
+            ),
             '_content' => [
                 $filename,
             ],

--- a/tests/functionnal/ITILSolution.php
+++ b/tests/functionnal/ITILSolution.php
@@ -37,6 +37,7 @@ namespace tests\units;
 
 use CommonITILObject;
 use DbTestCase;
+use Glpi\Toolbox\Sanitizer;
 use Ticket;
 
 /* Test for inc/itilsolution.class.php */
@@ -351,8 +352,11 @@ class ITILSolution extends DbTestCase
             'items_id' => $ticket->getID(),
             'itemtype' => 'Ticket',
             'name'    => 'a solution',
-            'content' => '&lt;p&gt; &lt;/p&gt;&lt;p&gt;&lt;img id="3e29dffe-0237ea21-5e5e7034b1d1a1.00000000"'
-         . ' src="data:image/png;base64,' . $base64Image . '" width="12" height="12" /&gt;&lt;/p&gt;',
+            'content' => Sanitizer::sanitize(<<<HTML
+<p>Test with a ' (add)</p>
+<p><img id="3e29dffe-0237ea21-5e5e7034b1d1a1.00000000" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
+HTML
+            ),
             '_content' => [
                 $filename,
             ],
@@ -376,8 +380,11 @@ class ITILSolution extends DbTestCase
         copy(__DIR__ . '/../fixtures/uploads/bar.png', GLPI_TMP_DIR . '/' . $filename);
         $success = $instance->update([
             'id' => $instance->getID(),
-            'content' => '&lt;p&gt; &lt;/p&gt;&lt;p&gt;&lt;img id="3e29dffe-0237ea21-5e5e7034b1d1a1.33333333"'
-         . ' src="data:image/png;base64,' . $base64Image . '" width="12" height="12" /&gt;&lt;/p&gt;',
+            'content' => Sanitizer::sanitize(<<<HTML
+<p>Test with a ' (update)</p>
+<p><img id="3e29dffe-0237ea21-5e5e7034b1d1a1.33333333" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
+HTML
+            ),
             '_content' => [
                 $filename,
             ],

--- a/tests/functionnal/ITILSolution.php
+++ b/tests/functionnal/ITILSolution.php
@@ -371,7 +371,8 @@ HTML
 
         $instance->add($input);
         $this->boolean($instance->isNewItem())->isFalse();
-        $expected = 'a href=\"/front/document.send.php?docid=';
+        $this->boolean($instance->getFromDB($instance->getId()))->isTrue();
+        $expected = 'a href="/front/document.send.php?docid=';
         $this->string($instance->fields['content'])->contains($expected);
 
        // Test uploads for item update
@@ -396,7 +397,8 @@ HTML
             ]
         ]);
         $this->boolean($success)->isTrue();
-        $expected = 'a href=\"/front/document.send.php?docid=';
+        $this->boolean($instance->getFromDB($instance->getId()))->isTrue();
+        $expected = 'a href="/front/document.send.php?docid=';
         $this->string($instance->fields['content'])->contains($expected);
     }
 

--- a/tests/functionnal/ITILSolution.php
+++ b/tests/functionnal/ITILSolution.php
@@ -371,7 +371,7 @@ HTML
 
         $instance->add($input);
         $this->boolean($instance->isNewItem())->isFalse();
-        $expected = 'a href="/front/document.send.php?docid=';
+        $expected = 'a href=\"/front/document.send.php?docid=';
         $this->string($instance->fields['content'])->contains($expected);
 
        // Test uploads for item update
@@ -396,7 +396,7 @@ HTML
             ]
         ]);
         $this->boolean($success)->isTrue();
-        $expected = 'a href="/front/document.send.php?docid=';
+        $expected = 'a href=\"/front/document.send.php?docid=';
         $this->string($instance->fields['content'])->contains($expected);
     }
 

--- a/tests/functionnal/KnowbaseItem.php
+++ b/tests/functionnal/KnowbaseItem.php
@@ -215,7 +215,8 @@ HTML
         copy(__DIR__ . '/../fixtures/uploads/foo.png', GLPI_TMP_DIR . '/' . $filename);
         $instance->add($input);
         $this->boolean($instance->isNewItem())->isFalse();
-        $expected = 'a href=\"/front/document.send.php?docid=';
+        $this->boolean($instance->getFromDB($instance->getId()))->isTrue();
+        $expected = 'a href="/front/document.send.php?docid=';
         $this->string($instance->fields['answer'])->contains($expected);
 
        // Test uploads for item update
@@ -241,8 +242,9 @@ HTML
             ],
         ]);
         $this->boolean($success)->isTrue();
+        $this->boolean($instance->getFromDB($instance->getId()))->isTrue();
        // Ensure there is an anchor to the uploaded document
-        $expected = 'a href=\"/front/document.send.php?docid=';
+        $expected = 'a href="/front/document.send.php?docid=';
         $this->string($instance->fields['answer'])->contains($expected);
     }
 

--- a/tests/functionnal/KnowbaseItem.php
+++ b/tests/functionnal/KnowbaseItem.php
@@ -36,6 +36,7 @@
 namespace test\units;
 
 use DbTestCase;
+use Glpi\Toolbox\Sanitizer;
 
 /* Test for inc/knowbaseitem.class.php */
 
@@ -193,8 +194,11 @@ class KnowbaseItem extends DbTestCase
         $instance = new \KnowbaseItem();
         $input = [
             'name'     => 'Test to remove',
-            'answer'   => '&lt;p&gt; &lt;/p&gt;&lt;p&gt;&lt;img id="3e29dffe-0237ea21-5e5e7034b1d1a1.00000000"'
-                        . ' src="data:image/png;base64,' . $base64Image . '" width="12" height="12" /&gt;&lt;/p&gt;',
+            'answer'   => Sanitizer::sanitize(<<<HTML
+<p>Test with a ' (add)</p>
+<p><img id="3e29dffe-0237ea21-5e5e7034b1d1a1.00000000" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
+HTML
+            ),
             '_answer' => [
                 $filename,
             ],
@@ -211,7 +215,7 @@ class KnowbaseItem extends DbTestCase
         copy(__DIR__ . '/../fixtures/uploads/foo.png', GLPI_TMP_DIR . '/' . $filename);
         $instance->add($input);
         $this->boolean($instance->isNewItem())->isFalse();
-        $expected = 'a href="/front/document.send.php?docid=';
+        $expected = 'a href=\"/front/document.send.php?docid=';
         $this->string($instance->fields['answer'])->contains($expected);
 
        // Test uploads for item update
@@ -221,8 +225,11 @@ class KnowbaseItem extends DbTestCase
         file_put_contents($tmpFilename, base64_decode($base64Image));
         $success = $instance->update([
             'id'       => $instance->getID(),
-            'answer'   => '&lt;p&gt; &lt;/p&gt;&lt;p&gt;&lt;img id="3e29dffe-0237ea21-5e5e7034b1ffff.33333333"'
-                        . ' src="data:image/png;base64,' . $base64Image . '" width="12" height="12" /&gt;&lt;/p&gt;',
+            'answer'   => Sanitizer::sanitize(<<<HTML
+<p>Test with a ' (update)</p>
+<p><img id="3e29dffe-0237ea21-5e5e7034b1ffff.33333333" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
+HTML
+            ),
             '_answer' => [
                 $filename,
             ],
@@ -235,7 +242,7 @@ class KnowbaseItem extends DbTestCase
         ]);
         $this->boolean($success)->isTrue();
        // Ensure there is an anchor to the uploaded document
-        $expected = 'a href="/front/document.send.php?docid=';
+        $expected = 'a href=\"/front/document.send.php?docid=';
         $this->string($instance->fields['answer'])->contains($expected);
     }
 

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -3104,7 +3104,8 @@ HTML
         ];
         copy(__DIR__ . '/../fixtures/uploads/foo.png', GLPI_TMP_DIR . '/' . $filename);
         $instance->add($input);
-        $expected = 'a href=\"/front/document.send.php?docid=';
+        $this->boolean($instance->getFromDB($instance->getId()))->isTrue();
+        $expected = 'a href="/front/document.send.php?docid=';
         $this->string($instance->fields['content'])->contains($expected);
 
        // Test uploads for item update
@@ -3128,7 +3129,8 @@ HTML
                 '5e5e92ffd9bd91.44444444',
             ]
         ]);
-        $expected = 'a href=\"/front/document.send.php?docid=';
+        $this->boolean($instance->getFromDB($instance->getId()))->isTrue();
+        $expected = 'a href="/front/document.send.php?docid=';
         $this->string($instance->fields['content'])->contains($expected);
     }
 

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -3087,8 +3087,11 @@ class Ticket extends DbTestCase
         $instance = new \Ticket();
         $input = [
             'name'    => 'a ticket',
-            'content' => '&lt;p&gt; &lt;/p&gt;&lt;p&gt;&lt;img id="3e29dffe-0237ea21-5e5e7034b1d1a1.00000000"'
-         . ' src="data:image/png;base64,' . $base64Image . '" width="12" height="12" /&gt;&lt;/p&gt;',
+            'content' => Sanitizer::sanitize(<<<HTML
+<p>Test with a ' (add)</p>
+<p><img id="3e29dffe-0237ea21-5e5e7034b1d1a1.00000000" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
+HTML
+            ),
             '_content' => [
                 $filename,
             ],
@@ -3110,8 +3113,11 @@ class Ticket extends DbTestCase
         copy(__DIR__ . '/../fixtures/uploads/bar.png', GLPI_TMP_DIR . '/' . $filename);
         $instance->update([
             'id' => $instance->getID(),
-            'content' => '&lt;p&gt; &lt;/p&gt;&lt;p&gt;&lt;img id="3e29dffe-0237ea21-5e5e7034b1d1a1.33333333"'
-         . ' src="data:image/png;base64,' . $base64Image . '" width="12" height="12" /&gt;&lt;/p&gt;',
+            'content' => Sanitizer::sanitize(<<<HTML
+<p>Test with a ' (update)</p>
+<p><img id="3e29dffe-0237ea21-5e5e7034b1d1a1.33333333" src="data:image/png;base64,{$base64Image}" width="12" height="12"></p>
+HTML
+            ),
             '_content' => [
                 $filename,
             ],

--- a/tests/functionnal/Ticket.php
+++ b/tests/functionnal/Ticket.php
@@ -3104,7 +3104,7 @@ HTML
         ];
         copy(__DIR__ . '/../fixtures/uploads/foo.png', GLPI_TMP_DIR . '/' . $filename);
         $instance->add($input);
-        $expected = 'a href="/front/document.send.php?docid=';
+        $expected = 'a href=\"/front/document.send.php?docid=';
         $this->string($instance->fields['content'])->contains($expected);
 
        // Test uploads for item update
@@ -3128,7 +3128,7 @@ HTML
                 '5e5e92ffd9bd91.44444444',
             ]
         ]);
-        $expected = 'a href="/front/document.send.php?docid=';
+        $expected = 'a href=\"/front/document.send.php?docid=';
         $this->string($instance->fields['content'])->contains($expected);
     }
 

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -550,10 +550,17 @@ class Toolbox extends DbTestCase
         $expected_url   = str_replace('{docid}', $doc_id, $expected_url);
         $expected_result = '<a href="' . $expected_url . '" target="_blank" ><img alt="' . $img_tag . '" width="10" src="' . $expected_url . '" /></a>';
 
-       // Processed data is expected to be escaped
-        $content_text = \Toolbox::addslashes_deep($content_text);
-        $expected_result = Sanitizer::encodeHtmlSpecialChars($expected_result);
+        // Processed data is expected to be sanitized, and expected result should remain sanitized
+        $this->string(
+            \Toolbox::convertTagToImage(Sanitizer::sanitize($content_text), $item, [$doc_id => ['tag' => $img_tag]])
+        )->isEqualTo(Sanitizer::sanitize($expected_result));
 
+        // Processed data may also be escaped using Toolbox::addslashes_deep(), and expected result should be escaped too
+        $this->string(
+            \Toolbox::convertTagToImage(\Toolbox::addslashes_deep($content_text), $item, [$doc_id => ['tag' => $img_tag]])
+        )->isEqualTo(\Toolbox::addslashes_deep($expected_result));
+
+        // Processed data may also be not sanitized, and expected result should not be sanitized
         $this->string(
             \Toolbox::convertTagToImage($content_text, $item, [$doc_id => ['tag' => $img_tag]])
         )->isEqualTo($expected_result);
@@ -607,10 +614,6 @@ class Toolbox extends DbTestCase
         $content_text   = '<img id="' . $img_tag . '" width="10" height="10" />';
         $expected_url   = str_replace('{docid}', $doc_id, $expected_url);
         $expected_result = '<a href="' . $expected_url . '" target="_blank" ><img alt="' . $img_tag . '" width="10" src="' . $expected_url . '" /></a>';
-
-       // Processed data is expected to be escaped
-        $content_text = \Toolbox::addslashes_deep($content_text);
-        $expected_result = Sanitizer::encodeHtmlSpecialChars($expected_result);
 
        // Save old config
         global $CFG_GLPI;
@@ -682,13 +685,21 @@ class Toolbox extends DbTestCase
             $expected_result .= '<a href="' . $expected_url . '" target="_blank" ><img alt="' . $doc['tag'] . '" width="10" src="' . $expected_url . '" /></a>';
         }
 
-       // Processed data is expected to be escaped
-        $content_text = \Toolbox::addslashes_deep($content_text);
-        $expected_result = Sanitizer::encodeHtmlSpecialChars($expected_result);
+        // Processed data is expected to be sanitized, and expected result should remain sanitized
+        $this->string(
+            \Toolbox::convertTagToImage(Sanitizer::sanitize($content_text), $item, $doc_data)
+        )->isEqualTo(Sanitizer::sanitize($expected_result));
 
+        // Processed data may also be escaped using Toolbox::addslashes_deep(), and expected result should be escaped too
+        $this->string(
+            \Toolbox::convertTagToImage(\Toolbox::addslashes_deep($content_text), $item, $doc_data)
+        )->isEqualTo(\Toolbox::addslashes_deep($expected_result));
+
+        // Processed data may also be not sanitized, and expected result should not be sanitized
         $this->string(
             \Toolbox::convertTagToImage($content_text, $item, $doc_data)
         )->isEqualTo($expected_result);
+
     }
 
     /**
@@ -727,15 +738,27 @@ class Toolbox extends DbTestCase
         $expected_url_2    = '/front/document.send.php?docid=' . $doc_id_2 . '&tickets_id=' . $item->fields['id'];
         $expected_result_2 = '<a href="' . $expected_url_2 . '" target="_blank" ><img alt="' . $img_tag . '" width="10" src="' . $expected_url_2 . '" /></a>';
 
-       // Processed data is expected to be escaped
-        $content_text = \Toolbox::addslashes_deep($content_text);
-        $expected_result_1 = Sanitizer::encodeHtmlSpecialChars($expected_result_1);
-        $expected_result_2 = Sanitizer::encodeHtmlSpecialChars($expected_result_2);
 
+        // Processed data is expected to be sanitized, and expected result should remain sanitized
+        $this->string(
+            \Toolbox::convertTagToImage(Sanitizer::sanitize($content_text), $item, [$doc_id_1 => ['tag' => $img_tag]])
+        )->isEqualTo(Sanitizer::sanitize($expected_result_1));
+        $this->string(
+            \Toolbox::convertTagToImage(Sanitizer::sanitize($content_text), $item, [$doc_id_2 => ['tag' => $img_tag]])
+        )->isEqualTo(Sanitizer::sanitize($expected_result_2));
+
+        // Processed data may also be escaped using Toolbox::addslashes_deep(), and expected result should be escaped too
+        $this->string(
+            \Toolbox::convertTagToImage(\Toolbox::addslashes_deep($content_text), $item, [$doc_id_1 => ['tag' => $img_tag]])
+        )->isEqualTo(\Toolbox::addslashes_deep($expected_result_1));
+        $this->string(
+            \Toolbox::convertTagToImage(\Toolbox::addslashes_deep($content_text), $item, [$doc_id_2 => ['tag' => $img_tag]])
+        )->isEqualTo(\Toolbox::addslashes_deep($expected_result_2));
+
+        // Processed data may also be not sanitized, and expected result should not be sanitized
         $this->string(
             \Toolbox::convertTagToImage($content_text, $item, [$doc_id_1 => ['tag' => $img_tag]])
         )->isEqualTo($expected_result_1);
-
         $this->string(
             \Toolbox::convertTagToImage($content_text, $item, [$doc_id_2 => ['tag' => $img_tag]])
         )->isEqualTo($expected_result_2);
@@ -768,10 +791,17 @@ class Toolbox extends DbTestCase
         $expected_result  = '<a href="' . $expected_url . '" target="_blank" ><img alt="' . $img_tag . '" width="10" src="' . $expected_url . '" /></a>';
         $expected_result .= $expected_result;
 
-       // Processed data is expected to be escaped
-        $content_text = \Toolbox::addslashes_deep($content_text);
-        $expected_result = Sanitizer::encodeHtmlSpecialChars($expected_result);
+        // Processed data is expected to be sanitized, and expected result should remain sanitized
+        $this->string(
+            \Toolbox::convertTagToImage(Sanitizer::sanitize($content_text), $item, [$doc_id => ['tag' => $img_tag]])
+        )->isEqualTo(Sanitizer::sanitize($expected_result));
 
+        // Processed data may also be escaped using Toolbox::addslashes_deep(), and expected result should be escaped too
+        $this->string(
+            \Toolbox::convertTagToImage(\Toolbox::addslashes_deep($content_text), $item, [$doc_id => ['tag' => $img_tag]])
+        )->isEqualTo(\Toolbox::addslashes_deep($expected_result));
+
+        // Processed data may also be not sanitized, and expected result should not be sanitized
         $this->string(
             \Toolbox::convertTagToImage($content_text, $item, [$doc_id => ['tag' => $img_tag]])
         )->isEqualTo($expected_result);

--- a/tests/functionnal/Toolbox.php
+++ b/tests/functionnal/Toolbox.php
@@ -699,7 +699,6 @@ class Toolbox extends DbTestCase
         $this->string(
             \Toolbox::convertTagToImage($content_text, $item, $doc_data)
         )->isEqualTo($expected_result);
-
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11882

Due to a mistake in sanitizing process refactoring, quotes unescaped in `Toolbox::addFiles()`.

Fixed lines were using `Toolbox::unclean_cross_side_scripting_deep()` in GLPI 9.5.