### PR TITLE
Move main asset header back to the nav header

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -328,6 +328,7 @@ body input {
 .bs-visible {
     visibility: visible !important;
 }
+
 .bs-invisible {
     visibility: hidden !important;
 }

--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -323,3 +323,11 @@ body,
 body input {
     font-variant-ligatures: no-contextual;
 }
+
+/** Bootstrap visibility classes (The utility class behavior is different in _styles.scss) */
+.bs-visible {
+    visibility: visible !important;
+}
+.bs-invisible {
+    visibility: hidden !important;
+}

--- a/css/includes/components/_asset-form.scss
+++ b/css/includes/components/_asset-form.scss
@@ -60,6 +60,7 @@
             .card-title {
                 padding-left: 0 !important;
             }
+
             .badge {
                 margin-left: 0 !important;
             }

--- a/css/includes/components/_asset-form.scss
+++ b/css/includes/components/_asset-form.scss
@@ -31,7 +31,8 @@
  * ---------------------------------------------------------------------
  */
 
-.asset {
+.asset,
+.navigationheader {
     .card-header {
         background-color: $header-bg;
         color: $header-fg;
@@ -52,6 +53,16 @@
 
         .badge .ribbon {
             left: 0.5rem;
+        }
+
+        // remove margin-left is small screen
+        @include media-breakpoint-down(sm) {
+            .card-title {
+                padding-left: 0 !important;
+            }
+            .badge {
+                margin-left: 0 !important;
+            }
         }
     }
 
@@ -76,4 +87,21 @@
 
 #page > .asset {
     margin-top: 15px; // Fix top of form when embedded in iframe (Usually positioned properly because of .tab-content)
+}
+
+.navigationheader {
+    .main-header {
+        padding-top: 0;
+        padding-bottom: 0;
+
+        .ribbon {
+            position: relative;
+            left: -0.25rem;
+        }
+    }
+
+    .card-header {
+        background-color: transparent !important;
+        border-color: transparent !important;
+    }
 }

--- a/js/common.js
+++ b/js/common.js
@@ -1455,18 +1455,15 @@ $(document.body).on('shown.bs.tab', 'a[data-bs-toggle="tab"]', (e) => {
     if (nav_header.length > 0) {
         const is_recursive_toggle = nav_header.find('span.is_recursive-toggle');
         if (is_recursive_toggle.length > 0) {
-            is_recursive_toggle.find('input').css({
-                'transition': 'none'
-            });
-            if (is_main_tab) {
-                is_recursive_toggle.css({
-                    'visibility': 'visible',
-                });
-            } else {
-                is_recursive_toggle.css({
-                    'visibility': 'hidden',
-                });
+            const checkbox = is_recursive_toggle.find('input');
+            const disabled_state = checkbox.prop('disabled');
+            // if data-disabled-initial is not set, set it to the current disabled state
+            if (checkbox.attr('data-disabled-initial') === undefined) {
+                checkbox.attr('data-disabled-initial', disabled_state || false);
             }
+            const original_disabled_state = checkbox.attr('data-disabled-initial') === 'true';
+            // disable input element inside the toggle
+            checkbox.prop('disabled', is_main_tab ? original_disabled_state : true);
         }
     }
 });

--- a/js/common.js
+++ b/js/common.js
@@ -1446,3 +1446,24 @@ function strip_tags(html_string) {
     var dom = new DOMParser().parseFromString(html_string, 'text/html');
     return dom.body.textContent;
 }
+
+$(document.body).on('shown.bs.tab', 'a[data-bs-toggle="tab"]', (e) => {
+    const new_tab = $(e.target);
+    // Main tab is the first in the list (check parent li)
+    const is_main_tab = new_tab.parent().index() === 0;
+    const nav_header = new_tab.closest('.card-tabs').parent().find('.navigationheader');
+    if (nav_header.length > 0) {
+        const is_recursive_toggle = nav_header.find('span.is_recursive-toggle');
+        if (is_recursive_toggle.length > 0) {
+            if (is_main_tab) {
+                is_recursive_toggle.css({
+                    'visibility': 'visible',
+                });
+            } else {
+                is_recursive_toggle.css({
+                    'visibility': 'hidden',
+                });
+            }
+        }
+    }
+});

--- a/js/common.js
+++ b/js/common.js
@@ -1455,6 +1455,9 @@ $(document.body).on('shown.bs.tab', 'a[data-bs-toggle="tab"]', (e) => {
     if (nav_header.length > 0) {
         const is_recursive_toggle = nav_header.find('span.is_recursive-toggle');
         if (is_recursive_toggle.length > 0) {
+            is_recursive_toggle.find('input').css({
+                'transition': 'none'
+            });
             if (is_main_tab) {
                 is_recursive_toggle.css({
                     'visibility': 'visible',

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -483,9 +483,12 @@ class CommonDBTM extends CommonGLPI
     public function showForm($ID, array $options = [])
     {
         $this->initForm($ID, $options);
+        $new_item = static::isNewID($ID);
+        $in_modal = (bool) ($_GET['_in_modal'] ?? false);
         TemplateRenderer::getInstance()->display('generic_show_form.html.twig', [
             'item'   => $this,
             'params' => $options,
+            'no_header' => !$new_item && !$in_modal
         ]);
         return true;
     }

--- a/src/User.php
+++ b/src/User.php
@@ -2264,6 +2264,70 @@ class User extends CommonDBTM
         return Profile::currentUserHaveMoreRightThan($user_prof);
     }
 
+    protected function getFormHeaderToolbar(): array
+    {
+        $ID = $this->getID();
+        $toolbar = [];
+
+        if ($ID > 0) {
+            $vcard_lbl = __s('Download user VCard');
+            $vcard_url = self::getFormURLWithID($ID) . "&amp;getvcard=1";
+            $vcard_btn = <<<HTML
+            <a href="{$vcard_url}" target="_blank"
+                     class="btn btn-icon btn-sm btn-ghost-secondary"
+                     title="{$vcard_lbl}"
+                     data-bs-toggle="tooltip" data-bs-placement="bottom">
+               <i class="far fa-address-card fa-lg"></i>
+            </a>
+HTML;
+            $toolbar[] = $vcard_btn;
+
+            $error_message = null;
+            $impersonate_form = self::getFormURLWithID($ID);
+            if (Session::canImpersonate($ID, $error_message)) {
+                $impersonate_lbl = __s('Impersonate');
+                $csrf_token = Session::getNewCSRFToken();
+                $impersonate_btn = <<<HTML
+                    <form method="post" action="{$impersonate_form}">
+                        <input type="hidden" name="id" value="{$ID}">
+                        <input type="hidden" name="_glpi_csrf_token" value="{$csrf_token}">
+                        <button type="button" name="impersonate" value="1"
+                            class="btn btn-icon btn-sm btn-ghost-secondary btn-impersonate"
+                            title="{$impersonate_lbl}"
+                            data-bs-toggle="tooltip" data-bs-placement="bottom">
+                            <i class="fas fa-user-secret fa-lg"></i>
+                        </button>
+                    </form>
+HTML;
+
+                // "impersonate" button type is set to "button" on form display to prevent it to be used
+                // by default (as it is the first found in current form) when pressing "enter" key.
+                // When clicking it, switch to "submit" type to make it submit current user form.
+                $impersonate_js = <<<JAVASCRIPT
+               (function($) {
+                  $('button[type="button"][name="impersonate"]').click(
+                     function () {
+                        $(this).attr('type', 'submit');
+                     }
+                  );
+               })(jQuery);
+JAVASCRIPT;
+                $toolbar[] = $impersonate_btn . Html::scriptBlock($impersonate_js);
+            } elseif ($error_message !== null) {
+                $impersonate_btn = <<<HTML
+               <button type="button" name="impersonate" value="1"
+                       class="btn btn-icon btn-sm  btn-ghost-danger btn-impersonate"
+                       title="{$error_message}"
+                       data-bs-toggle="tooltip" data-bs-placement="bottom">
+                  <i class="fas fa-user-secret fa-lg"></i>
+               </button>
+HTML;
+                $toolbar[] = $impersonate_btn;
+            }
+        }
+        return $toolbar;
+    }
+
     /**
      * Print the user form.
      *
@@ -2305,61 +2369,11 @@ class User extends CommonDBTM
 
         $formtitle = $this->getTypeName(1);
 
-        $header_toolbar = [];
-        if ($ID > 0) {
-            $vcard_lbl = __s('Download user VCard');
-            $vcard_url = User::getFormURLWithID($ID) . "&amp;getvcard=1";
-            $vcard_btn = <<<HTML
-            <a href="{$vcard_url}" target="_blank"
-                     class="btn btn-icon btn-sm btn-ghost-secondary"
-                     title="{$vcard_lbl}"
-                     data-bs-toggle="tooltip" data-bs-placement="bottom">
-               <i class="far fa-address-card fa-lg"></i>
-            </a>
-HTML;
-            $header_toolbar[] = $vcard_btn;
-
-            $error_message = null;
-            if (Session::canImpersonate($ID, $error_message)) {
-                $impersonate_lbl = __s('Impersonate');
-                $impersonate_btn = <<<HTML
-               <button type="button" name="impersonate" value="1"
-                       class="btn btn-icon btn-sm btn-ghost-secondary btn-impersonate"
-                       title="{$impersonate_lbl}"
-                       data-bs-toggle="tooltip" data-bs-placement="bottom">
-                  <i class="fas fa-user-secret fa-lg"></i>
-               </button>
-HTML;
-
-               // "impersonate" button type is set to "button" on form display to prevent it to be used
-               // by default (as it is the first found in current form) when pressing "enter" key.
-               // When clicking it, switch to "submit" type to make it submit current user form.
-                $impersonate_js = <<<JAVASCRIPT
-               (function($) {
-                  $('button[type="button"][name="impersonate"]').click(
-                     function () {
-                        $(this).attr('type', 'submit');
-                     }
-                  );
-               })(jQuery);
-JAVASCRIPT;
-                $header_toolbar[] = $impersonate_btn . Html::scriptBlock($impersonate_js);
-            } elseif ($error_message !== null) {
-                $impersonate_btn = <<<HTML
-               <button type="button" name="impersonate" value="1"
-                       class="btn btn-icon btn-sm  btn-ghost-danger btn-impersonate"
-                       title="{$error_message}"
-                       data-bs-toggle="tooltip" data-bs-placement="bottom">
-                  <i class="fas fa-user-secret fa-lg"></i>
-               </button>
-HTML;
-                $header_toolbar[] = $impersonate_btn;
-            }
-        }
-
         $options['formtitle']      = $formtitle;
         $options['formoptions']    = ($options['formoptions'] ?? '') . " enctype='multipart/form-data'";
-        $options['header_toolbar'] = $header_toolbar;
+        if (!self::isNewID($ID)) {
+            $options['no_header'] = true;
+        }
         $this->showFormHeader($options);
         $rand = mt_rand();
 

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -32,13 +32,10 @@
  #}
 
 {% set target       = params['target'] ?? item.getFormURL() %}
-{% set canedit      = params['canedit'] ?? true %}
 {% set withtemplate = params['withtemplate'] ?? '' %}
 {% set rand         = random() %}
 {% set nametype     = params['formtitle'] ?? item.getTypeName(1) %}
-{% set friendlyname = params['friendlyname'] ?? item.getHeaderName() %}
 {% set no_id        = params['noid'] ?? false %}
-{% set id           = item.fields['id'] ?? -1 %}
 {% set formoptions  = params['formoptions'] ?? '' %}
 
 {% set entity_id = 0 %}
@@ -55,13 +52,10 @@
    {% endif %}
 {% endif %}
 
-{% if item.canEdit(item.fields['id']) %}
-<form name="massaction_{{ rand }}" id="massaction_{{ rand }}" method="post"
-      action="{{ path('/front/massiveaction.php') }}" data-submit-once>
-   <div id="massive_container_{{ rand }}"></div>
-   <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
-</form>
+{% set no_header = no_header|default(false) %}
+{% set open_form = no_header or item.isNewID(item.fields['id']) or in_twig is not defined %}
 
+{% if open_form and item.canEdit(item.fields['id']) %}
 <form name="asset_form" method="post" action="{{ target }}" {{ formoptions|raw }} enctype="multipart/form-data" data-submit-once>
    <input type="hidden" name="entities_id" value="{{ entity_id }}" />
    {% if _request['_in_modal'] is defined and _request['_in_modal'] == "1" %}
@@ -69,94 +63,10 @@
    {% endif %}
 {% endif %}
    <div id="mainformtable">
-      {% set template_name = item.fields['template_name']|verbatim_value %}
-      {% if withtemplate == 2 and not item.isNewItem() %}
-         <input type="hidden" name="template_name" value="{{ template_name }}" />
-         {% set nametype = __('Created from the template %s')|format(template_name) %}
-      {% elseif withtemplate == 1 %}
-         <input type="hidden" name="is_template" value="1" />
-      {% elseif item.isNewItem() %}
-         {% set nametype = __('%1$s - %2$s')|format(__('New item'), nametype) %}
+      {% if no_header == false and (in_twig is defined or _get._in_modal|default(false)) %}
+         {{ include('components/form/header_content.html.twig', {'inside_main': true}) }}
       {% else %}
-         {% if noid == false and (session('glpiis_ids_visible') or nametype|length == 0) %}
-            {% set nametype = __('%1$s - %2$s')|format(nametype, item.fields['id']) %}
-         {% endif %}
-      {% endif %}
-
-      {% if no_header is not defined or no_header == false %}
-         <div class="card-header main-header d-flex flex-wrap mx-n2 mt-n2 align-items-stretch">
-            {% if withtemplate == 1 %}
-               <input type="text" class="form-control ms-4 mb-2" placeholder="{{ __('Template name') }}"
-                  name="template_name" id="textfield_template_name{{ rand }}"
-                  value="{{ template_name }}" />
-            {% endif %}
-            <h3 class="card-title d-flex align-items-center ps-4">
-               {% set icon = item.getIcon() %}
-               {% if icon|length > 0 %}
-                  <div class="ribbon ribbon-bookmark ribbon-top ribbon-start bg-blue s-1">
-                     <i class="{{ icon }} fa-2x"></i>
-                  </div>
-               {% endif %}
-               <span>
-               {% if item.id > 0 %}
-                  {{ nametype }} - {{ friendlyname }}
-               {% else %}
-                  {{ nametype }}
-               {% endif %}
-               </span>
-               {% if header_toolbar %}
-                  <div class="d-inline-block toolbar ms-2">
-                     {% for raw_element in header_toolbar %}
-                        {{ raw_element|raw }}
-                     {% endfor %}
-                  </div>
-               {% endif %}
-            </h3>
-
-            {% set single_actions_ms_auto = true %}
-            {% if item.isEntityAssign() and is_multi_entities_mode() and item is not instanceof('Entity') %}
-               {% set single_actions_ms_auto = false %}
-               <span class="badge entity-name mx-1 px-2 ms-auto align-items-center" title="{{ entity_name }}">
-                  <i class="ti ti-stack me-2"></i>
-                  {{ entity_name }}
-               </span>
-
-               {% if item.maybeRecursive() %}
-                  <span class="badge is_recursive-toggle mx-1 px-2 align-items-center">
-                     <label class="form-check d-flex align-items-center mb-0">
-                        {% set disabled = canedit == false %}
-                        {% set comment  = __('Change visibility in child entities.') %}
-
-                        {% if item is instanceof('CommonDBChild') %}
-                           {% set comment  = __('Can՛t change this attribute. It՛s inherited from its parent.') %}
-                           {% set disabled = true %}
-                        {% elseif not item.can(id, 'recursive') %}
-                           {% set comment  = __('You are not allowed to change the visibility flag for child entities.') %}
-                           {% set disabled = true %}
-                        {% elseif not item.canUnrecurs() %}
-                           {% set comment  = __('Flag change forbidden. Linked items found.') %}
-                           {% set disabled = true %}
-                        {% endif %}
-
-                        {% if not disabled %}<input type="hidden" name="is_recursive" value="0" />{% endif %}
-                        <input class="form-check-input" type="checkbox" name="is_recursive" value="1"
-                              {% if item.isRecursive() %}checked="checked"{% endif %}
-                              {% if disabled %}disabled="disabled"{% endif %} />
-                        {% if item is instanceof('CommonDBChild') and item.isNewItem() and item.isRecursive() %}
-                            {# Send value on hidden field to ensure creation will use inherited recursivity on CommonDBChild #}
-                            <input type="hidden" name="is_recursive" value="1" />
-                        {% endif %}
-                        <span class="form-check-label mb-0 mx-2">
-                           {{ __('Child entities') }}
-                           <i class="fas fa-info ms-1" title="{{ comment }}"></i>
-                        </span>
-                     </label>
-                  </span>
-               {% endif %}
-            {% endif %}
-
-            {{ include('components/form/single-action.html.twig') }}
-         </div>
+         <input type="hidden" name="is_recursive" value="{{ item.fields['is_recursive']|default(1) }}" />
       {% endif %}
 
       {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_ITEM_FORM'), {'item': item, 'options': params}) }}

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -63,7 +63,7 @@
    {% endif %}
 {% endif %}
    <div id="mainformtable">
-      {% if no_header == false and (in_twig is defined or _get._in_modal|default(false)) %}
+      {% if no_header == false and ((in_twig is defined or _get._in_modal|default(false)) or (in_twig is not defined and item.isNewID(item.fields['id']))) %}
          {{ include('components/form/header_content.html.twig', {'inside_main': true}) }}
       {% else %}
          <input type="hidden" name="is_recursive" value="{{ item.fields['is_recursive']|default(1) }}" />

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -54,6 +54,10 @@
 
 {% set no_header = no_header|default(false) %}
 {% set open_form = no_header or item.isNewID(item.fields['id']) or in_twig is not defined %}
+{# Include header content if one or more condition matches and no_header is not explicitly true: #}
+{# - This template is called from another twig template (as opposed to from PHP and most likely a legacy form) OR is in a modal #}
+{# - Not from a twig template and it is a new item #}
+{% set include_header_content = no_header == false and ((in_twig is defined or _get._in_modal|default(false)) or (in_twig is not defined and item.isNewID(item.fields['id']))) %}
 
 {% if open_form and item.canEdit(item.fields['id']) %}
 <form name="asset_form" method="post" action="{{ target }}" {{ formoptions|raw }} enctype="multipart/form-data" data-submit-once>
@@ -63,7 +67,7 @@
    {% endif %}
 {% endif %}
    <div id="mainformtable">
-      {% if no_header == false and ((in_twig is defined or _get._in_modal|default(false)) or (in_twig is not defined and item.isNewID(item.fields['id']))) %}
+      {% if include_header_content %}
          {{ include('components/form/header_content.html.twig', {'inside_main': true}) }}
       {% else %}
          <input type="hidden" name="is_recursive" value="{{ item.fields['is_recursive']|default(1) }}" />

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -1,0 +1,170 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2022 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% set canedit      = params['canedit'] ?? true %}
+{% set withtemplate = params['withtemplate'] ?? '' %}
+{% set rand         = rand|default(random()) %}
+{% set nametype     = params['formtitle'] ?? item.getTypeName(1) %}
+{% set friendlyname = params['friendlyname'] ?? item.getHeaderName() %}
+{% set id           = item.fields['id'] ?? -1 %}
+{% set in_navheader = in_navheader|default(false) %}
+
+{% set entity_name = entity_name|default('') %}
+{% if entity_id is not defined and item.isEntityAssign() %}
+   {% if item.getType() == 'Entity' and item.fields['id'] == 0 %}
+      {% set entity_id = null %}
+   {% else %}
+      {% set entity_id = params['entities_id'] ?? item.getEntityID() ?? session('glpiactive_entity') %}
+   {% endif %}
+
+   {% if is_multi_entities_mode() %}
+      {% set entity_name = get_item_name('Entity', item.getEntityID()) %}
+   {% endif %}
+{% elseif entity_id is not defined %}
+   {% set entity_id = 0 %}
+{% endif %}
+
+{% set template_name = item.fields['template_name']|verbatim_value %}
+{% if withtemplate == 2 and not item.isNewItem() %}
+   <input type="hidden" name="template_name" value="{{ template_name }}" />
+   {% set nametype = __('Created from the template %s')|format(template_name) %}
+{% elseif withtemplate == 1 %}
+   <input type="hidden" name="is_template" value="1" />
+{% elseif item.isNewItem() %}
+   {% set nametype = __('%1$s - %2$s')|format(__('New item'), nametype) %}
+{% else %}
+   {% if noid == false and (session('glpiis_ids_visible') or nametype|length == 0) %}
+      {% set nametype = __('%1$s - %2$s')|format(nametype, item.fields['id']) %}
+   {% endif %}
+{% endif %}
+
+{% if item.canEdit(item.fields['id']) %}
+   <form name="massaction_{{ rand }}" id="massaction_{{ rand }}" method="post"
+         action="{{ path('/front/massiveaction.php') }}" data-submit-once>
+      <div id="massive_container_{{ rand }}"></div>
+      <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+   </form>
+{% endif %}
+
+<div id="header_{{ rand }}"
+     class="card-header main-header d-flex flex-wrap mx-n2 mt-n2 align-items-stretch {% if in_navheader %} align-self-end {% endif %} flex-grow-1">
+   {% if withtemplate == 1 %}
+      <input type="text" class="form-control ms-4 mb-2" placeholder="{{ __('Template name') }}"
+             name="template_name" id="textfield_template_name{{ rand }}"
+             value="{{ template_name }}" />
+   {% endif %}
+   <h3 class="card-title d-flex align-items-center {{ in_navheader ? "ps-5" : "ps-4" }}">
+      {% set icon = item.getIcon() %}
+      {% if not in_navheader and icon|length > 0 %}
+         <div class="ribbon ribbon-bookmark ribbon-top ribbon-start bg-blue s-1">
+            <i class="{{ icon }} fa-2x"></i>
+         </div>
+      {% endif %}
+      <span {% if in_navheader %} class="status rounded-1" {% endif %}>
+         {% if in_navheader %}
+            <i class="{{ icon }}"></i>
+         {% endif %}
+         {% if item.id > 0 %}
+            {{ nametype }} - {{ friendlyname }}
+         {% else %}
+            {{ nametype }}
+         {% endif %}
+      </span>
+      {% if header_toolbar %}
+         <div class="d-inline-block toolbar ms-2">
+            {% for raw_element in header_toolbar %}
+               {{ raw_element|raw }}
+            {% endfor %}
+         </div>
+      {% endif %}
+   </h3>
+
+   {% set single_actions_ms_auto = true %}
+   {% if item.isEntityAssign() and is_multi_entities_mode() and item is not instanceof('Entity') %}
+      {% set single_actions_ms_auto = false %}
+      <span class="badge entity-name mx-1 px-2 ms-auto align-items-center" title="{{ entity_name }}">
+                  <i class="ti ti-stack me-2"></i>
+                  {{ entity_name }}
+               </span>
+
+      {% if item.maybeRecursive() %}
+         <span class="badge is_recursive-toggle mx-1 px-2 align-items-center">
+            <label class="form-check d-flex align-items-center mb-0">
+               {% set disabled = canedit == false %}
+               {% set comment  = __('Change visibility in child entities.') %}
+
+               {% if item is instanceof('CommonDBChild') %}
+                  {% set comment  = __('Can՛t change this attribute. It՛s inherited from its parent.') %}
+                  {% set disabled = true %}
+               {% elseif not item.can(id, 'recursive') %}
+                  {% set comment  = __('You are not allowed to change the visibility flag for child entities.') %}
+                  {% set disabled = true %}
+               {% elseif not item.canUnrecurs() %}
+                  {% set comment  = __('Flag change forbidden. Linked items found.') %}
+                  {% set disabled = true %}
+               {% endif %}
+
+               {% if not disabled %}<input type="hidden" name="is_recursive" value="0" />{% endif %}
+               <input class="form-check-input" type="checkbox" name="is_recursive" value="1"
+                  {% if item.isRecursive() %}checked="checked"{% endif %}
+                  {% if disabled %}disabled="disabled"{% endif %} />
+               {% if item is instanceof('CommonDBChild') and item.isNewItem() and item.isRecursive() %}
+                  {# Send value on hidden field to ensure creation will use inherited recursivity on CommonDBChild #}
+                  <input type="hidden" name="is_recursive" value="1" />
+               {% endif %}
+               <span class="form-check-label mb-0 mx-2">
+                  {{ __('Child entities') }}
+                  <i class="fas fa-info ms-1" title="{{ comment }}"></i>
+               </span>
+            </label>
+         </span>
+      {% endif %}
+   {% endif %}
+
+   {{ include('components/form/single-action.html.twig') }}
+
+   {% if inside_main is not defined %}
+      <script>
+         $("#header_{{ rand }} input[name='is_recursive']").on('change', function(e) {
+             const asset_form = $("form[name='asset_form']");
+             // If asset form has an is_recursive checkbox, we need set the value to the one in the header
+             if (asset_form.length) {
+                 const chk = asset_form.find("input[name='is_recursive']");
+                 if (chk.length) {
+                     chk.val(e.target.checked ? 1 : 0);
+                 }
+             }
+         });
+      </script>
+   {% endif %}
+</div>

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -39,7 +39,7 @@
 {% endif %}
 
 <div class="asset {{ bg }}">
-   {{ include('components/form/header.html.twig') }}
+   {{ include('components/form/header.html.twig', {'in_twig': true}) }}
 
    {% set rand = random() %}
    {% set params  = params ?? [] %}

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -33,6 +33,7 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
+{% set no_header = no_header|default(not item.isNewItem() and not _get._in_modal|default(false)) %}
 {% set bg = '' %}
 {% if item.isDeleted() %}
    {% set bg = 'asset-deleted' %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11493

Visually moved the item type and name header back to the navigation header so that is would be visible in each tab of an asset form.

![Selection_079](https://user-images.githubusercontent.com/17678637/174881094-df85e952-26f6-4c38-a0b0-7b88e638b36c.png)


~Still working on the functionality of the massive action dropdown and child entity checkbox as they are no longer located within the main form and are therefore missing some required inputs. Some more testing with modals needs done too. Modals of at least dropdown itemtypes seem to work properly with showing the header inside the form rather than the navigation header.~