### PR TITLE
fix warning null value when call dropdown of computers

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3258,7 +3258,7 @@ class Dropdown
                     } else if ($item instanceof CommonDCModelDropdown) {
                         $outputval = sprintf(__('%1$s - %2$s'), $data[$field], $data['product_number']);
                     } else {
-                        $outputval = $data[$field];
+                        $outputval = $data[$field] ?? "";
                     }
 
                     $ID         = $data['id'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Displaying a dropdown of computer triggers a warning:

```
[2022-06-20 14:44:21] glpiphplog.NOTICE:   *** PHP Deprecated function (8192): strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/glpi/10.0.git/src/Dropdown.php at line 3282
  Backtrace :
  ajax/getDropdownValue.php:50                       Dropdown::getDropdownValue()
```

This kind of display (computer's dropdown) is not very usual in GLPI and we missed it since, i think, a long time.
