### PR TITLE
Fix global search

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -3032,6 +3032,8 @@ JAVASCRIPT;
         }
         echo "</div>";
         echo "</div>";
+        echo "</div>";
+        echo "</div>";
     }
 
     /**

--- a/src/Search.php
+++ b/src/Search.php
@@ -2553,7 +2553,7 @@ class Search
 
         echo "<a id='more-criteria$rand_criteria' role='button'
             class='normalcriteria fold-search list-group-item p-2 border-0'
-            style='display: none;'>...</a>";
+            style='display: none;'></a>";
 
         echo "</div>"; // .list
 


### PR DESCRIPTION
When first criteria is a global rule,

if we want to remove it 

![image](https://user-images.githubusercontent.com/7335054/176206508-db2aa568-9da0-46db-b0dd-835c9fb24bf7.png)


all search form is removed

![image](https://user-images.githubusercontent.com/7335054/176206522-7747609f-42ac-4e84-a9c5-2d9be26e3c96.png)

Remove useless 'dot' 

![image](https://user-images.githubusercontent.com/7335054/176207114-7b0d4c1e-2ed9-4cd8-b169-c8833455451d.png)

which remains when we add criterion (global or not)

![image](https://user-images.githubusercontent.com/7335054/176207369-3d523a57-cf85-4d30-8691-7e922933e8cc.png)


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
