### PR TITLE
feat(socket): add several socket from item

### DIFF
--- a/front/networkport.form.php
+++ b/front/networkport.form.php
@@ -78,6 +78,15 @@ if (isset($_POST["add"])) {
         unset($input['from_logical_number']);
         unset($input['to_logical_number']);
 
+        if ($_POST["to_logical_number"] < $_POST["from_logical_number"]) {
+            Session::addMessageAfterRedirect(
+                __("'To' should not be smaller than 'From'"),
+                false,
+                ERROR
+            );
+            Html::back();
+        }
+
         for ($i = $_POST["from_logical_number"]; $i <= $_POST["to_logical_number"]; $i++) {
             $add = "";
             if ($i < 10) {

--- a/front/socket.form.php
+++ b/front/socket.form.php
@@ -72,6 +72,15 @@ if (isset($_POST["add"]) || isset($_POST["execute_single"]) || isset($_POST["exe
         $initialName = $_POST["name"];
         $wiring_side = $_POST["wiring_side"];
 
+        if ($_POST["_to"] < $_POST["_from"]) {
+            Session::addMessageAfterRedirect(
+                __("'To' should not be smaller than 'From'"),
+                false,
+                ERROR
+            );
+            Html::back();
+        }
+
         for ($i = $_POST["_from"]; $i <= $_POST["_to"]; $i++) {
             $_POST["name"] = $_POST["_before"] . $initialName . $i . $_POST["_after"];
             $_POST["position"] =  $i;

--- a/front/socket.form.php
+++ b/front/socket.form.php
@@ -51,7 +51,7 @@ if (!isset($_GET["itemtype"])) {
 }
 
 $socket = new Socket();
-if (isset($_POST["add"])) {
+if (isset($_POST["add"]) && !isset($_POST["execute_multi"])) {
     $socket->check(-1, CREATE, $_POST);
 
     if ($socket->add($_POST)) {
@@ -101,6 +101,7 @@ if (isset($_POST["add"])) {
 
     for ($i = $_POST["_from"]; $i <= $_POST["_to"]; $i++) {
         $_POST["name"] = $_POST["_before"] . $i . $_POST["_after"];
+        $_POST["position"] =  $i;
         $socket->add($_POST);
     }
     Event::log(
@@ -150,6 +151,10 @@ if (isset($_POST["add"])) {
 
     if (isset($itemtype)) {
         $options['itemtype'] = $itemtype;
+    }
+
+    if (isset($_GET["several"])) {
+        $options['several'] = $_GET["several"];
     }
 
    // Add a socket from item : format data

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1561,7 +1561,7 @@ class Dropdown
      *    - showItemSpecificity : given an item, the AJAX file to open if there is special
      *                            treatment. For instance, select a Item_Device* for CommonDevice
      *    - emptylabel          : Empty choice's label (default self::EMPTY_VALUE)
-     *    - display_emptychoice : display empty choice, cannot be used when "multiple" option set to true (default false)
+     *    - display_emptychoice : display empty choice, cannot be used when "multiple" option set to true (default true)
      *    - used                : array / Already used items ID: not to display in dropdown (default empty)
      *    - display             : true : display directly, false return the html
      *
@@ -1582,7 +1582,7 @@ class Dropdown
             'checkright'                => false,
             'showItemSpecificity'       => '',
             'emptylabel'                => self::EMPTY_VALUE,
-            'display_emptychoice'       => false,
+            'display_emptychoice'       => true,
             'used'                      => [],
             'ajax_page'                 => $CFG_GLPI["root_doc"] . "/ajax/dropdownAllItems.php",
             'display'                   => true,

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1561,6 +1561,7 @@ class Dropdown
      *    - showItemSpecificity : given an item, the AJAX file to open if there is special
      *                            treatment. For instance, select a Item_Device* for CommonDevice
      *    - emptylabel          : Empty choice's label (default self::EMPTY_VALUE)
+     *    - display_emptychoice : display empty choice, cannot be used when "multiple" option set to true (default false)
      *    - used                : array / Already used items ID: not to display in dropdown (default empty)
      *    - display             : true : display directly, false return the html
      *

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1581,6 +1581,7 @@ class Dropdown
             'checkright'                => false,
             'showItemSpecificity'       => '',
             'emptylabel'                => self::EMPTY_VALUE,
+            'display_emptychoice'       => false,
             'used'                      => [],
             'ajax_page'                 => $CFG_GLPI["root_doc"] . "/ajax/dropdownAllItems.php",
             'display'                   => true,
@@ -1595,12 +1596,13 @@ class Dropdown
         }
 
         $select = self::showItemType($params['itemtypes'], [
-            'checkright'    => $params['checkright'],
-            'name'          => $params['itemtype_name'],
-            'emptylabel'    => $params['emptylabel'],
-            'display'       => $params['display'],
-            'rand'          => $params['rand'],
-            'track_changes' => $params['itemtype_track_changes'],
+            'checkright'          => $params['checkright'],
+            'name'                => $params['itemtype_name'],
+            'emptylabel'          => $params['emptylabel'],
+            'display_emptychoice' => $params['display_emptychoice'],
+            'display'             => $params['display'],
+            'rand'                => $params['rand'],
+            'track_changes'       => $params['itemtype_track_changes'],
         ]);
 
         $p_ajax = [

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -285,7 +285,7 @@ class Socket extends CommonDBChild
      *    - display
      * @return string ID of the select
      **/
-    public static function dropdownWiringSide($name, $options = [], $full = false)
+    public static function dropdownWiringSide($name, $options = [], bool $full = false)
     {
         $params = [
             'value'     => 0,

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -65,6 +65,7 @@ class Socket extends CommonDBChild
 
     const REAR    = 1;
     const FRONT   = 2;
+    const BOTH    = 3;
 
     public function canCreateItem()
     {
@@ -284,7 +285,7 @@ class Socket extends CommonDBChild
      *    - display
      * @return string ID of the select
      **/
-    public static function dropdownWiringSide($name, $options = [])
+    public static function dropdownWiringSide($name, $options = [], $full = false)
     {
         $params = [
             'value'     => 0,
@@ -297,7 +298,7 @@ class Socket extends CommonDBChild
             }
         }
 
-        return Dropdown::showFromArray($name, self::getSides(), $params);
+        return Dropdown::showFromArray($name, self::getSides($full), $params);
     }
 
 
@@ -305,12 +306,18 @@ class Socket extends CommonDBChild
      * Get sides
      * @return array Array of types
      **/
-    public static function getSides()
+    public static function getSides($full = false)
     {
-        return [
+        $data =  [
             self::REAR   => __('Rear'),
             self::FRONT  => __('Front'),
         ];
+
+        if ($full) {
+            $data[self::BOTH] =  __('Create both');
+        }
+
+        return $data;
     }
 
 

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -306,7 +306,7 @@ class Socket extends CommonDBChild
      * Get sides
      * @return array Array of types
      **/
-    public static function getSides($full = false)
+    public static function getSides(bool $full = false)
     {
         $data =  [
             self::REAR   => __('Rear'),

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -40,6 +40,7 @@ use Cable;
 use CommonDBChild;
 use CommonDBTM;
 use CommonGLPI;
+use Computer;
 use Dropdown;
 use Glpi\Application\View\TemplateRenderer;
 use Html;
@@ -206,7 +207,9 @@ class Socket extends CommonDBChild
             $item->getFromDB($this->fields['items_id']);
         } else {
             $this->check(-1, CREATE, $options);
-            $item->getFromDB($options['from_items_id']);
+            if (isset($options['from_items_id'])) {
+                $item->getFromDB($options['from_items_id']);
+            }
         }
 
         TemplateRenderer::getInstance()->display('pages/assets/socket.html.twig', [
@@ -866,6 +869,7 @@ class Socket extends CommonDBChild
             echo "<td>" . __('Itemtype') . "</td><td>";
             Dropdown::showSelectItemFromItemtypes([
                 'itemtypes' => $socket_itemtypes,
+                'default_itemtype' => Computer::getType(),
             ]);
             echo "</td>";
 
@@ -905,6 +909,7 @@ class Socket extends CommonDBChild
             echo "<td>" . __('Itemtype') . "</td><td>";
             Dropdown::showSelectItemFromItemtypes([
                 'itemtypes' => $socket_itemtypes,
+                'default_itemtype' => Computer::getType(),
             ]);
             echo "</td>";
 

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -173,9 +173,7 @@ class Socket extends CommonDBChild
                     refreshNetworkPortDropdown(itemtype, items_id, 'show_networkport_field');
                 });
             ");
-
         }
-
     }
 
     /**
@@ -692,12 +690,12 @@ class Socket extends CommonDBChild
             echo "<tr class='tab_bg_2'>";
             echo "<td class='tab_bg_2 center'>";
             echo "<td>\n";
-            echo "<input type='submit' name='add_several' value=\"" .__('New socket for this item...') . "\" class='btn btn-primary'>\n";
+            echo "<input type='submit' name='add_several' value=\"" . __('New socket for this item...') . "\" class='btn btn-primary'>\n";
             echo "</td>";
             echo "<td>\n";
             echo __('Add several sockets');
             echo "&nbsp;<input type='checkbox' name='several' value='1'></td>\n";
-           echo "</tr></table></div>\n";
+            echo "</tr></table></div>\n";
             Html::closeForm();
             echo "</div>";
         }

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -192,8 +192,8 @@ class Socket extends CommonDBChild
     {
 
         $itemtype = null;
-        if (isset($options['itemtype']) && !empty($options['itemtype'])) {
-            $itemtype = $options['itemtype'];
+        if (isset($options['from_itemtype']) && !empty($options['from_itemtype'])) {
+            $itemtype = $options['from_itemtype'];
         } else if (isset($this->fields['itemtype']) && !empty($this->fields['itemtype'])) {
             $itemtype = $this->fields['itemtype'];
         } else {
@@ -206,7 +206,7 @@ class Socket extends CommonDBChild
             $item->getFromDB($this->fields['items_id']);
         } else {
             $this->check(-1, CREATE, $options);
-            $item->getFromDB($options['items_id']);
+            $item->getFromDB($options['from_items_id']);
         }
 
         TemplateRenderer::getInstance()->display('pages/assets/socket.html.twig', [
@@ -691,20 +691,23 @@ class Socket extends CommonDBChild
         if ($item->getID() && self::canCreate()) {
             echo "<div class='firstbloc'>";
             echo "\n<form method='get' action='" . Socket::getFormURL() . "'>\n";
-            echo "<input type='hidden' name='items_id' value='" . $item->getID() . "'>\n";
-            echo "<input type='hidden' name='itemtype' value='" . $item->getType() . "'>\n";
+            echo "<input type='hidden' name='_from_items_id' value='" . $item->getID() . "'>\n";
+            echo "<input type='hidden' name='_from_itemtype' value='" . $item->getType() . "'>\n";
             echo "<div class='firstbloc'><table class='tab_cadre_fixe'>\n";
             echo "<tr class='tab_bg_2'>";
             echo "<td class='tab_bg_2 center'>";
             echo "<td>\n";
-            echo "<input type='submit' name='add_several' value=\"" . __('New socket for this item...') . "\" class='btn btn-primary'>\n";
+
+            echo "<button class='btn btn-primary' type='submit' name='_add_fromitem'>";
+            echo "<span>" . __('New socket for this item...') . "</span>";
+            echo "</button>";
+
             echo "</td>";
             echo "<td>\n";
             echo __('Add several sockets');
             echo "&nbsp;<input type='checkbox' name='several' value='1'></td>\n";
             echo "</tr></table></div>\n";
-            Html::closeForm();
-            echo "</div>";
+            echo "</form></div>";
         }
 
         $iterator = $DB->request([

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -193,8 +193,8 @@ class Socket extends CommonDBChild
     {
 
         $itemtype = null;
-        if (isset($options['from_itemtype']) && !empty($options['from_itemtype'])) {
-            $itemtype = $options['from_itemtype'];
+        if (isset($options['_add_fromitem']) && !empty($options['_add_fromitem'])) {
+            $itemtype = $options['_add_fromitem']['_from_itemtype'];
         } else if (isset($this->fields['itemtype']) && !empty($this->fields['itemtype'])) {
             $itemtype = $this->fields['itemtype'];
         } else {
@@ -207,8 +207,8 @@ class Socket extends CommonDBChild
             $item->getFromDB($this->fields['items_id']);
         } else {
             $this->check(-1, CREATE, $options);
-            if (isset($options['from_items_id'])) {
-                $item->getFromDB($options['from_items_id']);
+            if (isset($options['_add_fromitem'])) {
+                $item->getFromDB($options['_add_fromitem']['_from_items_id']);
             }
         }
 

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -870,6 +870,7 @@ class Socket extends CommonDBChild
             Dropdown::showSelectItemFromItemtypes([
                 'itemtypes' => $socket_itemtypes,
                 'default_itemtype' => Computer::getType(),
+                'display_emptychoice' => false,
             ]);
             echo "</td>";
 
@@ -910,6 +911,7 @@ class Socket extends CommonDBChild
             Dropdown::showSelectItemFromItemtypes([
                 'itemtypes' => $socket_itemtypes,
                 'default_itemtype' => Computer::getType(),
+                'display_emptychoice' => false,
             ]);
             echo "</td>";
 

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -143,34 +143,39 @@ class Socket extends CommonDBChild
         }
         echo "</span>";
 
-        echo "<span id='show_networkport_field'>";
-        NetworkPort::dropdown(['name'                => 'networkports_id',
-            'value'               => $networkports_id,
-            'display_emptychoice' => true,
-            'condition'           => ['items_id' => $items_id,
-                'itemtype' => $itemtype
-            ],
-            'comments' => false
-        ]);
-        echo "</span>";
 
-       //Listener to update breacrumb / socket
-        echo Html::scriptBlock("
-         //listener to remove socket selector and breadcrumb
-         $(document).on('change', '#dropdown_itemtype" . $rand_itemtype . "', function(e) {
-            $('#show_front_asset_breadcrumb').empty();
-            $('#show_front_sockets_field').empty();
-         });
+        //Do not display NetworkPort field if several mode
+        if (!isset($options['several'])) {
+            echo "<span id='show_networkport_field'>";
+            NetworkPort::dropdown(['name'                => 'networkports_id',
+                'value'               => $networkports_id,
+                'display_emptychoice' => true,
+                'condition'           => ['items_id' => $items_id,
+                    'itemtype' => $itemtype
+                ],
+                'comments' => false
+            ]);
+            echo "</span>";
 
-         //listener to refresh socket selector and breadcrumb
-         $(document).on('change', '#dropdown_items_id" . $rand_items_id . "', function(e) {
-            var items_id = $('#dropdown_items_id" . $rand_items_id . "').find(':selected').val();
-            var itemtype = $('#dropdown_itemtype" . $rand_itemtype . "').find(':selected').val();
-            refreshAssetBreadcrumb(itemtype, items_id, 'show_asset_breadcrumb');
-            refreshNetworkPortDropdown(itemtype, items_id, 'show_networkport_field');
+           //Listener to update breacrumb / socket
+            echo Html::scriptBlock("
+                //listener to remove socket selector and breadcrumb
+                $(document).on('change', '#dropdown_itemtype" . $rand_itemtype . "', function(e) {
+                    $('#show_front_asset_breadcrumb').empty();
+                    $('#show_front_sockets_field').empty();
+                });
 
-         });
-      ");
+                //listener to refresh socket selector and breadcrumb
+                $(document).on('change', '#dropdown_items_id" . $rand_items_id . "', function(e) {
+                    var items_id = $('#dropdown_items_id" . $rand_items_id . "').find(':selected').val();
+                    var itemtype = $('#dropdown_itemtype" . $rand_itemtype . "').find(':selected').val();
+                    refreshAssetBreadcrumb(itemtype, items_id, 'show_asset_breadcrumb');
+                    refreshNetworkPortDropdown(itemtype, items_id, 'show_networkport_field');
+                });
+            ");
+
+        }
+
     }
 
     /**
@@ -680,15 +685,20 @@ class Socket extends CommonDBChild
        // Link to open a new socket
         if ($item->getID() && self::canCreate()) {
             echo "<div class='firstbloc'>";
-            Html::showSimpleForm(
-                Socket::getFormURL(),
-                '_add_fromitem',
-                __('New socket for this item...'),
-                [
-                    '_from_itemtype' => $item->getType(),
-                    '_from_items_id' => $item->getID(),
-                ]
-            );
+            echo "\n<form method='get' action='" . Socket::getFormURL() . "'>\n";
+            echo "<input type='hidden' name='items_id' value='" . $item->getID() . "'>\n";
+            echo "<input type='hidden' name='itemtype' value='" . $item->getType() . "'>\n";
+            echo "<div class='firstbloc'><table class='tab_cadre_fixe'>\n";
+            echo "<tr class='tab_bg_2'>";
+            echo "<td class='tab_bg_2 center'>";
+            echo "<td>\n";
+            echo "<input type='submit' name='add_several' value=\"" .__('New socket for this item...') . "\" class='btn btn-primary'>\n";
+            echo "</td>";
+            echo "<td>\n";
+            echo __('Add several sockets');
+            echo "&nbsp;<input type='checkbox' name='several' value='1'></td>\n";
+           echo "</tr></table></div>\n";
+            Html::closeForm();
             echo "</div>";
         }
 

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -221,11 +221,6 @@ class Socket extends CommonDBChild
 
     public function prepareInputForAdd($input)
     {
-        // If no items_id is set, do not store itemtype or items_id
-        if (!isset($input['items_id']) || empty($input['items_id'])) {
-            unset($input['itemtype']);
-            unset($input['items_id']);
-        }
         $input = $this->retrievedataFromNetworkPort($input);
         return $input;
     }
@@ -233,11 +228,6 @@ class Socket extends CommonDBChild
 
     public function prepareInputForUpdate($input)
     {
-        // If no items_id is set, do not store itemtype or items_id
-        if (!isset($input['items_id']) || empty($input['items_id'])) {
-            unset($input['itemtype']);
-            unset($input['items_id']);
-        }
         $input = $this->retrievedataFromNetworkPort($input);
         return $input;
     }

--- a/templates/pages/assets/socket.html.twig
+++ b/templates/pages/assets/socket.html.twig
@@ -53,12 +53,18 @@
     {{ fields.nullField() }}
    {% endif %}
 
+   {% set full = false %}
+   {% if params['several'] is defined %}
+      {% set full = true %}
+   {% endif %}
+
    {% set wiring_side %}
       {% do call('Glpi\\Socket::dropdownWiringSide', [
          'wiring_side',
          {
             'value': item.fields['wiring_side'],
-         }
+         },
+         full
       ]) %}
    {% endset %}
    {{ fields.htmlField(

--- a/templates/pages/assets/socket.html.twig
+++ b/templates/pages/assets/socket.html.twig
@@ -117,7 +117,7 @@
          {}
       ) }}
 
-		<input type="hidden" name="execute_multi" value="1">
+      <input type="hidden" name="execute_multi" value="1">
    {% endif %}
 
 {% endblock %}

--- a/templates/pages/assets/socket.html.twig
+++ b/templates/pages/assets/socket.html.twig
@@ -40,9 +40,10 @@
    <input type="hidden" name="items_id" value="{{ params["items_id"] }}">
 
    {{ fields.nullField() }}
+   {% set add_several = params['several'] is defined and params['several'] %}
 
    {# Do not display position if several mode, value is compute on add #}
-   {% if params['several'] is not defined %}
+   {% if not add_several %}
       {{ fields.numberField(
          'position',
          item.fields['position'],
@@ -53,18 +54,13 @@
     {{ fields.nullField() }}
    {% endif %}
 
-   {% set full = false %}
-   {% if params['several'] is defined %}
-      {% set full = true %}
-   {% endif %}
-
    {% set wiring_side %}
       {% do call('Glpi\\Socket::dropdownWiringSide', [
          'wiring_side',
          {
             'value': item.fields['wiring_side'],
          },
-         full
+         add_several
       ]) %}
    {% endset %}
    {{ fields.htmlField(
@@ -87,7 +83,7 @@
       _n('Network port', 'Network ports', get_plural_number()),
    ) }}
 
-   {% if params['several'] is defined %}
+   {% if add_several %}
 
       {{ fields.dropdownNumberField(
          '_from',
@@ -107,14 +103,14 @@
          }
       ) }}
 
-		{{ fields.textField(
+      {{ fields.textField(
          '_before',
          '',
          __('Prefix'),
          {}
       ) }}
 
-		{{ fields.textField(
+      {{ fields.textField(
          '_after',
          '',
          __('Suffix'),

--- a/templates/pages/assets/socket.html.twig
+++ b/templates/pages/assets/socket.html.twig
@@ -41,13 +41,17 @@
 
    {{ fields.nullField() }}
 
-   {{ fields.numberField(
-      'position',
-      item.fields['position'],
-      __('Position'),
-      field_options
-   ) }}
-
+   {# Do not display position if several mode, value is compute on add #}
+   {% if params['several'] is not defined %}
+      {{ fields.numberField(
+         'position',
+         item.fields['position'],
+         __('Position'),
+         field_options
+      ) }}
+   {% else %}
+    {{ fields.nullField() }}
+   {% endif %}
 
    {% set wiring_side %}
       {% do call('Glpi\\Socket::dropdownWiringSide', [
@@ -76,5 +80,42 @@
       networkports,
       _n('Network port', 'Network ports', get_plural_number()),
    ) }}
+
+   {% if params['several'] is defined %}
+
+      {{ fields.dropdownNumberField(
+         '_from',
+         1,
+         __('From'),
+         {
+            'min': 1
+         }
+      ) }}
+
+      {{ fields.dropdownNumberField(
+         '_to',
+         1,
+         __('To'),
+         {
+            'min': 1
+         }
+      ) }}
+
+		{{ fields.textField(
+         '_before',
+         '',
+         __('Prefix'),
+         {}
+      ) }}
+
+		{{ fields.textField(
+         '_after',
+         '',
+         __('Suffix'),
+         {}
+      ) }}
+
+		<input type="hidden" name="execute_multi" value="1">
+   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Permit to add several ```Socket``` from an item

![image](https://user-images.githubusercontent.com/7335054/173537257-a85f5e6c-0d0d-418b-82d1-4b806c80f7b6.png)

![image](https://user-images.githubusercontent.com/7335054/173537278-45b6c7f6-e81b-4432-8d27-46dde772d280.png)

Compared to the standard add form

```Position``` field is hidden (compute on add) and ```NetworkPort``` field is hidden too (useless here)

![image](https://user-images.githubusercontent.com/7335054/173537604-d123d615-9b5a-489c-b5ae-47c272f56d92.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
