### PR TITLE
fix(ux): fix combox empty choice width

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -397,7 +397,7 @@ class Dropdown
         }
 
         if (strlen($icons) > 0) {
-            $output = "<div class='btn-group btn-group-sm " . ($params['width'] == "100%" ? "w-100" : "") . "' role='group'>{$output} {$icons}</div>";
+            $output = "<div class='btn-group btn-group-sm " . ($params['width'] == "100%" ? "w-150" : "") . "' role='group'>{$output} {$icons}</div>";
         }
 
         $output .= Ajax::commonDropdownUpdateItem($params, false);


### PR DESCRIPTION
Fix dropdown width with empty choice

Before 

![image](https://user-images.githubusercontent.com/7335054/176834081-da146f84-00a6-40c3-8ee6-e58b65acc40a.png)

After

![image](https://user-images.githubusercontent.com/7335054/176834099-35ccf335-ba3a-45d4-aa5f-a6287e871303.png)




| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12063
