### PR TITLE
fix(inventory): allow network managment on create

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -695,7 +695,7 @@ abstract class MainAsset extends InventoryAsset
             $_SESSION['glpiactive_entity']         = $entities_id;
         }
 
-        if ($this->is_discovery === true) {
+        if ($this->is_discovery === true && !$this->isNew()) {
             //do not update from network discoveries
             //prevents discoveries to remove all ports, IPs and so on found with network inventory
             return;


### PR DESCRIPTION
Network data are never created from discovery

This PR fix this


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
