### PR TITLE
Fix array of additional actors after BR

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1259,12 +1259,12 @@ class Ticket extends CommonITILObject
                     switch ($a) {
                         case 'user':
                              $additionalfield           = '_additional_' . $t . 's';
-                             $input[$additionalfield][] = ['users_id' => $input['_' . $a . 's_id_' . $t]];
+                             $input[$additionalfield] = ['users_id' => $input['_' . $a . 's_id_' . $t]];
                             break;
 
                         default:
                             $additionalfield           = '_additional_' . $a . 's_' . $t . 's';
-                            $input[$additionalfield][] = $input['_' . $a . 's_id_' . $t];
+                            $input[$additionalfield] = $input['_' . $a . 's_id_' . $t];
                             break;
                     }
                 }


### PR DESCRIPTION
Code for creating _additonal actor arrays was incorrectly creating two dimensional arrays
Example if this was supplied:
```
      [_groups_id_assign] => Array
          (
              [0] => 78
              [1] => 77
              [2] => 76
          )
```
Result was:
```
      [_additional_groups_assigns] => Array
          (
              [0] => Array
                  (
                      [0] => 77
                      [1] => 80
                      [2] => 79
                  )

          )

```
And in turn CommonITILObject::addAdditionalActors() called $groupactors->add() with incorrect parameters:
```
Array
  (
      [tickets_id] => 117
      [type] => 2
      [groups_id] => Array
          (
              [0] => 77
              [1] => 80
              [2] => 79
          )

  )
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11671
