### PR TITLE
Fix tests on MySQL 8.0

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -1471,10 +1471,14 @@ class DBmysql {
 
       $structure = str_replace(
          [
+            " COLLATE utf8mb3_unicode_ci",
             " COLLATE utf8_unicode_ci",
+            " CHARACTER SET utf8mb3",
             " CHARACTER SET utf8",
             ', ',
          ], [
+            '',
+            '',
             '',
             '',
             ',',


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

On latest versions on MySQL 8.0, `SHOW CREATE TABLE` outputs `utf8mb3` instead of `utf8`.