### PR TITLE
fix(form task): missing date

### DIFF
--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -196,6 +196,21 @@
                         }
                      ) }}
 
+                     {% set task_date_lbl %}
+                        <i class="fas fa-calendar fa-fw me-1"
+                           title="{{ __('Date') }}"></i>
+                     {% endset %}
+                     {{ fields.datetimeField(
+                        'date',
+                        subitem.fields['date'],
+                        task_date_lbl,
+                        {
+                           'full_width': true,
+                           'icon_label': true,
+                           'rand': rand,
+                        }
+                     ) }}
+
                      {# Category #}
                      {% set task_category_lbl %}
                         <i class="fas fa-tag fa-fw me-1" title="{{ _n('Category', 'Categories', 1) }}"></i>

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -198,7 +198,7 @@
 
                      {% set task_date_lbl %}
                         <i class="fas fa-calendar fa-fw me-1"
-                           title="{{ __('Date') }}"></i>
+                           title="{{ _n('Date', 'Dates', 1) }}"></i>
                      {% endset %}
                      {{ fields.datetimeField(
                         'date',


### PR DESCRIPTION
The 'date' field of a task was no longer editable in 10 whereas it was in 9.5, because it was no longer in the form.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24337
