### PR TITLE
Faq: fix categories form

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -260,13 +260,14 @@ class Dropdown
         );
 
         // Add icon
+        $add_item_icon = "";
         if (
             ($item instanceof CommonDropdown)
             && $item->canCreate()
             && !isset($_REQUEST['_in_modal'])
             && $params['addicon']
         ) {
-            $add_item_icon = '<div class="btn btn-outline-secondary"
+            $add_item_icon .= '<div class="btn btn-outline-secondary"
                            title="' . __s('Add') . '" data-bs-toggle="modal" data-bs-target="#add_' . $field_id . '">';
             $add_item_icon .= Ajax::createIframeModalWindow('add_' . $field_id, $item->getFormURL(), ['display' => false]);
             $add_item_icon .= "<span data-bs-toggle='tooltip'>

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -258,6 +258,24 @@ class Dropdown
             $params['url'],
             $p
         );
+
+        // Add icon
+        if (
+            ($item instanceof CommonDropdown)
+            && $item->canCreate()
+            && !isset($_REQUEST['_in_modal'])
+            && $params['addicon']
+        ) {
+            $add_item_icon = '<div class="btn btn-outline-secondary"
+                           title="' . __s('Add') . '" data-bs-toggle="modal" data-bs-target="#add_' . $field_id . '">';
+            $add_item_icon .= Ajax::createIframeModalWindow('add_' . $field_id, $item->getFormURL(), ['display' => false]);
+            $add_item_icon .= "<span data-bs-toggle='tooltip'>
+              <i class='fa-fw ti ti-plus'></i>
+              <span class='sr-only'>" . __s('Add') . "</span>
+                </span>";
+            $add_item_icon .= '</div>';
+        }
+
        // Display comment
         $icons = "";
         if ($params['comments']) {
@@ -316,14 +334,7 @@ class Dropdown
                 && !isset($_REQUEST['_in_modal'])
                 && $params['addicon']
             ) {
-                  $icons .= '<div class="btn btn-outline-secondary"
-                               title="' . __s('Add') . '" data-bs-toggle="modal" data-bs-target="#add_' . $field_id . '">';
-                  $icons .= Ajax::createIframeModalWindow('add_' . $field_id, $item->getFormURL(), ['display' => false]);
-                  $icons .= "<span data-bs-toggle='tooltip'>
-                  <i class='fa-fw ti ti-plus'></i>
-                  <span class='sr-only'>" . __s('Add') . "</span>
-               </span>";
-                  $icons .= '</div>';
+                  $icons .= $add_item_icon;
             }
 
            // Supplier Links
@@ -377,6 +388,11 @@ class Dropdown
                 $icons .= "</span>";
                 $icons .= '</div>';
             }
+        }
+
+        // Trick to get the "+" button to work with dropdowns that support multiple values
+        if (strlen($icons) == 0 && strlen($add_item_icon) > 0) {
+            $icons .= $add_item_icon;
         }
 
         if (strlen($icons) > 0) {

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -399,6 +399,15 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
             $kb_item_item->add($params);
         }
 
+        // Support old "knowbaseitemcategories_id" input
+        // Delete this code after 10.1 release
+        if (isset($this->input['knowbaseitemcategories_id'])) {
+            Toolbox::deprecated("knowbaseitemcategories_id is depreacted, please use _categories");
+            $categories = $this->input['knowbaseitemcategories_id'];
+            $this->input['_categories'] = is_array($categories) ? $categories : [$categories];
+            unset($this->input['knowbaseitemcategories_id']);
+        }
+
         // Handle categories
         $this->update1NTableData(KnowbaseItem_KnowbaseItemCategory::class, "_categories");
     }
@@ -745,6 +754,15 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
                 'force_update'  => true,
             ]
         );
+
+        // Support old "knowbaseitemcategories_id" input
+        // Delete this code after 10.1 release
+        if (isset($this->input['knowbaseitemcategories_id'])) {
+            Toolbox::deprecated("knowbaseitemcategories_id is depreacted, please use _categories");
+            $categories = $this->input['knowbaseitemcategories_id'];
+            $this->input['_categories'] = is_array($categories) ? $categories : [$categories];
+            unset($this->input['knowbaseitemcategories_id']);
+        }
 
         // Update categories
         $this->update1NTableData(KnowbaseItem_KnowbaseItemCategory::class, '_categories');

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -242,7 +242,6 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         $this->addStandardTab(__CLASS__, $ong, $options);
         $this->addStandardTab('KnowbaseItem_Item', $ong, $options);
         $this->addStandardTab('Document_Item', $ong, $options);
-        $this->addStandardTab('KnowbaseItem_KnowbaseItemCategory', $ong, $options);
         $this->addStandardTab('KnowbaseItemTranslation', $ong, $options);
         $this->addStandardTab('Log', $ong, $options);
         $this->addStandardTab('KnowbaseItem_Revision', $ong, $options);

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -400,9 +400,8 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         }
 
         // Support old "knowbaseitemcategories_id" input
