### PR TITLE
avoid to return to default sort when we have only one column sorted

### DIFF
--- a/js/modules/Search/Table.js
+++ b/js/modules/Search/Table.js
@@ -60,6 +60,7 @@ window.GLPI.Search.Table = class Table extends GenericView {
         const target_column = $(target);
         const all_colums = this.getElement().find('thead th');
         const sort_order = target_column.attr('data-sort-order');
+        const nb_col_sorted = $('[data-sort-num]').length;
 
         if (!multisort && (sort_order === null || sort_order === 'nosort')) {
             // Remove all sorts and set this new column as the primary sort
@@ -70,7 +71,17 @@ window.GLPI.Search.Table = class Table extends GenericView {
             });
         }
 
-        const new_order = sort_order === 'ASC' ? 'DESC' : (sort_order === 'DESC' ? 'nosort' : 'ASC');
+        const new_order = sort_order === 'ASC'
+            ? 'DESC'
+            : (
+                sort_order === 'DESC'
+                    ? (
+                        nb_col_sorted > 1
+                            ? 'nosort'
+                            : 'ASC'
+                    )
+                    : 'ASC'
+            );
         target_column.attr('data-sort-order', new_order);
 
         let sort_num = target_column.attr('data-sort-num');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24361

The fixed bug is clearly visible on Ticket list, you can try to order the "Last update" column.
As we remove the last order on the view, the ajax query return the default sort (and so we loop).

After multiple tries, i found this easy solution to track the number of columns already sorted, and if we are in the case with 1 column, we replace the order from nosort to 'ASC' (aka switch between ASC and DESC).
So with one colum sorted, we can't return anymore to an unsorted state and we can't trigger the load of the default sort of the backend.