### PR TITLE
Fix asset picture lightbox

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -430,9 +430,9 @@
          {% set url = options['url'] ?? null %}
          {% set options = options|filter((v, k) => k != 'url' and k != 'clearable') %}
          {% if url is not empty %}
-            <a href="{{ url }}" {{ call('Html::parseAttributes', [link_options]) }}>
+            <a href="{{ url }}" {{ call('Html::parseAttributes', [link_options])|raw }}>
          {% endif %}
-               <img src="{{ value|verbatim_value }}" {{ call('Html::parseAttributes', [options]) }} />
+               <img src="{{ value|verbatim_value }}" {{ call('Html::parseAttributes', [options])|raw }} />
          {% if url is not empty %}
             </a>
          {% endif %}

--- a/templates/components/photoswipe.html.twig
+++ b/templates/components/photoswipe.html.twig
@@ -135,7 +135,7 @@
                      'full_width': true,
                      'mb': '',
                      'clearable': clearable,
-                     'class': 'pswp-trigger',
+                     'class': 'cursor-pointer pswp-trigger',
                      'alt': img['title']|default(''),
                      'itemprop': 'thumbnail'
                   },
@@ -158,7 +158,7 @@
       $(".pswp-img{{ rand }}").on('click', 'figure .pswp-trigger', function(event) {
          event.preventDefault();
          const options = {
-            index: $(this).index(),
+            index: $(this).closest('figure').index(),
             bgOpacity: 0.7,
             showHideOpacity: true,
             shareButtons: [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

3 bugs fixed that prevented the lightbox from working properly on asset forms.
1. Attributes on the `img` elements were double quoted because the `raw` filter was not used
2. The pointer cursor was not showing when hovering over the images to show they could be clicked
3. The index option for the lightbox was always 0 because it was using the index of the `img` within the `figure` instead of the index of the `figure`. This caused the lightbox to always start on the first image regardless of which one was clicked.