### PR TITLE
Separate agent clean actions and add uninstall integration

### DIFF
--- a/install/migrations/update_10.0.x_to_10.1.0/native_inventory.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/native_inventory.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2022 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+// Get inventory config values
+$c = getAllDataFromTable('glpi_configs', ['context' => 'inventory']);
+$inventory_config = [];
+foreach ($c as $config) {
+    $inventory_config[$config['name']] = $config['value'];
+}
+
+if (isset($inventory_config['stale_agents_action'])) {
+    // If stale_agents_action was 0 (clean), enable the separate clean action
+    $stale_agents_clean = (int)$inventory_config['stale_agents_action'] === 0;
+    // stale_agents_status with -1 = No Change. If the status was set previously, but then the action changed to clean, the status value would not have been changed.
+    // We want to reset the status to -1, so that it doesn't change the status unexpectedly.
+    $stale_agents_status = (!$stale_agents_clean && $inventory_config['stale_agents_status']) ? $inventory_config['stale_agents_status'] : -1;
+
+    // New inventory config values
+    $new_inventory_config = [
+        'stale_agents_clean' => $stale_agents_clean,
+        'stale_agents_status' => $stale_agents_status,
+    ];
+
+    $DB->updateOrInsert('glpi_configs', [
+        'context' => 'inventory',
+        'name' => 'stale_agents_clean',
+        'value' => $new_inventory_config['stale_agents_clean'],
+    ], [
+        'context' => 'inventory',
+        'name' => 'stale_agents_clean',
+    ]);
+    $DB->updateOrInsert('glpi_configs', [
+        'context' => 'inventory',
+        'name' => 'stale_agents_status',
+        'value' => $new_inventory_config['stale_agents_status'],
+    ], [
+        'context' => 'inventory',
+        'name' => 'stale_agents_status',
+    ]);
+    // Remove old action config
+    $DB->deleteOrDie('glpi_configs', [
+        'context' => 'inventory',
+        'name' => 'stale_agents_action',
+    ]);
+}

--- a/install/migrations/update_10.0.x_to_10.1.0/native_inventory.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/native_inventory.php
@@ -38,12 +38,7 @@
  * @var Migration $migration
  */
 
