### PR TITLE
Self-service: load tinymce on ticket page

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -591,7 +591,10 @@ $CFG_GLPI['javascript'] = [
     ],
     'admin'        => ['clipboard', 'sortable'],
     'preference'   => ['clipboard'],
-    'self-service' => array_merge(['tinymce'], $reservations_libs)
+    'self-service' => array_merge(['tinymce'], $reservations_libs),
+    'tickets'      => [
+        'ticket' => ['tinymce']
+    ]
 ];
 
 // push reservations libs to reservations itemtypes (they shoul in asset sector)


### PR DESCRIPTION
It seems like tinymce is not always loaded when using the self-service ticket's view.

![image](https://user-images.githubusercontent.com/42734840/173543425-225bcd30-dd0c-4238-8a71-efeab5185b12.png)

After checking in `$CFG_GLPI['javascript']`, there was indeed no js lib defined for this page.

Sometimes the lib was still loaded because some ajax call on the page end up requiring it, so it might be a bit tricky to reproduce the issue.

I was however able to reproduce almost 100% of the time by doing:
- Switch to self service
- Click here 
![image](https://user-images.githubusercontent.com/42734840/173544438-663ed088-3f46-43a5-9212-6d547097a8a2.png)
- Go to any ticket with some followups
- Check your browser console


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24220
