### PR TITLE
API: fix default ranges

### DIFF
--- a/apirest.md
+++ b/apirest.md
@@ -603,7 +603,7 @@ Note: To download a document see [Download a document file](#download-a-document
   * *expand_dropdowns* (default: false): show dropdown name instead of id. Optional.
   * *get_hateoas* (default: true): Show relation of item in a links attribute. Optional.
   * *only_id* (default: false): keep only id keys in returned data. Optional.
-  * *range* (default: 0-50):  a string with a couple of number for start and end of pagination separated by a '-'. Ex: 150-200. Optional.
+  * *range* (default: 0-49):  a string with a couple of number for start and end of pagination separated by a '-'. Ex: 150-199. Optional.
   * *sort* (default 1): name of the field to sort by. Optional.
   * *order* (default ASC): ASC - Ascending sort / DESC Descending sort. Optional.
   * *searchText* (default NULL): array of filters to pass on the query (with key = field and value the text to search)
@@ -629,7 +629,7 @@ $ curl -X GET \
 'http://path/to/glpi/apirest.php/Computer/?expand_dropdowns=true'
 
 < 206 OK
-< Content-Range: 0-50/200
+< Content-Range: 0-49/200
 < Accept-Range: 990
 < [
    {
@@ -712,7 +712,7 @@ $ curl -X GET \
   * *expand_dropdowns* (default: false): show dropdown name instead of id. Optional.
   * *get_hateoas* (default: true): Show item's relations in a links attribute. Optional.
   * *only_id* (default: false): keep only id keys in returned data. Optional.
-  * *range* (default: 0-50): a string with a couple of number for start and end of pagination separated by a '-' char. Ex: 150-200. Optional.
+  * *range* (default: 0-49): a string with a couple of number for start and end of pagination separated by a '-' char. Ex: 150-199. Optional.
   * *sort* (default 1): id of the "searchoption" to sort by. Optional.
   * *order* (default ASC): ASC - Ascending sort / DESC Descending sort. Optional.
   * *add_keys_names*: Retrieve friendly names. Array containing fkey(s) and/or "id". Optional.
@@ -734,7 +734,7 @@ $ curl -X GET \
 'http://path/to/glpi/apirest.php/User/2/Log'
 
 < 200 OK
-< Content-Range: 0-50/200
+< Content-Range: 0-549200
 < Accept-Range: 990
 < [
    {
@@ -811,7 +811,7 @@ $ curl -X GET \
 'http://path/to/glpi/apirest.php/getMultipleItems?items\[0\]\[itemtype\]\=User&items\[0\]\[items_id\]\=2&items\[1\]\[itemtype\]\=Entity&items\[1\]\[items_id\]\=0'
 
 < 200 OK
-< Content-Range: 0-50/200
+< Content-Range: 0-49/200
 < Accept-Range: 990
 < [{
    "id": 2,
@@ -982,7 +982,7 @@ $ curl -X GET \
 
   * *sort* (default 1): id of the searchoption to sort by. Optional.
   * *order* (default ASC): ASC - Ascending sort / DESC Descending sort. Optional.
-  * *range* (default 0-50): a string with a couple of number for start and end of pagination separated by a '-'. Ex: 150-200.
+  * *range* (default 0-49): a string with a couple of number for start and end of pagination separated by a '-'. Ex: 150-199.
                              Optional.
   * *forcedisplay*: array of columns to display (default empty = use display preferences and searched criteria).
                      Some columns will be always presents (1: id, 2: name, 80: Entity).

--- a/apirest.md
+++ b/apirest.md
@@ -734,7 +734,7 @@ $ curl -X GET \
 'http://path/to/glpi/apirest.php/User/2/Log'
 
 < 200 OK
-< Content-Range: 0-549200
+< Content-Range: 0-49/200
 < Accept-Range: 990
 < [
    {

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -1057,7 +1057,7 @@ abstract class API
      * - 'expand_dropdowns' (default: false): show dropdown's names instead of id. Optionnal
      * - 'get_hateoas'      (default: true): show relations of items in a links attribute. Optionnal
      * - 'only_id'          (default: false): keep only id in fields list. Optionnal
-     * - 'range'            (default: 0-50): limit the list to start-end attributes
+     * - 'range'            (default: 0-49): limit the list to start-end attributes
      * - 'sort'             (default: id): sort by the field.
      * - 'order'            (default: ASC): ASC(ending) or DESC(ending).
      * - 'searchText'       (default: NULL): array of filters to pass on the query (with key = field and value the search)
@@ -1076,11 +1076,11 @@ abstract class API
 
         $itemtype = $this->handleDepreciation($itemtype);
 
-       // default params
+        // default params
         $default = ['expand_dropdowns' => false,
             'get_hateoas'       => true,
             'only_id'           => false,
-            'range'             => "0-" . $_SESSION['glpilist_limit'],
+            'range'             => "0-" . ($_SESSION['glpilist_limit']) - 1,
             'sort'              => "id",
             'order'             => "ASC",
             'searchText'        => null,
@@ -1099,21 +1099,17 @@ abstract class API
         $item->getEmpty();
         $table = getTableForItemType($itemtype);
 
-       // transform range parameter in start and limit variables
-        if (isset($params['range']) > 0) {
-            if (preg_match("/^[0-9]+-[0-9]+\$/", $params['range'])) {
-                $range = explode("-", $params['range']);
-                $params['start']      = $range[0];
-                $params['list_limit'] = $range[1] - $range[0] + 1;
-                $params['range']      = $range;
-            } else {
-                $this->returnError("range must be in format : [start-end] with integers");
-            }
+        // transform range parameter in start and limit variables
+        if (preg_match("/^[0-9]+-[0-9]+\$/", $params['range'])) {
+            $range = explode("-", $params['range']);
+            $params['start']      = $range[0];
+            $params['list_limit'] = $range[1] - $range[0] + 1;
+            $params['range']      = $range;
         } else {
-            $params['range'] = [0, $_SESSION['glpilist_limit']];
+            $this->returnError("range must be in format : [start-end] with integers");
         }
 
-       // check parameters
+        // check parameters
         if (
             isset($params['order'])
             && !in_array(strtoupper($params['order']), ['DESC', 'ASC'])
@@ -1529,7 +1525,7 @@ abstract class API
      *            - value : value to search.
      *    - 'sort' :  id of searchoption to sort by (default 1). Optionnal.
      *    - 'order' : ASC - Ascending sort / DESC Descending sort (default ASC). Optionnal.
-     *    - 'range' : a string with a couple of number for start and end of pagination separated by a '-'. Ex : 150-200. (default 0-50)
+     *    - 'range' : a string with a couple of number for start and end of pagination separated by a '-'. Ex : 150-199. (default 0-49)
      *                Optionnal.
      *    - 'forcedisplay': array of columns to display (default empty = empty use display pref and search criterias).
      *                      Some columns will be always presents (1-id, 2-name, 80-Entity).
@@ -1627,7 +1623,7 @@ abstract class API
         }
 
        // transform range parameter in start and limit variables
-        if (isset($params['range']) > 0) {
+        if (isset($params['range'])) {
             if (preg_match("/^[0-9]+-[0-9]+\$/", $params['range'])) {
                 $range = explode("-", $params['range']);
                 $params['start']      = $range[0];
@@ -1637,7 +1633,7 @@ abstract class API
                 $this->returnError("range must be in format : [start-end] with integers");
             }
         } else {
-            $params['range'] = [0, $_SESSION['glpilist_limit']];
+            $params['range'] = [0, $_SESSION['glpilist_limit'] - 1];
         }
 
        // force reset


### PR DESCRIPTION
There are some inconsistencies regarding the 'range' parameter of the API.

For example, let's search for ticket in the GLPI interface:

![image](https://user-images.githubusercontent.com/42734840/173833821-a4a20fd8-f762-49f6-8b2c-a002bcb4398a.png)

I've got 101 tickets in my database and 20 are shown on the first page.

Now if I run the same search on the API (which will use the same default page size as the search engine) I would expect to get 20 results too, right ?
Wrong, I get 21:

![image](https://user-images.githubusercontent.com/42734840/173834166-0d163381-11b9-44d5-aaac-417efd197336.png)

Headers show that the content range is 0-20:

![image](https://user-images.githubusercontent.com/42734840/173834982-4429ec45-143f-4cd6-9805-edebde891ac9.png)

Since ranges start at 0, it should be 0-19 in order to get a precise 20 results first page.

I've updated the `getItems` endpoint to use the correct default values.
I've also updated the examples values for this option in the documentation like `0-50` or `150-200` which doesn't make sense if the index start at 0 (it should be `0-49` and `150-199`)

For the `search` endpoint, it actually show the correct amount of results:

![image](https://user-images.githubusercontent.com/42734840/173843688-1ab0a5c5-c961-4cd3-8eba-e9fb3c869fa3.png)

But the content-range displayed at the end of the results is incorrect:

![image](https://user-images.githubusercontent.com/42734840/173843818-18d15b4b-36ab-45e4-a124-f7728b947334.png)

It should be 0-19 since there are 20 items displayed.

I've updated this endpoint to show the correct-content range.

I still think 0 based index are confusing (which seems to be a fact given the errors described above, some developers were probably confused when dealing with ranges).

A possible (future) improvement would be two different parameters like `page` and `limit` which seems to be one of the most commonly used solutions is most APIs (`?page=1&limit=10` instead of `?range=0-9`).

I've also seen some API that return a JSON `next_page` token in case of partial results.
Instead of specifying a range in your next request, you send the `next_page` token.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
