### PR TITLE
fix(inventory): format date if needed

### DIFF
--- a/src/Inventory/Asset/Device.php
+++ b/src/Inventory/Asset/Device.php
@@ -112,7 +112,9 @@ abstract class Device extends InventoryAsset
                 }
 
                 //force convertion if needed for date format as 2015-04-16T00:00:00Z
-                $val->date = date('Y-m-d', strtotime($val->date));
+                if (isset($val->date)) {
+                    $val->date = date('Y-m-d', strtotime($val->date));
+                }
 
                 //create device or get existing device ID
                 $device_id = $device->import(\Toolbox::addslashes_deep((array)$val) + ['with_history' => false]);

--- a/src/Inventory/Asset/Device.php
+++ b/src/Inventory/Asset/Device.php
@@ -112,6 +112,7 @@ abstract class Device extends InventoryAsset
                 }
 
                 //force convertion if needed for date format as 2015-04-16T00:00:00Z
+                // TODO : need to straighten up date format globally (especially for JSON inventory) which does not use the converter
                 if (isset($val->date)) {
                     $val->date = date('Y-m-d', strtotime($val->date));
                 }

--- a/src/Inventory/Asset/Device.php
+++ b/src/Inventory/Asset/Device.php
@@ -111,6 +111,9 @@ abstract class Device extends InventoryAsset
                     $val->designation = $itemdevice->getTypeName(1);
                 }
 
+                //force convertion if needed for date format as 2015-04-16T00:00:00Z
+                $val->date = date('Y-m-d', strtotime($val->date));
+
                 //create device or get existing device ID
                 $device_id = $device->import(\Toolbox::addslashes_deep((array)$val) + ['with_history' => false]);
 

--- a/src/Inventory/Asset/Device.php
+++ b/src/Inventory/Asset/Device.php
@@ -113,7 +113,7 @@ abstract class Device extends InventoryAsset
 
                 //force convertion if needed for date format as 2015-04-16T00:00:00Z
                 // TODO : need to straighten up date format globally (especially for JSON inventory) which does not use the converter
-                if (isset($val->date)) {
+                if (property_exists($val, 'date')) {
                     $val->date = date('Y-m-d', strtotime($val->date));
                 }
 


### PR DESCRIPTION
Prevent SQL error for incorrect date value

```sql
[2022-07-06 09:40:54] glpisqllog.ERROR: DBmysql::query() in /dev/GLPI/10.0-bugfixes/src/DBmysql.php line 370
  *** MySQL query error:
  SQL: INSERT INTO `glpi_devicefirmwares` (`date`, `version`, `designation`, `devicefirmwaretypes_id`, `date_creation`, `date_mod`) VALUES ('2015-04-16T00:00:00Z', 'B200M4.2.2.4a.0.041620151912', ' BIOS', '1', '2022-07-06 09:40:54', '2022-07-06 09:40:54')
  Error: Incorrect date value: '2015-04-16T00:00:00Z' for column 'date' at row 1
  Backtrace :
```
Error encountered from ```ESX inventory``` with ```glpiinventory``` plugin

Maybe this fix need to be placed in ```glpi_project/inventory_format```

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
