### PR TITLE
Surround number input attributes values by quotes

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -160,9 +160,9 @@
          {{ options.readonly ? 'readonly' : '' }}
          {{ options.disabled ? 'disabled' : '' }}
          {{ options.required ? 'required' : '' }}
-         {{ options.min is defined ? 'min=' ~ options.min : '' }}
-         {{ options.max is defined ? 'max=' ~ options.max : '' }}
-         {{ options.step is defined ? 'step=' ~ options.step : '' }} />
+         {% if options.min is defined %}min="{{ options.min }}"{% endif %}
+         {% if options.max is defined %}max="{{ options.max }}"{% endif %}
+         {% if options.step is defined %}step="{{ options.step }}"{% endif %} />
    {% endset %}
    {{ _self.field(name, field, label, options) }}
 {% endmacro %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

If `numberField` macro is called using `min: '', max:'', step: any'`, generated html will be
`<input type="number" min= max= step=any />`
which will be evaluated to
`<input type="number" min="max=" step="any" />`

Surrounding values with quotes will prevent this kind of issues.