### PR TITLE
fix(massive action): update location empty

### DIFF
--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -926,7 +926,7 @@ class MassiveAction
 
     public static function showMassiveActionsSubForm(MassiveAction $ma)
     {
-        global $CFG_GLPI;
+        global $CFG_GLPI, $DB;
 
         switch ($ma->getAction()) {
             case 'update':
@@ -1199,12 +1199,14 @@ class MassiveAction
                             $search['condition'][] = 'is_problem';
                             break;
                         case 'Ticket':
-                            $search['condition'][] = [
-                                'OR' => [
-                                    'is_incident',
-                                    'is_request'
-                                ]
-                            ];
+                            if ($DB->fieldExists($search['table'], 'is_incident') || $DB->fieldExists($search['table'], 'is_request')) {
+                                $search['condition'][] = [
+                                    'OR' => [
+                                        'is_incident',
+                                        'is_request'
+                                    ]
+                                ];
+                            }
                             break;
                     }
                     if (isset($ma->POST['additionalvalues'])) {


### PR DESCRIPTION
In the ticket's massive actions, the list of locations was always empty.

![image](https://user-images.githubusercontent.com/8530352/175244158-6fc3a97c-aef3-4544-94cf-fbffdf023dcf.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24307
