### PR TITLE
feat(rule): add itemtype to RuleImportEntity

### DIFF
--- a/src/RuleImportEntity.php
+++ b/src/RuleImportEntity.php
@@ -123,6 +123,10 @@ class RuleImportEntity extends Rule
                 'field' => 'name',
                 'name' => __('Serial number')
             ],
+            'itemtype' => [
+                'field' => 'itemtype',
+                'name' => __('Itemtype')
+            ],
             'oscomment' => [
                 'field' => 'name',
                 'name' => sprintf('%s > %s', OperatingSystem::getTypeName(1), __('Comments'))
@@ -144,7 +148,7 @@ class RuleImportEntity extends Rule
      **/
     public function displayAdditionalRuleCondition($condition, $criteria, $name, $value, $test = false)
     {
-        global $PLUGIN_HOOKS;
+        global $PLUGIN_HOOKS, $CFG_GLPI;
 
         if ($criteria['field'] == '_source') {
             $tab = ['GLPI' => __('GLPI')];
@@ -155,6 +159,11 @@ class RuleImportEntity extends Rule
                 $tab[$plug] = Plugin::getInfo($plug, 'name');
             }
             Dropdown::showFromArray($name, $tab);
+            return true;
+        }
+
+        if ($criteria['field'] == 'itemtype') {
+            Dropdown::showItemTypes($name, $CFG_GLPI['asset_types'], ['value' => $value]);
             return true;
         }
 


### PR DESCRIPTION
Add ```itemtype``` criteria

![image](https://user-images.githubusercontent.com/7335054/174577881-d6d8d6b5-6832-4042-82bf-46436417ea2a.png)

```itemtype``` value is always send to ```Rule``` engine

see: 

https://github.com/glpi-project/glpi/blob/691086765a58056a6a29e6504253b4770ed5daae/src/Inventory/Asset/MainAsset.php#L463-L465

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