-        // Delete this code after 10.1 release
+        // FIXME Deprecate it in GLPI 10.1
         if (isset($this->input['knowbaseitemcategories_id'])) {
-            Toolbox::deprecated("knowbaseitemcategories_id is depreacted, please use _categories");
             $categories = $this->input['knowbaseitemcategories_id'];
             $this->input['_categories'] = is_array($categories) ? $categories : [$categories];
             unset($this->input['knowbaseitemcategories_id']);
@@ -756,9 +755,8 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         );
 
         // Support old "knowbaseitemcategories_id" input
-        // Delete this code after 10.1 release
+        // FIXME Deprecate it in GLPI 10.1
         if (isset($this->input['knowbaseitemcategories_id'])) {
-            Toolbox::deprecated("knowbaseitemcategories_id is depreacted, please use _categories");
             $categories = $this->input['knowbaseitemcategories_id'];
             $this->input['_categories'] = is_array($categories) ? $categories : [$categories];
             unset($this->input['knowbaseitemcategories_id']);

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -400,16 +400,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         }
 
         // Handle categories
-        if (isset($this->input['knowbaseitemcategories_id'])) {
-            $kb_cats = is_array($this->input['knowbaseitemcategories_id']) ? $this->input['knowbaseitemcategories_id'] : [$this->input['knowbaseitemcategories_id']];
-            foreach ($kb_cats as $kb_cat) {
-                $kb_cat_item = new KnowbaseItem_KnowbaseItemCategory();
-                $kb_cat_item->add([
-                    'knowbaseitems_id' => $this->getID(),
-                    'knowbaseitemcategories_id' => $kb_cat,
-                ]);
-            }
-        }
+        $this->update1NTableData(KnowbaseItem_KnowbaseItemCategory::class, "_categories");
     }
 
 
@@ -430,6 +421,9 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
 
        // Profile / entities
         $this->profiles = KnowbaseItem_Profile::getProfiles($this->fields['id']);
+
+        // Load categories
+        $this->load1NTableData(KnowbaseItem_KnowbaseItemCategory::class, '_categories');
     }
 
 
@@ -751,6 +745,9 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
                 'force_update'  => true,
             ]
         );
+
+        // Update categories
+        $this->update1NTableData(KnowbaseItem_KnowbaseItemCategory::class, '_categories');
     }
 
 
@@ -829,17 +826,18 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         $options['formoptions'] = "data-track-changes=true";
         $this->showFormHeader($options);
         echo "<tr class='tab_bg_1'>";
-        if ($this->isNewItem()) {
-            echo "<td>" . KnowbaseItemCategory::getTypeName(Session::getPluralNumber()) . "</td>";
-            echo "<td>";
-            KnowbaseItemCategory::dropdown([
-                'value' => [],
-                'multiple' => true,
-            ]);
-            echo "</td>";
-        } else {
-            echo "<td colspan=2></td>";
-        }
+        echo "<td>" . KnowbaseItemCategory::getTypeName(Session::getPluralNumber()) . "</td>";
+        echo "<td>";
+        // See CommonDBTM::update1NTableData, hidden input needed to handle empty values
+        echo  Html::input("__categories_defined", ["type" => "hidden", "value" => 1]);
+        KnowbaseItemCategory::dropdown([
+            'name'     => "_categories[]",
+            'value'    => $this->fields['_categories'] ?? [],
+            'multiple' => true,
+            'width'    => "100%",
+        ]);
+        echo "</td>";
+
         echo "<td>";
         echo "<input type='hidden' name='users_id' value=\"" . Session::getLoginUserID() . "\">";
         if ($this->fields["date_creation"]) {

--- a/src/KnowbaseItem_KnowbaseItemCategory.php
+++ b/src/KnowbaseItem_KnowbaseItemCategory.php
@@ -44,7 +44,7 @@ class KnowbaseItem_KnowbaseItemCategory extends CommonDBRelation
     public static $itemtype_1          = 'KnowbaseItem';
     public static $items_id_1          = 'knowbaseitems_id';
     public static $itemtype_2          = 'KnowbaseItemCategory';
-    public static $items_id_2          = 'Knowbaseitemcategories_id';
+    public static $items_id_2          = 'knowbaseitemcategories_id';
     public static $checkItem_2_Rights  = self::HAVE_VIEW_RIGHT_ON_ITEM;
 
    // From CommonDBTM

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -202,19 +202,20 @@ class DbTestCase extends \GLPITestCase
      *
      * @param string $itemtype
      * @param array $input
+     * @param array $skip_fields Fields that wont be checked after creation
      *
      * @return CommonDBTM
      */
-    protected function createItem($itemtype, $input): CommonDBTM
+    protected function createItem($itemtype, $input, $skip_fields = []): CommonDBTM
     {
         $item = new $itemtype();
         $input = Sanitizer::sanitize($input);
         $id = $item->add($input);
         $this->integer($id)->isGreaterThan(0);
 
-       // Remove special fields
-        $input = array_filter($input, function ($key) {
-            return strpos($key, '_') !== 0;
+        // Remove special fields
+        $input = array_filter($input, function ($key) use ($skip_fields) {
+            return !in_array($key, $skip_fields) && strpos($key, '_') !== 0;
         }, ARRAY_FILTER_USE_KEY);
 
         $this->checkInput($item, $id, $input);

--- a/tests/functionnal/KnowbaseItem.php
+++ b/tests/functionnal/KnowbaseItem.php
@@ -409,7 +409,7 @@ class KnowbaseItem extends DbTestCase
             'comment' => __FUNCTION__ . '_1',
             'entities_id' => $root_entity,
             'is_recursive' => 1,
-            'knowbaseitemcategories_id' => 0,
+            '_categories' => [],
         ]);
         $this->integer($kb_cat_id1)->isGreaterThan(0);
 
@@ -418,7 +418,7 @@ class KnowbaseItem extends DbTestCase
             'comment' => __FUNCTION__ . '_2',
             'entities_id' => $root_entity,
             'is_recursive' => 1,
-            'knowbaseitemcategories_id' => 0,
+            '_categories' => [],
         ]);
         $this->integer($kb_cat_id2)->isGreaterThan(0);
 
