### PR TITLE
Fix restore of contract value during ticket creation

### DIFF
--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -223,7 +223,7 @@
                {{ fields.dropdownField(
                   'Contract',
                   '_contracts_id',
-                  item.fields['_contracts_id'],
+                  params['_contracts_id']|default(0),
                   'Contract'|itemtype_name,
                   field_options|merge({
                      'entity': item.fields['entities_id'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11993

The virtual `_contracts_id` fields is not present in the default fields array for Tickets, so its value does not get restored from the saved input into that array. It is only restored to and available from the `params` twig variable.