### PR TITLE
Feature/global lock add

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1281,6 +1281,7 @@ class CommonDBTM extends CommonGLPI
             $table_fields = $DB->listFields($this->getTable());
 
             // fill array for add
+            $this->cleanLockedsOnAdd();
             foreach (array_keys($this->input) as $key) {
                 if (
                     ($key[0] != '_')
@@ -1705,6 +1706,25 @@ class CommonDBTM extends CommonGLPI
         }
 
         return false;
+    }
+
+    /**
+     * Clean locked fields from add, if needed
+     *
+     * @return void
+     */
+    protected function cleanLockedsOnAdd()
+    {
+        if (isset($this->input['is_dynamic']) && $this->input['is_dynamic'] == true) {
+            $lockedfield = new Lockedfield();
+            $locks = $lockedfield->getLocks($this->getType(), 0);
+            foreach ($locks as $lock) {
+                if (isset($this->input[$lock])) {
+                    $lockedfield->setLastValue($this->getType(), 0, $lock, $this->input[$lock]);
+                    unset($this->input[$lock]);
+                }
+            }
+        }
     }
 
     /**

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1719,7 +1719,7 @@ class CommonDBTM extends CommonGLPI
             $lockedfield = new Lockedfield();
             $locks = $lockedfield->getLocks($this->getType(), 0);
             foreach ($locks as $lock) {
-                if (isset($this->input[$lock])) {
+                if (array_key_exists($lock, $this->input)) {
                     $lockedfield->setLastValue($this->getType(), 0, $lock, $this->input[$lock]);
                     unset($this->input[$lock]);
                 }

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -91,7 +91,7 @@ abstract class MainAsset extends InventoryAsset
         $namespaced = explode('\\', static::class);
         $this->itemtype = array_pop($namespaced);
         $this->item = $item;
-       //store raw data for reference
+        //store raw data for reference
         $this->raw_data = $data;
     }
 
@@ -124,7 +124,7 @@ abstract class MainAsset extends InventoryAsset
 
             $val = new \stdClass();
 
-           //set update system
+            //set update system
             $val->autoupdatesystems_id = $entry->content->autoupdatesystems_id ?? 'GLPI Native Inventory';
             $val->last_inventory_update = $_SESSION["glpi_currenttime"];
 
@@ -186,7 +186,7 @@ abstract class MainAsset extends InventoryAsset
             $val->$key = $property;
         }
 
-       // * Type of the asset
+        // * Type of the asset
         if (isset($hardware)) {
             $types_id = $this->getTypesFieldName();
             if (
@@ -195,7 +195,7 @@ abstract class MainAsset extends InventoryAsset
                 && $hardware->vmsystem != 'Physical'
             ) {
                 $val->$types_id = $hardware->vmsystem;
-               // HACK FOR BSDJail, remove serial and UUID (because it's of host, not container)
+                // HACK FOR BSDJail, remove serial and UUID (because it's of host, not container)
                 if ($hardware->vmsystem == 'BSDJail') {
                     if (property_exists($val, 'serial')) {
                         $val->serial = '';
@@ -264,7 +264,7 @@ abstract class MainAsset extends InventoryAsset
             }
         }
 
-       // * USERS
+        // * USERS
         $cnt = 0;
         if (isset($this->extra_data['users'])) {
             if (count($this->extra_data['users']) > 0) {
@@ -367,7 +367,7 @@ abstract class MainAsset extends InventoryAsset
 
         if (property_exists($bios, 'ssn')) {
             $val->serial = trim($bios->ssn);
-           // HP patch for serial begin with 'S'
+            // HP patch for serial begin with 'S'
             if (
                 property_exists($val, 'manufacturers_id')
                 && strstr($val->manufacturers_id, "ewlett")
@@ -449,7 +449,7 @@ abstract class MainAsset extends InventoryAsset
                     }
                 }
 
-               // Case of virtualmachines
+                // Case of virtualmachines
                 if (
                     !isset($input['mac'])
                      && !isset($input['ip'])
@@ -473,7 +473,7 @@ abstract class MainAsset extends InventoryAsset
 
         $input['itemtype'] = $this->item->getType();
 
-       // * entity rules
+        // * entity rules
         $input['entities_id'] = $this->entities_id;
 
         return $input;

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -142,14 +142,6 @@ abstract class MainAsset extends InventoryAsset
                 $this->postPrepare($val);
             }
 
-            //locked fields
-            $lockedfield = new Lockedfield();
-            $locks = $lockedfield->getLocks($this->item->getType(), 0);
-            foreach ($locks as $lock) {
-                if (property_exists($val, $lock)) {
-                    unset($val->$lock);
-                }
-            }
             $this->data[] = $val;
         }
 
@@ -505,6 +497,15 @@ abstract class MainAsset extends InventoryAsset
         $blacklist = new Blacklist();
 
         foreach ($this->data as $key => $data) {
+            //locked fields
+            $lockedfield = new Lockedfield();
+            $locks = $lockedfield->getLocks($this->item->getType(), 0);
+            foreach ($locks as $lock) {
+                if (property_exists($data, $lock)) {
+                    unset($data->$lock);
+                }
+            }
+
             $blacklist->processBlackList($data);
 
             $this->current_key = $key;

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -497,15 +497,6 @@ abstract class MainAsset extends InventoryAsset
         $blacklist = new Blacklist();
 
         foreach ($this->data as $key => $data) {
-            //locked fields
-            $lockedfield = new Lockedfield();
-            $locks = $lockedfield->getLocks($this->item->getType(), 0);
-            foreach ($locks as $lock) {
-                if (property_exists($data, $lock)) {
-                    unset($data->$lock);
-                }
-            }
-
             $blacklist->processBlackList($data);
 
             $this->current_key = $key;
@@ -651,6 +642,17 @@ abstract class MainAsset extends InventoryAsset
         $_SESSION['glpiactiveentities']        = [$entities_id];
         $_SESSION['glpiactiveentities_string'] = $entities_id;
         $_SESSION['glpiactive_entity']         = $entities_id;
+
+        //locked fields
+        $lockedfield = new Lockedfield();
+        $locks = $lockedfield->getLocks($this->item->getType(), $items_id);
+        foreach ($this->data as &$data) {
+            foreach ($locks as $lock) {
+                if (property_exists($data, $lock)) {
+                    unset($data->$lock);
+                }
+            }
+        }
 
         //handleLinks relies on $this->data; update it before the call
         $this->handleLinks();

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -42,6 +42,7 @@ use CommonDBTM;
 use Dropdown;
 use Glpi\Inventory\Conf;
 use Glpi\Inventory\Request;
+use Lockedfield;
 use RefusedEquipment;
 use RuleImportAssetCollection;
 use RuleImportEntityCollection;
@@ -141,6 +142,14 @@ abstract class MainAsset extends InventoryAsset
                 $this->postPrepare($val);
             }
 
+            //locked fields
+            $lockedfield = new Lockedfield();
+            $locks = $lockedfield->getLocks($this->item->getType(), 0);
+            foreach ($locks as $lock) {
+                if (property_exists($val, $lock)) {
+                    unset($val->$lock);
+                }
+            }
             $this->data[] = $val;
         }
 

--- a/tests/functionnal/Glpi/Inventory/Inventory.php
+++ b/tests/functionnal/Glpi/Inventory/Inventory.php
@@ -3361,7 +3361,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->array($cloc);
         $locations_id = $cloc['id'];
 
-       //check created equipments
+        //check created equipments
         $expected_eq_count = 302;
         $iterator = $DB->request([
             'FROM'   => \NetworkEquipment::getTable(),

--- a/tests/functionnal/Lockedfield.php
+++ b/tests/functionnal/Lockedfield.php
@@ -315,6 +315,127 @@ class Lockedfield extends DbTestCase
         <IPS>
           <IP>10.75.230.125</IP>
         </IPS>
+        <MAC>00:1b:a9:12:11:f2</MAC>
+        <MANUFACTURER>Brother</MANUFACTURER>
+        <MEMORY>32</MEMORY>
+        <MODEL>Brother HL-5350DN series</MODEL>
+        <NAME>CE75I09008</NAME>
+        <RAM>32</RAM>
+        <SERIAL>D9J230159</SERIAL>
+        <TYPE>PRINTER</TYPE>
+        <UPTIME>14 days, 22:48:33.30</UPTIME>
+      </INFO>
+    </DEVICE>
+  </CONTENT><QUERY>SNMP</QUERY><DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID></REQUEST>
+";
+        $existing_locations = countElementsInTable(\Location::getTable());
+        $lockedfield = new \Lockedfield();
+
+        $converter = new \Glpi\Inventory\Converter();
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $inventory = new \Glpi\Inventory\Inventory($json);
+
+        if ($inventory->inError()) {
+            $this->dump($inventory->getErrors());
+        }
+        $this->boolean($inventory->inError())->isFalse();
+        $this->array($inventory->getErrors())->isEmpty();
+
+        //check matchedlogs
+        $criteria = [
+            'FROM' => \RuleMatchedLog::getTable(),
+            'LEFT JOIN' => [
+                \Rule::getTable() => [
+                    'ON' => [
+                        \RuleMatchedLog::getTable() => 'rules_id',
+                        \Rule::getTable() => 'id'
+                    ]
+                ]
+            ],
+            'WHERE' => []
+        ];
+        $iterator = $DB->request($criteria);
+        $this->string($iterator->current()['name'])->isIdenticalTo('Printer import (by serial)');
+
+        $printers_id = $inventory->getItem()->fields['id'];
+        $this->integer($printers_id)->isGreaterThan(0);
+
+        $printer = new \Printer();
+        $this->boolean($printer->getFromDB($printers_id))->isTrue();
+        $this->integer($printer->fields['locations_id'])->isEqualTo(0);
+
+        //ensure no new manufacturer has been added
+        $this->integer(countElementsInTable(\Location::getTable()))->isIdenticalTo($existing_locations);
+
+        //manually update to lock locations_id field
+        $locations_id = getItemByTypeName('Location', '_location02', true);
+        $this->boolean(
+            $printer->update([
+                'id' => $printers_id,
+                'locations_id' => $locations_id,
+                'id_dynamic' => true
+            ])
+        )->isTrue();
+        $this->array($lockedfield->getLocks($printer->getType(), $printers_id))->isIdenticalTo(['locations_id']);
+
+
+        //Replay, with a location
+        $xml = "<?xml version=\"1.0\"?>
+<REQUEST><CONTENT><DEVICE>
+      <INFO>
+        <COMMENTS>Brother NC-6800h, Firmware Ver.1.01  (08.12.12),MID 84UB03</COMMENTS>
+        <ID>1907</ID>
+        <IPS>
+          <IP>10.75.230.125</IP>
+        </IPS>
+        <LOCATION>Greffe Charron</LOCATION>
+        <MAC>00:1b:a9:12:11:f2</MAC>
+        <MANUFACTURER>Brother</MANUFACTURER>
+        <MEMORY>32</MEMORY>
+        <MODEL>Brother HL-5350DN series</MODEL>
+        <NAME>CE75I09008</NAME>
+        <RAM>32</RAM>
+        <SERIAL>D9J230159</SERIAL>
+        <TYPE>PRINTER</TYPE>
+        <UPTIME>14 days, 22:48:33.30</UPTIME>
+      </INFO>
+    </DEVICE>
+  </CONTENT><QUERY>SNMP</QUERY><DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID></REQUEST>
+";
+
+        $converter = new \Glpi\Inventory\Converter();
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $inventory = new \Glpi\Inventory\Inventory($json);
+
+        if ($inventory->inError()) {
+            $this->dump($inventory->getErrors());
+        }
+        $this->boolean($inventory->inError())->isFalse();
+        $this->array($inventory->getErrors())->isEmpty();
+
+        $this->boolean($printer->getFromDB($printers_id))->isTrue();
+        $this->integer($printer->fields['locations_id'])->isEqualTo($locations_id);
+
+        //ensure no new manufacturer has been added
+        $this->integer(countElementsInTable(\Location::getTable()))->isIdenticalTo($existing_locations);
+    }
+
+    public function testNoLocationGlobal()
+    {
+        global $DB;
+
+        $xml = "<?xml version=\"1.0\"?>
+<REQUEST><CONTENT><DEVICE>
+      <INFO>
+        <COMMENTS>Brother NC-6800h, Firmware Ver.1.01  (08.12.12),MID 84UB03</COMMENTS>
+        <ID>1907</ID>
+        <IPS>
+          <IP>10.75.230.125</IP>
+        </IPS>
         <LOCATION>Greffe Charron</LOCATION>
         <MAC>00:1b:a9:12:11:f2</MAC>
         <MANUFACTURER>Brother</MANUFACTURER>

--- a/tests/functionnal/Lockedfield.php
+++ b/tests/functionnal/Lockedfield.php
@@ -366,7 +366,7 @@ class Lockedfield extends DbTestCase
         $this->boolean($printer->getFromDB($printers_id))->isTrue();
         $this->integer($printer->fields['locations_id'])->isEqualTo(0);
 
-        //ensure no new manufacturer has been added
+        //ensure no new location has been added
         $this->integer(countElementsInTable(\Location::getTable()))->isIdenticalTo($existing_locations);
 
         //manually update to lock locations_id field
@@ -420,7 +420,7 @@ class Lockedfield extends DbTestCase
         $this->boolean($printer->getFromDB($printers_id))->isTrue();
         $this->integer($printer->fields['locations_id'])->isEqualTo($locations_id);
 
-        //ensure no new manufacturer has been added
+        //ensure no new location has been added
         $this->integer(countElementsInTable(\Location::getTable()))->isIdenticalTo($existing_locations);
     }
 
@@ -496,7 +496,7 @@ class Lockedfield extends DbTestCase
         $this->boolean($printer->getFromDB($printers_id))->isTrue();
         $this->integer($printer->fields['locations_id'])->isEqualTo(0);
 
-        //ensure no new manufacturer has been added
+        //ensure no new location has been added
         $this->integer(countElementsInTable(\Location::getTable()))->isIdenticalTo($existing_locations);
     }
 }

--- a/tests/functionnal/Lockedfield.php
+++ b/tests/functionnal/Lockedfield.php
@@ -57,7 +57,7 @@ class Lockedfield extends DbTestCase
         $this->boolean($lockedfield->isHandled($computer))->isTrue();
         $this->array($lockedfield->getLocks($computer->getType(), $cid))->isEmpty();
 
-       //update computer manually, to add a locked field
+        //update computer manually, to add a locked field
         $this->boolean(
             (bool)$computer->update(['id' => $cid, 'otherserial' => 'AZERTY'])
         )->isTrue();
@@ -65,7 +65,7 @@ class Lockedfield extends DbTestCase
         $this->boolean($computer->getFromDB($cid))->isTrue();
         $this->array($lockedfield->getLocks($computer->getType(), $cid))->isIdenticalTo(['otherserial']);
 
-       //ensure new dynamic update does not override otherserial again
+        //ensure new dynamic update does not override otherserial again
         $this->boolean(
             (bool)$computer->update([
                 'id' => $cid,
@@ -78,7 +78,7 @@ class Lockedfield extends DbTestCase
         $this->variable($computer->fields['otherserial'])->isEqualTo('AZERTY');
         $this->array($lockedfield->getLocks($computer->getType(), $cid))->isIdenticalTo(['otherserial']);
 
-       //ensure new dynamic update do not set new lock on regular update
+        //ensure new dynamic update do not set new lock on regular update
         $this->boolean(
             (bool)$computer->update([
                 'id' => $cid,
@@ -91,7 +91,7 @@ class Lockedfield extends DbTestCase
         $this->variable($computer->fields['name'])->isEqualTo('Computer name changed');
         $this->array($lockedfield->getLocks($computer->getType(), $cid))->isIdenticalTo(['otherserial']);
 
-       //ensure regular update do work on locked field
+        //ensure regular update do work on locked field
         $this->boolean(
             (bool)$computer->update(['id' => $cid, 'otherserial' => 'QWERTY'])
         )->isTrue();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Two changes:
- global locks are now check at itemtype creation,
- locks are now handled in MainAsset::prepare, to ensure linked items (like location, manufacturer and so on) are not created at all.