@@ -427,7 +427,7 @@ class KnowbaseItem extends DbTestCase
         $kbitems_id1 = $kbitem->add([
             'name' => __FUNCTION__ . '_1',
             'answer' => __FUNCTION__ . '_1',
-            'knowbaseitemcategories_id' => $kb_cat_id1,
+            '_categories' => [$kb_cat_id1],
         ]);
         $this->integer($kbitems_id1)->isGreaterThan(0);
 
@@ -445,7 +445,7 @@ class KnowbaseItem extends DbTestCase
         $kbitems_id2 = $kbitem->add([
             'name' => __FUNCTION__ . '_2',
             'answer' => __FUNCTION__ . '_2',
-            'knowbaseitemcategories_id' => [$kb_cat_id1, $kb_cat_id2],
+            '_categories' => [$kb_cat_id1, $kb_cat_id2],
         ]);
         $this->integer($kbitems_id2)->isGreaterThan(0);
 

--- a/tests/functionnal/KnowbaseItem.php
+++ b/tests/functionnal/KnowbaseItem.php
@@ -414,14 +414,11 @@ class KnowbaseItem extends DbTestCase
         ]);
 
         // Create KB item with category
-        $kb_item = null;
-        $this->when(function () use ($category, &$kb_item) {
-            $kb_item = $this->createItem(\KnowbaseItem::class, [
-                'name' => __FUNCTION__ . '_1',
-                'answer' => __FUNCTION__ . '_1',
-                'knowbaseitemcategories_id' => $category->getID(),
-            ], ['knowbaseitemcategories_id']);
-        })->error()->withType(E_USER_DEPRECATED)->exists();
+        $kb_item = $this->createItem(\KnowbaseItem::class, [
+            'name' => __FUNCTION__ . '_1',
+            'answer' => __FUNCTION__ . '_1',
+            'knowbaseitemcategories_id' => $category->getID(),
+        ], ['knowbaseitemcategories_id']);
 
         // Get categories linked to our kb_item
         $linked_categories = (new \KnowbaseItem_KnowbaseItemCategory())->find([


### PR DESCRIPTION
I've found a couple issues regarding FAQ categories.
For more context, these issues seems related to the change allowing multiple categories : https://github.com/glpi-project/glpi/pull/9898 and https://github.com/glpi-project/glpi/pull/11372.

Creation form: 

![image](https://user-images.githubusercontent.com/42734840/173524751-2cc160b2-004c-4c32-bfee-6516b16043bd.png)

- Input is way too small
- Inserting multiple values do not work, only one value is save
- Missing "+" button to add a new category (this is not related directly to categories - GLPI do not support the "+" button for "multiple" dropdown)

Edit form:

![image](https://user-images.githubusercontent.com/42734840/173525252-23a95b7f-2f78-4970-b3a7-bbfc7ad64904.png)

- The input to edit categories is missing (it was placed here in 9.5).

### Changes

Creation form:

![image](https://user-images.githubusercontent.com/42734840/173525758-a6956b84-5036-40f0-b65c-8e92d792b514.png)

- Input now have the same size as the one below
- Inserting multiple values is now working as expected
- "+" button now available

Update form:

![image](https://user-images.githubusercontent.com/42734840/173528346-91e1cc43-4bc1-41f0-b997-44c42587fda9.png)

- Can edit categories



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24232
