### PR TITLE
Keep inventory agent updated for any item type

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -298,7 +298,8 @@ class Agent extends CommonDBTM
             $input['tag'] = $metadata['tag'];
         }
 
-        if ($deviceid === 'foo' || !in_array($metadata['itemtype'], $CFG_GLPI['agent_types'])) {
+        $has_expected_agent_type = in_array($metadata['itemtype'], $CFG_GLPI['agent_types']);
+        if ($deviceid === 'foo' || (!$has_expected_agent_type && !$aid)) {
             $input += [
                 'items_id' => 0,
                 'id' => 0
@@ -311,6 +312,10 @@ class Agent extends CommonDBTM
         if ($aid) {
             $input['id'] = $aid;
             $this->update($input);
+            // Don't keep linked item unless having expected agent type
+            if (!$has_expected_agent_type) {
+                $this->fields['items_id'] = 0;
+            }
         } else {
             $input['items_id'] = 0;
             $aid = $this->add($input);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a

This PR is another solution to the problem #11948 fixes. I figured out, #11948 if fixing the case agent object property for an inventory is missing tag as it is not fully updates. But it fixes the problem just before running rules engine.

Here, when starting the inventory import, we keep the agent updated even if the agent type is not matching. In that case, we also need to forget the items_id which is the agent linked item id. So it is not preloaded as item object property at [src/Inventory/Inventory.php#L308](https://github.com/glpi-project/glpi/blob/fbf1c2f137c1a698896e86b6ee0d5d89ccbdc4c0/src/Inventory/Inventory.php#L308).