### PR TITLE
fix scrolling to last entry when timeline is set to a reverse order

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6542,7 +6542,7 @@ abstract class CommonITILObject extends CommonDBTM
             'with_validations'  => true,
             'expose_private'    => false,
             'bypass_rights'     => false,
-            'sort_by_date_desc' => false,
+            'sort_by_date_desc' => $_SESSION['glpitimeline_order'] == CommonITILObject::TIMELINE_ORDER_REVERSE,
             'is_self_service'   => false,
         ];
 

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -150,7 +150,7 @@
 </div>
 
 {% set openfollowup = (_get['_openfollowup'] ?? false) %}
-{% set timeline_reversed = user_pref('timeline_order') == constant('CommonITILObject::TIMELINE_ORDER_REVERSE') %}
+{% set is_timeline_reversed = user_pref('timeline_order') == constant('CommonITILObject::TIMELINE_ORDER_REVERSE') %}
 
 <script type="text/javascript">
 $(function() {
@@ -167,20 +167,16 @@ $(function() {
    });
 
    var scrollToTimelineStart = function() {
-      // small delay to be sure all content is loaded
-      // otherwise, height of answer html may not be taken in account by document height
-      setTimeout(() => {
-         // scroll body to ensure we are at bottom (useful for responsive display)
-         $('html, body').animate({
-            scrollTop: {{ timeline_reversed ? "-" : "" }}$(document).height()
-         }, 0, function(){
+        // scroll body to ensure we are at bottom (useful for responsive display)
+        $('html, body').animate({
+        scrollTop: {{ is_timeline_reversed ? "-" : "" }}$(document).height()
+        }, 0, function(){
             // scroll timeline with animation
             var timeline = $("#itil-object-container .itil-left-side");
             timeline.animate({
-               scrollTop: {{ timeline_reversed ? "-" : "" }}timeline.prop('scrollHeight')
+                scrollTop: {{ is_timeline_reversed ? "-" : "" }}timeline.prop('scrollHeight')
             }, 'slow');
-         });
-      }, 200);
+        });
    };
 
    {% if openfollowup %}

--- a/templates/components/itilobject/layout.html.twig
+++ b/templates/components/itilobject/layout.html.twig
@@ -61,7 +61,8 @@
    {% endif %}
 
    <div class="row d-flex flex-column alin-items-stretch itil-object">
-      {% set fl_direction = (item.isNewItem ? 'flex-column' : 'flex-column-reverse') %}
+      {% set is_timeline_reversed = user_pref('timeline_order') == constant('CommonITILObject::TIMELINE_ORDER_REVERSE') %}
+      {% set fl_direction = (item.isNewItem or is_timeline_reversed ? 'flex-column' : 'flex-column-reverse') %}
       <div class="itil-left-side col-12 {{ left_side_cls }} order-last order-md-first pt-2 pe-2 pe-md-4 d-flex {{ fl_direction }} border-top border-4">
          {% if item.isNewItem() %}
             {{ include('components/itilobject/timeline/new_form.html.twig') }}

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -31,13 +31,15 @@
  # ---------------------------------------------------------------------
  #}
 
-{% set timeline_order = "flex-column" %}
-{% if user_pref('timeline_order') == constant('CommonITILObject::TIMELINE_ORDER_REVERSE') %}
-    {% set timeline_order = "flex-column-reverse" %}
-{% endif %}
+{% set is_timeline_reversed = user_pref('timeline_order') == constant('CommonITILObject::TIMELINE_ORDER_REVERSE') %}
 
-<div class="itil-timeline d-flex {{ timeline_order }} align-items-start mb-auto">
-   {{ include('components/itilobject/timeline/main_description.html.twig') }}
+<div class="itil-timeline d-flex flex-column align-items-start mb-auto">
+    {% if not is_timeline_reversed %}
+        {{ include('components/itilobject/timeline/main_description.html.twig') }}
+    {% else %}
+        {{ include('components/itilobject/timeline/approbation_form.html.twig') }}
+        {{ include('components/itilobject/answer.html.twig') }}
+    {% endif %}
 
    {% set status_closed = (item.fields['status'] in item.getClosedStatusArray()) %}
    {% for entry in timeline %}
@@ -171,18 +173,24 @@
       </div>
    {% endfor %}
 
-   <div class="timeline-item tasks-title d-none">
-      <h3>{{ _n('Task', 'Tasks', get_plural_number()) }}</h3>
-   </div>
+    {% if is_timeline_reversed %}
+        {{ include('components/itilobject/timeline/main_description.html.twig') }}
+    {% endif %}
 
-   {{ include('components/itilobject/timeline/todo-list-summary.html.twig') }}
+    <div class="timeline-item tasks-title d-none">
+        <h3>{{ _n('Task', 'Tasks', get_plural_number()) }}</h3>
+    </div>
 
-   <div class="timeline-item validations-title d-none mt-4">
-      <h3>{{ _n('Validation', 'Validations', get_plural_number()) }}</h3>
-   </div>
+    {{ include('components/itilobject/timeline/todo-list-summary.html.twig') }}
 
-   {{ include('components/itilobject/timeline/approbation_form.html.twig') }}
-   {{ include('components/itilobject/answer.html.twig') }}
+    <div class="timeline-item validations-title d-none mt-4">
+        <h3>{{ _n('Validation', 'Validations', get_plural_number()) }}</h3>
+    </div>
+
+    {% if not is_timeline_reversed %}
+        {{ include('components/itilobject/timeline/approbation_form.html.twig') }}
+        {{ include('components/itilobject/answer.html.twig') }}
+    {% endif %}
 
 </div>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

I decided to remove the `column-reverse` class which is problematic with scrolling and adapted directly order in `CommonItilobject::getTimelineItems`.

Now as the last items is on top and the natural scrolling is to set the scrollbar to top, everything work without any css "hacks".
For natural order, we just need to keep the parent as `column-reverse` (as it is currently) to have the correct scrolling position also

Small adaptations of DOM was necessary but it seems much more clear now how the natural/reverse order work i think (i gladly take your opinion)


