### PR TITLE
Fix 'Entity for software creation' field handling

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -381,8 +381,8 @@ class Entity extends CommonTreeDropdown
         foreach ($input as $field => $value) {
             $strategy_field = str_replace('_id', '_strategy', $field);
             if (preg_match('/_id(_.+)?/', $field) === 1 && $DB->fieldExists($this->getTable(), $strategy_field)) {
-                if ($value > 0) {
-                    // Value is positive -> set strategy to 0 (prevent inheritance).
+                if ($value > 0 || ($value == 0 && preg_match('/^entities_id(_\w+)?/', $field) === 1)) {
+                    // Value contains a valid id -> set strategy to 0 (prevent inheritance).
                     $input[$strategy_field] = 0;
                 } elseif ($value < 0) {
                     // Value is negative -> move it into strategy field.
@@ -1867,7 +1867,10 @@ class Entity extends CommonTreeDropdown
         ]);
 
         if ($entity->fields['entities_id_software'] == self::CONFIG_PARENT) {
-            $inherited_value = self::getUsedConfig('entities_strategy_software', $entity->fields['entities_id'], 'entities_id_software');
+            $inherited_strategy = self::getUsedConfig('entities_strategy_software', $entity->fields['entities_id']);
+            $inherited_value    = $inherited_strategy === 0
+                ? self::getUsedConfig('entities_strategy_software', $entity->fields['entities_id'], 'entities_id_software')
+                : $inherited_strategy;
             self::inheritedValue(self::getSpecificValueToDisplay('entities_id_software', $inherited_value));
         }
         echo "</td><td colspan='2'></td></tr>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

1. Fix root entity handling in update process (`strategy` field was not set to `0`, so inheritance was still applied).
2. Fix inherited value display.