### PR TITLE
Fix KB item selection

### DIFF
--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -625,7 +625,6 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
             $where['OR'] = [
                 'glpi_knowbaseitems.users_id'       => Session::getLoginUserID(),
                 'glpi_knowbaseitems_users.users_id' => Session::getLoginUserID(),
-                'glpi_knowbaseitems.is_faq'         => 1,
             ];
         } else if ($is_public_faq_context) {
             $where = [


### PR DESCRIPTION
Error while searching for KB items. Regression introduced in a290f76277e7fb96aedb825c287be639bcb1661c (file inc/knowbiseitem.class.php)

When searching for KB items from Formcreator, the result may give items without any target (entity, profile, user or group). 

The problem is in the 3rd line of the WHERE clause ```OR `glpi_knowbaseitems`.`is_faq` = '1'``` 

This PR reverts a part of the above mentionned commit

here is the faulty request

```sql

SELECT
    `glpi_knowbaseitems`.*,
    `glpi_knowbaseitems_knowbaseitemcategories`.`knowbaseitemcategories_id`,
    GROUP_CONCAT(
        DISTINCT `glpi_knowbaseitemcategories`.`completename`
    ) AS category,
    COUNT(`glpi_knowbaseitems_users`.`id`) + COUNT(`glpi_groups_knowbaseitems`.`id`) + COUNT(`glpi_knowbaseitems_profiles`.`id`) + COUNT(`glpi_entities_knowbaseitems`.`id`) AS `visibility_count`
FROM
    `glpi_knowbaseitems`
    LEFT JOIN `glpi_knowbaseitems_users` ON (
        `glpi_knowbaseitems_users`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`
    )
    LEFT JOIN `glpi_groups_knowbaseitems` ON (
        `glpi_groups_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`
    )
    LEFT JOIN `glpi_knowbaseitems_profiles` ON (
        `glpi_knowbaseitems_profiles`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`
    )
    LEFT JOIN `glpi_entities_knowbaseitems` ON (
        `glpi_entities_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`
    )
    LEFT JOIN `glpi_knowbaseitems_knowbaseitemcategories` ON (
        `glpi_knowbaseitems_knowbaseitemcategories`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`
    )
    LEFT JOIN `glpi_knowbaseitemcategories` ON (
        `glpi_knowbaseitemcategories`.`id` = `glpi_knowbaseitems_knowbaseitemcategories`.`knowbaseitemcategories_id`
    )
WHERE
    (
        `glpi_knowbaseitems`.`users_id` = '3'
        OR `glpi_knowbaseitems_users`.`users_id` = '3'
        OR `glpi_knowbaseitems`.`is_faq` = '1'
        OR (
            `glpi_groups_knowbaseitems`.`groups_id` IN ('-1')
            AND (
                `glpi_groups_knowbaseitems`.`no_entity_restriction` = '1'
                OR (
                    `glpi_groups_knowbaseitems`.`entities_id` IN (
                        '0'
                    )
                )
            )
        )
        OR (
            `glpi_knowbaseitems_profiles`.`profiles_id` = '1'
            AND (
                `glpi_knowbaseitems_profiles`.`no_entity_restriction` = '1'
                OR (
                    (
                        `glpi_knowbaseitems_profiles`.`entities_id` IN (
                            '0'
                        )
                    )
                )
            )
        )
        OR (
            `glpi_entities_knowbaseitems`.`entities_id` IN (
                '0'
            )
        )
    )
    AND (
        (
            `glpi_knowbaseitems`.`is_faq` = '1'
            OR `glpi_knowbaseitems_users`.`users_id` = '3'
        )
    )
    AND `glpi_knowbaseitems_knowbaseitemcategories`.`knowbaseitemcategories_id` IN ('1', '2', '3', '4')
GROUP BY
    `glpi_knowbaseitems`.`id`
```

Here is a working requestin GLPI 9.5

```sql

SELECT
    `glpi_knowbaseitems`.*,
    `glpi_knowbaseitemcategories`.`completename` AS `category`,
    COUNT(`glpi_knowbaseitems_users`.`id`) + COUNT(`glpi_groups_knowbaseitems`.`id`) + COUNT(`glpi_knowbaseitems_profiles`.`id`) + COUNT(`glpi_entities_knowbaseitems`.`id`) AS `visibility_count`
FROM
    `glpi_knowbaseitems`
    LEFT JOIN `glpi_knowbaseitems_users` ON (
        `glpi_knowbaseitems_users`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`
    )
    LEFT JOIN `glpi_groups_knowbaseitems` ON (
        `glpi_groups_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`
    )
    LEFT JOIN `glpi_knowbaseitems_profiles` ON (
        `glpi_knowbaseitems_profiles`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`
    )
    LEFT JOIN `glpi_entities_knowbaseitems` ON (
        `glpi_entities_knowbaseitems`.`knowbaseitems_id` = `glpi_knowbaseitems`.`id`
    )
    LEFT JOIN `glpi_knowbaseitemcategories` ON (
        `glpi_knowbaseitemcategories`.`id` = `glpi_knowbaseitems`.`knowbaseitemcategories_id`
    )
WHERE
    (
        `glpi_knowbaseitems`.`users_id` = '3'
        OR `glpi_knowbaseitems_users`.`users_id` = '3'
        OR (
            `glpi_groups_knowbaseitems`.`groups_id` IN ('-1')
            AND (
                `glpi_groups_knowbaseitems`.`entities_id` < '0'
                OR (
                    `glpi_groups_knowbaseitems`.`entities_id` IN ('0')
                )
            )
        )
        OR (
            `glpi_knowbaseitems_profiles`.`profiles_id` = '1'
            AND (
                `glpi_knowbaseitems_profiles`.`entities_id` < '0'
                OR (
                    (
                        `glpi_knowbaseitems_profiles`.`entities_id` IN ('0')
                    )
                )
            )
        )
        OR (
            `glpi_entities_knowbaseitems`.`entities_id` IN ('0')
        )
    )

    AND `glpi_knowbaseitems`.`is_faq` = '1'
    AND (
        `glpi_knowbaseitems`.`knowbaseitemcategories_id` IN ('0', '1', '2', '3', '4', '5', '6')
    )
GROUP BY
    `glpi_knowbaseitems`.`id`,
    `glpi_knowbaseitemcategories`.`completename`
```

