### PR TITLE
Fix is_glpi_class check

### DIFF
--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -269,7 +269,11 @@ final class DbUtils
             $itemtype = null;
             if (class_exists($base_itemtype)) {
                 $class_file = (new ReflectionClass($base_itemtype))->getFileName();
-                $is_glpi_class = $class_file !== false && str_starts_with(realpath($class_file), realpath(GLPI_ROOT));
+                $is_glpi_class = $class_file !== false && (
+                    str_starts_with(realpath($class_file), realpath(GLPI_ROOT))
+                    || str_starts_with(realpath($class_file), realpath(GLPI_MARKETPLACE_DIR))
+                    || str_starts_with(realpath($class_file), realpath(GLPI_PLUGIN_DOC_DIR))
+                );
                 if ($is_glpi_class) {
                     $itemtype = $base_itemtype;
                 }


### PR DESCRIPTION
The current `is_glpi_class` check only allow for classes to be inside the `glpi` folder.

This is not always the case as plugins like `fields` or `genericobject` create classes in the `files/_plugins` folder, which can be outside the `glpi` folder.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24075 !24299
