### PR TITLE
Re-implement agent cleanup

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -765,6 +765,16 @@ $empty_data_builder = new class
                 'mode' => CronTask::MODE_EXTERNAL,
                 'lastrun' => null,
                 'logs_lifetime' => 30,
+            ], [
+                'id' => 43,
+                'itemtype' => 'Agent',
+                'name' => 'cronCleanoldagents',
+                'frequency' => DAY_TIMESTAMP,
+                'param' => null,
+                'state' => CronTask::STATE_WAITING,
+                'mode' => CronTask::MODE_EXTERNAL,
+                'lastrun' => null,
+                'logs_lifetime' => 30,
             ],
         ];
 

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -768,7 +768,7 @@ $empty_data_builder = new class
             ], [
                 'id' => 43,
                 'itemtype' => 'Agent',
-                'name' => 'cronCleanoldagents',
+                'name' => 'Cleanoldagents',
                 'frequency' => DAY_TIMESTAMP,
                 'param' => null,
                 'state' => CronTask::STATE_WAITING,

--- a/install/migrations/update_10.0.1_to_10.0.2/native_inventory.php
+++ b/install/migrations/update_10.0.1_to_10.0.2/native_inventory.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+$inventory_config = getAllDataFromTable('glpi_configs', ['context' => 'inventory']);
+
+if (!isset($inventory_config['agents_action'])) {
+    $migrated = false;
+
+    if ($DB->tableExists('glpi_plugin_glpiinventory_configs')) {
+        $iterator = $DB->request([
+            'SELECT' => ['type', 'value'],
+            'FROM' => 'glpi_plugin_glpiinventory_configs',
+            'WHERE' => ['type' => 'agents_action']
+        ]);
+        if ($iterator->count() > 0) {
+            $migrated = true;
+            $migration->addConfig(
+                ['agents_action' => $iterator->current()['value']],
+                'inventory'
+            );
+        }
+    }
+
+    if (!$migrated && $DB->tableExists('glpi_plugin_fusioninventory_configs')) {
+        $iterator = $DB->request([
+            'SELECT' => ['type', 'value'],
+            'FROM' => 'glpi_plugin_fusioninventory_configs',
+            'WHERE' => ['type' => 'agents_action']
+        ]);
+        if ($iterator->count() > 0) {
+            $migrated = true;
+            $migration->addConfig(
+                ['agents_action' => $iterator->current()['value']],
+                'inventory'
+            );
+        }
+    }
+
+    if (!$migrated) {
+        $migration->addConfig(
+            ['agents_action' => 0],
+            'inventory'
+        );
+    }
+}
+
+CronTask::register('Agent', 'cronCleanoldagents', DAY_TIMESTAMP, [
+    'comment' => 'Clean old agents',
+    'state' => CronTask::STATE_WAITING,
+    'mode' => CronTask::MODE_EXTERNAL,
+    'logs_lifetime' => 30
+]);

--- a/install/migrations/update_10.0.1_to_10.0.2/native_inventory.php
+++ b/install/migrations/update_10.0.1_to_10.0.2/native_inventory.php
@@ -81,7 +81,7 @@ if (!isset($inventory_config['agents_action'])) {
     }
 }
 
-CronTask::register('Agent', 'cronCleanoldagents', DAY_TIMESTAMP, [
+CronTask::register('Agent', 'Cleanoldagents', DAY_TIMESTAMP, [
     'comment' => 'Clean old agents',
     'state' => CronTask::STATE_WAITING,
     'mode' => CronTask::MODE_EXTERNAL,

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -707,7 +707,7 @@ class Agent extends CommonDBTM
                     $cron_status = true;
                 }
             } else if (isset($config['agents_status'])) {
-                //change status of agents
+                //change status of agents linked assets
                 foreach ($iterator as $data) {
                     $itemtype = $data['itemtype'];
                     if (is_subclass_of($itemtype, CommonDBTM::class)) {

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -376,7 +376,7 @@ class DbUtils extends DbTestCase
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'id'))->isGreaterThan(0)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'context'))->isGreaterThan(0)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_tickets', 'entities_id'))->isIdenticalTo(2)
-            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'itemtype', ['frequency' => '86400']))->isIdenticalTo(16)
+            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'itemtype', ['frequency' => '86400']))->isIdenticalTo(17)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'id', ['frequency' => '86400']))->isIdenticalTo(19)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'context', ['name' => 'version']))->isIdenticalTo(1)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'id', ['context' => 'fakecontext']))->isIdenticalTo(0);

--- a/tests/functionnal/DbUtils.php
+++ b/tests/functionnal/DbUtils.php
@@ -377,7 +377,7 @@ class DbUtils extends DbTestCase
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'context'))->isGreaterThan(0)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_tickets', 'entities_id'))->isIdenticalTo(2)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'itemtype', ['frequency' => '86400']))->isIdenticalTo(17)
-            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'id', ['frequency' => '86400']))->isIdenticalTo(19)
+            ->integer($this->testedInstance->countDistinctElementsInTable('glpi_crontasks', 'id', ['frequency' => '86400']))->isIdenticalTo(20)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'context', ['name' => 'version']))->isIdenticalTo(1)
             ->integer($this->testedInstance->countDistinctElementsInTable('glpi_configs', 'id', ['context' => 'fakecontext']))->isIdenticalTo(0);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes (Fixed regression)
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The agent cleanup options remain in the GLPI Inventory plugin, but they are not used by the plugin or by native inventory. The cleanup configuration was not re-added when the agent class was migrated.