-// Get inventory config values
-$c = getAllDataFromTable('glpi_configs', ['context' => 'inventory']);
-$inventory_config = [];
-foreach ($c as $config) {
-    $inventory_config[$config['name']] = $config['value'];
-}
+$inventory_config = \Config::getConfigurationValues('inventory');
 
 if (isset($inventory_config['stale_agents_action'])) {
     // If stale_agents_action was 0 (clean), enable the separate clean action

--- a/install/migrations/update_10.0.x_to_10.1.0/native_inventory.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/native_inventory.php
@@ -45,7 +45,7 @@ if (isset($inventory_config['stale_agents_action'])) {
     $stale_agents_clean = (int)$inventory_config['stale_agents_action'] === 0;
     // stale_agents_status with -1 = No Change. If the status was set previously, but then the action changed to clean, the status value would not have been changed.
     // We want to reset the status to -1, so that it doesn't change the status unexpectedly.
-    $stale_agents_status = $stale_agents_status = (!$stale_agents_clean && isset($inventory_config['stale_agents_status'])) ? $inventory_config['stale_agents_status'] : -1;
+    $stale_agents_status = (!$stale_agents_clean && isset($inventory_config['stale_agents_status'])) ? $inventory_config['stale_agents_status'] : -1;
 
     // New inventory config values
     $new_inventory_config = [

--- a/install/migrations/update_10.0.x_to_10.1.0/native_inventory.php
+++ b/install/migrations/update_10.0.x_to_10.1.0/native_inventory.php
@@ -45,7 +45,7 @@ if (isset($inventory_config['stale_agents_action'])) {
     $stale_agents_clean = (int)$inventory_config['stale_agents_action'] === 0;
     // stale_agents_status with -1 = No Change. If the status was set previously, but then the action changed to clean, the status value would not have been changed.
     // We want to reset the status to -1, so that it doesn't change the status unexpectedly.
-    $stale_agents_status = (!$stale_agents_clean && $inventory_config['stale_agents_status']) ? $inventory_config['stale_agents_status'] : -1;
+    $stale_agents_status = $stale_agents_status = (!$stale_agents_clean && isset($inventory_config['stale_agents_status'])) ? $inventory_config['stale_agents_status'] : -1;
 
     // New inventory config values
     $new_inventory_config = [

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -36,7 +36,6 @@
 
 use Glpi\Application\ErrorHandler;
 use Glpi\Application\View\TemplateRenderer;
-use Glpi\Inventory\Conf;
 use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\Sanitizer;
 use GuzzleHttp\Client as Guzzle_Client;
@@ -761,26 +760,6 @@ class Agent extends CommonDBTM
             }
             // Run the action
             if (!$action['callback']($agent, $config, $item)) {
-                return false;
-            }
-        }
-        if ($item !== null && in_array('change_status', $actions_to_apply, true)) {
-            $result = $item->update([
-                'id' => $item->fields['id'],
-                'states_id' => $config['agents_status']
-            ]);
-            if (!$result) {
-                return false;
-            }
-        }
-        if ($item !== null && in_array('apply_uninstall_profile', $actions_to_apply, true)) {
-            \PluginUninstallUninstall::uninstall(get_class($item), $config['stale_agents_status'], [
-                get_class($item) => [$item->fields['id'] => true]
-            ], '');
-        }
-        if (in_array('clean', $actions_to_apply, true)) {
-            $result = $agent->delete(['id' => $agent->fields['id']]);
-            if (!$result) {
                 return false;
             }
         }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -695,7 +695,7 @@ class Agent extends CommonDBTM
         /** @phpstan-var array{item_action: bool, callback: callable(?Agent, array, ?CommonDBTM):bool}[] $actions_to_apply */
         $actions_to_apply = [];
         $need_item = false;
-        if (isset($config['stale_agents_status']) && $config['stale_agents_status'] >= 0) {
+        if (isset($config['stale_agents_status']) && (int) $config['stale_agents_status'] >= 0) {
             // 0 = none, -1 or other negative = no change
             $need_item = true;
             $actions_to_apply[] = [
@@ -750,9 +750,7 @@ class Agent extends CommonDBTM
         // Run all actions, with the clean action running last
         foreach ($actions_to_apply as $action) {
             // Run the action
-            if (!$action['callback']($agent, $config, $item)) {
-                return false;
-            }
+            $action['callback']($agent, $config, $item);
         }
         return true;
     }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -714,7 +714,7 @@ class Agent extends CommonDBTM
          * @phpstan-var array{label: string, item_action: boolean, render_callback: callable, action_callback: callable}[] $actions
          */
         foreach ($plugin_actions as $plugin => $actions) {
-            if (is_array($actions) && \Plugin::isPluginActive($plugin)) {
+            if (is_array($actions) && Plugin::isPluginActive($plugin)) {
                 foreach ($actions as $action) {
                     if ($action['item_action']) {
                         $need_item = true;
@@ -735,20 +735,8 @@ class Agent extends CommonDBTM
 
         // If an action to apply needs the item
         if ($need_item) {
-            $orphan = false;
-            try {
-                $item = new $agent->fields['itemtype']();
-                if ($item instanceof CommonDBTM) {
-                    if (!$item->getFromDB($agent->fields['items_id'])) {
-                        $orphan = true;
-                    }
-                } else {
-                    $orphan = true;
-                }
-            } catch (\Exception $e) {
-                $orphan = true;
-            }
-            if ($orphan) {
+            $item = is_a($agent->fields['itemtype'], CommonDBTM::class, true) ? new $agent->fields['itemtype']() : null;
+            if ($item !== null && $item->getFromDB($agent->fields['items_id']) === false) {
                 $item = null;
             }
         }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -723,9 +723,8 @@ class Agent extends CommonDBTM
                         );
                         continue;
                     }
-                    if ($action['item_action']) {
-                        $need_item = true;
-                    }
+                    // Assume plugins always need the item
+                    $need_item = true;
                     $actions_to_apply[] = $action['action_callback'];
                 }
             }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -716,6 +716,13 @@ class Agent extends CommonDBTM
         foreach ($plugin_actions as $plugin => $actions) {
             if (is_array($actions) && Plugin::isPluginActive($plugin)) {
                 foreach ($actions as $action) {
+                    if (!is_callable($action['action_callback'] ?? null)) {
+                        trigger_error(
+                            sprintf('Invalid plugin "%s" action callback for "%s" hook.', $plugin, Hooks::STALE_AGENT_CONFIG),
+                            E_USER_WARNING
+                        );
+                        continue;
+                    }
                     if ($action['item_action']) {
                         $need_item = true;
                     }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -743,10 +743,6 @@ class Agent extends CommonDBTM
 
         // Run all actions, with the clean action running last
         foreach ($actions_to_apply as $action) {
-            // If the action needs the item, and we don't have one, skip it
-            if ($action['item_action'] && $item === null) {
-                continue;
-            }
             // Run the action
             if (!$action['callback']($agent, $config, $item)) {
                 return false;

--- a/src/Config.php
+++ b/src/Config.php
@@ -3118,16 +3118,19 @@ HTML;
                     'name'      => $name
                 ])
             ) {
-                $input = ['id'      => $config->getID(),
-                    'context' => $context,
-                    'value'   => $value
+                $input = [
+                    'id'        => $config->getID(),
+                    'name'      => $name,
+                    'context'   => $context,
+                    'value'     => $value
                 ];
 
                 $config->update($input);
             } else {
-                $input = ['context' => $context,
-                    'name'    => $name,
-                    'value'   => $value
+                $input = [
+                    'context'   => $context,
+                    'name'      => $name,
+                    'value'     => $value
                 ];
 
                 $config->add($input);

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -871,7 +871,7 @@ class Conf extends CommonGLPI
                     $field = $action['render_callback']($config);
                     if (!empty($field)) {
                         echo "<td>";
-                        echo $action['label'];
+                        echo $action['label'] ?? '';
                         echo "</td>";
                         echo "<td width='20%'>";
                         echo $field;

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -926,7 +926,11 @@ class Conf extends CommonGLPI
         $defaults = self::$defaults;
         unset($values['_glpi_csrf_token']);
 
-        $unknown = array_diff_key($values, $defaults);
+        $inv_values = array_filter($values, static function ($value) {
+            return !str_starts_with($value, '_');
+        });
+
+        $unknown = array_diff_key($inv_values, $defaults);
         if (count($unknown)) {
             $msg = sprintf(
                 __('Some properties are not known: %1$s'),

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -133,12 +133,21 @@ class Conf extends CommonGLPI
         'import_printer'                 => 1,
         'import_peripheral'              => 1,
         'stale_agents_delay'             => 0,
-        'stale_agents_action'            => 0,
+        'stale_agents_clean'             => 1,
         'stale_agents_status'            => 0,
+        'stale_agents_uninstall'         => 0,
     ];
 
+    /**
+     * @var int
+     * @deprecated 10.1.0 No effect
+     */
     public const STALE_AGENT_ACTION_CLEAN = 0;
 
+    /**
+     * @var int
+     * @deprecated 10.1.0 No effect
+     */
     public const STALE_AGENT_ACTION_STATUS = 1;
 
     /**
@@ -274,7 +283,8 @@ class Conf extends CommonGLPI
     /**
      * Get possible actions for stale agents
      *
-     * @return string
+     * @return array
+     * @deprecated 10.1.0 No effect
      */
     public static function getStaleAgentActions(): array
     {
@@ -822,51 +832,40 @@ class Conf extends CommonGLPI
             ]
         );
         echo "</td>";
-        echo "<td>" . _n('Action', 'Actions', 1) . "</td>";
+        echo "<td>" . __('Clean agent') . "</td>";
         echo "<td width='20%'>";
         //action
-        $rand = Dropdown::showFromArray(
-            'stale_agents_action',
-            self::getStaleAgentActions(),
-            [
-                'value' => $config['stale_agents_action'] ?? self::STALE_AGENT_ACTION_CLEAN,
-                'on_change' => 'changestatus();',
-            ]
-        );
-        //if action == action_status => show blocation else hide blocaction
-        echo Html::scriptBlock("
-         function changestatus() {
-            if ($('#dropdown_stale_agents_action$rand').val() != 0) {
-               $('#blocaction1').show();
-               $('#blocaction2').show();
-            } else {
-               $('#blocaction1').hide();
-               $('#blocaction2').hide();
-            }
-         }
-         changestatus();
-
-      ");
+        Dropdown::showYesNo('stale_agents_clean', $config['stale_agents_clean'] ?? 0);
         echo "</td>";
         echo "</tr>";
         //blocaction with status
-        echo "<tr class='tab_bg_1'><td colspan=2></td>";
+        echo "<tr class='tab_bg_1'>";
         echo "<td>";
-        echo "<span id='blocaction1' style='display:none'>";
         echo __('Change the status');
-        echo "</span>";
         echo "</td>";
         echo "<td width='20%'>";
-        echo "<span id='blocaction2' style='display:none'>";
         State::dropdown(
             [
                 'name'   => 'stale_agents_status',
                 'value'  => $config['stale_agents_status'] ?? -1,
-                'entity' => $_SESSION['glpiactive_entity']
+                'entity' => $_SESSION['glpiactive_entity'],
+                'toadd'  => [-1 => __('No change')]
             ]
         );
-        echo "</span>";
         echo "</td>";
+        if (\Plugin::isPluginActive('uninstall') && \PluginUninstallModel::canView()) {
+            echo "<td>" . __('Apply uninstall profile') . "</td>";
+            echo "<td width='20%'>";
+            \PluginUninstallModel::dropdown([
+                'name'   => 'stale_agents_uninstall',
+                'value'  => $config['stale_agents_uninstall'] ?? 0,
+                'entity' => $_SESSION['glpiactive_entity'],
+                'condition' => [
+                    'types_id' => \PluginUninstallModel::TYPE_MODEL_UNINSTALL
+                ]
+            ]);
+            echo "</td>";
+        }
         echo "</tr>";
 
         if ($canedit) {

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -865,6 +865,14 @@ class Conf extends CommonGLPI
         foreach ($plugin_actions as $plugin => $actions) {
             if (is_array($actions) && \Plugin::isPluginActive($plugin)) {
                 foreach ($actions as $action) {
+                    if (!is_callable($action['render_callback'] ?? null)) {
+                        trigger_error(
+                            sprintf('Invalid plugin "%s" render callback for "%s" hook.', $plugin, Hooks::STALE_AGENT_CONFIG),
+                            E_USER_WARNING
+                        );
+                        continue;
+                    }
+
                     if (!$odd) {
                         echo "<tr class='tab_bg_1'>";
                     }

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -136,7 +136,6 @@ class Conf extends CommonGLPI
         'stale_agents_delay'             => 0,
         'stale_agents_clean'             => 1,
         'stale_agents_status'            => 0,
-        'stale_agents_uninstall'         => 0,
     ];
 
     /**
@@ -926,11 +925,11 @@ class Conf extends CommonGLPI
         $defaults = self::$defaults;
         unset($values['_glpi_csrf_token']);
 
-        $inv_values = array_filter($values, static function ($value) {
-            return !str_starts_with($value, '_');
-        });
+        $ext_configs = array_filter($values, static function ($k, $v) {
+            return str_starts_with($v, '_');
+        }, ARRAY_FILTER_USE_BOTH);
 
-        $unknown = array_diff_key($inv_values, $defaults);
+        $unknown = array_diff_key($values, $defaults, $ext_configs);
         if (count($unknown)) {
             $msg = sprintf(
                 __('Some properties are not known: %1$s'),
@@ -947,6 +946,7 @@ class Conf extends CommonGLPI
         foreach ($defaults as $prop => $default_value) {
             $to_process[$prop] = $values[$prop] ?? $default_value;
         }
+        $to_process = array_merge($to_process, $ext_configs);
         \Config::setConfigurationValues('inventory', $to_process);
         $this->currents = $to_process;
         return true;

--- a/src/Plugin/Hooks.php
+++ b/src/Plugin/Hooks.php
@@ -133,6 +133,8 @@ class Hooks
     const HANDLE_WAKEONLAN_TASK    = 'handle_wakeonlan_task';
     const HANDLE_REMOTEINV_TASK    = 'handle_remoteinventory_task';
 
+    const STALE_AGENT_CONFIG = 'stale_agent_config';
+
    // Debug / Development hooks
     const DEBUG_TABS = 'debug_tabs';
 

--- a/tests/functionnal/Agent.php
+++ b/tests/functionnal/Agent.php
@@ -353,8 +353,8 @@ class Agent extends DbTestCase
         $agent = new \Agent();
         $rand = mt_rand();
         $agents_id = $agent->add([
-            'name' => __FUNCTION__ . $rand. '-2018-07-09-09-07-13',
-            'deviceid' => __FUNCTION__ . $rand. '-2018-07-09-09-07-13',
+            'name' => __FUNCTION__ . $rand . '-2018-07-09-09-07-13',
+            'deviceid' => __FUNCTION__ . $rand . '-2018-07-09-09-07-13',
             'version' => '2.5.2-1.fc31',
             'itemtype' => $itemtype,
             'items_id' => $items_id,
@@ -456,8 +456,8 @@ class Agent extends DbTestCase
         $agent = new \Agent();
         $rand = mt_rand();
         $agents_id = $agent->add([
-            'name' => __FUNCTION__ . $rand. '-2018-07-09-09-07-13',
-            'deviceid' => __FUNCTION__ . $rand. '-2018-07-09-09-07-13',
+            'name' => __FUNCTION__ . $rand . '-2018-07-09-09-07-13',
+            'deviceid' => __FUNCTION__ . $rand . '-2018-07-09-09-07-13',
             'version' => '2.5.2-1.fc31',
             'itemtype' => $itemtype,
             'items_id' => $items_id,

--- a/tests/functionnal/Agent.php
+++ b/tests/functionnal/Agent.php
@@ -397,28 +397,6 @@ class Agent extends DbTestCase
         // Force run the cleanup cron task (direct call the function)
         $crontask = new \CronTask();
         $this->boolean(\Agent::cronCleanoldagents($crontask))->isTrue();
-        // Restore stale_agents_delay config value
-        $DB->updateOrInsert(
-            \Config::getTable(),
-            [
-                'name' => 'stale_agents_delay',
-                'value' => $original_stale_days
-            ],
-            [
-                'name' => 'stale_agents_delay'
-            ]
-        );
-        // Restore stale_agents_clean config value
-        $DB->updateOrInsert(
-            \Config::getTable(),
-            [
-                'name' => 'stale_agents_clean',
-                'value' => $original_stale_clean
-            ],
-            [
-                'name' => 'stale_agents_clean'
-            ]
-        );
         // Verify that the agent has been deleted
         $this->boolean($agent->getFromDB($agents_id))->isFalse();
     }
@@ -470,10 +448,6 @@ class Agent extends DbTestCase
             'id' => $agents_id,
             'last_contact' => date('Y-m-d H:i:s', strtotime('-' . ($test_stale_days + 1) . ' days'))
         ]))->isTrue();
-        // Get current stale_agents_delay config value
-        $original_stale_days = \Config::getConfigurationValues('inventory', ['stale_agents_delay'])['stale_agents_delay'] ?? 0;
-        $original_stale_status = \Config::getConfigurationValues('inventory', ['stale_agents_status'])['stale_agents_status'] ?? -1;
-        $original_stale_clean = \Config::getConfigurationValues('inventory', ['stale_agents_clean'])['stale_agents_clean'] ?? 1;
 
         // Set stale_agents_delay
         $DB->updateOrInsert(
@@ -538,37 +512,5 @@ class Agent extends DbTestCase
             $item->getFromDB($items_id);
             $this->integer($item->fields['states_id'])->isEqualTo(2);
         }
-
-        // Restore config values
-        $DB->updateOrInsert(
-            \Config::getTable(),
-            [
-                'name' => 'stale_agents_status',
-                'value' => $original_stale_status
-            ],
-            [
-                'name' => 'stale_agents_status'
-            ]
-        );
-        $DB->updateOrInsert(
-            \Config::getTable(),
-            [
-                'name' => 'stale_agents_clean',
-                'value' => $original_stale_clean
-            ],
-            [
-                'name' => 'stale_agents_clean'
-            ]
-        );
-        $DB->updateOrInsert(
-            \Config::getTable(),
-            [
-                'name' => 'stale_agents_delay',
-                'value' => $original_stale_days
-            ],
-            [
-                'name' => 'stale_agents_delay'
-            ]
-        );
     }
 }

--- a/tests/functionnal/Agent.php
+++ b/tests/functionnal/Agent.php
@@ -367,9 +367,6 @@ class Agent extends DbTestCase
             'id' => $agents_id,
             'last_contact' => date('Y-m-d H:i:s', strtotime('-' . ($test_stale_days + 1) . ' days'))
         ]))->isTrue();
-        // Get current stale_agents_delay config value
-        $original_stale_days = \Config::getConfigurationValues('inventory', ['stale_agents_delay'])['stale_agents_delay'] ?? 0;
-        $original_stale_clean = \Config::getConfigurationValues('inventory', ['stale_agents_clean'])['stale_agents_clean'] ?? 1;
 
         // Set stale_agents_delay
         $DB->updateOrInsert(

--- a/tests/functionnal/Agent.php
+++ b/tests/functionnal/Agent.php
@@ -390,6 +390,16 @@ class Agent extends DbTestCase
                 'name' => 'stale_agents_clean'
             ]
         );
+        $DB->updateOrInsert(
+            \Config::getTable(),
+            [
+                'name' => 'stale_agents_status',
+                'value' => -1
+            ],
+            [
+                'name' => 'stale_agents_status'
+            ]
+        );
 
         // Force run the cleanup cron task (direct call the function)
         $crontask = new \CronTask();
@@ -503,7 +513,7 @@ class Agent extends DbTestCase
                 'name' => 'stale_agents_status'
             ]
         );
-        // Should return true even if the agent has an invalid item
+
         $this->boolean(\Agent::cronCleanoldagents($crontask))->isTrue();
         if ($items_id > 0) {
             $item->getFromDB($items_id);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !23415

Separates the agent cleanup actions so that you have the option to cleanup the agent and change the status of the related item instead of choosing one action or the other.
This also adds integration with the uninstall plugin to allow applying an uninstall model to the related item during cleanup.