### PR TITLE
Force ID display for ITIL Object headers

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1034,7 +1034,9 @@ class CommonGLPI implements CommonGLPIInterface
             if ($this instanceof CommonITILObject) {
                 echo "<h3 class='navigationheader-title strong d-flex align-items-center'>";
                 echo "<i class='" . $this->getIcon() . " me-1'></i>";
-                echo $this->getNameID();
+                echo $this->getNameID([
+                    'forceid' => $this instanceof CommonITILObject
+                ]);
                 echo "</h3>";
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11606

In older versions, the ID as shown within the form itself at all times.
Instead of adding it back into the fields panel, it may be cleaner to just force the display of the ID within the header.