### PR TITLE
Add access error log

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2933,7 +2933,11 @@ class CommonDBTM extends CommonGLPI
             if (!$this->can($ID, $right, $input)) {
                // Gestion timeout session
                 Session::redirectIfNotLoggedIn();
-                Html::displayRightError();
+                $user_id = Session::getLoginUserID() ?? 'Anonymous';
+                $right_name = Session::getRightNameForError($right);
+                $itemtype = static::getType();
+                $info = "User ID: $user_id failed a can* method check for right $right ($right_name) on item Type: $itemtype ID: $ID";
+                Html::displayRightError($info);
             }
         }
     }
@@ -2978,7 +2982,11 @@ class CommonDBTM extends CommonGLPI
         if (!$this->canGlobal($right)) {
            // Gestion timeout session
             Session::redirectIfNotLoggedIn();
-            Html::displayRightError();
+            $user_id = Session::getLoginUserID() ?? 'Anonymous';
+            $right_name = Session::getRightNameForError($right);
+            $itemtype = static::getType();
+            $info = "User ID: $user_id failed a global can* method check for right $right ($right_name) on item Type: $itemtype";
+            Html::displayRightError($info);
         }
     }
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2933,10 +2933,9 @@ class CommonDBTM extends CommonGLPI
             if (!$this->can($ID, $right, $input)) {
                // Gestion timeout session
                 Session::redirectIfNotLoggedIn();
-                $user_id = Session::getLoginUserID() ?? 'Anonymous';
                 $right_name = Session::getRightNameForError($right);
                 $itemtype = static::getType();
-                $info = "User ID: $user_id failed a can* method check for right $right ($right_name) on item Type: $itemtype ID: $ID";
+                $info = "User failed a can* method check for right $right ($right_name) on item Type: $itemtype ID: $ID";
                 Html::displayRightError($info);
             }
         }
@@ -2982,10 +2981,9 @@ class CommonDBTM extends CommonGLPI
         if (!$this->canGlobal($right)) {
            // Gestion timeout session
             Session::redirectIfNotLoggedIn();
-            $user_id = Session::getLoginUserID() ?? 'Anonymous';
             $right_name = Session::getRightNameForError($right);
             $itemtype = static::getType();
-            $info = "User ID: $user_id failed a global can* method check for right $right ($right_name) on item Type: $itemtype";
+            $info = "User failed a global can* method check for right $right ($right_name) on item Type: $itemtype";
             Html::displayRightError($info);
         }
     }

--- a/src/Html.php
+++ b/src/Html.php
@@ -609,8 +609,22 @@ class Html
      *
      * @return void
      **/
-    public static function displayRightError()
+    public static function displayRightError(string $additional_info = '')
     {
+        $requested_url = (isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : 'Unknown');
+        $user_id = Session::getLoginUserID() ?? 'Anonymous';
+        if (empty($additional_info)) {
+            $additional_info = __('No additional information given');
+        }
+        $internal_message = "User ID: $user_id tried to access or perform an action on $requested_url with insufficient rights. Additional information: $additional_info\n";
+        $internal_message .= "\tStack Trace:\n";
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        $trace_string = '';
+        foreach ($backtrace as $frame) {
+            $trace_string .= "\t\t" . $frame['file'] . ':' . $frame['line'] . ' ' . $frame['function'] . '()' . "\n";
+        }
+        $internal_message .= $trace_string;
+        Toolbox::logInFile('access-errors', $internal_message);
         self::displayErrorAndDie(__("You don't have permission to perform this action."));
     }
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -885,7 +885,8 @@ class Session
         if (Session::getCurrentInterface() != "central") {
            // Gestion timeout session
             self::redirectIfNotLoggedIn();
-            Html::displayRightError();
+            $user_id = self::getLoginUserID() ?? 'Anonymous';
+            Html::displayRightError("User ID: $user_id The current profile does not use the standard interface");
         }
     }
 
