### PR TITLE
feat(inventory): get tag from related agent for NetDiscovery

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -36,6 +36,7 @@
 
 namespace Glpi\Inventory\Asset;
 
+use Agent;
 use Auth;
 use CommonDBTM;
 use Dropdown;
@@ -391,6 +392,14 @@ abstract class MainAsset extends InventoryAsset
 
         if (isset($this->getAgent()->fields['tag'])) {
             $input['tag'] = $this->getAgent()->fields['tag'];
+        }
+
+        //form discovery mode try to get related agent TAG by it's deviceid
+        $agent = new Agent();
+        if (!isset($input['tag'])) {
+            if ($agent->getFromDBByCrit(['deviceid' => $this->getAgent()->fields['deviceid']])) {
+                $input['tag'] = $agent->fields['tag'];
+            }
         }
 
         $models_id = $this->getModelsFieldName();

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -396,7 +396,7 @@ abstract class MainAsset extends InventoryAsset
 
         //form discovery mode try to get related agent TAG by it's deviceid
         $agent = new Agent();
-        if (!isset($input['tag'])) {
+        if (!isset($input['tag']) && $this->is_discovery === true ) {
             if ($agent->getFromDBByCrit(['deviceid' => $this->getAgent()->fields['deviceid']])) {
                 $input['tag'] = $agent->fields['tag'];
             }

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -394,7 +394,7 @@ abstract class MainAsset extends InventoryAsset
             $input['tag'] = $this->getAgent()->fields['tag'];
         }
 
-        //form discovery mode try to get related agent TAG by it's deviceid
+        // for discovery mode, try to get TAG from agent by its deviceid
         $agent = new Agent();
         if (!isset($input['tag']) && $this->is_discovery === true ) {
             if ($agent->getFromDBByCrit(['deviceid' => $this->getAgent()->fields['deviceid']])) {

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -396,7 +396,7 @@ abstract class MainAsset extends InventoryAsset
 
         // for discovery mode, try to get TAG from agent by its deviceid
         $agent = new Agent();
-        if (!isset($input['tag']) && $this->is_discovery === true ) {
+        if (!isset($input['tag']) && $this->is_discovery === true) {
             if ($agent->getFromDBByCrit(['deviceid' => $this->getAgent()->fields['deviceid']])) {
                 $input['tag'] = $agent->fields['tag'];
             }


### PR DESCRIPTION
If ```TAG``` not available  (ie netDiscovery)
Try to find related ```TAG``` Agent with ```deviceID``` 

and make it available from ```Rule``` engine


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
