### PR TITLE
Fix selected tech in ITILCategory form

### DIFF
--- a/templates/dropdown_form.html.twig
+++ b/templates/dropdown_form.html.twig
@@ -94,7 +94,7 @@
                     {{ fields.dropdownField(
                         'User',
                         field['name'],
-                        subitem.fields[field['name']],
+                        item.fields[field['name']],
                         field['label'],
                         {
                             'entity': item.fields['entities_id'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

`subitem` was probably due to a bad copy/paste, this variable is only used for timeline items in templates.
Result was that drodown was never showing the current value as selected.