@@ -902,7 +903,8 @@ class Session
         if (!$CFG_GLPI["use_public_faq"]) {
             self::checkValidSessionId();
             if (!self::haveRight('knowbase', KnowbaseItem::READFAQ)) {
-                Html::displayRightError();
+                $user_id = self::getLoginUserID() ?? 'Anonymous';
+                Html::displayRightError("User ID: $user_id Missing FAQ right");
             }
         }
     }
@@ -919,7 +921,8 @@ class Session
         if (Session::getCurrentInterface() != "helpdesk") {
            // Gestion timeout session
             self::redirectIfNotLoggedIn();
-            Html::displayRightError();
+            $user_id = self::getLoginUserID() ?? 'Anonymous';
+            Html::displayRightError("User ID: $user_id The current profile does not use the simplified interface");
         }
     }
 
@@ -934,10 +937,38 @@ class Session
         if (!isset($_SESSION["glpiname"])) {
            // Gestion timeout session
             self::redirectIfNotLoggedIn();
-            Html::displayRightError();
+            $user_id = self::getLoginUserID() ?? 'Anonymous';
+            Html::displayRightError("User ID: $user_id has no valid session but seems to be logged in");
         }
     }
 
+    /**
+     * Get the name of the right.
+     *
+     * This only works for well-known rights.
+     * @param int $right The right
+     * @return string The right name
+     * @internal No backwards compatibility promise. Use in core only.
+     */
+    public static function getRightNameForError(int $right): string
+    {
+        // Well known rights
+        $rights = [
+            READ => 'READ',
+            UPDATE => 'UPDATE',
+            CREATE => 'CREATE',
+            DELETE => 'DELETE',
+            PURGE => 'PURGE',
+            ALLSTANDARDRIGHT => 'ALLSTANDARDRIGHT',
+            READNOTE => 'READNOTE',
+            UPDATENOTE => 'UPDATENOTE',
+            UNLOCK => 'UNLOCK',
+        ];
+        if (in_array($right, $rights, true)) {
+            return $rights[$right];
+        }
+        return "unknown right name";
+    }
 
     /**
      * Check if I have the right $right to module $module (conpare to session variable)
@@ -953,7 +984,9 @@ class Session
         if (!self::haveRight($module, $right)) {
            // Gestion timeout session
             self::redirectIfNotLoggedIn();
-            Html::displayRightError();
+            $right_name = self::getRightNameForError($right);
+            $user_id = self::getLoginUserID() ?? 'Anonymous';
+            Html::displayRightError("User ID: $user_id is missing the $right ($right_name) right for $module");
         }
     }
 
@@ -970,7 +1003,15 @@ class Session
         self::checkValidSessionId();
         if (!self::haveRightsOr($module, $rights)) {
             self::redirectIfNotLoggedIn();
-            Html::displayRightError();
+            $user_id = self::getLoginUserID() ?? 'Anonymous';
+            $info = "User ID: $user_id is missing all of the following rights: ";
+            foreach ($rights as $right) {
+                $right_name = self::getRightNameForError($right);
+                $info .= $right . "($right_name), ";
+            }
+            $info = substr($info, 0, -2);
+            $info .= " for $module";
+            Html::displayRightError($info);
         }
     }
 
@@ -1007,7 +1048,14 @@ class Session
         if (!$valid) {
            // Gestion timeout session
             self::redirectIfNotLoggedIn();
-            Html::displayRightError();
+            $user_id = self::getLoginUserID() ?? 'Anonymous';
+            $info = "User ID: $user_id is missing all of the following rights: ";
+            foreach ($modules as $mod => $right) {
+                $right_name = self::getRightNameForError($right);
+                $info .= $right . "($right_name) for module $mod, ";
+            }
+            $info = substr($info, 0, -2);
+            Html::displayRightError($info);
         }
     }
 
@@ -1429,7 +1477,10 @@ class Session
             GLPI_USE_CSRF_CHECK
             && (!Session::validateCSRF($data))
         ) {
-           // Output JSON if requested by client
+            $requested_url = (isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : 'Unknown');
+            $user_id = self::getLoginUserID() ?? 'Anonymous';
+            Toolbox::logInFile('access-errors', "CSRF check failed for User ID: $user_id at $requested_url");
+            // Output JSON if requested by client
             if (strpos($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json') !== false) {
                 http_response_code(403);
                 die(json_encode(["message" => __("The action you have requested is not allowed.")]));

--- a/src/Session.php
+++ b/src/Session.php
@@ -885,8 +885,7 @@ class Session
         if (Session::getCurrentInterface() != "central") {
            // Gestion timeout session
             self::redirectIfNotLoggedIn();
-            $user_id = self::getLoginUserID() ?? 'Anonymous';
-            Html::displayRightError("User ID: $user_id The current profile does not use the standard interface");
+            Html::displayRightError("The current profile does not use the standard interface");
         }
     }
 
@@ -903,8 +902,7 @@ class Session
         if (!$CFG_GLPI["use_public_faq"]) {
             self::checkValidSessionId();
             if (!self::haveRight('knowbase', KnowbaseItem::READFAQ)) {
-                $user_id = self::getLoginUserID() ?? 'Anonymous';
-                Html::displayRightError("User ID: $user_id Missing FAQ right");
+                Html::displayRightError("Missing FAQ right");
             }
         }
     }
@@ -921,8 +919,7 @@ class Session
         if (Session::getCurrentInterface() != "helpdesk") {
            // Gestion timeout session
             self::redirectIfNotLoggedIn();
-            $user_id = self::getLoginUserID() ?? 'Anonymous';
-            Html::displayRightError("User ID: $user_id The current profile does not use the simplified interface");
+            Html::displayRightError("The current profile does not use the simplified interface");
         }
     }
 
@@ -937,8 +934,7 @@ class Session
         if (!isset($_SESSION["glpiname"])) {
            // Gestion timeout session
             self::redirectIfNotLoggedIn();
-            $user_id = self::getLoginUserID() ?? 'Anonymous';
-            Html::displayRightError("User ID: $user_id has no valid session but seems to be logged in");
+            Html::displayRightError("User has no valid session but seems to be logged in");
         }
     }
 
@@ -985,8 +981,7 @@ class Session
            // Gestion timeout session
             self::redirectIfNotLoggedIn();
             $right_name = self::getRightNameForError($right);
-            $user_id = self::getLoginUserID() ?? 'Anonymous';
-            Html::displayRightError("User ID: $user_id is missing the $right ($right_name) right for $module");
+            Html::displayRightError("User is missing the $right ($right_name) right for $module");
         }
     }
 
@@ -1003,8 +998,7 @@ class Session
         self::checkValidSessionId();
         if (!self::haveRightsOr($module, $rights)) {
             self::redirectIfNotLoggedIn();
-            $user_id = self::getLoginUserID() ?? 'Anonymous';
-            $info = "User ID: $user_id is missing all of the following rights: ";
+            $info = "User is missing all of the following rights: ";
             foreach ($rights as $right) {
                 $right_name = self::getRightNameForError($right);
                 $info .= $right . "($right_name), ";
@@ -1048,8 +1042,7 @@ class Session
         if (!$valid) {
            // Gestion timeout session
             self::redirectIfNotLoggedIn();
-            $user_id = self::getLoginUserID() ?? 'Anonymous';
-            $info = "User ID: $user_id is missing all of the following rights: ";
+            $info = "User is missing all of the following rights: ";
             foreach ($modules as $mod => $right) {
                 $right_name = self::getRightNameForError($right);
                 $info .= $right . "($right_name) for module $mod, ";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

When an access-related issue occurs and causes the script execution to stop, a generic error is given to the user (good for security to not give exact details to them) but more information isn't available anywhere on the server for debugging.
This PR adds an "access-errors.log" file to log additional information including the user ID, request URI, and a sanitized stack trace (no arguments) and an optional message that can be changed based on the context.