### PR TITLE
Update AuthLDAP.php

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2599,8 +2599,11 @@ class AuthLDAP extends CommonDBTM
                                     ]);
 
                                     foreach ($iterator as $group) {
-                                         $groups[$group['ldap_value']] = ["cn"          => $group['ldap_value'],
-                                             "search_type" => "users"
+                                        $dn = $group['ldap_value'];
+                                        preg_match ('/(,dc=.*$)/',$dn,$dc);
+                                        $dn_prefix = substr($dn,0,strlen($dn)-strlen($dc[1]));
+                                        $groups[$dn_prefix . strtolower($dc[1])] = ["cn"          => $dn,
+                                                               "search_type" => "users"]
                                          ];
                                     }
                                 }
@@ -2609,14 +2612,12 @@ class AuthLDAP extends CommonDBTM
                                     $ligne_extra = 0; $ligne_extra < $infos[$ligne][$extra_attribute]["count"];
                                     $ligne_extra++
                                 ) {
-                                    $groups[$infos[$ligne][$extra_attribute][$ligne_extra]]
-                                    = ["cn"   => self::getGroupCNByDn(
-                                        $ldap_connection,
-                                        $infos[$ligne][$extra_attribute][$ligne_extra]
-                                    ),
-                                        "search_type"
-                                             => "users"
-                                    ];
+                                    $dn= $infos[$ligne][$extra_attribute][$ligne_extra];
+                                    preg_match ('/(,dc=.*$)/',$dn,$dc);
+                                    $dn_prefix = substr($dn,0,strlen($dn)-strlen($dc[1]));
+                                    $groups[$dn_prefix . strtolower($dc[1])]
+                                       = ["cn"   => self::getGroupCNByDn($ldap_connection,$dn),
+                                               "search_type" => "users"];
                                 }
                             }
                         }


### PR DESCRIPTION
RFC 4519 says that for LDAP DCs, "the equality matching rule is case insensitive, as   is today's DNS" (section 2.4).
Sometimes, GLPI could get identical answers for groups from LDAP servers with different cases (lowercase and upercase) in the DC parts of the DN. Thus it will treat them as different entries and show them in the list of available group items for import.

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
