### PR TITLE
Ticketd: fix timeline scroll with middle click

### DIFF
--- a/templates/components/itilobject/layout.html.twig
+++ b/templates/components/itilobject/layout.html.twig
@@ -61,9 +61,7 @@
    {% endif %}
 
    <div class="row d-flex flex-column alin-items-stretch itil-object">
-      {% set is_timeline_reversed = user_pref('timeline_order') == constant('CommonITILObject::TIMELINE_ORDER_REVERSE') %}
-      {% set fl_direction = (item.isNewItem or is_timeline_reversed ? 'flex-column' : 'flex-column-reverse') %}
-      <div class="itil-left-side col-12 {{ left_side_cls }} order-last order-md-first pt-2 pe-2 pe-md-4 d-flex {{ fl_direction }} border-top border-4">
+      <div class="itil-left-side col-12 {{ left_side_cls }} order-last order-md-first pt-2 pe-2 pe-md-4 border-top border-4">
          {% if item.isNewItem() %}
             {{ include('components/itilobject/timeline/new_form.html.twig') }}
          {% else %}


### PR DESCRIPTION
When viewing a ticket, the right panel (tickets details) is scroll-able using the middle mouse button but the left side (ticket timeline) isn't.

![image](https://user-images.githubusercontent.com/42734840/177498749-4a6a922c-b987-4c47-a32d-5d4e0d00bc64.png)

This seems to be caused by an obsolete flex div:

![image](https://user-images.githubusercontent.com/42734840/177498309-6a0dd4c7-a53c-4196-b041-aede2df298fe.png)

This div contains only one element (the timeline container) so the `d-flex` and `flex-column-reverse` classes do not do anything.
Removing them fix the scrolling issues.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
