### PR TITLE
Allow forcing closure when adding solution via rules

### DIFF
--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -241,8 +241,8 @@ class ITILSolution extends CommonDBChild
                 Entity::CONFIG_NEVER
             );
 
-           // 0 = immediatly
-            if ($autoclosedelay != 0) {
+           // 0  or ticket status CLOSED = immediately
+            if ($autoclosedelay != 0 && $this->item->fields["status"] != $this->item::CLOSED) {
                 $status = CommonITILValidation::WAITING;
             }
         }
@@ -319,8 +319,8 @@ class ITILSolution extends CommonDBChild
                     Entity::CONFIG_NEVER
                 );
 
-                // 0 = immediatly
-                if ($autoclosedelay == 0) {
+                // 0 = immediately or ticket status CLOSED force status
+                if ($autoclosedelay == 0 || $this->item->fields["status"] == $this->item::CLOSED) {
                      $status = $item::CLOSED;
                 }
             }

--- a/tests/functionnal/ITILSolution.php
+++ b/tests/functionnal/ITILSolution.php
@@ -475,4 +475,29 @@ HTML
 
         $this->string($solution->fields['content'])->isEqualTo('test template2');
     }
+
+    public function testAddOnClosedTicket()
+    {
+        $this->login();
+        // Create new ticket
+        $ticket = $this->getNewITILObject('Ticket', true);
+        // Close ticket
+        $this->boolean($ticket->update([
+            'id'    => $ticket->fields['id'],
+            'status' => \CommonITILObject::CLOSED,
+        ]))->isTrue();
+        // Create solution
+        $solution = new \ITILSolution();
+        $solutions_id = $solution->add([
+            'itemtype'           => 'Ticket',
+            'items_id'           => $ticket->fields['id'],
+            'content'            => 'test solution',
+        ]);
+        $this->integer($solutions_id)->isGreaterThan(0);
+        // Verify solution is not waiting for approval. Should default to being approved.
+        $this->integer($solution->fields['status'])->isEqualTo(\CommonITILValidation::ACCEPTED);
+        // Verify the ticket status is still closed.
+        $this->boolean($ticket->getFromDB($ticket->fields['id']))->isTrue();
+        $this->integer($ticket->fields['status'])->isEqualTo(\CommonITILObject::CLOSED);
+    }
 }


### PR DESCRIPTION
Actually applying a solution to a ticket means to change its status to SOLVED (if GLPI is not configured to immediately close the ticket) and wait for approval.
Sometimes, a kind of a strong reject could be required for some tickets, ignoring autoclosure state/delay defined for the entity.
This modification offers the possibility to close a ticket and apply a solution for it by rule (in this order). Other usages could be imagined with tickets solutions and other statuses, but I didn't find a way to inform ITILSolution objects about ticket status modifications...

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
