### PR TITLE
Self-service: add missing breadcrumbs

### DIFF
--- a/front/helpdesk.faq.php
+++ b/front/helpdesk.faq.php
@@ -43,7 +43,7 @@ if (isset($_GET["redirect"])) {
 Session::checkFaqAccess();
 
 if (Session::getLoginUserID()) {
-    Html::helpHeader(__('FAQ'));
+    Html::helpHeader(__('FAQ'), 'faq');
 } else {
     $_SESSION["glpilanguage"] = $_SESSION['glpilanguage'] ?? $CFG_GLPI['language'];
    // Anonymous FAQ

--- a/front/helpdesk.public.php
+++ b/front/helpdesk.public.php
@@ -93,7 +93,7 @@ if (
 Session::checkValidSessionId();
 
 if (isset($_GET['create_ticket'])) {
-    Html::helpHeader(__('New ticket'));
+    Html::helpHeader(__('New ticket'), "create_ticket");
     $ticket = new Ticket();
     $ticket->showFormHelpdesk(Session::getLoginUserID());
 } else {

--- a/front/reservationitem.php
+++ b/front/reservationitem.php
@@ -38,7 +38,7 @@ include('../inc/includes.php');
 Session::checkRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM]);
 
 if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(__('Simplified interface'));
+    Html::helpHeader(__('Simplified interface'), 'reservation');
 } else {
     Html::header(Reservation::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "reservationitem");
 }

--- a/inc/define.php
+++ b/inc/define.php
@@ -595,7 +595,10 @@ $CFG_GLPI['javascript'] = [
     'self-service' => array_merge(['tinymce'], $reservations_libs),
     'tickets'      => [
         'ticket' => ['tinymce']
-    ]
+    ],
+    'create_ticket' => ['tinymce'],
+    'reservation'   => array_merge(['tinymce'], $reservations_libs),
+    'faq'           => ['tinymce'],
 ];
 
 // push reservations libs to reservations itemtypes (they shoul in asset sector)


### PR DESCRIPTION
Following our discussion in #11894, add missing breadcrumbs for all self-service main pages.

### New ticket page

#### Before

![image](https://user-images.githubusercontent.com/42734840/173784422-974801d0-4e4e-487f-a258-58e955e7073e.png)

#### After

![image](https://user-images.githubusercontent.com/42734840/173784552-1a27ccb1-4cb1-4a4c-925f-9834c607bdde.png)


### Reservation page

#### Before

![image](https://user-images.githubusercontent.com/42734840/173784647-4a653549-c8ee-4fa4-89e6-324d01253cfb.png)

#### After

![image](https://user-images.githubusercontent.com/42734840/173784760-d5e8f525-b562-47f1-8833-ad56bc1f625e.png)


### FAQ page

#### Before

![image](https://user-images.githubusercontent.com/42734840/173784836-8773cd49-1314-46f4-9dd1-435dbc0dc6b1.png)


#### After

![image](https://user-images.githubusercontent.com/42734840/173784907-960c0f94-d42e-46b4-b44a-8720b96f5d68.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
