### PR TITLE
Fix updating recipients on NS itemtype notifications

### DIFF
--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -449,7 +449,8 @@ class NotificationTarget extends CommonDBChild
 
         $type   = "";
         $action = "";
-        $target = self::getInstanceByType(stripslashes($input['itemtype']));
+        $itemtype = \Glpi\Toolbox\Sanitizer::unsanitize($input['itemtype']);
+        $target = self::getInstanceByType($itemtype);
 
         if (!isset($input['notifications_id'])) {
             return;

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -449,7 +449,7 @@ class NotificationTarget extends CommonDBChild
 
         $type   = "";
         $action = "";
-        $target = self::getInstanceByType($itemtype);
+        $target = self::getInstanceByType($input['itemtype']);
 
         if (!isset($input['notifications_id'])) {
             return;

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -449,7 +449,6 @@ class NotificationTarget extends CommonDBChild
 
         $type   = "";
         $action = "";
-        $itemtype = \Glpi\Toolbox\Sanitizer::unsanitize($input['itemtype']);
         $target = self::getInstanceByType($itemtype);
 
         if (!isset($input['notifications_id'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12136

The itemtype did not contain escaped slashes in my testing so stripslashes was not needed. Using the Sanitizer class seems to handle the itemtype properly if the slashes are escaped or not.