### PR TITLE
Fix extra CSS fetching from TinyMCE

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3816,8 +3816,8 @@ JS;
         $language_url = $CFG_GLPI['root_doc'] . '/public/lib/tinymce-i18n/langs6/' . $language . '.js';
 
        // Apply all GLPI styles to editor content
-        $content_css = preg_replace('/^.*href="([^"]+)".*$/', '$1', self::scss('css/palettes/' . $_SESSION['glpipalette'] ?? 'auror'))
-         . ',' . preg_replace('/^.*href="([^"]+)".*$/', '$1', self::css('public/lib/base.css'));
+        $content_css = preg_replace('/^.*href="([^"]+)".*$/', '$1', self::scss(('css/palettes/' . $_SESSION['glpipalette'] ?? 'auror') . '.scss', ['force_no_version' => true]))
+         . ',' . preg_replace('/^.*href="([^"]+)".*$/', '$1', self::css('public/lib/base.css', ['force_no_version' => true]));
 
         $cache_suffix = '?v=' . FrontEnd::getVersionCacheKey(GLPI_VERSION);
         $readonlyjs   = $readonly ? 'true' : 'false';
@@ -5462,13 +5462,15 @@ HTML;
             $options['media'] = 'all';
         }
 
-        $version = GLPI_VERSION;
-        if (isset($options['version'])) {
-            $version = $options['version'];
-            unset($options['version']);
-        }
+        if (!isset($options['force_no_version']) || !$options['force_no_version']) {
+            $version = GLPI_VERSION;
+            if (isset($options['version'])) {
+                $version = $options['version'];
+                unset($options['version']);
+            }
 
-        $url .= ((strpos($url, '?') !== false) ? '&' : '?') . 'v=' . FrontEnd::getVersionCacheKey($version);
+            $url .= ((strpos($url, '?') !== false) ? '&' : '?') . 'v=' . FrontEnd::getVersionCacheKey($version);
+        }
 
         return sprintf(
             '<link rel="stylesheet" type="text/css" href="%s" %s>',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The content CSS paths for `base.css` and the current palette given to the TinyMCE instances did not match the path of the resources loaded and cached from regular page requests. This forced the browser to try and re-fetch those resources at least one extra time even if it was already cached.

The paths provided to TinyMCE already had a version parameter but TinyMCE was adding another one (did not replace it).
Additionally, the path for the palette was missing the `scss` extension even though it was present in the path when loading a page normally. This PR adds an option to get a SCSS/CSS link without a version and then rely on TinyMCE to append it with the provided cache suffix.

Realistically, this improvement is minor if both stylesheets are already cached with both versions of the URL. In debug mode, the fix has no effect since resources are sent with `no-cache`.