### PR TITLE
fix: is_recursive

### DIFF
--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -135,7 +135,7 @@
                            {% set disabled = true %}
                         {% endif %}
 
-                        <input type="hidden" name="is_recursive" value="0" />
+                        {% if canedit %}<input type="hidden" name="is_recursive" value="0" />{% endif %}
                         <input class="form-check-input" type="checkbox" name="is_recursive" value="1"
                               {% if item.isRecursive() %}checked="checked"{% endif %}
                               {% if disabled %}disabled="disabled"{% endif %} />

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -135,7 +135,7 @@
                            {% set disabled = true %}
                         {% endif %}
 
-                        {% if canedit %}<input type="hidden" name="is_recursive" value="0" />{% endif %}
+                        {% if not disabled %}<input type="hidden" name="is_recursive" value="0" />{% endif %}
                         <input class="form-check-input" type="checkbox" name="is_recursive" value="1"
                               {% if item.isRecursive() %}checked="checked"{% endif %}
                               {% if disabled %}disabled="disabled"{% endif %} />

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -135,6 +135,7 @@
                            {% set disabled = true %}
                         {% endif %}
 
+                        <input type="hidden" name="is_recursive" value="0" />
                         <input class="form-check-input" type="checkbox" name="is_recursive" value="1"
                               {% if item.isRecursive() %}checked="checked"{% endif %}
                               {% if disabled %}disabled="disabled"{% endif %} />


### PR DESCRIPTION
When the `is_recursive` checkbox was unchecked the value `0` was not sent and therefore the field could not be modified.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24361
