### PR TITLE
fix(itiltask): empty date

### DIFF
--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -548,7 +548,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             $input["users_id"] = $uid;
         }
 
-        if (!isset($input["date"])) {
+        if (!isset($input["date"]) || empty($input["date"])) {
             $input["date"] = $_SESSION["glpi_currenttime"];
         }
         if (!isset($input["is_private"])) {


### PR DESCRIPTION
Following #12041, if the date was not filled in, a null date was recorded instead of the current date, as when the field is not present.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24337
