### PR TITLE
Fix impact labels in dark themes

### DIFF
--- a/js/impact.js
+++ b/js/impact.js
@@ -715,6 +715,11 @@ var GLPIImpact = {
     * @returns {Array}
     */
     getNetworkStyle: function() {
+        let body_text_color = $(document.body).css("--tblr-body-color");
+        // If body color is somehow invalid, default to black
+        if (!body_text_color || body_text_color === "") {
+            body_text_color = "#000000";
+        }
         return [
             {
                 selector: 'core',
@@ -722,6 +727,12 @@ var GLPIImpact = {
                     'selection-box-opacity'     : '0.2',
                     'selection-box-border-width': '0',
                     'selection-box-color'       : '#24acdf'
+                }
+            },
+            {
+                selector: 'node',
+                style: {
+                    color: body_text_color
                 }
             },
             {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

The color of the label text in Impact Analysis always seem to be black which means that it is invisible when using the Midnight palette. This PR sets the node color to the `--tblr-body-color` CSS var value to let it adapt regardless of the palette used.