### PR TITLE
Fix license notice in Agent class

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -9,6 +9,7 @@
  *
  * @copyright 2015-2022 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @copyright 2010-2022 by the FusionInventory Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -675,6 +676,7 @@ class Agent extends CommonDBTM
      * @global object $DB
      * @param object $task
      * @return boolean true if successful, otherwise false
+     * @copyright 2010-2022 by the FusionInventory Development Team.
      */
     public static function cronCleanoldagents($task = null)
     {

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -9,6 +9,7 @@
  *
  * @copyright 2015-2022 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @copyright 2010-2022 by the FusionInventory Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -328,6 +329,7 @@ class Conf extends CommonGLPI
      * Print the config form for display
      *
      * @return true (Always true)
+     * @copyright 2010-2022 by the FusionInventory Development Team. (Agent cleanup section)
      **/
     public function showConfigForm()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The cron method was not sufficiently changed from the FusionInventory code and requires attribution.
I added a line to the file's header as well as a `copyright` tag on the problematic method itself so it is easy to know that it is the problematic method.