### PR TITLE
Pending reasons: remove unneeded warnings

### DIFF
--- a/src/PendingReasonCron.php
+++ b/src/PendingReasonCron.php
@@ -107,7 +107,9 @@ class PendingReasonCron extends CommonDBTM
             }
 
             if ($item->fields['status'] != CommonITILObject::WAITING) {
-                trigger_error("Status is not pending", E_USER_WARNING);
+                $pending_item->delete([
+                    'id' => $pending_item->fields['id'],
+                ]);
                 continue;
             }
 
@@ -122,8 +124,15 @@ class PendingReasonCron extends CommonDBTM
                     continue;
                 }
 
-               // Load followup template
-                $fup_template = ITILFollowupTemplate::getById($pending_reason->fields['itilfollowuptemplates_id']);
+                $template_id = $pending_reason->fields['itilfollowuptemplates_id'];
+
+                // No template defined; can't bump
+                if (!$template_id) {
+                    continue;
+                }
+
+                // Load followup template
+                $fup_template = ITILFollowupTemplate::getById($template_id);
                 if (!$fup_template) {
                     trigger_error("Failed to load ITILFollowupTemplate::{$pending_reason->fields['itilfollowuptemplates_id']}", E_USER_WARNING);
                     continue;


### PR DESCRIPTION
These changes impact the `cronPendingreason_autobump_autosolve` function, which handle tickets "bumps" and "auto resolution".

As a reminder, this action use the date from the `glpi_pendingreasons_items` table, where you can find data like this:

![image](https://user-images.githubusercontent.com/42734840/176675706-4e5d5c94-da6d-45bb-a50c-a582b714d839.png)

For each row, the cron will check if the ticket must be bumped / solved.

1\) The old code would emit a warning `Status is not pending` if we found a matching ticket for a row that isn't pending (a ticket is supposed to be pending to be bumped or solved)

This isn't supposed to happen as when the ticket status is updated to anything else than pending, the matching data in `glpi_pendingreasons_items` is deleted.

The warning was in place to indicate that something went wrong (forgotten edge case ?) and that the row was not deleted as expected.
However, since it does not indicate **where** the process went wrong, it isn't very helpful and just spams the logs for nothing.

-> It seems better to fix the data (delete the incorrect row) and emit no warnings.

2\) We would also emit a warning if we failed to load the followup template that must be used to bump the ticket

It seems this warning also trigger when the template is undefined (`itilfollowuptemplates_id` = 0), which is not on purpose (it isn't that we failed to load the data - there is no data specified to load).

-> No more warning in this case, we do not need to log a simple configuration error.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24362
