### PR TITLE
fix: change entity tree

### DIFF
--- a/ajax/entitytreesons.php
+++ b/ajax/entitytreesons.php
@@ -98,7 +98,7 @@ if (!array_key_exists($subckey, $all_entitiestree)) {
 /* scans the tree to select the active entity */
 $entitiestree = [];
 $entitytree = $all_entitiestree[$subckey];
-$adapt_tree = static function (&$entities) use (&$adapt_tree, $ancestors) {
+$select_tree = static function (&$entities) use (&$select_tree, $ancestors) {
     foreach ($entities as &$entity) {
         if (isset($ancestors[$entity['key']])) {
             $entity['expanded'] = 'true';
@@ -107,12 +107,12 @@ $adapt_tree = static function (&$entities) use (&$adapt_tree, $ancestors) {
             $entity['selected'] = 'true';
         }
         if (isset($entity['children'])) {
-            $adapt_tree($entity['children']);
+            $select_tree($entity['children']);
         }
     }
     return $entities;
 };
-$adapt_tree($entitytree);
+$select_tree($entitytree);
 $entitiestree = array_merge($entitiestree, $entitytree);
 
 echo json_encode($entitiestree);

--- a/ajax/entitytreesons.php
+++ b/ajax/entitytreesons.php
@@ -52,57 +52,68 @@ if (Session::getCurrentInterface() == 'helpdesk') {
 $ancestors = getAncestorsOf('glpi_entities', $_SESSION['glpiactive_entity']);
 
 $ckey    = 'entity_selector';
-$subckey = sha1($_SESSION['glpiactiveentities_string'] . json_encode($_SESSION['glpiactiveprofile']['entities']));
+$subckey = sha1(json_encode($_SESSION['glpiactiveprofile']['entities']));
 $all_entitiestree = $GLPI_CACHE->get($ckey, []);
-if (array_key_exists($subckey, $all_entitiestree)) {
-    echo json_encode($all_entitiestree[$subckey]);
-    exit;
+
+/* calculates the tree to save it in the cache if it is not already there */
+if (!array_key_exists($subckey, $all_entitiestree)) {
+    $entitiestree = [];
+    foreach ($_SESSION['glpiactiveprofile']['entities'] as $default_entity) {
+        $default_entity_id = $default_entity['id'];
+
+        $entitytree  = $default_entity['is_recursive'] ? getTreeForItem('glpi_entities', $default_entity_id) : [$default_entity['id'] => $default_entity];
+        $adapt_tree = static function (&$entities) use (&$adapt_tree, $base_path) {
+            foreach ($entities as $entities_id => &$entity) {
+                $entity['key']   = $entities_id;
+
+                $title = "<a href='$base_path?active_entity={$entities_id}'>{$entity['name']}</a>";
+                $entity['title'] = $title;
+                unset($entity['name']);
+
+                if (isset($entity['tree']) && count($entity['tree']) > 0) {
+                    $entity['folder'] = true;
+
+                    $entity['title'] .= "<a href='$base_path?active_entity={$entities_id}&is_recursive=1'>
+                <i class='fas fa-angle-double-down ms-1' data-bs-toggle='tooltip' data-bs-placement='right' title='" . __('+ sub-entities') . "'></i>
+                </a>";
+
+                    $children = $adapt_tree($entity['tree']);
+                    $entity['children'] = array_values($children);
+                }
+
+                unset($entity['tree']);
+            }
+
+            return $entities;
+        };
+        $adapt_tree($entitytree);
+
+        $entitiestree = array_merge($entitiestree, $entitytree);
+    }
+
+    $all_entitiestree[$subckey] = $entitiestree;
+    $GLPI_CACHE->set($ckey, $all_entitiestree);
 }
 
+/* scans the tree to select the active entity */
 $entitiestree = [];
-foreach ($_SESSION['glpiactiveprofile']['entities'] as $default_entity) {
-    $default_entity_id = $default_entity['id'];
-
-    $entitytree  = $default_entity['is_recursive'] ? getTreeForItem('glpi_entities', $default_entity_id) : [$default_entity['id'] => $default_entity];
-    $adapt_tree = static function (&$entities) use (&$adapt_tree, $base_path, $ancestors) {
-        foreach ($entities as $entities_id => &$entity) {
-            $entity['key']   = $entities_id;
-
-            $title = "<a href='$base_path?active_entity={$entities_id}'>{$entity['name']}</a>";
-            $entity['title'] = $title;
-            unset($entity['name']);
-
-            if (isset($ancestors[$entities_id])) {
-                $entity['expanded'] = 'true';
-            }
-
-            if ($entities_id == $_SESSION['glpiactive_entity']) {
-                $entity['selected'] = 'true';
-            }
-
-            if (isset($entity['tree']) && count($entity['tree']) > 0) {
-                $entity['folder'] = true;
-
-                $entity['title'] .= "<a href='$base_path?active_entity={$entities_id}&is_recursive=1'>
-               <i class='fas fa-angle-double-down ms-1' data-bs-toggle='tooltip' data-bs-placement='right' title='" . __('+ sub-entities') . "'></i>
-            </a>";
-
-                $children = $adapt_tree($entity['tree']);
-                $entity['children'] = array_values($children);
-            }
-
-            unset($entity['tree']);
+$entitytree = $all_entitiestree[$subckey];
+$adapt_tree = static function (&$entities) use (&$adapt_tree, $ancestors) {
+    foreach ($entities as &$entity) {
+        if (isset($ancestors[$entity['key']])) {
+            $entity['expanded'] = 'true';
         }
-
-        return $entities;
-    };
-    $adapt_tree($entitytree);
-
-    $entitiestree = array_merge($entitiestree, $entitytree);
-}
-
-$all_entitiestree[$subckey] = $entitiestree;
-$GLPI_CACHE->set($ckey, $all_entitiestree);
+        if ($entity['key'] == $_SESSION['glpiactive_entity']) {
+            $entity['selected'] = 'true';
+        }
+        if (isset($entity['children'])) {
+            $adapt_tree($entity['children']);
+        }
+    }
+    return $entities;
+};
+$adapt_tree($entitytree);
+$entitiestree = array_merge($entitiestree, $entitytree);
 
 echo json_encode($entitiestree);
 exit;

--- a/ajax/entitytreesons.php
+++ b/ajax/entitytreesons.php
@@ -52,7 +52,7 @@ if (Session::getCurrentInterface() == 'helpdesk') {
 $ancestors = getAncestorsOf('glpi_entities', $_SESSION['glpiactive_entity']);
 
 $ckey    = 'entity_selector';
-$subckey = sha1($_SESSION['glpiactiveentities_string']);
+$subckey = sha1($_SESSION['glpiactiveentities_string'] . json_encode($_SESSION['glpiactiveprofile']['entities']));
 $all_entitiestree = $GLPI_CACHE->get($ckey, []);
 if (array_key_exists($subckey, $all_entitiestree)) {
     echo json_encode($all_entitiestree[$subckey]);
@@ -76,7 +76,7 @@ foreach ($_SESSION['glpiactiveprofile']['entities'] as $default_entity) {
                 $entity['expanded'] = 'true';
             }
 
-            if ($entities_id == $_SESSION['glpiactive_entity_name']) {
+            if ($entities_id == $_SESSION['glpiactive_entity']) {
                 $entity['selected'] = 'true';
             }
 


### PR DESCRIPTION
When changing entities, the selection tree was sometimes incomplete: the parent entity of the one already active was missing, even though the user has the rights.

![image](https://user-images.githubusercontent.com/8530352/176689782-ab4caf7e-26ed-45c4-a2aa-b48e3226da9e.png)

Conversely, the tree could display entities that the user does not have access to, but does not have access to the content.


In addition, the active entity was not highlighted.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24361
