### PR TITLE
Set inventory isDiscovery status before calling hook

### DIFF
--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -260,7 +260,9 @@ class Request extends AbstractRequest
     public function network($data)
     {
         $this->inventory = new Inventory();
-        $this->inventory->setData($data, $this->getMode());
+        $this->inventory
+            ->setDiscovery($this->isDiscovery())
+            ->setData($data, $this->getMode());
 
         $response = [];
         $hook_params = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a

The is_netdiscovery statut was not passed to hooks.

This fix would have prevent the need of glpi-project/glpi-inventory-plugin#135