### PR TITLE
Changing notification type for new tickets directly closed upon creation

### DIFF
--- a/src/Change.php
+++ b/src/Change.php
@@ -344,7 +344,7 @@ class Change extends CommonITILObject
 
     public function post_addItem()
     {
-        global $CFG_GLPI, $DB;
+        global $DB;
 
         parent::post_addItem();
 
@@ -406,20 +406,7 @@ class Change extends CommonITILObject
             }
         }
 
-       // Processing notifications
-        if ($CFG_GLPI["use_notifications"]) {
-           // Clean reload of the change
-            $this->getFromDB($this->fields['id']);
-
-            $type = "new";
-            if (
-                isset($this->fields["status"])
-                && in_array($this->input["status"], $this->getSolvedStatusArray())
-            ) {
-                $type = "solved";
-            }
-            NotificationEvent::raiseEvent($type, $this);
-        }
+        $this->handleNewItemNotifications();
 
         if (
             isset($this->input['_from_items_id'])

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7692,6 +7692,30 @@ abstract class CommonITILObject extends CommonDBTM
     }
 
     /**
+     * Handle notifications to be sent after item creation.
+     *
+     * @return void
+     */
+    public function handleNewItemNotifications(): void
+    {
+        global $CFG_GLPI;
+
+        if (!isset($this->input['_disablenotif']) && $CFG_GLPI['use_notifications']) {
+            $this->getFromDB($this->fields['id']); // Reload item to get actual status
+
+            NotificationEvent::raiseEvent('new', $this);
+
+            $status = $this->fields['status'] ?? null;
+            if (in_array($status, $this->getSolvedStatusArray())) {
+                NotificationEvent::raiseEvent('solved', $this);
+            }
+            if (in_array($status, $this->getClosedStatusArray())) {
+                NotificationEvent::raiseEvent('closed', $this);
+            }
+        }
+    }
+
+    /**
      * Manage Validation add from input (form and rules)
      *
      * @param array $input

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -330,7 +330,7 @@ class Problem extends CommonITILObject
 
     public function post_addItem()
     {
-        global $CFG_GLPI, $DB;
+        global $DB;
 
         parent::post_addItem();
 
@@ -370,20 +370,7 @@ class Problem extends CommonITILObject
             }
         }
 
-       // Processing Email
-        if (!isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"]) {
-           // Clean reload of the problem
-            $this->getFromDB($this->fields['id']);
-
-            $type = "new";
-            if (
-                isset($this->fields["status"])
-                && in_array($this->input["status"], $this->getSolvedStatusArray())
-            ) {
-                $type = "solved";
-            }
-            NotificationEvent::raiseEvent($type, $this);
-        }
+        $this->handleNewItemNotifications();
 
         if (
             isset($this->input['_from_items_id'])

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2115,13 +2115,14 @@ class Ticket extends CommonITILObject
             $this->getFromDB($this->fields['id']);
 
             $type = "new";
+            NotificationEvent::raiseEvent("new", $this);
+            
             if (isset($this->fields["status"]) && ($this->fields["status"] == self::SOLVED)) {
-                $type = "solved";
+                NotificationEvent::raiseEvent("solved", $this);
             }
             if (isset($this->fields["status"]) && ($this->fields["status"] == self::CLOSED)) {
-                $type = "closed";
+                NotificationEvent::raiseEvent("closed", $this);
             }
-            NotificationEvent::raiseEvent($type, $this);
         }
     }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1940,8 +1940,6 @@ class Ticket extends CommonITILObject
 
     public function post_addItem()
     {
-        global $CFG_GLPI;
-
        // Log this event
         $username = 'anonymous';
         if (isset($_SESSION["glpiname"])) {
@@ -2109,19 +2107,7 @@ class Ticket extends CommonITILObject
 
         parent::post_addItem();
 
-       // Processing Email
-        if (!isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"]) {
-           // Clean reload of the ticket
-            $this->getFromDB($this->fields['id']);
-
-            NotificationEvent::raiseEvent("new", $this);
-            if (isset($this->fields["status"]) && ($this->fields["status"] == self::SOLVED)) {
-                NotificationEvent::raiseEvent("solved", $this);
-            }
-            if (isset($this->fields["status"]) && ($this->fields["status"] == self::CLOSED)) {
-                NotificationEvent::raiseEvent("closed", $this);
-            }
-        }
+        $this->handleNewItemNotifications();
     }
 
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2121,7 +2121,7 @@ class Ticket extends CommonITILObject
             if (isset($this->fields["status"]) && ($this->fields["status"] == self::CLOSED)) {
                 $type = "closed";
             }
-           NotificationEvent::raiseEvent($type, $this);
+            NotificationEvent::raiseEvent($type, $this);
         }
     }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2118,7 +2118,10 @@ class Ticket extends CommonITILObject
             if (isset($this->fields["status"]) && ($this->fields["status"] == self::SOLVED)) {
                 $type = "solved";
             }
-            NotificationEvent::raiseEvent($type, $this);
+            if (isset($this->fields["status"]) && ($this->fields["status"] == self::CLOSED)) {
+                $type = "closed";
+            }
+           NotificationEvent::raiseEvent($type, $this);
         }
     }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2116,7 +2116,6 @@ class Ticket extends CommonITILObject
 
             $type = "new";
             NotificationEvent::raiseEvent("new", $this);
-            
             if (isset($this->fields["status"]) && ($this->fields["status"] == self::SOLVED)) {
                 NotificationEvent::raiseEvent("solved", $this);
             }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2114,7 +2114,6 @@ class Ticket extends CommonITILObject
            // Clean reload of the ticket
             $this->getFromDB($this->fields['id']);
 
-            $type = "new";
             NotificationEvent::raiseEvent("new", $this);
             if (isset($this->fields["status"]) && ($this->fields["status"] == self::SOLVED)) {
                 NotificationEvent::raiseEvent("solved", $this);


### PR DESCRIPTION
When a new ticket is created, a notification is sent to actors. Its type is "New Ticket". If a rule closes (rejects) the ticket upon creation, this "New Ticket" notification template is still used. In a perfect world, there should be both New Ticket and Close Ticket notifications sent, but as actually this is not possible, Close Ticket notification seems to be more accurate.

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
