### PR TITLE
fix(planning template): status not editable

### DIFF
--- a/src/PlanningExternalEventTemplate.php
+++ b/src/PlanningExternalEventTemplate.php
@@ -94,7 +94,7 @@ class PlanningExternalEventTemplate extends CommonDropdown
 
         switch ($field['type']) {
             case 'planningstate':
-                Planning::dropdownState("state", $this->fields["state"], false, [
+                Planning::dropdownState("state", $this->fields["state"], true, [
                     'width' => '100%',
                 ]);
                 break;


### PR DESCRIPTION
On a template, the status was no longer definable (creation, update).

_It was possible in 9.5.7_

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24229
