### PR TITLE
9.5.7 migration: Remove duplicated items_os before adding unicity

### DIFF
--- a/install/migrations/update_9.5.6_to_9.5.7.php
+++ b/install/migrations/update_9.5.6_to_9.5.7.php
@@ -84,6 +84,37 @@ function update956to957()
     );
     /** /Replace -1 values for glpi_networkportaliases.networkports_id_alias field */
 
+    /** Fix duplicate date in glpi_items_operatingsystems table */
+    // First, find item that contains duplicated data
+    $data = $DB->request([
+        'SELECT' => [
+            'MAX' => 'id as valid_entry_id',
+            'items_id',
+            'itemtype',
+        ],
+        'FROM' => 'glpi_items_operatingsystems',
+        'WHERE' => [
+            'operatingsystems_id' => [-1, 0]
+        ],
+        'GROUPBY' => [
+            'items_id',
+            'itemtype'
+        ],
+        'HAVING' => [new QueryExpression("COUNT(*) > 1")]
+    ]);
+
+    // Keep only the latest value for each items with duplicated data
+    foreach ($data as $row) {
+        $delete = $DB->buildDelete('glpi_items_operatingsystems', [
+            'operatingsystems_id' => [-1, 0],
+            'itemtype' => $row['itemtype'],
+            'items_id' => $row['items_id'],
+            'id' => ['!=', $row['valid_entry_id']],
+        ]);
+        $migration->addPostQuery($delete);
+    }
+    /** /Fix duplicate date in glpi_items_operatingsystems table */
+
     /** Replace -1 values for glpi_items_operatingsystems table foreign key fields */
     foreach (['operatingsystems_id', 'operatingsystemversions_id', 'operatingsystemservicepacks_id'] as $item_os_fkey) {
         $migration->addPostQuery(


### PR DESCRIPTION
The 9.5.7 migration fixed some weird fusioninventory data from `glpi_items_operatingsystems` by changing some foreign keys from -1 to 0.

It has the unexpected effect of triggering a failed unicity constraint if there are both a -1 and 0 value for the `operatingsystems_id` field (the -1 is modified to 0 and we end up with two row with 0 -> unicity check fail)

We will fix this by removing this duplicated values before this "clean up" process.

First step is to identify the affected items, we will do so with the following request:

![image](https://user-images.githubusercontent.com/42734840/176440108-fff2dae6-2bca-491c-9b25-c0ee425912f8.png)

This query give us :
* The affected item (items_id + itemtype)
* The entry of the only valid value (which will always be the latest entry to be inserted,)

Then, for each results we run a delete query like so:
```sql
DELETE FROM glpi_items_operatingsystems
WHERE 
    operatingsystems_id IN (0, -1)
    AND itemtype = {itemtype}
    AND items_id = {items_id}
    AND id != {max(id)}
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24314, !23979
