### PR TITLE
Fix LDAP group import options

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2298,13 +2298,13 @@ class AuthLDAP extends CommonDBTM
                               $dn_index,
                               ['massive_tags'  => 'select_item_child_entities',
                                   'name'          => "ldap_import_recursive[$dn_index]",
-                                  'specific_tags' => ['data-glpicore-ma-tags' => 'entities_id']
+                                  'specific_tags' => ['data-glpicore-ma-tags' => 'common']
                               ]
                           );
                             echo "</td>";
                     } else {
                         echo Html::hidden("ldap_import_recursive[$dn_index]", ['value'                 => 0,
-                            'data-glpicore-ma-tags' => 'entities_id'
+                            'data-glpicore-ma-tags' => 'common'
                         ]);
                     }
                     echo "</tr>";

--- a/src/Html.php
+++ b/src/Html.php
@@ -2519,10 +2519,12 @@ HTML;
             $options['specific_tags']['data-glpicore-ma-tags'] = 'common';
         }
 
-       // encode quotes and brackets to prevent maformed name attribute
-        $id = htmlspecialchars($id, ENT_QUOTES);
-        $id = str_replace(['[', ']'], ['&amp;#91;', '&amp;#93;'], $id);
-        $options['name']          = "item[$itemtype][" . $id . "]";
+        if (empty($options['name'])) {
+            // encode quotes and brackets to prevent maformed name attribute
+            $id = htmlspecialchars($id, ENT_QUOTES);
+            $id = str_replace(['[', ']'], ['&amp;#91;', '&amp;#93;'], $id);
+            $options['name'] = "item[$itemtype][" . $id . "]";
+        }
 
         $options['zero_on_empty'] = false;
 
@@ -2710,7 +2712,7 @@ HTML;
                         $js_modal_fields .= '#' . $p['container'] . ' ';
                     }
                     $js_modal_fields .= "[data-glpicore-ma-tags~=" . $p['tag_to_send'] . "]').each(function( index ) {
-                  fields[$(this).attr('name')] = $(this).attr('value');
+                  fields[$(this).attr('name')] = $(this).val();
                   if (($(this).attr('type') == 'checkbox') && (!$(this).is(':checked'))) {
                      fields[$(this).attr('name')] = 0;
                   }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12056

3 fixes:
1. The JS used to set the massive action inputs in the massive action modal used the `value` attribute of elements with a specific data attribute. This was not working for the select element to select the target entity. The `val` method needed to be used instead.
2. The recursive entity option was shown as a massive action checkbox which was not using the provided name and instead set it to the expected name as if it were the main checkbox used to select the items.
3. The recursive entity option was not passed in the massive actions. It seems like the `data-glpicore-ma-tags` has to be set to `common` otherwise, there is no effect.