### PR TITLE
fix(richtext): paste of several images

### DIFF
--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -321,37 +321,38 @@ if (typeof tinyMCE != 'undefined') {
                 stopEvent(event);
 
                 //extract base64 data
-                var base64 = extractSrcFromImgTag(event.content);
-
-                //transform to blob and insert into editor
-                if (base64.length) {
+                $('<div></div>').append(event.content).find('img').each(function() {
+                    var base64 = $(this).attr('src');
+                    //transform to blob and insert into editor
                     var file = dataURItoBlob(base64);
 
                     insertImageInTinyMCE(editor, file);
-                }
+                });
 
             } else if (isImageBlobFromPaste(event.content)) {
                 stopEvent(event);
 
-                var src = extractSrcFromImgTag(event.content);
+                $('<div></div>').append(event.content).find('img').each(function() {
+                    var src = $(this).attr('src');
 
-                var xhr = new XMLHttpRequest();
-                xhr.open('GET', src, true);
-                xhr.responseType = 'blob';
-                xhr.onload = function() {
-                    if (this.status !== 200) {
-                        console.error("paste error");
-                        return;
-                    }
+                    var xhr = new XMLHttpRequest();
+                    xhr.open('GET', src, true);
+                    xhr.responseType = 'blob';
+                    xhr.onload = function() {
+                        if (this.status !== 200) {
+                            console.error("paste error");
+                            return;
+                        }
 
-                    var file = this.response;
-                    if (/^image\/.+/.test(file.type)) {
-                        var ext = file.type.replace('image/', '');
-                        file.name = 'image_paste' + Math.floor((Math.random() * 10000000) + 1) + '.' + ext;
-                        insertImageInTinyMCE(editor, file);
-                    }
-                };
-                xhr.send();
+                        var file = this.response;
+                        if (/^image\/.+/.test(file.type)) {
+                            var ext = file.type.replace('image/', '');
+                            file.name = 'image_paste' + Math.floor((Math.random() * 10000000) + 1) + '.' + ext;
+                            insertImageInTinyMCE(editor, file);
+                        }
+                    };
+                    xhr.send();
+                });
             }
 
             // event was stopped, we have to manually remove 'draghover' class

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -316,23 +316,37 @@ var insertImageInTinyMCE = function(editor, image) {
 if (typeof tinyMCE != 'undefined') {
     tinyMCE.PluginManager.add('glpi_upload_doc', function(editor) {
         editor.on('PastePreProcess', function(event) {
+            var content = event.content;
             //Check if data is an image
             if (isImageFromPaste(event.content)) {
                 stopEvent(event);
 
                 //extract base64 data
                 $('<div></div>').append(event.content).find('img').each(function() {
+                    var before = content.split(this.outerHTML)[0];
+                    content = content.split(this.outerHTML)[1];
+                    if (before.length > 0) {
+                        editor.execCommand('mceInsertContent', false, before);
+                    }
                     var base64 = $(this).attr('src');
                     //transform to blob and insert into editor
                     var file = dataURItoBlob(base64);
 
                     insertImageInTinyMCE(editor, file);
                 });
+                if (content.length > 0) {
+                    editor.execCommand('mceInsertContent', false, content);
+                }
 
             } else if (isImageBlobFromPaste(event.content)) {
                 stopEvent(event);
 
                 $('<div></div>').append(event.content).find('img').each(function() {
+                    var before = content.split(this.outerHTML)[0];
+                    content = content.split(this.outerHTML)[1];
+                    if (before.length > 0) {
+                        editor.execCommand('mceInsertContent', false, before);
+                    }
                     var src = $(this).attr('src');
 
                     var xhr = new XMLHttpRequest();
@@ -353,6 +367,9 @@ if (typeof tinyMCE != 'undefined') {
                     };
                     xhr.send();
                 });
+                if (content.length > 0) {
+                    editor.execCommand('mceInsertContent', false, content);
+                }
             }
 
             // event was stopped, we have to manually remove 'draghover' class

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -215,11 +215,9 @@ var insertImgFromFile = function(editor, fileImg, tag) {
                     imgHeight = imgHeight * ratio;     // Reset height to match scaled image
                 }
 
-                editor.execCommand(
-                    'mceInsertContent',
-                    false,
-                    "<img width='"+imgWidth+"' height='"+imgHeight+"' id='"+tag.replace(regex,'')+"' src='"+imageUrl+"'>"
-                );
+                var content = editor.getContent();
+                content = content.replace('<img data-file="' + fileImg + '">', "<img width='"+imgWidth+"' height='"+imgHeight+"' id='"+tag.replace(regex,'')+"' src='"+imageUrl+"'>");
+                editor.setContent(content);
 
                 // loading done, remove indicator
                 editor.setProgressState(false);
@@ -305,6 +303,7 @@ var extractSrcFromImgTag = function(content) {
  */
 var insertImageInTinyMCE = function(editor, image) {
     //make ajax call for upload doc
+    editor.execCommand('mceInsertContent', false, '<img data-file="' + image + '">');
     uploadFile(image, editor);
 };
 

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -217,7 +217,8 @@ var insertImgFromFile = function(editor, fileImg, tag) {
 
                 var content = editor.getContent();
                 content = content.replace('<img data-file="' + fileImg + '">', "<img width='"+imgWidth+"' height='"+imgHeight+"' id='"+tag.replace(regex,'')+"' src='"+imageUrl+"'>");
-                editor.setContent(content);
+                editor.setContent('');
+                editor.execCommand('mceInsertContent', false, content);
 
                 // loading done, remove indicator
                 editor.setProgressState(false);


### PR DESCRIPTION
When we pasted text with several images, only the first image was processed.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24266
