### PR TITLE
Itemtype dropdown: do not impact glpiUnsavedFormChanges when setting initial value

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1478,6 +1478,7 @@ class Dropdown
         $params['checkright']          = false;
         $params['toupdate']            = '';
         $params['display']             = true;
+        $params['track_changes']       = true;
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -1542,20 +1543,20 @@ class Dropdown
     {
         global $CFG_GLPI;
 
-        $params = [];
-        $params['itemtype_name']       = 'itemtype';
-        $params['items_id_name']       = 'items_id';
-        $params['itemtypes']           = '';
-        $params['default_itemtype']    = 0;
-        $params['entity_restrict']     = -1;
-        $params['onlyglobal']          = false;
-        $params['checkright']          = false;
-        $params['showItemSpecificity'] = '';
-        $params['emptylabel']          = self::EMPTY_VALUE;
-        $params['used']                = [];
-        $params['ajax_page']           = $CFG_GLPI["root_doc"] . "/ajax/dropdownAllItems.php";
-        $params['display']             = true;
-        $params['rand']                = mt_rand();
+        $params['itemtype_name']          = 'itemtype';
+        $params['items_id_name']          = 'items_id';
+        $params['itemtypes']              = '';
+        $params['default_itemtype']       = 0;
+        $params['entity_restrict']        = -1;
+        $params['onlyglobal']             = false;
+        $params['checkright']             = false;
+        $params['showItemSpecificity']    = '';
+        $params['emptylabel']             = self::EMPTY_VALUE;
+        $params['used']                   = [];
+        $params['ajax_page']              = $CFG_GLPI["root_doc"] . "/ajax/dropdownAllItems.php";
+        $params['display']                = true;
+        $params['rand']                   = mt_rand();
+        $params['itemtype_track_changes'] = true;
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -1564,11 +1565,12 @@ class Dropdown
         }
 
         $select = self::showItemType($params['itemtypes'], [
-            'checkright' => $params['checkright'],
-            'name'       => $params['itemtype_name'],
-            'emptylabel' => $params['emptylabel'],
-            'display'    => $params['display'],
-            'rand'       => $params['rand'],
+            'checkright'    => $params['checkright'],
+            'name'          => $params['itemtype_name'],
+            'emptylabel'    => $params['emptylabel'],
+            'display'       => $params['display'],
+            'rand'          => $params['rand'],
+            'track_changes' => $params['itemtype_track_changes'],
         ]);
 
         $p_ajax = [
@@ -1610,11 +1612,7 @@ class Dropdown
         if (array_key_exists('default_itemtype', $options)) {
             $out .= "<script type='text/javascript' >\n";
             $out .= "$(function() {";
-            // Keep track of window.glpiUnsavedFormChanges state
-            $out .= "var unsaved = window.glpiUnsavedFormChanges;";
             $out .= Html::jsSetDropdownValue($field_id, $params['default_itemtype']);
-            // Revert window.glpiUnsavedFormChanges state
-            $out .= "window.glpiUnsavedFormChanges = unsaved;";
             $out .= "});</script>\n";
 
             $p_ajax["idtable"] = $params['default_itemtype'];
@@ -2027,6 +2025,7 @@ class Dropdown
         $param['noselect2']           = false;
         $param['templateResult']      = "templateResult";
         $param['templateSelection']   = "templateSelection";
+        $param['track_changes']       = "true";
 
         if (is_array($options) && count($options)) {
             if (isset($options['value']) && strlen($options['value'])) {
@@ -2105,6 +2104,10 @@ class Dropdown
 
             if ($param["required"]) {
                 $output .= " required='required'";
+            }
+
+            if (!$param[$param['track_changes']]) {
+                $output .= " data-track-changes=''";
             }
 
             $output .= '>';

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1543,6 +1543,7 @@ class Dropdown
     {
         global $CFG_GLPI;
 
+        $params = [];
         $params['itemtype_name']          = 'itemtype';
         $params['items_id_name']          = 'items_id';
         $params['itemtypes']              = '';

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2107,7 +2107,7 @@ class Dropdown
                 $output .= " required='required'";
             }
 
-            if (!$param[$param['track_changes']]) {
+            if (!$param['track_changes']) {
                 $output .= " data-track-changes=''";
             }
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1610,7 +1610,11 @@ class Dropdown
         if (array_key_exists('default_itemtype', $options)) {
             $out .= "<script type='text/javascript' >\n";
             $out .= "$(function() {";
+            // Keep track of window.glpiUnsavedFormChanges state
+            $out .= "var unsaved = window.glpiUnsavedFormChanges;";
             $out .= Html::jsSetDropdownValue($field_id, $params['default_itemtype']);
+            // Revert window.glpiUnsavedFormChanges state
+            $out .= "window.glpiUnsavedFormChanges = unsaved;";
             $out .= "});</script>\n";
 
             $p_ajax["idtable"] = $params['default_itemtype'];

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1558,7 +1558,7 @@ class Dropdown
         $params['ajax_page']              = $CFG_GLPI["root_doc"] . "/ajax/dropdownAllItems.php";
         $params['display']                = true;
         $params['rand']                   = mt_rand();
-        $params['itemtype_track_changes'] = true;
+        $params['itemtype_track_changes'] = false;
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1510,6 +1510,7 @@ class Dropdown
                 'emptylabel'          => $params['emptylabel'],
                 'display'             => $params['display'],
                 'rand'                => $params['rand'],
+                'track_changes'       => $params['track_changes'],
             ]);
         }
         return 0;


### PR DESCRIPTION
It seems that the initial value of this dropdown is set using js, which will trigger `glpiUnsavedFormChanges  = true`.
This will trigger the "unsaved changes" warning on page exit every time, which we do not want to happen as no data was actually modified by the user.

```php
Html::jsSetDropdownValue($field_id, $params['default_itemtype']);
```

Note that you may not be able to reproduce this issue on a standard GLPI installation, as we do not use this dropdown on any page with the "unsaved changes" warning enabled (as far as I know).

However, some plugins or specific patches (or potential future developments) may add this dropdown and cause the issue described above.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24304
