### PR TITLE
Fix agent itemtype updated with unexpected value

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -342,10 +342,16 @@ class Agent extends CommonDBTM
         $input = Toolbox::addslashes_deep($input);
         if ($aid) {
             $input['id'] = $aid;
+            // We should not update itemtype in db if not an expected one
+            if (!$has_expected_agent_type) {
+                unset($input['itemtype']);
+            }
             $this->update($input);
             // Don't keep linked item unless having expected agent type
             if (!$has_expected_agent_type) {
                 $this->fields['items_id'] = 0;
+                // But always keep itemtype for class instantiation
+                $this->fields['itemtype'] = $metadata['itemtype'];
             }
         } else {
             $input['items_id'] = 0;


### PR DESCRIPTION
Don't update agent type in db with unexpected one
but keep it for class instantiation

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
