### PR TITLE
Fix magic MassiveAction::__set() method

### DIFF
--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -472,7 +472,6 @@ class MassiveAction
     public function __set(string $property, $value)
     {
         // TODO Deprecate access to variables in GLPI 10.1.
-        $value = null;
         switch ($property) {
             case 'display_progress_bars':
                 $this->$property = $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

Due to a copy/paste residue, the magic `MassiveAction::__set()` method was always forcing values to `null`.