### PR TITLE
Fix display of allowed statuses for new ITIL Objects

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -3313,7 +3313,10 @@ abstract class CommonITILObject extends CommonDBTM
 
         switch ($p['showtype']) {
             case 'allowed':
-                $tab = static::getAllowedStatusArray($p['value_calculation'] ?: $p['value']);
+                $current = isset($p['value_calculation']) && $p['value_calculation'] !== ''
+                    ? $p['value_calculation']
+                    : $p['value'];
+                $tab = static::getAllowedStatusArray($current);
                 break;
 
             case 'search':

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -3313,7 +3313,7 @@ abstract class CommonITILObject extends CommonDBTM
 
         switch ($p['showtype']) {
             case 'allowed':
-                $tab = static::getAllowedStatusArray($p['value_calculation'] ?? $p['value']);
+                $tab = static::getAllowedStatusArray($p['value_calculation'] ?: $p['value']);
                 break;
 
             case 'search':


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !24027

See: https://github.com/glpi-project/glpi/issues/11858#issuecomment-1168514243

The `value_calculation` property may be an empty string which `??` would not have made `value` be used instead. The `?:` operator would be needed so that any time the `value_calculation` property is falsy (including empty strings), the `value` is used instead.