### PR TITLE
fix(change): invalid status when reopening change

### DIFF
--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -312,9 +312,12 @@ class ITILFollowup extends CommonDBChild
         ) {
             $needupdateparent = false;
             if (
-                ($parentitem->countUsers(CommonITILActor::ASSIGN) > 0)
-                || ($parentitem->countGroups(CommonITILActor::ASSIGN) > 0)
-                || ($parentitem->countSuppliers(CommonITILActor::ASSIGN) > 0)
+                isset($parentitem::getAllStatusArray($parentitem->getType())[CommonITILObject::ASSIGNED])
+                && (
+                    ($parentitem->countUsers(CommonITILActor::ASSIGN) > 0)
+                    || ($parentitem->countGroups(CommonITILActor::ASSIGN) > 0)
+                    || ($parentitem->countSuppliers(CommonITILActor::ASSIGN) > 0)
+                )
             ) {
                //check if lifecycle allowed new status
                 if (


### PR DESCRIPTION
When reopening a change, the status was set to "ASSIGNED" which is not a change status.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
