### PR TITLE
Handle missing 'From' header in collected emails

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -769,7 +769,7 @@ class MailCollector extends CommonDBTM
 
                         if (!$tkt['_blacklisted']) {
                               global $DB;
-                              $rejinput['from']              = $requester;
+                              $rejinput['from']              = $requester ?? '';
                               $rejinput['to']                = $headers['to'];
                               $rejinput['users_id']          = $tkt['_users_id_requester'];
                               $rejinput['subject']           = Sanitizer::sanitize($this->cleanSubject($headers['subject']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11941

A quick fix for #11941.

Adding an option to use the `Sender` header would probably be interesting, but, anyway, we have to properly handle emails that does not provide the mandatory `From` header.